### PR TITLE
a11y fix: change master checkbox in instance table label to show/hide all visualizations

### DIFF
--- a/src/DetailsView/handlers/master-checkbox-config-provider.ts
+++ b/src/DetailsView/handlers/master-checkbox-config-provider.ts
@@ -22,7 +22,7 @@ export class MasterCheckBoxConfigProvider {
             : MasterCheckBoxConfigProvider.MASTER_CHECKBOX_ICON_NAME_DISABLED;
         const iconClassName = classNames({ 'master-visualization-column-header-selected': iconName === 'view' });
         const name = 'Visualization toggle';
-        const label = `Toggle all visualizations ${allEnabled ? 'checked' : 'not checked'}`;
+        const label = `${allEnabled ? 'Hide' : 'Show'} all visualizations`;
         const onColumnClick = this.getMasterCheckBoxClickHandler(assessmentNavState, allEnabled);
 
         return {

--- a/src/tests/unit/tests/DetailsView/handlers/master-check-box-config-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/handlers/master-check-box-config-handler.test.ts
@@ -26,7 +26,7 @@ describe('MasterCheckBoxConfigProviderTest', () => {
         expect(config.iconName).toBe('view');
         expect(config.iconClassName).toBe('master-visualization-column-header-selected');
         expect(config.name).toBe('Visualization toggle');
-        expect(config.ariaLabel).toBe('Toggle all visualizations checked');
+        expect(config.ariaLabel).toBe('Hide all visualizations');
 
         actionMessageCreatorMock.verifyAll();
     });
@@ -46,6 +46,6 @@ describe('MasterCheckBoxConfigProviderTest', () => {
         expect(config.iconClassName).toBeDefined();
         expect(config.iconClassName.trim()).toHaveLength(0);
         expect(config.name).toBe('Visualization toggle');
-        expect(config.ariaLabel).toBe('Toggle all visualizations not checked');
+        expect(config.ariaLabel).toBe('Show all visualizations');
     });
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1423774
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.

#### Description of changes

Changed the label of the master checkbox in assessment instance table to be more fitting based on feedback.
