### PR TITLE
1443625: Link Function requirement should treat href='#' similar to href='' or no href

### DIFF
--- a/src/scanner/link-function.ts
+++ b/src/scanner/link-function.ts
@@ -36,7 +36,7 @@ export const linkFunctionConfiguration: RuleConfiguration = {
 
 function matches(node: HTMLElement, virtualNode: HTMLElement): boolean {
     const href = node.getAttribute('href');
-    return !href || AxeUtils.hasCustomWidgetMarkup(node);
+    return !href || href === '#' || AxeUtils.hasCustomWidgetMarkup(node);
 }
 
 function evaluateLinkFunction(node: HTMLElement, options: any, virtualNode: any, context: any): boolean {

--- a/src/tests/unit/tests/scanner/link-function.test.ts
+++ b/src/tests/unit/tests/scanner/link-function.test.ts
@@ -24,18 +24,21 @@ describe('link function', () => {
         });
     });
 
-    describe('verify matches', () => {
-        it('matches because no href', () => {
+    describe('matches', () => {
+        it('matches elements with no href attribute', () => {
             testMatches(null, false, true);
         });
-        it('matches because empty string as href', () => {
+        it('matches elements with an empty href attribute', () => {
             testMatches('', false, true);
         });
-        it('matches because has custom widget markup returns true', () => {
-            testMatches('href', true, true);
+        it('matches elements with an empty anchor tag as their href value', () => {
+            testMatches('#', false, true);
         });
-        it('does not match', () => {
-            testMatches('href', false, false);
+        it('matches elements that axe-core considers to have custom widget markup', () => {
+            testMatches('valid-href-value', true, true);
+        });
+        it("does not match elements with meaningful href values that axe-core doesn't flag", () => {
+            testMatches('valid-href-value', false, false);
         });
     });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes 1443625
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

![image](https://user-images.githubusercontent.com/376284/53538501-c4b87480-3ac2-11e9-85f8-0ac34becc7a0.png)

Makes `<a>` tags that represent empty anchor links (`href="#"`) considered the same as tags with no or empty-string href attributes for the purposes of asking the user to verify whether they are widget-like
