### PR TITLE
Refactor initial assessment store data generator tests

### DIFF
--- a/src/tests/unit/tests/background/__snapshots__/initial-assessment-store-data-generator.test.ts.snap
+++ b/src/tests/unit/tests/background/__snapshots__/initial-assessment-store-data-generator.test.ts.snap
@@ -1,0 +1,74 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InitialAssessmentStoreDataGenerator.generateInitialState generates the pinned default state from assessmentsProvider data when no persistedData is provided 1`] = `
+Object {
+  "assessmentNavState": Object {
+    "selectedTestStep": "assessment-1-step-1",
+    "selectedTestType": -1,
+  },
+  "assessments": Object {
+    "assessment-1": Object {
+      "fullAxeResultsMap": null,
+      "generatedAssessmentInstancesMap": null,
+      "manualTestStepResultMap": Object {
+        "assessment-1-step-1": Object {
+          "id": "assessment-1-step-1",
+          "instances": Array [],
+          "status": 1,
+        },
+        "assessment-1-step-2": Object {
+          "id": "assessment-1-step-2",
+          "instances": Array [],
+          "status": 1,
+        },
+        "assessment-1-step-3": Object {
+          "id": "assessment-1-step-3",
+          "instances": Array [],
+          "status": 1,
+        },
+      },
+      "testStepStatus": Object {
+        "assessment-1-step-1": Object {
+          "isStepScanned": false,
+          "stepFinalResult": 1,
+        },
+        "assessment-1-step-2": Object {
+          "isStepScanned": false,
+          "stepFinalResult": 1,
+        },
+        "assessment-1-step-3": Object {
+          "isStepScanned": false,
+          "stepFinalResult": 1,
+        },
+      },
+    },
+    "assessment-2": Object {
+      "fullAxeResultsMap": null,
+      "generatedAssessmentInstancesMap": null,
+      "manualTestStepResultMap": Object {
+        "assessment-2-step-1": Object {
+          "id": "assessment-2-step-1",
+          "instances": Array [],
+          "status": 1,
+        },
+        "assessment-2-step-2": Object {
+          "id": "assessment-2-step-2",
+          "instances": Array [],
+          "status": 1,
+        },
+      },
+      "testStepStatus": Object {
+        "assessment-2-step-1": Object {
+          "isStepScanned": false,
+          "stepFinalResult": 1,
+        },
+        "assessment-2-step-2": Object {
+          "isStepScanned": false,
+          "stepFinalResult": 1,
+        },
+      },
+    },
+  },
+  "persistedTabInfo": null,
+}
+`;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: This is in preparation for updating the generator to be compatible with the planned fix for #390.
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] **N/A** Added screenshots/GIFs for UI changes.

#### Description of changes

This cleans up the `initial-assessment-store-data-generator` tests to
* use more descriptive test names
* use current snapshotting practices
* use `.each` where appropriate
* make helper variable setup less verbose
* move setup data specific and relevant to individual test cases into those test cases
* use ManualTestStatus enums instead of magic integers

I'll be adding some new test cases as part of the #390 fixes and wanted to do that separately from refactoring the existing ones. Some of the cases reveal that the existing product logic is kind of questionable (eg, the allowances for null/undefined/{} data are not consistent between different properties), but I wanted to keep this PR strictly to refactoring the tests, and leave improving the actual generator logic for a separate PR.