### PR TITLE
Add stable signature to our window.postMessage formats

### DIFF
--- a/src/injected/frameCommunicators/window-message-marshaller.ts
+++ b/src/injected/frameCommunicators/window-message-marshaller.ts
@@ -6,7 +6,7 @@ import { ClientBrowserAdapter } from '../../common/client-browser-adapter';
 //
 // This identifier is used by some partner teams to distinguish (and allow) our messages in
 // scenarios that would normally block unrecognized messages.
-export const STABLE_MESSAGE_SIGNATURE = 'e467510c-ca1f-47df-ace1-a39f7f0678c9';
+export const MESSAGE_STABLE_SIGNATURE = 'e467510c-ca1f-47df-ace1-a39f7f0678c9';
 
 export interface IWindowMessage {
     messageId: string;
@@ -68,7 +68,7 @@ export class WindowMessageMarshaller {
             command: command,
             message: payload,
             error: error,
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             messageSourceId: this.messageSourceId,
             messageVersion: this.messageVersion,
         };
@@ -77,7 +77,7 @@ export class WindowMessageMarshaller {
     protected isMessageOurs(postedMessage: IWindowMessage): boolean {
         return (
             postedMessage &&
-            postedMessage.messageStableSignature === STABLE_MESSAGE_SIGNATURE &&
+            postedMessage.messageStableSignature === MESSAGE_STABLE_SIGNATURE &&
             postedMessage.messageSourceId === this.messageSourceId &&
             postedMessage.messageVersion === this.messageVersion &&
             typeof postedMessage.messageId === 'string'

--- a/src/tests/unit/tests/injected/frameCommunicators/window-message-marshaller.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/window-message-marshaller.test.ts
@@ -6,7 +6,7 @@ import { ClientBrowserAdapter } from '../../../../../common/client-browser-adapt
 import {
     IWindowMessage,
     WindowMessageMarshaller,
-    STABLE_MESSAGE_SIGNATURE,
+    MESSAGE_STABLE_SIGNATURE,
 } from '../../../../../injected/frameCommunicators/window-message-marshaller';
 
 describe('WindowMessageMarshallerTests', () => {
@@ -45,12 +45,12 @@ describe('WindowMessageMarshallerTests', () => {
         JSON.stringify({ messageId: '12' } as IWindowMessage),
         JSON.stringify({ messageSourceId: messageSourceId } as IWindowMessage),
         JSON.stringify({ messageVersion: messageVersion } as IWindowMessage),
-        JSON.stringify({ messageStableSignature: STABLE_MESSAGE_SIGNATURE } as IWindowMessage),
+        JSON.stringify({ messageStableSignature: MESSAGE_STABLE_SIGNATURE } as IWindowMessage),
         // Only one required field missing
         JSON.stringify({
             // messageId: { unknownMessageIdType: true } as any,
             message: validMessageProperty,
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             messageSourceId: messageSourceId,
             messageVersion: messageVersion,
         } as IWindowMessage),
@@ -64,14 +64,14 @@ describe('WindowMessageMarshallerTests', () => {
         JSON.stringify({
             messageId: validMessageId,
             message: validMessageProperty,
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             // messageSourceId: 'unknown source id',
             messageVersion: messageVersion,
         } as IWindowMessage),
         JSON.stringify({
             messageId: validMessageId,
             message: validMessageProperty,
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             messageSourceId: messageSourceId,
             // messageVersion: 'unknown version',
         } as IWindowMessage),
@@ -79,7 +79,7 @@ describe('WindowMessageMarshallerTests', () => {
         JSON.stringify({
             messageId: { unknownMessageIdType: true } as any,
             message: validMessageProperty,
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             messageSourceId: messageSourceId,
             messageVersion: messageVersion,
         } as IWindowMessage),
@@ -93,14 +93,14 @@ describe('WindowMessageMarshallerTests', () => {
         JSON.stringify({
             messageId: validMessageId,
             message: validMessageProperty,
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             messageSourceId: 'unknown source id',
             messageVersion: messageVersion,
         } as IWindowMessage),
         JSON.stringify({
             messageId: validMessageId,
             message: validMessageProperty,
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             messageSourceId: messageSourceId,
             messageVersion: 'unknown version',
         } as IWindowMessage),
@@ -116,14 +116,14 @@ describe('WindowMessageMarshallerTests', () => {
                 stack: 'stack',
                 name: 'name',
             },
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             messageSourceId: messageSourceId,
             messageVersion: messageVersion,
             messageId: 'id1',
             command: 'someCommand',
         } as IWindowMessage, // with message
         {
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             messageSourceId: messageSourceId,
             messageVersion: messageVersion,
             messageId: 'id1',
@@ -142,7 +142,7 @@ describe('WindowMessageMarshallerTests', () => {
             command: command,
             message: payload,
             error: undefined,
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             messageSourceId: manifest.name,
             messageVersion: manifest.version,
         };
@@ -161,7 +161,7 @@ describe('WindowMessageMarshallerTests', () => {
             command: command,
             message: payload,
             error: undefined,
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             messageSourceId: manifest.name,
             messageVersion: manifest.version,
         };
@@ -184,7 +184,7 @@ describe('WindowMessageMarshallerTests', () => {
                 stack: payload.stack,
                 name: payload.name,
             },
-            messageStableSignature: STABLE_MESSAGE_SIGNATURE,
+            messageStableSignature: MESSAGE_STABLE_SIGNATURE,
             messageSourceId: manifest.name,
             messageVersion: manifest.version,
         };


### PR DESCRIPTION
#### Pull request checklist

- *n/a - minor feature to unblock partner team* Addresses an existing issue: 
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- *n/a - non-UI* Added screenshots/GIFs for UI changes.

#### Description of changes

We recently received an ask from a partner team to be able to uniquely identify our extension's window.postMessage formats, so they can specifically allow them in their application (they normally consider unrecognized message formats as a reason to immediately crash the application as a defense in depth mechanism against malicious messages). We currently embed the extension name/version, but these aren't necessarily stable across branding changes, different releases, or different testing/staging environments. This change adds an additional identifier which will be more stable over time.
