### PR TITLE
Bug-fix: make overview container use the filtered provider

### DIFF
--- a/src/DetailsView/components/overview-content/overview-content-container.tsx
+++ b/src/DetailsView/components/overview-content/overview-content-container.tsx
@@ -14,6 +14,7 @@ import { GetAssessmentSummaryModelFromProviderAndStoreData } from '../../reports
 import { TargetChangeDialog } from '../target-change-dialog';
 import { OverviewHeading } from './overview-heading';
 import { HelpLinkDeps, OverviewHelpSection } from './overview-help-section';
+import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-flag-store-data';
 
 const linkDataSource: HyperlinkDefinition[] = [
     {
@@ -34,26 +35,29 @@ export type OverviewContainerDeps = {
     assessmentsProvider: IAssessmentsProvider;
     getAssessmentSummaryModelFromProviderAndStoreData: GetAssessmentSummaryModelFromProviderAndStoreData;
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+    assessmentsProviderWithFeaturesEnabled: (assessmentProvider: IAssessmentsProvider, flags: FeatureFlagStoreData) => IAssessmentsProvider;
 } & HelpLinkDeps;
 
 export interface OverviewContainerProps {
     deps: OverviewContainerDeps;
     assessmentStoreData: IAssessmentStoreData;
     tabStoreData: ITabStoreData;
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export const OverviewContainer = NamedSFC<OverviewContainerProps>('OverviewContainer', props => {
-    const { deps, assessmentStoreData, tabStoreData } = props;
-    const { assessmentsProvider, getAssessmentSummaryModelFromProviderAndStoreData } = deps;
+    const { deps, assessmentStoreData, tabStoreData, featureFlagStoreData } = props;
+    const { assessmentsProvider, getAssessmentSummaryModelFromProviderAndStoreData, assessmentsProviderWithFeaturesEnabled } = deps;
     const prevTarget = assessmentStoreData.persistedTabInfo;
     const currentTarget = {
         id: tabStoreData.id,
         url: tabStoreData.url,
         title: tabStoreData.title,
     };
+    const filteredProvider = assessmentsProviderWithFeaturesEnabled(assessmentsProvider, featureFlagStoreData);
 
     const summaryData: IOverviewSummaryReportModel = getAssessmentSummaryModelFromProviderAndStoreData(
-        assessmentsProvider,
+        filteredProvider,
         assessmentStoreData,
     );
 

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
           "assessmentsProvider": Object {
             "all": [Function],
           },
+          "assessmentsProviderWithFeaturesEnabled": [Function],
           "detailsViewActionMessageCreator": Object {},
           "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
         }

--- a/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
@@ -12,6 +12,7 @@ import {
     OverviewContainerDeps,
 } from '../../../../../../DetailsView/components/overview-content/overview-content-container';
 import { HelpLinkDeps } from '../../../../../../DetailsView/components/overview-content/overview-help-section';
+import { Mock, MockBehavior } from 'typemoq';
 
 describe('OverviewContainer', () => {
     const openExternalLink = jest.fn();
@@ -28,8 +29,9 @@ describe('OverviewContainer', () => {
     const assessmentsProvider: IAssessmentsProvider = {
         all: () => [],
     } as any;
+    const filteredProvider = {} as IAssessmentsProvider;
     const detailsViewActionMessageCreatorStub = {} as DetailsViewActionMessageCreator;
-
+    const assessmentsProviderWithFeaturesEnabledMock = Mock.ofInstance((provider, featureFlagData) => null, MockBehavior.Strict);
     const getAssessmentSummaryModelFromProviderAndStoreData = jest.fn();
 
     const deps: OverviewContainerDeps = {
@@ -37,12 +39,25 @@ describe('OverviewContainer', () => {
         actionInitiators: helpLinkDeps.actionInitiators,
         getAssessmentSummaryModelFromProviderAndStoreData: getAssessmentSummaryModelFromProviderAndStoreData,
         detailsViewActionMessageCreator: detailsViewActionMessageCreatorStub,
+        assessmentsProviderWithFeaturesEnabled: assessmentsProviderWithFeaturesEnabledMock.object,
     };
+    const featureFlagDataStub = {};
     const assessmentStoreData: IAssessmentStoreData = {
         persistedTabInfo: {} as PersistedTabInfo,
     } as IAssessmentStoreData;
 
-    const component = <OverviewContainer deps={deps} assessmentStoreData={assessmentStoreData} tabStoreData={tabStoreDataStub} />;
+    assessmentsProviderWithFeaturesEnabledMock
+        .setup(mock => mock(assessmentsProvider, featureFlagDataStub))
+        .returns(() => filteredProvider);
+
+    const component = (
+        <OverviewContainer
+            deps={deps}
+            assessmentStoreData={assessmentStoreData}
+            featureFlagStoreData={featureFlagDataStub}
+            tabStoreData={tabStoreDataStub}
+        />
+    );
     const wrapper = shallow(component);
 
     test('component is defined and matches snapshot', () => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.

#### Description of changes

Overview should not be using the assessment provider as is; it should use the filtered provider which filters based on the feature flags that may have certain assessments not visible publicly.

#### Notes for reviewers

The reason for this change is that adding a new assessment and enabling the FF for it causes the app to break.
