### PR TITLE
Remove obsolete variant dev release targets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -73,12 +73,6 @@ module.exports = function(grunt) {
                         dest: extensionPath,
                         expand: true,
                     },
-                    {
-                        cwd: './deploy/extension',
-                        src: ['*'],
-                        dest: extensionPath,
-                        expand: true,
-                    },
                 ],
             },
             images: {

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ You can start an interactive watch session that automatically runs tests affecte
 `npm test` runs all unit tests.
 `npm test -- -u` runs all unit tests and updates snapshot files.
 
-
 `npm run test:e2e` runs all end-to-end tests - you'll need to run `npm run build` first if you've changed non-test code.
 `npm run test:e2e -- -u` runs all end-to-end tests and updates snapshot files.
 

--- a/targets.config.js
+++ b/targets.config.js
@@ -46,48 +46,6 @@ module.exports = {
             },
         },
     },
-    'dev-internal': {
-        config: {
-            options: {
-                ...internalOptions,
-                ...icons.dev,
-                debug: true,
-                extensionFullName: 'Accessibility Insights for Web - dev-internal',
-                telemetryBuildName: 'DevInternal',
-            },
-        },
-    },
-    'dev-internal-release': {
-        config: {
-            options: {
-                ...internalOptions,
-                ...icons.dev,
-                extensionFullName: 'Accessibility Insights for Web - dev-internal-release',
-                telemetryBuildName: 'DevInternalRelease',
-            },
-        },
-    },
-    'dev-public': {
-        config: {
-            options: {
-                ...publicOptions,
-                ...icons.dev,
-                debug: true,
-                extensionFullName: 'Accessibility Insights for Web - dev-public',
-                telemetryBuildName: 'DevPublic',
-            },
-        },
-    },
-    'dev-public-release': {
-        config: {
-            options: {
-                ...publicOptions,
-                ...icons.dev,
-                extensionFullName: 'Accessibility Insights for Web - dev-public-release',
-                telemetryBuildName: 'DevPublicRelease',
-            },
-        },
-    },
     open: {
         release: true,
         config: {


### PR DESCRIPTION
Per Mark, these targets are obsolete. It looks also like the related /deploy/extension/ folder is no longer used, so removing it from Grunt's consideration.