### PR TITLE
[Cleanup - TSLint] Remove max length TSLint rule in favor of prettier

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,6 @@
     // We eventually want there to only be one tslint.json file, and to have all checks be build-enforced
     "extends": "./tslint.build-enforced.json",
     "rules": {
-        "max-line-length": [true, 140],
         "no-default-export": true,
         "no-shadowed-variable": true, // Disallows shadowing variable declarations
         "typedef": [true, "call-signature", "property-declaration"]


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.

#### Description of changes
Remove `max-line-length: 140` rule from `tslint.json`

#### Notes for reviewers

The basic idea of adding that rule is to make sure that we dont get lines of code which are above 140 but since we have already automated that process by `autoFormat` from `prettier` with `printWidth` as 140 and also we added a vscode ruler which marks our lines to be at 140 for visual guidance to contributors.
So, it makes sense to get rid of this rule from tslint file.

Let me know what you guys think.