### PR TITLE
Replace oboslete eg2.tslint plugin with new replacement

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
     "recommendations": [
         "esbenp.prettier-vscode",
-        "ms-vscode.vscode-typescript-tslint-plugin", 
+        "ms-vscode.vscode-typescript-tslint-plugin",
         "msjsdiag.debugger-for-chrome",
         "psioniq.psi-header"
     ]


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: (no bug)
- [ ] Added relevant unit test for your changes. (`npm run test`) n/a
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` n/a
- [ ] Ran precheckin (`npm run precheckin`) n/a
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

As of 10/23/18, there is an [official Microsoft TSLint plugin for vscode](https://marketplace.visualstudio.com/items?itemName=ms-vscode.vscode-typescript-tslint-plugin) that obsoletes the older one with id `eg2.tslint`. In particular, the new one delegates TSLint's work to a language server in its own process, which means it is faster and can check the semantic/type-checking based rules: 

![image](https://user-images.githubusercontent.com/376284/52737582-86c73680-2f81-11e9-8fbe-d2b1e612e1c8.png)

#### Notes for reviewers

This just updates the recommendation, but there isn't an anti-recommendation option - users will have to uninstall the old plugin themselves. I'll @mention folks in teams to suggest this.
