### PR TITLE
1454468: landmark test crashes details view if target page contains unrecognized landmark role

### DIFF
--- a/src/assessments/landmarks/landmarks-instance-details-column-renderer.tsx
+++ b/src/assessments/landmarks/landmarks-instance-details-column-renderer.tsx
@@ -11,7 +11,7 @@ export function landmarksAssessmentInstanceDetailsColumnRenderer(
     item: IAssessmentInstanceRowData<ILandmarksAssessmentProperties>,
 ): JSX.Element {
     const propertyBag = item.instance.propertyBag;
-    const background = LandmarkFormatter.landmarkStyles[propertyBag.role].borderColor;
+    const background = LandmarkFormatter.getStyleForLandmarkRole(propertyBag.role).borderColor;
     let textContent = propertyBag.role;
     if (propertyBag.label != null) {
         textContent += `: ${propertyBag.label}`;

--- a/src/injected/visualization/landmark-formatter.ts
+++ b/src/injected/visualization/landmark-formatter.ts
@@ -16,18 +16,10 @@ interface ElemData {
 }
 
 export class LandmarkFormatter extends FailureInstanceFormatter {
-    public static landmarkStyles: { [role: string]: IHeadingStyleConfiguration } = {
-        aside: {
-            borderColor: '#00cccc',
-            fontColor: '#000000',
-        },
+    private static readonly landmarkStyles: { [role: string]: IHeadingStyleConfiguration } = {
         banner: {
             borderColor: '#ff9900',
             fontColor: '#000000',
-        },
-        blank: {
-            borderColor: '#C00000',
-            fontColor: '#FFFFFF',
         },
         complementary: {
             borderColor: '#00cccc',
@@ -37,16 +29,8 @@ export class LandmarkFormatter extends FailureInstanceFormatter {
             borderColor: '#00cc00',
             fontColor: '#000000',
         },
-        footer: {
-            borderColor: '#00cc00',
-            fontColor: '#000000',
-        },
         form: {
             borderColor: '#999999',
-            fontColor: '#000000',
-        },
-        header: {
-            borderColor: '#ff9900',
             fontColor: '#000000',
         },
         main: {
@@ -67,6 +51,15 @@ export class LandmarkFormatter extends FailureInstanceFormatter {
         },
     };
 
+    private static readonly invalidLandmarkStyle: IHeadingStyleConfiguration = {
+        borderColor: '#C00000',
+        fontColor: '#FFFFFF',
+    };
+
+    public static getStyleForLandmarkRole(role: string): IHeadingStyleConfiguration {
+        return LandmarkFormatter.landmarkStyles[role] || LandmarkFormatter.invalidLandmarkStyle;
+    }
+
     public getDialogRenderer(): DialogRenderer {
         return null;
     }
@@ -75,7 +68,7 @@ export class LandmarkFormatter extends FailureInstanceFormatter {
         // parse down the IHtmlElementAxeResult to see if it is contained in the map
         const elemData = this.decorateLabelText(data.propertyBag || this.getLandmarkInfo(data));
 
-        const style = LandmarkFormatter.landmarkStyles[elemData.role] || LandmarkFormatter.landmarkStyles.blank;
+        const style = LandmarkFormatter.getStyleForLandmarkRole(elemData.role);
 
         const drawerConfig: IDrawerConfiguration = {
             textBoxConfig: {

--- a/src/tests/unit/tests/assessments/landmarks-instance-details-column-renderer.test.tsx
+++ b/src/tests/unit/tests/assessments/landmarks-instance-details-column-renderer.test.tsx
@@ -20,7 +20,7 @@ describe('LandmarksInstanceDetailsColumnRendererTest', () => {
         } as IAssessmentInstanceRowData<ILandmarksAssessmentProperties>;
         const expected = (
             <AssessmentInstanceDetailsColumn
-                background={LandmarkFormatter.landmarkStyles.banner.borderColor}
+                background={LandmarkFormatter.getStyleForLandmarkRole('banner').borderColor}
                 textContent={'banner: label'}
                 tooltipId={null}
                 customClassName="radio"
@@ -40,7 +40,7 @@ describe('LandmarksInstanceDetailsColumnRendererTest', () => {
         } as IAssessmentInstanceRowData<ILandmarksAssessmentProperties>;
         const expected = (
             <AssessmentInstanceDetailsColumn
-                background={LandmarkFormatter.landmarkStyles.banner.borderColor}
+                background={LandmarkFormatter.getStyleForLandmarkRole('banner').borderColor}
                 textContent={'banner'}
                 tooltipId={null}
                 customClassName="radio"

--- a/src/tests/unit/tests/injected/visualization/landmark-formatter.test.ts
+++ b/src/tests/unit/tests/injected/visualization/landmark-formatter.test.ts
@@ -18,35 +18,22 @@ describe('LandmarkFormatterTests', () => {
         testStyling(config, 'banner');
     });
 
-    const roles: string[] = [
-        'banner',
-        'complementary',
-        'contentinfo',
-        'form',
-        'main',
-        'navigation',
-        'region',
-        'header',
-        'aside',
-        'search',
-        'footer',
-        'blank',
-    ];
+    const landmarkRoles: string[] = ['banner', 'complementary', 'contentinfo', 'form', 'main', 'navigation', 'region', 'search'];
 
-    test.each(roles)('verifyStylingFor - %s', role => {
+    test.each(landmarkRoles)('verify styling for landmark role %s', role => {
         const axeData = getAxeData(role);
         const config = testSubject.getDrawerConfiguration(null, axeData);
         testStyling(config, role);
     });
 
-    test('verifyStylingForFailureInstacne', () => {
-        const role = 'blank';
-        const config = testSubject.getDrawerConfiguration(null, getAxeData(role, true));
+    test.each(['application', 'unrecognized-role'])('verify styling for non-landmark-role %s', role => {
+        const axeData = getAxeData(role, true);
+        const config = testSubject.getDrawerConfiguration(null, axeData);
         testStyling(config, role, true);
     });
 
     function getLandmarkStyle(key: string): IHeadingStyleConfiguration {
-        const landmarkStyle = LandmarkFormatter.landmarkStyles[key];
+        const landmarkStyle = LandmarkFormatter.getStyleForLandmarkRole(key);
 
         expect(landmarkStyle).toBeDefined();
         return landmarkStyle;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes 1454468
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

Before, the extension crashed trying to render a failure details instance for this element (which now doesn't crash and visualizes reasonably):

![image](https://user-images.githubusercontent.com/376284/53534914-98e2c200-3ab5-11e9-81e4-9c6541ecaf7d.png)

Per discussion with Fer, the ideal behavior here would actually be for the landmarks test to not show the things that aren't using valid landmark roles at all, rather than showing them in red. This hardens the LandmarkFormatter to avoid crashing the extension in the case where it's given an invalid landmark role, which fixes the motivating bug.

The root cause for why we're seeing an element with a non-landmark role show up as input to the landmarks visualizer is that axe-core is still treating the application role as landmark type, which was correct in aria 1.0 but not aria 1.1. https://github.com/dequelabs/axe-core/issues/672 tracks the axe issue.