### PR TITLE
Fixed typos in content

### DIFF
--- a/src/assessments/prerecorded-multimedia/test-steps/no-obstruction.tsx
+++ b/src/assessments/prerecorded-multimedia/test-steps/no-obstruction.tsx
@@ -8,7 +8,7 @@ import ManualTestRecordYourResults from '../../common/manual-test-record-your-re
 import { TestStep } from '../../types/test-step';
 import { PrerecordedMultimediaTestStep } from './test-steps';
 
-const noObstructionDescription: JSX.Element = <span>The captions must not obscure or obstruct relevant information in the video.</span>;
+const noObstructionDescription: JSX.Element = <span>Captions must not obscure or obstruct relevant information in the video.</span>;
 
 const noObstructionHowToTest: JSX.Element = (
     <div>

--- a/src/content/test/audio-video-only/audio-only-equivalent.tsx
+++ b/src/content/test/audio-video-only/audio-only-equivalent.tsx
@@ -38,10 +38,16 @@ export const infoAndExamples = create(({ Markup, Link }) => <>
 
     />
 
-    <h4>For more examples, see the following articles:</h4>
+    <h2>More examples</h2>
+
+    <h3>WCAG success criteria</h3>
     <Markup.Links>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html">
             Understanding Success Criterion 1.2.1: Audio-only and Video-only (Prerecorded)</Markup.HyperLink>
+    </Markup.Links>
+
+    <h3>Sufficient techniques</h3>
+    <Markup.Links>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G158">
             Providing an alternative for time-based media for audio-only content</Markup.HyperLink>
     </Markup.Links>

--- a/src/content/test/audio-video-only/video-only-equivalent.tsx
+++ b/src/content/test/audio-video-only/video-only-equivalent.tsx
@@ -6,7 +6,7 @@ export const infoAndExamples = create(({ Markup, Link }) => <>
 
     <h1>Video-only equivalent</h1>
 
-    <p>Pre-recorded video-only content must be accompanied by an equivalent text or audio alternative. (<Link.WCAG_1_2_1 />)</p>
+    <p>Pre-recorded video-only content must be accompanied by an equivalent text or audio alternative.</p>
 
 
     <h2>Why it matters</h2>
@@ -35,7 +35,7 @@ export const infoAndExamples = create(({ Markup, Link }) => <>
         failText={
             <>
                 A web site presents a time-lapse video of a person preparing an entree.
-                As each ingredient is added, its name and amount are displayed.
+                As each ingredient is added, its name and amount are displayed as on-screen text.
             </>
         }
 
@@ -48,10 +48,16 @@ export const infoAndExamples = create(({ Markup, Link }) => <>
 
     />
 
-    <h4>For more examples, see the following articles:</h4>
+    <h2>More examples</h2>
+
+    <h3>WCAG success criteria</h3>
     <Markup.Links>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html">
             Understanding Success Criterion 1.2.1: Audio-only and Video-only (Prerecorded)</Markup.HyperLink>
+    </Markup.Links>
+
+    <h3>Sufficient techniques</h3>
+    <Markup.Links>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G159">
             Providing an alternative for time-based media for video-only content</Markup.HyperLink>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G166">

--- a/src/content/test/live-multimedia/captions.tsx
+++ b/src/content/test/live-multimedia/captions.tsx
@@ -5,6 +5,7 @@ import { React, create } from '../../common';
 export const infoAndExamples = create(({ Markup, Link }) => <>
 
     <h1>Captions</h1>
+    <p>Captions must be provided for live (streaming) video with audio</p>
 
     <h2>Why it matters</h2>
     <p>
@@ -18,19 +19,22 @@ export const infoAndExamples = create(({ Markup, Link }) => <>
 
     <h3>From a user's perspective</h3>
     <p>
-        <Markup.Emphasis>"Provide captions for events with live audio or video so I can take part in the event with everyone else."</Markup.Emphasis>
+        <Markup.Emphasis>"Provide captions for events with live audio or video so I can take
+            part in the event with everyone else."</Markup.Emphasis>
     </p>
 
     <h2>Example</h2>
 
     <Markup.PassFail
         failText={
-            <p>A gaming website provides live multimedia (video with audio) coverage of a video game competition. No captions are provided.</p>
+            <p>A gaming website provides live multimedia (video with audio) coverage of
+                a video game competition. No captions are provided.</p>
         }
 
         passText={
             <p>The website provides real-time captions for the audio track.
-            The captions include all speech, identify the speakers, and describe other significant audio, such as the buzzers that start and end each match and audience applause.</p>
+            The captions include all speech, identify the speakers, and describe other
+            significant audio, such as the buzzers that start and end each match and audience applause.</p>
         }
     />
 
@@ -39,17 +43,17 @@ export const infoAndExamples = create(({ Markup, Link }) => <>
     <h3>WCAG success criteria</h3>
     <Markup.Links>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Understanding/captions-live.html">
-        Understanding Success Criterion 1.2.4: Captions (Live)</Markup.HyperLink>
+            Understanding Success Criterion 1.2.4: Captions (Live)</Markup.HyperLink>
     </Markup.Links>
 
     <h3>Sufficient techniques</h3>
     <Markup.Links>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G9">
-        Creating captions for live synchronized media</Markup.HyperLink>
+            Creating captions for live synchronized media</Markup.HyperLink>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G93">
-        Providing open (always visible) captions</Markup.HyperLink>
+            Providing open (always visible) captions</Markup.HyperLink>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G87">
-        Providing closed captions</Markup.HyperLink>
+            Providing closed captions</Markup.HyperLink>
     </Markup.Links>
 
 </>);

--- a/src/content/test/text-legibility/resize-text.tsx
+++ b/src/content/test/text-legibility/resize-text.tsx
@@ -10,11 +10,15 @@ export const infoAndExamples = create(({ Markup }) => <>
 
     <h2>Why it matters</h2>
     <p>
-        Most people find it easier to read text when it is sufficiently large. People with mild visual disabilities, low vision, or limited color perception are likely to find text unreadable when text is too small.
+        Most people find it easier to read text when it is sufficiently large.
+        People with mild visual disabilities, low vision, or limited color perception
+        are likely to find text unreadable when text is too small.
     </p>
     <p>
-        People with <Markup.HyperLink href="https://en.wikipedia.org/wiki/Presbyopia">presbyopia</Markup.HyperLink> also struggle to read small or low-contrast text.
-        A <Markup.HyperLink href="https://www.sciencedirect.com/science/article/pii/S0161642017337971">2018 study</Markup.HyperLink> found that 1.8 billion people worldwide have presbyopia. (All people are affected by presbyopia to some degree as they age.)
+        People with <Markup.HyperLink href="https://en.wikipedia.org/wiki/Presbyopia">presbyopia</Markup.HyperLink> also
+        struggle to read small or low-contrast text.
+        A <Markup.HyperLink href="https://www.sciencedirect.com/science/article/pii/S0161642017337971">2018 study</Markup.HyperLink> found
+        that 1.8 billion people worldwide have presbyopia. (All people are affected by presbyopia to some degree as they age.)
     </p>
 
     <h2>How to fix</h2>
@@ -53,7 +57,7 @@ export const infoAndExamples = create(({ Markup }) => <>
         }
 
         passText={
-            <p>Both the text and its container are sized scalable.</p>
+            <p>Both the text and its container are sized scalably.</p>
         }
         passExample={
             `<html>
@@ -110,7 +114,8 @@ export const infoAndExamples = create(({ Markup }) => <>
     <h3>Common failures</h3>
     <Markup.Links>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F69">
-            Failure of Success Criterion 1.4.4 when resizing visually rendered text up to 200 percent causes the text, image or controls to be clipped, truncated or obscured
+            Failure of Success Criterion 1.4.4 when resizing visually rendered text up to
+            200 percent causes the text, image or controls to be clipped, truncated or obscured
         </Markup.HyperLink>
         <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F80">
             Failure of Success Criterion 1.4.4 when text-based form controls do not resize when visually rendered text is resized up to 200%


### PR DESCRIPTION
In Multimedia -> No obstructions: In the requirement pane
The captions must be provided for live (streaming) video with audio

In Live Multimedia -> Captions -> Info & examples, Captions description is missing: "Captions must be provided for live (streaming) video with audio"

In Audio/Video -> Video-only equivalent -> Info & examples:
Pre-recorded video-only content must be accompanied by an equivalent text or audio alternative. (WCAG 1.2.1)

In Audio/Video -> Video-only equivalent -> Info & examples:
A web site presents a time-lapse video of a person preparing an entree. As each ingredient is added, its name and amount are displayed as on-screen text. ((missing content) 


In Audio/Video -> Video-only equivalent -> Info & examples & In Audio/Video -> Audio-only equivalent -> Info & examples:
Fix the links to match what is in spec


In Text legibility -> Resize text -> Info & examples:
change "Both the text and its container are sized scalable" to "Both the text and its container are sized scalably"