### PR TITLE
Switched from <i> and <b> tags

### DIFF
--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -20,6 +20,7 @@ import { ExportDialog } from './export-dialog';
 import { IssuesDetailsList } from './issues-details-list';
 import { IssuesDetailsPane, IssuesDetailsPaneDeps } from './Issues-details-pane';
 import { IssuesTableHandler } from './issues-table-handler';
+import * as Markup from '../../assessments/markup';
 
 export type IssuesTableDeps = IssuesDetailsPaneDeps & {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
@@ -168,7 +169,7 @@ export class IssuesTable extends React.Component<IssuesTableProps, IssuesTableSt
     private renderDisabledMessage(): JSX.Element {
         return (
             <div className="details-disabled-message" role="alert">
-                Turn on <b>{this.configuration.displayableData.title}</b> to see a list of failures.
+                Turn on <Markup.Term>{this.configuration.displayableData.title}</Markup.Term> to see a list of failures.
             </div>
         );
     }

--- a/src/DetailsView/components/scoping-container.tsx
+++ b/src/DetailsView/components/scoping-container.tsx
@@ -10,6 +10,7 @@ import { ScopingActionMessageCreator } from '../../common/message-creators/scopi
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { IScopingStoreData } from '../../common/types/store-data/scoping-store-data';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
+import * as Markup from '../../assessments/markup';
 
 export interface IScopingContainerProps {
     actionMessageCreator: DetailsViewActionMessageCreator;
@@ -26,9 +27,10 @@ export class ScopingContainer extends React.Component<IScopingContainerProps> {
             <p>To add a Selector, type the Selector’s name in the appropriate text box and click the “+ Add Selector” button.</p>
             <p>Note: iframe Selectors need to be entered in the following format: iframeSelector; selectorWithinIframe</p>
             <p>
-                Any selectors entered need to follow CSS selector syntax. For example, a selector needs to be prefaced with a <b>#</b> if it
-                represents an id (e.g. <i>#idName</i>) and with a <b>.</b> if it represents a class (e.g. <i>.className</i> or{' '}
-                <i>.class1.class2</i> for elements with two classes)
+                Any selectors entered need to follow CSS selector syntax. For example, a selector needs to be prefaced with a{' '}
+                <Markup.Term>#</Markup.Term> if it represents an id (e.g. <Markup.Term>#idName</Markup.Term>) and with a{' '}
+                <Markup.Term>.</Markup.Term> if it represents a class (e.g. <Markup.Term>.className</Markup.Term> or{' '}
+                <Markup.Term>.class1.class2</Markup.Term> for elements with two classes)
             </p>
         </div>
     );
@@ -36,8 +38,8 @@ export class ScopingContainer extends React.Component<IScopingContainerProps> {
     public static readonly includeInstructions = (
         <div>
             <p>
-                The selectors entered in this textbox will be the only elements that will be scanned; if <i>Include</i> is left empty, by
-                default the entire document will be scanned.
+                The selectors entered in this textbox will be the only elements that will be scanned; if <Markup.Term>Include</Markup.Term>{' '}
+                is left empty, by default the entire document will be scanned.
             </p>
         </div>
     );
@@ -45,10 +47,11 @@ export class ScopingContainer extends React.Component<IScopingContainerProps> {
     public static readonly excludeInstructions = (
         <div>
             <p>
-                The selectors entered in this textbox will be excluded from the scan. If <i>Exclude</i> is empty, the scan will show the
-                elements in <i>Include</i>. If <i>Exclude</i> is not empty, the scan will show elements in <i>Include</i> that are not
-                listed in <i>Exclude</i>; if <i>Include</i> is empty, the scan will show elements in the entire document that are not listed
-                in <i>Exclude</i>.
+                The selectors entered in this textbox will be excluded from the scan. If <Markup.Term>Exclude</Markup.Term> is empty, the
+                scan will show the elements in <Markup.Term>Include</Markup.Term>. If <Markup.Term>Exclude</Markup.Term> is not empty, the
+                scan will show elements in <Markup.Term>Include</Markup.Term> that are not listed in <Markup.Term>Exclude</Markup.Term>; if{' '}
+                <Markup.Term>Include</Markup.Term> is empty, the scan will show elements in the entire document that are not listed in{' '}
+                <Markup.Term>Exclude</Markup.Term>.
             </p>
         </div>
     );

--- a/src/assessments/markup.tsx
+++ b/src/assessments/markup.tsx
@@ -8,11 +8,11 @@ export function Tag(props: { tagName: string; isBold?: boolean }): JSX.Element {
 }
 
 export function Emphasis(props: { children: React.ReactNode }): JSX.Element {
-    return <i>{props.children}</i>;
+    return <em>{props.children}</em>;
 }
 
 export function Term(props: { children: React.ReactNode }): JSX.Element {
-    return <b>{props.children}</b>;
+    return <strong>{props.children}</strong>;
 }
 
 export function Code(props: { children: React.ReactNode }): JSX.Element {

--- a/src/content/adhoc/tabstops/why-it-matters.tsx
+++ b/src/content/adhoc/tabstops/why-it-matters.tsx
@@ -92,7 +92,7 @@ export const whyItMatters = create(({ Markup, Link }) => (
 
                 <ul>
                     <li>
-                        Be sure styling doesn't make any element <i>appear</i> to have the input focus.
+                        Be sure styling doesn't make any element <Markup.Emphasis>appear</Markup.Emphasis> to have the input focus.
                     </li>
                 </ul>
 

--- a/src/content/test/landmarks/landmark-roles.tsx
+++ b/src/content/test/landmarks/landmark-roles.tsx
@@ -24,7 +24,7 @@ export const infoAndExamples = create(({ Markup }) => (
         <Markup.PassFail
             failText={
                 <p>
-                    This div functions as a banner, but it has the <b>navigation</b> role.
+                    This div functions as a banner, but it has the <Markup.Term>navigation</Markup.Term> role.
                 </p>
             }
             failExample={`<div role="navigation">
@@ -32,7 +32,7 @@ export const infoAndExamples = create(({ Markup }) => (
             </div>`}
             passText={
                 <p>
-                    The div now has the <b>banner</b> role.
+                    The div now has the <Markup.Term>banner</Markup.Term> role.
                 </p>
             }
             passExample={`<div role="banner"> [A logo image and site name] </div>`}

--- a/src/content/test/landmarks/no-repeating-content.tsx
+++ b/src/content/test/landmarks/no-repeating-content.tsx
@@ -16,7 +16,7 @@ export const infoAndExamples = create(({ Markup }) => (
 
         <h2>How to fix</h2>
         <p>
-            Re-implement so no repeating blocks of content are contained within the <b>main</b> landmark.
+            Re-implement so no repeating blocks of content are contained within the <Markup.Term>main</Markup.Term> landmark.
         </p>
 
         <h2>Example</h2>
@@ -24,7 +24,7 @@ export const infoAndExamples = create(({ Markup }) => (
         <Markup.PassFail
             failText={
                 <p>
-                    Site navigation links, which appear on every page, are contained within the <b>main</b> landmark.
+                    Site navigation links, which appear on every page, are contained within the <Markup.Term>main</Markup.Term> landmark.
                 </p>
             }
             failExample={`<header>…</header>
@@ -37,7 +37,7 @@ export const infoAndExamples = create(({ Markup }) => (
             <footer>…</footer>`}
             passText={
                 <p>
-                    The site navigation links precede the <b>main</b> landmark.
+                    The site navigation links precede the <Markup.Term>main</Markup.Term> landmark.
                 </p>
             }
             passExample={`<header>…</header>

--- a/src/content/test/landmarks/primary-content.tsx
+++ b/src/content/test/landmarks/primary-content.tsx
@@ -16,7 +16,7 @@ export const infoAndExamples = create(({ Markup }) => (
 
         <h2>How to fix</h2>
         <p>
-            Re-implement so all primary content is contained within the page's <b>main</b> landmark.
+            Re-implement so all primary content is contained within the page's <Markup.Term>main</Markup.Term> landmark.
         </p>
 
         <h2>Example</h2>
@@ -24,7 +24,7 @@ export const infoAndExamples = create(({ Markup }) => (
         <Markup.PassFail
             failText={
                 <p>
-                    Some of the page's primary content is not contained within the <b>main</b> landmark.
+                    Some of the page's primary content is not contained within the <Markup.Term>main</Markup.Term> landmark.
                 </p>
             }
             failExample={`<header>…</header>
@@ -34,7 +34,7 @@ export const infoAndExamples = create(({ Markup }) => (
             <footer>…</footer>`}
             passText={
                 <p>
-                    All of the page's primary content is within the <b>main</b> landmark.
+                    All of the page's primary content is within the <Markup.Term>main</Markup.Term> landmark.
                 </p>
             }
             passExample={`<header>…</header>

--- a/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
@@ -19,6 +19,7 @@ import { ReportGenerator } from '../../../../../DetailsView/reports/report-gener
 import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
 import { RuleResult } from '../../../../../scanner/iruleresults';
 import { ShallowRenderer } from '../../../common/shallow-renderer';
+import * as Markup from '../../../../../assessments/markup';
 
 describe('IssuesTableTest', () => {
     const onExportButtonClickStub = () => {};
@@ -60,7 +61,7 @@ describe('IssuesTableTest', () => {
                     {getCommandBarFromProps(props)}
                     {getDialogFromProps(props, state)}
                     <div className="details-disabled-message" role="alert">
-                        Turn on <b>Automated checks</b> to see a list of failures.
+                        Turn on <Markup.Term>Automated checks</Markup.Term> to see a list of failures.
                     </div>
                 </div>
             </div>

--- a/src/tests/unit/tests/assessments/markup.test.tsx
+++ b/src/tests/unit/tests/assessments/markup.test.tsx
@@ -25,13 +25,13 @@ describe('markup tags', () => {
 
     test('test Emphasis', () => {
         const rendered = Markup.Emphasis({ children: 'children' });
-        const expected = <i>children</i>;
+        const expected = <em>children</em>;
         expect(rendered).toEqual(expected);
     });
 
     test('test Term', () => {
         const rendered = Markup.Term({ children: 'children' });
-        const expected = <b>children</b>;
+        const expected = <strong>children</strong>;
         expect(rendered).toEqual(expected);
     });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1463884
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [n/a] Added screenshots/GIFs for UI changes.
   No visual changes

#### Description of changes

Modified to use the `<em>` tag where `<i>` is currently used and `<strong>` where `<b>` is currently used. No visual changes expected.

#### Notes for reviewers

The key change is in Markup. Other changes are realigning stray `<b>` and `<i>` tags to use Markup in all cases.
