### PR TITLE
Refactor: tslint remove disable interface name

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -34,13 +34,13 @@ const messages = Messages.Visualizations;
 export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator {
     private windowUtils: WindowUtils;
 
-    constructor(postMessage: (message: IMessage) => void, tabId: number, telemetryFactory: TelemetryDataFactory, windowUtils: WindowUtils) {
+    constructor(postMessage: (message: Message) => void, tabId: number, telemetryFactory: TelemetryDataFactory, windowUtils: WindowUtils) {
         super(postMessage, tabId, telemetryFactory);
         this.windowUtils = windowUtils;
     }
     public updateIssuesSelectedTargets(selectedTargets: string[]): void {
         const payload: string[] = selectedTargets;
-        const message: IMessage = {
+        const message: Message = {
             type: messages.Issues.UpdateSelectedTargets,
             tabId: this._tabId,
             payload,
@@ -135,7 +135,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
 
     public updateFocusedInstanceTarget(instanceTarget: string[]): void {
         const payload: string[] = instanceTarget;
-        const message: IMessage = {
+        const message: Message = {
             type: messages.Issues.UpdateFocusedInstance,
             tabId: this._tabId,
             payload,

--- a/src/DetailsView/components/adhoc-issues-test-view.tsx
+++ b/src/DetailsView/components/adhoc-issues-test-view.tsx
@@ -3,7 +3,7 @@
 import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 
-import { IVisualizationConfiguration, VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration, VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { NamedSFC } from '../../common/react/named-sfc';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { ITabStoreData } from '../../common/types/store-data/itab-store-data';
@@ -31,7 +31,7 @@ export interface AdhocIssuesTestViewProps {
     issuesSelection: ISelection;
     reportGenerator: ReportGenerator;
     issuesTableHandler: IssuesTableHandler;
-    configuration: IVisualizationConfiguration;
+    configuration: VisualizationConfiguration;
 }
 
 export const AdhocIssuesTestView = NamedSFC<AdhocIssuesTestViewProps>('AdhocIssuesTestView', ({ children, ...props }) => {

--- a/src/DetailsView/components/adhoc-static-test-view.tsx
+++ b/src/DetailsView/components/adhoc-static-test-view.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { IVisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
 import { NamedSFC } from '../../common/react/named-sfc';
 import { ITabStoreData } from '../../common/types/store-data/itab-store-data';
 import { IVisualizationStoreData } from '../../common/types/store-data/ivisualization-store-data';
@@ -20,7 +20,7 @@ export interface AdhocStaticTestViewProps {
     selectedTest: VisualizationType;
     visualizationStoreData: IVisualizationStoreData;
     clickHandlerFactory: DetailsViewToggleClickHandlerFactory;
-    configuration: IVisualizationConfiguration;
+    configuration: VisualizationConfiguration;
     content?: ContentReference;
     guidance?: ContentReference;
 }

--- a/src/DetailsView/components/assessment-test-view.tsx
+++ b/src/DetailsView/components/assessment-test-view.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { AssessmentDefaultMessageGenerator } from '../../assessments/assessment-default-message-generator';
 import { IAssessmentsProvider } from '../../assessments/types/iassessments-provider';
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
-import { IVisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
 import { NamedSFC } from '../../common/react/named-sfc';
 import { IAssessmentStoreData } from '../../common/types/store-data/iassessment-result-data';
 import { ITabStoreData } from '../../common/types/store-data/itab-store-data';
@@ -24,7 +24,7 @@ export interface AssessmentTestViewProps {
     assessmentStoreData: IAssessmentStoreData;
     visualizationStoreData: IVisualizationStoreData;
     assessmentInstanceTableHandler: AssessmentInstanceTableHandler;
-    configuration: IVisualizationConfiguration;
+    configuration: VisualizationConfiguration;
 }
 
 export const AssessmentTestView = NamedSFC<AssessmentTestViewProps>('AssessmentTestView', ({ deps, ...props }) => {

--- a/src/DetailsView/components/assessment-view.tsx
+++ b/src/DetailsView/components/assessment-view.tsx
@@ -7,7 +7,7 @@ import { IAssessmentsProvider } from '../../assessments/types/iassessments-provi
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { CollapsibleComponent } from '../../common/components/collapsible-component';
 import { reactExtensionPoint } from '../../common/extensibility/react-extension-point';
-import { ITab } from '../../common/itab';
+import { Tab } from '../../common/itab';
 import { AssessmentNavState, IAssessmentData, PersistedTabInfo } from '../../common/types/store-data/iassessment-result-data';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { ContentLink, ContentLinkDeps } from '../../views/content/content-link';
@@ -39,7 +39,7 @@ export interface AssessmentViewProps {
     assessmentNavState: AssessmentNavState;
     assessmentInstanceTableHandler: AssessmentInstanceTableHandler;
     assessmentData: IAssessmentData;
-    currentTarget: ITab;
+    currentTarget: Tab;
     prevTarget: PersistedTabInfo;
     assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator;
     assessmentTestResult: AssessmentTestResult;

--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -9,7 +9,7 @@ import * as React from 'react';
 
 import * as Markup from '../../assessments/markup';
 import { VisualizationToggle } from '../../common/components/visualization-toggle';
-import { IVisualizationConfiguration, VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration, VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { FeatureFlags } from '../../common/feature-flags';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../common/types/visualization-type';
@@ -54,7 +54,7 @@ export interface IssuesTableState {
 }
 
 export class IssuesTable extends React.Component<IssuesTableProps, IssuesTableState> {
-    private configuration: IVisualizationConfiguration;
+    private configuration: VisualizationConfiguration;
     public static readonly exportTextareaLabel: string = 'Provide result description';
     public static readonly exportInstructions: string = 'Optional: please describe the result (it will be saved in the report).';
 

--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -4,7 +4,7 @@ import { map } from 'lodash';
 import * as React from 'react';
 
 import { IAssessmentsProvider } from '../../../assessments/types/iassessments-provider';
-import { IVisualizationConfiguration } from '../../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration } from '../../../common/configs/visualization-configuration-factory';
 import { ManualTestStatus, ManualTestStatusData } from '../../../common/types/manual-test-status';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { OutcomeStats, OutcomeTypeSemantic } from '../../reports/components/outcome-type';
@@ -99,7 +99,7 @@ export class LeftNavLinkBuilder {
     }
 
     public buildVisualizationConfigurationLink(
-        configuration: IVisualizationConfiguration,
+        configuration: VisualizationConfiguration,
         onLinkClick: onBaseLeftNavItemClick,
         type: VisualizationType,
         index: number,

--- a/src/DetailsView/components/target-change-dialog.tsx
+++ b/src/DetailsView/components/target-change-dialog.tsx
@@ -11,7 +11,7 @@ import { css } from '@uifabric/utilities';
 import * as Markup from '../../assessments/markup';
 import { BlockingDialog } from '../../common/components/blocking-dialog';
 import { NewTabLink } from '../../common/components/new-tab-link';
-import { ITab } from '../../common/itab';
+import { Tab } from '../../common/itab';
 import { PersistedTabInfo } from '../../common/types/store-data/iassessment-result-data';
 import { UrlParser } from '../../common/url-parser';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
@@ -23,7 +23,7 @@ export type TargetChangeDialogDeps = {
 export interface TargetChangeDialogProps {
     deps: TargetChangeDialogDeps;
     prevTab: PersistedTabInfo;
-    newTab: ITab;
+    newTab: Tab;
     actionMessageCreator: DetailsViewActionMessageCreator;
 }
 
@@ -79,7 +79,7 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
         );
     }
 
-    private renderPreviousTabLink(tab: ITab): JSX.Element {
+    private renderPreviousTabLink(tab: Tab): JSX.Element {
         return (
             <TooltipHost content={tab.url} id={'previous-target-page-link'} calloutProps={{ gapSpace: 0 }}>
                 <NewTabLink role="link" className="target-page-link" href={tab.url}>
@@ -89,7 +89,7 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
         );
     }
 
-    private renderCurrentTabLink(tab: ITab): JSX.Element {
+    private renderCurrentTabLink(tab: Tab): JSX.Element {
         return (
             <TooltipHost content={tab.url} id={'current-target-page-link'} calloutProps={{ gapSpace: 0 }}>
                 <Link
@@ -103,7 +103,7 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
         );
     }
 
-    private showTargetChangeDialog(prevTab: PersistedTabInfo, newTab: ITab): boolean {
+    private showTargetChangeDialog(prevTab: PersistedTabInfo, newTab: Tab): boolean {
         if (isEmpty(prevTab)) {
             return false;
         }
@@ -118,7 +118,7 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
         return this.didTargetTabChanged(prevTab, newTab) || urlChanged === true;
     }
 
-    private didTargetTabChanged(prevTab: PersistedTabInfo, newTab: ITab): boolean {
+    private didTargetTabChanged(prevTab: PersistedTabInfo, newTab: Tab): boolean {
         return prevTab.id !== newTab.id;
     }
 }

--- a/src/DetailsView/components/target-page-changed-view.tsx
+++ b/src/DetailsView/components/target-page-changed-view.tsx
@@ -3,12 +3,12 @@
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import * as React from 'react';
 
-import { IDisplayableVisualizationTypeData } from '../../common/configs/visualization-configuration-factory';
+import { DisplayableVisualizationTypeData } from '../../common/configs/visualization-configuration-factory';
 import { VisualizationType } from '../../common/types/visualization-type';
 
 export interface TargetPageChangedViewProps {
     type: VisualizationType;
-    displayableData: IDisplayableVisualizationTypeData;
+    displayableData: DisplayableVisualizationTypeData;
     toggleClickHandler: (event) => void;
 }
 

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -18,7 +18,7 @@ import { initializeFabricIcons } from '../common/fabric-icons';
 import { getAllFeatureFlagDetails } from '../common/feature-flags';
 import { getInnerTextFromJsxElement } from '../common/get-inner-text-from-jsx-element';
 import { HTMLElementUtils } from '../common/html-element-utils';
-import { ITab } from '../common/itab';
+import { Tab } from '../common/itab';
 import { BugActionMessageCreator } from '../common/message-creators/bug-action-message-creator';
 import { ContentActionMessageCreator } from '../common/message-creators/content-action-message-creator';
 import { DropdownActionMessageCreator } from '../common/message-creators/dropdown-action-message-creator';
@@ -93,7 +93,7 @@ initializeFabricIcons();
 if (isNaN(tabId) === false) {
     chromeAdapter.getTab(
         tabId,
-        (tab: ITab): void => {
+        (tab: Tab): void => {
             if (chromeAdapter.getRuntimeLastError()) {
                 const renderer = createNullifiedRenderer(document, ReactDOM.render);
                 renderer.render();

--- a/src/Devtools/inspect-handler.ts
+++ b/src/Devtools/inspect-handler.ts
@@ -3,7 +3,7 @@
 import { IDevToolsChromeAdapter } from '../background/dev-tools-chrome-adapter';
 import { ConnectionNames } from '../common/constants/connection-names';
 import { IBaseStore } from '../common/istore';
-import { IDevToolsOpenMessage } from '../common/types/dev-tools-open-message';
+import { DevToolsOpenMessage } from '../common/types/dev-tools-open-message';
 import { DevToolState } from '../common/types/store-data/idev-tool-state';
 
 export class InspectHandler {
@@ -31,6 +31,6 @@ export class InspectHandler {
             name: ConnectionNames.devTools,
         });
 
-        backgroundPageConnection.postMessage({ tabId: this._devToolsChromeAdapter.getInspectedWindowTabId() } as IDevToolsOpenMessage);
+        backgroundPageConnection.postMessage({ tabId: this._devToolsChromeAdapter.getInspectedWindowTabId() } as DevToolsOpenMessage);
     }
 }

--- a/src/ad-hoc-visualizations/color/visualization.tsx
+++ b/src/ad-hoc-visualizations/color/visualization.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { AdHocTestkeys } from '../../common/configs/adhoc-test-keys';
 import { TestMode } from '../../common/configs/test-mode';
-import { IVisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
 import { Messages } from '../../common/messages';
 import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
 import { VisualizationType } from '../../common/types/visualization-type';
@@ -16,7 +16,7 @@ import { VisualizationInstanceProcessor } from '../../injected/visualization-ins
 
 const { guidance } = content.color;
 
-export const ColorAdHocVisualization: IVisualizationConfiguration = {
+export const ColorAdHocVisualization: VisualizationConfiguration = {
     getTestView: props => <AdhocStaticTestView {...props} />,
     key: AdHocTestkeys.Color,
     testMode: TestMode.Adhoc,

--- a/src/ad-hoc-visualizations/headings/visualization.tsx
+++ b/src/ad-hoc-visualizations/headings/visualization.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import { AdHocTestkeys } from '../../common/configs/adhoc-test-keys';
 import { TestMode } from '../../common/configs/test-mode';
-import { IVisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
 import { Messages } from '../../common/messages';
 import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
 import { VisualizationType } from '../../common/types/visualization-type';
@@ -17,7 +17,7 @@ import { ScannerUtils } from './../../injected/scanner-utils';
 
 const { guidance } = content.headings;
 
-export const HeadingsAdHocVisualization: IVisualizationConfiguration = {
+export const HeadingsAdHocVisualization: VisualizationConfiguration = {
     getTestView: props => <AdhocStaticTestView {...props} />,
     key: AdHocTestkeys.Headings,
     testMode: TestMode.Adhoc,

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import { AdHocTestkeys } from '../../common/configs/adhoc-test-keys';
 import { TestMode } from '../../common/configs/test-mode';
-import { IVisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
 import { Messages } from '../../common/messages';
 import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
 import { VisualizationType } from '../../common/types/visualization-type';
@@ -14,7 +14,7 @@ import { AdhocIssuesTestView } from '../../DetailsView/components/adhoc-issues-t
 import { VisualizationInstanceProcessor } from '../../injected/visualization-instance-processor';
 import { ScannerUtils } from './../../injected/scanner-utils';
 
-export const IssuesAdHocVisualization: IVisualizationConfiguration = {
+export const IssuesAdHocVisualization: VisualizationConfiguration = {
     key: AdHocTestkeys.Issues,
     testMode: TestMode.Adhoc,
     getTestView: props => <AdhocIssuesTestView {...props} />,

--- a/src/ad-hoc-visualizations/landmarks/visualization.tsx
+++ b/src/ad-hoc-visualizations/landmarks/visualization.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import { AdHocTestkeys } from '../../common/configs/adhoc-test-keys';
 import { TestMode } from '../../common/configs/test-mode';
-import { IVisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
 import { Messages } from '../../common/messages';
 import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
 import { VisualizationType } from '../../common/types/visualization-type';
@@ -16,7 +16,7 @@ import { VisualizationInstanceProcessor } from '../../injected/visualization-ins
 import { ScannerUtils } from './../../injected/scanner-utils';
 
 const { guidance } = content.landmarks;
-export const LandmarksAdHocVisualization: IVisualizationConfiguration = {
+export const LandmarksAdHocVisualization: VisualizationConfiguration = {
     getTestView: props => <AdhocStaticTestView {...props} />,
     key: AdHocTestkeys.Landmarks,
     testMode: TestMode.Adhoc,

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { AdHocTestkeys } from '../../common/configs/adhoc-test-keys';
 import { TestMode } from '../../common/configs/test-mode';
-import { IVisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
 import { Messages } from '../../common/messages';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { generateUID } from '../../common/uid-generator';
@@ -13,7 +13,7 @@ import { AdhocStaticTestView } from '../../DetailsView/components/adhoc-static-t
 import { VisualizationInstanceProcessor } from '../../injected/visualization-instance-processor';
 
 const { guidance, extraGuidance, howToTest } = content.tabstops;
-export const TabStopsAdHocVisualization: IVisualizationConfiguration = {
+export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     getTestView: props => <AdhocStaticTestView content={howToTest} guidance={extraGuidance} {...props} />,
     key: AdHocTestkeys.TabStops,
     testMode: TestMode.Adhoc,

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { AssessmentToggleActionPayload } from '../background/actions/action-payloads';
 import { InstanceIdentifierGenerator } from '../background/instance-identifier-generator';
 import { RequirementComparer } from '../common/assessment/requirement-comparer';
-import { IAssesssmentVisualizationConfiguration } from '../common/configs/visualization-configuration-factory';
+import { AssesssmentVisualizationConfiguration } from '../common/configs/visualization-configuration-factory';
 import { Messages } from '../common/messages';
 import { ManualTestStatus } from '../common/types/manual-test-status';
 import { FeatureFlagStoreData } from '../common/types/store-data/feature-flag-store-data';
@@ -133,7 +133,7 @@ export class AssessmentBuilder {
             return stepConfig.getNotificationMessage(selectorMap);
         };
 
-        const visualizationConfiguration: IAssesssmentVisualizationConfiguration = {
+        const visualizationConfiguration: AssesssmentVisualizationConfiguration = {
             getTestView: props => <AssessmentTestView {...props} />,
             getStoreData: data => data.assessments[`${key}Assessment`],
             enableTest: AssessmentBuilder.enableTest,
@@ -204,7 +204,7 @@ export class AssessmentBuilder {
 
         assessment.executeAssessmentScanPolicy = assessment.executeAssessmentScanPolicy || AssessmentBuilder.nullScanPolicy;
 
-        const visualizationConfiguration: IAssesssmentVisualizationConfiguration = {
+        const visualizationConfiguration: AssesssmentVisualizationConfiguration = {
             getTestView: props => <AssessmentTestView {...props} />,
             getAssessmentData: data => data.assessments[key],
             setAssessmentData: (data, selectorMap, instanceMap) => {
@@ -228,7 +228,7 @@ export class AssessmentBuilder {
             getSwitchToTargetTabOnScan: AssessmentBuilder.getSwitchToTargetTabOnScan(steps),
             getInstanceIdentiferGenerator: AssessmentBuilder.getInstanceIdentifier(steps),
             getUpdateVisibility: AssessmentBuilder.getUpdateVisibility(steps),
-        } as IAssesssmentVisualizationConfiguration;
+        } as AssesssmentVisualizationConfiguration;
 
         AssessmentBuilder.BuildStepsReportDescription(steps);
 

--- a/src/assessments/custom-widgets/test-steps/cues.tsx
+++ b/src/assessments/custom-widgets/test-steps/cues.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../../assessments/common/analyzer-configuration-factory';
-import { ICustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
+import { CustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName } from '../../../content/strings/application';
@@ -63,7 +63,7 @@ export const Cues: TestStep = {
         {
             key: 'cues-info-custom-widgets',
             name: 'Cues',
-            onRender: CustomWidgetsColumnRendererFactory.getWithoutLink<ICustomWidgetPropertyBag>([
+            onRender: CustomWidgetsColumnRendererFactory.getWithoutLink<CustomWidgetPropertyBag>([
                 {
                     propertyName: 'role',
                     displayName: 'Widget role',
@@ -90,12 +90,12 @@ export const Cues: TestStep = {
         },
     ],
     reportInstanceFields: [
-        ReportInstanceField.fromColumnValueBagField<ICustomWidgetPropertyBag>('Widget role', 'role'),
-        ReportInstanceField.fromPropertyBagFunction<ICustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
+        ReportInstanceField.fromColumnValueBagField<CustomWidgetPropertyBag>('Widget role', 'role'),
+        ReportInstanceField.fromPropertyBagFunction<CustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
             getFlatDesignPatternStringFromRole(pb.role),
         ),
-        ReportInstanceField.fromColumnValueBagField<ICustomWidgetPropertyBag>('HTML cues', 'htmlCues'),
-        ReportInstanceField.fromColumnValueBagField<ICustomWidgetPropertyBag>('ARIA cues', 'ariaCues'),
+        ReportInstanceField.fromColumnValueBagField<CustomWidgetPropertyBag>('HTML cues', 'htmlCues'),
+        ReportInstanceField.fromColumnValueBagField<CustomWidgetPropertyBag>('ARIA cues', 'ariaCues'),
     ],
     getAnalyzer: provider =>
         provider.createRuleAnalyzer(

--- a/src/assessments/custom-widgets/test-steps/design-pattern.tsx
+++ b/src/assessments/custom-widgets/test-steps/design-pattern.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../../assessments/common/analyzer-configuration-factory';
 import { NewTabLink } from '../../../common/components/new-tab-link';
-import { ICustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
+import { CustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName } from '../../../content/strings/application';
@@ -52,7 +52,7 @@ export const DesignPattern: TestStep = {
         {
             key: 'design-pattern-info',
             name: 'Design pattern',
-            onRender: CustomWidgetsColumnRendererFactory.getWithLink<ICustomWidgetPropertyBag>([
+            onRender: CustomWidgetsColumnRendererFactory.getWithLink<CustomWidgetPropertyBag>([
                 {
                     propertyName: 'role',
                     displayName: 'Widget role',
@@ -72,11 +72,11 @@ export const DesignPattern: TestStep = {
         },
     ],
     reportInstanceFields: [
-        ReportInstanceField.fromColumnValueBagField<ICustomWidgetPropertyBag>('Widget role', 'role'),
-        ReportInstanceField.fromPropertyBagFunction<ICustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
+        ReportInstanceField.fromColumnValueBagField<CustomWidgetPropertyBag>('Widget role', 'role'),
+        ReportInstanceField.fromPropertyBagFunction<CustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
             getFlatDesignPatternStringFromRole(pb.role),
         ),
-        ReportInstanceField.fromColumnValueBagField<ICustomWidgetPropertyBag>('Accesssible name', 'text'),
+        ReportInstanceField.fromColumnValueBagField<CustomWidgetPropertyBag>('Accesssible name', 'text'),
     ],
     getAnalyzer: provider =>
         provider.createRuleAnalyzer(

--- a/src/assessments/custom-widgets/test-steps/instructions.tsx
+++ b/src/assessments/custom-widgets/test-steps/instructions.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../../assessments/common/analyzer-configuration-factory';
-import { ICustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
+import { CustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName } from '../../../content/strings/application';
@@ -47,7 +47,7 @@ export const Instructions: TestStep = {
         {
             key: 'instruction-info-custom-widgets',
             name: 'Instructions',
-            onRender: CustomWidgetsColumnRendererFactory.getWithoutLink<ICustomWidgetPropertyBag>([
+            onRender: CustomWidgetsColumnRendererFactory.getWithoutLink<CustomWidgetPropertyBag>([
                 {
                     propertyName: 'designPattern',
                     displayName: 'Design pattern',
@@ -67,11 +67,11 @@ export const Instructions: TestStep = {
         },
     ],
     reportInstanceFields: [
-        ReportInstanceField.fromPropertyBagFunction<ICustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
+        ReportInstanceField.fromPropertyBagFunction<CustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
             getFlatDesignPatternStringFromRole(pb.role),
         ),
-        ReportInstanceField.fromColumnValueBagField<ICustomWidgetPropertyBag>('Accessible name', 'text'),
-        ReportInstanceField.fromColumnValueBagField<ICustomWidgetPropertyBag>('Accessible description', 'describedBy'),
+        ReportInstanceField.fromColumnValueBagField<CustomWidgetPropertyBag>('Accessible name', 'text'),
+        ReportInstanceField.fromColumnValueBagField<CustomWidgetPropertyBag>('Accessible description', 'describedBy'),
     ],
     getAnalyzer: provider =>
         provider.createRuleAnalyzer(

--- a/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
+++ b/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../../assessments/common/analyzer-configuration-factory';
-import { ICustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
+import { CustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName } from '../../../content/strings/application';
@@ -50,7 +50,7 @@ export const KeyboardInteraction: TestStep = {
         {
             key: 'keyboard-interaction-info',
             name: 'Keyboard Interaction',
-            onRender: CustomWidgetsColumnRendererFactory.getWithLink<ICustomWidgetPropertyBag>([
+            onRender: CustomWidgetsColumnRendererFactory.getWithLink<CustomWidgetPropertyBag>([
                 {
                     propertyName: 'designPattern',
                     displayName: 'Design pattern',
@@ -65,10 +65,10 @@ export const KeyboardInteraction: TestStep = {
         },
     ],
     reportInstanceFields: [
-        ReportInstanceField.fromPropertyBagFunction<ICustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
+        ReportInstanceField.fromPropertyBagFunction<CustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
             getFlatDesignPatternStringFromRole(pb.role),
         ),
-        ReportInstanceField.fromColumnValueBagField<ICustomWidgetPropertyBag>('Accessible name', 'text'),
+        ReportInstanceField.fromColumnValueBagField<CustomWidgetPropertyBag>('Accessible name', 'text'),
     ],
     getAnalyzer: provider =>
         provider.createRuleAnalyzer(

--- a/src/assessments/custom-widgets/test-steps/label.tsx
+++ b/src/assessments/custom-widgets/test-steps/label.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../../assessments/common/analyzer-configuration-factory';
-import { ICustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
+import { CustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName } from '../../../content/strings/application';
@@ -46,7 +46,7 @@ export const Label: TestStep = {
         {
             key: 'label-info-custom-widgets',
             name: 'Label',
-            onRender: CustomWidgetsColumnRendererFactory.getWithoutLink<ICustomWidgetPropertyBag>([
+            onRender: CustomWidgetsColumnRendererFactory.getWithoutLink<CustomWidgetPropertyBag>([
                 {
                     propertyName: 'designPattern',
                     displayName: 'Design pattern',
@@ -66,11 +66,11 @@ export const Label: TestStep = {
         },
     ],
     reportInstanceFields: [
-        ReportInstanceField.fromPropertyBagFunction<ICustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
+        ReportInstanceField.fromPropertyBagFunction<CustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
             getFlatDesignPatternStringFromRole(pb.role),
         ),
-        ReportInstanceField.fromColumnValueBagField<ICustomWidgetPropertyBag>('Accessible name', 'text'),
-        ReportInstanceField.fromColumnValueBagField<ICustomWidgetPropertyBag>('Accessible description', 'describedBy'),
+        ReportInstanceField.fromColumnValueBagField<CustomWidgetPropertyBag>('Accessible name', 'text'),
+        ReportInstanceField.fromColumnValueBagField<CustomWidgetPropertyBag>('Accessible description', 'describedBy'),
     ],
     getAnalyzer: provider =>
         provider.createRuleAnalyzer(

--- a/src/assessments/custom-widgets/test-steps/role-state-property.tsx
+++ b/src/assessments/custom-widgets/test-steps/role-state-property.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../../assessments/common/analyzer-configuration-factory';
 import { NewTabLink } from '../../../common/components/new-tab-link';
-import { ICustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
+import { CustomWidgetPropertyBag } from '../../../common/types/property-bag/icustom-widgets';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName } from '../../../content/strings/application';
@@ -67,7 +67,7 @@ export const RoleStateProperty: TestStep = {
         {
             key: 'role-state-property-info',
             name: 'Role, state, property',
-            onRender: CustomWidgetsColumnRendererFactory.getWithLink<ICustomWidgetPropertyBag>([
+            onRender: CustomWidgetsColumnRendererFactory.getWithLink<CustomWidgetPropertyBag>([
                 {
                     propertyName: 'designPattern',
                     displayName: 'Design pattern',
@@ -82,10 +82,10 @@ export const RoleStateProperty: TestStep = {
         },
     ],
     reportInstanceFields: [
-        ReportInstanceField.fromPropertyBagFunction<ICustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
+        ReportInstanceField.fromPropertyBagFunction<CustomWidgetPropertyBag>('Design pattern', 'designPattern', pb =>
             getFlatDesignPatternStringFromRole(pb.role),
         ),
-        ReportInstanceField.fromColumnValueBagField<ICustomWidgetPropertyBag>('Accessible name', 'text'),
+        ReportInstanceField.fromColumnValueBagField<CustomWidgetPropertyBag>('Accessible name', 'text'),
     ],
     getAnalyzer: provider =>
         provider.createRuleAnalyzer(

--- a/src/assessments/native-widgets/test-steps/cues.tsx
+++ b/src/assessments/native-widgets/test-steps/cues.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../../assessments/common/analyzer-configuration-factory';
-import { ICuesPropertyBag } from '../../../common/types/property-bag/icues';
+import { CuesPropertyBag } from '../../../common/types/property-bag/icues';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName } from '../../../content/strings/application';
@@ -60,7 +60,7 @@ const howToTest: JSX.Element = (
     </div>
 );
 
-const propertyBagConfig: PropertyBagColumnRendererConfig<ICuesPropertyBag>[] = [
+const propertyBagConfig: PropertyBagColumnRendererConfig<CuesPropertyBag>[] = [
     {
         propertyName: 'element',
         displayName: 'Element',
@@ -97,7 +97,7 @@ export const Cues: TestStep = {
         {
             key: 'cues-info',
             name: 'Cues',
-            onRender: PropertyBagColumnRendererFactory.get<ICuesPropertyBag>(propertyBagConfig),
+            onRender: PropertyBagColumnRendererFactory.get<CuesPropertyBag>(propertyBagConfig),
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),

--- a/src/assessments/text-legibility/test-steps/contrast.tsx
+++ b/src/assessments/text-legibility/test-steps/contrast.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { PropertyBagColumnRendererFactory } from '../../../assessments/common/property-bag-column-renderer-factory';
 import { TextLegibilityTestStep } from '../../../assessments/text-legibility/test-steps/test-step';
 import { NewTabLink } from '../../../common/components/new-tab-link';
-import { IContrastPropertyBag } from '../../../common/types/property-bag/icontrast';
+import { ContrastPropertyBag } from '../../../common/types/property-bag/icontrast';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName, windowsPlatformTitle } from '../../../content/strings/application';
@@ -54,7 +54,7 @@ const contrastHowToTest: JSX.Element = (
 
 const key = TextLegibilityTestStep.contrast;
 
-const propertyBagConfig: PropertyBagColumnRendererConfig<IContrastPropertyBag>[] = [
+const propertyBagConfig: PropertyBagColumnRendererConfig<ContrastPropertyBag>[] = [
     {
         propertyName: 'textString',
         displayName: 'Text string',

--- a/src/assessments/types/iassessment.ts
+++ b/src/assessments/types/iassessment.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { RequirementOrdering } from '../../common/assessment/requirement';
-import { IAssesssmentVisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
+import { AssesssmentVisualizationConfiguration } from '../../common/configs/visualization-configuration-factory';
 import { AnyExtension } from '../../common/extensibility/extension-point';
 import { IAssessmentData } from '../../common/types/store-data/iassessment-result-data';
 import { VisualizationType } from '../../common/types/visualization-type';
@@ -25,10 +25,10 @@ export interface ManualAssessment extends BaseAssessment {}
 
 export interface AssistedAssessment extends BaseAssessment {
     storeDataKey: string;
-    visualizationConfiguration?: Partial<IAssesssmentVisualizationConfiguration>;
+    visualizationConfiguration?: Partial<AssesssmentVisualizationConfiguration>;
 }
 
 export interface Assessment extends BaseAssessment {
-    getVisualizationConfiguration: () => IAssesssmentVisualizationConfiguration;
+    getVisualizationConfiguration: () => AssesssmentVisualizationConfiguration;
     requirementOrder: RequirementOrdering;
 }

--- a/src/assessments/types/test-step.ts
+++ b/src/assessments/types/test-step.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 
-import { IUniquelyIdentifiableInstances } from '../../background/instance-identifier-generator';
+import { UniquelyIdentifiableInstances } from '../../background/instance-identifier-generator';
 import { ManualTestStatus } from '../../common/types/manual-test-status';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { AssessmentNavState, IGeneratedAssessmentInstance } from '../../common/types/store-data/iassessment-result-data';
@@ -40,7 +40,7 @@ export interface TestStep {
     getNotificationMessage?: (selectorMap: DictionaryStringTo<any>) => string;
     doNotScanByDefault?: boolean;
     switchToTargetTabOnScan?: boolean;
-    generateInstanceIdentifier?: (instance: IUniquelyIdentifiableInstances) => string;
+    generateInstanceIdentifier?: (instance: UniquelyIdentifiableInstances) => string;
     reportInstanceFields?: ReportInstanceFields;
     renderReportDescription?: () => JSX.Element;
     getInstanceStatus?: (result: DecoratedAxeNodeResult) => ManualTestStatus;

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -37,7 +37,7 @@ export class ActionCreator {
     private visualizationScanResultActions: VisualizationScanResultActions;
     private detailsViewActions: DetailsViewActions;
     private previewFeaturesActions: PreviewFeaturesActions;
-    private registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback;
+    private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
     private detailsViewController: DetailsViewController;
     private chromeFeatureController: ChromeFeatureController;
     private telemetryEventHandler: TelemetryEventHandler;
@@ -55,7 +55,7 @@ export class ActionCreator {
 
     constructor(
         actionHub: ActionHub,
-        registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback,
+        registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
         detailsViewController: DetailsViewController,
         chromeFeatureController: ChromeFeatureController,
         telemetryEventHandler: TelemetryEventHandler,

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -26,13 +26,13 @@ const AssessmentMessages = Messages.Assessment;
 
 export class AssessmentActionCreator {
     private assessmentActions: AssessmentActions;
-    private registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback;
+    private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
     private telemetryEventHandler: TelemetryEventHandler;
 
     constructor(
         assessmentActions: AssessmentActions,
         telemetryEventHandler: TelemetryEventHandler,
-        registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback,
+        registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
     ) {
         this.assessmentActions = assessmentActions;
         this.telemetryEventHandler = telemetryEventHandler;

--- a/src/background/actions/command-actions.ts
+++ b/src/background/actions/command-actions.ts
@@ -2,12 +2,11 @@
 // Licensed under the MIT License.
 import { Action } from '../../common/flux/action';
 
-// tslint:disable-next-line:interface-name
-export interface IGetCommandsPayload {
+export interface GetCommandsPayload {
     commands: chrome.commands.Command[];
     tabId: number;
 }
 
 export class CommandActions {
-    public readonly getCommands = new Action<IGetCommandsPayload>();
+    public readonly getCommands = new Action<GetCommandsPayload>();
 }

--- a/src/background/actions/content-action-creator.ts
+++ b/src/background/actions/content-action-creator.ts
@@ -11,7 +11,7 @@ export class ContentActionCreator {
     constructor(
         private readonly contentActions: ContentActions,
         private readonly telemetryEventHandler: TelemetryEventHandler,
-        private readonly registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback,
+        private readonly registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
         private readonly detailsViewController: DetailsViewController,
     ) {}
 

--- a/src/background/actions/dev-tools-action-creator.ts
+++ b/src/background/actions/dev-tools-action-creator.ts
@@ -9,12 +9,12 @@ import { DevToolActions } from './dev-tools-actions';
 export class DevToolsActionCreator {
     private devtoolActions: DevToolActions;
     private telemetryEventHandler: TelemetryEventHandler;
-    private registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback;
+    private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
 
     constructor(
         devToolsAction: DevToolActions,
         telemetryEventHandler: TelemetryEventHandler,
-        registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback,
+        registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
     ) {
         this.devtoolActions = devToolsAction;
         this.telemetryEventHandler = telemetryEventHandler;

--- a/src/background/actions/global-action-creator.ts
+++ b/src/background/actions/global-action-creator.ts
@@ -16,7 +16,7 @@ import {
     SetLaunchPanelState,
     SetTelemetryStatePayload,
 } from './action-payloads';
-import { CommandActions, IGetCommandsPayload } from './command-actions';
+import { CommandActions, GetCommandsPayload } from './command-actions';
 import { FeatureFlagActions, FeatureFlagPayload } from './feature-flag-actions';
 import { GlobalActionHub } from './global-action-hub';
 import { LaunchPanelStateActions } from './launch-panel-state-action';
@@ -77,7 +77,7 @@ export class GlobalActionCreator {
     @autobind
     private onGetCommands(payload, tabId: number): void {
         this.browserAdapter.getCommands((commands: chrome.commands.Command[]) => {
-            const getCommandsPayload: IGetCommandsPayload = {
+            const getCommandsPayload: GetCommandsPayload = {
                 commands: commands,
                 tabId: tabId,
             };

--- a/src/background/actions/inspect-action-creator.ts
+++ b/src/background/actions/inspect-action-creator.ts
@@ -10,13 +10,13 @@ export class InspectActionCreator {
     private inspectActions: InspectActions;
     private browserAdapter: BrowserAdapter;
     private telemetryEventHandler: TelemetryEventHandler;
-    private registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback;
+    private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
 
     constructor(
         inspectActions: InspectActions,
         telemetryEventHandler: TelemetryEventHandler,
         browserAdapter: BrowserAdapter,
-        registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback,
+        registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
     ) {
         this.inspectActions = inspectActions;
         this.telemetryEventHandler = telemetryEventHandler;

--- a/src/background/actions/inspect-action-creator.ts
+++ b/src/background/actions/inspect-action-creator.ts
@@ -4,7 +4,7 @@ import { Messages } from '../../common/messages';
 import * as TelemetryEvents from '../../common/telemetry-events';
 import { BrowserAdapter } from '../browser-adapter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
-import { IInspectPayload, InspectActions } from './inspect-actions';
+import { InspectPayload, InspectActions } from './inspect-actions';
 
 export class InspectActionCreator {
     private inspectActions: InspectActions;
@@ -25,13 +25,13 @@ export class InspectActionCreator {
     }
 
     public registerCallbacks(): void {
-        this.registerTypeToPayloadCallback(Messages.Inspect.ChangeInspectMode, (payload: IInspectPayload, tabId: number) =>
+        this.registerTypeToPayloadCallback(Messages.Inspect.ChangeInspectMode, (payload: InspectPayload, tabId: number) =>
             this.onChangeInspectMode(payload, tabId),
         );
         this.registerTypeToPayloadCallback(Messages.Inspect.GetCurrentState, () => this.onGetInspectCurrentState());
     }
 
-    private onChangeInspectMode(payload: IInspectPayload, tabId: number): void {
+    private onChangeInspectMode(payload: InspectPayload, tabId: number): void {
         const eventName = TelemetryEvents.CHANGE_INSPECT_MODE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.browserAdapter.switchToTab(tabId);

--- a/src/background/actions/inspect-action-creator.ts
+++ b/src/background/actions/inspect-action-creator.ts
@@ -4,7 +4,7 @@ import { Messages } from '../../common/messages';
 import * as TelemetryEvents from '../../common/telemetry-events';
 import { BrowserAdapter } from '../browser-adapter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
-import { InspectPayload, InspectActions } from './inspect-actions';
+import { InspectActions, InspectPayload } from './inspect-actions';
 
 export class InspectActionCreator {
     private inspectActions: InspectActions;

--- a/src/background/actions/inspect-actions.ts
+++ b/src/background/actions/inspect-actions.ts
@@ -4,13 +4,12 @@ import { Action } from '../../common/flux/action';
 import { InspectMode } from '../inspect-modes';
 import { BaseActionPayload } from './action-payloads';
 
-// tslint:disable-next-line:interface-name
-export interface IInspectPayload extends BaseActionPayload {
+export interface InspectPayload extends BaseActionPayload {
     inspectMode: InspectMode;
 }
 
 export class InspectActions {
-    public readonly changeInspectMode = new Action<IInspectPayload>();
+    public readonly changeInspectMode = new Action<InspectPayload>();
     public readonly getCurrentState = new Action<void>();
     public readonly setHoveredOverSelector = new Action<string[]>();
 }

--- a/src/background/actions/scoping-action-creator.ts
+++ b/src/background/actions/scoping-action-creator.ts
@@ -9,14 +9,14 @@ import { ScopingActions } from './scoping-actions';
 
 export class ScopingActionCreator {
     private scopingActions: ScopingActions;
-    private registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback;
+    private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
     private telemetryEventHandler: TelemetryEventHandler;
     private detailsViewController: DetailsViewController;
 
     constructor(
         scopingActions: ScopingActions,
         telemetryEventHandler: TelemetryEventHandler,
-        registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback,
+        registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
         detailsViewController: DetailsViewController,
     ) {
         this.scopingActions = scopingActions;

--- a/src/background/actions/scoping-actions.ts
+++ b/src/background/actions/scoping-actions.ts
@@ -3,8 +3,7 @@
 import { Action } from '../../common/flux/action';
 import { BaseActionPayload } from './action-payloads';
 
-// tslint:disable-next-line:interface-name
-export interface IScopingPayload extends BaseActionPayload {
+export interface ScopingPayload extends BaseActionPayload {
     inputType: string;
     selector: string[];
 }
@@ -12,7 +11,7 @@ export interface IScopingPayload extends BaseActionPayload {
 export class ScopingActions {
     public readonly openScopingPanel = new Action<void>();
     public readonly closeScopingPanel = new Action<void>();
-    public readonly addSelector = new Action<IScopingPayload>();
-    public readonly deleteSelector = new Action<IScopingPayload>();
+    public readonly addSelector = new Action<ScopingPayload>();
+    public readonly deleteSelector = new Action<ScopingPayload>();
     public readonly getCurrentState = new Action<void>();
 }

--- a/src/background/actions/tab-action-creator.ts
+++ b/src/background/actions/tab-action-creator.ts
@@ -9,12 +9,12 @@ import { TabActions } from './tab-actions';
 
 export class TabActionCreator {
     private tabActions: TabActions;
-    private registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback;
+    private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
     private browserAdapter: BrowserAdapter;
     private telemetryEventHandler: TelemetryEventHandler;
 
     constructor(
-        registerTypeToPayloadCallback: IRegisterTypeToPayloadCallback,
+        registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
         browserAdapter: BrowserAdapter,
         telemetryEventHandler: TelemetryEventHandler,
         tabActions: TabActions,

--- a/src/background/actions/tab-actions.ts
+++ b/src/background/actions/tab-actions.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 import { Action } from '../../common/flux/action';
 
-import { ITab } from '../../common/itab.d';
+import { Tab } from '../../common/itab.d';
 
 export class TabActions {
-    public readonly tabUpdate = new Action<ITab>();
+    public readonly tabUpdate = new Action<Tab>();
     public readonly getCurrentState = new Action();
     public readonly injectedScripts = new Action();
     public readonly tabRemove = new Action();
-    public readonly tabChange = new Action<ITab>();
+    public readonly tabChange = new Action<Tab>();
     public readonly tabVisibilityChange = new Action<boolean>();
 }

--- a/src/background/assessment-data-converter.ts
+++ b/src/background/assessment-data-converter.ts
@@ -13,7 +13,7 @@ import {
     IUserCapturedInstance,
 } from './../common/types/store-data/iassessment-result-data.d';
 import { DecoratedAxeNodeResult, IHtmlElementAxeResults } from './../injected/scanner-utils';
-import { IUniquelyIdentifiableInstances } from './instance-identifier-generator';
+import { UniquelyIdentifiableInstances } from './instance-identifier-generator';
 
 export class AssessmentDataConverter {
     private generateUID: () => string;
@@ -26,7 +26,7 @@ export class AssessmentDataConverter {
         previouslyGeneratedInstances: IAssessmentInstancesMap,
         selectorMap: DictionaryStringTo<IHtmlElementAxeResults>,
         stepName: string,
-        generateInstanceIdentifier: (instance: IUniquelyIdentifiableInstances) => string,
+        generateInstanceIdentifier: (instance: UniquelyIdentifiableInstances) => string,
         getInstanceStatus: (result: DecoratedAxeNodeResult) => ManualTestStatus,
     ): IAssessmentInstancesMap {
         let instancesMap: IAssessmentInstancesMap = {};
@@ -58,7 +58,7 @@ export class AssessmentDataConverter {
         previouslyGeneratedInstances: IAssessmentInstancesMap,
         events: ITabStopEvent[],
         stepName: string,
-        generateInstanceIdentifier: (instance: IUniquelyIdentifiableInstances) => string,
+        generateInstanceIdentifier: (instance: UniquelyIdentifiableInstances) => string,
     ): IAssessmentInstancesMap {
         let instancesMap: IAssessmentInstancesMap = {};
 

--- a/src/background/dev-tools-listener.ts
+++ b/src/background/dev-tools-listener.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { ConnectionNames } from '../common/constants/connection-names';
 import { Messages } from '../common/messages';
-import { IDevToolsOpenMessage } from '../common/types/dev-tools-open-message';
+import { DevToolsOpenMessage } from '../common/types/dev-tools-open-message';
 import { OnDevToolOpenPayload } from './actions/action-payloads';
 import { BrowserAdapter } from './browser-adapter';
 import { TabToContextMap } from './tab-context';
@@ -23,7 +23,7 @@ export class DevToolsListener {
     public initialize() {
         this._chromeAdapter.addListenerOnConnect((devToolsConnection: PortWithTabId) => {
             if (devToolsConnection.name === ConnectionNames.devTools) {
-                const devToolsListener = (message: IDevToolsOpenMessage, port: chrome.runtime.Port) => {
+                const devToolsListener = (message: DevToolsOpenMessage, port: chrome.runtime.Port) => {
                     devToolsConnection.targetPageTabId = message.tabId;
                     this.sendDevToolStatus(devToolsConnection, true);
                 };

--- a/src/background/feature-flags-controller.ts
+++ b/src/background/feature-flags-controller.ts
@@ -28,7 +28,7 @@ export class FeatureFlagsController {
             feature: feature,
             enabled: false,
         };
-        const message: IMessage = {
+        const message: Message = {
             type: Messages.FeatureFlags.SetFeatureFlag,
             payload: payload,
             tabId: null,
@@ -41,7 +41,7 @@ export class FeatureFlagsController {
             feature: feature,
             enabled: true,
         };
-        const message: IMessage = {
+        const message: Message = {
             type: Messages.FeatureFlags.SetFeatureFlag,
             payload: payload,
             tabId: null,
@@ -50,7 +50,7 @@ export class FeatureFlagsController {
     }
 
     public resetFeatureFlags(): void {
-        const message: IMessage = {
+        const message: Message = {
             type: Messages.FeatureFlags.ResetFeatureFlag,
             tabId: null,
         };

--- a/src/background/install-data-generator.ts
+++ b/src/background/install-data-generator.ts
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapter } from './browser-adapter';
-import { IInstallationData } from './installation-data';
+import { InstallationData } from './installation-data';
 import { LocalStorageDataKeys } from './local-storage-data-keys';
 
 export class InstallDataGenerator {
     private generateGuid: () => string;
     private dateGetter: () => Date;
-    private installationData: IInstallationData;
+    private installationData: InstallationData;
     private browserAdapter: BrowserAdapter;
 
     constructor(
-        initialInstallationData: IInstallationData,
+        initialInstallationData: InstallationData,
         generateGuid: () => string,
         dateGetter: () => Date,
         browserAdapter: BrowserAdapter,

--- a/src/background/installation-data.d.ts
+++ b/src/background/installation-data.d.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-// tslint:disable-next-line:interface-name
-export interface IInstallationData {
+export interface InstallationData {
     id: string;
     month: number;
     year: number;

--- a/src/background/instance-identifier-generator.ts
+++ b/src/background/instance-identifier-generator.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-// tslint:disable-next-line:interface-name
-interface IHTMLInstance {
+interface HTMLInstance {
     html: string;
 }
 
@@ -11,7 +10,7 @@ interface ISelectorInstance {
 }
 
 // tslint:disable-next-line:interface-name
-export type IUniquelyIdentifiableInstances = IHTMLInstance & ISelectorInstance;
+export type IUniquelyIdentifiableInstances = HTMLInstance & ISelectorInstance;
 
 // tslint:disable-next-line:interface-name
 export interface IInstanceWithHtmlAndSelector {

--- a/src/background/instance-identifier-generator.ts
+++ b/src/background/instance-identifier-generator.ts
@@ -10,8 +10,7 @@ interface SelectorInstance {
 
 export type UniquelyIdentifiableInstances = HTMLInstance & SelectorInstance;
 
-// tslint:disable-next-line:interface-name
-export interface IInstanceWithHtmlAndSelector {
+export interface InstanceWithHtmlAndSelector {
     html: string;
     target: string[];
 }
@@ -21,7 +20,7 @@ export class InstanceIdentifierGenerator {
         return instance.target.join(';');
     }
 
-    public static defaultHtmlSelectorIdentifier(instance: IInstanceWithHtmlAndSelector): string {
+    public static defaultHtmlSelectorIdentifier(instance: InstanceWithHtmlAndSelector): string {
         return instance.html + ',' + instance.target.join(';');
     }
 }

--- a/src/background/instance-identifier-generator.ts
+++ b/src/background/instance-identifier-generator.ts
@@ -8,8 +8,7 @@ interface SelectorInstance {
     target: string[];
 }
 
-// tslint:disable-next-line:interface-name
-export type IUniquelyIdentifiableInstances = HTMLInstance & SelectorInstance;
+export type UniquelyIdentifiableInstances = HTMLInstance & SelectorInstance;
 
 // tslint:disable-next-line:interface-name
 export interface IInstanceWithHtmlAndSelector {

--- a/src/background/instance-identifier-generator.ts
+++ b/src/background/instance-identifier-generator.ts
@@ -4,13 +4,12 @@ interface HTMLInstance {
     html: string;
 }
 
-// tslint:disable-next-line:interface-name
-interface ISelectorInstance {
+interface SelectorInstance {
     target: string[];
 }
 
 // tslint:disable-next-line:interface-name
-export type IUniquelyIdentifiableInstances = HTMLInstance & ISelectorInstance;
+export type IUniquelyIdentifiableInstances = HTMLInstance & SelectorInstance;
 
 // tslint:disable-next-line:interface-name
 export interface IInstanceWithHtmlAndSelector {
@@ -19,7 +18,7 @@ export interface IInstanceWithHtmlAndSelector {
 }
 
 export class InstanceIdentifierGenerator {
-    public static generateSelectorIdentifier(instance: ISelectorInstance): string {
+    public static generateSelectorIdentifier(instance: SelectorInstance): string {
         return instance.target.join(';');
     }
 

--- a/src/background/interpreter.ts
+++ b/src/background/interpreter.ts
@@ -10,7 +10,7 @@ export class Interpreter {
         this.messageToActionMapping[messageType] = callback;
     }
 
-    public interpret(message: IMessage): boolean {
+    public interpret(message: Message): boolean {
         if (this.messageToActionMapping[message.type]) {
             this.messageToActionMapping[message.type](message.payload, message.tabId);
             return true;

--- a/src/background/interpreter.ts
+++ b/src/background/interpreter.ts
@@ -3,10 +3,10 @@
 import { autobind } from '@uifabric/utilities';
 
 export class Interpreter {
-    protected messageToActionMapping: DictionaryStringTo<IPayloadCallback> = {};
+    protected messageToActionMapping: DictionaryStringTo<PayloadCallback> = {};
 
     @autobind
-    public registerTypeToPayloadCallback(messageType: string, callback: IPayloadCallback): void {
+    public registerTypeToPayloadCallback(messageType: string, callback: PayloadCallback): void {
         this.messageToActionMapping[messageType] = callback;
     }
 

--- a/src/background/message-distributor.ts
+++ b/src/background/message-distributor.ts
@@ -4,13 +4,13 @@ import { autobind } from '@uifabric/utilities';
 
 import { createDefaultLogger } from '../common/logging/default-logger';
 import { Logger } from '../common/logging/logger';
-import { ITab } from './../common/itab.d';
+import { Tab } from './../common/itab.d';
 import { BrowserAdapter } from './browser-adapter';
 import { GlobalContext } from './global-context';
 import { TabToContextMap } from './tab-context';
 
 export interface Sender {
-    tab?: ITab;
+    tab?: Tab;
 }
 
 export class MessageDistributor {

--- a/src/background/message-distributor.ts
+++ b/src/background/message-distributor.ts
@@ -26,7 +26,7 @@ export class MessageDistributor {
     }
 
     @autobind
-    private distributeMessage(message: IMessage, sender?: Sender) {
+    private distributeMessage(message: Message, sender?: Sender) {
         message.tabId = this.getTabId(message, sender);
 
         const isInterpretedUsingGlobalContext = this.globalContext.interpreter.interpret(message);
@@ -37,7 +37,7 @@ export class MessageDistributor {
         }
     }
 
-    private getTabId(message: IMessage, sender?: Sender): number {
+    private getTabId(message: Message, sender?: Sender): number {
         if (message != null && message.tabId != null) {
             return message.tabId;
         } else if (sender != null && sender.tab != null && sender.tab.id != null) {
@@ -47,7 +47,7 @@ export class MessageDistributor {
         return null;
     }
 
-    private tryInterpretUsingTabContext(message: IMessage) {
+    private tryInterpretUsingTabContext(message: Message) {
         let hasInterpreted: boolean;
         const tabContext = this.tabToContextMap[message.tabId];
 

--- a/src/background/storage-data.d.ts
+++ b/src/background/storage-data.d.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FeatureFlagStoreData } from './../types/store-data/feature-flag-store-data.d';
-import { IInstallationData } from './installation-data';
+import { InstallationData } from './installation-data';
 
 // tslint:disable-next-line:interface-name
 export interface ILocalStorageData {
     url?: string;
     featureFlags?: FeatureFlagStoreData;
     launchPanelSetting?: LaunchPanelType;
-    installationData?: IInstallationData;
+    installationData?: InstallationData;
 }

--- a/src/background/stores/global/command-store.ts
+++ b/src/background/stores/global/command-store.ts
@@ -5,7 +5,7 @@ import { autobind } from '@uifabric/utilities';
 import { StoreNames } from '../../../common/stores/store-names';
 import { ModifiedCommandsTelemetryData, SHORTCUT_MODIFIED } from '../../../common/telemetry-events';
 import { ICommandStoreData } from '../../../common/types/store-data/icommand-store-data';
-import { CommandActions, IGetCommandsPayload } from '../../actions/command-actions';
+import { CommandActions, GetCommandsPayload } from '../../actions/command-actions';
 import { TelemetryEventHandler } from '../../telemetry/telemetry-event-handler';
 import { BaseStore } from '../base-store';
 
@@ -33,7 +33,7 @@ export class CommandStore extends BaseStore<ICommandStoreData> {
     }
 
     @autobind
-    private onGetCommands(payload: IGetCommandsPayload): void {
+    private onGetCommands(payload: GetCommandsPayload): void {
         const modifiedCommands: chrome.commands.Command[] = this.getModifiedCommands(payload.commands);
         if (modifiedCommands.length > 0) {
             const telemetry: ModifiedCommandsTelemetryData = {

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -9,7 +9,7 @@ import { BrowserAdapter } from '../../browser-adapter';
 import { PersistedData } from '../../get-persisted-data';
 import { ILocalStorageData } from '../../storage-data';
 import { TelemetryEventHandler } from '../../telemetry/telemetry-event-handler';
-import { IStoreHub } from '../istore-hub';
+import { StoreHub } from '../istore-hub';
 import { IAssessmentsProvider } from './../../../assessments/types/iassessments-provider';
 import { AssessmentDataConverter } from './../../assessment-data-converter';
 import { AssessmentDataRemover } from './../../assessment-data-remover';
@@ -20,7 +20,7 @@ import { LaunchPanelStore } from './launch-panel-store';
 import { ScopingStore } from './scoping-store';
 import { UserConfigurationStore } from './user-configuration-store';
 
-export class GlobalStoreHub implements IStoreHub {
+export class GlobalStoreHub implements StoreHub {
     public commandStore: CommandStore;
     public featureFlagStore: FeatureFlagStore;
     public launchPanelStore: LaunchPanelStore;

--- a/src/background/stores/global/scoping-store.ts
+++ b/src/background/stores/global/scoping-store.ts
@@ -6,7 +6,7 @@ import * as _ from 'lodash/index';
 import { StoreNames } from '../../../common/stores/store-names';
 import { IScopingStoreData } from '../../../common/types/store-data/scoping-store-data';
 import { BaseStore } from '../base-store';
-import { ScopingPayload, ScopingActions } from './../../actions/scoping-actions';
+import { ScopingActions, ScopingPayload } from './../../actions/scoping-actions';
 import { ScopingInputTypes } from './../../scoping-input-types';
 
 export class ScopingStore extends BaseStore<IScopingStoreData> {

--- a/src/background/stores/global/scoping-store.ts
+++ b/src/background/stores/global/scoping-store.ts
@@ -6,7 +6,7 @@ import * as _ from 'lodash/index';
 import { StoreNames } from '../../../common/stores/store-names';
 import { IScopingStoreData } from '../../../common/types/store-data/scoping-store-data';
 import { BaseStore } from '../base-store';
-import { IScopingPayload, ScopingActions } from './../../actions/scoping-actions';
+import { ScopingPayload, ScopingActions } from './../../actions/scoping-actions';
 import { ScopingInputTypes } from './../../scoping-input-types';
 
 export class ScopingStore extends BaseStore<IScopingStoreData> {
@@ -37,7 +37,7 @@ export class ScopingStore extends BaseStore<IScopingStoreData> {
     }
 
     @autobind
-    private onAddSelector(payload: IScopingPayload): void {
+    private onAddSelector(payload: ScopingPayload): void {
         let shouldUpdate: boolean = true;
         _.forEach(Object.keys(this.state.selectors[payload.inputType]), key => {
             if (_.isEqual(this.state.selectors[payload.inputType][key], payload.selector)) {
@@ -52,7 +52,7 @@ export class ScopingStore extends BaseStore<IScopingStoreData> {
     }
 
     @autobind
-    private onDeleteSelector(payload: IScopingPayload): void {
+    private onDeleteSelector(payload: ScopingPayload): void {
         _.forEach(Object.keys(this.state.selectors[payload.inputType]), key => {
             if (_.isEqual(this.state.selectors[payload.inputType][key], payload.selector)) {
                 this.state.selectors[payload.inputType].splice(key, 1);

--- a/src/background/stores/inspect-store.ts
+++ b/src/background/stores/inspect-store.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
-
 import { StoreNames } from '../../common/stores/store-names';
 import { IInspectStoreData } from '../../common/types/store-data/inspect-store-data';
-import { InspectPayload, InspectActions } from '../actions/inspect-actions';
+import { InspectActions, InspectPayload } from '../actions/inspect-actions';
 import { TabActions } from '../actions/tab-actions';
 import { InspectMode } from '../inspect-modes';
 import { BaseStore } from './base-store';

--- a/src/background/stores/inspect-store.ts
+++ b/src/background/stores/inspect-store.ts
@@ -4,7 +4,7 @@ import { autobind } from '@uifabric/utilities';
 
 import { StoreNames } from '../../common/stores/store-names';
 import { IInspectStoreData } from '../../common/types/store-data/inspect-store-data';
-import { IInspectPayload, InspectActions } from '../actions/inspect-actions';
+import { InspectPayload, InspectActions } from '../actions/inspect-actions';
 import { TabActions } from '../actions/tab-actions';
 import { InspectMode } from '../inspect-modes';
 import { BaseStore } from './base-store';
@@ -37,7 +37,7 @@ export class InspectStore extends BaseStore<IInspectStoreData> {
     }
 
     @autobind
-    private onChangeInspectMode(payload: IInspectPayload): void {
+    private onChangeInspectMode(payload: InspectPayload): void {
         this.state.inspectMode = payload.inspectMode;
         this.state.hoveredOverSelector = null;
         this.emitChanged();

--- a/src/background/stores/istore-hub.d.ts
+++ b/src/background/stores/istore-hub.d.ts
@@ -3,8 +3,7 @@
 import { IBaseStore } from '../../common/istore';
 import { StoreType } from '../../common/types/store-type';
 
-// tslint:disable-next-line:interface-name
-export interface IStoreHub {
+export interface StoreHub {
     getAllStores(): IBaseStore<any>[];
     getStoreType(): StoreType;
 }

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -7,12 +7,12 @@ import { ActionHub } from '../actions/action-hub';
 import { DetailsViewStore } from './details-view-store';
 import { DevToolStore } from './dev-tools-store';
 import { InspectStore } from './inspect-store';
-import { IStoreHub } from './istore-hub';
+import { StoreHub } from './istore-hub';
 import { TabStore } from './tab-store';
 import { VisualizationScanResultStore } from './visualization-scan-result-store';
 import { VisualizationStore } from './visualization-store';
 
-export class TabContextStoreHub implements IStoreHub {
+export class TabContextStoreHub implements StoreHub {
     public tabStore: TabStore;
     public visualizationStore: VisualizationStore;
     public visualizationScanResultStore: VisualizationScanResultStore;

--- a/src/background/stores/tab-store.ts
+++ b/src/background/stores/tab-store.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
 
-import { ITab } from '../../common/itab.d';
+import { Tab } from '../../common/itab.d';
 import { StoreNames } from '../../common/stores/store-names';
 import { ITabStoreData } from '../../common/types/store-data/itab-store-data';
 import { TabActions } from '../actions/tab-actions';
@@ -56,7 +56,7 @@ export class TabStore extends BaseStore<ITabStoreData> {
     }
 
     @autobind
-    private onTabUpdate(payload: ITab): void {
+    private onTabUpdate(payload: Tab): void {
         this.state.id = payload.id;
         this.state.title = payload.title;
         this.state.url = payload.url;
@@ -70,7 +70,7 @@ export class TabStore extends BaseStore<ITabStoreData> {
     }
 
     @autobind
-    private onTabChange(payload: ITab): void {
+    private onTabChange(payload: Tab): void {
         this.state.title = payload.title;
         this.state.url = payload.url;
         this.state.isChanged = true;

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -3,7 +3,7 @@
 import { autobind } from '@uifabric/utilities';
 
 import { TestMode } from '../../common/configs/test-mode';
-import { IVisualizationConfiguration, VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration, VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { EnumHelper } from '../../common/enum-helper';
 import { ITab } from '../../common/itab';
 import { StoreNames } from '../../common/stores/store-names';
@@ -186,7 +186,7 @@ export class VisualizationStore extends BaseStore<IVisualizationStoreData> {
         this.emitChanged();
     }
 
-    private isAssessment(config: IVisualizationConfiguration): boolean {
+    private isAssessment(config: VisualizationConfiguration): boolean {
         return config.testMode === TestMode.Assessments;
     }
 

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -5,7 +5,7 @@ import { autobind } from '@uifabric/utilities';
 import { TestMode } from '../../common/configs/test-mode';
 import { VisualizationConfiguration, VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { EnumHelper } from '../../common/enum-helper';
-import { ITab } from '../../common/itab';
+import { Tab } from '../../common/itab';
 import { StoreNames } from '../../common/stores/store-names';
 import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
 import { IAssessmentScanData, IVisualizationStoreData, TestsEnabledState } from '../../common/types/store-data/ivisualization-store-data';
@@ -126,7 +126,7 @@ export class VisualizationStore extends BaseStore<IVisualizationStoreData> {
     }
 
     @autobind
-    private onTabChange(payload: ITab) {
+    private onTabChange(payload: Tab) {
         this.state = {
             ...this.getDefaultState(),
             selectedFastPassDetailsView: this.state.selectedFastPassDetailsView,

--- a/src/background/tab-controller.ts
+++ b/src/background/tab-controller.ts
@@ -148,7 +148,7 @@ export class TabController {
         const payload: PageVisibilityChangeTabPayload = {
             hidden: isHidden,
         };
-        const message: IMessage = {
+        const message: Message = {
             type: Messages.Tab.VisibilityChange,
             payload: payload,
             tabId: tabId,

--- a/src/common/configs/visualization-configuration-factory.ts
+++ b/src/common/configs/visualization-configuration-factory.ts
@@ -57,8 +57,7 @@ export interface AssesssmentVisualizationConfiguration {
     getUpdateVisibility: (testStep?: string) => boolean;
 }
 
-// tslint:disable-next-line:interface-name
-export interface IVisualizationConfiguration extends AssesssmentVisualizationConfiguration {
+export interface VisualizationConfiguration extends AssesssmentVisualizationConfiguration {
     key: string;
     testMode: TestMode;
     featureFlagToEnable?: string;
@@ -77,7 +76,7 @@ export interface IVisualizationConfiguration extends AssesssmentVisualizationCon
 }
 
 export class VisualizationConfigurationFactory {
-    private configurationByType: DictionaryNumberTo<IVisualizationConfiguration>;
+    private configurationByType: DictionaryNumberTo<VisualizationConfiguration>;
 
     constructor() {
         this.configurationByType = {
@@ -93,7 +92,7 @@ export class VisualizationConfigurationFactory {
         return _.find(_.values(this.configurationByType), config => config.key === key);
     }
 
-    public getConfiguration(type: VisualizationType): IVisualizationConfiguration {
+    public getConfiguration(type: VisualizationType): VisualizationConfiguration {
         if (Assessments.isValidType(type)) {
             const assessment = Assessments.forType(type);
             const defaults = {

--- a/src/common/configs/visualization-configuration-factory.ts
+++ b/src/common/configs/visualization-configuration-factory.ts
@@ -27,8 +27,7 @@ import { TelemetryProcessor } from '../types/telemetry-processor';
 import { VisualizationType } from '../types/visualization-type';
 import { TestMode } from './test-mode';
 
-// tslint:disable-next-line:interface-name
-export interface IDisplayableVisualizationTypeData {
+export interface DisplayableVisualizationTypeData {
     title: string;
     enableMessage: string;
     toggleLabel: string;
@@ -68,7 +67,7 @@ export interface IVisualizationConfiguration extends IAssesssmentVisualizationCo
     getStoreData: (data: TestsEnabledState) => IScanData;
     getAssessmentData?: (data: IAssessmentStoreData) => IAssessmentData;
     setAssessmentData?: (data: IAssessmentStoreData, selectorMap: DictionaryStringTo<any>, instanceMap?: DictionaryStringTo<any>) => void;
-    displayableData: IDisplayableVisualizationTypeData;
+    displayableData: DisplayableVisualizationTypeData;
     chromeCommand: string;
     launchPanelDisplayOrder: number;
     adhocToolsPanelDisplayOrder: number;

--- a/src/common/configs/visualization-configuration-factory.ts
+++ b/src/common/configs/visualization-configuration-factory.ts
@@ -34,8 +34,7 @@ export interface DisplayableVisualizationTypeData {
     linkToDetailsViewText: string;
 }
 
-// tslint:disable-next-line:interface-name
-export interface IAssesssmentVisualizationConfiguration {
+export interface AssesssmentVisualizationConfiguration {
     key: string;
     getTestView: (props: TestViewProps) => JSX.Element;
     getStoreData: (data: TestsEnabledState) => IScanData;
@@ -59,7 +58,7 @@ export interface IAssesssmentVisualizationConfiguration {
 }
 
 // tslint:disable-next-line:interface-name
-export interface IVisualizationConfiguration extends IAssesssmentVisualizationConfiguration {
+export interface IVisualizationConfiguration extends AssesssmentVisualizationConfiguration {
     key: string;
     testMode: TestMode;
     featureFlagToEnable?: string;

--- a/src/common/configs/visualization-configuration-factory.ts
+++ b/src/common/configs/visualization-configuration-factory.ts
@@ -9,7 +9,7 @@ import { LandmarksAdHocVisualization } from '../../ad-hoc-visualizations/landmar
 import { TabStopsAdHocVisualization } from '../../ad-hoc-visualizations/tab-stops/visualization';
 import { Assessments } from '../../assessments/assessments';
 import { ToggleActionPayload } from '../../background/actions/action-payloads';
-import { IUniquelyIdentifiableInstances } from '../../background/instance-identifier-generator';
+import { UniquelyIdentifiableInstances } from '../../background/instance-identifier-generator';
 import { TestViewProps } from '../../DetailsView/components/test-view';
 import { AnalyzerProvider } from '../../injected/analyzers/analyzer-provider';
 import { IAnalyzer } from '../../injected/analyzers/ianalyzer';
@@ -55,7 +55,7 @@ export interface IAssesssmentVisualizationConfiguration {
     getNotificationMessage: (selectorMap: DictionaryStringTo<any>, testStep?: string) => string;
     getDrawer: (provider: DrawerProvider, testStep?: string) => IDrawer;
     getSwitchToTargetTabOnScan: (testStep?: string) => boolean;
-    getInstanceIdentiferGenerator: (testStep?: string) => (instance: IUniquelyIdentifiableInstances) => string;
+    getInstanceIdentiferGenerator: (testStep?: string) => (instance: UniquelyIdentifiableInstances) => string;
     getUpdateVisibility: (testStep?: string) => boolean;
 }
 

--- a/src/common/iinstruction.d.ts
+++ b/src/common/iinstruction.d.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-// tslint:disable-next-line:interface-name
-export interface IInstruction {
+export interface Instruction {
     title: string;
     details: string[];
 }

--- a/src/common/itab.d.ts
+++ b/src/common/itab.d.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-// tslint:disable-next-line:interface-name
-export interface ITab {
+export interface Tab {
     id?: number;
     url?: string;
     title?: string;

--- a/src/common/message-creators/base-action-message-creator.ts
+++ b/src/common/message-creators/base-action-message-creator.ts
@@ -5,15 +5,15 @@ import { Messages } from '../messages';
 import { TelemetryData } from '../telemetry-events';
 
 export abstract class BaseActionMessageCreator {
-    private postMessageDelegate: (message: IMessage) => void;
+    private postMessageDelegate: (message: Message) => void;
     protected _tabId: number;
 
-    constructor(postMessage: (message: IMessage) => void, tabId: number) {
+    constructor(postMessage: (message: Message) => void, tabId: number) {
         this.postMessageDelegate = postMessage;
         this._tabId = tabId;
     }
 
-    protected dispatchMessage(message: IMessage): void {
+    protected dispatchMessage(message: Message): void {
         this.postMessageDelegate(message);
     }
 
@@ -29,7 +29,7 @@ export abstract class BaseActionMessageCreator {
             eventName: eventName,
             telemetry: eventData,
         };
-        const message: IMessage = {
+        const message: Message = {
             type: Messages.Telemetry.Send,
             payload,
         };

--- a/src/common/message-creators/bug-action-message-creator.ts
+++ b/src/common/message-creators/bug-action-message-creator.ts
@@ -8,7 +8,7 @@ import { BaseActionMessageCreator } from './base-action-message-creator';
 
 export class BugActionMessageCreator extends BaseActionMessageCreator {
     constructor(
-        postMessage: (message: IMessage) => void,
+        postMessage: (message: Message) => void,
         tabId: number,
         private telemetryFactory: TelemetryDataFactory,
         private source: TelemetryEventSource,

--- a/src/common/message-creators/content-action-message-creator.ts
+++ b/src/common/message-creators/content-action-message-creator.ts
@@ -16,7 +16,7 @@ export class ContentActionMessageCreator extends BaseActionMessageCreator {
     };
 
     constructor(
-        postMessage: (message: IMessage) => void,
+        postMessage: (message: Message) => void,
         tabId: number,
         private readonly telemetryFactory: TelemetryDataFactory,
         private readonly source: TelemetryEventSource,

--- a/src/common/message-creators/dev-tool-action-message-creator.ts
+++ b/src/common/message-creators/dev-tool-action-message-creator.ts
@@ -8,13 +8,13 @@ import { TelemetryDataFactory } from '../telemetry-data-factory';
 export class DevToolActionMessageCreator extends BaseActionMessageCreator {
     protected telemetryFactory: TelemetryDataFactory;
 
-    constructor(postMessage: (message: IMessage) => void, tabId: number, telemetryFactory: TelemetryDataFactory) {
+    constructor(postMessage: (message: Message) => void, tabId: number, telemetryFactory: TelemetryDataFactory) {
         super(postMessage, tabId);
         this.telemetryFactory = telemetryFactory;
     }
 
     public setDevToolStatus(status: boolean) {
-        const message: IMessage = {
+        const message: Message = {
             tabId: this._tabId,
             type: Messages.DevTools.DevtoolStatus,
             payload: {
@@ -30,7 +30,7 @@ export class DevToolActionMessageCreator extends BaseActionMessageCreator {
             target: target,
             telemetry: this.telemetryFactory.forInspectElement(event, target),
         };
-        const message: IMessage = {
+        const message: Message = {
             tabId: this._tabId,
             type: Messages.DevTools.InspectElement,
             payload,
@@ -43,7 +43,7 @@ export class DevToolActionMessageCreator extends BaseActionMessageCreator {
         const payload: InspectFrameUrlPayload = {
             frameUrl: frameUrl,
         };
-        const message: IMessage = {
+        const message: Message = {
             tabId: this._tabId,
             type: Messages.DevTools.InspectFrameUrl,
             payload,

--- a/src/common/message-creators/dropdown-action-message-creator.ts
+++ b/src/common/message-creators/dropdown-action-message-creator.ts
@@ -9,7 +9,7 @@ import { BaseActionMessageCreator } from './base-action-message-creator';
 export class DropdownActionMessageCreator extends BaseActionMessageCreator {
     private telemetryFactory: TelemetryDataFactory;
 
-    constructor(postMessage: (message: IMessage) => void, tabId: number, telemetryFactory: TelemetryDataFactory) {
+    constructor(postMessage: (message: Message) => void, tabId: number, telemetryFactory: TelemetryDataFactory) {
         super(postMessage, tabId);
         this.telemetryFactory = telemetryFactory;
     }

--- a/src/common/message-creators/inspect-action-message-creator.ts
+++ b/src/common/message-creators/inspect-action-message-creator.ts
@@ -13,7 +13,7 @@ export class InspectActionMessageCreator extends BaseActionMessageCreator {
     private source: TelemetryEventSource;
 
     constructor(
-        postMessage: (message: IMessage) => void,
+        postMessage: (message: Message) => void,
         tabId: number,
         telemetryFactory: TelemetryDataFactory,
         source: TelemetryEventSource,

--- a/src/common/message-creators/inspect-action-message-creator.ts
+++ b/src/common/message-creators/inspect-action-message-creator.ts
@@ -4,7 +4,7 @@ import { autobind } from '@uifabric/utilities';
 import { InspectMode } from '../../background/inspect-modes';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
-import { IInspectPayload } from './../../background/actions/inspect-actions';
+import { InspectPayload } from './../../background/actions/inspect-actions';
 import { TelemetryEventSource } from './../telemetry-events';
 import { BaseActionMessageCreator } from './base-action-message-creator';
 
@@ -27,7 +27,7 @@ export class InspectActionMessageCreator extends BaseActionMessageCreator {
     public changeInspectMode(event: React.MouseEvent<HTMLElement> | MouseEvent, inspectMode: InspectMode): void {
         const type = Messages.Inspect.ChangeInspectMode;
         const telemetry = this.telemetryFactory.withTriggeredByAndSource(event, this.source);
-        const payload: IInspectPayload = {
+        const payload: InspectPayload = {
             inspectMode,
             telemetry,
         };

--- a/src/common/message-creators/scoping-action-message-creator.ts
+++ b/src/common/message-creators/scoping-action-message-creator.ts
@@ -12,7 +12,7 @@ export class ScopingActionMessageCreator extends BaseActionMessageCreator {
     private source: TelemetryEventSource;
 
     constructor(
-        postMessage: (message: IMessage) => void,
+        postMessage: (message: Message) => void,
         tabId: number,
         telemetryFactory: TelemetryDataFactory,
         source: TelemetryEventSource,

--- a/src/common/message-creators/scoping-action-message-creator.ts
+++ b/src/common/message-creators/scoping-action-message-creator.ts
@@ -3,7 +3,7 @@
 import { autobind } from '@uifabric/utilities';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
-import { IScopingPayload } from './../../background/actions/scoping-actions';
+import { ScopingPayload } from './../../background/actions/scoping-actions';
 import { TelemetryEventSource } from './../telemetry-events';
 import { BaseActionMessageCreator } from './base-action-message-creator';
 
@@ -26,7 +26,7 @@ export class ScopingActionMessageCreator extends BaseActionMessageCreator {
     public addSelector(event: React.MouseEvent<HTMLElement> | MouseEvent, inputType: string, selector: string[]): void {
         const type = Messages.Scoping.AddSelector;
         const telemetry = this.telemetryFactory.forAddSelector(event, inputType, this.source);
-        const payload: IScopingPayload = {
+        const payload: ScopingPayload = {
             inputType,
             selector,
             telemetry,
@@ -43,7 +43,7 @@ export class ScopingActionMessageCreator extends BaseActionMessageCreator {
     public deleteSelector(event: React.MouseEvent<HTMLElement> | MouseEvent, inputType: string, selector: string[]): void {
         const type = Messages.Scoping.DeleteSelector;
         const telemetry = this.telemetryFactory.forDeleteSelector(event, inputType, this.source);
-        const payload: IScopingPayload = {
+        const payload: ScopingPayload = {
             inputType,
             selector,
             telemetry,

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -5,10 +5,10 @@ import { IStoreActionMessageCreator } from './istore-action-message-creator';
 import { StoreActionMessageCreator } from './store-action-message-creator';
 
 export class StoreActionMessageCreatorFactory {
-    private postMessage: (message: IMessage) => void;
+    private postMessage: (message: Message) => void;
     private tabId: number;
 
-    constructor(postMessage: (message: IMessage) => void, tabId: number) {
+    constructor(postMessage: (message: Message) => void, tabId: number) {
         this.postMessage = postMessage;
         this.tabId = tabId;
     }

--- a/src/common/message-creators/store-action-message-creator.ts
+++ b/src/common/message-creators/store-action-message-creator.ts
@@ -6,7 +6,7 @@ import { IStoreActionMessageCreator } from './istore-action-message-creator';
 export class StoreActionMessageCreator extends BaseActionMessageCreator implements IStoreActionMessageCreator {
     private getStateMessages: string[];
 
-    constructor(messages: string[], postMessage: (message: IMessage) => void, tabId: number) {
+    constructor(messages: string[], postMessage: (message: Message) => void, tabId: number) {
         super(postMessage, tabId);
         this.getStateMessages = messages;
     }

--- a/src/common/message-creators/visualization-action-message-creator.ts
+++ b/src/common/message-creators/visualization-action-message-creator.ts
@@ -14,7 +14,7 @@ export class VisualizationActionMessageCreator extends BaseActionMessageCreator 
             telemetry,
         };
 
-        const message: IMessage = {
+        const message: Message = {
             tabId: this._tabId,
             type: Messages.Visualizations.Common.Toggle,
             payload,

--- a/src/common/message.d.ts
+++ b/src/common/message.d.ts
@@ -6,12 +6,11 @@ interface Message {
     payload?: any;
 }
 
-// tslint:disable-next-line:interface-name
-interface IPayloadCallback {
+interface PayloadCallback {
     (payload: any, tabId): void;
 }
 
 // tslint:disable-next-line:interface-name
 interface IRegisterTypeToPayloadCallback {
-    (messageType: string, callback: IPayloadCallback): void;
+    (messageType: string, callback: PayloadCallback): void;
 }

--- a/src/common/message.d.ts
+++ b/src/common/message.d.ts
@@ -10,7 +10,6 @@ interface PayloadCallback {
     (payload: any, tabId): void;
 }
 
-// tslint:disable-next-line:interface-name
-interface IRegisterTypeToPayloadCallback {
+interface RegisterTypeToPayloadCallback {
     (messageType: string, callback: PayloadCallback): void;
 }

--- a/src/common/message.d.ts
+++ b/src/common/message.d.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-// tslint:disable-next-line:interface-name
-interface IMessage {
+interface Message {
     type: string;
     tabId?: number;
     payload?: any;

--- a/src/common/state-dispatcher.ts
+++ b/src/common/state-dispatcher.ts
@@ -2,16 +2,16 @@
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
 
-import { IStoreHub } from '../background/stores/istore-hub';
+import { StoreHub } from '../background/stores/istore-hub';
 import { GenericStoreMessageTypes } from './constants/generic-store-messages-types';
 import { IBaseStore } from './istore';
 import { StoreUpdateMessage } from './types/store-update-message';
 
 export class StateDispatcher {
     private broadcastMessage: (message: StoreUpdateMessage<any>) => void;
-    private stores: IStoreHub;
+    private stores: StoreHub;
 
-    constructor(broadcastMessage: (message: Object) => void, stores: IStoreHub) {
+    constructor(broadcastMessage: (message: Object) => void, stores: StoreHub) {
         this.broadcastMessage = broadcastMessage;
         this.stores = stores;
     }

--- a/src/common/types/dev-tools-open-message.ts
+++ b/src/common/types/dev-tools-open-message.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-// tslint:disable-next-line:interface-name
-export interface IDevToolsOpenMessage {
+export interface DevToolsOpenMessage {
     tabId: number;
 }

--- a/src/common/types/property-bag/icontrast.d.ts
+++ b/src/common/types/property-bag/icontrast.d.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { ColumnValueBag } from './column-value-bag';
 
-// tslint:disable-next-line:interface-name
-export interface IContrastPropertyBag extends ColumnValueBag {
+export interface ContrastPropertyBag extends ColumnValueBag {
     textString: string;
     size: string;
 }

--- a/src/common/types/property-bag/icues.d.ts
+++ b/src/common/types/property-bag/icues.d.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { ColumnValueBag } from './column-value-bag';
 
-// tslint:disable-next-line:interface-name
-export interface ICuesPropertyBag extends ColumnValueBag {
+export interface CuesPropertyBag extends ColumnValueBag {
     element: string;
     accessibleName: string;
     htmlCues: BagOf<string>;

--- a/src/common/types/property-bag/icustom-widgets.ts
+++ b/src/common/types/property-bag/icustom-widgets.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { BagOf, ColumnValueBag } from './column-value-bag';
 
-// tslint:disable-next-line:interface-name
-export interface ICustomWidgetPropertyBag extends ColumnValueBag {
+export interface CustomWidgetPropertyBag extends ColumnValueBag {
     role: string;
     text: string; // Accessible name
     describedBy: string; // Accessible description

--- a/src/common/types/store-data/iassessment-result-data.d.ts
+++ b/src/common/types/store-data/iassessment-result-data.d.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 import { VisualizationType } from '../visualization-type';
 import { ManualTestStatusData, ManualTestStatus } from '../manual-test-status';
-import { ITab } from '../../itab';
+import { Tab } from '../../itab';
 
 export type TestStepInstance = IUserCapturedInstance & IGeneratedAssessmentInstance;
 
-export type PersistedTabInfo = ITab & {
+export type PersistedTabInfo = Tab & {
     appRefreshed: boolean;
 };
 // tslint:disable-next-line:interface-name

--- a/src/injected/analyzer-state-update-handler.ts
+++ b/src/injected/analyzer-state-update-handler.ts
@@ -3,7 +3,7 @@
 import { TestMode } from '../common/configs/test-mode';
 import { EnumHelper } from '../common/enum-helper';
 import { VisualizationType } from '../common/types/visualization-type';
-import { IVisualizationConfiguration, VisualizationConfigurationFactory } from './../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration, VisualizationConfigurationFactory } from './../common/configs/visualization-configuration-factory';
 import { IAssessmentScanData, IScanData, IVisualizationStoreData } from './../common/types/store-data/ivisualization-store-data.d';
 
 export class AnalyzerStateUpdateHandler {
@@ -58,7 +58,7 @@ export class AnalyzerStateUpdateHandler {
     }
 
     private isTestTerminated(
-        config: IVisualizationConfiguration,
+        config: VisualizationConfiguration,
         prevState: IVisualizationStoreData,
         currState: IVisualizationStoreData,
         step: string,
@@ -70,7 +70,7 @@ export class AnalyzerStateUpdateHandler {
         return prevState != null && prevEnabled === true && currEnabled === false;
     }
 
-    private getTestKeysFromConfiguration(config: IVisualizationConfiguration, currState: IVisualizationStoreData) {
+    private getTestKeysFromConfiguration(config: VisualizationConfiguration, currState: IVisualizationStoreData) {
         const keys = [];
         if (this.isAssessment(config)) {
             const prevScanState = config.getStoreData(currState.tests) as IAssessmentScanData;
@@ -83,7 +83,7 @@ export class AnalyzerStateUpdateHandler {
         return keys;
     }
 
-    private isAssessment(config: IVisualizationConfiguration) {
+    private isAssessment(config: VisualizationConfiguration) {
         return config.testMode === TestMode.Assessments;
     }
 }

--- a/src/injected/client-view-controller.ts
+++ b/src/injected/client-view-controller.ts
@@ -4,7 +4,7 @@ import { autobind } from '@uifabric/utilities';
 import * as _ from 'lodash/index';
 
 import { TestMode } from '../common/configs/test-mode';
-import { IVisualizationConfiguration, VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration, VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { EnumHelper } from '../common/enum-helper';
 import { FeatureFlagStoreData } from '../common/types/store-data/feature-flag-store-data';
 import { ITabStoreData } from '../common/types/store-data/itab-store-data';
@@ -133,11 +133,11 @@ export class ClientViewController {
         });
     }
 
-    private isAssessment(config: IVisualizationConfiguration) {
+    private isAssessment(config: VisualizationConfiguration) {
         return config.testMode === TestMode.Assessments;
     }
 
-    private isAssessmentDataForCurrentPage(config: IVisualizationConfiguration): boolean {
+    private isAssessmentDataForCurrentPage(config: VisualizationConfiguration): boolean {
         return (
             !this.isAssessment(config) ||
             this.currentAssessmentState.persistedTabInfo === null ||

--- a/src/injected/instance-visibility-checker.ts
+++ b/src/injected/instance-visibility-checker.ts
@@ -73,7 +73,7 @@ export class InstanceVisibilityChecker {
                 };
             });
 
-            const message: IMessage = {
+            const message: Message = {
                 type: Messages.Assessment.UpdateInstanceVisibility,
                 payload: { payloadBatch },
             };

--- a/src/injected/target-page-action-message-creator.ts
+++ b/src/injected/target-page-action-message-creator.ts
@@ -11,7 +11,7 @@ import { TelemetryEventSource } from './../common/telemetry-events';
 export class TargetPageActionMessageCreator extends BaseActionMessageCreator {
     protected telemetryFactory: TelemetryDataFactory;
 
-    constructor(postMessage: (message: IMessage) => void, tabId: number, telemetryFactory: TelemetryDataFactory) {
+    constructor(postMessage: (message: Message) => void, tabId: number, telemetryFactory: TelemetryDataFactory) {
         super(postMessage, tabId);
         this.telemetryFactory = telemetryFactory;
     }

--- a/src/popup/scripts/actions/popup-action-message-creator.ts
+++ b/src/popup/scripts/actions/popup-action-message-creator.ts
@@ -18,12 +18,7 @@ export class PopupActionMessageCreator extends BaseActionMessageCreator {
     private telemetryFactory: TelemetryDataFactory;
     private windowUtils: WindowUtils;
 
-    constructor(
-        postMessage: (message: IMessage) => void,
-        tabId: number,
-        telemetryFactory: TelemetryDataFactory,
-        windowUtils?: WindowUtils,
-    ) {
+    constructor(postMessage: (message: Message) => void, tabId: number, telemetryFactory: TelemetryDataFactory, windowUtils?: WindowUtils) {
         super(postMessage, tabId);
         this.telemetryFactory = telemetryFactory;
         this.windowUtils = windowUtils || new WindowUtils();

--- a/src/popup/scripts/components/diagnostic-view-toggle.tsx
+++ b/src/popup/scripts/components/diagnostic-view-toggle.tsx
@@ -7,10 +7,7 @@ import { IToggle } from 'office-ui-fabric-react/lib/Toggle';
 import * as React from 'react';
 
 import { VisualizationToggle } from '../../../common/components/visualization-toggle';
-import {
-    IVisualizationConfiguration,
-    VisualizationConfigurationFactory,
-} from '../../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration, VisualizationConfigurationFactory } from '../../../common/configs/visualization-configuration-factory';
 import { KeyCodeConstants } from '../../../common/constants/keycode-constants';
 import { FeatureFlags } from '../../../common/feature-flags';
 import { TelemetryEventSource } from '../../../common/telemetry-events';
@@ -41,7 +38,7 @@ export interface DiagnosticViewToggleState {
 }
 
 export class DiagnosticViewToggle extends React.Component<DiagnosticViewToggleProps, DiagnosticViewToggleState> {
-    private configuration: IVisualizationConfiguration;
+    private configuration: VisualizationConfiguration;
     private _toggle: React.RefObject<IToggle> = React.createRef<IToggle>();
     private dom: NodeSelector & Node;
     private _isMounted: boolean;

--- a/src/popup/scripts/target-tab-finder.ts
+++ b/src/popup/scripts/target-tab-finder.ts
@@ -3,12 +3,12 @@
 import { autobind } from '@uifabric/utilities';
 
 import { BrowserAdapter } from '../../background/browser-adapter';
-import { ITab } from '../../common/itab';
+import { Tab } from '../../common/itab';
 import { UrlParser } from '../../common/url-parser';
 import { UrlValidator } from '../../common/url-validator';
 
 export interface TargetTabInfo {
-    tab: ITab;
+    tab: Tab;
     hasAccess: boolean;
 }
 
@@ -26,7 +26,7 @@ export class TargetTabFinder {
     }
 
     @autobind
-    private getTabInfo(): Promise<ITab> {
+    private getTabInfo(): Promise<Tab> {
         return new Promise((resolve, reject) => {
             const tabIdInUrl = this.urlParser.getIntParam(this.win.location.href, 'tabId');
 
@@ -36,12 +36,12 @@ export class TargetTabFinder {
                         active: true,
                         currentWindow: true,
                     },
-                    (tabs: ITab[]): void => {
+                    (tabs: Tab[]): void => {
                         resolve(tabs.pop());
                     },
                 );
             } else {
-                this.browserAdapter.getTab(tabIdInUrl, (tab: ITab) => {
+                this.browserAdapter.getTab(tabIdInUrl, (tab: Tab) => {
                     resolve(tab);
                 });
             }
@@ -49,7 +49,7 @@ export class TargetTabFinder {
     }
 
     @autobind
-    private async createTargetTabInfo(tab: ITab): Promise<TargetTabInfo> {
+    private async createTargetTabInfo(tab: Tab): Promise<TargetTabInfo> {
         const hasAccess = await this.urlValidator.isSupportedUrl(tab.url, this.browserAdapter);
         const targetTab: TargetTabInfo = {
             tab: tab,

--- a/src/tests/unit/common/test-assessment-provider.tsx
+++ b/src/tests/unit/common/test-assessment-provider.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { AssessmentsProvider } from '../../../assessments/assessments-provider';
 import { Assessment } from '../../../assessments/types/iassessment';
 import { RequirementComparer } from '../../../common/assessment/requirement-comparer';
-import { IAssesssmentVisualizationConfiguration } from '../../../common/configs/visualization-configuration-factory';
+import { AssesssmentVisualizationConfiguration } from '../../../common/configs/visualization-configuration-factory';
 import { FeatureFlags } from '../../../common/feature-flags';
 import { ManualTestStatus } from '../../../common/types/manual-test-status';
 import { VisualizationType } from '../../../common/types/visualization-type';
@@ -75,7 +75,7 @@ const assessmentWithColumns: Assessment = {
     getVisualizationConfiguration: () => {
         return {
             getAssessmentData: data => data.assessments['assessment-1'],
-        } as IAssesssmentVisualizationConfiguration;
+        } as AssesssmentVisualizationConfiguration;
     },
     requirementOrder: RequirementComparer.byOrdinal,
 };
@@ -110,7 +110,7 @@ const simpleAssessment = {
     getVisualizationConfiguration: () => {
         return {
             getAssessmentData: data => data.assessments['assessment-2'],
-        } as IAssesssmentVisualizationConfiguration;
+        } as AssesssmentVisualizationConfiguration;
     },
     requirementOrder: RequirementComparer.byOrdinal,
 };
@@ -151,7 +151,7 @@ const automatedAssessment = {
     getVisualizationConfiguration: () => {
         return {
             getAssessmentData: data => data.assessments['assessment-3'],
-        } as IAssesssmentVisualizationConfiguration;
+        } as AssesssmentVisualizationConfiguration;
     },
     requirementOrder: RequirementComparer.byOutcomeAndName,
 };

--- a/src/tests/unit/stubs/details-view-action-message-creator-stub.ts
+++ b/src/tests/unit/stubs/details-view-action-message-creator-stub.ts
@@ -37,7 +37,7 @@ export class DetailsViewActionMessageCreatorStub extends DetailsViewActionMessag
         throw new Error('Method not implemented.');
     }
     protected _tabId: number;
-    protected dispatchMessage(message: IMessage): void {
+    protected dispatchMessage(message: Message): void {
         throw new Error('Method not implemented.');
     }
     protected dispatchType(type: string): void {

--- a/src/tests/unit/stubs/interpreter-stub.ts
+++ b/src/tests/unit/stubs/interpreter-stub.ts
@@ -5,7 +5,7 @@ import { Interpreter } from '../../../background/interpreter';
 export class InterpreterStub extends Interpreter {
     public registerTypeToPayloadCallback(messageType: string, callback: IPayloadCallback): void {}
 
-    public interpret(message: IMessage): boolean {
+    public interpret(message: Message): boolean {
         return false;
     }
 }

--- a/src/tests/unit/stubs/interpreter-stub.ts
+++ b/src/tests/unit/stubs/interpreter-stub.ts
@@ -3,7 +3,7 @@
 import { Interpreter } from '../../../background/interpreter';
 
 export class InterpreterStub extends Interpreter {
-    public registerTypeToPayloadCallback(messageType: string, callback: IPayloadCallback): void {}
+    public registerTypeToPayloadCallback(messageType: string, callback: PayloadCallback): void {}
 
     public interpret(message: Message): boolean {
         return false;

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -87,7 +87,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
             source: testSource,
         };
         const eventStub = {};
-        const expectedMessage: IMessage = {
+        const expectedMessage: Message = {
             type: Messages.Tab.Switch,
             tabId: tabId,
             payload: {

--- a/src/tests/unit/tests/DetailsView/components/adhoc-issues-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/adhoc-issues-test-view.test.tsx
@@ -5,7 +5,7 @@ import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
-import { IDisplayableVisualizationTypeData } from '../../../../../common/configs/visualization-configuration-factory';
+import { DisplayableVisualizationTypeData } from '../../../../../common/configs/visualization-configuration-factory';
 import { ITabStoreData } from '../../../../../common/types/store-data/itab-store-data';
 import { IVisualizationScanResultData } from '../../../../../common/types/store-data/ivisualization-scan-result-data';
 import { IScanData, IVisualizationStoreData, TestsEnabledState } from '../../../../../common/types/store-data/ivisualization-store-data';
@@ -21,7 +21,7 @@ describe('AdhocIssuesTestView', () => {
     let props: AdhocIssuesTestViewProps;
     let getStoreDataMock: IMock<(data: TestsEnabledState) => IScanData>;
     let clickHandlerFactoryMock: IMock<DetailsViewToggleClickHandlerFactory>;
-    let displayableDataStub: IDisplayableVisualizationTypeData;
+    let displayableDataStub: DisplayableVisualizationTypeData;
     let contentStub: JSX.Element;
     let scanDataStub: IScanData;
     let clickHandlerStub: (event: any) => void;
@@ -41,7 +41,7 @@ describe('AdhocIssuesTestView', () => {
         displayableDataStub = {
             title: 'test title',
             toggleLabel: 'test toggle label',
-        } as IDisplayableVisualizationTypeData;
+        } as DisplayableVisualizationTypeData;
         contentStub = {} as JSX.Element;
         scanDataStub = {
             enabled: true,

--- a/src/tests/unit/tests/DetailsView/components/adhoc-static-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/adhoc-static-test-view.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
-import { IDisplayableVisualizationTypeData } from '../../../../../common/configs/visualization-configuration-factory';
+import { DisplayableVisualizationTypeData } from '../../../../../common/configs/visualization-configuration-factory';
 import { IScanData, IVisualizationStoreData, TestsEnabledState } from '../../../../../common/types/store-data/ivisualization-store-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import {
@@ -19,7 +19,7 @@ describe('AdhocStaticTestView', () => {
     let props: AdhocStaticTestViewProps;
     let getStoreDataMock: IMock<(data: TestsEnabledState) => IScanData>;
     let clickHandlerFactoryMock: IMock<DetailsViewToggleClickHandlerFactory>;
-    let displayableDataStub: IDisplayableVisualizationTypeData;
+    let displayableDataStub: DisplayableVisualizationTypeData;
     let scanDataStub: IScanData;
     let clickHandlerStub: (event: any) => void;
     let visualizationStoreDataStub: IVisualizationStoreData;
@@ -31,7 +31,7 @@ describe('AdhocStaticTestView', () => {
         displayableDataStub = {
             title: 'test title',
             toggleLabel: 'test toggle label',
-        } as IDisplayableVisualizationTypeData;
+        } as DisplayableVisualizationTypeData;
         scanDataStub = {
             enabled: true,
         };

--- a/src/tests/unit/tests/DetailsView/components/assessment-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-test-view.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
-import { IVisualizationConfiguration } from '../../../../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration } from '../../../../../common/configs/visualization-configuration-factory';
 import { IAssessmentData, IAssessmentStoreData } from '../../../../../common/types/store-data/iassessment-result-data';
 import { IScanData, IVisualizationStoreData, TestsEnabledState } from '../../../../../common/types/store-data/ivisualization-store-data';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
@@ -24,7 +24,7 @@ describe('AssessmentTestView', () => {
     let visualizationStoreDataStub: IVisualizationStoreData;
     let actionMessageCreatorStub: DetailsViewActionMessageCreator;
     let assessmentInstanceHandlerStub: AssessmentInstanceTableHandler;
-    let configuration: IVisualizationConfiguration;
+    let configuration: VisualizationConfiguration;
     let assessmentStoreDataStub: IAssessmentStoreData;
     let assessmentDataStub: IAssessmentData;
     const selectedTestStep = 'step';
@@ -46,7 +46,7 @@ describe('AssessmentTestView', () => {
             getStoreData: getStoreDataMock.object,
             getAssessmentData: getAssessmentDataMock.object,
             getTestStatus: getTestStatusMock.object,
-        } as IVisualizationConfiguration;
+        } as VisualizationConfiguration;
         assessmentStoreDataStub = {
             assessmentNavState: {
                 selectedTestType: selectedTest,

--- a/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
@@ -6,7 +6,7 @@ import { IMock, Mock, MockBehavior } from 'typemoq';
 import { AssessmentsProvider } from '../../../../../../assessments/assessments-provider';
 import { Assessment } from '../../../../../../assessments/types/iassessment';
 import { IAssessmentsProvider } from '../../../../../../assessments/types/iassessments-provider';
-import { IVisualizationConfiguration } from '../../../../../../common/configs/visualization-configuration-factory';
+import { VisualizationConfiguration } from '../../../../../../common/configs/visualization-configuration-factory';
 import { ManualTestStatus, ManualTestStatusData } from '../../../../../../common/types/manual-test-status';
 import { VisualizationType } from '../../../../../../common/types/visualization-type';
 import { BaseLeftNavLink, onBaseLeftNavItemClick } from '../../../../../../DetailsView/components/base-left-nav';
@@ -99,7 +99,7 @@ describe('LeftNavBuilder', () => {
                 displayableData: {
                     title: titleStub,
                 },
-            } as IVisualizationConfiguration;
+            } as VisualizationConfiguration;
 
             const actual = testSubject.buildVisualizationConfigurationLink(
                 configStub,

--- a/src/tests/unit/tests/DetailsView/components/left-nav/visualization-based-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/visualization-based-left-nav.test.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../../../common/configs/visualization-configuration-factory';
 import { VisualizationType } from '../../../../../../common/types/visualization-type';
@@ -25,7 +25,7 @@ describe('VisualizationBasedLeftNav', () => {
     let onLinkClickStub: onBaseLeftNavItemClick;
     let visualizationsStub: VisualizationType[];
     let configFactoryMock: IMock<VisualizationConfigurationFactory>;
-    let configStub: IVisualizationConfiguration;
+    let configStub: VisualizationConfiguration;
 
     beforeEach(() => {
         visualizationsStub = [-1, -2];
@@ -33,7 +33,7 @@ describe('VisualizationBasedLeftNav', () => {
         configFactoryMock = Mock.ofType(VisualizationConfigurationFactory, MockBehavior.Strict);
         onLinkClickStub = (event, item) => null;
         linkStub = {} as BaseLeftNavLink;
-        configStub = {} as IVisualizationConfiguration;
+        configStub = {} as VisualizationConfiguration;
 
         deps = {
             leftNavLinkBuilder: leftNavLinkBuilderMock.object,

--- a/src/tests/unit/tests/DetailsView/components/target-change-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/target-change-dialog.test.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { BlockingDialog } from '../../../../../common/components/blocking-dialog';
-import { ITab } from '../../../../../common/itab';
+import { Tab } from '../../../../../common/itab';
 import { PersistedTabInfo } from '../../../../../common/types/store-data/iassessment-result-data';
 import { UrlParser } from '../../../../../common/url-parser';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
@@ -47,7 +47,7 @@ describe('TargetChangeDialog test set for prev tab null', () => {
 describe('TargetChangeDialog test sets for same prev tab and newTab values', () => {
     let urlParserMock: IMock<UrlParser>;
     let prevTab: PersistedTabInfo;
-    let newTab: ITab;
+    let newTab: Tab;
 
     beforeEach(() => {
         prevTab = {

--- a/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
@@ -3,7 +3,7 @@
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import * as React from 'react';
 
-import { IDisplayableVisualizationTypeData } from '../../../../../common/configs/visualization-configuration-factory';
+import { DisplayableVisualizationTypeData } from '../../../../../common/configs/visualization-configuration-factory';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { TargetPageChangedView, TargetPageChangedViewProps } from '../../../../../DetailsView/components/target-page-changed-view';
 
@@ -15,7 +15,7 @@ describe('TargetPageChangedView', () => {
         const displayableData = {
             title: 'test title',
             toggleLabel: 'test toggle label',
-        } as IDisplayableVisualizationTypeData;
+        } as DisplayableVisualizationTypeData;
 
         const props: TargetPageChangedViewProps = {
             type: type,

--- a/src/tests/unit/tests/DetailsView/components/test-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-view-container.test.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { It, Mock, MockBehavior } from 'typemoq';
 
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../../common/configs/visualization-configuration-factory';
 import { TestViewContainer, TestViewContainerProps } from '../../../../../DetailsView/components/test-view-container';
@@ -18,7 +18,7 @@ describe('TestViewContainerTest', () => {
 
         const configStub = {
             getTestView: getTestViewMock.object,
-        } as IVisualizationConfiguration;
+        } as VisualizationConfiguration;
 
         const props = {
             tabStoreData: {

--- a/src/tests/unit/tests/DetailsView/details-view-main-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-main-content.test.tsx
@@ -5,7 +5,7 @@ import { IMock, Mock, MockBehavior } from 'typemoq';
 
 import { FeatureFlagStore } from '../../../../background/stores/global/feature-flag-store';
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../common/configs/visualization-configuration-factory';
 import { NamedSFC, ReactSFCWithDisplayName } from '../../../../common/react/named-sfc';
@@ -36,7 +36,7 @@ describe('DetailsViewMainContentTest', () => {
     let clickHandlerFactoryMock: IMock<DetailsViewToggleClickHandlerFactory>;
     let clickHandlerStub: (event: any) => void;
     let getStoreDataMock: IMock<(data: TestsEnabledState) => IScanData>;
-    let configStub: IVisualizationConfiguration;
+    let configStub: VisualizationConfiguration;
     let scanDataStub: IScanData;
     let props: DetailsViewMainContentProps;
     let rightPanelConfig: DetailsRightPanelConfiguration;
@@ -71,7 +71,7 @@ describe('DetailsViewMainContentTest', () => {
             configStub = {
                 getStoreData: getStoreDataMock.object,
                 displayableData: {},
-            } as IVisualizationConfiguration;
+            } as VisualizationConfiguration;
 
             scanDataStub = {
                 enabled: false,
@@ -172,7 +172,7 @@ describe('DetailsViewMainContentTest', () => {
     function setupConfigFactoryMock(
         factoryMock: IMock<VisualizationConfigurationFactory>,
         givenGetStoreDataMock: IMock<(data: TestsEnabledState) => IScanData>,
-        config: IVisualizationConfiguration,
+        config: VisualizationConfiguration,
         scanData: IScanData,
         givenProps: DetailsViewMainContentProps,
     ): void {

--- a/src/tests/unit/tests/DetailsView/handlers/get-document-title.test.ts
+++ b/src/tests/unit/tests/DetailsView/handlers/get-document-title.test.ts
@@ -3,7 +3,7 @@
 import { Mock, MockBehavior } from 'typemoq';
 
 import {
-    IDisplayableVisualizationTypeData,
+    DisplayableVisualizationTypeData,
     IVisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../../common/configs/visualization-configuration-factory';
@@ -14,7 +14,7 @@ describe('getTestViewTitle', () => {
         const configFactory = Mock.ofType(VisualizationConfigurationFactory, MockBehavior.Strict);
         const displayableDataStub = {
             title: 'fake title',
-        } as IDisplayableVisualizationTypeData;
+        } as DisplayableVisualizationTypeData;
         const type = -1;
         const configStub = { displayableData: displayableDataStub } as IVisualizationConfiguration;
 

--- a/src/tests/unit/tests/DetailsView/handlers/get-document-title.test.ts
+++ b/src/tests/unit/tests/DetailsView/handlers/get-document-title.test.ts
@@ -4,7 +4,7 @@ import { Mock, MockBehavior } from 'typemoq';
 
 import {
     DisplayableVisualizationTypeData,
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../../common/configs/visualization-configuration-factory';
 import { getOverviewTitle, getTestViewTitle, GetTestViewTitleProps } from '../../../../../DetailsView/handlers/get-document-title';
@@ -16,7 +16,7 @@ describe('getTestViewTitle', () => {
             title: 'fake title',
         } as DisplayableVisualizationTypeData;
         const type = -1;
-        const configStub = { displayableData: displayableDataStub } as IVisualizationConfiguration;
+        const configStub = { displayableData: displayableDataStub } as VisualizationConfiguration;
 
         configFactory.setup(cf => cf.getConfiguration(type)).returns(() => configStub);
 

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -1028,7 +1028,7 @@ class ActionCreatorValidator {
     private devToolActionsContainerMock = Mock.ofType(DevToolActions);
 
     private contentScriptInjectorStrictMock = Mock.ofType<ContentScriptInjector>(null, MockBehavior.Strict);
-    private registerCallbackMock = Mock.ofInstance((messageType: string, callback: IPayloadCallback) => {});
+    private registerCallbackMock = Mock.ofInstance((messageType: string, callback: PayloadCallback) => {});
     private getManifestMock = Mock.ofInstance(() => {
         return null;
     });

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -13,7 +13,7 @@ import { Messages } from '../../../../../common/messages';
 import * as TelemetryEvents from '../../../../../common/telemetry-events';
 
 describe('AssessmentActionCreatorTest', () => {
-    let registerTypeToPayloadCallbackMock: IMock<IRegisterTypeToPayloadCallback>;
+    let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
     let assessmentActionsMock: IMock<AssessmentActions>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     const tabId = -1;

--- a/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
@@ -15,7 +15,7 @@ describe('DevToolsActionCreatorTest', () => {
     const tabId: number = -1;
     let devtoolActionsMock: IMock<DevToolActions>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
-    let registerTypeToPayloadCallback: IMock<IRegisterTypeToPayloadCallback>;
+    let registerTypeToPayloadCallback: IMock<RegisterTypeToPayloadCallback>;
 
     let testObject: DevToolsActionCreator;
 

--- a/src/tests/unit/tests/background/actions/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/global-action-creator.test.ts
@@ -15,7 +15,7 @@ import { FeatureFlagActions, FeatureFlagPayload } from '../../../../../backgroun
 import { GlobalActionCreator } from '../../../../../background/actions/global-action-creator';
 import { GlobalActionHub } from '../../../../../background/actions/global-action-hub';
 import { LaunchPanelStateActions } from '../../../../../background/actions/launch-panel-state-action';
-import { IScopingPayload, ScopingActions } from '../../../../../background/actions/scoping-actions';
+import { ScopingPayload, ScopingActions } from '../../../../../background/actions/scoping-actions';
 import { UserConfigurationActions } from '../../../../../background/actions/user-configuration-actions';
 import { ChromeAdapter } from '../../../../../background/browser-adapter';
 import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';
@@ -152,7 +152,7 @@ describe('GlobalActionCreatorTest', () => {
 
     test('registerCallback for onAddSelector', () => {
         const actionName = 'addSelector';
-        const payload: IScopingPayload = {
+        const payload: ScopingPayload = {
             inputType: 'generic',
             selector: ['iframe', 'selector'],
         };
@@ -172,7 +172,7 @@ describe('GlobalActionCreatorTest', () => {
 
     test('registerCallback for onDeleteSelector', () => {
         const actionName = 'deleteSelector';
-        const payload: IScopingPayload = {
+        const payload: ScopingPayload = {
             inputType: 'generic',
             selector: ['iframe', 'selector'],
         };

--- a/src/tests/unit/tests/background/actions/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/global-action-creator.test.ts
@@ -15,7 +15,7 @@ import { FeatureFlagActions, FeatureFlagPayload } from '../../../../../backgroun
 import { GlobalActionCreator } from '../../../../../background/actions/global-action-creator';
 import { GlobalActionHub } from '../../../../../background/actions/global-action-hub';
 import { LaunchPanelStateActions } from '../../../../../background/actions/launch-panel-state-action';
-import { ScopingPayload, ScopingActions } from '../../../../../background/actions/scoping-actions';
+import { ScopingActions, ScopingPayload } from '../../../../../background/actions/scoping-actions';
 import { UserConfigurationActions } from '../../../../../background/actions/user-configuration-actions';
 import { ChromeAdapter } from '../../../../../background/browser-adapter';
 import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { InspectActionCreator } from '../../../../../background/actions/inspect-action-creator';
-import { InspectPayload, InspectActions } from '../../../../../background/actions/inspect-actions';
+import { InspectActions, InspectPayload } from '../../../../../background/actions/inspect-actions';
 import { BrowserAdapter, ChromeAdapter } from '../../../../../background/browser-adapter';
 import { InspectMode } from '../../../../../background/inspect-modes';
 import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -16,7 +16,7 @@ describe('InspectActionCreatorTest', () => {
     const tabId: number = -1;
     let inspectActionsMock: IMock<InspectActions>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
-    let registerTypeToPayloadCallbackMock: IMock<IRegisterTypeToPayloadCallback>;
+    let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
     let browserAdapterMock: IMock<BrowserAdapter>;
 
     let testObject: InspectActionCreator;

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -4,7 +4,7 @@ import * as _ from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { InspectActionCreator } from '../../../../../background/actions/inspect-action-creator';
-import { IInspectPayload, InspectActions } from '../../../../../background/actions/inspect-actions';
+import { InspectPayload, InspectActions } from '../../../../../background/actions/inspect-actions';
 import { BrowserAdapter, ChromeAdapter } from '../../../../../background/browser-adapter';
 import { InspectMode } from '../../../../../background/inspect-modes';
 import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';
@@ -47,7 +47,7 @@ describe('InspectActionCreatorTest', () => {
     });
 
     test('onChangeInspectMode', () => {
-        const payload: IInspectPayload = {
+        const payload: InspectPayload = {
             inspectMode: InspectMode.scopingAddInclude,
         };
 

--- a/src/tests/unit/tests/background/actions/scoping-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/scoping-action-creator.test.ts
@@ -13,7 +13,7 @@ import { Messages } from '../../../../../common/messages';
 import { SCOPING_CLOSE, SCOPING_OPEN } from '../../../../../common/telemetry-events';
 
 describe('ScopingActionCreatorTest', () => {
-    let registerTypeToPayloadCallbackMock: IMock<IRegisterTypeToPayloadCallback>;
+    let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
     let scopingActionsMock: IMock<ScopingActions>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let detailsViewControllerStrictMock: IMock<DetailsViewController>;

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -17,7 +17,7 @@ describe('TestActionCreatorTest', () => {
     let tabActionsMock: IMock<TabActions>;
     let browserAdapterMock: IMock<BrowserAdapter>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
-    let registerTypeToPayloadCallbackMock: IMock<IRegisterTypeToPayloadCallback>;
+    let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
     let testObject: TabActionCreator;
     const tabId: number = -1;
     const iTabPayload: Tab = {

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -9,7 +9,7 @@ import { TabActions } from '../../../../../background/actions/tab-actions';
 import { BrowserAdapter, ChromeAdapter } from '../../../../../background/browser-adapter';
 import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';
 import { Action } from '../../../../../common/flux/action';
-import { ITab } from '../../../../../common/itab';
+import { Tab } from '../../../../../common/itab';
 import { Messages } from '../../../../../common/messages';
 import { SWITCH_BACK_TO_TARGET, TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
 
@@ -20,7 +20,7 @@ describe('TestActionCreatorTest', () => {
     let registerTypeToPayloadCallbackMock: IMock<IRegisterTypeToPayloadCallback>;
     let testObject: TabActionCreator;
     const tabId: number = -1;
-    const iTabPayload: ITab = {
+    const iTabPayload: Tab = {
         id: -1,
         url: 'url',
         title: 'title',

--- a/src/tests/unit/tests/background/assessment-data-converter.test.ts
+++ b/src/tests/unit/tests/background/assessment-data-converter.test.ts
@@ -3,7 +3,7 @@
 import { IMock, It, Mock } from 'typemoq';
 
 import { AssessmentDataConverter } from '../../../../background/assessment-data-converter';
-import { IUniquelyIdentifiableInstances } from '../../../../background/instance-identifier-generator';
+import { UniquelyIdentifiableInstances } from '../../../../background/instance-identifier-generator';
 import { ManualTestStatus } from '../../../../common/types/manual-test-status';
 import { IAssessmentInstancesMap, ITestStepResult } from '../../../../common/types/store-data/iassessment-result-data';
 import { DecoratedAxeNodeResult, IHtmlElementAxeResults } from '../../../../injected/scanner-utils';
@@ -24,7 +24,7 @@ describe('AssessmentDataConverterTest', () => {
     let identifierStub: string;
     let selectorStub: string;
     let htmlStub: string;
-    let generateInstanceIdentifierMock: IMock<(instance: IUniquelyIdentifiableInstances) => string>;
+    let generateInstanceIdentifierMock: IMock<(instance: UniquelyIdentifiableInstances) => string>;
 
     beforeEach(() => {
         testSubject = new AssessmentDataConverter(() => uid);
@@ -456,7 +456,7 @@ describe('AssessmentDataConverterTest', () => {
         expect(testSubject.generateFailureInstance(description)).toEqual(expectedResult);
     });
 
-    function setupGenerateInstanceIdentifierMock(instance: IUniquelyIdentifiableInstances, identifier: string): void {
+    function setupGenerateInstanceIdentifierMock(instance: UniquelyIdentifiableInstances, identifier: string): void {
         generateInstanceIdentifierMock.setup(giim => giim(It.isValue(instance))).returns(() => identifier);
     }
 });

--- a/src/tests/unit/tests/background/chrome-command-handler.test.ts
+++ b/src/tests/unit/tests/background/chrome-command-handler.test.ts
@@ -130,7 +130,7 @@ describe('ChromeCommandHandlerTest', () => {
         storeState = new VisualizationStoreDataBuilder().withDisable(visualizationType).build();
         const configuration = visualizationConfigurationFactory.getConfiguration(visualizationType);
 
-        let receivedMessage: IMessage;
+        let receivedMessage: Message;
         interpreterMock
             .setup(x => x.interpret(It.isAny()))
             .returns(message => {
@@ -162,7 +162,7 @@ describe('ChromeCommandHandlerTest', () => {
         storeState = new VisualizationStoreDataBuilder().withEnable(visualizationType).build();
         const configuration = visualizationConfigurationFactory.getConfiguration(visualizationType);
 
-        let receivedMessage: IMessage;
+        let receivedMessage: Message;
         interpreterMock
             .setup(x => x.interpret(It.isAny()))
             .returns(message => {

--- a/src/tests/unit/tests/background/completed-test-step-telemetry-creator.test.ts
+++ b/src/tests/unit/tests/background/completed-test-step-telemetry-creator.test.ts
@@ -36,7 +36,7 @@ function testBeforeAfterAssessmentData(
         interpreterMock.object,
     );
 
-    const expectedMessage: IMessage = {
+    const expectedMessage: Message = {
         type: Messages.Telemetry.Send,
         tabId: 1,
         payload: {
@@ -193,7 +193,7 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
             })
             .verifiable(Times.atLeastOnce());
 
-        const expectedMessage: IMessage = {
+        const expectedMessage: Message = {
             type: Messages.Telemetry.Send,
         };
         interpreterMock.setup(im => im.interpret(It.isValue(expectedMessage))).verifiable(Times.never());
@@ -214,7 +214,7 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
         const interpreterMock = Mock.ofType(Interpreter, MockBehavior.Strict);
         const data = getMockAssessmentStoreDataUnknowns();
         const expectedTelemetry = getMockTelemetryData(-1, 'assessment-1-step-1', true, 1);
-        const expectedMessage: IMessage = {
+        const expectedMessage: Message = {
             type: Messages.Telemetry.Send,
             tabId: 1,
             payload: {

--- a/src/tests/unit/tests/background/dev-tools-listener.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-listener.test.ts
@@ -7,7 +7,7 @@ import { Interpreter } from '../../../../background/interpreter';
 import { TabContext, TabToContextMap } from '../../../../background/tab-context';
 import { ConnectionNames } from '../../../../common/constants/connection-names';
 import { Messages } from '../../../../common/messages';
-import { IDevToolsOpenMessage } from '../../../../common/types/dev-tools-open-message';
+import { DevToolsOpenMessage } from '../../../../common/types/dev-tools-open-message';
 import { ChromeAdapterMock, PortWithTabTabIdStub } from '../../mock-helpers/chrome-adapter-mock';
 import { PortOnDisconnectMock } from '../../mock-helpers/port-on-disconnect-mock';
 import { PortOnMessageMock } from '../../mock-helpers/port-on-message-mock';
@@ -91,7 +91,7 @@ describe('DevToolsListenerTests', () => {
             onDisconnectPortMock.getObject(),
         );
         let connectListenerCB: (port: PortWithTabTabIdStub) => void;
-        let messageListenerCB: (message: IDevToolsOpenMessage, port: chrome.runtime.Port) => void;
+        let messageListenerCB: (message: DevToolsOpenMessage, port: chrome.runtime.Port) => void;
 
         onMessagePortMock.setupAddListenerMock(cb => {
             messageListenerCB = cb;
@@ -138,7 +138,7 @@ describe('DevToolsListenerTests', () => {
             onDisconnectPortMockValidator.getObject(),
         );
         let connectListenerCB: (port: PortWithTabTabIdStub) => void;
-        let disconnectMessageCB: (message: IDevToolsOpenMessage, port: chrome.runtime.Port) => void;
+        let disconnectMessageCB: (message: DevToolsOpenMessage, port: chrome.runtime.Port) => void;
 
         portStub.targetPageTabId = 2;
 

--- a/src/tests/unit/tests/background/feature-flags-controller.test.ts
+++ b/src/tests/unit/tests/background/feature-flags-controller.test.ts
@@ -68,7 +68,7 @@ describe('FeatureFlagsControllerTest', () => {
             feature: feature,
             enabled: false,
         };
-        const message: IMessage = {
+        const message: Message = {
             type: Messages.FeatureFlags.SetFeatureFlag,
             payload: payload,
             tabId: null,
@@ -87,7 +87,7 @@ describe('FeatureFlagsControllerTest', () => {
             feature: feature,
             enabled: true,
         };
-        const message: IMessage = {
+        const message: Message = {
             type: Messages.FeatureFlags.SetFeatureFlag,
             payload: payload,
             tabId: null,
@@ -101,7 +101,7 @@ describe('FeatureFlagsControllerTest', () => {
     });
 
     test('resetFeatureFlags', () => {
-        const message: IMessage = {
+        const message: Message = {
             type: Messages.FeatureFlags.ResetFeatureFlag,
             tabId: null,
         };

--- a/src/tests/unit/tests/background/inspect-store.test.ts
+++ b/src/tests/unit/tests/background/inspect-store.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { InspectPayload, InspectActions } from '../../../../background/actions/inspect-actions';
+import { InspectActions, InspectPayload } from '../../../../background/actions/inspect-actions';
 import { TabActions } from '../../../../background/actions/tab-actions';
 import { InspectMode } from '../../../../background/inspect-modes';
 import { InspectStore } from '../../../../background/stores/inspect-store';

--- a/src/tests/unit/tests/background/inspect-store.test.ts
+++ b/src/tests/unit/tests/background/inspect-store.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IInspectPayload, InspectActions } from '../../../../background/actions/inspect-actions';
+import { InspectPayload, InspectActions } from '../../../../background/actions/inspect-actions';
 import { TabActions } from '../../../../background/actions/tab-actions';
 import { InspectMode } from '../../../../background/inspect-modes';
 import { InspectStore } from '../../../../background/stores/inspect-store';
@@ -32,7 +32,7 @@ describe('InspectStoreTest', () => {
 
     test('on changeMode', () => {
         const initialState = getDefaultState();
-        const payload: IInspectPayload = {
+        const payload: InspectPayload = {
             inspectMode: InspectMode.scopingAddInclude,
         };
 

--- a/src/tests/unit/tests/background/install-data-generator.test.ts
+++ b/src/tests/unit/tests/background/install-data-generator.test.ts
@@ -4,7 +4,7 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { ChromeAdapter } from '../../../../background/browser-adapter';
 import { InstallDataGenerator } from '../../../../background/install-data-generator';
-import { IInstallationData } from '../../../../background/installation-data';
+import { InstallationData } from '../../../../background/installation-data';
 import { LocalStorageDataKeys } from '../../../../background/local-storage-data-keys';
 import { generateUID } from '../../../../common/uid-generator';
 
@@ -37,7 +37,7 @@ describe('InstallDataGeneratorTest', () => {
         const guidStub = 'somestub';
         const monthStub = 5;
         const yearStub = 22;
-        const installationDataStub: IInstallationData = {
+        const installationDataStub: InstallationData = {
             id: guidStub,
             month: monthStub,
             year: yearStub,
@@ -83,12 +83,12 @@ describe('InstallDataGeneratorTest', () => {
         const monthStub = 5;
         const yearStub = 2000;
 
-        const installationDataStub: IInstallationData = {
+        const installationDataStub: InstallationData = {
             id: guidStub,
             month: monthStub,
             year: yearStub,
         };
-        const initialInstallationData: IInstallationData = {
+        const initialInstallationData: InstallationData = {
             id: guidStub,
             month: monthStub,
             year: 1999,
@@ -134,12 +134,12 @@ describe('InstallDataGeneratorTest', () => {
         const monthStub = 5;
         const yearStub = 2000;
 
-        const installationDataStub: IInstallationData = {
+        const installationDataStub: InstallationData = {
             id: guidStub,
             month: monthStub,
             year: yearStub,
         };
-        const initialInstallationData: IInstallationData = {
+        const initialInstallationData: InstallationData = {
             id: guidStub,
             month: 4,
             year: yearStub,

--- a/src/tests/unit/tests/background/message-distributor.test.ts
+++ b/src/tests/unit/tests/background/message-distributor.test.ts
@@ -96,7 +96,7 @@ describe('MessageDistributorTest', () => {
 
     test('should distribute message, when sender has tab id', () => {
         const tabId = 1;
-        const message = { payload: {} } as IMessage;
+        const message = { payload: {} } as Message;
 
         const globalInterpreterMock = createInterpreterMockWithInteraction();
         globalInterpreter = globalInterpreterMock.object;

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -25,7 +25,7 @@ import { ChromeAdapter } from '../../../../../background/browser-adapter';
 import { AssessmentStore } from '../../../../../background/stores/assessment-store';
 import { AssesssmentVisualizationConfiguration } from '../../../../../common/configs/visualization-configuration-factory';
 import { IndexedDBAPI } from '../../../../../common/indexedDB/indexedDB';
-import { ITab } from '../../../../../common/itab';
+import { Tab } from '../../../../../common/itab';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import { DetailsViewPivotType } from '../../../../../common/types/details-view-pivot-type';
 import { ManualTestStatus, ManualTestStatusData, TestStepData } from '../../../../../common/types/manual-test-status';
@@ -424,7 +424,7 @@ describe('AssessmentStoreTest', () => {
         const tabId = 1000;
         const url = 'url';
         const title = 'title';
-        const tab: ITab = {
+        const tab: Tab = {
             id: tabId,
             url,
             title,
@@ -452,7 +452,7 @@ describe('AssessmentStoreTest', () => {
         const tabId = 1000;
         const url = 'url';
         const title = 'title';
-        const tab: ITab = {
+        const tab: Tab = {
             id: tabId,
             url,
             title,
@@ -640,7 +640,7 @@ describe('AssessmentStoreTest', () => {
         const tabId = 1000;
         const url = 'url';
         const title = 'title';
-        const tab: ITab = {
+        const tab: Tab = {
             id: tabId,
             url,
             title,
@@ -661,7 +661,7 @@ describe('AssessmentStoreTest', () => {
 
     test('onUpdateTargetTabId: tab is null', () => {
         const tabId = 1000;
-        const tab: ITab = null;
+        const tab: Tab = null;
         browserMock
             .setup(b => b.getTab(tabId, It.isAny()))
             .returns((id, cb) => cb(tab))

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -23,7 +23,7 @@ import { AssessmentDataConverter } from '../../../../../background/assessment-da
 import { AssessmentDataRemover } from '../../../../../background/assessment-data-remover';
 import { ChromeAdapter } from '../../../../../background/browser-adapter';
 import { AssessmentStore } from '../../../../../background/stores/assessment-store';
-import { IAssesssmentVisualizationConfiguration } from '../../../../../common/configs/visualization-configuration-factory';
+import { AssesssmentVisualizationConfiguration } from '../../../../../common/configs/visualization-configuration-factory';
 import { IndexedDBAPI } from '../../../../../common/indexedDB/indexedDB';
 import { ITab } from '../../../../../common/itab';
 import { StoreNames } from '../../../../../common/stores/store-names';
@@ -55,7 +55,7 @@ let assessmentsProviderMock: IMock<IAssessmentsProvider>;
 let indexDBInstanceMock: IMock<IndexedDBAPI>;
 let assessmentMock: IMock<Assessment>;
 let getInstanceIdentiferGeneratorMock: IMock<(step: string) => Function>;
-let configStub: IAssesssmentVisualizationConfiguration;
+let configStub: AssesssmentVisualizationConfiguration;
 let instanceIdentifierGeneratorStub: (instances) => string;
 
 const assessmentKey: string = 'assessment-1';
@@ -72,7 +72,7 @@ describe('AssessmentStoreTest', () => {
         configStub = {
             getAssessmentData: data => data.assessments[assessmentKey],
             getInstanceIdentiferGenerator: getInstanceIdentiferGeneratorMock.object,
-        } as IAssesssmentVisualizationConfiguration;
+        } as AssesssmentVisualizationConfiguration;
 
         assessmentsProvider = CreateTestAssessmentProvider();
         assessmentsProviderMock = Mock.ofType(AssessmentsProvider, MockBehavior.Strict);
@@ -288,7 +288,7 @@ describe('AssessmentStoreTest', () => {
             getAssessmentData: state => {
                 return state.assessments[assessmentKey];
             },
-        } as IAssesssmentVisualizationConfiguration;
+        } as AssesssmentVisualizationConfiguration;
 
         getVisualizationConfigurationMock
             .setup(gvcm => gvcm())
@@ -337,7 +337,7 @@ describe('AssessmentStoreTest', () => {
             getAssessmentData: state => {
                 return state.assessments[assessmentKey];
             },
-        } as IAssesssmentVisualizationConfiguration;
+        } as AssesssmentVisualizationConfiguration;
 
         getVisualizationConfigurationMock
             .setup(gvcm => gvcm())
@@ -387,7 +387,7 @@ describe('AssessmentStoreTest', () => {
             getAssessmentData: state => {
                 return state.assessments[assessmentKey];
             },
-        } as IAssesssmentVisualizationConfiguration;
+        } as AssesssmentVisualizationConfiguration;
 
         getVisualizationConfigurationMock
             .setup(gvcm => gvcm())

--- a/src/tests/unit/tests/background/stores/global/command-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/command-store.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { IMock, It, Mock, Times } from 'typemoq';
 
-import { CommandActions, IGetCommandsPayload } from '../../../../../../background/actions/command-actions';
+import { CommandActions, GetCommandsPayload } from '../../../../../../background/actions/command-actions';
 import { CommandStore } from '../../../../../../background/stores/global/command-store';
 import { TelemetryEventHandler } from '../../../../../../background/telemetry/telemetry-event-handler';
 import { StoreNames } from '../../../../../../common/stores/store-names';
@@ -32,7 +32,7 @@ describe('CommandStoreTest', () => {
         const initialState: ICommandStoreData = prototype.getDefaultState();
         const expectedState: ICommandStoreData = prototype.getDefaultState();
 
-        const payload: IGetCommandsPayload = {
+        const payload: GetCommandsPayload = {
             commands: [],
             tabId: 1,
         };
@@ -64,7 +64,7 @@ describe('CommandStoreTest', () => {
         };
 
         const tabId = 1;
-        const payload: IGetCommandsPayload = {
+        const payload: GetCommandsPayload = {
             commands: [newCommand],
             tabId: tabId,
         };
@@ -106,7 +106,7 @@ describe('CommandStoreTest', () => {
         };
 
         const tabId = 1;
-        const payload: IGetCommandsPayload = {
+        const payload: GetCommandsPayload = {
             commands: [newCommand],
             tabId: tabId,
         };

--- a/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ScopingPayload, ScopingActions } from '../../../../../../background/actions/scoping-actions';
+import { ScopingActions, ScopingPayload } from '../../../../../../background/actions/scoping-actions';
 import { ScopingInputTypes } from '../../../../../../background/scoping-input-types';
 import { ScopingStore } from '../../../../../../background/stores/global/scoping-store';
 import { StoreNames } from '../../../../../../common/stores/store-names';

--- a/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IScopingPayload, ScopingActions } from '../../../../../../background/actions/scoping-actions';
+import { ScopingPayload, ScopingActions } from '../../../../../../background/actions/scoping-actions';
 import { ScopingInputTypes } from '../../../../../../background/scoping-input-types';
 import { ScopingStore } from '../../../../../../background/stores/global/scoping-store';
 import { StoreNames } from '../../../../../../common/stores/store-names';
@@ -36,7 +36,7 @@ describe('ScopingStoreTest', () => {
 
     test('on addSelector', () => {
         const initialState = getDefaultState();
-        const payload: IScopingPayload = {
+        const payload: ScopingPayload = {
             inputType: 'include',
             selector: ['iframe', 'selector'],
         };
@@ -49,7 +49,7 @@ describe('ScopingStoreTest', () => {
     });
 
     test('on addSelector prevent duplicate selector', () => {
-        const payload: IScopingPayload = {
+        const payload: ScopingPayload = {
             inputType: 'include',
             selector: ['iframe', 'selector'],
         };
@@ -65,7 +65,7 @@ describe('ScopingStoreTest', () => {
 
     test('on deleteSelector with an actual selector', () => {
         const initialState = getDefaultState();
-        const payload: IScopingPayload = {
+        const payload: ScopingPayload = {
             inputType: ScopingInputTypes.include,
             selector: ['iframe', 'selector'],
         };
@@ -80,7 +80,7 @@ describe('ScopingStoreTest', () => {
     test('on deleteSelector prevent deletion of non-existent selector', () => {
         const initialState = getDefaultState();
         const actualSelector = ['iframe', 'selector'];
-        const payload: IScopingPayload = {
+        const payload: ScopingPayload = {
             inputType: ScopingInputTypes.include,
             selector: ['selector'],
         };

--- a/src/tests/unit/tests/background/stores/tab-store.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-store.test.ts
@@ -3,7 +3,7 @@
 import { TabActions } from '../../../../../background/actions/tab-actions';
 import { VisualizationActions } from '../../../../../background/actions/visualization-actions';
 import { TabStore } from '../../../../../background/stores/tab-store';
-import { ITab } from '../../../../../common/itab';
+import { Tab } from '../../../../../common/itab';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import { ITabStoreData } from '../../../../../common/types/store-data/itab-store-data';
 import { createStoreWithNullParams, StoreTester } from '../../../common/store-tester';
@@ -23,7 +23,7 @@ describe('TabStoreTest', () => {
     test('onTabUpdate', () => {
         const initialState = new TabStoreDataBuilder().build();
 
-        const payload: ITab = {
+        const payload: Tab = {
             id: -1,
             title: 'test-title',
             url: 'test-url',
@@ -61,7 +61,7 @@ describe('TabStoreTest', () => {
             .with('title', 'title 1')
             .build();
 
-        const payload: ITab = {
+        const payload: Tab = {
             title: 'title 2',
             url: 'url 2',
         };

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -19,7 +19,7 @@ import { TabContextFactory } from '../../../../background/tab-context-factory';
 import { TargetTabController } from '../../../../background/target-tab-controller';
 import { TelemetryEventHandler } from '../../../../background/telemetry/telemetry-event-handler';
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../common/configs/visualization-configuration-factory';
 import { Messages } from '../../../../common/messages';
@@ -28,7 +28,7 @@ import { StoreUpdateMessage } from '../../../../common/types/store-update-messag
 import { VisualizationType } from '../../../../common/types/visualization-type';
 import { WindowUtils } from '../../../../common/window-utils';
 
-function getConfigs(type: VisualizationType): IVisualizationConfiguration {
+function getConfigs(type: VisualizationType): VisualizationConfiguration {
     return new VisualizationConfigurationFactory().getConfiguration(type);
 }
 

--- a/src/tests/unit/tests/background/tab-controller.test.ts
+++ b/src/tests/unit/tests/background/tab-controller.test.ts
@@ -106,7 +106,7 @@ describe('TabControllerTest', () => {
         const getTabCallbackInput = {
             data: 'abc',
         };
-        const interpretInput: IMessage = {
+        const interpretInput: Message = {
             type: Messages.Tab.Update,
             payload: getTabCallbackInput,
             tabId: tabId,
@@ -183,7 +183,7 @@ describe('TabControllerTest', () => {
         const tabId = 1;
         let tabUpdatedCallback: (details: chrome.webNavigation.WebNavigationFramedCallbackDetails) => void = null;
         let tabRemovedCallback: Function = null;
-        const interpretInput: IMessage = {
+        const interpretInput: Message = {
             type: Messages.Tab.Remove,
             payload: null,
             tabId: tabId,
@@ -229,7 +229,7 @@ describe('TabControllerTest', () => {
     test('onDetailsViewTabRemoved', () => {
         let tabUpdatedCallback: (details: chrome.webNavigation.WebNavigationFramedCallbackDetails) => void = null;
         const tabId = 2;
-        const interpretInput: IMessage = {
+        const interpretInput: Message = {
             type: Messages.Visualizations.DetailsView.Close,
             payload: null,
             tabId: tabId,
@@ -278,7 +278,7 @@ describe('TabControllerTest', () => {
         };
 
         openTabIds.forEach((tabId, index) => {
-            const interpretInput: IMessage = {
+            const interpretInput: Message = {
                 type: Messages.Tab.Update,
                 payload: tabs[tabId],
                 tabId: tabId,
@@ -342,7 +342,7 @@ describe('TabControllerTest', () => {
             id: tabId,
         };
 
-        const interpretInput: IMessage = {
+        const interpretInput: Message = {
             type: Messages.Tab.Change,
             payload: getTabCallbackInput,
             tabId: tabId,
@@ -399,14 +399,14 @@ describe('TabControllerTest', () => {
             populate: false,
             windowTypes: ['normal', 'popup'],
         };
-        const interpretInput1: IMessage = {
+        const interpretInput1: Message = {
             type: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: false,
             },
             tabId: 1,
         };
-        const interpretInput2: IMessage = {
+        const interpretInput2: Message = {
             type: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: true,
@@ -490,14 +490,14 @@ describe('TabControllerTest', () => {
             populate: false,
             windowTypes: ['normal', 'popup'],
         };
-        const interpretInput1: IMessage = {
+        const interpretInput1: Message = {
             type: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: false,
             },
             tabId: 1,
         };
-        const interpretInput2: IMessage = {
+        const interpretInput2: Message = {
             type: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: true,
@@ -582,14 +582,14 @@ describe('TabControllerTest', () => {
         const windowStub = {
             id: 1,
         };
-        const interpretInput1: IMessage = {
+        const interpretInput1: Message = {
             type: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: false,
             },
             tabId: 1,
         };
-        const interpretInput2: IMessage = {
+        const interpretInput2: Message = {
             type: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: true,

--- a/src/tests/unit/tests/background/target-tab-controller.test.ts
+++ b/src/tests/unit/tests/background/target-tab-controller.test.ts
@@ -5,7 +5,7 @@ import { IMock, Mock, Times } from 'typemoq';
 import { ChromeAdapter } from '../../../../background/browser-adapter';
 import { TargetTabController } from '../../../../background/target-tab-controller';
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../common/configs/visualization-configuration-factory';
 import { VisualizationType } from '../../../../common/types/visualization-type';
@@ -14,7 +14,7 @@ describe('TargetTabControllerTest', () => {
     let browserAdapterMock: IMock<ChromeAdapter>;
     let configurationFactoryMock: IMock<VisualizationConfigurationFactory>;
     let testSubject: TargetTabController;
-    let configStub: IVisualizationConfiguration;
+    let configStub: VisualizationConfiguration;
     let getSwitchToTargetTabCallbackMock: IMock<(step: string) => boolean>;
     let test: VisualizationType;
     let tabId: number;
@@ -26,7 +26,7 @@ describe('TargetTabControllerTest', () => {
         configurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
         configStub = {
             getSwitchToTargetTabOnScan: getSwitchToTargetTabCallbackMock.object,
-        } as IVisualizationConfiguration;
+        } as VisualizationConfiguration;
         tabId = -1;
         test = -2;
         step = 'some step';

--- a/src/tests/unit/tests/background/telemetry/telemetry-event-handler.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-event-handler.test.ts
@@ -7,7 +7,7 @@ import { BaseActionPayload } from '../../../../../background/actions/action-payl
 import { BrowserAdapter, ChromeAdapter } from '../../../../../background/browser-adapter';
 import { TelemetryClient } from '../../../../../background/telemetry/telemetry-client';
 import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';
-import { ITab } from '../../../../../common/itab';
+import { Tab } from '../../../../../common/itab';
 import { TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
 
 describe('TelemetryEventHandlerTest', () => {

--- a/src/tests/unit/tests/common/message-creators/bug-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/bug-action-message-creator.test.ts
@@ -38,7 +38,7 @@ describe('BugActionMessageCreator', () => {
         const payload: BaseActionPayload = {
             telemetry,
         };
-        const expectedMessage: IMessage = {
+        const expectedMessage: Message = {
             type: Messages.SettingsPanel.OpenPanel,
             tabId,
             payload,
@@ -62,7 +62,7 @@ describe('BugActionMessageCreator', () => {
             eventName: FILE_ISSUE_CLICK,
             telemetry,
         };
-        const expectedMessage: IMessage = {
+        const expectedMessage: Message = {
             type: Messages.Telemetry.Send,
             tabId,
             payload,

--- a/src/tests/unit/tests/common/message-creators/dropdown-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/dropdown-action-message-creator.test.ts
@@ -57,7 +57,7 @@ describe('DropdownActionMessageCreatorTest', () => {
         telemetryFactoryMock.verifyAll();
     });
 
-    function getExpectedMessage(messageType: string): IMessage {
+    function getExpectedMessage(messageType: string): Message {
         return {
             tabId: tabId,
             type: messageType,
@@ -81,7 +81,7 @@ describe('DropdownActionMessageCreatorTest', () => {
             .verifiable(Times.once());
     }
 
-    function setupPostMessage(expectedMessage: IMessage): void {
+    function setupPostMessage(expectedMessage: Message): void {
         postMessageMock.setup(post => post(It.isValue(expectedMessage))).verifiable(Times.once());
     }
 });

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -7,7 +7,7 @@ import { StoreActionMessageCreatorFactory } from '../../../../../common/message-
 import { Messages } from '../../../../../common/messages';
 
 describe('StoreActionMessageCreatorFactoryTest', () => {
-    let postMessageMock: IMock<(_message: IMessage) => void>;
+    let postMessageMock: IMock<(_message: Message) => void>;
     const tabId: number = -1;
 
     beforeEach(() => {

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator.test.ts
@@ -6,12 +6,12 @@ import { StoreActionMessageCreator } from '../../../../../common/message-creator
 
 describe('StateActionMessageCreator', () => {
     const tabId: number = -1;
-    let postMessageMock: IMock<(message: IMessage) => void>;
+    let postMessageMock: IMock<(message: Message) => void>;
 
     test('getAllStates', () => {
         const messages = ['a', 'b', 'c', 'd'];
 
-        postMessageMock = Mock.ofInstance((_message: IMessage) => {}, MockBehavior.Strict);
+        postMessageMock = Mock.ofInstance((_message: Message) => {}, MockBehavior.Strict);
 
         messages.forEach(message => setupPostMessageMock(message));
 

--- a/src/tests/unit/tests/common/notification-creator.test.ts
+++ b/src/tests/unit/tests/common/notification-creator.test.ts
@@ -4,7 +4,7 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { ChromeAdapter } from '../../../../background/browser-adapter';
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../common/configs/visualization-configuration-factory';
 import { NotificationCreator } from '../../../../common/notification-creator';
@@ -89,7 +89,7 @@ describe('NotificationCreator', () => {
             .returns(() => {
                 return {
                     getNotificationMessage: getNotificationMessageMock.object,
-                } as IVisualizationConfiguration;
+                } as VisualizationConfiguration;
             });
 
         testObject.createNotificationByVisualizationKey(selectorStub, key, type);

--- a/src/tests/unit/tests/common/state-dispatcher.test.ts
+++ b/src/tests/unit/tests/common/state-dispatcher.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
-import { IStoreHub } from '../../../../background/stores/istore-hub';
+import { StoreHub } from '../../../../background/stores/istore-hub';
 import { GenericStoreMessageTypes } from '../../../../common/constants/generic-store-messages-types';
 import { IBaseStore } from '../../../../common/istore';
 import { StateDispatcher } from '../../../../common/state-dispatcher';
@@ -95,7 +95,7 @@ describe('StateDispatcherTest', () => {
     });
 });
 
-class StoreHubStub implements IStoreHub {
+class StoreHubStub implements StoreHub {
     public getAllStores(): IBaseStore<any>[] {
         throw new Error('Method not implemented.');
     }

--- a/src/tests/unit/tests/common/visualization-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/visualization-action-message-creator.test.ts
@@ -36,7 +36,7 @@ describe('VisualizationActionMessageCreatorTest', () => {
             telemetry,
         };
 
-        const expectedMessage: IMessage = {
+        const expectedMessage: Message = {
             tabId: tabId,
             type: Messages.Visualizations.Common.Toggle,
             payload,

--- a/src/tests/unit/tests/injected/analyzer-controller.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-controller.test.ts
@@ -8,7 +8,7 @@ import { FeatureFlagStore } from '../../../../background/stores/global/feature-f
 import { ScopingStore } from '../../../../background/stores/global/scoping-store';
 import { VisualizationStore } from '../../../../background/stores/visualization-store';
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../common/configs/visualization-configuration-factory';
 import { EnumHelper } from '../../../../common/enum-helper';
@@ -35,7 +35,7 @@ describe('AnalyzerControllerTests', () => {
     let getAnalyzerMock: IMock<(provider: AnalyzerProvider) => IAnalyzer<any>>;
     let getIdentifierMock: IMock<() => string>;
     let identifier: string;
-    let configStub: IVisualizationConfiguration;
+    let configStub: VisualizationConfiguration;
 
     let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
 
@@ -229,7 +229,7 @@ describe('AnalyzerControllerTests', () => {
             .verifiable(Times.never());
     }
 
-    function setupVisualizationConfigurationFactory(type: VisualizationType, returnedConfig: IVisualizationConfiguration): void {
+    function setupVisualizationConfigurationFactory(type: VisualizationType, returnedConfig: VisualizationConfiguration): void {
         visualizationConfigurationFactoryMock
             .setup(v => v.getConfiguration(type))
             .returns((visType: VisualizationType) => {

--- a/src/tests/unit/tests/injected/analyzers/batched-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/batched-analyzer.test.ts
@@ -6,7 +6,7 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { ScopingInputTypes } from '../../../../../background/scoping-input-types';
 import { ScopingStore } from '../../../../../background/stores/global/scoping-store';
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../../common/configs/visualization-configuration-factory';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
@@ -67,7 +67,7 @@ describe('BatchedRuleAnalyzer', () => {
             .returns(() => {
                 return {
                     displayableData: { title: testName },
-                } as IVisualizationConfiguration;
+                } as VisualizationConfiguration;
             })
             .verifiable();
     });

--- a/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
@@ -6,7 +6,7 @@ import { IMock, It, Mock, Times } from 'typemoq';
 import { ScopingInputTypes } from '../../../../../background/scoping-input-types';
 import { ScopingStore } from '../../../../../background/stores/global/scoping-store';
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../../common/configs/visualization-configuration-factory';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
@@ -68,7 +68,7 @@ describe('RuleAnalyzer', () => {
             .returns(() => {
                 return {
                     displayableData: { title: testName },
-                } as IVisualizationConfiguration;
+                } as VisualizationConfiguration;
             })
             .verifiable();
     });

--- a/src/tests/unit/tests/injected/drawing-controller.test.ts
+++ b/src/tests/unit/tests/injected/drawing-controller.test.ts
@@ -5,7 +5,7 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { AssessmentsProvider } from '../../../../assessments/assessments-provider';
 import { IAssessmentsProvider } from '../../../../assessments/types/iassessments-provider';
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../common/configs/visualization-configuration-factory';
 import { EnumHelper } from '../../../../common/enum-helper';
@@ -77,7 +77,7 @@ describe('DrawingControllerTest', () => {
     let instanceVisibilityCheckerMock: IMock<InstanceVisibilityChecker>;
     let hTMLElementUtils: IMock<HTMLElementUtils>;
     let visualizationConfigFactory: IMock<VisualizationConfigurationFactory>;
-    let visualizationConfigStub: IVisualizationConfiguration;
+    let visualizationConfigStub: VisualizationConfiguration;
     let getIdentifierMock: IMock<(step?: string) => string>;
     let getDrawerMock: IMock<(provider: DrawerProvider, testStep?: string) => IDrawer>;
     let drawerProvider: IMock<DrawerProvider>;
@@ -97,7 +97,7 @@ describe('DrawingControllerTest', () => {
         visualizationConfigStub = {
             getIdentifier: getIdentifierMock.object,
             getDrawer: getDrawerMock.object,
-        } as IVisualizationConfiguration;
+        } as VisualizationConfiguration;
         numVisualizationTypes = EnumHelper.getNumericValues(VisualizationType).length;
     });
 

--- a/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
+++ b/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
@@ -6,7 +6,7 @@ import { Assessments } from '../../../../assessments/assessments';
 import { IAssessmentsProvider } from '../../../../assessments/types/iassessments-provider';
 import { UniquelyIdentifiableInstances } from '../../../../background/instance-identifier-generator';
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../common/configs/visualization-configuration-factory';
 import { HTMLElementUtils } from '../../../../common/html-element-utils';
@@ -23,7 +23,7 @@ describe('InstanceVisibilityCheckerTest', () => {
     let testSubject: InstanceVisibilityChecker;
     const assessmentsProvider: IAssessmentsProvider = Assessments;
     let configFactoryMock: IMock<VisualizationConfigurationFactory>;
-    let configStub: IVisualizationConfiguration;
+    let configStub: VisualizationConfiguration;
     let getInstanceIdentiferGeneratorMock: IMock<(step: string) => Function>;
     let getUpdateVisibilityMock: IMock<(step: string) => boolean>;
     let generateInstanceIdentifierMock: IMock<(instance: UniquelyIdentifiableInstances) => string>;
@@ -41,7 +41,7 @@ describe('InstanceVisibilityCheckerTest', () => {
         configStub = {
             getInstanceIdentiferGenerator: getInstanceIdentiferGeneratorMock.object,
             getUpdateVisibility: getUpdateVisibilityMock.object,
-        } as IVisualizationConfiguration;
+        } as VisualizationConfiguration;
 
         testSubject = new InstanceVisibilityChecker(
             sendMessageMock.object,

--- a/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
+++ b/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
@@ -125,7 +125,7 @@ describe('InstanceVisibilityCheckerTest', () => {
 
         setupConfigurationFactoryMocks(testType, testStepDrawerId, expectedUniquelyIdentifiableInstances, elementFoundGeneratedIds);
 
-        const expectedPayload: IMessage = {
+        const expectedPayload: Message = {
             type: Messages.Assessment.UpdateInstanceVisibility,
             payload: {
                 payloadBatch: [
@@ -189,7 +189,7 @@ describe('InstanceVisibilityCheckerTest', () => {
 
         setupConfigurationFactoryMocks(testType, testStepDrawerId, [expectedUniquelyIdentifiableInstance], [elementFoundGeneratedId]);
 
-        const expectedPayload: IMessage = {
+        const expectedPayload: Message = {
             type: Messages.Assessment.UpdateInstanceVisibility,
             payload: {
                 payloadBatch: [
@@ -238,7 +238,7 @@ describe('InstanceVisibilityCheckerTest', () => {
             .returns(() => null)
             .verifiable(Times.once());
 
-        const expectedPayload: IMessage = {
+        const expectedPayload: Message = {
             type: Messages.Assessment.UpdateInstanceVisibility,
             payload: {
                 payloadBatch: [

--- a/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
+++ b/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
@@ -4,7 +4,7 @@ import { IMock, It, Mock, Times } from 'typemoq';
 
 import { Assessments } from '../../../../assessments/assessments';
 import { IAssessmentsProvider } from '../../../../assessments/types/iassessments-provider';
-import { IUniquelyIdentifiableInstances } from '../../../../background/instance-identifier-generator';
+import { UniquelyIdentifiableInstances } from '../../../../background/instance-identifier-generator';
 import {
     IVisualizationConfiguration,
     VisualizationConfigurationFactory,
@@ -26,7 +26,7 @@ describe('InstanceVisibilityCheckerTest', () => {
     let configStub: IVisualizationConfiguration;
     let getInstanceIdentiferGeneratorMock: IMock<(step: string) => Function>;
     let getUpdateVisibilityMock: IMock<(step: string) => boolean>;
-    let generateInstanceIdentifierMock: IMock<(instance: IUniquelyIdentifiableInstances) => string>;
+    let generateInstanceIdentifierMock: IMock<(instance: UniquelyIdentifiableInstances) => string>;
     let testType: VisualizationType;
 
     beforeEach(() => {
@@ -99,11 +99,11 @@ describe('InstanceVisibilityCheckerTest', () => {
             {
                 target: frameResults[0].target,
                 html: elements[0].outerHTML,
-            } as IUniquelyIdentifiableInstances,
+            } as UniquelyIdentifiableInstances,
             {
                 target: frameResults[1].target,
                 html: elements[1].outerHTML,
-            } as IUniquelyIdentifiableInstances,
+            } as UniquelyIdentifiableInstances,
         ];
 
         windowUtilsMock
@@ -299,7 +299,7 @@ describe('InstanceVisibilityCheckerTest', () => {
     function setupConfigurationFactoryMocks(
         getConfigType: VisualizationType,
         drawerIdentifier: string,
-        instances: IUniquelyIdentifiableInstances[],
+        instances: UniquelyIdentifiableInstances[],
         returnedIdentifiers: string[],
     ): void {
         getUpdateVisibilityMock.setup(guvm => guvm(drawerIdentifier)).returns(() => true);

--- a/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
+++ b/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
@@ -83,7 +83,7 @@ describe('TargetPageActionMessageCreator', () => {
         const payload: BaseActionPayload = {
             telemetry,
         };
-        const expectedMessage: IMessage = {
+        const expectedMessage: Message = {
             type: Messages.SettingsPanel.OpenPanel,
             tabId,
             payload,

--- a/src/tests/unit/tests/popup/scripts/components/diagnostic-view-toggle-factory.test.tsx
+++ b/src/tests/unit/tests/popup/scripts/components/diagnostic-view-toggle-factory.test.tsx
@@ -8,7 +8,7 @@ import { FeatureFlagStore } from '../../../../../../background/stores/global/fea
 import { VisualizationStore } from '../../../../../../background/stores/visualization-store';
 import { TestMode } from '../../../../../../common/configs/test-mode';
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../../../common/configs/visualization-configuration-factory';
 import { TelemetryEventSource } from '../../../../../../common/telemetry-events';
@@ -32,24 +32,24 @@ describe('DiagnosticViewToggleFactoryTest', () => {
     ];
 
     const featureFlagStub: string = 'test_heading_feature_flag';
-    const firstVisualizationConfiguration: IVisualizationConfiguration = {
+    const firstVisualizationConfiguration: VisualizationConfiguration = {
         testMode: TestMode.Adhoc,
         featureFlagToEnable: featureFlagStub,
         launchPanelDisplayOrder: 2,
         adhocToolsPanelDisplayOrder: 1,
-    } as IVisualizationConfiguration;
-    const secondVisualizationConfiguration: IVisualizationConfiguration = {
+    } as VisualizationConfiguration;
+    const secondVisualizationConfiguration: VisualizationConfiguration = {
         testMode: TestMode.Adhoc,
         featureFlagToEnable: null,
         launchPanelDisplayOrder: 1,
         adhocToolsPanelDisplayOrder: 2,
-    } as IVisualizationConfiguration;
-    const alwaysDisabledConfiguration: IVisualizationConfiguration = {
+    } as VisualizationConfiguration;
+    const alwaysDisabledConfiguration: VisualizationConfiguration = {
         testMode: null,
         featureFlagToEnable: null,
         launchPanelDisplayOrder: 1,
         adhocToolsPanelDisplayOrder: 2,
-    } as IVisualizationConfiguration;
+    } as VisualizationConfiguration;
 
     const visualizationStoreData = new VisualizationStoreDataBuilder().build();
     const domMock = {} as any;

--- a/src/tests/unit/tests/popup/scripts/components/diagnostic-view-toggle.test.tsx
+++ b/src/tests/unit/tests/popup/scripts/components/diagnostic-view-toggle.test.tsx
@@ -12,7 +12,7 @@ import { It, Mock, Times } from 'typemoq';
 
 import { VisualizationToggle } from '../../../../../../common/components/visualization-toggle';
 import {
-    IVisualizationConfiguration,
+    VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../../../common/configs/visualization-configuration-factory';
 import { FeatureFlags } from '../../../../../../common/feature-flags';
@@ -364,7 +364,7 @@ class DiagnosticViewTogglePropsBuilder {
     private addEventListenerMock = Mock.ofInstance((e, ev) => {});
     private featureFlags: DictionaryStringTo<boolean> = {};
     private deps: ContentLinkDeps = {} as ContentLinkDeps;
-    private configurationStub: IVisualizationConfiguration;
+    private configurationStub: VisualizationConfiguration;
 
     constructor(type: VisualizationType, telemetrySource: TelemetryEventSource) {
         this.type = type;

--- a/src/tests/unit/tests/popup/scripts/target-tab-finder.test.ts
+++ b/src/tests/unit/tests/popup/scripts/target-tab-finder.test.ts
@@ -3,7 +3,7 @@
 import { IMock, It, Mock } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../../background/browser-adapter';
-import { ITab } from '../../../../../common/itab';
+import { Tab } from '../../../../../common/itab';
 import { UrlParser } from '../../../../../common/url-parser';
 import { UrlValidator } from '../../../../../common/url-validator';
 import { TargetTabFinder } from '../../../../../popup/scripts/target-tab-finder';
@@ -15,7 +15,7 @@ describe('TargetTabFinderTest', () => {
     let urlParserMock: IMock<UrlParser>;
     let urlValidatorMock: IMock<UrlValidator>;
     const tabId: number = 15;
-    let tabStub: ITab;
+    let tabStub: Tab;
 
     beforeEach(() => {
         windowStub = {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 **N/A**
- [ ] Added relevant unit test for your changes. (`npm run test`) **N/A**
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` **N/A**
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes. **N/A**

#### Description of changes

Updated interface names by removing the prefixed `I` that previously required `// tslint:disable-next-line:interface-name` to pass tslint checks.

#### Notes for reviewers

There are other interface names that will be renamed in a future PR.
