### PR TITLE
[Bug] Add better guard clause in TargetChangeDialog

### DIFF
--- a/src/DetailsView/components/target-change-dialog.tsx
+++ b/src/DetailsView/components/target-change-dialog.tsx
@@ -105,7 +105,7 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
         }
 
         const { urlParser } = this.props.deps;
-        const urlChanged = prevTab && urlParser.areURLHostNamesEqual(prevTab.url, newTab.url) === false;
+        const urlChanged = prevTab.url && urlParser.areURLHostNamesEqual(prevTab.url, newTab.url) === false;
 
         return this.didTargetTabChanged(prevTab, newTab) || urlChanged === true;
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
@@ -1,5 +1,89 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TargetChangeDialog test sets for same prev tab and newTab values snapshot: render the only information available in prevTab is appRefreshed 1`] = `
+<StyledWithResponsiveMode
+  dialogContentProps={
+    Object {
+      "title": "Assessment in progress",
+      "type": 0,
+    }
+  }
+  hidden={false}
+  modalProps={
+    Object {
+      "className": "target-change-dialog-modal",
+      "containerClassName": "insights-dialog-main-override target-change-dialog",
+      "isBlocking": true,
+    }
+  }
+>
+  <div>
+    There is already an assessment running on 
+    <StyledTooltipHostBase
+      calloutProps={
+        Object {
+          "gapSpace": 0,
+        }
+      }
+      id="previous-target-page-link"
+    >
+      <NewTabLink
+        className="target-page-link"
+        role="link"
+      />
+    </StyledTooltipHostBase>
+    . Would you like to continue your current assessment on the new target of 
+    <StyledTooltipHostBase
+      calloutProps={
+        Object {
+          "gapSpace": 0,
+        }
+      }
+      content="https://www.abc.com"
+      id="current-target-page-link"
+    >
+      <StyledLinkBase
+        className="target-page-link"
+        role="link"
+      >
+        test title 2
+      </StyledLinkBase>
+    </StyledTooltipHostBase>
+    ?
+  </div>
+  <p>
+    <Term>
+      Note
+    </Term>
+    : If ‘Continue previous’ is selected, the previous assessment will be connected to this new page.
+  </p>
+  <p>
+    If ‘Start new’ is selected, all previous progress will be lost.
+  </p>
+  <StyledDialogFooterBase>
+    <div
+      className="target-change-dialog-button-container"
+    >
+      <div
+        className="button ms-Grid-col  action-cancel-button-col restart-button"
+      >
+        <CustomizedDefaultButton
+          text="Start new"
+        />
+      </div>
+      <div
+        className="button ms-Grid-col  action-cancel-button-col continue-button"
+      >
+        <CustomizedDefaultButton
+          autoFocus={true}
+          text="Continue previous"
+        />
+      </div>
+    </div>
+  </StyledDialogFooterBase>
+</StyledWithResponsiveMode>
+`;
+
 exports[`TargetChangeDialog test sets for same prev tab and newTab values snapshot: render when previous tab info shows app is refreshed 1`] = `
 <StyledWithResponsiveMode
   dialogContentProps={

--- a/src/tests/unit/tests/DetailsView/components/target-change-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/target-change-dialog.test.tsx
@@ -189,4 +189,30 @@ describe('TargetChangeDialog test sets for same prev tab and newTab values', () 
         const component = new TargetChangeDialog(targetChangeProps);
         expect(component.render()).toMatchSnapshot();
     });
+
+    test('snapshot: render the only information available in prevTab is appRefreshed', () => {
+        const actionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator);
+        prevTab = {
+            appRefreshed: true,
+        };
+        newTab = {
+            ...newTab,
+            url: 'https://www.abc.com',
+            id: 123,
+        };
+        urlParserMock
+            .setup(urlParserObject => urlParserObject.areURLHostNamesEqual(prevTab.url, newTab.url))
+            .returns(() => false)
+            .verifiable(Times.never());
+
+        const targetChangeProps: TargetChangeDialogProps = {
+            deps: { urlParser: urlParserMock.object },
+            prevTab,
+            newTab,
+            actionMessageCreator: actionMessageCreatorMock.object,
+        };
+
+        const component = new TargetChangeDialog(targetChangeProps);
+        expect(component.render()).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes WI#1448716
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)

#### Description of changes
Add better target clause to avoid unnecessary checks for url. For eg - if app is refreshed, the target change dialog needs to be shown irrespective of the dialog, so avoid url checks is just better here.

