### PR TITLE
Changed default values in columns from hyphen to "(no value)" for better accessibility

### DIFF
--- a/src/assessments/common/property-bag-column-renderer.tsx
+++ b/src/assessments/common/property-bag-column-renderer.tsx
@@ -7,6 +7,8 @@ import { ColumnValue, ColumnValueBag } from '../../common/types/property-bag/col
 import { AssessmentInstanceRowData } from '../../DetailsView/components/assessment-instance-table';
 import { DictionaryStringTo } from '../../types/common-types';
 
+export const NoValue = '(no value)';
+
 export interface PropertyBagColumnRendererConfig<TPropertyBag extends ColumnValueBag> {
     propertyName: keyof TPropertyBag & string;
     displayName: string;

--- a/src/assessments/custom-widgets/test-steps/cues.tsx
+++ b/src/assessments/custom-widgets/test-steps/cues.tsx
@@ -11,6 +11,7 @@ import * as content from '../../../content/test/custom-widgets/cues';
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
+import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { TestStep } from '../../types/test-step';
@@ -67,23 +68,23 @@ export const Cues: TestStep = {
                 {
                     propertyName: 'role',
                     displayName: 'Widget role',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
                 {
                     propertyName: 'designPattern',
                     displayName: 'Design pattern',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
                 {
                     propertyName: 'htmlCues',
                     displayName: 'HTML cues',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                     expand: true,
                 },
                 {
                     propertyName: 'ariaCues',
                     displayName: 'ARIA cues',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                     expand: true,
                 },
             ]),

--- a/src/assessments/custom-widgets/test-steps/design-pattern.tsx
+++ b/src/assessments/custom-widgets/test-steps/design-pattern.tsx
@@ -12,6 +12,7 @@ import * as content from '../../../content/test/custom-widgets/design-pattern';
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
+import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { TestStep } from '../../types/test-step';
@@ -56,17 +57,17 @@ export const DesignPattern: TestStep = {
                 {
                     propertyName: 'role',
                     displayName: 'Widget role',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
                 {
                     propertyName: 'designPattern',
                     displayName: 'Design pattern',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
                 {
                     propertyName: 'text',
                     displayName: 'Accessible name',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
             ]),
         },

--- a/src/assessments/custom-widgets/test-steps/instructions.tsx
+++ b/src/assessments/custom-widgets/test-steps/instructions.tsx
@@ -11,6 +11,7 @@ import * as content from '../../../content/test/custom-widgets/instructions';
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
+import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { TestStep } from '../../types/test-step';
@@ -51,17 +52,17 @@ export const Instructions: TestStep = {
                 {
                     propertyName: 'designPattern',
                     displayName: 'Design pattern',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
                 {
                     propertyName: 'text',
                     displayName: 'Accessible name',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
                 {
                     propertyName: 'describedBy',
                     displayName: 'Accessible description',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
             ]),
         },

--- a/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
+++ b/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
@@ -11,6 +11,7 @@ import * as content from '../../../content/test/custom-widgets/keyboard-interact
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
+import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { TestStep } from '../../types/test-step';
@@ -54,12 +55,12 @@ export const KeyboardInteraction: TestStep = {
                 {
                     propertyName: 'designPattern',
                     displayName: 'Design pattern',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
                 {
                     propertyName: 'text',
                     displayName: 'Accessible name',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
             ]),
         },

--- a/src/assessments/custom-widgets/test-steps/label.tsx
+++ b/src/assessments/custom-widgets/test-steps/label.tsx
@@ -11,6 +11,7 @@ import * as content from '../../../content/test/custom-widgets/label';
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
+import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { TestStep } from '../../types/test-step';
@@ -50,17 +51,17 @@ export const Label: TestStep = {
                 {
                     propertyName: 'designPattern',
                     displayName: 'Design pattern',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
                 {
                     propertyName: 'text',
                     displayName: 'Accessible name',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
                 {
                     propertyName: 'describedBy',
                     displayName: 'Accessible description',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
             ]),
         },

--- a/src/assessments/custom-widgets/test-steps/role-state-property.tsx
+++ b/src/assessments/custom-widgets/test-steps/role-state-property.tsx
@@ -12,6 +12,7 @@ import * as content from '../../../content/test/custom-widgets/role-state-proper
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
+import { NoValue } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { TestStep } from '../../types/test-step';
@@ -71,12 +72,12 @@ export const RoleStateProperty: TestStep = {
                 {
                     propertyName: 'designPattern',
                     displayName: 'Design pattern',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
                 {
                     propertyName: 'text',
                     displayName: 'Accessible name',
-                    defaultValue: '-',
+                    defaultValue: NoValue,
                 },
             ]),
         },

--- a/src/assessments/images/test-steps/image-function.tsx
+++ b/src/assessments/images/test-steps/image-function.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { PropertyBagColumnRendererConfig } from '../../../assessments/common/property-bag-column-renderer';
+import { NoValue, PropertyBagColumnRendererConfig } from '../../../assessments/common/property-bag-column-renderer';
 import { ImageFunctionPropertyBag } from '../../../common/types/property-bag/iimage-function';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
@@ -56,12 +56,12 @@ const propertyBagConfig: PropertyBagColumnRendererConfig<ImageFunctionPropertyBa
     {
         propertyName: 'codedAs',
         displayName: 'Coded as',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'accessibleName',
         displayName: 'Accessible name',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
 ];
 

--- a/src/assessments/images/test-steps/images-of-text.tsx
+++ b/src/assessments/images/test-steps/images-of-text.tsx
@@ -10,7 +10,7 @@ import * as content from '../../../content/test/images/images-of-text';
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
-import { PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
+import { NoValue, PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { TestStep } from '../../types/test-step';
@@ -39,7 +39,7 @@ const propertyBagConfig: PropertyBagColumnRendererConfig<ImagesOfTextPropertyBag
     {
         propertyName: 'accessibleName',
         displayName: 'Accessible name',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
 ];
 

--- a/src/assessments/images/test-steps/text-alternative.tsx
+++ b/src/assessments/images/test-steps/text-alternative.tsx
@@ -10,7 +10,7 @@ import * as content from '../../../content/test/images/text-alternative';
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
-import { PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
+import { NoValue, PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
@@ -62,12 +62,12 @@ const propertyBagConfig: PropertyBagColumnRendererConfig<TextAlternativeProperty
     {
         propertyName: 'accessibleName',
         displayName: 'Accessible name',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'accessibleDescription',
         displayName: 'Accessible description',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
 ];
 

--- a/src/assessments/links/test-steps/link-function.tsx
+++ b/src/assessments/links/test-steps/link-function.tsx
@@ -12,7 +12,7 @@ import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/compo
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
-import { PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
+import { NoValue, PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { TestStep } from '../../types/test-step';
@@ -41,27 +41,27 @@ const propertyBagConfig: PropertyBagColumnRendererConfig<LinkFunctionPropertyBag
     {
         propertyName: 'accessibleName',
         displayName: 'Accessible name',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'url',
         displayName: 'URL',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'role',
         displayName: 'Role',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'tabIndex',
         displayName: 'Tab Index',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'ariaAttributes',
         displayName: 'Aria attributes',
-        defaultValue: '-',
+        defaultValue: NoValue,
         expand: true,
     },
 ];

--- a/src/assessments/links/test-steps/link-purpose.tsx
+++ b/src/assessments/links/test-steps/link-purpose.tsx
@@ -12,7 +12,7 @@ import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/compo
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
-import { PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
+import { NoValue, PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { TestStep } from '../../types/test-step';
@@ -57,17 +57,17 @@ const propertyBagConfig: PropertyBagColumnRendererConfig<LinkPurposePropertyBag>
     {
         propertyName: 'accessibleName',
         displayName: 'Accessible name',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'accessibleDescription',
         displayName: 'Accessible description',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'url',
         displayName: 'URL',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
 ];
 

--- a/src/assessments/native-widgets/test-steps/cues.tsx
+++ b/src/assessments/native-widgets/test-steps/cues.tsx
@@ -11,7 +11,7 @@ import * as content from '../../../content/test/native-widgets/cues';
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
-import { PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
+import { NoValue, PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
@@ -64,23 +64,23 @@ const propertyBagConfig: PropertyBagColumnRendererConfig<CuesPropertyBag>[] = [
     {
         propertyName: 'element',
         displayName: 'Element',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'accessibleName',
         displayName: 'Accessible name',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'htmlCues',
         displayName: 'HTML cues',
-        defaultValue: '-',
+        defaultValue: NoValue,
         expand: true,
     },
     {
         propertyName: 'ariaCues',
         displayName: 'ARIA cues',
-        defaultValue: '-',
+        defaultValue: NoValue,
         expand: true,
     },
 ];

--- a/src/assessments/native-widgets/test-steps/instructions.tsx
+++ b/src/assessments/native-widgets/test-steps/instructions.tsx
@@ -11,7 +11,7 @@ import * as content from '../../../content/test/native-widgets/instructions';
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
-import { PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
+import { NoValue, PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
@@ -47,17 +47,17 @@ const propertyBagConfig: PropertyBagColumnRendererConfig<IDefaultWidgetPropertyB
     {
         propertyName: 'element',
         displayName: 'Element',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'accessibleName',
         displayName: 'Accessible name',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'accessibleDescription',
         displayName: 'Accessible description',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
 ];
 

--- a/src/assessments/native-widgets/test-steps/label.tsx
+++ b/src/assessments/native-widgets/test-steps/label.tsx
@@ -11,7 +11,7 @@ import * as content from '../../../content/test/native-widgets/label';
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
-import { PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
+import { NoValue, PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
 import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
@@ -42,17 +42,17 @@ const propertyBagConfig: PropertyBagColumnRendererConfig<IDefaultWidgetPropertyB
     {
         propertyName: 'element',
         displayName: 'Element',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'accessibleName',
         displayName: 'Accessible name',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'accessibleDescription',
         displayName: 'Accessible description',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
 ];
 

--- a/src/assessments/native-widgets/test-steps/widget-function.tsx
+++ b/src/assessments/native-widgets/test-steps/widget-function.tsx
@@ -12,7 +12,7 @@ import * as content from '../../../content/test/native-widgets/widget-function';
 import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
-import { PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
+import { NoValue, PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { TestStep } from '../../types/test-step';
@@ -45,28 +45,28 @@ const propertyBagConfig: PropertyBagColumnRendererConfig<WidgetFunctionPropertyB
     {
         propertyName: 'element',
         displayName: 'Element',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'accessibleName',
         displayName: 'Accessible name',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'role',
         displayName: 'Role',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'ariaAttributes',
         displayName: 'ARIA attributes',
-        defaultValue: '-',
+        defaultValue: NoValue,
         expand: true,
     },
     {
         propertyName: 'tabIndex',
         displayName: 'Tab index',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
 ];
 

--- a/src/assessments/text-legibility/test-steps/contrast.tsx
+++ b/src/assessments/text-legibility/test-steps/contrast.tsx
@@ -14,7 +14,7 @@ import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/compo
 import { ScannerUtils } from '../../../injected/scanner-utils';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import AssistedTestRecordYourResults from '../../common/assisted-test-record-your-results';
-import { PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
+import { NoValue, PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
 import * as Markup from '../../markup';
 import { ReportInstanceField } from '../../types/report-instance-field';
 import { TestStep } from '../../types/test-step';
@@ -58,7 +58,7 @@ const propertyBagConfig: PropertyBagColumnRendererConfig<ContrastPropertyBag>[] 
     {
         propertyName: 'textString',
         displayName: 'Text string',
-        defaultValue: '-',
+        defaultValue: NoValue,
     },
     {
         propertyName: 'size',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes 145509
- [ ] **N/A** Added relevant unit test for your changes. (`npm run test`)
- [ ] **N/A** Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

Replaced all instances of the hyphen character `'-'` in column default values with `'(no value)'`. Created a string constant for holding the default.

![image](https://user-images.githubusercontent.com/7016281/54634784-21fb7200-4a40-11e9-8f8e-b922043f8b13.png "Screenshot of instance instructions in Native Widgets showing (no value) in Accessible description")

#### Notes for reviewers

Tested with NVDA - reads "NO VALUE"
Tested with JAWS - reads "left paren - NO VALUE - right paren"