### PR TITLE
Update old image references to remove console error

### DIFF
--- a/src/DetailsView/detailsView.html
+++ b/src/DetailsView/detailsView.html
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 <html dir="ltr" lang="en">
     <head>
-        <link rel="shortcut icon" type="image/x-icon" href="../icons/insights-logo_3_16.png" />
+        <link rel="shortcut icon" type="image/x-icon" href="../icons/brand/blue/brand-blue-16px.png" />
         <link rel="stylesheet" type="text/css" href="../common/styles/fabric.min.css" />
         <link rel="stylesheet" type="text/css" href="./Styles/default/detailsview.css" />
         <title>Accessibility Insights for Web</title>

--- a/src/insights.html
+++ b/src/insights.html
@@ -5,7 +5,7 @@ Licensed under the MIT License.
 
 <html dir="ltr" lang="en">
     <head>
-        <link rel="shortcut icon" type="image/x-icon" href="./icons/insights-logo_3_16.png" />
+        <link rel="shortcut icon" type="image/x-icon" href="./icons/brand/blue/brand-blue-16px.png" />
         <link rel="stylesheet" type="text/css" href="./common/styles/fabric.min.css" />
         <link rel="stylesheet" type="text/css" href="./views/insights/insights.css" />
         <title>Accessibility Insights for Web</title>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -7,9 +7,9 @@
         "default_popup": "popup/popup.html"
     },
     "icons": {
-        "16": "icons/insights-logo_3_16.png",
-        "48": "icons/insights-logo_3_48.png",
-        "128": "icons/insights-logo_3_128.png"
+        "16": "icons/brand/blue/brand-blue-16px.png",
+        "48": "icons/brand/blue/brand-blue-48px.png",
+        "128": "icons/brand/blue/brand-blue-128px.png"
     },
     "content_security_policy": "script-src 'self' 'unsafe-eval' https://az416426.vo.msecnd.net; object-src 'self'",
     "background": {


### PR DESCRIPTION
We still had some places in the code that referred to the old image names (insights-logo_3_16). These are generally replaced with the correct images as part of the build, so that's OK for most references, but the one in DetailsView is replaced at runtime. Since the old image URL was there initially, we would see the following error on the details view console:
```
Failed to load resource: net::ERR_FILE_NOT_FOUND
```
After these changes, the error no longer appears. I have manually verified that insights.html shows the correct icon without error, and that manifests are still updated to use the correct color icons.