### PR TITLE
Improve local "npm run test" speed from 2:28 to 1:11

### DIFF
--- a/src/tests/jest.common.config.js
+++ b/src/tests/jest.common.config.js
@@ -13,5 +13,5 @@ module.exports = {
     transform: {
         '^.+\\.(ts|tsx)$': 'ts-jest',
     },
-    verbose: true,
+    verbose: false,
 };


### PR DESCRIPTION
#### Pull request checklist

- [x] **(n/a)** Addresses an existing issue
- [x] **(n/a)** Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] **(n/a)** Added screenshots/GIFs for UI changes.

#### Description of changes

A huge amount of `npm run test`'s time was being spent in console output that we don't need. Removing the verbose output per https://github.com/facebook/jest/issues/6694#issuecomment-409574937 cuts the total runtime on my dev box by more than half.

#### Notes for reviewers

I also experimented with replacing the default reporter, per the same suggestion, but found that this had a negligible impact after the verbose change.
