### PR TITLE
Revised rebranding message and DL join link.

### DIFF
--- a/src/DetailsView/components/rebranding-message-bar.tsx
+++ b/src/DetailsView/components/rebranding-message-bar.tsx
@@ -12,5 +12,5 @@ export const RebrandingMessageBar = NamedSFC('RebrandingMessageBar', () =>
 
     <MessageBar className="info-message-bar">
         Keros for Web has been rebranded to Accessibility Insights for Web.
-        Join <NewTabLink href={url}>Accessibility Insights Updates and Discussions</NewTabLink> to receive email announcements.
+        <NewTabLink href={url}>Join Accessibility Insights Updates and Discussions</NewTabLink> to receive email announcements.
     </MessageBar>);

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/rebranding-message-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/rebranding-message-bar.test.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`RebrandingMessageBar renders as expected 1`] = `
 "<StyledMessageBarBase className=\\"info-message-bar\\">
-  Keros for Web has been rebranded to Accessibility Insights for Web. Join 
+  Keros for Web has been rebranded to Accessibility Insights for Web.
   <NewTabLink href=\\"https://idwebelements/GroupManagement.aspx?Group=a11yInsightsUpdates&Operation=join\\">
-    Accessibility Insights Updates and Discussions
+    Join Accessibility Insights Updates and Discussions
   </NewTabLink>
    to receive email announcements.
 </StyledMessageBarBase>"


### PR DESCRIPTION
The intention is to point to the new discussion distribution list.

![image](https://user-images.githubusercontent.com/7016281/51152984-2f6b6480-1823-11e9-91cc-7d1bb7f7c509.png)
