### PR TITLE
Added Highlight tag for providing Do and Don't highlighting in content

### DIFF
--- a/src/content/test/multimedia/synchronization.tsx
+++ b/src/content/test/multimedia/synchronization.tsx
@@ -23,13 +23,15 @@ export const infoAndExamples = create(({ Markup, Link }) => (
             failText={
                 <p>
                     The audio description track is poorly synchronized with the video’s sound effects (shown in brackets). "He turns and
-                    looks out the window. [(BANG, THUD) She pulls a gun from her purse]. He falls to the floor."
+                    looks out the window. <Markup.Highlight>(BANG, THUD) She pulls a gun from her purse</Markup.Highlight>. He falls to the
+                    floor."
                 </p>
             }
             passText={
                 <p>
                     The audio description track is synchronized in a way that makes the overall narrative more understandable. "He turns and
-                    looks out the window. [She pulls a gun from her purse. (BANG, THUD)] He falls to the floor."
+                    looks out the window. <Markup.Highlight>She pulls a gun from her purse. (BANG, THUD)</Markup.Highlight> He falls to the
+                    floor."
                 </p>
             }
         />

--- a/src/tests/unit/tests/views/content/__snapshots__/markup.test.tsx.snap
+++ b/src/tests/unit/tests/views/content/__snapshots__/markup.test.tsx.snap
@@ -71,6 +71,14 @@ exports[`ContentPage .Markup <Fail> renders 1`] = `
 </Column>
 `;
 
+exports[`ContentPage .Markup <Highlight> renders 1`] = `
+<span
+  className="highlight"
+>
+  HIGHLIGHTED
+</span>
+`;
+
 exports[`ContentPage .Markup <HyperLink> renders 1`] = `
 <NewTabLink
   href="http://my.link"

--- a/src/tests/unit/tests/views/content/markup.test.tsx
+++ b/src/tests/unit/tests/views/content/markup.test.tsx
@@ -26,6 +26,7 @@ describe('ContentPage', () => {
         Column,
         HyperLink,
         CodeExample,
+        Highlight,
         Links,
         LandmarkLegend,
         Table,
@@ -198,6 +199,11 @@ describe('ContentPage', () => {
                 const wrapper = shallow(<CodeExample>With [quite] a [number] of [highlights].</CodeExample>);
                 expect(getHighlights(wrapper)).toEqual(['With ', '[quite]', ' a ', '[number]', ' of ', '[highlights]', '.']);
             });
+        });
+
+        it('<Highlight> renders', () => {
+            const wrapper = shallow(<Highlight>HIGHLIGHTED</Highlight>);
+            expect(wrapper.getElement()).toMatchSnapshot();
         });
 
         describe('<Links>', () => {

--- a/src/views/content/markup.tsx
+++ b/src/views/content/markup.tsx
@@ -37,6 +37,7 @@ export type Markup = {
     Column: React.SFC;
     HyperLink: React.SFC<{ href: string }>;
     Title: React.SFC<{ children: string }>;
+    Highlight: React.SFC;
     CodeExample: React.SFC<CodeExampleProps>;
     Links: React.SFC;
     Table: React.SFC;
@@ -132,6 +133,10 @@ export const createMarkup = (deps: MarkupDeps, options: ContentPageOptions) => {
 
     function LandmarkLegend(props: { role: string; children: React.ReactNode }): JSX.Element {
         return <span className={`landmarks-legend ${props.role}-landmark`}>{props.children}</span>;
+    }
+
+    function Highlight(props: { children: React.ReactNode }): JSX.Element {
+        return <span className="highlight">{props.children}</span>;
     }
 
     function Table(props: { children: React.ReactNode }): JSX.Element {
@@ -249,6 +254,7 @@ export const createMarkup = (deps: MarkupDeps, options: ContentPageOptions) => {
         HyperLink,
         Title,
         CodeExample,
+        Highlight,
         Links,
         LandmarkLegend,
         Table,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1419052
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

There is a square bracket primitive that, in code samples, will highlight the code bracketed and color it according to if it is in a Pass or Fail section. This PR adds a ```<Highlight>``` tag to accomplish the same in textual content.

![image](https://user-images.githubusercontent.com/7016281/52816710-b5631100-3056-11e9-899a-dcac06baf93d.png)


#### Notes for reviewers


