### PR TITLE
Changed container for telemetry message from P to DIV

### DIFF
--- a/src/popup/scripts/components/telemetry-permission-dialog.tsx
+++ b/src/popup/scripts/components/telemetry-permission-dialog.tsx
@@ -53,7 +53,7 @@ export class TelemetryPermissionDialog extends React.Component<TelemetryPermissi
                     containerClassName: 'insights-dialog-main-override telemetry-permission-dialog',
                 }}
             >
-                <p className="telemetry-permission-details">{telemetryPopupNotice}</p>
+                <div className="telemetry-permission-details">{telemetryPopupNotice}</div>
                 <div className="telemetry-checkbox-section">
                     <Checkbox
                         label={telemetryPopupCheckboxTitle}

--- a/src/tests/end-to-end/tests/popup/__snapshots__/first-time-dialog.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/first-time-dialog.test.ts.snap
@@ -39,16 +39,16 @@ exports[`First time Dialog content should match snapshot 1`] = `
             <div
               class="ms-Dialog-content innerContent-000"
             >
-              <p
+              <div
                 class="telemetry-permission-details"
-              />
-              <p>
-                By opting into telemetry, you help the community develop inclusive software.
-              </p>
-              <p>
-                We collect anonymized data to identify the top accessibility issues found by the users. This will help focus the accessibility tools and standards community to improve guidelines, rules engines, and features.
-              </p>
-              <p />
+              >
+                <p>
+                  By opting into telemetry, you help the community develop inclusive software.
+                </p>
+                <p>
+                  We collect anonymized data to identify the top accessibility issues found by the users. This will help focus the accessibility tools and standards community to improve guidelines, rules engines, and features.
+                </p>
+              </div>
               <div
                 class="telemetry-checkbox-section"
               >

--- a/src/tests/unit/tests/popup/scripts/components/__snapshots__/telemetry-permission-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/popup/scripts/components/__snapshots__/telemetry-permission-dialog.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`TelemetryPermissionDialogTest render dialog 1`] = `
     }
   }
 >
-  <p
+  <div
     className="telemetry-permission-details"
   >
     <React.Fragment>
@@ -31,7 +31,7 @@ exports[`TelemetryPermissionDialogTest render dialog 1`] = `
         </p>
       </React.Fragment>
     </React.Fragment>
-  </p>
+  </div>
   <div
     className="telemetry-checkbox-section"
   >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1468878
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

#### Description of changes

The message has invalid HTML where a P tag is contained in another P tag. I changed the outermost P to a DIV. No user-perceivable change in screenshot.

![image](https://user-images.githubusercontent.com/7016281/54845680-40a77600-4c97-11e9-8e54-ec3eb118c793.png "Screenshot of telemetry popup showing no visual change")

#### Notes for reviewers

Just markup and snapshots.
