### PR TITLE
Added Markup.Inline to allow for certain cases where links must be inlined with "and"

### DIFF
--- a/src/content/test/parsing/guidance.tsx
+++ b/src/content/test/parsing/guidance.tsx
@@ -35,17 +35,19 @@ export const guidance = create(({ Markup, Link }) => (
                 Fully conforming to specifications
             </Markup.HyperLink>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H88">Using HTML according to spec</Markup.HyperLink>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H74">
-                Ensuring that opening and closing tags are used according to specification
-            </Markup.HyperLink>{' '}
-            and{' '}
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H93">
-                Ensuring that id attributes are unique on a Web page
-            </Markup.HyperLink>{' '}
-            and{' '}
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H94">
-                Ensuring that elements do not contain duplicate attributes
-            </Markup.HyperLink>
+            <Markup.Inline>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H74">
+                    Ensuring that opening and closing tags are used according to specification
+                </Markup.HyperLink>{' '}
+                and{' '}
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H93">
+                    Ensuring that id attributes are unique on a Web page
+                </Markup.HyperLink>{' '}
+                and{' '}
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H94">
+                    Ensuring that elements do not contain duplicate attributes
+                </Markup.HyperLink>
+            </Markup.Inline>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H75">
                 Ensuring that Web pages are well-formed
             </Markup.HyperLink>

--- a/src/content/test/parsing/parsing.tsx
+++ b/src/content/test/parsing/parsing.tsx
@@ -66,17 +66,19 @@ export const infoAndExamples = create(({ Markup }) => (
                 Fully conforming to specifications
             </Markup.HyperLink>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H88">Using HTML according to spec</Markup.HyperLink>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H74">
-                Ensuring that opening and closing tags are used according to specification
-            </Markup.HyperLink>{' '}
-            and{' '}
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H93">
-                Ensuring that id attributes are unique on a Web page
-            </Markup.HyperLink>{' '}
-            and{' '}
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H94">
-                Ensuring that elements do not contain duplicate attributes
-            </Markup.HyperLink>
+            <Markup.Inline>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H74">
+                    Ensuring that opening and closing tags are used according to specification
+                </Markup.HyperLink>{' '}
+                and{' '}
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H93">
+                    Ensuring that id attributes are unique on a Web page
+                </Markup.HyperLink>{' '}
+                and{' '}
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H94">
+                    Ensuring that elements do not contain duplicate attributes
+                </Markup.HyperLink>
+            </Markup.Inline>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H75">
                 Ensuring that Web pages are well-formed
             </Markup.HyperLink>

--- a/src/content/test/timed-events/guidance.tsx
+++ b/src/content/test/timed-events/guidance.tsx
@@ -101,13 +101,15 @@ export const guidance = create(({ Markup, Link }) => (
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G180">
                 Providing the user with a means to set the time limit to 10 times the default time limit
             </Markup.HyperLink>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR16">
-                Providing a script that warns the user a time limit is about to expire
-            </Markup.HyperLink>{' '}
-            and{' '}
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR1">
-                Allowing the user to extend the default time limit
-            </Markup.HyperLink>
+            <Markup.Inline>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR16">
+                    Providing a script that warns the user a time limit is about to expire
+                </Markup.HyperLink>{' '}
+                and{' '}
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR1">
+                    Allowing the user to extend the default time limit
+                </Markup.HyperLink>
+            </Markup.Inline>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G4">
                 Allowing the content to be paused and restarted from where it was paused
             </Markup.HyperLink>

--- a/src/content/test/timed-events/time-limits.tsx
+++ b/src/content/test/timed-events/time-limits.tsx
@@ -80,13 +80,15 @@ export const infoAndExamples = create(({ Markup, Link }) => (
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G180">
                 Providing the user with a means to set the time limit to 10 times the default time limit
             </Markup.HyperLink>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR16">
-                Providing a script that warns the user a time limit is about to expire
-            </Markup.HyperLink>{' '}
-            and{' '}
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR1">
-                Allowing the user to extend the default time limit
-            </Markup.HyperLink>
+            <Markup.Inline>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR16">
+                    Providing a script that warns the user a time limit is about to expire
+                </Markup.HyperLink>{' '}
+                and{' '}
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR1">
+                    Allowing the user to extend the default time limit
+                </Markup.HyperLink>
+            </Markup.Inline>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G4">
                 Allowing the content to be paused and restarted from where it was paused
             </Markup.HyperLink>

--- a/src/tests/unit/tests/views/content/__snapshots__/markup.test.tsx.snap
+++ b/src/tests/unit/tests/views/content/__snapshots__/markup.test.tsx.snap
@@ -80,6 +80,14 @@ exports[`ContentPage .Markup <HyperLink> renders 1`] = `
 </NewTabLink>
 `;
 
+exports[`ContentPage .Markup <Inline> renders 1`] = `
+<div
+  className="content-inline"
+>
+  INLINED
+</div>
+`;
+
 exports[`ContentPage .Markup <LandmarkLegend> renders 1`] = `
 <span
   className="landmarks-legend test-landmark"

--- a/src/tests/unit/tests/views/content/markup.test.tsx
+++ b/src/tests/unit/tests/views/content/markup.test.tsx
@@ -24,6 +24,7 @@ describe('ContentPage', () => {
         PassFail,
         Columns,
         Column,
+        Inline,
         HyperLink,
         CodeExample,
         Links,
@@ -93,6 +94,11 @@ describe('ContentPage', () => {
 
         it('<Column> renders', () => {
             const wrapper = shallow(<Column>INSIDE COLUMN</Column>);
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
+
+        it('<Inline> renders', () => {
+            const wrapper = shallow(<Inline>INLINED</Inline>);
             expect(wrapper.getElement()).toMatchSnapshot();
         });
 

--- a/src/views/content/content.scss
+++ b/src/views/content/content.scss
@@ -61,6 +61,13 @@
     }
 
     .content-hyperlinks {
+        .content-inline {
+            line-height: 20px;
+            margin-bottom: 6px;
+            .insights-link {
+                display: inline;
+            }
+        }
         .insights-link {
             line-height: 20px;
             margin-bottom: 6px;

--- a/src/views/content/markup.tsx
+++ b/src/views/content/markup.tsx
@@ -35,6 +35,7 @@ export type Markup = {
     PassFail: React.SFC<PassFailProps>;
     Columns: React.SFC;
     Column: React.SFC;
+    Inline: React.SFC;
     HyperLink: React.SFC<{ href: string }>;
     Title: React.SFC<{ children: string }>;
     CodeExample: React.SFC<CodeExampleProps>;
@@ -82,6 +83,10 @@ export const createMarkup = (deps: MarkupDeps, options: ContentPageOptions) => {
                 <div className="content-hyperlinks">{React.Children.map(props.children, el => el)}</div>
             </>
         );
+    }
+
+    function Inline(props: { children: React.ReactNode }): JSX.Element {
+        return <div className="content-inline">{props.children}</div>;
     }
 
     function Do(props: { children: React.ReactNode }): JSX.Element {
@@ -246,6 +251,7 @@ export const createMarkup = (deps: MarkupDeps, options: ContentPageOptions) => {
         PassFail,
         Columns,
         Column,
+        Inline,
         HyperLink,
         Title,
         CodeExample,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1414329
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

Currently, every item in a Markup.Links block is on a separate line. In some cases, there is a desire to have a set of links separated by "ands". This PR creates a way to support this. Note the second to the last element in the screenshot.

![image](https://user-images.githubusercontent.com/7016281/53046957-2125ef00-3446-11e9-89bc-12ac41fc478d.png)


#### Notes for reviewers

Ideas for an alternate approach or naming are welcome.