### PR TITLE
Fix jest watch rerunning all tests on any src change

### DIFF
--- a/src/tests/unit/jest.config.js
+++ b/src/tests/unit/jest.config.js
@@ -11,7 +11,7 @@ module.exports = {
     setupFiles: [`${currentDir}/jest-setup.ts`],
     moduleFileExtensions: ['ts', 'tsx', 'js'],
     rootDir: rootDir,
-    roots: ['<rootDir>/src'],
+    roots: [currentDir],
     collectCoverage: true,
     collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx}', '!<rootDir>/src/tests/**/*', '!<rootDir>/src/**/*.d.ts'],
     coverageReporters: ['json', 'lcov', 'text', 'cobertura'],


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: no bug #
- [ ] Added relevant unit test for your changes. (`npm run test`): n/a
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`: n/a
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes. n/a

#### Description of changes

#135 accidentally set up unit tests to use a root dir of /src, which means jest --watch tries to rerun every test on any src change. This reverts back to the previous rootDir configuration at the /src/tests/unit/ folder, which restores the old watch behavior
