### PR TITLE
make test summary details a table for screen reader

### DIFF
--- a/src/DetailsView/reports/components/assessment-summary-details.scss
+++ b/src/DetailsView/reports/components/assessment-summary-details.scss
@@ -4,35 +4,32 @@
 
 .assessment-summary-details {
     display: flex;
-    flex-direction: row;
-}
 
-.assessment-summary-details-column {
-    display: flex;
-    flex-direction: column;
-    width: 50%;
-}
+    .assessment-summary-details-body {
+        column-count: 2;
+        column-gap: 2%;
+        display: block;
+        width: 100%;
 
-.test-summary {
-    display: flex;
-justify-content: space-between;
-    width: 94%;
-    margin-left: 2%;
-    margin-right: 2%;
-    padding: 2% 1% 2% 1%;
-}
+        .test-summary {
+            display: flex;
+            width: 98%;
+            padding: 2% 1% 2% 1%;
+            justify-content: space-between;
+        }
 
-.test-summary + .test-summary {
-    border-top: $neutral-alpha-8 solid 1px;
-}
+        .test-summary {
+            border-bottom: $neutral-alpha-8 solid 1px;
+        }
+        .test-summary-status {
+            display: flex;
+            align-items: center;
+        }
 
-.test-summary-status {
-    display: flex;
-    align-items: center;
-}
-
-.test-summary-display-name {
-    font-family: Segoe UI Semibold;
-    font-size: 14px;
-    line-height: 20px;
+        .test-summary-display-name {
+            font-family: Segoe UI Semibold;
+            font-size: 14px;
+            line-height: 20px;
+        }
+    }
 }

--- a/src/DetailsView/reports/components/assessment-summary-details.tsx
+++ b/src/DetailsView/reports/components/assessment-summary-details.tsx
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { chunk } from 'lodash/index';
 import * as React from 'react';
 
 import { IAssessmentSummaryReportModel } from '../assessment-report-model';
-import { OutcomeIconSet } from './outcome-icon-set';
 import { OutcomeChipSet } from './outcome-chip-set';
+import { OutcomeIconSet } from './outcome-icon-set';
 
 export interface IAssessmentSummaryDetailsProps {
     testSummaries: IAssessmentSummaryReportModel[];
@@ -14,32 +13,26 @@ export interface IAssessmentSummaryDetailsProps {
 export class AssessmentSummaryDetails extends React.Component<IAssessmentSummaryDetailsProps> {
     public render(): JSX.Element {
         return (
-            <div className="assessment-summary-details">
-                {this.getTestDetailsColumns()}
+            <div role="table" className="assessment-summary-details">
+                <div role="rowgroup" className="assessment-summary-details-body">
+                    {this.getTestDetailsColumns()}
+                </div>
             </div>
         );
     }
 
     private getTestDetailsColumns(): JSX.Element[] {
-        const summaryBatches = chunk(this.props.testSummaries, Math.ceil(this.props.testSummaries.length / 2));
-
-        return summaryBatches.map((batch, index) => {
-            return (
-                <div className="assessment-summary-details-column" key={index}>
-                    {this.getTestDetailsList(batch, index)}
-                </div>
-            );
-        });
+        return this.getTestDetailsList(this.props.testSummaries, 1);
     }
 
     private getTestDetailsList(summaries: IAssessmentSummaryReportModel[], colIndex: number): JSX.Element[] {
         return summaries.map((testSummary, index) => {
             return (
-                <div key={`${colIndex}-${index}`} className="test-summary">
-                    <div className="test-summary-display-name">
+                <div role="row" key={`${colIndex}-${index}`} className="test-summary">
+                    <div role="cell" className="test-summary-display-name">
                         {testSummary.displayName}
                     </div>
-                    <div key={`${colIndex}-${index}-status`} className="test-summary-status">
+                    <div role="cell" key={`${colIndex}-${index}-status`} className="test-summary-status">
                         {
                             testSummary.pass + testSummary.incomplete + testSummary.fail > 7
                                 ? <OutcomeChipSet {...testSummary} />

--- a/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/assessment-summary-details.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/assessment-summary-details.test.tsx.snap
@@ -3,20 +3,25 @@
 exports[`AssessmentSummaryDetails render Correct composition 1`] = `
 <div
   className="assessment-summary-details"
+  role="table"
 >
   <div
-    className="assessment-summary-details-column"
+    className="assessment-summary-details-body"
+    role="rowgroup"
   >
     <div
       className="test-summary"
+      role="row"
     >
       <div
         className="test-summary-display-name"
+        role="cell"
       >
         Assessment1
       </div>
       <div
         className="test-summary-status"
+        role="cell"
       >
         <OutcomeIconSet
           displayName="Assessment1"
@@ -26,20 +31,19 @@ exports[`AssessmentSummaryDetails render Correct composition 1`] = `
         />
       </div>
     </div>
-  </div>
-  <div
-    className="assessment-summary-details-column"
-  >
     <div
       className="test-summary"
+      role="row"
     >
       <div
         className="test-summary-display-name"
+        role="cell"
       >
         Assessment2
       </div>
       <div
         className="test-summary-status"
+        role="cell"
       >
         <OutcomeIconSet
           displayName="Assessment2"
@@ -56,20 +60,25 @@ exports[`AssessmentSummaryDetails render Correct composition 1`] = `
 exports[`AssessmentSummaryDetails render Renders an OutcomeChipSet for 8 items 1`] = `
 <div
   className="assessment-summary-details"
+  role="table"
 >
   <div
-    className="assessment-summary-details-column"
+    className="assessment-summary-details-body"
+    role="rowgroup"
   >
     <div
       className="test-summary"
+      role="row"
     >
       <div
         className="test-summary-display-name"
+        role="cell"
       >
         test
       </div>
       <div
         className="test-summary-status"
+        role="cell"
       >
         <OutcomeChipSet
           displayName="test"
@@ -86,20 +95,25 @@ exports[`AssessmentSummaryDetails render Renders an OutcomeChipSet for 8 items 1
 exports[`AssessmentSummaryDetails render Renders an OutcomeIconSet for 7 items 1`] = `
 <div
   className="assessment-summary-details"
+  role="table"
 >
   <div
-    className="assessment-summary-details-column"
+    className="assessment-summary-details-body"
+    role="rowgroup"
   >
     <div
       className="test-summary"
+      role="row"
     >
       <div
         className="test-summary-display-name"
+        role="cell"
       >
         test
       </div>
       <div
         className="test-summary-status"
+        role="cell"
       >
         <OutcomeIconSet
           displayName="test"

--- a/src/tests/unit/tests/DetailsView/reports/components/assessment-summary-details.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/assessment-summary-details.test.tsx
@@ -22,8 +22,6 @@ describe('AssessmentSummaryDetails', () => {
                     .reportSummaryDetailsData,
             };
 
-            const component = shallow(<AssessmentSummaryDetails {...props} />);
-            expect(component.find('.assessment-summary-details-column').length).toBe(2);
             expect(shallowRender(<AssessmentSummaryDetails {...props} />)).toMatchSnapshot();
         });
 


### PR DESCRIPTION
fix for 1428742 - using column-count css property instead of creating multiple section groups;
column-count & table tag doesnt work with edge (exported html needs to work on edge too). So, using div with role table