### PR TITLE
[Bug Fix: 1448707] Add scan complete alert to be read by AT

### DIFF
--- a/src/DetailsView/components/test-step-view.tsx
+++ b/src/DetailsView/components/test-step-view.tsx
@@ -76,6 +76,7 @@ export class TestStepView extends React.Component<TestStepViewProps> {
 
         return (
             <React.Fragment>
+                {this.renderScanCompleteAlert()}
                 <h3 className="test-step-instances-header">Instances</h3>
                 <AssessmentInstanceTable
                     instancesMap={this.props.instancesMap}
@@ -90,6 +91,11 @@ export class TestStepView extends React.Component<TestStepViewProps> {
         );
     }
 
+    private renderScanCompleteAlert() {
+        if (!this.props.testStep.isManual && this.props.isStepScanned) {
+            return <div role="alert" aria-live="polite" aria-label="Scan Complete" />;
+        }
+    }
     private getSelectedStep(): Readonly<TestStep> {
         return this.props.assessmentsProvider.getStep(
             this.props.assessmentNavState.selectedTestType,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/test-step-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/test-step-view.test.tsx.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TestStepViewTest render snapshot matches with manual false and scanning is finished 1`] = `
+"<div className=\\"test-step-view\\">
+  <div className=\\"test-step-title-container\\">
+    <h3 className=\\"test-step-view-title\\">
+      Test Step Test Name
+    </h3>
+    <ContentPanelButton deps={[undefined]} reference={[undefined]} iconName=\\"info\\">
+      Info &amp; examples
+    </ContentPanelButton>
+  </div>
+  <CollapsibleComponent header={{...}} content={{...}} contentClassName=\\"test-step-instructions\\" />
+  <div role=\\"alert\\" aria-live=\\"polite\\" aria-label=\\"Scan Complete\\" />
+  <h3 className=\\"test-step-instances-header\\">
+    Instances
+  </h3>
+  <AssessmentInstanceTable instancesMap={{...}} assessmentInstanceTableHandler={{...}} assessmentNavState={{...}} renderInstanceTableHeader={[undefined]} getDefaultMessage={[undefined]} assessmentDefaultMessageGenerator={[undefined]} hasVisualHelper={true} />
+</div>"
+`;
+
+exports[`TestStepViewTest render, variable part for assisted test 1`] = `
+"<div className=\\"test-step-view\\">
+  <div className=\\"test-step-title-container\\">
+    <h3 className=\\"test-step-view-title\\">
+      Test Step Test Name
+    </h3>
+    <ContentPanelButton deps={[undefined]} reference={[undefined]} iconName=\\"info\\">
+      Info &amp; examples
+    </ContentPanelButton>
+  </div>
+  <CollapsibleComponent header={{...}} content={{...}} contentClassName=\\"test-step-instructions\\" />
+  <h3 className=\\"test-step-instances-header\\">
+    Instances
+  </h3>
+  <AssessmentInstanceTable instancesMap={{...}} assessmentInstanceTableHandler={{...}} assessmentNavState={{...}} renderInstanceTableHeader={[undefined]} getDefaultMessage={[undefined]} assessmentDefaultMessageGenerator={[undefined]} hasVisualHelper={true} />
+</div>"
+`;

--- a/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
@@ -91,6 +91,8 @@ describe('TestStepViewTest', () => {
         expect(instanceTable.prop('instancesMap')).toEqual(props.instancesMap);
         expect(instanceTable.prop('assessmentInstanceTableHandler')).toEqual(props.assessmentInstanceTableHandler);
         expect(props.assessmentNavState).toEqual(instanceTable.prop('assessmentNavState'));
+
+        expect(wrapper.debug()).toMatchSnapshot();
     });
 
     test('render, variable part for manual test', () => {
@@ -128,6 +130,16 @@ describe('TestStepViewTest', () => {
         const visualHelper = wrapper.find('.toggle-stub');
 
         getVisualHelperToggleMock.verifyAll();
+    });
+
+    test('render snapshot matches with manual false and scanning is finished', () => {
+        const props = TestStepViewPropsBuilder.default(getVisualHelperToggleMock.object)
+            .withIsManual(false)
+            .withStepScanComplete(true)
+            .build();
+
+        const wrapper = Enzyme.shallow(<TestStepView {...props} />);
+        expect(wrapper.debug()).toMatchSnapshot();
     });
 
     function validateManualTestStepView(wrapper: Enzyme.ShallowWrapper, props: TestStepViewProps): void {
@@ -231,6 +243,11 @@ class TestStepViewPropsBuilder extends BaseDataBuilder<TestStepViewProps> {
 
     public withoutInstanceMap(): TestStepViewPropsBuilder {
         this.data.instancesMap = {};
+        return this;
+    }
+
+    public withStepScanComplete(isStepScanned: boolean): TestStepViewPropsBuilder {
+        this.data.isStepScanned = isStepScanned;
         return this;
     }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1448707
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

Whenever we were scanning the dom for a11y issues, the Scanner was announced by NVDA(any screen reader) but it never said anything about scanning completed. 
Added a live region for "automated/assisted (non-manual test steps)" that does that.

Check gif and bug for more context.

#### GIF

![scanning](https://user-images.githubusercontent.com/4496335/53995020-af59d080-40e8-11e9-951d-fcbc09d7f84c.gif)
