### PR TITLE
1430897: page-title step should not show visual helper toggle

### DIFF
--- a/src/DetailsView/components/assessment-instance-table.tsx
+++ b/src/DetailsView/components/assessment-instance-table.tsx
@@ -3,7 +3,14 @@
 import { has } from 'lodash';
 import { autobind, IRenderFunction } from '@uifabric/utilities';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import { CheckboxVisibility, ConstrainMode, DetailsList, IObjectWithKey, IDetailsRowProps } from 'office-ui-fabric-react/lib/DetailsList';
+import {
+    CheckboxVisibility,
+    ConstrainMode,
+    DetailsList,
+    IObjectWithKey,
+    IDetailsRowProps,
+    IColumn,
+} from 'office-ui-fabric-react/lib/DetailsList';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import * as React from 'react';
 
@@ -15,7 +22,6 @@ import {
 } from '../../common/types/store-data/iassessment-result-data';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
 import { ManualTestStatus } from '../../common/types/manual-test-status';
-import { IDetailsViewProps } from '../idetails-view-props';
 
 export interface IAssessmentInstanceTableProps {
     instancesMap: IDictionaryStringTo<IGeneratedAssessmentInstance>;
@@ -24,11 +30,12 @@ export interface IAssessmentInstanceTableProps {
     renderInstanceTableHeader: (table: AssessmentInstanceTable, items: IAssessmentInstanceRowData[]) => JSX.Element;
     getDefaultMessage: Function;
     assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator;
+    hasVisualHelper: boolean;
 }
 
 export interface IAssessmentInstanceRowData<P = {}> extends IObjectWithKey {
     statusChoiceGroup: JSX.Element;
-    visualizationButton: JSX.Element;
+    visualizationButton?: JSX.Element;
     instance: IGeneratedAssessmentInstance<P>;
 }
 
@@ -46,8 +53,14 @@ export class AssessmentInstanceTable extends React.Component<IAssessmentInstance
         const items: IAssessmentInstanceRowData[] = this.props.assessmentInstanceTableHandler.createAssessmentInstanceTableItems(
             this.props.instancesMap,
             this.props.assessmentNavState,
+            this.props.hasVisualHelper,
         );
-        const columns = this.props.assessmentInstanceTableHandler.getColumnConfigs(this.props.instancesMap, this.props.assessmentNavState);
+
+        const columns: IColumn[] = this.props.assessmentInstanceTableHandler.getColumnConfigs(
+            this.props.instancesMap,
+            this.props.assessmentNavState,
+            this.props.hasVisualHelper,
+        );
 
         const getDefaultMessage = this.props.getDefaultMessage(this.props.assessmentDefaultMessageGenerator);
         const defaultMessageComponent = getDefaultMessage(this.props.instancesMap, this.props.assessmentNavState.selectedTestStep);

--- a/src/DetailsView/components/assessment-table-column-config-handler.tsx
+++ b/src/DetailsView/components/assessment-table-column-config-handler.tsx
@@ -55,12 +55,14 @@ export class AssessmentTableColumnConfigHandler {
         this.assessmentProvider = assessmentProvider;
     }
 
-    public getColumnConfigs(assessmentNavState: IAssessmentNavState, allEnabled: boolean): IColumn[] {
+    public getColumnConfigs(assessmentNavState: IAssessmentNavState, allEnabled: boolean, hasVisualHelper: boolean): IColumn[] {
         let allColumns: IColumn[] = [];
         const stepConfig = this.assessmentProvider.getStep(assessmentNavState.selectedTestType, assessmentNavState.selectedTestStep);
 
-        const masterCheckbox = this.getMasterCheckboxColumn(assessmentNavState, allEnabled);
-        allColumns.push(masterCheckbox);
+        if (hasVisualHelper) {
+            const masterCheckbox = this.getMasterCheckboxColumn(assessmentNavState, allEnabled);
+            allColumns.push(masterCheckbox);
+        }
 
         const customColumns = this.getCustomColumns(assessmentNavState);
         allColumns = allColumns.concat(customColumns);

--- a/src/DetailsView/components/test-step-view.tsx
+++ b/src/DetailsView/components/test-step-view.tsx
@@ -82,18 +82,26 @@ export class TestStepView extends React.Component<ITestStepViewProps> {
                         renderInstanceTableHeader={this.props.testStep.renderInstanceTableHeader}
                         getDefaultMessage={this.props.testStep.getDefaultMessage}
                         assessmentDefaultMessageGenerator={this.props.assessmentDefaultMessageGenerator}
+                        hasVisualHelper={this.doesSelectedStepHaveVisualHelper()}
                     />
                 </React.Fragment>
             );
         }
     }
 
-    private renderVisualHelperToggle(): JSX.Element {
-        const stepConfig = this.props.assessmentsProvider.getStep(
+    private getSelectedStep(): Readonly<TestStep> {
+        return this.props.assessmentsProvider.getStep(
             this.props.assessmentNavState.selectedTestType,
             this.props.assessmentNavState.selectedTestStep,
         );
-        if (stepConfig.getVisualHelperToggle == null) {
+    }
+
+    private doesSelectedStepHaveVisualHelper(): boolean {
+        return this.getSelectedStep().getVisualHelperToggle != null;
+    }
+
+    private renderVisualHelperToggle(): JSX.Element {
+        if (!this.doesSelectedStepHaveVisualHelper()) {
             return null;
         }
 
@@ -105,6 +113,6 @@ export class TestStepView extends React.Component<ITestStepViewProps> {
             isStepScanned: this.props.isStepScanned,
         };
 
-        return stepConfig.getVisualHelperToggle(visualHelperToggleConfig);
+        return this.getSelectedStep().getVisualHelperToggle(visualHelperToggleConfig);
     }
 }

--- a/src/DetailsView/handlers/assessment-instance-table-handler.tsx
+++ b/src/DetailsView/handlers/assessment-instance-table-handler.tsx
@@ -60,13 +60,14 @@ export class AssessmentInstanceTableHandler {
     public createAssessmentInstanceTableItems(
         instancesMap: IDictionaryStringTo<IGeneratedAssessmentInstance>,
         assessmentNavState: IAssessmentNavState,
+        hasVisualHelper: boolean,
     ): IAssessmentInstanceRowData[] {
         const assessmentInstances = this.getInstanceKeys(instancesMap, assessmentNavState).map(key => {
             const instance = instancesMap[key];
             return {
                 key: key,
                 statusChoiceGroup: this.renderChoiceGroup(instance, key, assessmentNavState),
-                visualizationButton: this.renderSelectedButton(instance, key, assessmentNavState),
+                visualizationButton: hasVisualHelper ? this.renderSelectedButton(instance, key, assessmentNavState) : null,
                 instance: instance,
             } as IAssessmentInstanceRowData;
         });
@@ -76,6 +77,7 @@ export class AssessmentInstanceTableHandler {
     public getColumnConfigs(
         instancesMap: IDictionaryStringTo<IGeneratedAssessmentInstance>,
         assessmentNavState: IAssessmentNavState,
+        hasVisualHelper: boolean,
     ): IColumn[] {
         let allEnabled: boolean = true;
         const instanceKeys = this.getInstanceKeys(instancesMap, assessmentNavState);
@@ -88,7 +90,7 @@ export class AssessmentInstanceTableHandler {
             }
         }
 
-        return this.assessmentTableColumnConfigHandler.getColumnConfigs(assessmentNavState, allEnabled);
+        return this.assessmentTableColumnConfigHandler.getColumnConfigs(assessmentNavState, allEnabled, hasVisualHelper);
     }
 
     public createCapturedInstanceTableItems(

--- a/src/assessments/page/test-steps/page-title.tsx
+++ b/src/assessments/page/test-steps/page-title.tsx
@@ -67,5 +67,4 @@ export const PageTitle: TestStep = {
                 testType: VisualizationType.PageAssessment,
             }),
         ),
-    getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
@@ -101,12 +101,12 @@ describe('AssessmentInstanceTableTest', () => {
         ];
 
         assessmentInstanceTableHandlerMock
-            .setup(a => a.createAssessmentInstanceTableItems(props.instancesMap, props.assessmentNavState))
+            .setup(a => a.createAssessmentInstanceTableItems(props.instancesMap, props.assessmentNavState, props.hasVisualHelper))
             .returns(() => items)
             .verifiable(Times.once());
 
         assessmentInstanceTableHandlerMock
-            .setup(a => a.getColumnConfigs(props.instancesMap, props.assessmentNavState))
+            .setup(a => a.getColumnConfigs(props.instancesMap, props.assessmentNavState, props.hasVisualHelper))
             .returns(() => cols)
             .verifiable(Times.once());
 
@@ -163,12 +163,12 @@ describe('AssessmentInstanceTableTest', () => {
         ];
 
         assessmentInstanceTableHandlerMock
-            .setup(a => a.createAssessmentInstanceTableItems(props.instancesMap, props.assessmentNavState))
+            .setup(a => a.createAssessmentInstanceTableItems(props.instancesMap, props.assessmentNavState, props.hasVisualHelper))
             .returns(() => items)
             .verifiable(Times.once());
 
         assessmentInstanceTableHandlerMock
-            .setup(a => a.getColumnConfigs(props.instancesMap, props.assessmentNavState))
+            .setup(a => a.getColumnConfigs(props.instancesMap, props.assessmentNavState, props.hasVisualHelper))
             .returns(() => cols)
             .verifiable(Times.once());
 
@@ -364,6 +364,7 @@ describe('AssessmentInstanceTableTest', () => {
             assessmentDefaultMessageGenerator: defaultMessageGeneratorMock,
             renderInstanceTableHeader: (table: AssessmentInstanceTable, items: IAssessmentInstanceRowData[]) =>
                 table.renderDefaultInstanceTableHeader(items),
+            hasVisualHelper: true,
         };
     }
 });

--- a/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
+++ b/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
@@ -66,7 +66,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
 
         actionMessageCreatorMock.setup(a => a.undoManualTestStatusChange).verifiable(Times.atLeastOnce());
 
-        const rows = testSubject.createAssessmentInstanceTableItems(instancesMap, assessmentNavState);
+        const rows = testSubject.createAssessmentInstanceTableItems(instancesMap, assessmentNavState, true);
         const choiceGroup: JSX.Element = (
             <TestStatusChoiceGroup
                 test={5}
@@ -168,9 +168,9 @@ describe('AssessmentInstanceTableHandlerTest', () => {
                 html: '',
             },
         };
-        configFactoryMock.setup(c => c.getColumnConfigs(navState, true)).verifiable(Times.once());
+        configFactoryMock.setup(c => c.getColumnConfigs(navState, true, true)).verifiable(Times.once());
 
-        testSubject.getColumnConfigs(instanceMap as IDictionaryStringTo<IGeneratedAssessmentInstance>, navState);
+        testSubject.getColumnConfigs(instanceMap as IDictionaryStringTo<IGeneratedAssessmentInstance>, navState, true);
 
         configFactoryMock.verifyAll();
     });


### PR DESCRIPTION
The page title requirement showed the option to toggle a visual helper because it knows how to automatically populate an instance table, but we don't have a meaningful visualizer for page title. This PR enables a non-manual test step to omit a getVisualHelperToggle prop to indicate that there is no applicable visual toggle, and for the toggles above and within the instance table to be omitted accordingly.