### PR TITLE
Added LICENSE.txt to docs for external access

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,7 @@ module.exports = function(grunt) {
             './src/assessments/color/test-steps/flashing-text-example.html',
             './test-results',
             './docs/NOTICE.html',
+            './docs/LICENSE.txt',
         ],
         file_type_method: 'INCLUDE',
         file_types: ['.ts', '.tsx', '.d.ts', '.js', '.html', '.css', '.scss', '.yaml', '.md', '.txt', '.xml'],

--- a/docs/LICENSE.txt
+++ b/docs/LICENSE.txt
@@ -1,5 +1,3 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
 Accessibility Insights for Web
 
 Copyright (c) Microsoft Corporation


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1448101
- [ ] **n/a** Added relevant unit test for your changes. (`npm run test`)
- [ ] **n/a** Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] **n/a** Added screenshots/GIFs for UI changes.

#### Description of changes

I added a LICENSE.txt file in docs so it can be linked to from the chrome store.

The extension must be .txt to serve properly from GitHub Pages.

#### Notes for reviewers


