### PR TITLE
Remove double register for SEND_TELEMETRY message

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
-
 import { TestMode } from '../../common/configs/test-mode';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { Messages } from '../../common/messages';
@@ -23,7 +22,6 @@ import {
     BaseActionPayload,
     OnDetailsViewOpenPayload,
     OnDetailsViewPivotSelected,
-    PayloadWithEventName,
     ToggleActionPayload,
     VisualizationTogglePayload,
 } from './action-payloads';
@@ -107,8 +105,6 @@ export class ActionCreator {
             visualizationMessages.DetailsView.SetDetailsViewRightContentPanel,
             this.onSetDetailsViewRightContentPanel,
         );
-
-        this.registerTypeToPayloadCallback(Messages.Telemetry.Send, this.onSendTelemetry);
 
         this.registerTypeToPayloadCallback(Messages.ChromeFeature.configureCommand, this.onOpenConfigureCommandTab);
 
@@ -328,12 +324,6 @@ export class ActionCreator {
         } else {
             this.visualizationActions.disableVisualization.invoke(payload.test);
         }
-    }
-
-    @autobind
-    private onSendTelemetry(payload: PayloadWithEventName): void {
-        const eventName = payload.eventName;
-        this.telemetryEventHandler.publishTelemetry(eventName, payload);
     }
 
     @autobind

--- a/src/common/message-creators/base-action-message-creator.ts
+++ b/src/common/message-creators/base-action-message-creator.ts
@@ -29,6 +29,7 @@ export abstract class BaseActionMessageCreator {
             eventName: eventName,
             telemetry: eventData,
         };
+
         const message: Message = {
             type: Messages.Telemetry.Send,
             payload,

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -538,19 +538,6 @@ describe('ActionCreatorTest', () => {
         builder.verifyAll();
     });
 
-    test('registerCallback for onSendTelemetry', () => {
-        const payload = { eventName: 'launch-panel/open', telemetry: {} };
-        const args = [payload, 1];
-        const builder = new ActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Telemetry.Send, args)
-            .setupTelemetrySend('launch-panel/open', payload, 1);
-
-        const actionCreator = builder.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        builder.verifyAll();
-    });
-
     test('registerCallback for tabbed element added', () => {
         const tabbedElement: AddTabbedElementPayload = {
             tabbedElements: [


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1410093
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.

#### Description of changes

The double telemetry happen for `Message.Telemetry.Send` message. The reason simply being: both `GlobalActionCreator` and `ActionCreator` were registering a listener for this message (and of course, sending the telemetry on the listener).

This bug affected the following telemetry events:
- contentPageOpened
- contentHyperLinkOpened
- ExportResults (this is the one mentioned on the bug)
- DetailsViewOpened
- FileIssueClick
- IssuesDialogOpened
- CopyIssueDetails
- TutorialOpen
- PopupInitialized
- LaunchPanelOpen

I validated all this events to not be duplicated anymore.

#### Notes for reviewers

**N/A**
