### PR TITLE
Fix a11y bug where NVDA reads extra Unavailable on add/saving failure instance

### DIFF
--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -104,7 +104,7 @@ export class FailureInstancePanelControl extends React.Component<IFailureInstanc
                 />
                 <ActionAndCancelButtonsComponent
                     isHidden={false}
-                    primaryButtonDisabled={this.state.isPanelOpen && this.state.failureDescription === ''}
+                    primaryButtonDisabled={this.state.failureDescription === ''}
                     primaryButtonText={this.props.actionType === CapturedInstanceActionType.CREATE ? 'Add' : 'Save'}
                     primaryButtonOnClick={
                         this.props.actionType === CapturedInstanceActionType.CREATE ?
@@ -125,13 +125,13 @@ export class FailureInstancePanelControl extends React.Component<IFailureInstanc
     @autobind
     protected onAddFailureInstance(): void {
         this.props.addFailureInstance(this.state.failureDescription, this.props.test, this.props.step);
-        this.setState({ isPanelOpen: false, failureDescription: '' });
+        this.setState({ isPanelOpen: false });
     }
 
     @autobind
     protected onSaveEditedFailureInstance(): void {
         this.props.editFailureInstance(this.state.failureDescription, this.props.test, this.props.step, this.props.instanceId);
-        this.setState({ isPanelOpen: false, failureDescription: '' });
+        this.setState({ isPanelOpen: false });
     }
 
     @autobind
@@ -141,6 +141,6 @@ export class FailureInstancePanelControl extends React.Component<IFailureInstanc
 
     @autobind
     protected closeFailureInstancePanel(): void {
-        this.setState({ isPanelOpen: false, failureDescription: '' });
+        this.setState({ isPanelOpen: false });
     }
 }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: add
   </CustomizedActionButton>
   <GenericPanel isOpen={false} className=\\"failure-instance-panel\\" onDismiss={[Function: bound ]} title=\\"Add a failure instance\\" hasCloseButton={false} closeButtonAriaLabel={{...}}>
     <StyledTextFieldBase label=\\"Observed failure\\" multiline={true} rows={8} value=\\"\\" onChange={[Function: bound ]} />
-    <ActionAndCancelButtonsComponent isHidden={false} primaryButtonDisabled={false} primaryButtonText=\\"Add\\" primaryButtonOnClick={[Function: bound ]} cancelButtonOnClick={[Function: bound ]} />
+    <ActionAndCancelButtonsComponent isHidden={false} primaryButtonDisabled={true} primaryButtonText=\\"Add\\" primaryButtonOnClick={[Function: bound ]} cancelButtonOnClick={[Function: bound ]} />
   </GenericPanel>
 </Fragment>"
 `;
@@ -19,7 +19,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
   </StyledLinkBase>
   <GenericPanel isOpen={false} className=\\"failure-instance-panel\\" onDismiss={[Function: bound ]} title=\\"Edit failure instance\\" hasCloseButton={false} closeButtonAriaLabel={{...}}>
     <StyledTextFieldBase label=\\"Observed failure\\" multiline={true} rows={8} value=\\"\\" onChange={[Function: bound ]} />
-    <ActionAndCancelButtonsComponent isHidden={false} primaryButtonDisabled={false} primaryButtonText=\\"Save\\" primaryButtonOnClick={[Function: bound ]} cancelButtonOnClick={[Function: bound ]} />
+    <ActionAndCancelButtonsComponent isHidden={false} primaryButtonDisabled={true} primaryButtonText=\\"Save\\" primaryButtonOnClick={[Function: bound ]} cancelButtonOnClick={[Function: bound ]} />
   </GenericPanel>
 </Fragment>"
 `;

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -46,8 +46,9 @@ describe('FailureInstancePanelControlTest', () => {
 
     test('openFailureInstancePanel', () => {
         const props = createPropsWithType(CapturedInstanceActionType.CREATE);
-        props.originalText = 'ot';
+        props.originalText = 'original text';
         const wrapper = shallow(<FailureInstancePanelControl {...props} />);
+        wrapper.find(TextField).props().onChange(null, 'a previously entered description');
         wrapper.find(ActionButton).props().onClick(null);
 
         expect(wrapper.state().isPanelOpen).toBe(true);
@@ -55,12 +56,17 @@ describe('FailureInstancePanelControlTest', () => {
     });
 
     test('closeFailureInstancePanel', () => {
+        const description = 'description';
         const props = createPropsWithType(CapturedInstanceActionType.CREATE);
         const wrapper = shallow(<FailureInstancePanelControl {...props} />);
+        wrapper.find(TextField).props().onChange(null, description);
+
         wrapper.find(GenericPanel).props().onDismiss();
 
         expect(wrapper.state().isPanelOpen).toBe(false);
-        expect(wrapper.state().failureDescription).toEqual('');
+
+        // This shouldn't be cleared because it stays briefly visible as the panel close animation happens
+        expect(wrapper.state().failureDescription).toEqual(description);
     });
 
     test('onSaveEditedFailureInstance', () => {
@@ -79,11 +85,9 @@ describe('FailureInstancePanelControlTest', () => {
         wrapper.find(ActionAndCancelButtonsComponent).props().primaryButtonOnClick(null);
 
         expect(wrapper.state().isPanelOpen).toBe(false);
-        expect(wrapper.state().failureDescription).toEqual('');
 
-        // The save button shouldn't become disabled as a result of pressing it because if it does,
-        // NVDA reads a spurious "unavailable" message as the panel is closing.
-        expect(wrapper.find(ActionAndCancelButtonsComponent).props().primaryButtonDisabled).toBe(false);
+        // This shouldn't be cleared because it stays briefly visible as the panel close animation happens
+        expect(wrapper.state().failureDescription).toEqual(description);
 
         editInstanceMock.verifyAll();
     });
@@ -102,11 +106,9 @@ describe('FailureInstancePanelControlTest', () => {
         wrapper.find(ActionAndCancelButtonsComponent).props().primaryButtonOnClick(null);
 
         expect(wrapper.state().isPanelOpen).toBe(false);
-        expect(wrapper.state().failureDescription).toEqual('');
 
-        // The add button shouldn't become disabled as a result of pressing it because if it does,
-        // NVDA reads a spurious "unavailable" message as the panel is closing.
-        expect(wrapper.find(ActionAndCancelButtonsComponent).props().primaryButtonDisabled).toBe(false);
+        // This shouldn't be cleared because it stays briefly visible as the panel close animation happens
+        expect(wrapper.state().failureDescription).toEqual(description);
 
         addInstanceMock.verifyAll();
     });


### PR DESCRIPTION
Fixes bug 1423872, where if you are adding or editing a failure instance in an assessment, navigate via keyboard to the "add"/"save" button, and hit enter, NVDA will read a spurious "Unavailable" message as the panel is closing. The root cause is that the "add"/"save" button becomes disabled as the panel is performing its close animation, and the "Unavailable" comes from NVDA reading out a description of a now-disabled-but-not-quite-yet-removed-from-dom input with keyboard focus.