### PR TITLE
adding semantic slots into themes

### DIFF
--- a/src/common/components/theme.tsx
+++ b/src/common/components/theme.tsx
@@ -28,9 +28,7 @@ export class ThemeInner extends React.Component<ThemeInnerProps> {
         if (enableHighContrastCurr === enableHighContrastPrev) {
             return;
         }
-        this.props.deps.loadTheme({
-            palette: enableHighContrastCurr ? HighContrastThemePalette : DefaultThemePalette,
-        });
+        this.props.deps.loadTheme(enableHighContrastCurr ? HighContrastThemePalette : DefaultThemePalette);
     }
 
     public render(): JSX.Element {

--- a/src/common/styles/default-theme-palette.ts
+++ b/src/common/styles/default-theme-palette.ts
@@ -1,28 +1,30 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
-// generated from default theme from https://developer.microsoft.com/en-us/fabric#/styles/themegenerator
-export const DefaultThemePalette = {
-    themePrimary: '#0078d4',
-    themeLighterAlt: '#eff6fc',
-    themeLighter: '#deecf9',
-    themeLight: '#c7e0f4',
-    themeTertiary: '#71afe5',
-    themeSecondary: '#2b88d8',
-    themeDarkAlt: '#106ebe',
-    themeDark: '#005a9e',
-    themeDarker: '#004578',
-    neutralLighterAlt: '#f8f8f8',
-    neutralLighter: '#f4f4f4',
-    neutralLight: '#eaeaea',
-    neutralQuaternaryAlt: '#dadada',
-    neutralQuaternary: '#d0d0d0',
-    neutralTertiaryAlt: '#c8c8c8',
-    neutralTertiary: '#c2c2c2',
-    neutralSecondary: '#858585',
-    neutralPrimaryAlt: '#4b4b4b',
-    neutralPrimary: '#333333',
-    neutralDark: '#272727',
-    black: '#1d1d1d',
-    white: '#ffffff',
+import { IPartialTheme } from '@uifabric/styling';
+export const DefaultThemePalette: IPartialTheme = {
+    // generated from default theme from https://developer.microsoft.com/en-us/fabric#/styles/themegenerator
+    palette: {
+        themePrimary: '#0078d4',
+        themeLighterAlt: '#eff6fc',
+        themeLighter: '#deecf9',
+        themeLight: '#c7e0f4',
+        themeTertiary: '#71afe5',
+        themeSecondary: '#2b88d8',
+        themeDarkAlt: '#106ebe',
+        themeDark: '#005a9e',
+        themeDarker: '#004578',
+        neutralLighterAlt: '#f8f8f8',
+        neutralLighter: '#f4f4f4',
+        neutralLight: '#eaeaea',
+        neutralQuaternaryAlt: '#dadada',
+        neutralQuaternary: '#d0d0d0',
+        neutralTertiaryAlt: '#c8c8c8',
+        neutralTertiary: '#c2c2c2',
+        neutralSecondary: '#858585',
+        neutralPrimaryAlt: '#4b4b4b',
+        neutralPrimary: '#333333',
+        neutralDark: '#272727',
+        black: '#1d1d1d',
+        white: '#ffffff',
+    },
 };

--- a/src/common/styles/high-contrast-theme-palette.ts
+++ b/src/common/styles/high-contrast-theme-palette.ts
@@ -1,28 +1,35 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { IPartialTheme } from '@uifabric/styling';
 
-// generated from https://developer.microsoft.com/en-us/fabric#/styles/themegenerator with white body text and black background
-export const HighContrastThemePalette = {
-    themePrimary: '#0078d4',
-    themeLighterAlt: '#eff6fc',
-    themeLighter: '#deecf9',
-    themeLight: '#c7e0f4',
-    themeTertiary: '#71afe5',
-    themeSecondary: '#2b88d8',
-    themeDarkAlt: '#106ebe',
-    themeDark: '#005a9e',
-    themeDarker: '#004578',
-    neutralLighterAlt: '#0b0b0b',
-    neutralLighter: '#151515',
-    neutralLight: '#252525',
-    neutralQuaternaryAlt: '#2f2f2f',
-    neutralQuaternary: '#373737',
-    neutralTertiaryAlt: '#595959',
-    neutralTertiary: '#c8c8c8',
-    neutralSecondary: '#d0d0d0',
-    neutralPrimaryAlt: '#dadada',
-    neutralPrimary: '#ffffff',
-    neutralDark: '#f4f4f4',
-    black: '#f8f8f8',
-    white: '#000000',
+export const HighContrastThemePalette: IPartialTheme = {
+    // basic palette from https://developer.microsoft.com/en-us/fabric#/styles/themegenerator with white text and #161616 background
+    palette: {
+        themePrimary: '#0078d4',
+        themeLighterAlt: '#eff6fc',
+        themeLighter: '#deecf9',
+        themeLight: '#c7e0f4',
+        themeTertiary: '#71afe5',
+        themeSecondary: '#2b88d8',
+        themeDarkAlt: '#106ebe',
+        themeDark: '#005a9e',
+        themeDarker: '#004578',
+        neutralLighterAlt: '#212121',
+        neutralLighter: '#2a2a2a',
+        neutralLight: '#393939',
+        neutralQuaternaryAlt: '#424242',
+        neutralQuaternary: '#494949',
+        neutralTertiaryAlt: '#686868',
+        neutralTertiary: '#c8c8c8',
+        neutralSecondary: '#d0d0d0',
+        neutralPrimaryAlt: '#dadada',
+        neutralPrimary: '#ffffff',
+        neutralDark: '#f4f4f4',
+        black: '#f8f8f8',
+        white: '#161616',
+    },
+    semanticColors: {
+        link: '#FFFF00',
+        disabledText: '#C285FF',
+    },
 };

--- a/src/tests/unit/tests/common/components/theme.test.tsx
+++ b/src/tests/unit/tests/common/components/theme.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import * as _ from 'lodash';
 import * as React from 'react';
 
 import { ThemeDeps, ThemeInner, ThemeInnerProps } from '../../../../../common/components/theme';
@@ -34,9 +33,7 @@ describe('ThemeInner', () => {
     });
 
     test.each([true, false])('componentDidUpdate: is high contrast mode enabled: %s', (enableHighContrast: boolean) => {
-        const theme = {
-            palette: enableHighContrast ? HighContrastThemePalette : DefaultThemePalette,
-        };
+        const theme = enableHighContrast ? HighContrastThemePalette : DefaultThemePalette;
         const wrapper = shallow(<ThemeInner {...props} />);
         wrapper.setProps({ storeState: { userConfigurationStoreData: { enableHighContrast } } });
         expect(loadThemeMock).toBeCalledWith(theme);


### PR DESCRIPTION
Slight refactor so that we can more easily define non-palette parts of themes such as OF's semantic slots when applicable. In future may be nice to see if we can reuse the css variables in colors.scss for the semantic slots here.