### PR TITLE
Change text color of overview links to fix color-contrast issue

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -1562,7 +1562,10 @@ div.insights-dialog-main-override {
                             font-family: Segoe UI;
                             line-height: 20px;
                             font-size: 15px;
-                            color: $communication-shade-20;
+                            a {
+                                color: red !important;
+                                background-color: aqua;
+                            }
                         }
                     }
                 }

--- a/src/DetailsView/components/overview-content/overview-help-links.tsx
+++ b/src/DetailsView/components/overview-content/overview-help-links.tsx
@@ -17,8 +17,9 @@ export const HelpLinks = NamedSFC('HelpLinks', (props: HelpLinksProps) => {
     return (
         <>
             {linkInformation.map((link: HyperlinkDefinition) => (
-                <div className="help-link" key={link.href}>
+                <div key={link.href}>
                     <ExternalLink
+                        className="help-links"
                         deps={props.deps}
                         href={link.href}
                     >

--- a/src/common/components/external-link.tsx
+++ b/src/common/components/external-link.tsx
@@ -7,17 +7,20 @@ import { ActionInitiators } from '../action/action-initiator';
 import { NamedSFC } from '../react/named-sfc';
 
 export type ExternalLinkDeps = {
-    actionInitiators: Pick<ActionInitiators, 'openExternalLink'>,
+    actionInitiators: Pick<ActionInitiators, 'openExternalLink'>;
 };
 export type ExternalLinkProps = {
-    deps: ExternalLinkDeps,
-    href: string,
-    title?: string,
+    deps: ExternalLinkDeps;
+    href: string;
+    title?: string;
+    className?: string;
 };
 
-export const ExternalLink = NamedSFC<ExternalLinkProps>('ExternalLink', ({ deps, href, title, children }) => {
+export const ExternalLink = NamedSFC<ExternalLinkProps>('ExternalLink', ({ deps, href, title, children, className }) => {
     const onClick = e => deps.actionInitiators.openExternalLink(e, { href });
-    return <Link target="_blank" href={href} title={title} onClick={onClick}>
-        {children}
-    </Link>;
+    return (
+        <Link className={className} target="_blank" href={href} title={title} onClick={onClick}>
+            {children}
+        </Link>
+    );
 });

--- a/src/common/components/new-tab-link.tsx
+++ b/src/common/components/new-tab-link.tsx
@@ -6,6 +6,6 @@ import * as React from 'react';
 
 export class NewTabLink extends BaseComponent<ILinkProps> {
     public render(): JSX.Element {
-        return <Link {...this.props} target="_blank" />;
+        return <Link className="insights-links" {...this.props} target="_blank" />;
     }
 }


### PR DESCRIPTION
Change hyperlink color in Overview Help section to fix color-contrast issue.

Fixes: Bug 1419486: color-contrast violation in Assessment overview help links

0 issues from `A11YSelfValidator.validate()` after this change.