### PR TITLE
[bugfix] Fix the style for err tag

### DIFF
--- a/src/DetailsView/reports/components/outcome.scss
+++ b/src/DetailsView/reports/components/outcome.scss
@@ -48,13 +48,13 @@ $outcome-fail-summary-color: $negative-outcome;
     }
     .count {
         font-family: $fontFamily;
-        line-height: $outcome-chip-icon-size;
+        line-height: $outcome-chip-icon-size - 2;
         font-size: 11px;
         border-radius: 0 8px 8px 0;
         padding: 0 6px 0 10px;
         font-weight: 700;
         margin-left: -5px;
-        height: $outcome-chip-icon-size;
+        height: $outcome-chip-icon-size - 2;
     }
     &.outcome-chip-pass {
         @include check-icon-styles($outcome-chip-icon-size, 1px);


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1396990
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes
make changes to the tag styling so that: 
1. The tag with the X needs to be the ****same size**** of the tag that has the number and
2. it has to have ****even spacing**** around the “x”

![image](https://user-images.githubusercontent.com/15974344/54792703-6fbcd980-4bfc-11e9-9873-e7c85062c655.png)

