### PR TITLE
[Refactor] use react-dom/server for react-static-renderer markup generator

### DIFF
--- a/src/DetailsView/reports/assessment-report-html-generator.tsx
+++ b/src/DetailsView/reports/assessment-report-html-generator.tsx
@@ -67,7 +67,7 @@ export class AssessmentReportHtmlGenerator {
             </React.Fragment>
         );
 
-        const reportBody = this.renderer.renderToStaticMarkup(reportElement, 'html');
+        const reportBody = this.renderer.renderToStaticMarkup(reportElement);
 
         return `<html lang="en">${reportBody}</html>`;
     }

--- a/src/DetailsView/reports/react-static-renderer.ts
+++ b/src/DetailsView/reports/react-static-renderer.ts
@@ -1,20 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
-import * as ReactDOM from 'react-dom';
+import * as ReactDOMServer from 'react-dom/server';
 
 export class ReactStaticRenderer {
-    public renderToStaticMarkup(element: JSX.Element, parentElementName: string) {
-        const parentDomElement = document.createElement(parentElementName);
-        ReactDOM.render(element, parentDomElement);
-        const markup = parentDomElement.innerHTML;
-        return this.removeReactCruft(markup);
-    }
-
-    private removeReactCruft(s: string): string {
-        return s
-            .replace(/<!-- react-text: [0-9]* -->/g, '')
-            .replace(/<!-- \/react-text -->/g, '')
-            .replace(/ data-reactroot=""/, '');
+    public renderToStaticMarkup(element: JSX.Element): string {
+        return ReactDOMServer.renderToStaticMarkup(element);
     }
 }

--- a/src/DetailsView/reports/report-html-generator.tsx
+++ b/src/DetailsView/reports/report-html-generator.tsx
@@ -23,7 +23,7 @@ export class ReportHtmlGenerator {
         description: string,
     ): string {
         const headElement: JSX.Element = <ReportHead />;
-        const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(headElement, 'html');
+        const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(headElement);
 
         const bodyElement: JSX.Element =
             <ReportBody
@@ -36,7 +36,7 @@ export class ReportHtmlGenerator {
                 extensionVersion={this.extensionVersion}
                 axeVersion={this.axeVersion}
             />;
-        const bodyMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(bodyElement, 'html');
+        const bodyMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(bodyElement);
 
         return '<html lang="en">' + headMarkup + bodyMarkup + '</html>';
     }

--- a/src/tests/unit/tests/DetailsView/reports/assessment-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/assessment-report-html-generator.test.tsx
@@ -48,7 +48,7 @@ describe('AssessmentReportHtmlGenerator', () => {
                 </body>
             </React.Fragment>
         );
-        const expectedBody = '<head>styles</head><body>report-body</body>';
+        const expectedBody: string = '<head>styles</head><body>report-body</body>';
         const expectedHtml = `<html lang="en">${expectedBody}</html>`;
 
         const testDate = new Date(2018, 9, 19, 11, 25);
@@ -67,7 +67,7 @@ describe('AssessmentReportHtmlGenerator', () => {
             .returns(() => model);
 
         rendererMock
-            .setup(r => r.renderToStaticMarkup(It.isObjectWith(expectedComponent), 'html'))
+            .setup(r => r.renderToStaticMarkup(It.isObjectWith(expectedComponent)))
             .returns(() => expectedBody);
 
         const testSubject = new AssessmentReportHtmlGenerator(

--- a/src/tests/unit/tests/DetailsView/reports/react-static-renderer.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/react-static-renderer.test.tsx
@@ -14,7 +14,7 @@ describe('ReactStaticRendererTest', () => {
         );
 
         const testObject = new ReactStaticRenderer();
-        const actual = testObject.renderToStaticMarkup(element, 'div');
+        const actual = testObject.renderToStaticMarkup(element);
 
         const expected = '<div><h1>Header</h1><a href="https://url/">Link</a></div>';
         expect(actual).toEqual(expected);

--- a/src/tests/unit/tests/DetailsView/reports/report-html-generator.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/report-html-generator.test.tsx
@@ -35,11 +35,11 @@ describe('ReportHtmlGeneratorTest', () => {
 
         const renderer = Mock.ofType(ReactStaticRenderer, MockBehavior.Strict);
         renderer
-            .setup(r => r.renderToStaticMarkup(It.isObjectWith(headElement), It.isValue('html')))
+            .setup(r => r.renderToStaticMarkup(It.isObjectWith(headElement)))
             .returns(() => '<head-markup />')
             .verifiable(Times.once());
         renderer
-            .setup(r => r.renderToStaticMarkup(It.isObjectWith(bodyElement), It.isValue('html')))
+            .setup(r => r.renderToStaticMarkup(It.isObjectWith(bodyElement)))
             .returns(() => '<body-markup />')
             .verifiable(Times.once());
 


### PR DESCRIPTION
Removing `react-static-renderer`

This takes care of making this static html generation future proof, as it removes all the react gunk that is added currently or might be added by react team later. No difference in the report even after using this; so win-win.