### PR TITLE
tslint remove disable interface name 2

### DIFF
--- a/src/assessments/images/test-steps/image-function.tsx
+++ b/src/assessments/images/test-steps/image-function.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 import { PropertyBagColumnRendererConfig } from '../../../assessments/common/property-bag-column-renderer';
-import { IImageFunctionPropertyBag } from '../../../common/types/property-bag/iimage-function';
+import { ImageFunctionPropertyBag } from '../../../common/types/property-bag/iimage-function';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName } from '../../../content/strings/application';
@@ -48,7 +48,7 @@ const howToTest: JSX.Element = (
 
 const key = ImagesTestStep.imageFunction;
 
-const propertyBagConfig: PropertyBagColumnRendererConfig<IImageFunctionPropertyBag>[] = [
+const propertyBagConfig: PropertyBagColumnRendererConfig<ImageFunctionPropertyBag>[] = [
     {
         propertyName: 'imageType',
         displayName: 'Image type',

--- a/src/assessments/images/test-steps/images-of-text.tsx
+++ b/src/assessments/images/test-steps/images-of-text.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { IImagesOfTextPropertyBag } from '../../../common/types/property-bag/iimage-of-text';
+import { ImagesOfTextPropertyBag } from '../../../common/types/property-bag/iimage-of-text';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName } from '../../../content/strings/application';
@@ -31,7 +31,7 @@ const howToTest: JSX.Element = (
 
 const key = ImagesTestStep.imageOfText;
 
-const propertyBagConfig: PropertyBagColumnRendererConfig<IImagesOfTextPropertyBag>[] = [
+const propertyBagConfig: PropertyBagColumnRendererConfig<ImagesOfTextPropertyBag>[] = [
     {
         propertyName: 'imageType',
         displayName: 'Image type',

--- a/src/assessments/images/test-steps/text-alternative.tsx
+++ b/src/assessments/images/test-steps/text-alternative.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { ITextAlternativePropertyBag } from '../../../common/types/property-bag/itext-alternative';
+import { TextAlternativePropertyBag } from '../../../common/types/property-bag/itext-alternative';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName } from '../../../content/strings/application';
@@ -54,7 +54,7 @@ const howToTest: JSX.Element = (
 
 const key = ImagesTestStep.textAlternative;
 
-const propertyBagConfig: PropertyBagColumnRendererConfig<ITextAlternativePropertyBag>[] = [
+const propertyBagConfig: PropertyBagColumnRendererConfig<TextAlternativePropertyBag>[] = [
     {
         propertyName: 'imageType',
         displayName: 'Image type',

--- a/src/assessments/links/test-steps/link-function.tsx
+++ b/src/assessments/links/test-steps/link-function.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 import { PropertyBagColumnRendererFactory } from '../../../assessments/common/property-bag-column-renderer-factory';
-import { ILinkFunctionPropertyBag } from '../../../common/types/property-bag/ilink-function';
+import { LinkFunctionPropertyBag } from '../../../common/types/property-bag/ilink-function';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { title } from '../../../content/strings/application';
@@ -37,7 +37,7 @@ const LinkFunctionHowToTest: JSX.Element = (
     </div>
 );
 
-const propertyBagConfig: PropertyBagColumnRendererConfig<ILinkFunctionPropertyBag>[] = [
+const propertyBagConfig: PropertyBagColumnRendererConfig<LinkFunctionPropertyBag>[] = [
     {
         propertyName: 'accessibleName',
         displayName: 'Accessible name',
@@ -78,7 +78,7 @@ export const LinkFunction: TestStep = {
         {
             key: 'link-function-info',
             name: 'Link info',
-            onRender: PropertyBagColumnRendererFactory.get<ILinkFunctionPropertyBag>(propertyBagConfig),
+            onRender: PropertyBagColumnRendererFactory.get<LinkFunctionPropertyBag>(propertyBagConfig),
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),

--- a/src/assessments/links/test-steps/link-purpose.tsx
+++ b/src/assessments/links/test-steps/link-purpose.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 
 import { PropertyBagColumnRendererFactory } from '../../../assessments/common/property-bag-column-renderer-factory';
-import { ILinkPurposePropertyBag } from '../../../common/types/property-bag/ilink-purpose';
+import { LinkPurposePropertyBag } from '../../../common/types/property-bag/ilink-purpose';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { title } from '../../../content/strings/application';
@@ -53,7 +53,7 @@ const LinkPurposeHowToTest: JSX.Element = (
     </div>
 );
 
-const propertyBagConfig: PropertyBagColumnRendererConfig<ILinkPurposePropertyBag>[] = [
+const propertyBagConfig: PropertyBagColumnRendererConfig<LinkPurposePropertyBag>[] = [
     {
         propertyName: 'accessibleName',
         displayName: 'Accessible name',

--- a/src/assessments/native-widgets/test-steps/widget-function.tsx
+++ b/src/assessments/native-widgets/test-steps/widget-function.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { AnalyzerConfigurationFactory } from '../../../assessments/common/analyzer-configuration-factory';
 import { PropertyBagColumnRendererFactory } from '../../../assessments/common/property-bag-column-renderer-factory';
-import { IWidgetFunctionPropertyBag } from '../../../common/types/property-bag/iwidget-function';
+import { WidgetFunctionPropertyBag } from '../../../common/types/property-bag/iwidget-function';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import { productName } from '../../../content/strings/application';
@@ -41,7 +41,7 @@ const howToTest: JSX.Element = (
     </div>
 );
 
-const propertyBagConfig: PropertyBagColumnRendererConfig<IWidgetFunctionPropertyBag>[] = [
+const propertyBagConfig: PropertyBagColumnRendererConfig<WidgetFunctionPropertyBag>[] = [
     {
         propertyName: 'element',
         displayName: 'Element',
@@ -82,7 +82,7 @@ export const WidgetFunction: TestStep = {
         {
             key: 'widget-function-info',
             name: 'Widget function',
-            onRender: PropertyBagColumnRendererFactory.get<IWidgetFunctionPropertyBag>(propertyBagConfig),
+            onRender: PropertyBagColumnRendererFactory.get<WidgetFunctionPropertyBag>(propertyBagConfig),
         },
     ],
     reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),

--- a/src/common/types/property-bag/iimage-function.d.ts
+++ b/src/common/types/property-bag/iimage-function.d.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { ColumnValueBag } from './column-value-bag';
 
-// tslint:disable-next-line:interface-name
-export interface IImageFunctionPropertyBag extends ColumnValueBag {
+export interface ImageFunctionPropertyBag extends ColumnValueBag {
     imageType: string;
     accessibleName: string;
     codedAs: string;

--- a/src/common/types/property-bag/iimage-of-text.d.ts
+++ b/src/common/types/property-bag/iimage-of-text.d.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { ColumnValueBag } from './column-value-bag';
 
-// tslint:disable-next-line:interface-name
-export interface IImagesOfTextPropertyBag extends ColumnValueBag {
+export interface ImagesOfTextPropertyBag extends ColumnValueBag {
     imageType: string;
     accessibleName: string;
 }

--- a/src/common/types/property-bag/ilink-function.d.ts
+++ b/src/common/types/property-bag/ilink-function.d.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { BagOf, ColumnValueBag } from './column-value-bag';
 
-// tslint:disable-next-line:interface-name
-export interface ILinkFunctionPropertyBag extends ColumnValueBag {
+export interface LinkFunctionPropertyBag extends ColumnValueBag {
     accessibleName: string;
     url: string;
     role: string;

--- a/src/common/types/property-bag/ilink-purpose.d.ts
+++ b/src/common/types/property-bag/ilink-purpose.d.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { ColumnValueBag } from './column-value-bag';
 
-// tslint:disable-next-line:interface-name
-export interface ILinkPurposePropertyBag extends ColumnValueBag {
+export interface LinkPurposePropertyBag extends ColumnValueBag {
     accessibleName: string;
     accessibleDescription: string;
     url: string;

--- a/src/common/types/property-bag/itext-alternative.d.ts
+++ b/src/common/types/property-bag/itext-alternative.d.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { ColumnValueBag } from './column-value-bag';
 
-// tslint:disable-next-line:interface-name
-export interface ITextAlternativePropertyBag extends ColumnValueBag {
+export interface TextAlternativePropertyBag extends ColumnValueBag {
     imageType: string;
     accessibleName: string;
     accessibleDescription: string;

--- a/src/common/types/property-bag/iwidget-function.d.ts
+++ b/src/common/types/property-bag/iwidget-function.d.ts
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { BagOf, ColumnValueBag } from './column-value-bag';
 
-// tslint:disable-next-line:interface-name
-export interface IWidgetFunctionPropertyBag extends ColumnValueBag {
+export interface WidgetFunctionPropertyBag extends ColumnValueBag {
     element: string;
     accessibleName: string;
     role: string;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 **N/A**
- [ ] Added relevant unit test for your changes. (`npm run test`) **N/A**
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` **N/A**
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes. **N/A**

#### Description of changes

Removed the prefixed `I` from interface names that previously used `// tslint:disable-next-line:interface-name` to pass tslint checks.

#### Notes for reviewers

Second part of refactoring for interface names
