### PR TITLE
Reaname setUserConfig to more specific setTelemetryConfig

### DIFF
--- a/src/background/actions/global-action-creator.ts
+++ b/src/background/actions/global-action-creator.ts
@@ -58,7 +58,7 @@ export class GlobalActionCreator {
         this._interpreter.registerTypeToPayloadCallback(Messages.Telemetry.Send, this.onSendTelemetry);
 
         this._interpreter.registerTypeToPayloadCallback(Messages.UserConfig.GetCurrentState, this.onGetUserConfigState);
-        this._interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetUserConfig, this.onSetUserConfiguration);
+        this._interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetTelemetryConfig, this.onSetTelemetryConfiguration);
         this._interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetHighContrastConfig, this.onSetHighContrastMode);
     }
 
@@ -126,7 +126,7 @@ export class GlobalActionCreator {
     }
 
     @autobind
-    private onSetUserConfiguration(payload: SetTelemetryStatePayload): void {
+    private onSetTelemetryConfiguration(payload: SetTelemetryStatePayload): void {
         this._userConfigActions.setTelemetryState.invoke(payload);
     }
 

--- a/src/common/message-creators/user-config-message-creator.ts
+++ b/src/common/message-creators/user-config-message-creator.ts
@@ -11,7 +11,7 @@ export class UserConfigMessageCreator extends BaseActionMessageCreator {
         };
 
         this.dispatchMessage({
-            type: Messages.UserConfig.SetUserConfig,
+            type: Messages.UserConfig.SetTelemetryConfig,
             tabId: this._tabId,
             payload,
         });

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -99,7 +99,7 @@ export class Messages {
 
     public static readonly UserConfig = {
         GetCurrentState: 'insights/userConfig/getCurrentState',
-        SetUserConfig: 'insights/userConfig/set',
+        SetTelemetryConfig: 'insights/userConfig/setTelemetryConfig',
         SetHighContrastConfig: 'insights/userConfig/setHighContrastConfig',
     };
 

--- a/src/tests/unit/tests/background/actions/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/global-action-creator.test.ts
@@ -159,14 +159,14 @@ describe('GlobalActionCreatorTest', () => {
         validator.verifyAll();
     });
 
-    test('registerCallback for on UserConfig.SetUserConfig', () => {
+    test('registerCallback for on UserConfig.SetTelemetryConfig', () => {
         const payload: UserConfigurationStoreData = {
             enableTelemetry: true,
             isFirstTime: false,
             enableHighContrast: false,
         };
         const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.UserConfig.SetUserConfig)
+            .setupRegistrationCallback(Messages.UserConfig.SetTelemetryConfig)
             .setupActionsOnUserConfig('setTelemetryState')
             .setupUserConfigActionWithInvokeParameter('setTelemetryState', payload);
 

--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -97,7 +97,7 @@ describe('UserConfigurationStoreTest', () => {
         { enableTelemetry: true, isFirstTime: false, enableHighContrastMode: false } as SetUserConfigTestCase,
         { enableTelemetry: false, isFirstTime: false, enableHighContrastMode: false } as SetUserConfigTestCase,
         { enableTelemetry: false, isFirstTime: true, enableHighContrastMode: false } as SetUserConfigTestCase,
-    ])('setUserConfiguration action: %o', (testCase: SetUserConfigTestCase) => {
+    ])('setTelemetryConfig action: %o', (testCase: SetUserConfigTestCase) => {
         const storeTester = createStoreToTestAction('setTelemetryState');
         initialStoreData = {
             enableTelemetry: testCase.enableTelemetry,
@@ -126,7 +126,7 @@ describe('UserConfigurationStoreTest', () => {
     test.each([
         { enableTelemetry: false, isFirstTime: false, enableHighContrastMode: true } as SetUserConfigTestCase,
         { enableTelemetry: false, isFirstTime: false, enableHighContrastMode: false } as SetUserConfigTestCase,
-    ])('setUserConfiguration action: %o', (testCase: SetUserConfigTestCase) => {
+    ])('setHighContrast action: %o', (testCase: SetUserConfigTestCase) => {
         const storeTester = createStoreToTestAction('setHighContrastMode');
         initialStoreData = {
             enableTelemetry: false,

--- a/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
@@ -29,7 +29,7 @@ describe('UserConfigMessageCreatorTest', () => {
         };
         const expectedMessage = {
             tabId: 1,
-            type: Messages.UserConfig.SetUserConfig,
+            type: Messages.UserConfig.SetTelemetryConfig,
             payload,
         };
 


### PR DESCRIPTION
Rename the `SetUserConfig` action message to more explicit `SetTelemetryConfig` because thats the purpose of it.
Previously Userconfig only had telemetry related config, but now has more than that, like high contrast.