### PR TITLE
Set placeholder text for GitHub issues URL

### DIFF
--- a/src/DetailsView/components/settings-panel.tsx
+++ b/src/DetailsView/components/settings-panel.tsx
@@ -166,6 +166,7 @@ export class SettingsPanel extends React.Component<SettingsPanelProps> {
                 label="Enter desired GitHub repo link:"
                 onChange={this.onGitHubRepositoryChange}
                 value={this.getBugServiceProperty('gitHub', 'repository')}
+                placeholder="https://github.com/owner/repo/issues"
             />
         );
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/settings-panel.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/settings-panel.test.tsx.snap
@@ -305,6 +305,7 @@ exports[`SettingsPanelTest render - { isPanelOpen: true,
         <StyledTextFieldBase
           label="Enter desired GitHub repo link:"
           onChange={[Function]}
+          placeholder="https://github.com/owner/repo/issues"
           value="test-repository"
         />
       </React.Fragment>
@@ -407,6 +408,7 @@ exports[`SettingsPanelTest render - { isPanelOpen: true,
         <StyledTextFieldBase
           label="Enter desired GitHub repo link:"
           onChange={[Function]}
+          placeholder="https://github.com/owner/repo/issues"
         />
       </React.Fragment>
     }
@@ -605,6 +607,7 @@ exports[`SettingsPanelTest render - { isPanelOpen: true,
         <StyledTextFieldBase
           label="Enter desired GitHub repo link:"
           onChange={[Function]}
+          placeholder="https://github.com/owner/repo/issues"
         />
       </React.Fragment>
     }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Part of feature 1437153
- [X] Added relevant unit test for your changes. (`npm run test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`npm run precheckin`)
- [X] Added screenshots/GIFs for UI changes.

#### Description of changes

Added placeholder text in the settings UX for the GitHub repo URL
![image](https://user-images.githubusercontent.com/1752950/53380540-99971f00-3922-11e9-922d-7d867893e43e.png)

#### Notes for reviewers

Change is just setting the placeholder property on the TextField component, and updating 3 snapshots.
