### PR TITLE
fix vertical scroll on the assessment panel

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -888,8 +888,7 @@ div.insights-file-issue-details-dialog-container {
                     .details-view-assessment-content {
                         flex-grow: 1;
                         display: flex;
-                        min-height: 25vh;
-                        max-height: 77vh;
+                        height: 0;
                         border-top: 1px solid $neutral-8;
                     }
                     .assessment-requirements-title {

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -889,6 +889,7 @@ div.insights-file-issue-details-dialog-container {
                         flex-grow: 1;
                         display: flex;
                         min-height: 25vh;
+                        max-height: 77vh !important;
                         border-top: 1px solid $neutral-8;
                     }
                     .assessment-requirements-title {

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -889,7 +889,7 @@ div.insights-file-issue-details-dialog-container {
                         flex-grow: 1;
                         display: flex;
                         min-height: 25vh;
-                        max-height: 77vh !important;
+                        max-height: 77vh;
                         border-top: 1px solid $neutral-8;
                     }
                     .assessment-requirements-title {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #413
- [ ] Added relevant unit test for your changes. (`npm run test`) - n/a
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` - n/a
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

With new chrome (73 & above) the details view page was behaving weird on scroll. Check the attached Gif for current behavior.
Fixed it by adding a max-height to the `issue-details-dialog-container`

#### GIF

##### Current
![previous](https://user-images.githubusercontent.com/4496335/54790262-befe0c80-4bf2-11e9-9990-de473d2fd4ef.gif)

##### Fixed

![fixed](https://user-images.githubusercontent.com/4496335/54790270-c4f3ed80-4bf2-11e9-9160-876e8fd97f7f.gif)

