### PR TITLE
[TSLint] Final no-typedef fixes

### DIFF
--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -5,7 +5,7 @@ import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 
 import { AssessmentToggleActionPayload } from '../background/actions/action-payloads';
-import { InstanceIdentifierGenerator } from '../background/instance-identifier-generator';
+import { InstanceIdentifierGenerator, UniquelyIdentifiableInstances } from '../background/instance-identifier-generator';
 import { RequirementComparer } from '../common/assessment/requirement-comparer';
 import { AssesssmentVisualizationConfiguration } from '../common/configs/visualization-configuration-factory';
 import { Messages } from '../common/messages';
@@ -29,7 +29,7 @@ import { ReportInstanceField } from './types/report-instance-field';
 import { TestStep } from './types/test-step';
 
 export class AssessmentBuilder {
-    private static applyDefaultReportFieldMap(step: TestStep) {
+    private static applyDefaultReportFieldMap(step: TestStep): void {
         const { comment, snippet, path } = ReportInstanceField.common;
 
         const defaults = step.isManual ? [comment] : [path, snippet];
@@ -86,13 +86,13 @@ export class AssessmentBuilder {
         return testStepLink.renderRequirementDescriptionWithIndex();
     }
 
-    private static enableTest(scanData: IScanData, payload: AssessmentToggleActionPayload) {
+    private static enableTest(scanData: IScanData, payload: AssessmentToggleActionPayload): void {
         const scanAssessmentData = scanData as IAssessmentScanData;
         scanAssessmentData.enabled = true;
         scanAssessmentData.stepStatus[payload.step] = true;
     }
 
-    private static disableTest(scanData: IScanData, step: string) {
+    private static disableTest(scanData: IScanData, step: string): void {
         const scanAssessmentData = scanData as IAssessmentScanData;
         scanAssessmentData.stepStatus[step] = false;
         scanAssessmentData.enabled = Object.keys(scanAssessmentData.stepStatus).some(key => scanAssessmentData.stepStatus[key] === true);
@@ -239,11 +239,13 @@ export class AssessmentBuilder {
         } as Assessment;
     }
 
-    private static getStepConfig(steps: TestStep[], testStep: string) {
+    private static getStepConfig(steps: TestStep[], testStep: string): TestStep {
         return steps.find(step => step.key === testStep);
     }
 
-    private static getVisualizationInstanceProcessor(steps: TestStep[]) {
+    private static getVisualizationInstanceProcessor(
+        steps: TestStep[],
+    ): (testStep: string) => VisualizationInstanceProcessorCallback<PropertyBags, PropertyBags> {
         return (testStep: string): VisualizationInstanceProcessorCallback<PropertyBags, PropertyBags> => {
             const stepConfig = AssessmentBuilder.getStepConfig(steps, testStep);
             if (stepConfig == null || stepConfig.visualizationInstanceProcessor == null) {
@@ -253,7 +255,7 @@ export class AssessmentBuilder {
         };
     }
 
-    private static getSwitchToTargetTabOnScan(steps: TestStep[]) {
+    private static getSwitchToTargetTabOnScan(steps: TestStep[]): (testStep: string) => boolean {
         return (testStep: string): boolean => {
             const stepConfig = AssessmentBuilder.getStepConfig(steps, testStep);
             if (stepConfig == null || stepConfig.switchToTargetTabOnScan == null) {
@@ -263,7 +265,7 @@ export class AssessmentBuilder {
         };
     }
 
-    private static getInstanceIdentifier(steps: TestStep[]) {
+    private static getInstanceIdentifier(steps: TestStep[]): (testStep: string) => (instance: UniquelyIdentifiableInstances) => string {
         return (testStep: string) => {
             const stepConfig = AssessmentBuilder.getStepConfig(steps, testStep);
             if (stepConfig == null || stepConfig.generateInstanceIdentifier == null) {
@@ -273,7 +275,7 @@ export class AssessmentBuilder {
         };
     }
 
-    private static BuildStepsReportDescription(steps: TestStep[]) {
+    private static BuildStepsReportDescription(steps: TestStep[]): void {
         steps.forEach(step => {
             step.renderReportDescription = () => {
                 const descriptionCopy = _.cloneDeep(step.description);
@@ -297,7 +299,7 @@ export class AssessmentBuilder {
         return children;
     }
 
-    private static getUpdateVisibility(steps: TestStep[]) {
+    private static getUpdateVisibility(steps: TestStep[]): (testStep: string) => boolean {
         return (testStep: string): boolean => {
             const stepConfig = AssessmentBuilder.getStepConfig(steps, testStep);
             if (stepConfig == null || stepConfig.updateVisibility == null) {

--- a/src/common/components/with-store-subscription.tsx
+++ b/src/common/components/with-store-subscription.tsx
@@ -15,6 +15,7 @@ export type WithStoreSubscriptionDeps<T> = {
     storeActionMessageCreator: IStoreActionMessageCreator;
 };
 
+// tslint:disable-next-line: typedef
 export function withStoreSubscription<P extends WithStoreSubscriptionProps<S>, S>(WrappedComponent: React.ComponentType<P>) {
     return class extends React.Component<P, S> {
         constructor(props: P) {

--- a/src/common/components/with-store-subscription.tsx
+++ b/src/common/components/with-store-subscription.tsx
@@ -15,8 +15,9 @@ export type WithStoreSubscriptionDeps<T> = {
     storeActionMessageCreator: IStoreActionMessageCreator;
 };
 
-// tslint:disable-next-line: typedef
-export function withStoreSubscription<P extends WithStoreSubscriptionProps<S>, S>(WrappedComponent: React.ComponentType<P>) {
+export function withStoreSubscription<P extends WithStoreSubscriptionProps<S>, S>(
+    WrappedComponent: React.ComponentType<P>,
+): React.ComponentClass<P, S> {
     return class extends React.Component<P, S> {
         constructor(props: P) {
             super(props);

--- a/src/tests/unit/common/base-data-builder.ts
+++ b/src/tests/unit/common/base-data-builder.ts
@@ -11,7 +11,7 @@ export abstract class BaseDataBuilder<T> {
         return this.data;
     }
 
-    public with<P extends keyof T>(property: P, value: T[P]) {
+    public with<P extends keyof T>(property: P, value: T[P]): this {
         this.data[property] = value;
         return this;
     }

--- a/tslint.build-enforced.json
+++ b/tslint.build-enforced.json
@@ -50,6 +50,7 @@
         "semicolon": [true, "always", "ignore-bound-class-methods"],
         "trailing-comma": [true, { "multiline": "always", "singleline": "never" }],
         "triple-equals": [true, "allow-null-check", "allow-undefined-check"],
+        "typedef": [true, "call-signature", "property-declaration"],
         "typedef-whitespace": [
             true,
             {

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,6 @@
     "extends": "./tslint.build-enforced.json",
     "rules": {
         "no-default-export": true,
-        "no-shadowed-variable": true, // Disallows shadowing variable declarations
-        "typedef": [true, "call-signature", "property-declaration"]
+        "no-shadowed-variable": true // Disallows shadowing variable declarations
     }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.

#### Description of changes
Removes remaning `no-typedef` lint errors

#### Notes for reviewers

There are 2 peculiar cases in this PR:
  - base-data-builder.ts : that class is abstract and has a function `with`, where if I specify `BaseDataBuilder<T>` as return type; a lot of other tests start to fail. So,
     - First way of fixing is to keep the class abstract and specify `this` as return type
     - Second is to make it a normal class and then add `BaseDataBuilder<T>` as its return type. This option builds and compiles the code at the moment but then with newer version of TS(3.3.3), gives an error.

I chose the first one as the simpler fix. Open to change if someone knows what is the significance of `abstract` in that class and is it safe to remove it.

 - ~with-store-subscription.tsx: the function `withStoreSubscription` returns anonymous class which I dont know how to put in `typedef` info. So disabling that line~

