### PR TITLE
Fix casing to fix e2e test on linux

### DIFF
--- a/src/tests/end-to-end/common/browser.ts
+++ b/src/tests/end-to-end/common/browser.ts
@@ -50,7 +50,7 @@ export class Browser {
     }
 
     public async getDetailsViewPageUrl(targetTabId: number): Promise<string> {
-        return this.getExtensionUrl(`detailsView/detailsView.html?tabId=${targetTabId}`);
+        return this.getExtensionUrl(`DetailsView/detailsView.html?tabId=${targetTabId}`);
     }
 
     public async closeAllPages(): Promise<void> {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 **N/A**
- [ ] Added relevant unit test for your changes. (`npm run test`) **N/A**
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`**N/A**
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

![01 - e2e test log](https://user-images.githubusercontent.com/2837582/54455291-af755400-4718-11e9-90f1-4ab1740fab21.png)

Running `mpn run test:e2e` throws an error on *Settings Dropdown* e2e test. The error comes from a wrong casing on a file path.

#### Notes for reviewers

**N/A**
