### PR TITLE
Added a warning bar to assessment view for when the target page url is changed

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -796,18 +796,18 @@ div.insights-dialog-main-override {
                 height: 100%;
                 width: 100%;
                 display: flex;
-                margin-top: 24px;
+                flex-direction: column;
                 min-height: 0;
                 .target-page-changed,
                 .static-content-details-view {
-                    margin-left: 24px;
-                    margin-right: 24px;
+                    margin: 24px 24px 0px 24px;
                 }
                 .issues-table {
                     height: 100%;
                     width: 100%;
                     display: flex;
                     flex-direction: column;
+                    margin-top: 24px;
                     > h1,
                     .details-view-toggle,
                     .details-disabled-message {
@@ -825,6 +825,7 @@ div.insights-dialog-main-override {
                     display: flex;
                     flex-direction: column;
                     width: 100%;
+                    margin-top: 24px;
                     .assessment-title {
                         width: 100%;
                         display: flex;
@@ -1250,6 +1251,7 @@ div.insights-dialog-main-override {
                     display: flex;
                     flex-direction: row;
                     flex-wrap: wrap;
+                    margin-top: 24px;
                     .overview-text-summary-section {
                         display: flex;
                         flex-direction: column;

--- a/src/DetailsView/components/assessment-url-changed-warning.tsx
+++ b/src/DetailsView/components/assessment-url-changed-warning.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { MessageBarType, MessageBar } from 'office-ui-fabric-react/lib/MessageBar';
+import * as React from 'react';
+
+import { ITab } from '../../common/itab';
+import { NamedSFC } from '../../common/react/named-sfc';
+import { UrlParser } from '../../common/url-parser';
+
+export interface AssessmentURLChangedWarningDeps {
+    urlParser: UrlParser;
+}
+
+export interface AssessmentURLChangedWarningProps {
+    deps: AssessmentURLChangedWarningDeps;
+    currentTarget: ITab;
+    prevTarget: ITab;
+}
+
+const urlChangedText: string = 'The target page URL has changed. We recommend doing an assessment in a single target page.';
+
+export const AssessmentURLChangedWarning = NamedSFC<AssessmentURLChangedWarningProps>('AssessmentURLChangedWarning', props => {
+    const { deps, prevTarget, currentTarget } = props;
+    const { urlParser } = deps;
+
+    const urlChanged = prevTarget != null && urlParser.areURLHostNamesEqual(prevTarget.url, currentTarget.url) === false;
+
+    if (urlChanged === false) {
+        return null;
+    }
+
+    return (
+        <div>
+            <MessageBar messageBarType={MessageBarType.warning}>{urlChangedText}</MessageBar>
+        </div>
+    );
+});

--- a/src/DetailsView/components/assessment-view.tsx
+++ b/src/DetailsView/components/assessment-view.tsx
@@ -15,6 +15,7 @@ import { ContentPageComponent } from '../../views/content/content-page';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { detailsViewExtensionPoint } from '../extensions/details-view-extension-point';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
+import { AssessmentURLChangedWarning, AssessmentURLChangedWarningDeps } from './assessment-url-changed-warning';
 import { TargetChangeDialog } from './target-change-dialog';
 import { TestStepView, TestStepViewDeps } from './test-step-view';
 import { TestStepNavDeps, TestStepsNav } from './test-steps-nav';
@@ -26,7 +27,8 @@ export const AssessmentViewMainContentExtensionPoint = reactExtensionPoint<WithA
 
 export type AssessmentViewDeps = ContentLinkDeps &
     TestStepViewDeps &
-    TestStepNavDeps & {
+    TestStepNavDeps &
+    AssessmentURLChangedWarningDeps & {
         detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
         assessmentsProvider: IAssessmentsProvider;
     };
@@ -63,15 +65,18 @@ export class AssessmentView extends React.Component<IAssessmentViewProps> {
         const extPointProps = { extensions, assessmentTestResult };
 
         return (
-            <div className="assessment-content">
-                {this.renderTargetChangeDialog()}
-                {this.renderTitle(assessmentTestResult.definition.title, assessmentTestResult.definition.guidance)}
-                {this.renderGettingStarted(assessmentTestResult.definition.gettingStarted)}
-                <AssessmentViewMainContentExtensionPoint.component {...extPointProps}>
-                    {this.renderRequirements()}
-                    {this.renderMainContent(assessmentTestResult)}
-                </AssessmentViewMainContentExtensionPoint.component>
-            </div>
+            <>
+                <AssessmentURLChangedWarning {...this.props} />
+                <div className="assessment-content">
+                    {this.renderTargetChangeDialog()}
+                    {this.renderTitle(assessmentTestResult.definition.title, assessmentTestResult.definition.guidance)}
+                    {this.renderGettingStarted(assessmentTestResult.definition.gettingStarted)}
+                    <AssessmentViewMainContentExtensionPoint.component {...extPointProps}>
+                        {this.renderRequirements()}
+                        {this.renderMainContent(assessmentTestResult)}
+                    </AssessmentViewMainContentExtensionPoint.component>
+                </div>
+            </>
         );
     }
 

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -81,8 +81,8 @@ import { ReportNameGenerator } from './reports/report-name-generator';
 declare const window: AutoChecker & Window;
 
 const chromeAdapter = new ChromeAdapter();
-const url = new URL(window.location.href);
-const tabId = new UrlParser().getIntParam(window.location.href, 'tabId');
+const urlParser = new UrlParser();
+const tabId = urlParser.getIntParam(window.location.href, 'tabId');
 const dom = document;
 const documentElementSetter = new DocumentManipulator(dom);
 
@@ -254,6 +254,7 @@ if (isNaN(tabId) === false) {
                     storeActionMessageCreator,
                     storesHub,
                     loadTheme,
+                    urlParser,
                 };
 
                 const renderer = new DetailsViewRenderer(

--- a/src/common/url-parser.ts
+++ b/src/common/url-parser.ts
@@ -6,4 +6,10 @@ export class UrlParser {
         const url = new URL(urlString);
         return parseInt(url.searchParams.get(key), 10);
     }
+
+    public areURLHostNamesEqual(urlA: string, urlB: string): boolean {
+        const urlAObj = new URL(urlA);
+        const urlBObj = new URL(urlB);
+        return urlAObj.hostname === urlBObj.hostname;
+    }
 }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-url-changed-warning.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-url-changed-warning.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AssessmentURLChangedWarning should return null as the target urls are same 1`] = `null`;
+
+exports[`AssessmentURLChangedWarning should return the message bar component as urls are different 1`] = `
+<div>
+  <StyledMessageBarBase
+    messageBarType={5}
+  >
+    The target page URL has changed. We recommend doing an assessment in a single target page.
+  </StyledMessageBarBase>
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-view.test.tsx.snap
@@ -1,30 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssessmentViewTest render 1`] = `
-"<div className=\\"assessment-content\\">
-  <TargetChangeDialog prevTab={{...}} newTab={{...}} actionMessageCreator={{...}} />
-  <div className=\\"assessment-title\\">
-    <h1 className=\\"assessment-header\\">
-      assessment 1
-       
-      <ContentLink deps={{...}} reference={[Function]} iconName=\\"info\\" />
-    </h1>
+"<Fragment>
+  <AssessmentURLChangedWarning deps={{...}} prevTarget={{...}} currentTarget={{...}} isScanning={false} isEnabled={false} content={{...}} actionMessageCreator={{...}} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} assessmentProvider={{...}} assessmentData={{...}} assessmentDefaultMessageGenerator={{...}} assessmentTestResult={{...}} />
+  <div className=\\"assessment-content\\">
+    <TargetChangeDialog prevTab={{...}} newTab={{...}} actionMessageCreator={{...}} />
+    <div className=\\"assessment-title\\">
+      <h1 className=\\"assessment-header\\">
+        assessment 1
+         
+        <ContentLink deps={{...}} reference={[Function]} iconName=\\"info\\" />
+      </h1>
+    </div>
+    <CollapsibleComponent header={{...}} content={{...}} contentClassName=\\"assessment-getting-started\\" containerClassName=\\"assessment-getting-started-container\\" />
+    <AssessmentViewMainContentExtensionPoint extensions={[undefined]} assessmentTestResult={{...}}>
+      <div className=\\"assessment-requirements-title\\">
+        <h2 className=\\"assessment-requirements\\">
+          Requirements
+        </h2>
+      </div>
+      <div className=\\"details-view-assessment-content\\">
+        <div className=\\"test-steps-nav-container\\">
+          <TestStepsNav deps={{...}} ariaLabel=\\"Requirements\\" selectedTest={-1} selectedTestStep=\\"assessment-1-step-1\\" stepStatus={{...}} />
+        </div>
+        <div className=\\"test-step-view-container\\">
+          <TestStepView deps={{...}} isScanning={false} testStep={{...}} renderStaticContent={[undefined]} instancesMap={{...}} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} manualTestStepResultMap={{...}} actionMessageCreator={{...}} assessmentsProvider={{...}} isStepEnabled={false} isStepScanned={false} assessmentDefaultMessageGenerator={{...}} />
+        </div>
+      </div>
+    </AssessmentViewMainContentExtensionPoint>
   </div>
-  <CollapsibleComponent header={{...}} content={{...}} contentClassName=\\"assessment-getting-started\\" containerClassName=\\"assessment-getting-started-container\\" />
-  <AssessmentViewMainContentExtensionPoint extensions={[undefined]} assessmentTestResult={{...}}>
-    <div className=\\"assessment-requirements-title\\">
-      <h2 className=\\"assessment-requirements\\">
-        Requirements
-      </h2>
-    </div>
-    <div className=\\"details-view-assessment-content\\">
-      <div className=\\"test-steps-nav-container\\">
-        <TestStepsNav deps={{...}} ariaLabel=\\"Requirements\\" selectedTest={-1} selectedTestStep=\\"assessment-1-step-1\\" stepStatus={{...}} />
-      </div>
-      <div className=\\"test-step-view-container\\">
-        <TestStepView deps={{...}} isScanning={false} testStep={{...}} renderStaticContent={[undefined]} instancesMap={{...}} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} manualTestStepResultMap={{...}} actionMessageCreator={{...}} assessmentsProvider={{...}} isStepEnabled={false} isStepScanned={false} assessmentDefaultMessageGenerator={{...}} />
-      </div>
-    </div>
-  </AssessmentViewMainContentExtensionPoint>
-</div>"
+</Fragment>"
 `;

--- a/src/tests/unit/tests/DetailsView/components/assessment-url-changed-warning.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-url-changed-warning.test.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { shallow } from 'enzyme';
+import { IMock, Mock, MockBehavior } from 'typemoq';
+import * as React from 'react';
+
+import { ITab } from '../../../../../common/itab';
+import { UrlParser } from '../../../../../common/url-parser';
+import {
+    AssessmentURLChangedWarning,
+    AssessmentURLChangedWarningDeps,
+} from '../../../../../DetailsView/components/assessment-url-changed-warning';
+
+describe('AssessmentURLChangedWarning', () => {
+    let urlParserMock: IMock<UrlParser>;
+    let targetA: ITab;
+    let targetB: ITab;
+    let deps: AssessmentURLChangedWarningDeps;
+
+    beforeEach(() => {
+        urlParserMock = Mock.ofType(UrlParser, MockBehavior.Strict);
+        targetA = {
+            url: 'some url',
+        };
+
+        targetB = {
+            url: 'some other url',
+        };
+
+        deps = {
+            urlParser: urlParserMock.object,
+        };
+    });
+
+    it('should return null as the target urls are same', () => {
+        urlParserMock.setup(parserMock => parserMock.areURLHostNamesEqual(targetA.url, targetB.url)).returns(() => true);
+        const testSubject = shallow(<AssessmentURLChangedWarning deps={deps} prevTarget={targetA} currentTarget={targetB} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    it('should return the message bar component as urls are different', () => {
+        urlParserMock.setup(parserMock => parserMock.areURLHostNamesEqual(targetA.url, targetB.url)).returns(() => false);
+        const testSubject = shallow(<AssessmentURLChangedWarning deps={deps} prevTarget={targetA} currentTarget={targetB} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
@@ -17,6 +17,7 @@ import { AssessmentView, AssessmentViewDeps, IAssessmentViewProps } from '../../
 import { AssessmentInstanceTableHandler } from '../../../../../DetailsView/handlers/assessment-instance-table-handler';
 import { outcomeTypeFromTestStatus, outcomeTypeSemanticsFromTestStatus } from '../../../../../DetailsView/reports/components/outcome-type';
 import { contentProvider, CreateTestAssessmentProvider } from '../../../common/test-assessment-provider';
+import { UrlParser } from '../../../../../common/url-parser';
 
 describe('AssessmentViewTest', () => {
     const assessmentsProvider = CreateTestAssessmentProvider();
@@ -217,6 +218,7 @@ class AssessmentViewPropsBuilder {
             outcomeTypeFromTestStatus: Mock.ofInstance(outcomeTypeFromTestStatus).object,
             getInnerTextFromJsxElement: Mock.ofInstance(getInnerTextFromJsxElement).object,
             outcomeTypeSemanticsFromTestStatus: Mock.ofInstance(outcomeTypeSemanticsFromTestStatus).object,
+            urlParser: Mock.ofType(UrlParser).object,
         };
         const assessment = this.provider.all()[0];
         const firstStep = assessment.steps[0];

--- a/src/tests/unit/tests/common/url-parser.test.ts
+++ b/src/tests/unit/tests/common/url-parser.test.ts
@@ -56,4 +56,17 @@ describe('UrlParserTest', () => {
             expect(testSubject.getIntParam(testCase.url, testCase.key)).toBeNaN();
         });
     });
+
+    describe('areURLHostNamesEqual', () => {
+        it('should return false as the host names are not the same', () => {
+            const urlA = 'http://test.com';
+            const urlB = 'http://notsame.com';
+            expect(testSubject.areURLHostNamesEqual(urlA, urlB)).toEqual(false);
+        });
+        it('should return true as the host names are the same', () => {
+            const urlA = 'http://same.com';
+            const urlB = 'http://same.com/randompath&someparam=true';
+            expect(testSubject.areURLHostNamesEqual(urlA, urlB)).toEqual(true);
+        });
+    });
 });


### PR DESCRIPTION


#### Pull request checklist

- [x] Addresses an existing issue: Fixes WI#1451015
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

We want to add a warning bar in the assessment view (for tests only for now) that will show up when the user changes the url sufficiently (to start, we are using host name).

![image](https://user-images.githubusercontent.com/32555133/52757762-ad559380-2fba-11e9-9e9a-613b4be65cb3.png)
