### PR TITLE
chore: add an application string so that we can track the traffic fro…

### DIFF
--- a/src/scanner/axe-configurator.ts
+++ b/src/scanner/axe-configurator.ts
@@ -7,6 +7,7 @@ import { localeConfiguration } from './locale-configuration';
 
 export class AxeConfigurator {
     public configureAxe(axe: typeof Axe, configuration: RuleConfiguration[]) {
+        axe.configure({ branding: { brand: 'axe', application: 'msftAI' } });
         axe.configure(this.createAxeConfigurationFromCustomRules(configuration) as any);
         axe.configure({ locale: localeConfiguration });
     }

--- a/src/tests/unit/tests/scanner/axe-configurator.test.ts
+++ b/src/tests/unit/tests/scanner/axe-configurator.test.ts
@@ -74,6 +74,8 @@ describe('AxeConfigurator', () => {
 
             configureMock.setup(cm => cm(It.isValue({ locale: localeConfiguration }))).verifiable();
 
+            configureMock.setup(cm => cm(It.isValue({ branding: { brand: 'axe', application: 'msftAI' } }))).verifiable();
+
             const axeStub = {
                 configure: configureMock.object,
             };


### PR DESCRIPTION
…m accessibility insights

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.

#### Description of changes

The addition of an application ID will allow the traffic to be differentiated from axe API traffic
