### PR TITLE
Move common test helper code out of individual test files

### DIFF
--- a/src/tests/unit/common/visual-helper-toggle-config-builder.ts
+++ b/src/tests/unit/common/visual-helper-toggle-config-builder.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { VisualHelperToggleConfig } from '../../../assessments/types/test-step';
 import { ManualTestStatus } from '../../../common/types/manual-test-status';
 import {
@@ -9,6 +11,7 @@ import { VisualizationType } from '../../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../../../DetailsView/actions/details-view-action-message-creator';
 import { DictionaryStringTo } from '../../../types/common-types';
 import { BaseDataBuilder } from './base-data-builder';
+
 export class VisualHelperToggleConfigBuilder extends BaseDataBuilder<VisualHelperToggleConfig> {
     private stepKey = 'assessment-1-step-1';
     private otherKey = 'assessment-1-step-2';

--- a/src/tests/unit/common/visual-helper-toggle-config-builder.ts
+++ b/src/tests/unit/common/visual-helper-toggle-config-builder.ts
@@ -1,0 +1,96 @@
+import { VisualHelperToggleConfig } from '../../../assessments/types/test-step';
+import { ManualTestStatus } from '../../../common/types/manual-test-status';
+import {
+    IAssessmentResultType,
+    IGeneratedAssessmentInstance,
+    ITestStepResult,
+} from '../../../common/types/store-data/iassessment-result-data';
+import { VisualizationType } from '../../../common/types/visualization-type';
+import { DetailsViewActionMessageCreator } from '../../../DetailsView/actions/details-view-action-message-creator';
+import { DictionaryStringTo } from '../../../types/common-types';
+import { BaseDataBuilder } from './base-data-builder';
+export class VisualHelperToggleConfigBuilder extends BaseDataBuilder<VisualHelperToggleConfig> {
+    private stepKey = 'assessment-1-step-1';
+    private otherKey = 'assessment-1-step-2';
+    constructor() {
+        super();
+        this.data = {
+            assessmentNavState: {
+                selectedTestStep: this.stepKey,
+                selectedTestType: -1 as VisualizationType,
+            },
+            actionMessageCreator: null,
+            instancesMap: {
+                'assessment-1-step-1': {
+                    html: 'html',
+                    propertyBag: {},
+                    target: ['element2'],
+                } as IGeneratedAssessmentInstance,
+            } as DictionaryStringTo<IGeneratedAssessmentInstance>,
+            isStepEnabled: true,
+            isStepScanned: false,
+        };
+    }
+    public withActionMessageCreator(actionMessageCreator: DetailsViewActionMessageCreator): VisualHelperToggleConfigBuilder {
+        this.data.actionMessageCreator = actionMessageCreator;
+        return this;
+    }
+    public withToggleStepEnabled(stepEnabled: boolean): VisualHelperToggleConfigBuilder {
+        this.data.isStepEnabled = stepEnabled;
+        return this;
+    }
+    public withToggleStepScanned(stepScanned: boolean): VisualHelperToggleConfigBuilder {
+        this.data.isStepScanned = stepScanned;
+        return this;
+    }
+    public withNonEmptyFilteredMap(isVisualizationEnabled: boolean = false): VisualHelperToggleConfigBuilder {
+        this.data.instancesMap = {
+            'selector-1': {
+                testStepResults: {
+                    [this.stepKey]: {
+                        id: 'id1',
+                        status: ManualTestStatus.UNKNOWN,
+                        isVisualizationEnabled: isVisualizationEnabled,
+                    } as ITestStepResult,
+                } as IAssessmentResultType<any>,
+            } as IGeneratedAssessmentInstance,
+            'selector-2': {
+                testStepResults: {
+                    [this.stepKey]: {
+                        id: 'id1',
+                        status: ManualTestStatus.FAIL,
+                        isVisualizationEnabled: isVisualizationEnabled,
+                    } as ITestStepResult,
+                } as IAssessmentResultType<any>,
+            } as IGeneratedAssessmentInstance,
+        };
+        return this;
+    }
+    public withEmptyFilteredMap(): VisualHelperToggleConfigBuilder {
+        this.data.instancesMap = {
+            'selector-1': {
+                testStepResults: {
+                    [this.otherKey]: {
+                        id: 'id2',
+                        status: ManualTestStatus.UNKNOWN,
+                    } as ITestStepResult,
+                } as IAssessmentResultType<any>,
+            } as IGeneratedAssessmentInstance,
+        };
+        return this;
+    }
+    public withPassingFilteredMap(): VisualHelperToggleConfigBuilder {
+        this.data.instancesMap = {
+            'selector-1': {
+                testStepResults: {
+                    [this.stepKey]: {
+                        id: 'id2',
+                        status: ManualTestStatus.PASS,
+                    } as ITestStepResult,
+                } as IAssessmentResultType<any>,
+            } as IGeneratedAssessmentInstance,
+            'selector-2': null,
+        };
+        return this;
+    }
+}

--- a/src/tests/unit/common/visualization-toggle-props-builder.ts
+++ b/src/tests/unit/common/visualization-toggle-props-builder.ts
@@ -1,5 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { VisualizationToggleProps } from '../../../common/components/visualization-toggle';
 import { BaseDataBuilder } from './base-data-builder';
+
 export class VisualizationTogglePropsBuilder extends BaseDataBuilder<VisualizationToggleProps> {
     constructor() {
         super();

--- a/src/tests/unit/common/visualization-toggle-props-builder.ts
+++ b/src/tests/unit/common/visualization-toggle-props-builder.ts
@@ -1,0 +1,12 @@
+import { VisualizationToggleProps } from '../../../common/components/visualization-toggle';
+import { BaseDataBuilder } from './base-data-builder';
+export class VisualizationTogglePropsBuilder extends BaseDataBuilder<VisualizationToggleProps> {
+    constructor() {
+        super();
+        this.data = {
+            checked: false,
+            disabled: false,
+            visualizationName: null,
+        } as VisualizationToggleProps;
+    }
+}

--- a/src/tests/unit/tests/DetailsView/components/assessment-visualization-enabled-toggle.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-visualization-enabled-toggle.test.tsx
@@ -8,13 +8,14 @@ import { IMock, Mock, Times } from 'typemoq';
 import { VisualizationToggle, VisualizationToggleProps } from '../../../../../common/components/visualization-toggle';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import { AssessmentVisualizationEnabledToggle } from '../../../../../DetailsView/components/assessment-visualization-enabled-toggle';
-import { VisualHelperToggleTestPropsBuilder, VisualizationTogglePropsBuilder } from './restart-scan-visual-helper-toggle.test';
+import { VisualHelperToggleConfigBuilder } from '../../../common/visual-helper-toggle-config-builder';
+import { VisualizationTogglePropsBuilder } from '../../../common/visualization-toggle-props-builder';
 
 describe('AssessmentVisualizationEnabledToggle', () => {
     const actionMessageCreatorMock: IMock<DetailsViewActionMessageCreator> = Mock.ofType(DetailsViewActionMessageCreator);
 
     it('render with disabled message', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(true)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)
@@ -47,7 +48,7 @@ describe('AssessmentVisualizationEnabledToggle', () => {
     });
 
     it('render: toggle not disabled', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(true)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)
@@ -77,7 +78,7 @@ describe('AssessmentVisualizationEnabledToggle', () => {
     });
 
     it('render: have non empty instance map with a visible instance', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(false)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)
@@ -108,7 +109,7 @@ describe('AssessmentVisualizationEnabledToggle', () => {
     });
 
     it('render: have non empty instance map without a visible instance', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(false)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)
@@ -138,7 +139,7 @@ describe('AssessmentVisualizationEnabledToggle', () => {
     });
 
     it('enables all visualizations when none are shown', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(true)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)
@@ -162,7 +163,7 @@ describe('AssessmentVisualizationEnabledToggle', () => {
     });
 
     it('disables all visualizations when some are shown', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(true)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)

--- a/src/tests/unit/tests/DetailsView/components/restart-scan-visual-helper-toggle.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/restart-scan-visual-helper-toggle.test.tsx
@@ -5,19 +5,11 @@ import * as _ from 'lodash';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
-import { VisualHelperToggleConfig } from '../../../../../assessments/types/test-step';
 import { VisualizationToggle, VisualizationToggleProps } from '../../../../../common/components/visualization-toggle';
-import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
-import {
-    IAssessmentResultType,
-    IGeneratedAssessmentInstance,
-    ITestStepResult,
-} from '../../../../../common/types/store-data/iassessment-result-data';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import { RestartScanVisualHelperToggle } from '../../../../../DetailsView/components/restart-scan-visual-helper-toggle';
-import { DictionaryStringTo } from '../../../../../types/common-types';
-import { BaseDataBuilder } from '../../../common/base-data-builder';
+import { VisualHelperToggleConfigBuilder } from '../../../common/visual-helper-toggle-config-builder';
+import { VisualizationTogglePropsBuilder } from '../../../common/visualization-toggle-props-builder';
 
 describe('RestartScanVisualHelperToggleTest', () => {
     const stepKey = 'assessment-1-step-1';
@@ -28,7 +20,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
     });
 
     test('render', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(true)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)
@@ -57,7 +49,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
     });
 
     test('onClick: step enabled', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(true)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)
@@ -75,7 +67,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
     });
 
     test('onClick: step disabled', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(false)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)
@@ -109,107 +101,3 @@ describe('RestartScanVisualHelperToggleTest', () => {
         return new VisualizationTogglePropsBuilder().with('visualizationName', 'Visual helper').with('className', 'visual-helper-toggle');
     }
 });
-
-export class VisualHelperToggleTestPropsBuilder extends BaseDataBuilder<VisualHelperToggleConfig> {
-    private stepKey = 'assessment-1-step-1';
-    private otherKey = 'assessment-1-step-2';
-    constructor() {
-        super();
-
-        this.data = {
-            assessmentNavState: {
-                selectedTestStep: this.stepKey,
-                selectedTestType: -1 as VisualizationType,
-            },
-            actionMessageCreator: null,
-            instancesMap: {
-                'assessment-1-step-1': {
-                    html: 'html',
-                    propertyBag: {},
-                    target: ['element2'],
-                } as IGeneratedAssessmentInstance,
-            } as DictionaryStringTo<IGeneratedAssessmentInstance>,
-            isStepEnabled: true,
-            isStepScanned: false,
-        };
-    }
-
-    public withActionMessageCreator(actionMessageCreator: DetailsViewActionMessageCreator): VisualHelperToggleTestPropsBuilder {
-        this.data.actionMessageCreator = actionMessageCreator;
-        return this;
-    }
-
-    public withToggleStepEnabled(stepEnabled: boolean): VisualHelperToggleTestPropsBuilder {
-        this.data.isStepEnabled = stepEnabled;
-        return this;
-    }
-
-    public withToggleStepScanned(stepScanned: boolean): VisualHelperToggleTestPropsBuilder {
-        this.data.isStepScanned = stepScanned;
-        return this;
-    }
-
-    public withNonEmptyFilteredMap(isVisualizationEnabled: boolean = false): VisualHelperToggleTestPropsBuilder {
-        this.data.instancesMap = {
-            'selector-1': {
-                testStepResults: {
-                    [this.stepKey]: {
-                        id: 'id1',
-                        status: ManualTestStatus.UNKNOWN,
-                        isVisualizationEnabled: isVisualizationEnabled,
-                    } as ITestStepResult,
-                } as IAssessmentResultType<any>,
-            } as IGeneratedAssessmentInstance,
-            'selector-2': {
-                testStepResults: {
-                    [this.stepKey]: {
-                        id: 'id1',
-                        status: ManualTestStatus.FAIL,
-                        isVisualizationEnabled: isVisualizationEnabled,
-                    } as ITestStepResult,
-                } as IAssessmentResultType<any>,
-            } as IGeneratedAssessmentInstance,
-        };
-        return this;
-    }
-
-    public withEmptyFilteredMap(): VisualHelperToggleTestPropsBuilder {
-        this.data.instancesMap = {
-            'selector-1': {
-                testStepResults: {
-                    [this.otherKey]: {
-                        id: 'id2',
-                        status: ManualTestStatus.UNKNOWN,
-                    } as ITestStepResult,
-                } as IAssessmentResultType<any>,
-            } as IGeneratedAssessmentInstance,
-        };
-        return this;
-    }
-
-    public withPassingFilteredMap(): VisualHelperToggleTestPropsBuilder {
-        this.data.instancesMap = {
-            'selector-1': {
-                testStepResults: {
-                    [this.stepKey]: {
-                        id: 'id2',
-                        status: ManualTestStatus.PASS,
-                    } as ITestStepResult,
-                } as IAssessmentResultType<any>,
-            } as IGeneratedAssessmentInstance,
-            'selector-2': null,
-        };
-        return this;
-    }
-}
-
-export class VisualizationTogglePropsBuilder extends BaseDataBuilder<VisualizationToggleProps> {
-    constructor() {
-        super();
-        this.data = {
-            checked: false,
-            disabled: false,
-            visualizationName: null,
-        } as VisualizationToggleProps;
-    }
-}

--- a/src/tests/unit/tests/assessments/automated-checks/automated-checks-visualization-toggle.test.tsx
+++ b/src/tests/unit/tests/assessments/automated-checks/automated-checks-visualization-toggle.test.tsx
@@ -8,16 +8,14 @@ import { IMock, Mock } from 'typemoq';
 import { AutomatedChecksVisualizationToggle } from '../../../../../assessments/automated-checks/automated-checks-visualization-enabled-toggle';
 import { VisualizationToggle, VisualizationToggleProps } from '../../../../../common/components/visualization-toggle';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
-import {
-    VisualHelperToggleTestPropsBuilder,
-    VisualizationTogglePropsBuilder,
-} from '../../DetailsView/components/restart-scan-visual-helper-toggle.test';
+import { VisualHelperToggleConfigBuilder } from '../../../common/visual-helper-toggle-config-builder';
+import { VisualizationTogglePropsBuilder } from '../../../common/visualization-toggle-props-builder';
 
 describe('AutomatedChecksVisualizationToggle', () => {
     const actionMessageCreatorMock: IMock<DetailsViewActionMessageCreator> = Mock.ofType(DetailsViewActionMessageCreator);
 
     it('render with disabled message', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(true)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)
@@ -50,7 +48,7 @@ describe('AutomatedChecksVisualizationToggle', () => {
     });
 
     it('render: toggle not disabled', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(true)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)
@@ -80,7 +78,7 @@ describe('AutomatedChecksVisualizationToggle', () => {
     });
 
     it('render: toggle disabled when there are no failing instances for automated checks', () => {
-        const props = new VisualHelperToggleTestPropsBuilder()
+        const props = new VisualHelperToggleConfigBuilder()
             .withToggleStepEnabled(true)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)


### PR DESCRIPTION
#### Pull request checklist

- [x] **N/A** Addresses an existing issue: Fixes #0000
- [x] **N/A** Added relevant unit test for your changes. (`npm run test`)
- [x] **N/A** Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] **N/A** Added screenshots/GIFs for UI changes.

#### Description of changes

Wallaby complains with warnings when test files import other test files, since it causes it to double-run tests. This fixes the existing cases of these warnings by extracting the common test helpers into their own files.