### PR TITLE
1443532: Adding theming to popup page, basic HC colors for proof of concept

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -9,6 +9,8 @@
 @import '../../common/components/toast.scss';
 body {
     margin: 0;
+    background: $neutral-0;
+    color: $neutral-100;
 }
 
 .target-change-dialog-modal {

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -77,7 +77,9 @@
     --ada-blue-variant: #336d99;
 
     .high-contrast-theme {
-        --ada-blue: #e81123;
+        // Base
+        --neutral-0: #161616;
+        --neutral-100: #ffffff;
     }
 }
 

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -6,6 +6,7 @@ body {
     margin: 0;
     overflow-y: auto;
     height: 0px;
+    background: $neutral-0;
 }
 
 .telemetry-permission-dialog-modal {

--- a/src/popup/scripts/main-renderer.tsx
+++ b/src/popup/scripts/main-renderer.tsx
@@ -5,15 +5,15 @@ import * as ReactDOM from 'react-dom';
 
 import { BrowserAdapter } from '../../background/browser-adapter';
 import { DropdownClickHandler } from '../../common/dropdown-click-handler';
-import { IStoreActionMessageCreator } from '../../common/message-creators/istore-action-message-creator';
-import { IClientStoresHub } from '../../common/stores/iclient-stores-hub';
 import { subtitle, title } from '../../content/strings/application';
 import { DiagnosticViewToggleFactory } from './components/diagnostic-view-toggle-factory';
-import { PopupViewControllerState, PopupView, PopupViewControllerDeps, PopupViewWithStoreSubscription } from './components/popup-view';
+import { PopupViewControllerDeps, PopupViewWithStoreSubscription } from './components/popup-view';
 import { IPopupHandlers } from './handlers/ipopup-handlers';
 import { LaunchPadRowConfigurationFactory } from './launch-pad-row-configuration-factory';
+import { Theme, ThemeInnerState } from '../../common/components/theme';
+import { WithStoreSubscriptionDeps } from '../../common/components/with-store-subscription';
 
-export type MainRendererDeps = PopupViewControllerDeps;
+export type MainRendererDeps = PopupViewControllerDeps & WithStoreSubscriptionDeps<ThemeInnerState>;
 export class MainRenderer {
     constructor(
         private readonly deps: MainRendererDeps,
@@ -33,19 +33,23 @@ export class MainRenderer {
         const container = this.dom.querySelector('#popup-container');
 
         this.renderer(
-            <PopupViewWithStoreSubscription
-                deps={this.deps}
-                title={title}
-                subtitle={subtitle}
-                popupHandlers={this.popupHandlers}
-                popupWindow={this.popupWindow}
-                browserAdapter={this.browserAdapter}
-                targetTabUrl={this.targetTabUrl}
-                hasAccess={this.hasAccess}
-                launchPadRowConfigurationFactory={this.launchPadRowConfigurationFactory}
-                diagnosticViewToggleFactory={this.diagnosticViewToggleFactory}
-                dropdownClickHandler={this.dropdownClickHandler}
-            />,
+            <>
+                <Theme deps={this.deps} />
+                <PopupViewWithStoreSubscription
+                    deps={this.deps}
+                    title={title}
+                    subtitle={subtitle}
+                    popupHandlers={this.popupHandlers}
+                    popupWindow={this.popupWindow}
+                    browserAdapter={this.browserAdapter}
+                    targetTabUrl={this.targetTabUrl}
+                    hasAccess={this.hasAccess}
+                    launchPadRowConfigurationFactory={this.launchPadRowConfigurationFactory}
+                    diagnosticViewToggleFactory={this.diagnosticViewToggleFactory}
+                    dropdownClickHandler={this.dropdownClickHandler}
+                />
+                ,
+            </>,
             container,
         );
     }

--- a/src/tests/unit/tests/popup/scripts/main-renderer.test.tsx
+++ b/src/tests/unit/tests/popup/scripts/main-renderer.test.tsx
@@ -15,6 +15,7 @@ import { PopupViewControllerHandler } from '../../../../../popup/scripts/handler
 import { LaunchPadRowConfigurationFactory } from '../../../../../popup/scripts/launch-pad-row-configuration-factory';
 import { MainRenderer, MainRendererDeps } from '../../../../../popup/scripts/main-renderer';
 import { SupportLinkHandler } from '../../../../../popup/support-link-handler';
+import { Theme } from '../../../../../common/components/theme';
 
 describe('MainRenderer', () => {
     const expectedTitle = title;
@@ -47,24 +48,28 @@ describe('MainRenderer', () => {
             .setup(r =>
                 r(
                     It.isValue(
-                        <PopupViewWithStoreSubscription
-                            deps={deps}
-                            title={expectedTitle}
-                            subtitle={expectedSubtitle}
-                            popupHandlers={{
-                                diagnosticViewClickHandler: diagnosticViewClickHandlerMock.object,
-                                popupViewControllerHandler: gettingStartedDialogHandlerMock.object,
-                                launchPanelHeaderClickHandler: feedbackMenuClickhandlerMock.object,
-                                supportLinkHandler: supportLinkHandlerMock.object,
-                            }}
-                            popupWindow={popupWindowMock.object}
-                            browserAdapter={browserAdapterMock.object}
-                            targetTabUrl={targetTabUrl}
-                            hasAccess={hasAccess}
-                            launchPadRowConfigurationFactory={launchPadRowConfigurationFactoryMock.object}
-                            diagnosticViewToggleFactory={diagnosticViewToggleFactoryMock.object}
-                            dropdownClickHandler={dropdownClickHandlerMock.object}
-                        />,
+                        <>
+                            <Theme deps={deps} />
+                            <PopupViewWithStoreSubscription
+                                deps={deps}
+                                title={expectedTitle}
+                                subtitle={expectedSubtitle}
+                                popupHandlers={{
+                                    diagnosticViewClickHandler: diagnosticViewClickHandlerMock.object,
+                                    popupViewControllerHandler: gettingStartedDialogHandlerMock.object,
+                                    launchPanelHeaderClickHandler: feedbackMenuClickhandlerMock.object,
+                                    supportLinkHandler: supportLinkHandlerMock.object,
+                                }}
+                                popupWindow={popupWindowMock.object}
+                                browserAdapter={browserAdapterMock.object}
+                                targetTabUrl={targetTabUrl}
+                                hasAccess={hasAccess}
+                                launchPadRowConfigurationFactory={launchPadRowConfigurationFactoryMock.object}
+                                diagnosticViewToggleFactory={diagnosticViewToggleFactoryMock.object}
+                                dropdownClickHandler={dropdownClickHandlerMock.object}
+                            />
+                            ,
+                        </>,
                     ),
                     container,
                 ),

--- a/src/views/page/page.scss
+++ b/src/views/page/page.scss
@@ -4,6 +4,8 @@
 
 body {
     margin: 0;
+    background: $neutral-0;
+    color: $neutral-100;
 }
 
 header {


### PR DESCRIPTION
Implementing high contrast requires changing our custom UI & office fabric UI. This PR expands the ThemeSwitcher component to the popup page. It swaps background/foreground under HC to show proof-of-concept.

Officefabric components, real modifications to colors.scss, and target page changes will all happen in other PRs. 

The UI should be unchanged when the preview feature / setting is off. When the setting is on, you should see black and white switched in some cases. 