### PR TITLE
Revised "Launch Pad" to heading level 1 to 2. We had 2 level 1s before.

### DIFF
--- a/src/popup/scripts/components/launch-pad.tsx
+++ b/src/popup/scripts/components/launch-pad.tsx
@@ -55,7 +55,7 @@ export class LaunchPad extends React.Component<LaunchPadProps, undefined> {
         return (
             <div className="ms-Grid main-section">
                 <main>
-                    <div role="heading" aria-level={1} className="launch-pad-title ms-fontWeight-semibold">
+                    <div role="heading" aria-level={2} className="launch-pad-title ms-fontWeight-semibold">
                         Launch pad
                     </div>
                     <hr className="ms-fontColor-neutralTertiaryAlt launch-pad-hr" />

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -84,7 +84,7 @@ exports[`Launch Pad content should match snapshot 1`] = `
     >
       <main>
         <div
-          aria-level="1"
+          aria-level="2"
           class="launch-pad-title ms-fontWeight-semibold"
           role="heading"
         >

--- a/src/tests/unit/tests/popup/scripts/components/launch-pad.test.tsx
+++ b/src/tests/unit/tests/popup/scripts/components/launch-pad.test.tsx
@@ -46,7 +46,7 @@ describe('LaunchPad', () => {
         const expected = (
             <div className="ms-Grid main-section">
                 <main>
-                    <div role="heading" aria-level={1} className="launch-pad-title ms-fontWeight-semibold">
+                    <div role="heading" aria-level={2} className="launch-pad-title ms-fontWeight-semibold">
                         Launch pad
                     </div>
                     <hr className="ms-fontColor-neutralTertiaryAlt launch-pad-hr" />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1458555
- [X] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

The "launch pad" heading now references aria-level="2".

```
<div role="heading" aria-level="2" class="launch-pad-title ms-fontWeight-semibold">Launch pad</div>
```

![image](https://user-images.githubusercontent.com/7016281/53214675-5aa35980-3602-11e9-87f6-5b41532573ff.png)


#### Notes for reviewers

Verified with NVDA and JAWS
