### PR TITLE
Reduce PR/CI build wall clock time by ~2.5min

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 jobs:
 
-- job: 'unit_tests'
+- job: 'tslint_and_unit_tests'
 
   pool:
     vmImage: 'macOS-10.13'


### PR DESCRIPTION
- Disables detailed coverage publishing (still publishing coverage summary file), should save ~1min on the unit test job
- Moves drop publishing to e2e job, should save 100s in the unit test job at the cost of 40s in the e2e job

Should reduce combined PR build wall time from ~6:30 to ~4:00