### PR TITLE
Partial fix for test status choice group not being accessible in details list

### DIFF
--- a/src/DetailsView/components/test-status-choice-group.tsx
+++ b/src/DetailsView/components/test-status-choice-group.tsx
@@ -31,7 +31,7 @@ export class TestStatusChoiceGroup extends React.Component<ITestStatusChoiceGrou
                         className={ManualTestStatus[this.props.status]}
                         onChange={this.onChange}
                         componentRef={this.compomentRef}
-                        selectedKey={ManualTestStatus[this.props.status]}
+                        selectedKey={this.props.status === ManualTestStatus.UNKNOWN ? undefined : ManualTestStatus[this.props.status]}
                         options={[
                             { key: ManualTestStatus[ManualTestStatus.PASS], text: 'Pass', onRenderLabel: this.onRenderLabel },
                             { key: ManualTestStatus[ManualTestStatus.FAIL], text: 'Fail', onRenderLabel: this.onRenderLabel },

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/test-status-choice-group.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/test-status-choice-group.test.tsx.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TestStatusChoiceGroup render: selectedKey is not set to null as status is UNKNOWN 1`] = `
+<div>
+  <div
+    className="radio-button-group"
+  >
+    <StyledChoiceGroupBase
+      className="PASS"
+      componentRef={[Function]}
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "key": "PASS",
+            "onRenderLabel": [Function],
+            "text": "Pass",
+          },
+          Object {
+            "key": "FAIL",
+            "onRenderLabel": [Function],
+            "text": "Fail",
+          },
+        ]
+      }
+      selectedKey="PASS"
+    />
+  </div>
+  <div />
+</div>
+`;
+
+exports[`TestStatusChoiceGroup render: selectedKey is not set to undefined as status is PASS 1`] = `
+<div>
+  <div
+    className="radio-button-group"
+  >
+    <StyledChoiceGroupBase
+      className="PASS"
+      componentRef={[Function]}
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "key": "PASS",
+            "onRenderLabel": [Function],
+            "text": "Pass",
+          },
+          Object {
+            "key": "FAIL",
+            "onRenderLabel": [Function],
+            "text": "Fail",
+          },
+        ]
+      }
+      selectedKey="PASS"
+    />
+  </div>
+  <div />
+</div>
+`;
+
+exports[`TestStatusChoiceGroup render: selectedKey is set to null as status is UNKNOWN 1`] = `
+<div>
+  <div
+    className="radio-button-group"
+  >
+    <StyledChoiceGroupBase
+      className="UNKNOWN"
+      componentRef={[Function]}
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "key": "PASS",
+            "onRenderLabel": [Function],
+            "text": "Pass",
+          },
+          Object {
+            "key": "FAIL",
+            "onRenderLabel": [Function],
+            "text": "Fail",
+          },
+        ]
+      }
+    />
+  </div>
+  <div />
+</div>
+`;
+
+exports[`TestStatusChoiceGroup render: selectedKey is set to undefined as status is UNKNOWN 1`] = `
+<div>
+  <div
+    className="radio-button-group"
+  >
+    <StyledChoiceGroupBase
+      className="UNKNOWN"
+      componentRef={[Function]}
+      onChange={[Function]}
+      options={
+        Array [
+          Object {
+            "key": "PASS",
+            "onRenderLabel": [Function],
+            "text": "Pass",
+          },
+          Object {
+            "key": "FAIL",
+            "onRenderLabel": [Function],
+            "text": "Fail",
+          },
+        ]
+      }
+    />
+  </div>
+  <div />
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
@@ -61,6 +61,26 @@ describe('TestStatusChoiceGroup', () => {
         expect(labels.at(1).getDOMNode().innerHTML).toBe('');
     });
 
+    test('render: selectedKey is set to undefined as status is UNKNOWN', () => {
+        const props: ITestStatusChoiceGroupProps = {
+            status: ManualTestStatus.UNKNOWN,
+        } as ITestStatusChoiceGroupProps;
+
+        const actual = shallow(<TestStatusChoiceGroup {...props} />);
+
+        expect(actual.getElement()).toMatchSnapshot();
+    });
+
+    test('render: selectedKey is not set to undefined as status is PASS', () => {
+        const props: ITestStatusChoiceGroupProps = {
+            status: ManualTestStatus.PASS,
+        } as ITestStatusChoiceGroupProps;
+
+        const actual = shallow(<TestStatusChoiceGroup {...props} />);
+
+        expect(actual.getElement()).toMatchSnapshot();
+    })
+
     test('verify onChange', () => {
         const onGroupChoiceChangeMock = Mock.ofInstance((status, test, step, selector) => {});
         const onUndoMock = Mock.ofInstance((test, step, selector) => {});


### PR DESCRIPTION
Only a partial fix; before this it is not accessible at all. Now it doesn't behave like you would expect but you can at least hit it with keyboard navigation.