### PR TITLE
Bug-fix: the links on launch pad do not disable automated checks if already enabled

### DIFF
--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -260,10 +260,13 @@ export class VisualizationStore extends BaseStore<IVisualizationStoreData> {
             return updated;
         }
 
-        if (payload.pivotType === DetailsViewPivotType.allTest) {
+        if (this.state.selectedAdhocDetailsView !== payload.detailsViewType && payload.pivotType === DetailsViewPivotType.allTest) {
             this.state.selectedAdhocDetailsView = payload.detailsViewType;
             updated = true;
-        } else if (payload.pivotType === DetailsViewPivotType.fastPass) {
+        } else if (
+            this.state.selectedFastPassDetailsView !== payload.detailsViewType &&
+            payload.pivotType === DetailsViewPivotType.fastPass
+        ) {
             this.state.selectedFastPassDetailsView = payload.detailsViewType;
             updated = true;
         }

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -84,28 +84,33 @@ describe('VisualizationStoreTest ', () => {
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onUpdateSelectedPivotChild when view & pivot are the same', () => {
-        const actionName = 'updateSelectedPivotChild';
-        const viewType = VisualizationType.Landmarks;
-        const pivotType = DetailsViewPivotType.allTest;
+    [DetailsViewPivotType.allTest, DetailsViewPivotType.fastPass].forEach(pivotType => {
+        test('onUpdateSelectedPivotChild when view & pivot are the same', () => {
+            const actionName = 'updateSelectedPivotChild';
+            const viewType = VisualizationType.Issues;
 
-        const expectedState = new VisualizationStoreDataBuilder()
-            .with('selectedAdhocDetailsView', viewType)
-            .with('selectedDetailsViewPivot', pivotType)
-            .build();
-        const initialState = new VisualizationStoreDataBuilder()
-            .with('selectedAdhocDetailsView', viewType)
-            .with('selectedDetailsViewPivot', pivotType)
-            .build();
+            const expectedState = new VisualizationStoreDataBuilder()
+                .with('selectedAdhocDetailsView', viewType)
+                .with('selectedDetailsViewPivot', pivotType)
+                .build();
 
-        const payload: UpdateSelectedDetailsViewPayload = {
-            detailsViewType: viewType,
-            pivotType: pivotType,
-        };
+            const initialState = new VisualizationStoreDataBuilder()
+                .with('selectedAdhocDetailsView', viewType)
+                .with('selectedDetailsViewPivot', pivotType)
+                .build();
 
-        createStoreTesterForVisualizationActions(actionName)
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, expectedState);
+            initialState.tests.adhoc[AdHocTestkeys.Issues] = { enabled: true };
+            expectedState.tests.adhoc[AdHocTestkeys.Issues] = { enabled: true };
+
+            const payload: UpdateSelectedDetailsViewPayload = {
+                detailsViewType: viewType,
+                pivotType: pivotType,
+            };
+
+            createStoreTesterForVisualizationActions(actionName)
+                .withActionParam(payload)
+                .testListenerToNeverBeCalled(initialState, expectedState);
+        });
     });
 
     test('onUpdateSelectedPivotChild when view changes to null', () => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1471440
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

Fixes logic in the visualization store where it concluded we were updating the selected test even if that test was already selected in the details view (this would disable other tests).

#### Notes for reviewers

Here is a gif that now shows the correct behavior:
![fixforlaunchpadlinks](https://user-images.githubusercontent.com/32555133/53995453-eb416580-40e9-11e9-9a7e-8c8f7833a4e7.gif)

