### PR TITLE
Changed failure details background color to $neutral-2

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -1222,6 +1222,7 @@ div.insights-file-issue-details-dialog-container {
                     overflow-y: auto;
                     height: 40%;
                     min-height: 150px;
+                    background-color: $neutral-2;
                     > div {
                         border-top: 1px solid $neutral-8;
                     }

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -904,13 +904,13 @@ div.insights-file-issue-details-dialog-container {
                     }
                 }
                 .issues-table-details {
-                    margin-left: 24px;
                     height: 100%;
                     display: flex;
                     flex-direction: column;
                     min-height: 0;
                 }
                 .issues-details-list {
+                    margin-left: 24px;
                     display: flex;
                     flex-direction: column;
                     height: 60%;
@@ -1223,6 +1223,7 @@ div.insights-file-issue-details-dialog-container {
                     height: 40%;
                     min-height: 150px;
                     background-color: $neutral-2;
+                    padding-left: 24px;
                     > div {
                         border-top: 1px solid $neutral-8;
                     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes 1457633
- [ ] **N/A** Added relevant unit test for your changes. (`npm run test`)
- [ ] **N/A**Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

Added background color to Failure Details. One-line change to CSS.

![image](https://user-images.githubusercontent.com/7016281/54637289-8836c380-4a45-11e9-8a65-8868611cfb9a.png "Standard screenshot of Automated Checks")
![image](https://user-images.githubusercontent.com/7016281/54633301-1fe3e400-4a3d-11e9-93c2-88c8c755019f.png "High-Contrast screenshot of Automated Checks")

#### Notes for reviewers

The change is subtle but was requested by design. I also revised the padding and margins to match the figma.
