### PR TITLE
Fix source maps in dev tool by using eval-source-map option in webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,7 @@ const devConfig = {
     ...commonConfig,
     name: 'dev',
     mode: 'development',
-    devtool: 'source-map',
+    devtool: 'eval-source-map',
     output: {
         path: path.join(__dirname, 'extension/devBundle'),
         filename: '[name].bundle.js',


### PR DESCRIPTION
#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`npm run test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`npm run precheckin`)
- [n/a] Added screenshots/GIFs for UI changes.

#### Description of changes

The source maps in the dev environment do not work due to a change made in chrome.

Issue discussing this on webpack: https://github.com/webpack/webpack/issues/8506
Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=919575

#### Notes for reviewers

This will increase our dev deployment sizes but I think it is worth the benefit to be able to debug when needed in dev environment.

The specific option was chosen due to the webpack config documentation stating this:

> eval-source-map - Each module is executed with eval() and a SourceMap is added as a DataUrl to the eval(). Initially it is slow, but it provides fast rebuild speed and yields real files. Line numbers are correctly mapped since it gets mapped to the original code. It yields the best quality SourceMaps for development.

link: https://webpack.js.org/configuration/devtool/