### PR TITLE
Issue filing: Force feature flag on

### DIFF
--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -88,11 +88,11 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
         },
         {
             id: FeatureFlags.showBugFiling,
-            defaultValue: false,
-            displayableName: 'Show bug filing stubs',
-            displayableDescription: 'Show bug filing button stubs',
+            defaultValue: true,
+            displayableName: 'Issue filing',
+            displayableDescription: 'Enable File Issue buttons that allow you to create GitHub issues pre-populated with failure details.',
             isPreviewFeature: false,
-            forceDefault: false,
+            forceDefault: true,
         },
         {
             id: FeatureFlags.showInstanceVisibility,

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -21,7 +21,7 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.logTelemetryToConsole]: false,
             [FeatureFlags.showAllFeatureFlags]: false,
             [FeatureFlags.scoping]: false,
-            [FeatureFlags.showBugFiling]: false,
+            [FeatureFlags.showBugFiling]: true,
             [FeatureFlags.showInstanceVisibility]: false,
             [FeatureFlags.highContrastMode]: false,
         };


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes 1463437
- [X] Added relevant unit test for your changes. (`npm run test`) (updated existing FF value test)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` (not applicable)
- [X] Ran precheckin (`npm run precheckin`)
- [X] Added screenshots/GIFs for UI changes. (not applicable)

#### Description of changes

- Force the `showBugFiling` feature flag to be on, overriding existing settings.
- Updated the display name and description text for the feature flag, even though it's no longer shown in the UX.

#### Notes for reviewers

- Should not be merged until after other Issue Filing PRs are merged.
