### PR TITLE
More emphasis that this is a telemetry opt-in dialog

### DIFF
--- a/src/content/settings/improve-accessibility-insights.tsx
+++ b/src/content/settings/improve-accessibility-insights.tsx
@@ -7,7 +7,7 @@ import { brand, title } from '../strings/application';
 
 export const telemetryPopupTitle = `We need your help`;
 
-export const telemetryPopupCheckboxTitle = `I agree to help`;
+export const telemetryPopupCheckboxTitle = `I agree to enable telemetry`;
 
 export const telemetryNotice = (
     <>

--- a/src/tests/end-to-end/tests/popup/__snapshots__/first-time-dialog.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/first-time-dialog.test.ts.snap
@@ -79,7 +79,7 @@ exports[`First time Dialog content should match snapshot 1`] = `
                     <span
                       class="ms-Checkbox-text text-000"
                     >
-                      I agree to help
+                      I agree to enable telemetry
                     </span>
                   </label>
                 </div>

--- a/src/tests/unit/tests/popup/scripts/components/__snapshots__/telemetry-permission-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/popup/scripts/components/__snapshots__/telemetry-permission-dialog.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`TelemetryPermissionDialogTest render dialog 1`] = `
     <StyledCheckboxBase
       checked={true}
       className="telemetry-agree-checkbox"
-      label="I agree to help"
+      label="I agree to enable telemetry"
       onChange={[Function]}
     />
     <React.Fragment>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1458754
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes
![image](https://user-images.githubusercontent.com/9062104/53275988-1bccdc80-36b2-11e9-8e2e-d7b8b2c5e080.png)

Users may skip the description text that talks about how we're enabling telemetry; requested by Markus to make it clear to users that this is a telemetry opt-in dialog.

#### Notes for reviewers
this is a content only change (modified text in test too)
