### PR TITLE
remove jquery dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5938,11 +5938,6 @@
                 }
             }
         },
-        "jquery": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-            "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
-        },
         "js-base64": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
         "applicationinsights-js": "^1.0.20",
         "axe-core": "3.1.1",
         "classnames": "^2.2.6",
-        "jquery": "^3.3.1",
         "lodash": "^4.17.11",
         "office-ui-fabric-react": "6.142.0",
         "q": "1.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,10 +23,7 @@ const commonEntryFiles = {
     insights: [path.resolve(__dirname, 'src/views/insights/initializer.ts')],
     detailsView: [path.resolve(__dirname, 'src/DetailsView/details-view-initializer.ts')],
     devtools: [path.resolve(__dirname, 'src/devtools/dev-tool-init.ts')],
-    background: [
-        'script-loader!' + path.resolve(__dirname, 'node_modules/jquery/dist/jquery.min.js'),
-        path.resolve(__dirname, 'src/background/background-init.ts'),
-    ],
+    background: [path.resolve(__dirname, 'src/background/background-init.ts')],
 };
 
 const commonConfig = {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 - n/a
- [x] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` - n/a
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes. - n/a

#### Description of changes

removing jquery since we are not using it anymore. Found this issue to identify why we need unsafe-eval in our manifest. we still can't remove unsafe-eval due to this issue - https://github.com/dequelabs/axe-core/issues/1175

#### Notes for reviewers
Validated fast pass, adhoc tools, assessment, insights page to trigger core background operations to see if this causes any failure