### PR TITLE
Fix chrome-command-handler test 

### DIFF
--- a/src/background/chrome-command-handler.ts
+++ b/src/background/chrome-command-handler.ts
@@ -84,7 +84,7 @@ export class ChromeCommandHandler {
                 this.invokeToggleAction(visualizationType, state, tabId);
             }
         } catch (err) {
-            console.log('Error occurred at chrome command handler:', err);
+            console.error('Error occurred at chrome command handler:', err);
         }
     }
 


### PR DESCRIPTION
Failing mock (by missing setup) which was being masked by a try..catch block and then console.logged. This will fix the test by updating mock behavior (setting it to loose after an offline discussion with @dbjorge ) and also update to console.error to make the error more verbose.