### PR TITLE
BugFix: command bar styling refine

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -322,6 +322,7 @@ div.insights-file-issue-details-dialog-container {
         }
     }
     .header-bar {
+        padding-left: 12px;
         position: fixed;
         z-index: 1000;
         .gear-options-button-component {

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -318,7 +318,7 @@ div.insights-file-issue-details-dialog-container {
         }
         .details-view-command-buttons {
             display: flex;
-            margin-right: 24px;
+            margin-right: 16px;
         }
     }
     .header-bar {

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -300,7 +300,11 @@ div.insights-file-issue-details-dialog-container {
         justify-content: space-between;
         min-height: fit-content;
         align-items: center;
-        background-color: $neutral-4;
+        background-color: $neutral-0;
+        padding-left: 16px;
+        font-size: 14px;
+        font-weight: 600;
+        border-bottom: 1px solid $neutral-alpha-8;
         .details-view-target-page {
             padding: 13px 8px;
             display: inherit;
@@ -314,6 +318,7 @@ div.insights-file-issue-details-dialog-container {
         }
         .details-view-command-buttons {
             display: flex;
+            margin-right: 24px;
         }
     }
     .header-bar {

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -301,11 +301,11 @@ div.insights-file-issue-details-dialog-container {
         min-height: fit-content;
         align-items: center;
         background-color: $neutral-0;
-        padding-left: 16px;
         font-size: 14px;
         font-weight: 600;
         border-bottom: 1px solid $neutral-alpha-8;
         .details-view-target-page {
+            margin-left: 12px;
             padding: 13px 8px;
             display: inherit;
             white-space: nowrap;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1421040
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

1) There should be a ****margin of 16px (at least)****, with all items aligned with one another on the right and left. The list of test items and the settings gear in the upper right appear to have the correct margins.

2) Command bar should be white with a ****1px box shadow on the bottom**** rgba (0,0,0,0.8)



![image](https://user-images.githubusercontent.com/15974344/54790898-fff72080-4bf4-11e9-9f21-b11281a70f7d.png)

