### PR TITLE
Fix inconsistency in styling for pre tag - content change

### DIFF
--- a/src/assessments/sequence/test-steps/columns.tsx
+++ b/src/assessments/sequence/test-steps/columns.tsx
@@ -15,7 +15,7 @@ const howToTest: JSX.Element = (
         <p>This procedure uses the Chrome Developer Tools (F12) to inspect the page's HTML.</p>
         <ol>
             <li>
-                Search the page's HTML to determine whether the page includes any <Markup.Code>{'<pre>'}</Markup.Code> elements.
+                Search the page's HTML to determine whether the page includes any <Markup.Tag tagName="pre" /> elements.
             </li>
             <li>
                 Examine each <Markup.Tag tagName="pre" /> element to verify that white space characters are not used to arrange the text


### PR DESCRIPTION
### Pull request checklist

- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

### Description of changes

Fixed styling for pre tag in one of the content text.

### Notes for reviewers

Content change.

### Screenshot of the change:

#### Current:

<img width="1389" alt="screen shot 2019-02-27 at 3 33 01 pm" src="https://user-images.githubusercontent.com/4496335/53530562-0fc38f00-3aa5-11e9-9b49-55cf230d78d2.png">


#### Changed:
<img width="1393" alt="screen shot 2019-02-27 at 3 31 48 pm" src="https://user-images.githubusercontent.com/4496335/53530501-de4ac380-3aa4-11e9-89fd-ce9745d219ce.png">
