### PR TITLE
fix details view link behavior

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -270,11 +270,10 @@ export class ActionCreator {
 
     @autobind
     private onDetailsViewOpen(payload: OnDetailsViewOpenPayload, tabId: number): void {
+        this.onPivotChildSelected(payload, tabId);
         if (this.shouldEnableToggleOnDetailsViewOpen(payload.detailsViewType)) {
             this.enableToggleOnDetailsViewOpen(payload.detailsViewType, tabId);
         }
-
-        this.onPivotChildSelected(payload, tabId);
     }
 
     private shouldEnableToggleOnDetailsViewOpen(visualizationType: VisualizationType): boolean {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.

#### Description of changes
The reason for this bug to happen is that onPivotChildSelected will disable all the tests and enableToggleOnDetailsViewOpen will turn on the actual test. So onPivotChildSelected  should happen before enableToggleOnDetailsViewOpen.
