### PR TITLE
[Refactor] drawer util test to return proper element

### DIFF
--- a/src/tests/unit/tests/injected/visualization/drawer-utils.test.ts
+++ b/src/tests/unit/tests/injected/visualization/drawer-utils.test.ts
@@ -5,7 +5,7 @@ import { DrawerUtils } from '../../../../../injected/visualization/drawer-utils'
 describe('getBoundingClientRectIncludingChildren', () => {
     it('works if no children', () => {
         const elementStub = getElementStub(5, 5, 10, 10);
-        const result = DrawerUtils.getBoundingClientRectIncludingChildren(elementStub as any);
+        const result = DrawerUtils.getBoundingClientRectIncludingChildren(elementStub);
         expect(result.top).toBe(5);
         expect(result.left).toBe(5);
         expect(result.bottom).toBe(10);
@@ -14,7 +14,7 @@ describe('getBoundingClientRectIncludingChildren', () => {
 
     it('works if single child fully contained in parent dimensions', () => {
         const elementStub = getElementStub(5, 5, 10, 10, [getElementStub(7, 7, 9, 9)]);
-        const result = DrawerUtils.getBoundingClientRectIncludingChildren(elementStub as any);
+        const result = DrawerUtils.getBoundingClientRectIncludingChildren(elementStub);
         expect(result.top).toBe(5);
         expect(result.left).toBe(5);
         expect(result.bottom).toBe(10);
@@ -23,7 +23,7 @@ describe('getBoundingClientRectIncludingChildren', () => {
 
     it('works if single child partly contained in parent dimensions', () => {
         const elementStub = getElementStub(5, 5, 10, 10, [getElementStub(7, 7, 15, 15)]);
-        const result = DrawerUtils.getBoundingClientRectIncludingChildren(elementStub as any);
+        const result = DrawerUtils.getBoundingClientRectIncludingChildren(elementStub);
         expect(result.top).toBe(5);
         expect(result.left).toBe(5);
         expect(result.bottom).toBe(15);
@@ -32,7 +32,7 @@ describe('getBoundingClientRectIncludingChildren', () => {
 
     it('works if two children overflowing in all four parent dimensions', () => {
         const elementStub = getElementStub(5, 5, 10, 10, [getElementStub(0, 0, 7, 7), getElementStub(7, 7, 15, 15)]);
-        const result = DrawerUtils.getBoundingClientRectIncludingChildren(elementStub as any);
+        const result = DrawerUtils.getBoundingClientRectIncludingChildren(elementStub);
         expect(result.top).toBe(0);
         expect(result.left).toBe(0);
         expect(result.bottom).toBe(15);
@@ -41,15 +41,14 @@ describe('getBoundingClientRectIncludingChildren', () => {
 
     it('ignores children with empty bounding rectangles', () => {
         const elementStub = getElementStub(5, 5, 10, 10, [getElementStub(0, 0, 0, 0), getElementStub(7, 7, 15, 15)]);
-        const result = DrawerUtils.getBoundingClientRectIncludingChildren(elementStub as any);
+        const result = DrawerUtils.getBoundingClientRectIncludingChildren(elementStub);
         expect(result.top).toBe(5);
         expect(result.left).toBe(5);
         expect(result.bottom).toBe(15);
         expect(result.right).toBe(15);
     });
 
-    // tslint:disable-next-line: typedef
-    function getElementStub(top: number, left: number, bottom: number, right: number, children?: any[]) {
+    function getElementStub(top: number, left: number, bottom: number, right: number, children?: any[]): Element {
         return {
             children: children || [],
             getBoundingClientRect: () => {
@@ -62,6 +61,6 @@ describe('getBoundingClientRectIncludingChildren', () => {
                     width: right - left,
                 };
             },
-        };
+        } as any;
     }
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 - **N/A**
- [ ] Added relevant unit test for your changes. (`npm run test`) **N/A**
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` **N/A**
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes. **N/A**

#### Description of changes

🔧 drawer-util.test.ts to actually return proper element to fix lint error and also remove tslint:disable

#### Notes for reviewers

Carry over work from #375 
