### PR TITLE
Let AT user to use arrow key to navigate through data grid

### DIFF
--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-static-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-static-test-view.test.tsx.snap
@@ -1,11 +1,99 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AdhocStaticTestView render handles content & guidance 1`] = `"<StaticContentDetailsView deps={[function]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[function]} guidance={[function]} />"`;
+exports[`AdhocStaticTestView render handles content & guidance 1`] = `
+"<StaticContentDetailsView deps={[Function: function () {
+                    var args = [];
+                    for (var _i = 0; _i < arguments.length; _i++) {
+                        args[_i] = arguments[_i];
+                    }
+                    _this._interceptor.removeInvocation(invocation_1);
+                    var method = new MethodInfo(target, p);
+                    var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                    _this._interceptor.intercept(methodInvocation);
+                    return methodInvocation.returnValue;
+                }]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[Function: function () {
+                    var args = [];
+                    for (var _i = 0; _i < arguments.length; _i++) {
+                        args[_i] = arguments[_i];
+                    }
+                    _this._interceptor.removeInvocation(invocation_1);
+                    var method = new MethodInfo(target, p);
+                    var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                    _this._interceptor.intercept(methodInvocation);
+                    return methodInvocation.returnValue;
+                }]} guidance={[Function: function () {
+                    var args = [];
+                    for (var _i = 0; _i < arguments.length; _i++) {
+                        args[_i] = arguments[_i];
+                    }
+                    _this._interceptor.removeInvocation(invocation_1);
+                    var method = new MethodInfo(target, p);
+                    var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                    _this._interceptor.intercept(methodInvocation);
+                    return methodInvocation.returnValue;
+                }]} />"
+`;
 
-exports[`AdhocStaticTestView render handles content & no guidance 1`] = `"<StaticContentDetailsView deps={[function]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[function]} guidance={[undefined]} />"`;
+exports[`AdhocStaticTestView render handles content & no guidance 1`] = `
+"<StaticContentDetailsView deps={[Function: function () {
+                    var args = [];
+                    for (var _i = 0; _i < arguments.length; _i++) {
+                        args[_i] = arguments[_i];
+                    }
+                    _this._interceptor.removeInvocation(invocation_1);
+                    var method = new MethodInfo(target, p);
+                    var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                    _this._interceptor.intercept(methodInvocation);
+                    return methodInvocation.returnValue;
+                }]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[Function: function () {
+                    var args = [];
+                    for (var _i = 0; _i < arguments.length; _i++) {
+                        args[_i] = arguments[_i];
+                    }
+                    _this._interceptor.removeInvocation(invocation_1);
+                    var method = new MethodInfo(target, p);
+                    var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                    _this._interceptor.intercept(methodInvocation);
+                    return methodInvocation.returnValue;
+                }]} guidance={[undefined]} />"
+`;
 
-exports[`AdhocStaticTestView render handles no content & guidance 1`] = `"<StaticContentDetailsView deps={[function]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[undefined]} guidance={[function]} />"`;
+exports[`AdhocStaticTestView render handles no content & guidance 1`] = `
+"<StaticContentDetailsView deps={[Function: function () {
+                    var args = [];
+                    for (var _i = 0; _i < arguments.length; _i++) {
+                        args[_i] = arguments[_i];
+                    }
+                    _this._interceptor.removeInvocation(invocation_1);
+                    var method = new MethodInfo(target, p);
+                    var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                    _this._interceptor.intercept(methodInvocation);
+                    return methodInvocation.returnValue;
+                }]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[undefined]} guidance={[Function: function () {
+                    var args = [];
+                    for (var _i = 0; _i < arguments.length; _i++) {
+                        args[_i] = arguments[_i];
+                    }
+                    _this._interceptor.removeInvocation(invocation_1);
+                    var method = new MethodInfo(target, p);
+                    var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                    _this._interceptor.intercept(methodInvocation);
+                    return methodInvocation.returnValue;
+                }]} />"
+`;
 
-exports[`AdhocStaticTestView render handles no content & no guidance 1`] = `"<StaticContentDetailsView deps={[function]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[undefined]} guidance={[undefined]} />"`;
+exports[`AdhocStaticTestView render handles no content & no guidance 1`] = `
+"<StaticContentDetailsView deps={[Function: function () {
+                    var args = [];
+                    for (var _i = 0; _i < arguments.length; _i++) {
+                        args[_i] = arguments[_i];
+                    }
+                    _this._interceptor.removeInvocation(invocation_1);
+                    var method = new MethodInfo(target, p);
+                    var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                    _this._interceptor.intercept(methodInvocation);
+                    return methodInvocation.returnValue;
+                }]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[undefined]} guidance={[undefined]} />"
+`;
 
 exports[`AdhocStaticTestView should return target page changed view as tab is changed 1`] = `"<TargetPageChangedView displayableData={{...}} type={-1} toggleClickHandler={[Function: clickHandlerStub]} />"`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/static-content-details-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/static-content-details-view.test.tsx.snap
@@ -5,9 +5,29 @@ exports[`StaticContentDetailsViewTest renders content page component 1`] = `
   <h1>
     my test title
      
-    <ContentLink deps={[undefined]} reference={[function]} iconName=\\"info\\" />
+    <ContentLink deps={[undefined]} reference={[Function: function () {
+                        var args = [];
+                        for (var _i = 0; _i < arguments.length; _i++) {
+                            args[_i] = arguments[_i];
+                        }
+                        _this._interceptor.removeInvocation(invocation_1);
+                        var method = new MethodInfo(target, p);
+                        var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                        _this._interceptor.intercept(methodInvocation);
+                        return methodInvocation.returnValue;
+                    }]} iconName=\\"info\\" />
   </h1>
   <VisualizationToggle checked={true} onClick={[Function: proxy]} label=\\"my test toggle label\\" className=\\"details-view-toggle\\" visualizationName=\\"my test title\\" />
-  <ContentInclude deps={[undefined]} content={[function]} />
+  <ContentInclude deps={[undefined]} content={[Function: function () {
+                      var args = [];
+                      for (var _i = 0; _i < arguments.length; _i++) {
+                          args[_i] = arguments[_i];
+                      }
+                      _this._interceptor.removeInvocation(invocation_1);
+                      var method = new MethodInfo(target, p);
+                      var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
+                      _this._interceptor.intercept(methodInvocation);
+                      return methodInvocation.returnValue;
+                  }]} />
 </div>"
 `;


### PR DESCRIPTION
- [ ] Addresses an existing issue: Fixes #1458550
- [ done ] Added relevant unit test for your changes. (`npm run test`)
- [ done ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ done ] Ran precheckin (`npm run precheckin`)
- [ N/A ] Added screenshots/GIFs for UI changes.

#### Description of changes
Added aria-label to assessment instance table grid to let AT users to use arrow key to navigate through the data grid

#### Notes for reviewers
N/A
