### PR TITLE
Restored landmark colors to default color scheme

### DIFF
--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -55,6 +55,15 @@
     --ada-blue-variant: #336d99;
     --overview-percent-selected: var(--neutral-55);
     --index-circle-background: var(--communication-shade-10);
+    // Landmark colors
+    --landmark-contentinfo: #00a88c;
+    --landmark-main: #cb2e6d;
+    --landmark-complementary: #6b9d1a;
+    --landmark-banner: #d08311;
+    --landmark-region: #2560e0;
+    --landmark-navigation: #9b38e6;
+    --landmark-search: #d363d8;
+    --landmark-form: #0298c7;
     .high-contrast-theme {
         --ada-blue: #ffffff;
         --ada-blue-variant: #ffffff;
@@ -83,15 +92,6 @@
         --communication-tint-40: #38a9ff;
         --overview-percent-selected: black;
         --index-circle-background: var(--communication-tint-40);
-        // Landmark colors
-        --landmark-contentinfo: #00a88c;
-        --landmark-main: #cb2e6d;
-        --landmark-complementary: #6b9d1a;
-        --landmark-banner: #d08311;
-        --landmark-region: #2560e0;
-        --landmark-navigation: #9b38e6;
-        --landmark-search: #d363d8;
-        --landmark-form: #0298c7;
     }
 }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1404832
- N/A - CSS Only - Added relevant unit test for your changes. (`npm run test`)
- N/A - CSS Only -  Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

The high contrast changes broke the landmark page.

**Broken**
![image](https://user-images.githubusercontent.com/7016281/52812885-5f3da000-304d-11e9-9dc7-a265cc427c3c.png)

**Fixed**

![image](https://user-images.githubusercontent.com/7016281/52812926-754b6080-304d-11e9-97e6-2cfaccf6abe4.png)

#### Notes for reviewers

This change is CSS only.
