### PR TITLE
[BugFix] disable sandbox to avoid chromium crash when launch e2e test

### DIFF
--- a/src/tests/end-to-end/common/browser-factory.ts
+++ b/src/tests/end-to-end/common/browser-factory.ts
@@ -65,6 +65,7 @@ async function launchNewBrowser(): Promise<Puppeteer.Browser> {
             // Required to work around https://github.com/GoogleChrome/puppeteer/pull/774
             `--disable-extensions-except=${extensionPath}`,
             `--load-extension=${extensionPath}`,
+            '--no-sandbox',
         ],
         timeout: DEFAULT_BROWSER_LAUNCH_TIMEOUT_MS,
     });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1437600
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.

#### Notes for reviewers
Added '--no-sandbox' to chrome options. This will fix the issue we currently have, see http://chromedriver.chromium.org/help/chrome-doesn-t-start
However, I'm not sure if this introduces extra vulnerability into our e2e tests. 
Let me know your thoughts on this.
