### PR TITLE
[Refactor] allow normal imports in our typescript use

### DIFF
--- a/src/assessments/audio-video-only/assessment.tsx
+++ b/src/assessments/audio-video-only/assessment.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
+import React from 'react';
 
 import { VisualizationType } from '../../common/types/visualization-type';
 import { test as content } from '../../content/test';

--- a/src/assessments/automated-checks/assessment.tsx
+++ b/src/assessments/automated-checks/assessment.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
+import React from 'react';
 
 import { RequirementComparer } from '../../common/assessment/requirement-comparer';
 import { VisualizationType } from '../../common/types/visualization-type';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     "noErrorTruncation": false,
     "noStrictGenericChecks": false,
     "allowJs": false,
+    "allowSyntheticDefaultImports": true,
     "typeRoots": ["node_modules/@types"],
     "plugins": [
         { "name": "tslint-language-service" }


### PR DESCRIPTION
This setting allows us to import stuff without the use of `* as ... `

```tsx
import * as React from 'react';
import * as ReactDOM from 'react-dom';
```

can be changed to

```tsx
import React from 'react';
import ReactDOM from 'react-dom';
```

I changed a couple of them to check our code. It doesn't affect us adversely and it enables us to be more specific in our imports rather than using `* as `
 