### PR TITLE
Hide decorative icons on launch pad from JAWS.

### DIFF
--- a/src/popup/scripts/components/launch-pad-item-row.tsx
+++ b/src/popup/scripts/components/launch-pad-item-row.tsx
@@ -20,7 +20,7 @@ export class LaunchPadItemRow extends React.Component<ILaunchPadItemRowProps, un
         return (
             <div className="ms-Grid">
                 <div className="ms-Grid-row">
-                    <div className="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle">
+                    <div className="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle" aria-hidden="true">
                         <Icon iconName={this.props.iconName} className="popup-start-dialog-icon" />
                     </div>
                     <div className="ms-Grid-col ms-sm9">

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -104,6 +104,7 @@ exports[`Launch Pad content should match snapshot 1`] = `
                 class="ms-Grid-row"
               >
                 <div
+                  aria-hidden="true"
                   class="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle"
                 >
                   <i
@@ -150,6 +151,7 @@ exports[`Launch Pad content should match snapshot 1`] = `
                 class="ms-Grid-row"
               >
                 <div
+                  aria-hidden="true"
                   class="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle"
                 >
                   <i
@@ -196,6 +198,7 @@ exports[`Launch Pad content should match snapshot 1`] = `
                 class="ms-Grid-row"
               >
                 <div
+                  aria-hidden="true"
                   class="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle"
                 >
                   <i

--- a/src/tests/unit/tests/popup/scripts/components/launch-pad-item-row.test.tsx
+++ b/src/tests/unit/tests/popup/scripts/components/launch-pad-item-row.test.tsx
@@ -47,7 +47,7 @@ describe('LaunchPadItemRow', () => {
         const expected = (
             <div className="ms-Grid">
                 <div className="ms-Grid-row">
-                    <div className="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle">
+                    <div className="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle" aria-hidden="true">
                         <Icon iconName={props.iconName} className="popup-start-dialog-icon" />
                     </div>
                     <div className="ms-Grid-col ms-sm9">


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #1458556
- [X] Added relevant unit test for your changes. (`npm run test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.

#### Description of changes

Added aria-hidden to the icons on the launch pad to keep JAWS from focusing on them.

#### Notes for reviewers

Tested on JAWS and NVDA. 
It still reads "blank" on JAWS but the unnecessary focus is removed.
NVDA unchanged.
