### PR TITLE
1425036:  Fix missing label for checkbox buttons on group headers after OF6 update

### DIFF
--- a/src/DetailsView/components/details-group-header.tsx
+++ b/src/DetailsView/components/details-group-header.tsx
@@ -16,7 +16,10 @@ export interface DetailsGroupHeaderProps extends IGroupDividerProps {
 
 export class DetailsGroupHeader extends React.Component<DetailsGroupHeaderProps> {
     public render(): JSX.Element {
-        return <GroupHeader onRenderTitle={this.onRenderTitle} {...this.props} />;
+        const selectAllButtonProps = {
+            'aria-label': `${this.props.group.key} rule`,
+        };
+        return <GroupHeader onRenderTitle={this.onRenderTitle} selectAllButtonProps={selectAllButtonProps} {...this.props} />;
     }
 
     @autobind

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-group-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-group-header.test.tsx.snap
@@ -23,6 +23,11 @@ exports[`DetailsGroupHeader renders 1`] = `
     }
   }
   onRenderTitle={[Function]}
+  selectAllButtonProps={
+    Object {
+      "aria-label": "key rule",
+    }
+  }
 />
 `;
 


### PR DESCRIPTION
This adds an aria-label to the group header checkbox. We contributed this property to OF in [this PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/7777).