### PR TITLE
Fix two links in consistent identification

### DIFF
--- a/src/content/test/repetitive-content/consistent-identification.tsx
+++ b/src/content/test/repetitive-content/consistent-identification.tsx
@@ -55,12 +55,16 @@ export const infoAndExamples = create(({ Markup }) => (
         <h3>WCAG success criteria</h3>
         <Markup.Links>
             <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Understanding/consistent-identification">
-                Understanding Success Criterion 3.2.3: Consistent Identification
+                Understanding Success Criterion 3.2.4: Consistent Identification
             </Markup.HyperLink>
         </Markup.Links>
 
         <h3>Sufficent techniques</h3>
-        <h4>Using labels, names, and text alternatives consistently for content that has the same functionality</h4>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G197">
+                Using labels, names, and text alternatives consistently for content that has the same functionality
+            </Markup.HyperLink>
+        </Markup.Links>
 
         <h3>Common failures</h3>
         <Markup.Links>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1456856
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

two links were wrong (one was not shown as a link, the other had an incorrect WCAG number
![image](https://user-images.githubusercontent.com/9062104/53521500-2231ce80-3a8d-11e9-8f80-aac2470d5f5a.png)


#### Notes for reviewers

content only change
