### PR TITLE
Enable grunt watch to trigger tslint on changes to test files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3104,6 +3104,44 @@
         }
       }
     },
+    "extra-watch-webpack-plugin": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/extra-watch-webpack-plugin/-/extra-watch-webpack-plugin-1.0.3.tgz",
+      "integrity": "sha512-ZScQdMH6hNofRRN6QMQFg+aa5vqimfBgnPXmRDhdaLpttT6hrzpY9Oyren3Gh/FySPrgsvKCNbx/NFA7XNdIsg==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.2",
+        "is-glob": "^4.0.0",
+        "lodash.uniq": "^4.5.0",
+        "schema-utils": "^0.4.0"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "schema-utils": {
+          "version": "0.4.7",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.7.tgz",
+          "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0"
+          }
+        }
+      }
+    },
     "extract-zip": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
@@ -6416,6 +6454,12 @@
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
+      "dev": true
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6765,7 +6809,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -6775,8 +6818,7 @@
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "enzyme": "^3.6.0",
     "enzyme-adapter-react-16": "^1.5.0",
     "express": "^4.16.4",
+    "extra-watch-webpack-plugin": "^1.0.3",
     "fake-indexeddb": "^2.0.4",
     "fork-ts-checker-webpack-plugin": "^0.4.14",
     "grunt": "^1.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 const path = require('path')
 const webpack = require('webpack');
+const ExtraWatchWebpackPlugin = require('extra-watch-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
@@ -63,6 +64,13 @@ const devConfig = {
     name: 'dev',
     mode: 'development',
     devtool: 'source-map',
+    plugins: [
+        ...commonPlugins,
+        // This ensures that "grunt watch" will catch tslint errors in test files
+        new ExtraWatchWebpackPlugin({
+            files: ['src/**/*.ts', 'src/**/*.tsx']
+        })
+    ],
     output: {
         path: path.join(__dirname, "extension/devBundle"),
         filename: '[name].bundle.js',


### PR DESCRIPTION
`webpack --watch`'s normal behavior is to only trigger rebuilds on changes to files that an entry point is dependent on. However, in our case, we use webpack to run tslint (even on files that aren't an entry point dependent, like test files), so we want watch to trigger on changes to those files too.