### PR TITLE
[Refactor] force case sensitive imports from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,8 @@
         "paths": {
             "*": ["*"],
             "typemoq": ["typemoq/typemoq"]
-        }
+        },
+        "forceConsistentCasingInFileNames": true
     },
     "include": ["src/**/*.ts", "src/**/*.tsx", "references.ts"],
     "exclude": ["src/common/references.ts", "src/webpack.config.js"]


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 - **N/A**
- [ ] Added relevant unit test for your changes. (`npm run test`) **N/A**
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` **N/A**
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes. **N/A**

#### Description of changes

Adds `forceConsistentCasingInFileNames` parameter in `tsconfig` to make sure the file name casing problems are caught during build times (at least for TS files).

#### Notes for reviewers

Till the time we actually setup an Linux environment to run our checks and build checks, this will at least prevent any TS errors due to the casing errors in Linux. Let me know if this will work or not.

#### Screenshot of the Error that it will show if It finds anything

<img width="1621" alt="Screen Shot 2019-03-14 at 8 58 07 PM" src="https://user-images.githubusercontent.com/4496335/54407673-f8d38e00-469b-11e9-9062-8243125f9048.png">
