### PR TITLE
Using secondary-text color on instance list

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -599,6 +599,7 @@ div.insights-file-issue-details-dialog-container {
                 overflow: hidden;
                 white-space: nowrap;
                 text-overflow: ellipsis;
+                color: $secondary-text;
             }
             .radio-button-group {
                 float: left;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1470459
- [x] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`: **n/a** just scss changes
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes. **n/a** color change too subtle

#### Description of changes

Using `$secondry-text` color (from this [PR](https://github.com/Microsoft/accessibility-insights-web/pull/275))

#### Notes for reviewers

**n/a**
