### PR TITLE
fix some interface name lint errors and remove tslint disable

### DIFF
--- a/src/DetailsView/idetails-view-props.d.ts
+++ b/src/DetailsView/idetails-view-props.d.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { VisualizationType } from '../common/types/visualization-type';
 import { ScanData } from '../background/visualization-store';
-import { IHtmlElementAxeResults } from '../injected/scanner-utils';
+import { HtmlElementAxeResults } from '../injected/scanner-utils';
 
 export interface DetailsViewProps {
     type: VisualizationType;

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -5,7 +5,7 @@ import * as TelemetryEvents from '../../common/telemetry-events';
 import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
 import { ManualTestStatus } from '../../common/types/manual-test-status';
 import { VisualizationType } from '../../common/types/visualization-type';
-import { ITabStopEvent } from '../../injected/tab-stops-listener';
+import { TabStopEvent } from '../../injected/tab-stops-listener';
 import { LaunchPanelType } from '../../popup/scripts/components/popup-view';
 
 export interface BaseActionPayload {
@@ -97,7 +97,7 @@ export interface PageVisibilityChangeTabPayload extends BaseActionPayload {
 }
 
 export interface AddTabbedElementPayload extends BaseActionPayload {
-    tabbedElements: ITabStopEvent[];
+    tabbedElements: TabStopEvent[];
 }
 
 export interface SetLaunchPanelState extends BaseActionPayload {

--- a/src/background/assessment-data-converter.ts
+++ b/src/background/assessment-data-converter.ts
@@ -4,7 +4,7 @@ import * as _ from 'lodash/index';
 
 import { ManualTestStatus } from '../common/types/manual-test-status';
 import { PartialTabOrderPropertyBag } from '../injected/tab-order-property-bag';
-import { ITabStopEvent } from '../injected/tab-stops-listener';
+import { TabStopEvent } from '../injected/tab-stops-listener';
 import { DictionaryStringTo } from '../types/common-types';
 import {
     IAssessmentInstancesMap,
@@ -13,7 +13,7 @@ import {
     ITestStepResult,
     IUserCapturedInstance,
 } from './../common/types/store-data/iassessment-result-data.d';
-import { DecoratedAxeNodeResult, IHtmlElementAxeResults } from './../injected/scanner-utils';
+import { DecoratedAxeNodeResult, HtmlElementAxeResults } from './../injected/scanner-utils';
 import { UniquelyIdentifiableInstances } from './instance-identifier-generator';
 
 export class AssessmentDataConverter {
@@ -25,7 +25,7 @@ export class AssessmentDataConverter {
 
     public generateAssessmentInstancesMap(
         previouslyGeneratedInstances: IAssessmentInstancesMap,
-        selectorMap: DictionaryStringTo<IHtmlElementAxeResults>,
+        selectorMap: DictionaryStringTo<HtmlElementAxeResults>,
         stepName: string,
         generateInstanceIdentifier: (instance: UniquelyIdentifiableInstances) => string,
         getInstanceStatus: (result: DecoratedAxeNodeResult) => ManualTestStatus,
@@ -57,7 +57,7 @@ export class AssessmentDataConverter {
 
     public generateAssessmentInstancesMapForEvents(
         previouslyGeneratedInstances: IAssessmentInstancesMap,
-        events: ITabStopEvent[],
+        events: TabStopEvent[],
         stepName: string,
         generateInstanceIdentifier: (instance: UniquelyIdentifiableInstances) => string,
     ): IAssessmentInstancesMap {
@@ -86,7 +86,7 @@ export class AssessmentDataConverter {
 
     private getInitialAssessmentInstance(
         currentInstance: IGeneratedAssessmentInstance,
-        elementAxeResult: IHtmlElementAxeResults,
+        elementAxeResult: HtmlElementAxeResults,
         testStep: string,
         ruleResult: DecoratedAxeNodeResult,
         getInstanceStatus: (result: DecoratedAxeNodeResult) => ManualTestStatus,
@@ -120,7 +120,7 @@ export class AssessmentDataConverter {
 
     private getInitialAssessmentFromEvent(
         matchingInstance: IGeneratedAssessmentInstance,
-        event: ITabStopEvent,
+        event: TabStopEvent,
         testStep: string,
         selector: string,
     ): IGeneratedAssessmentInstance {
@@ -158,7 +158,7 @@ export class AssessmentDataConverter {
 
     private getTestStepResults<T>(
         ruleResult: DecoratedAxeNodeResult,
-        elementAxeResult: IHtmlElementAxeResults,
+        elementAxeResult: HtmlElementAxeResults,
         getInstanceStatus: (result: DecoratedAxeNodeResult) => ManualTestStatus,
     ): ITestStepResult {
         return {

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -6,12 +6,12 @@ import { forOwn } from 'lodash/index';
 import { StoreNames } from '../../common/stores/store-names';
 import { IVisualizationScanResultData } from '../../common/types/store-data/ivisualization-scan-result-data';
 import { ScanCompletedPayload } from '../../injected/analyzers/analyzer';
-import { DecoratedAxeNodeResult, IHtmlElementAxeResults } from '../../injected/scanner-utils';
+import { DecoratedAxeNodeResult, HtmlElementAxeResults } from '../../injected/scanner-utils';
 import { DictionaryStringTo } from '../../types/common-types';
 import { AddTabbedElementPayload } from '../actions/action-payloads';
 import { TabActions } from '../actions/tab-actions';
 import { VisualizationScanResultActions } from '../actions/visualization-scan-result-actions';
-import { ITabStopEvent } from './../../injected/tab-stops-listener';
+import { TabStopEvent } from './../../injected/tab-stops-listener';
 import { BaseStore } from './base-store';
 
 export class VisualizationScanResultStore extends BaseStore<IVisualizationScanResultData> {
@@ -70,7 +70,7 @@ export class VisualizationScanResultStore extends BaseStore<IVisualizationScanRe
             this.state.tabStops.tabbedElements = [];
         }
 
-        let tabbedElementsWithoutTabOrder: ITabStopEvent[] = _.map(this.state.tabStops.tabbedElements, element => {
+        let tabbedElementsWithoutTabOrder: TabStopEvent[] = _.map(this.state.tabStops.tabbedElements, element => {
             return {
                 timestamp: element.timestamp,
                 target: element.target,
@@ -137,10 +137,10 @@ export class VisualizationScanResultStore extends BaseStore<IVisualizationScanRe
         this.emitChanged();
     }
 
-    private getRowToRuleResultMap(selectorMap: DictionaryStringTo<IHtmlElementAxeResults>): DictionaryStringTo<DecoratedAxeNodeResult> {
+    private getRowToRuleResultMap(selectorMap: DictionaryStringTo<HtmlElementAxeResults>): DictionaryStringTo<DecoratedAxeNodeResult> {
         const selectedRows: DictionaryStringTo<DecoratedAxeNodeResult> = {};
 
-        forOwn(selectorMap, (selector: IHtmlElementAxeResults) => {
+        forOwn(selectorMap, (selector: HtmlElementAxeResults) => {
             const ruleResults = selector.ruleResults;
 
             forOwn(ruleResults, (rule: DecoratedAxeNodeResult) => {
@@ -151,8 +151,8 @@ export class VisualizationScanResultStore extends BaseStore<IVisualizationScanRe
         return selectedRows;
     }
 
-    private getSelectorMap(selectedRows: DictionaryStringTo<DecoratedAxeNodeResult>): DictionaryStringTo<IHtmlElementAxeResults> {
-        const selectorMap: DictionaryStringTo<IHtmlElementAxeResults> = {};
+    private getSelectorMap(selectedRows: DictionaryStringTo<DecoratedAxeNodeResult>): DictionaryStringTo<HtmlElementAxeResults> {
+        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {};
         forOwn(selectedRows, (selectedRow: DecoratedAxeNodeResult) => {
             const ruleResult = selectedRow;
             const ruleResults = selectorMap[ruleResult.selector] ? selectorMap[ruleResult.selector].ruleResults : {};

--- a/src/common/configs/visualization-configuration-factory.ts
+++ b/src/common/configs/visualization-configuration-factory.ts
@@ -12,7 +12,7 @@ import { UniquelyIdentifiableInstances } from '../../background/instance-identif
 import { TestViewProps } from '../../DetailsView/components/test-view';
 import { Analyzer } from '../../injected/analyzers/analyzer';
 import { AnalyzerProvider } from '../../injected/analyzers/analyzer-provider';
-import { IHtmlElementAxeResults, ScannerUtils } from '../../injected/scanner-utils';
+import { HtmlElementAxeResults, ScannerUtils } from '../../injected/scanner-utils';
 import { PropertyBags, VisualizationInstanceProcessorCallback } from '../../injected/visualization-instance-processor';
 import { DrawerProvider } from '../../injected/visualization/drawer-provider';
 import { IDrawer } from '../../injected/visualization/idrawer';
@@ -45,7 +45,7 @@ export interface AssesssmentVisualizationConfiguration {
     setAssessmentData?: (data: IAssessmentStoreData, selectorMap: DictionaryStringTo<any>, instanceMap?: DictionaryStringTo<any>) => void;
     analyzerMessageType: string;
     analyzerProgressMessageType?: string;
-    resultProcessor?: (scanner: ScannerUtils) => (results: ScanResults) => DictionaryStringTo<IHtmlElementAxeResults>;
+    resultProcessor?: (scanner: ScannerUtils) => (results: ScanResults) => DictionaryStringTo<HtmlElementAxeResults>;
     telemetryProcessor?: TelemetryProcessor<IAnalyzerTelemetryCallback>;
     getAnalyzer: (analyzerProvider: AnalyzerProvider, testStep?: string) => Analyzer;
     getIdentifier: (testStep?: string) => string;

--- a/src/common/types/store-data/ivisualization-scan-result-data.d.ts
+++ b/src/common/types/store-data/ivisualization-scan-result-data.d.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DecoratedAxeNodeResult, IHtmlElementAxeResults } from '../../../injected/scanner-utils';
+import { DecoratedAxeNodeResult, HtmlElementAxeResults } from '../../../injected/scanner-utils';
 import { TabOrderPropertyBag } from '../../../injected/tab-order-property-bag';
-import { ITabStopEvent } from '../../../injected/tab-stops-listener';
+import { TabStopEvent } from '../../../injected/tab-stops-listener';
 
 // tslint:disable-next-line:interface-name
 interface IScanResultData<TSelector> {
@@ -11,14 +11,14 @@ interface IScanResultData<TSelector> {
 }
 
 // tslint:disable-next-line:interface-name
-export interface IIssuesScanResultData extends IScanResultData<IHtmlElementAxeResults> {
-    selectedAxeResultsMap: DictionaryStringTo<IHtmlElementAxeResults>;
+export interface IIssuesScanResultData extends IScanResultData<HtmlElementAxeResults> {
+    selectedAxeResultsMap: DictionaryStringTo<HtmlElementAxeResults>;
     selectedIdToRuleResultMap: DictionaryStringTo<DecoratedAxeNodeResult>;
     fullIdToRuleResultMap: DictionaryStringTo<DecoratedAxeNodeResult>;
 }
 
 // tslint:disable-next-line:interface-name
-export interface ITabbedElementData extends ITabStopEvent {
+export interface ITabbedElementData extends TabStopEvent {
     tabOrder: number;
     propertyBag?: TabOrderPropertyBag;
 }

--- a/src/injected/analyzers/analyzer.ts
+++ b/src/injected/analyzers/analyzer.ts
@@ -8,8 +8,8 @@ import { TelemetryProcessor } from '../../common/types/telemetry-processor';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { ScanResults } from '../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../types/common-types';
-import { IHtmlElementAxeResults, ScannerUtils } from '../scanner-utils';
-import { ITabStopEvent } from '../tab-stops-listener';
+import { HtmlElementAxeResults, ScannerUtils } from '../scanner-utils';
+import { TabStopEvent } from '../tab-stops-listener';
 
 export interface AxeAnalyzerResult {
     results: DictionaryStringTo<any>;
@@ -29,7 +29,7 @@ export interface ScanCompletedPayload<TSelectorValue> extends ScanBasePayload {
 }
 
 export interface ScanUpdatePayload extends ScanBasePayload {
-    results: ITabStopEvent[];
+    results: TabStopEvent[];
 }
 
 export interface ScanBasePayload extends BaseActionPayload {
@@ -45,7 +45,7 @@ export interface AnalyzerConfiguration {
 
 export interface RuleAnalyzerConfiguration extends AnalyzerConfiguration {
     rules: string[];
-    resultProcessor: (scanner: ScannerUtils) => (results: ScanResults) => DictionaryStringTo<IHtmlElementAxeResults>;
+    resultProcessor: (scanner: ScannerUtils) => (results: ScanResults) => DictionaryStringTo<HtmlElementAxeResults>;
     telemetryProcessor: TelemetryProcessor<IAnalyzerTelemetryCallback>;
 }
 

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -3,7 +3,7 @@
 import { autobind } from '@uifabric/utilities';
 import * as Q from 'q';
 import { WindowUtils } from './../../common/window-utils';
-import { ITabStopEvent, TabStopsListener } from './../tab-stops-listener';
+import { TabStopEvent, TabStopsListener } from './../tab-stops-listener';
 import { AxeAnalyzerResult, FocusAnalyzerConfiguration, ScanBasePayload, ScanUpdatePayload } from './analyzer';
 import { BaseAnalyzer } from './base-analyzer';
 
@@ -16,7 +16,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
     private deferred: Q.Deferred<AxeAnalyzerResult>;
     private _windowUtils: WindowUtils;
 
-    private _pendingTabbedElements: ITabStopEvent[] = [];
+    private _pendingTabbedElements: TabStopEvent[] = [];
     private _onTabbedTimeoutId: number;
     protected config: FocusAnalyzerConfiguration;
 
@@ -42,7 +42,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
 
     protected getResults(): Q.Promise<AxeAnalyzerResult> {
         this.deferred = Q.defer<AxeAnalyzerResult>();
-        this.tabStopsListener.setTabEventListenerOnMainWindow((tabEvent: ITabStopEvent) => {
+        this.tabStopsListener.setTabEventListenerOnMainWindow((tabEvent: TabStopEvent) => {
             if (this._onTabbedTimeoutId != null) {
                 this._windowUtils.clearTimeout(this._onTabbedTimeoutId);
                 this._onTabbedTimeoutId = null;
@@ -69,7 +69,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
     }
 
     @autobind
-    protected onProgress(progressResult: ProgressResult<ITabStopEvent[]>): void {
+    protected onProgress(progressResult: ProgressResult<TabStopEvent[]>): void {
         const payload: ScanUpdatePayload = {
             key: this.config.key,
             testType: this.config.testType,

--- a/src/injected/client-utils.ts
+++ b/src/injected/client-utils.ts
@@ -5,32 +5,29 @@ export interface ClientRectOffset {
     top: number;
 }
 
-// tslint:disable-next-line:interface-name
-export interface IScrollAccessor {
+export interface ScrollAccessor {
     scrollX: number;
     scrollY: number;
 }
 
-// tslint:disable-next-line:interface-name
-export interface IBoundRectAccessor {
+export interface BoundRectAccessor {
     getBoundingClientRect: () => ClientRectOffset;
 }
 
-// tslint:disable-next-line:interface-name
-export interface IElementMatcher {
+export interface ElementMatcher {
     matches?: (selector: string) => boolean;
     webkitMatchesSelector?: (selector: string) => boolean;
     msMatchesSelector?: (selector: string) => boolean;
 }
 
 export class ClientUtils {
-    private scroll: IScrollAccessor;
+    private scroll: ScrollAccessor;
 
-    constructor(scroll: IScrollAccessor) {
+    constructor(scroll: ScrollAccessor) {
         this.scroll = scroll;
     }
 
-    public getOffset(element: IBoundRectAccessor): ClientRectOffset {
+    public getOffset(element: BoundRectAccessor): ClientRectOffset {
         const elementRect = element.getBoundingClientRect();
 
         return {
@@ -39,7 +36,7 @@ export class ClientUtils {
         };
     }
 
-    public matchesSelector(element: IElementMatcher, selectorString: string): boolean {
+    public matchesSelector(element: ElementMatcher, selectorString: string): boolean {
         const selector = (element.matches || element.webkitMatchesSelector || element.msMatchesSelector).bind(element);
 
         return selector(selectorString);

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -21,11 +21,11 @@ import { FrameMessageResponseCallback } from './frameCommunicators/window-messag
 import { IErrorMessageContent } from './frameCommunicators/window-message-marshaller';
 import { LayeredDetailsDialogComponent, LayeredDetailsDialogDeps } from './layered-details-dialog-component';
 import { MainWindowContext } from './main-window-context';
-import { DecoratedAxeNodeResult, IHtmlElementAxeResults } from './scanner-utils';
+import { DecoratedAxeNodeResult, HtmlElementAxeResults } from './scanner-utils';
 import { ShadowUtils } from './shadow-utils';
 
 export interface DetailsDialogWindowMessage {
-    data: IHtmlElementAxeResults;
+    data: HtmlElementAxeResults;
     featureFlagStoreData: FeatureFlagStoreData;
 }
 
@@ -47,7 +47,7 @@ export class DialogRenderer {
         }
     }
 
-    public render(data: IHtmlElementAxeResults, featureFlagStoreData: FeatureFlagStoreData): void {
+    public render(data: HtmlElementAxeResults, featureFlagStoreData: FeatureFlagStoreData): void {
         if (this.isInMainWindow()) {
             const mainWindowContext = MainWindowContext.get();
             mainWindowContext.getTargetPageActionMessageCreator().openIssuesDialog();
@@ -128,15 +128,15 @@ export class DialogRenderer {
         return dialogContainer;
     }
 
-    private getFailedRules(data: IHtmlElementAxeResults): DictionaryStringTo<DecoratedAxeNodeResult> {
+    private getFailedRules(data: HtmlElementAxeResults): DictionaryStringTo<DecoratedAxeNodeResult> {
         return data.ruleResults;
     }
 
-    private getTarget(data: IHtmlElementAxeResults): string[] {
+    private getTarget(data: HtmlElementAxeResults): string[] {
         return data.target;
     }
 
-    private getElementSelector(data: IHtmlElementAxeResults): string {
+    private getElementSelector(data: HtmlElementAxeResults): string {
         return data.target.join(';');
     }
 

--- a/src/injected/element-finder-by-position.ts
+++ b/src/injected/element-finder-by-position.ts
@@ -4,7 +4,7 @@ import { autobind } from '@uifabric/utilities';
 import * as Q from 'q';
 
 import { HTMLElementUtils } from '../common/html-element-utils';
-import { ClientUtils, IBoundRectAccessor } from './client-utils';
+import { BoundRectAccessor, ClientUtils } from './client-utils';
 import { FrameCommunicator } from './frameCommunicators/frame-communicator';
 import { FrameMessageResponseCallback } from './frameCommunicators/window-message-handler';
 import { IErrorMessageContent } from './frameCommunicators/window-message-marshaller';
@@ -69,7 +69,7 @@ export class ElementFinderByPosition {
             return deferred.promise;
         }
 
-        const elementRect = this.clientUtils.getOffset(element as IBoundRectAccessor);
+        const elementRect = this.clientUtils.getOffset(element as BoundRectAccessor);
 
         this.frameCommunicator
             .sendMessage<ElementFinderByPositionMessage, string[]>({

--- a/src/injected/frame-url-finder.ts
+++ b/src/injected/frame-url-finder.ts
@@ -6,13 +6,11 @@ import { HTMLElementUtils } from '../common/html-element-utils';
 import { WindowUtils } from '../common/window-utils';
 import { FrameCommunicator, IMessageRequest } from './frameCommunicators/frame-communicator';
 
-// tslint:disable-next-line:interface-name
-export interface ITargetMessage {
+export interface TargetMessage {
     target: string[];
 }
 
-// tslint:disable-next-line:interface-name
-export interface IFrameUrlMessage {
+export interface FrameUrlMessage {
     frameUrl: string;
 }
 
@@ -35,7 +33,7 @@ export class FrameUrlFinder {
     }
 
     @autobind
-    public processRequest(message: ITargetMessage): void {
+    public processRequest(message: TargetMessage): void {
         const target = message.target;
 
         if (target.length === 1) {
@@ -45,7 +43,7 @@ export class FrameUrlFinder {
                 message: {
                     frameUrl: this.windowUtils.getWindow().location.href,
                 },
-            } as IMessageRequest<IFrameUrlMessage>);
+            } as IMessageRequest<FrameUrlMessage>);
         } else if (target.length > 1) {
             this.frameCommunicator.sendMessage({
                 command: FrameUrlFinder.GetTargetFrameUrlCommand,
@@ -53,7 +51,7 @@ export class FrameUrlFinder {
                 message: {
                     target: target.slice(1),
                 },
-            } as IMessageRequest<ITargetMessage>);
+            } as IMessageRequest<TargetMessage>);
         }
     }
 }

--- a/src/injected/frame-url-message-dispatcher.ts
+++ b/src/injected/frame-url-message-dispatcher.ts
@@ -4,7 +4,7 @@ import { autobind } from '@uifabric/utilities';
 
 import { DevToolActionMessageCreator } from '../common/message-creators/dev-tool-action-message-creator';
 import { WindowUtils } from '../common/window-utils';
-import { FrameUrlFinder, IFrameUrlMessage } from './frame-url-finder';
+import { FrameUrlFinder, FrameUrlMessage } from './frame-url-finder';
 import { FrameCommunicator } from './frameCommunicators/frame-communicator';
 
 export class FrameUrlMessageDispatcher {
@@ -27,7 +27,7 @@ export class FrameUrlMessageDispatcher {
     }
 
     @autobind
-    public setTargetFrameUrl(targetFrameUrlMessage: IFrameUrlMessage): void {
+    public setTargetFrameUrl(targetFrameUrlMessage: FrameUrlMessage): void {
         this.devToolActionMessageCreator.setInspectFrameUrl(targetFrameUrlMessage.frameUrl);
     }
 }

--- a/src/injected/frameCommunicators/html-element-axe-results-helper.ts
+++ b/src/injected/frameCommunicators/html-element-axe-results-helper.ts
@@ -5,7 +5,7 @@ import { forOwn } from 'lodash';
 import { createDefaultLogger } from '../../common/logging/default-logger';
 import { Logger } from '../../common/logging/logger';
 import { DictionaryStringTo } from '../../types/common-types';
-import { IHtmlElementAxeResults } from '../scanner-utils';
+import { HtmlElementAxeResults } from '../scanner-utils';
 import { HTMLElementUtils } from './../../common/html-element-utils';
 
 // tslint:disable-next-line:interface-name
@@ -14,7 +14,7 @@ export interface IFrameResult {
     elementResults: IAssessmentVisualizationInstance[];
 }
 
-export interface AxeResultsWithFrameLevel extends IHtmlElementAxeResults {
+export interface AxeResultsWithFrameLevel extends HtmlElementAxeResults {
     targetIndex?: number;
 }
 

--- a/src/injected/scanner-utils.ts
+++ b/src/injected/scanner-utils.ts
@@ -28,8 +28,7 @@ export interface DecoratedAxeNodeResult {
     snippet: string;
 }
 
-// tslint:disable-next-line:interface-name
-export interface IHtmlElementAxeResults {
+export interface HtmlElementAxeResults {
     ruleResults: DictionaryStringTo<DecoratedAxeNodeResult>;
     isVisible: boolean;
     propertyBag?: any;
@@ -66,37 +65,37 @@ export class ScannerUtils {
     }
 
     @autobind
-    public getIncompleteInstances(results: ScanResults): DictionaryStringTo<IHtmlElementAxeResults> {
-        const resultsMap: DictionaryStringTo<IHtmlElementAxeResults> = {};
+    public getIncompleteInstances(results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> {
+        const resultsMap: DictionaryStringTo<HtmlElementAxeResults> = {};
         this.addIncompletesToDictionary(resultsMap, results.incomplete);
         return resultsMap;
     }
 
     @autobind
-    public getFailingInstances(results: ScanResults): DictionaryStringTo<IHtmlElementAxeResults> {
-        const resultsMap: DictionaryStringTo<IHtmlElementAxeResults> = {};
+    public getFailingInstances(results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> {
+        const resultsMap: DictionaryStringTo<HtmlElementAxeResults> = {};
         this.addFailuresToDictionary(resultsMap, results.violations);
         return resultsMap;
     }
 
     @autobind
-    public getPassingInstances(results: ScanResults): DictionaryStringTo<IHtmlElementAxeResults> {
-        const resultsMap: DictionaryStringTo<IHtmlElementAxeResults> = {};
+    public getPassingInstances(results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> {
+        const resultsMap: DictionaryStringTo<HtmlElementAxeResults> = {};
         this.addPassesToDictionary(resultsMap, results.passes);
         return resultsMap;
     }
 
     @autobind
-    public getAllCompletedInstances(results: ScanResults): DictionaryStringTo<IHtmlElementAxeResults> {
-        const resultsMap: DictionaryStringTo<IHtmlElementAxeResults> = {};
+    public getAllCompletedInstances(results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> {
+        const resultsMap: DictionaryStringTo<HtmlElementAxeResults> = {};
         this.addPassesToDictionary(resultsMap, results.passes);
         this.addFailuresToDictionary(resultsMap, results.violations);
         return resultsMap;
     }
 
     @autobind
-    public getFailingOrPassingInstances(results: ScanResults): DictionaryStringTo<IHtmlElementAxeResults> {
-        const resultsMap: DictionaryStringTo<IHtmlElementAxeResults> = {};
+    public getFailingOrPassingInstances(results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> {
+        const resultsMap: DictionaryStringTo<HtmlElementAxeResults> = {};
         this.addFailuresToDictionary(resultsMap, results.violations);
         if (Object.keys(resultsMap).length === 0) {
             this.addPassesToDictionary(resultsMap, results.passes);
@@ -104,19 +103,19 @@ export class ScannerUtils {
         return resultsMap;
     }
 
-    private addPassesToDictionary(dictionary: DictionaryStringTo<IHtmlElementAxeResults>, axeRules: RuleResult[]): void {
+    private addPassesToDictionary(dictionary: DictionaryStringTo<HtmlElementAxeResults>, axeRules: RuleResult[]): void {
         this.addResultstoDictionary(dictionary, axeRules, true);
     }
 
-    private addIncompletesToDictionary(dictionary: DictionaryStringTo<IHtmlElementAxeResults>, axeRules: RuleResult[]): void {
+    private addIncompletesToDictionary(dictionary: DictionaryStringTo<HtmlElementAxeResults>, axeRules: RuleResult[]): void {
         this.addResultstoDictionary(dictionary, axeRules, undefined);
     }
 
-    private addFailuresToDictionary(dictionary: DictionaryStringTo<IHtmlElementAxeResults>, axeRules: RuleResult[]): void {
+    private addFailuresToDictionary(dictionary: DictionaryStringTo<HtmlElementAxeResults>, axeRules: RuleResult[]): void {
         this.addResultstoDictionary(dictionary, axeRules, false);
     }
 
-    private addResultstoDictionary(dictionary: DictionaryStringTo<IHtmlElementAxeResults>, axeRules: RuleResult[], status: boolean): void {
+    private addResultstoDictionary(dictionary: DictionaryStringTo<HtmlElementAxeResults>, axeRules: RuleResult[], status: boolean): void {
         axeRules.forEach(ruleResult => {
             ruleResult.nodes.forEach(node => {
                 const selectorKey = node.target.join(';');

--- a/src/injected/tab-stops-listener.ts
+++ b/src/injected/tab-stops-listener.ts
@@ -11,8 +11,7 @@ import { FrameMessageResponseCallback } from './frameCommunicators/window-messag
 import { IErrorMessageContent } from './frameCommunicators/window-message-marshaller';
 import { ScannerUtils } from './scanner-utils';
 
-// tslint:disable-next-line:interface-name
-export interface ITabStopEvent {
+export interface TabStopEvent {
     timestamp: number;
     target: string[];
     html: string;
@@ -28,7 +27,7 @@ export class TabStopsListener {
     public static readonly stopListeningCommand = 'insights.stopListenToTabstops';
     public static readonly getTabbedElementsCommand = 'insights.getTabbedElements';
 
-    private tabEventListener: (tabbedItems: ITabStopEvent) => void;
+    private tabEventListener: (tabbedItems: TabStopEvent) => void;
 
     constructor(
         frameCommunicator: FrameCommunicator,
@@ -50,7 +49,7 @@ export class TabStopsListener {
         this.frameCommunicator.subscribe(TabStopsListener.stopListeningCommand, this.onStopListenToTabStops);
     }
 
-    public setTabEventListenerOnMainWindow(callback: (tabbedItems: ITabStopEvent) => void): void {
+    public setTabEventListenerOnMainWindow(callback: (tabbedItems: TabStopEvent) => void): void {
         if (this.windowUtils.isTopWindow()) {
             this.tabEventListener = callback;
         } else {
@@ -68,7 +67,7 @@ export class TabStopsListener {
 
     @autobind
     private onGetTabbedElements(
-        tabStopEvent: ITabStopEvent,
+        tabStopEvent: TabStopEvent,
         error: IErrorMessageContent,
         messageSourceWin: Window,
         responder?: FrameMessageResponseCallback,
@@ -86,7 +85,7 @@ export class TabStopsListener {
     }
 
     @autobind
-    private sendTabbedElements(tabStopEvent: ITabStopEvent): void {
+    private sendTabbedElements(tabStopEvent: TabStopEvent): void {
         if (this.windowUtils.isTopWindow()) {
             if (this.tabEventListener) {
                 this.tabEventListener(tabStopEvent);
@@ -99,8 +98,8 @@ export class TabStopsListener {
     }
 
     @autobind
-    private sendTabbedElementsToParent(tabStopEvent: ITabStopEvent): void {
-        const messageRequest: IMessageRequest<ITabStopEvent> = {
+    private sendTabbedElementsToParent(tabStopEvent: TabStopEvent): void {
+        const messageRequest: IMessageRequest<TabStopEvent> = {
             win: this.windowUtils.getParentWindow(),
             command: TabStopsListener.getTabbedElementsCommand,
             message: tabStopEvent,
@@ -169,7 +168,7 @@ export class TabStopsListener {
 
         const timestamp: Date = DateProvider.getDate();
 
-        const tabStopEvent: ITabStopEvent = {
+        const tabStopEvent: TabStopEvent = {
             timestamp: timestamp.getTime(),
             target: [this.scannerUtils.getUniqueSelector(target)],
             html: target.outerHTML,

--- a/src/injected/visualization/drawer.ts
+++ b/src/injected/visualization/drawer.ts
@@ -5,7 +5,7 @@ import { WindowUtils } from '../../common/window-utils';
 import { ClientUtils } from '../client-utils';
 import { DialogRenderer } from '../dialog-renderer';
 import { AxeResultsWithFrameLevel } from '../frameCommunicators/html-element-axe-results-helper';
-import { IHtmlElementAxeResults } from '../scanner-utils';
+import { HtmlElementAxeResults } from '../scanner-utils';
 import { ShadowUtils } from '../shadow-utils';
 import { BaseDrawer } from './base-drawer';
 import { DrawerUtils } from './drawer-utils';
@@ -46,7 +46,7 @@ export class Drawer extends BaseDrawer {
         }
     }
 
-    public initialize(config: IDrawerInitData<IHtmlElementAxeResults>): void {
+    public initialize(config: IDrawerInitData<HtmlElementAxeResults>): void {
         this.elementResults = config.data;
         this.featureFlagStoreData = config.featureFlagStoreData;
         this.eraseLayout();
@@ -62,7 +62,7 @@ export class Drawer extends BaseDrawer {
         }
     }
 
-    protected createHighlightElement(element: Element, data: IHtmlElementAxeResults): HTMLElement {
+    protected createHighlightElement(element: Element, data: HtmlElementAxeResults): HTMLElement {
         const currentDom = this.drawerUtils.getDocumentElement();
         const offset = this.clientUtils.getOffset(element);
         const body = currentDom.querySelector('body');

--- a/src/injected/visualization/idrawer.d.ts
+++ b/src/injected/visualization/idrawer.d.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IHtmlElementAxeResults } from '../scanner-utils';
+import { HtmlElementAxeResults } from '../scanner-utils';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 
 // tslint:disable-next-line:interface-name

--- a/src/injected/visualization/issues-formatter.ts
+++ b/src/injected/visualization/issues-formatter.ts
@@ -7,7 +7,7 @@ import { HTMLElementUtils } from '../../common/html-element-utils';
 import { WindowUtils } from '../../common/window-utils';
 import { DialogRenderer } from '../dialog-renderer';
 import { FrameCommunicator } from '../frameCommunicators/frame-communicator';
-import { IHtmlElementAxeResults } from '../scanner-utils';
+import { HtmlElementAxeResults } from '../scanner-utils';
 import { ShadowUtils } from '../shadow-utils';
 import { DrawerConfiguration, Formatter } from './formatter';
 import { HeadingStyleConfiguration } from './heading-formatter';
@@ -40,7 +40,7 @@ export class IssuesFormatter implements Formatter {
         fontColor: '#FFFFFF',
     };
 
-    public getDrawerConfiguration(element: HTMLElement, data: IHtmlElementAxeResults): DrawerConfiguration {
+    public getDrawerConfiguration(element: HTMLElement, data: HtmlElementAxeResults): DrawerConfiguration {
         const config: DrawerConfiguration = {
             failureBoxConfig: {
                 background: IssuesFormatter.style.borderColor,
@@ -64,7 +64,7 @@ export class IssuesFormatter implements Formatter {
         return this.dialogRenderer;
     }
 
-    private getText(data: IHtmlElementAxeResults): string {
+    private getText(data: HtmlElementAxeResults): string {
         const ruleIds = Object.keys(data.ruleResults);
         return `Failed rules: ${ruleIds.join(', ')}`;
     }

--- a/src/injected/visualization/landmark-formatter.ts
+++ b/src/injected/visualization/landmark-formatter.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { DialogRenderer } from '../dialog-renderer';
 import { IAssessmentVisualizationInstance } from '../frameCommunicators/html-element-axe-results-helper';
-import { IHtmlElementAxeResults } from '../scanner-utils';
+import { HtmlElementAxeResults } from '../scanner-utils';
 import { FailureInstanceFormatter } from './failure-instance-formatter';
 import { DrawerConfiguration } from './formatter';
 import { HeadingStyleConfiguration } from './heading-formatter';
@@ -83,7 +83,7 @@ export class LandmarkFormatter extends FailureInstanceFormatter {
         return drawerConfig;
     }
 
-    private getLandmarkInfo(data: IHtmlElementAxeResults): ElemData {
+    private getLandmarkInfo(data: HtmlElementAxeResults): ElemData {
         for (const idx in data.ruleResults) {
             if (data.ruleResults[idx].ruleId === 'unique-landmark') {
                 return this.getData(data.ruleResults[idx].any);

--- a/src/injected/visualization/single-target-drawer.ts
+++ b/src/injected/visualization/single-target-drawer.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IHtmlElementAxeResults } from '../scanner-utils';
+import { HtmlElementAxeResults } from '../scanner-utils';
 import { DrawerUtils } from './drawer-utils';
 import { IDrawer, IDrawerInitData } from './idrawer';
 import { SingleTargetFormatter } from './single-target-formatter';
@@ -16,7 +16,7 @@ export class SingleTargetDrawer implements IDrawer {
         this.formatter = formatter;
     }
 
-    public initialize(drawerInfo: IDrawerInitData<IHtmlElementAxeResults>): void {
+    public initialize(drawerInfo: IDrawerInitData<HtmlElementAxeResults>): void {
         this.eraseLayout();
         const elementResults = drawerInfo.data;
         const myDocument = this.drawerUtils.getDocumentElement();
@@ -44,7 +44,7 @@ export class SingleTargetDrawer implements IDrawer {
         return this.isEnabled;
     }
 
-    private getFirstElementTarget(document: Document, elementResults: IHtmlElementAxeResults[]): HTMLElement {
+    private getFirstElementTarget(document: Document, elementResults: HtmlElementAxeResults[]): HTMLElement {
         if (!elementResults[0]) {
             return null;
         }

--- a/src/injected/visualization/tab-stops-formatter.ts
+++ b/src/injected/visualization/tab-stops-formatter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DialogRenderer } from '../dialog-renderer';
-import { IHtmlElementAxeResults } from '../scanner-utils';
+import { HtmlElementAxeResults } from '../scanner-utils';
 import { IPartialSVGDrawerConfiguration } from './drawer-provider';
 import { Formatter, SVGDrawerConfiguration } from './formatter';
 
@@ -14,7 +14,7 @@ export class TabStopsFormatter implements Formatter {
         this.givenConfiguration = givenConfiguration;
     }
 
-    public getDrawerConfiguration(element: HTMLElement, data: IHtmlElementAxeResults): SVGDrawerConfiguration {
+    public getDrawerConfiguration(element: HTMLElement, data: HtmlElementAxeResults): SVGDrawerConfiguration {
         let ellipseRx: number = 16;
         const tabindex = element.getAttribute('tabindex');
         if (tabindex && parseInt(tabindex, 10) > 0) {

--- a/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-scan-result-store-data-builder.ts
@@ -3,7 +3,7 @@
 import { VisualizationScanResultStore } from '../../../background/stores/visualization-scan-result-store';
 import { ITabbedElementData, IVisualizationScanResultData } from '../../../common/types/store-data/ivisualization-scan-result-data';
 import { VisualizationType } from '../../../common/types/visualization-type';
-import { IHtmlElementAxeResults } from '../../../injected/scanner-utils';
+import { HtmlElementAxeResults } from '../../../injected/scanner-utils';
 import { DictionaryStringTo } from '../../../types/common-types';
 import { BaseDataBuilder } from './base-data-builder';
 
@@ -18,7 +18,7 @@ export class VisualizationScanResultStoreDataBuilder extends BaseDataBuilder<IVi
         return this;
     }
 
-    public withIssuesSelectedTargets(map: DictionaryStringTo<IHtmlElementAxeResults>): VisualizationScanResultStoreDataBuilder {
+    public withIssuesSelectedTargets(map: DictionaryStringTo<HtmlElementAxeResults>): VisualizationScanResultStoreDataBuilder {
         this.data.issues.selectedAxeResultsMap = map;
         return this;
     }

--- a/src/tests/unit/tests/background/assessment-data-converter.test.ts
+++ b/src/tests/unit/tests/background/assessment-data-converter.test.ts
@@ -6,8 +6,8 @@ import { AssessmentDataConverter } from '../../../../background/assessment-data-
 import { UniquelyIdentifiableInstances } from '../../../../background/instance-identifier-generator';
 import { ManualTestStatus } from '../../../../common/types/manual-test-status';
 import { IAssessmentInstancesMap, ITestStepResult } from '../../../../common/types/store-data/iassessment-result-data';
-import { DecoratedAxeNodeResult, IHtmlElementAxeResults } from '../../../../injected/scanner-utils';
-import { ITabStopEvent } from '../../../../injected/tab-stops-listener';
+import { DecoratedAxeNodeResult, HtmlElementAxeResults } from '../../../../injected/scanner-utils';
+import { TabStopEvent } from '../../../../injected/tab-stops-listener';
 import { DictionaryStringTo } from '../../../../types/common-types';
 
 describe('AssessmentDataConverterTest', () => {
@@ -41,7 +41,7 @@ describe('AssessmentDataConverterTest', () => {
             someProperty: 1,
         };
 
-        const selectorMap: DictionaryStringTo<IHtmlElementAxeResults> = {
+        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
             [selectorStub]: {
                 ruleResults: {
                     rule1: {
@@ -75,7 +75,7 @@ describe('AssessmentDataConverterTest', () => {
 
     test(`generateAssessmentInstancesMap: previouslyGeneratedInstances is null,
             new rule result is not false and any data is there.`, () => {
-        const selectorMap: DictionaryStringTo<IHtmlElementAxeResults> = {
+        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
             [selectorStub]: {
                 ruleResults: {
                     rule1: {
@@ -126,7 +126,7 @@ describe('AssessmentDataConverterTest', () => {
 
     test(`generateAssessmentInstancesMap: previouslyGeneratedInstances is null,
             new rule result is null (shouldn't happen but covered).`, () => {
-        const selectorMap: DictionaryStringTo<IHtmlElementAxeResults> = {
+        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
             [selectorStub]: {
                 ruleResults: {},
                 target: [selectorStub],
@@ -141,7 +141,7 @@ describe('AssessmentDataConverterTest', () => {
 
     test(`generateAssessmentInstancesMap: previouslyGeneratedInstances is not null,
             new rule result is null (shouldn't happen but covered).`, () => {
-        const selectorMap: DictionaryStringTo<IHtmlElementAxeResults> = {
+        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
             [selectorStub]: {
                 ruleResults: {},
                 target: [selectorStub],
@@ -162,7 +162,7 @@ describe('AssessmentDataConverterTest', () => {
 
     test(`generateAssessmentInstancesMap: previouslyGeneratedInstances is
             empty/does not match any new instances and any data is not there`, () => {
-        const selectorMap: DictionaryStringTo<IHtmlElementAxeResults> = {
+        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
             [selectorStub]: {
                 ruleResults: {
                     rule1: {
@@ -205,7 +205,7 @@ describe('AssessmentDataConverterTest', () => {
     });
 
     test('generateAssessmentInstancesMap: automated check status should be FAIL', () => {
-        const selectorMap: DictionaryStringTo<IHtmlElementAxeResults> = {
+        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
             [selectorStub]: {
                 ruleResults: {
                     rule1: {
@@ -249,7 +249,7 @@ describe('AssessmentDataConverterTest', () => {
 
     test('generateAssessmentInstancesMap: previouslyGeneratedInstances contains matching instance', () => {
         const anotherTestStep = 'another test step';
-        const selectorMap: DictionaryStringTo<IHtmlElementAxeResults> = {
+        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
             [selectorStub]: {
                 ruleResults: {
                     rule1: {
@@ -326,7 +326,7 @@ describe('AssessmentDataConverterTest', () => {
     test('generateAssessmentInstancesMapForEvents: previouslyGeneratedInstances is null', () => {
         const stepName = 'random step name';
         const previouslyGeneratedInstances = null;
-        const eventStub: ITabStopEvent = {
+        const eventStub: TabStopEvent = {
             target: [selectorStub],
             html: htmlStub,
             timestamp: 99,
@@ -360,7 +360,7 @@ describe('AssessmentDataConverterTest', () => {
     test("generateAssessmentInstancesMapForEvents: previouslyGeneratedInstances exists but doesn't match event", () => {
         const stepName = 'random step name';
 
-        const eventStub: ITabStopEvent = {
+        const eventStub: TabStopEvent = {
             target: [selectorStub],
             html: htmlStub,
             timestamp: 99,
@@ -399,7 +399,7 @@ describe('AssessmentDataConverterTest', () => {
     test('generateAssessmentInstancesMapForEvents: previouslyGeneratedInstances exists and selector matches event', () => {
         const oldTimestamp = 99;
         const newTimestamp = 88;
-        const eventStub: ITabStopEvent = {
+        const eventStub: TabStopEvent = {
             target: [selectorStub],
             html: htmlStub,
             timestamp: newTimestamp,

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -39,7 +39,7 @@ import {
 } from '../../../../../common/types/store-data/iassessment-result-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { ScanBasePayload, ScanCompletedPayload, ScanUpdatePayload } from '../../../../../injected/analyzers/analyzer';
-import { ITabStopEvent } from '../../../../../injected/tab-stops-listener';
+import { TabStopEvent } from '../../../../../injected/tab-stops-listener';
 import { ScanResults } from '../../../../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../../../../types/common-types';
 import { AssessmentDataBuilder } from '../../../common/assessment-data-builder';
@@ -534,7 +534,7 @@ describe('AssessmentStoreTest', () => {
         const payload: ScanUpdatePayload = {
             testType: assessmentType,
             key: stepKey,
-            results: {} as ITabStopEvent[],
+            results: {} as TabStopEvent[],
         };
 
         const expectedInstanceMap = {};

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -7,7 +7,7 @@ import { VisualizationScanResultStore } from '../../../../../background/stores/v
 import { StoreNames } from '../../../../../common/stores/store-names';
 import { ITabbedElementData, IVisualizationScanResultData } from '../../../../../common/types/store-data/ivisualization-scan-result-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { IHtmlElementAxeResults } from '../../../../../injected/scanner-utils';
+import { HtmlElementAxeResults } from '../../../../../injected/scanner-utils';
 import { ScanResults } from '../../../../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../../../../types/common-types';
 import { createStoreWithNullParams, StoreTester } from '../../../common/store-tester';
@@ -84,7 +84,7 @@ describe('VisualizationScanResultStoreTest', () => {
             },
         };
 
-        const selectorMap: DictionaryStringTo<IHtmlElementAxeResults> = {
+        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
             target1: {
                 target: ['target1'],
                 isVisible: true,
@@ -235,7 +235,7 @@ describe('VisualizationScanResultStoreTest', () => {
             },
         };
 
-        const selectorMap: DictionaryStringTo<IHtmlElementAxeResults> = {
+        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
             target1: {
                 target: ['target1'],
                 isVisible: true,
@@ -309,7 +309,7 @@ describe('VisualizationScanResultStoreTest', () => {
     test('onUpdateIssuesSelectedTargets', () => {
         const actionName = 'updateIssuesSelectedTargets';
 
-        const selectorMap: DictionaryStringTo<IHtmlElementAxeResults> = {
+        const selectorMap: DictionaryStringTo<HtmlElementAxeResults> = {
             '#heading-1': {
                 ruleResults: {
                     rule1: {
@@ -398,7 +398,7 @@ describe('VisualizationScanResultStoreTest', () => {
             .withIssuesSelectedTargets(selectorMap)
             .build();
 
-        const expectedSelectedMap: DictionaryStringTo<IHtmlElementAxeResults> = {
+        const expectedSelectedMap: DictionaryStringTo<HtmlElementAxeResults> = {
             '#heading-1': {
                 ruleResults: {
                     rule1: {

--- a/src/tests/unit/tests/client-utils.test.ts
+++ b/src/tests/unit/tests/client-utils.test.ts
@@ -2,25 +2,25 @@
 // Licensed under the MIT License.
 import { IMock, Mock } from 'typemoq';
 
-import { ClientRectOffset, ClientUtils, IBoundRectAccessor, IElementMatcher, IScrollAccessor } from '../../../injected/client-utils';
+import { BoundRectAccessor, ClientRectOffset, ClientUtils, ElementMatcher, ScrollAccessor } from '../../../injected/client-utils';
 
-class ScrollAccessorStub implements IScrollAccessor {
+class ScrollAccessorStub implements ScrollAccessor {
     public scrollX: number = 0;
     public scrollY: number = 0;
 }
 
-class BoundRectAccessorStub implements IBoundRectAccessor {
+class BoundRectAccessorStub implements BoundRectAccessor {
     public getBoundingClientRect(): ClientRectOffset {
         return null;
     }
 }
 
 describe('ClientUtilsTest', () => {
-    let scrollGetterMock: IMock<IScrollAccessor>;
+    let scrollGetterMock: IMock<ScrollAccessor>;
     let testObject: ClientUtils;
 
     beforeEach(() => {
-        scrollGetterMock = Mock.ofType<IScrollAccessor>(ScrollAccessorStub);
+        scrollGetterMock = Mock.ofType<ScrollAccessor>(ScrollAccessorStub);
         testObject = new ClientUtils(scrollGetterMock.object);
     });
 
@@ -30,7 +30,7 @@ describe('ClientUtilsTest', () => {
         });
         const elementStub = {
             msMatchesSelector: matchesMock.object,
-        } as IElementMatcher;
+        } as ElementMatcher;
 
         const selector1 = 'selector1';
         const selector2 = 'selector2';
@@ -50,7 +50,7 @@ describe('ClientUtilsTest', () => {
         const matchesMock = Mock.ofInstance((selector: string) => {
             return true;
         });
-        const elementStub: IElementMatcher = {
+        const elementStub: ElementMatcher = {
             webkitMatchesSelector: matchesMock.object,
         };
 
@@ -74,7 +74,7 @@ describe('ClientUtilsTest', () => {
         });
         const elementStub = {
             matches: matchesMock.object,
-        } as IElementMatcher;
+        } as ElementMatcher;
 
         const selector1 = 'selector1';
         const selector2 = 'selector2';
@@ -101,7 +101,7 @@ describe('ClientUtilsTest', () => {
         const elementTop = 100;
         const elementLeft = 25;
 
-        const elementMock = Mock.ofType<IBoundRectAccessor>(BoundRectAccessorStub);
+        const elementMock = Mock.ofType<BoundRectAccessor>(BoundRectAccessorStub);
         elementMock
             .setup(em => em.getBoundingClientRect())
             .returns(() => {

--- a/src/tests/unit/tests/injected/analyzers/batched-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/batched-analyzer.test.ts
@@ -15,7 +15,7 @@ import { VisualizationType } from '../../../../../common/types/visualization-typ
 import { RuleAnalyzerConfiguration } from '../../../../../injected/analyzers/analyzer';
 import { MessageType } from '../../../../../injected/analyzers/base-analyzer';
 import { BatchedRuleAnalyzer, IResultRuleFilter } from '../../../../../injected/analyzers/batched-rule-analyzer';
-import { IHtmlElementAxeResults, ScannerUtils } from '../../../../../injected/scanner-utils';
+import { HtmlElementAxeResults, ScannerUtils } from '../../../../../injected/scanner-utils';
 import { ScanOptions } from '../../../../../scanner/exposed-apis';
 import { RuleResult, ScanResults } from '../../../../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../../../../types/common-types';
@@ -89,7 +89,7 @@ describe('BatchedRuleAnalyzer', () => {
         const resultOne: RuleResult = {
             id: ruleOne,
         } as RuleResult;
-        const resultProcessorMockOne: IMock<(results: ScanResults) => DictionaryStringTo<IHtmlElementAxeResults>> = Mock.ofInstance(
+        const resultProcessorMockOne: IMock<(results: ScanResults) => DictionaryStringTo<HtmlElementAxeResults>> = Mock.ofInstance(
             results => null,
             MockBehavior.Strict,
         );
@@ -102,7 +102,7 @@ describe('BatchedRuleAnalyzer', () => {
             resultProcessor: scanner => resultProcessorMockOne.object,
         };
         const ruleTwo = 'the second rule';
-        const resultProcessorMockTwo: IMock<(results: ScanResults) => DictionaryStringTo<IHtmlElementAxeResults>> = Mock.ofInstance(
+        const resultProcessorMockTwo: IMock<(results: ScanResults) => DictionaryStringTo<HtmlElementAxeResults>> = Mock.ofInstance(
             results => null,
             MockBehavior.Strict,
         );
@@ -164,7 +164,7 @@ describe('BatchedRuleAnalyzer', () => {
     }
 
     function setupProcessingMocks(
-        resultProcessorMock: IMock<(results: ScanResults) => DictionaryStringTo<IHtmlElementAxeResults>>,
+        resultProcessorMock: IMock<(results: ScanResults) => DictionaryStringTo<HtmlElementAxeResults>>,
         config: RuleAnalyzerConfiguration,
         completeResults: ScanResults,
         filteredResults: ScanResults,

--- a/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
@@ -15,14 +15,14 @@ import { IScopingStoreData } from '../../../../../common/types/store-data/scopin
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { RuleAnalyzerConfiguration } from '../../../../../injected/analyzers/analyzer';
 import { RuleAnalyzer } from '../../../../../injected/analyzers/rule-analyzer';
-import { IHtmlElementAxeResults, ScannerUtils } from '../../../../../injected/scanner-utils';
+import { HtmlElementAxeResults, ScannerUtils } from '../../../../../injected/scanner-utils';
 import { ScanOptions } from '../../../../../scanner/exposed-apis';
 import { ScanResults } from '../../../../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../../../../types/common-types';
 
 describe('RuleAnalyzer', () => {
     let scannerUtilsMock: IMock<ScannerUtils>;
-    let resultProcessorMock: IMock<(results: ScanResults) => DictionaryStringTo<IHtmlElementAxeResults>>;
+    let resultProcessorMock: IMock<(results: ScanResults) => DictionaryStringTo<HtmlElementAxeResults>>;
     let dateGetterMock: IMock<() => Date>;
     let dateMock: IMock<Date>;
     let scopingStoreMock: IMock<ScopingStore>;

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -6,7 +6,7 @@ import { VisualizationType } from '../../../../../common/types/visualization-typ
 import { WindowUtils } from '../../../../../common/window-utils';
 import { FocusAnalyzerConfiguration, ScanBasePayload } from '../../../../../injected/analyzers/analyzer';
 import { TabStopsAnalyzer } from '../../../../../injected/analyzers/tab-stops-analyzer';
-import { ITabStopEvent, TabStopsListener } from '../../../../../injected/tab-stops-listener';
+import { TabStopEvent, TabStopsListener } from '../../../../../injected/tab-stops-listener';
 
 describe('TabStopsAnalyzerTests', () => {
     let windowUtilsMock: IMock<WindowUtils>;
@@ -15,7 +15,7 @@ describe('TabStopsAnalyzerTests', () => {
     let typeStub: VisualizationType;
     let testSubject: TabStopsAnalyzer;
     let tabStopsListenerMock: IMock<TabStopsListener>;
-    let tabEventHandler: (tabEvent: ITabStopEvent) => void;
+    let tabEventHandler: (tabEvent: TabStopEvent) => void;
     let setTimeOutCallBack: () => void;
 
     beforeEach(() => {
@@ -36,7 +36,7 @@ describe('TabStopsAnalyzerTests', () => {
     });
 
     test('analyze', async (completeSignal: () => void) => {
-        const tabEventStub: ITabStopEvent = {
+        const tabEventStub: TabStopEvent = {
             target: ['selector'],
             html: 'test',
             timestamp: 1,
@@ -77,12 +77,12 @@ describe('TabStopsAnalyzerTests', () => {
     });
 
     test('analyze: multiple events together (simulate timeoutId already created)', (completeSignal: () => void) => {
-        const tabEventStub1: ITabStopEvent = {
+        const tabEventStub1: TabStopEvent = {
             target: ['selector'],
             html: 'test',
             timestamp: 1,
         };
-        const tabEventStub2: ITabStopEvent = {
+        const tabEventStub2: TabStopEvent = {
             target: ['selector2'],
             html: 'test',
             timestamp: 2,
@@ -153,7 +153,7 @@ describe('TabStopsAnalyzerTests', () => {
     function setupTabStopsListenerForStartTabStops(): void {
         tabStopsListenerMock
             .setup(tslm => tslm.setTabEventListenerOnMainWindow(It.isAny()))
-            .callback((callback: (tabEvent: ITabStopEvent) => void) => {
+            .callback((callback: (tabEvent: TabStopEvent) => void) => {
                 tabEventHandler = callback;
             })
             .verifiable(Times.once());

--- a/src/tests/unit/tests/injected/dialog-renderer.test.tsx
+++ b/src/tests/unit/tests/injected/dialog-renderer.test.tsx
@@ -20,7 +20,7 @@ import { FrameMessageResponseCallback } from '../../../../injected/frameCommunic
 import { IErrorMessageContent } from '../../../../injected/frameCommunicators/window-message-marshaller';
 import { LayeredDetailsDialogComponent } from '../../../../injected/layered-details-dialog-component';
 import { MainWindowContext } from '../../../../injected/main-window-context';
-import { DecoratedAxeNodeResult, IHtmlElementAxeResults } from '../../../../injected/scanner-utils';
+import { DecoratedAxeNodeResult, HtmlElementAxeResults } from '../../../../injected/scanner-utils';
 import { ShadowUtils } from '../../../../injected/shadow-utils';
 import { TargetPageActionMessageCreator } from '../../../../injected/target-page-action-message-creator';
 import { DictionaryStringTo } from '../../../../types/common-types';
@@ -113,7 +113,7 @@ describe('DialogRendererTests', () => {
         };
         const expectedFailedRules: DictionaryStringTo<DecoratedAxeNodeResult> = {};
         expectedFailedRules[ruleId] = nodeResult;
-        const testData: IHtmlElementAxeResults = {
+        const testData: HtmlElementAxeResults = {
             ruleResults: expectedFailedRules,
             target: [ruleId],
             isVisible: true,
@@ -157,7 +157,7 @@ describe('DialogRendererTests', () => {
         };
         const expectedFailedRules: DictionaryStringTo<DecoratedAxeNodeResult> = {};
         expectedFailedRules[ruleId] = nodeResult;
-        const testData: IHtmlElementAxeResults = {
+        const testData: HtmlElementAxeResults = {
             ruleResults: expectedFailedRules,
             target: [ruleId],
             isVisible: true,
@@ -199,7 +199,7 @@ describe('DialogRendererTests', () => {
         };
         const expectedFailedRules: DictionaryStringTo<DecoratedAxeNodeResult> = {};
         expectedFailedRules[ruleId] = nodeResult;
-        const testData: IHtmlElementAxeResults = {
+        const testData: HtmlElementAxeResults = {
             ruleResults: expectedFailedRules,
             target: [ruleId],
             isVisible: true,
@@ -243,7 +243,7 @@ describe('DialogRendererTests', () => {
         };
         const expectedFailedRules: DictionaryStringTo<DecoratedAxeNodeResult> = {};
         expectedFailedRules[ruleId] = nodeResult;
-        const testData: IHtmlElementAxeResults = {
+        const testData: HtmlElementAxeResults = {
             ruleResults: expectedFailedRules,
             target: [ruleId],
             isVisible: true,
@@ -267,7 +267,7 @@ describe('DialogRendererTests', () => {
     });
 
     test('test render in iframe: shadow FF on', () => {
-        const testData: IHtmlElementAxeResults = {
+        const testData: HtmlElementAxeResults = {
             ruleResults: null,
             target: [],
             isVisible: true,
@@ -295,7 +295,7 @@ describe('DialogRendererTests', () => {
     });
 
     test('test render in iframe: shadow FF off', () => {
-        const testData: IHtmlElementAxeResults = {
+        const testData: HtmlElementAxeResults = {
             ruleResults: null,
             target: [],
             isVisible: true,
@@ -322,7 +322,7 @@ describe('DialogRendererTests', () => {
     });
 
     test('test main window subsribe and processRequest: shadow FF on', () => {
-        const testData: IHtmlElementAxeResults = {
+        const testData: HtmlElementAxeResults = {
             ruleResults: null,
             target: ['test string'],
             isVisible: true,
@@ -349,7 +349,7 @@ describe('DialogRendererTests', () => {
     });
 
     test('test main window subsribe and processRequest: shadowDom FF off', () => {
-        const testData: IHtmlElementAxeResults = {
+        const testData: HtmlElementAxeResults = {
             ruleResults: null,
             target: ['test string'],
             isVisible: true,

--- a/src/tests/unit/tests/injected/drawing-controller.test.ts
+++ b/src/tests/unit/tests/injected/drawing-controller.test.ts
@@ -20,7 +20,7 @@ import {
     IAssessmentVisualizationInstance,
 } from '../../../../injected/frameCommunicators/html-element-axe-results-helper';
 import { InstanceVisibilityChecker } from '../../../../injected/instance-visibility-checker';
-import { IHtmlElementAxeResults } from '../../../../injected/scanner-utils';
+import { HtmlElementAxeResults } from '../../../../injected/scanner-utils';
 import { Drawer } from '../../../../injected/visualization/drawer';
 import { DrawerProvider } from '../../../../injected/visualization/drawer-provider';
 import { IDrawer, IDrawerInitData } from '../../../../injected/visualization/idrawer';
@@ -205,8 +205,8 @@ describe('DrawingControllerTest', () => {
             .build();
         const iframeResults = ['iframeContent'];
         const iframeElement = 'iframeElement';
-        const visibleResultStub = {} as IHtmlElementAxeResults;
-        const notVisibleResultStub = { isVisible: false } as IHtmlElementAxeResults;
+        const visibleResultStub = {} as HtmlElementAxeResults;
+        const notVisibleResultStub = { isVisible: false } as HtmlElementAxeResults;
         const disabledResultStub = { isVisualizationEnabled: false } as IAssessmentVisualizationInstance;
         const resultsByFrames = [
             {
@@ -259,7 +259,7 @@ describe('DrawingControllerTest', () => {
 
         hTMLElementUtils.setup(dm => dm.getAllElementsByTagName(It.isAny())).verifiable(Times.never());
 
-        const expected: IDrawerInitData<IHtmlElementAxeResults> = {
+        const expected: IDrawerInitData<HtmlElementAxeResults> = {
             data: [visibleResultStub],
             featureFlagStoreData,
         };

--- a/src/tests/unit/tests/injected/frame-url-finder.test.ts
+++ b/src/tests/unit/tests/injected/frame-url-finder.test.ts
@@ -4,7 +4,7 @@ import { It, Mock, MockBehavior } from 'typemoq';
 
 import { HTMLElementUtils } from '../../../../common/html-element-utils';
 import { WindowUtils } from '../../../../common/window-utils';
-import { FrameUrlFinder, IFrameUrlMessage, ITargetMessage } from '../../../../injected/frame-url-finder';
+import { FrameUrlFinder, FrameUrlMessage, TargetMessage } from '../../../../injected/frame-url-finder';
 import { FrameCommunicator, IMessageRequest } from '../../../../injected/frameCommunicators/frame-communicator';
 
 describe('frameUrlFinderTest', () => {
@@ -31,10 +31,10 @@ describe('frameUrlFinderTest', () => {
             location: { href: 'testURL' },
         };
 
-        const mockProcessRequestMessage: ITargetMessage = {
+        const mockProcessRequestMessage: TargetMessage = {
             target: ['abc'],
         };
-        const mockSentMessage: IMessageRequest<IFrameUrlMessage> = {
+        const mockSentMessage: IMessageRequest<FrameUrlMessage> = {
             command: FrameUrlFinder.SetFrameUrlCommand,
             win: topWindowStub,
             message: {
@@ -70,10 +70,10 @@ describe('frameUrlFinderTest', () => {
         const mockHtmlUtils = Mock.ofType(HTMLElementUtils, MockBehavior.Strict);
         const frameStub = {} as any;
 
-        const mockProcessRequestMessage: ITargetMessage = {
+        const mockProcessRequestMessage: TargetMessage = {
             target: ['abc', 'def'],
         };
-        const mockSentMessage: IMessageRequest<ITargetMessage> = {
+        const mockSentMessage: IMessageRequest<TargetMessage> = {
             command: FrameUrlFinder.GetTargetFrameUrlCommand,
             frame: frameStub,
             message: {

--- a/src/tests/unit/tests/injected/frame-url-message-dispatcher.test.ts
+++ b/src/tests/unit/tests/injected/frame-url-message-dispatcher.test.ts
@@ -3,7 +3,7 @@
 import { Mock, MockBehavior } from 'typemoq';
 
 import { DevToolActionMessageCreator } from '../../../../common/message-creators/dev-tool-action-message-creator';
-import { FrameUrlFinder, IFrameUrlMessage } from '../../../../injected/frame-url-finder';
+import { FrameUrlFinder, FrameUrlMessage } from '../../../../injected/frame-url-finder';
 import { FrameUrlMessageDispatcher } from '../../../../injected/frame-url-message-dispatcher';
 import { FrameCommunicator } from '../../../../injected/frameCommunicators/frame-communicator';
 
@@ -14,7 +14,7 @@ describe('FrameUrlMessageDispatcherTest', () => {
 
     test('setTargetFrameUrl', () => {
         const devToolActionMessageCreatorMock = Mock.ofType(DevToolActionMessageCreator, MockBehavior.Strict);
-        const targetFrameUrlMessage: IFrameUrlMessage = {
+        const targetFrameUrlMessage: FrameUrlMessage = {
             frameUrl: 'testUrl',
         };
 

--- a/src/tests/unit/tests/injected/frame-url-search-initiator.test.ts
+++ b/src/tests/unit/tests/injected/frame-url-search-initiator.test.ts
@@ -3,7 +3,7 @@
 import { It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { DevToolState } from '../../../../common/types/store-data/idev-tool-state';
-import { FrameUrlFinder, ITargetMessage } from '../../../../injected/frame-url-finder';
+import { FrameUrlFinder, TargetMessage } from '../../../../injected/frame-url-finder';
 import { FrameUrlSearchInitiator } from '../../../../injected/frame-url-search-initiator';
 import { StoreMock } from '../../mock-helpers/store-mock';
 
@@ -14,7 +14,7 @@ describe('FrameUrlSearchInitiatorTest', () => {
 
     test('listenToStore: state implies to initiate the search for frame url', () => {
         const devToolStoreMock = new StoreMock<DevToolState>();
-        const frameUrlFinderMock = Mock.ofInstance({ processRequest: (message: ITargetMessage) => {} }, MockBehavior.Strict);
+        const frameUrlFinderMock = Mock.ofInstance({ processRequest: (message: TargetMessage) => {} }, MockBehavior.Strict);
         const testSubject = new FrameUrlSearchInitiator(devToolStoreMock.getObject(), frameUrlFinderMock.object as FrameUrlFinder);
         const mockState: DevToolState = {
             isOpen: null,
@@ -35,7 +35,7 @@ describe('FrameUrlSearchInitiatorTest', () => {
 
     test('listenToStore: frame url is already set; no need to find frame url', () => {
         const devToolStoreMock = new StoreMock<DevToolState>();
-        const frameUrlFinderMock = Mock.ofInstance({ processRequest: (message: ITargetMessage) => {} }, MockBehavior.Strict);
+        const frameUrlFinderMock = Mock.ofInstance({ processRequest: (message: TargetMessage) => {} }, MockBehavior.Strict);
         const testSubject = new FrameUrlSearchInitiator(devToolStoreMock.getObject(), frameUrlFinderMock.object as FrameUrlFinder);
         const mockState: DevToolState = {
             isOpen: null,
@@ -57,7 +57,7 @@ describe('FrameUrlSearchInitiatorTest', () => {
 
     test('listenToStore: element is at root; no need for finding frame url', () => {
         const devToolStoreMock = new StoreMock<DevToolState>();
-        const frameUrlFinderMock = Mock.ofInstance({ processRequest: (message: ITargetMessage) => {} }, MockBehavior.Strict);
+        const frameUrlFinderMock = Mock.ofInstance({ processRequest: (message: TargetMessage) => {} }, MockBehavior.Strict);
         const testSubject = new FrameUrlSearchInitiator(devToolStoreMock.getObject(), frameUrlFinderMock.object as FrameUrlFinder);
         const mockState: DevToolState = {
             isOpen: null,

--- a/src/tests/unit/tests/injected/scanner-utils.test.ts
+++ b/src/tests/unit/tests/injected/scanner-utils.test.ts
@@ -6,7 +6,7 @@ import { ScopingInputTypes } from '../../../../background/scoping-input-types';
 import { ScopingStore } from '../../../../background/stores/global/scoping-store';
 import { Logger } from '../../../../common/logging/logger';
 import { IScopingStoreData } from '../../../../common/types/store-data/scoping-store-data';
-import { DecoratedAxeNodeResult, IHtmlElementAxeResults, ScannerUtils } from '../../../../injected/scanner-utils';
+import { DecoratedAxeNodeResult, HtmlElementAxeResults, ScannerUtils } from '../../../../injected/scanner-utils';
 import { scan, ScanOptions } from '../../../../scanner/exposed-apis';
 import { RuleResult, ScanResults } from '../../../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../../../types/common-types';
@@ -382,7 +382,7 @@ describe('ScannerUtilsTest', () => {
     }
 
     function verifyElementSelector(
-        elementResult: IHtmlElementAxeResults,
+        elementResult: HtmlElementAxeResults,
         selector: string,
         ruleResultMap: DictionaryStringTo<boolean>,
         includeSnippet?: boolean,

--- a/src/tests/unit/tests/injected/tab-stops-listener.test.ts
+++ b/src/tests/unit/tests/injected/tab-stops-listener.test.ts
@@ -9,7 +9,7 @@ import { FrameCommunicator, IMessageRequest } from '../../../../injected/frameCo
 import { FrameMessageResponseCallback } from '../../../../injected/frameCommunicators/window-message-handler';
 import { IErrorMessageContent } from '../../../../injected/frameCommunicators/window-message-marshaller';
 import { ScannerUtils } from '../../../../injected/scanner-utils';
-import { ITabStopEvent, TabStopsListener } from '../../../../injected/tab-stops-listener';
+import { TabStopEvent, TabStopsListener } from '../../../../injected/tab-stops-listener';
 
 describe('TabStopsListenerTest', () => {
     const frameCommunicatorMock: IMock<FrameCommunicator> = Mock.ofType(FrameCommunicator);
@@ -161,7 +161,7 @@ describe('TabStopsListenerTest', () => {
         frameCommunicatorMock
             .setup(f =>
                 f.sendMessage(
-                    It.is((req: IMessageRequest<ITabStopEvent>) => {
+                    It.is((req: IMessageRequest<TabStopEvent>) => {
                         expect(req.command).toEqual(TabStopsListener.getTabbedElementsCommand);
                         expect(req.win).toEqual(topWindowStub);
                         expect(req.message.target).toMatchObject(['selector']);
@@ -219,7 +219,7 @@ describe('TabStopsListenerTest', () => {
         const eventStub = {
             target: targetElementStub,
         } as Event;
-        const tabEventListenMock = Mock.ofInstance((tabbedItems: ITabStopEvent) => {});
+        const tabEventListenMock = Mock.ofInstance((tabbedItems: TabStopEvent) => {});
 
         htmlElementUtilsMock
             .setup(h => h.getAllElementsByTagName('iframe'))
@@ -255,7 +255,7 @@ describe('TabStopsListenerTest', () => {
         tabEventListenMock
             .setup(t =>
                 t(
-                    It.is((event: ITabStopEvent) => {
+                    It.is((event: TabStopEvent) => {
                         expect(event.target).toEqual(['selector']);
                         return true;
                     }),
@@ -278,7 +278,7 @@ describe('TabStopsListenerTest', () => {
         const currentFocusedElementStub = {
             outerHTML: 'test html',
         };
-        const tabEventListenerMock = Mock.ofInstance((tabStopEvent: ITabStopEvent) => {});
+        const tabEventListenerMock = Mock.ofInstance((tabStopEvent: TabStopEvent) => {});
 
         windowUtilsMock
             .setup(w => w.isTopWindow())
@@ -300,7 +300,7 @@ describe('TabStopsListenerTest', () => {
         tabEventListenerMock
             .setup(t =>
                 t(
-                    It.is((tabStopEvent: ITabStopEvent) => {
+                    It.is((tabStopEvent: TabStopEvent) => {
                         expect(tabStopEvent.target).toMatchObject(['selector']);
                         expect(tabStopEvent.html).toEqual(currentFocusedElementStub.outerHTML);
                         return true;
@@ -339,7 +339,7 @@ describe('TabStopsListenerTest', () => {
         frameCommunicatorMock
             .setup(f =>
                 f.sendMessage(
-                    It.is((req: IMessageRequest<ITabStopEvent>) => {
+                    It.is((req: IMessageRequest<TabStopEvent>) => {
                         expect(req.command).toEqual(TabStopsListener.stopListeningCommand);
                         expect(req.frame).toEqual(frameStub);
                         return true;
@@ -360,14 +360,14 @@ describe('TabStopsListenerTest', () => {
 
     test('verify onGetTabbedElements in child frame', () => {
         const srcWindowStub = {};
-        const tabStopEventStub: ITabStopEvent = {
+        const tabStopEventStub: TabStopEvent = {
             target: ['selector'],
             html: 'test',
             timestamp: 1,
         };
         const frameStub = {};
         const parentWindowStub = {};
-        const messageStub: IMessageRequest<ITabStopEvent> = {
+        const messageStub: IMessageRequest<TabStopEvent> = {
             win: parentWindowStub as any,
             command: TabStopsListener.getTabbedElementsCommand,
             message: {
@@ -412,7 +412,7 @@ describe('TabStopsListenerTest', () => {
                 (
                     command,
                     onGetTabbedElements: (
-                        tabStopEvent: ITabStopEvent,
+                        tabStopEvent: TabStopEvent,
                         error: IErrorMessageContent,
                         messageSourceWin: Window,
                         responder?: FrameMessageResponseCallback,
@@ -436,13 +436,13 @@ describe('TabStopsListenerTest', () => {
 
     test('verify onGetTabbedElements in main frame', () => {
         const srcWindowStub = {};
-        const tabStopEventStub: ITabStopEvent = {
+        const tabStopEventStub: TabStopEvent = {
             target: ['selector'],
             html: 'test',
             timestamp: 1,
         };
         const frameStub = {};
-        const tabEventListenMock = Mock.ofInstance((tabbedItems: ITabStopEvent) => {});
+        const tabEventListenMock = Mock.ofInstance((tabbedItems: TabStopEvent) => {});
         const finalEventStub = {
             target: ['frame1', 'selector'],
             html: 'test',
@@ -481,7 +481,7 @@ describe('TabStopsListenerTest', () => {
                 (
                     command,
                     onGetTabbedElements: (
-                        tabStopEvent: ITabStopEvent,
+                        tabStopEvent: TabStopEvent,
                         error: IErrorMessageContent,
                         messageSourceWin: Window,
                         responder?: FrameMessageResponseCallback,
@@ -504,14 +504,14 @@ describe('TabStopsListenerTest', () => {
 
     test('verify onGetTabbedElements in main frame', () => {
         const srcWindowStub = {};
-        const tabStopEventStub: ITabStopEvent = {
+        const tabStopEventStub: TabStopEvent = {
             target: ['selector'],
             html: 'test',
             timestamp: 1,
         };
         const frameStub = {};
         let onGetTabbedElementsFunc: (
-            tabStopEvent: ITabStopEvent,
+            tabStopEvent: TabStopEvent,
             error: IErrorMessageContent,
             messageSourceWin: Window,
             responder?: FrameMessageResponseCallback,
@@ -547,7 +547,7 @@ describe('TabStopsListenerTest', () => {
                 (
                     command,
                     onGetTabbedElements: (
-                        tabStopEvent: ITabStopEvent,
+                        tabStopEvent: TabStopEvent,
                         error: IErrorMessageContent,
                         messageSourceWin: Window,
                         responder?: FrameMessageResponseCallback,
@@ -568,20 +568,20 @@ describe('TabStopsListenerTest', () => {
 
     test('unable to get frame element for the tabbed element', () => {
         const srcWindowStub = {};
-        const tabStopEventStub: ITabStopEvent = {
+        const tabStopEventStub: TabStopEvent = {
             target: ['selector'],
             html: 'test',
             timestamp: 1,
         };
         const frameStub = {};
-        const tabEventListenMock = Mock.ofInstance((tabbedItems: ITabStopEvent) => {});
+        const tabEventListenMock = Mock.ofInstance((tabbedItems: TabStopEvent) => {});
         const finalEventStub = {
             target: ['frame1', 'selector'],
             html: 'test',
             timestamp: 1,
         };
         let onGetTabbedElementsFunc: (
-            tabStopEvent: ITabStopEvent,
+            tabStopEvent: TabStopEvent,
             error: IErrorMessageContent,
             messageSourceWin: Window,
             responder?: FrameMessageResponseCallback,
@@ -619,7 +619,7 @@ describe('TabStopsListenerTest', () => {
                 (
                     command,
                     onGetTabbedElements: (
-                        tabStopEvent: ITabStopEvent,
+                        tabStopEvent: TabStopEvent,
                         error: IErrorMessageContent,
                         messageSourceWin: Window,
                         responder?: FrameMessageResponseCallback,

--- a/src/tests/unit/tests/injected/visualization/drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/drawer.test.ts
@@ -6,7 +6,7 @@ import { getDefaultFeatureFlagValues } from '../../../../../common/feature-flags
 import { WindowUtils } from '../../../../../common/window-utils';
 import { ClientUtils } from '../../../../../injected/client-utils';
 import { DialogRenderer } from '../../../../../injected/dialog-renderer';
-import { IHtmlElementAxeResults } from '../../../../../injected/scanner-utils';
+import { HtmlElementAxeResults } from '../../../../../injected/scanner-utils';
 import { ShadowUtils } from '../../../../../injected/shadow-utils';
 import { Drawer } from '../../../../../injected/visualization/drawer';
 import { DrawerUtils } from '../../../../../injected/visualization/drawer-utils';
@@ -1194,7 +1194,7 @@ describe('Drawer', () => {
         };
     }
 
-    function createElementResults(ids: string[]): IHtmlElementAxeResults[] {
+    function createElementResults(ids: string[]): HtmlElementAxeResults[] {
         return ids.map(id => {
             return {
                 ruleResults: {},

--- a/src/tests/unit/tests/injected/visualization/issues-formatter.test.ts
+++ b/src/tests/unit/tests/injected/visualization/issues-formatter.test.ts
@@ -6,7 +6,7 @@ import { ClientBrowserAdapter } from '../../../../../common/client-browser-adapt
 import { HTMLElementUtils } from '../../../../../common/html-element-utils';
 import { WindowUtils } from '../../../../../common/window-utils';
 import { FrameCommunicator } from '../../../../../injected/frameCommunicators/frame-communicator';
-import { IHtmlElementAxeResults } from '../../../../../injected/scanner-utils';
+import { HtmlElementAxeResults } from '../../../../../injected/scanner-utils';
 import { ShadowUtils } from '../../../../../injected/shadow-utils';
 import { HeadingStyleConfiguration } from '../../../../../injected/visualization/heading-formatter';
 import { IssuesFormatter } from '../../../../../injected/visualization/issues-formatter';
@@ -35,7 +35,7 @@ describe('IssuesFormatterTests', () => {
     });
 
     test('tooltip for the failed rules from the axe result', () => {
-        const axeData: IHtmlElementAxeResults = {
+        const axeData: HtmlElementAxeResults = {
             target: ['html'],
             isVisible: true,
             ruleResults: {

--- a/src/tests/unit/tests/injected/visualization/single-target-drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/single-target-drawer.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { IMock, Mock, Times } from 'typemoq';
 import { getDefaultFeatureFlagValues } from '../../../../../common/feature-flags';
-import { IHtmlElementAxeResults } from '../../../../../injected/scanner-utils';
+import { HtmlElementAxeResults } from '../../../../../injected/scanner-utils';
 import { DrawerUtils } from '../../../../../injected/visualization/drawer-utils';
 import { SingleTargetDrawerConfiguration } from '../../../../../injected/visualization/formatter';
 import { IDrawerInitData } from '../../../../../injected/visualization/idrawer';
@@ -28,12 +28,12 @@ describe('SingleTargetDrawer Tests', () => {
 
         const testSubject = new SingleTargetDrawer(drawerUtilsMock.object, formatterMock.object);
 
-        const drawerInfo: IDrawerInitData<IHtmlElementAxeResults> = {
+        const drawerInfo: IDrawerInitData<HtmlElementAxeResults> = {
             data: [
                 {
                     target: ['body'],
                 },
-            ] as IHtmlElementAxeResults[],
+            ] as HtmlElementAxeResults[],
             featureFlagStoreData: getDefaultFeatureFlagValues(),
         };
 
@@ -52,12 +52,12 @@ describe('SingleTargetDrawer Tests', () => {
 
         const testSubject = new SingleTargetDrawer(drawerUtilsMock.object, formatterMock.object);
 
-        const drawerInfo: IDrawerInitData<IHtmlElementAxeResults> = {
+        const drawerInfo: IDrawerInitData<HtmlElementAxeResults> = {
             data: [
                 {
                     target: ['body'],
                 },
-            ] as IHtmlElementAxeResults[],
+            ] as HtmlElementAxeResults[],
             featureFlagStoreData: getDefaultFeatureFlagValues(),
         };
 
@@ -83,12 +83,12 @@ describe('SingleTargetDrawer Tests', () => {
 
         const testSubject = new SingleTargetDrawer(drawerUtilsMock.object, formatterMock.object);
 
-        const drawerInfo: IDrawerInitData<IHtmlElementAxeResults> = {
+        const drawerInfo: IDrawerInitData<HtmlElementAxeResults> = {
             data: [
                 {
                     target: ['body'],
                 },
-            ] as IHtmlElementAxeResults[],
+            ] as HtmlElementAxeResults[],
             featureFlagStoreData: getDefaultFeatureFlagValues(),
         };
 
@@ -114,12 +114,12 @@ describe('SingleTargetDrawer Tests', () => {
 
         const testSubject = new SingleTargetDrawer(drawerUtilsMock.object, formatterMock.object);
 
-        const drawerInfo: IDrawerInitData<IHtmlElementAxeResults> = {
+        const drawerInfo: IDrawerInitData<HtmlElementAxeResults> = {
             data: [
                 {
                     target: ['body'],
                 },
-            ] as IHtmlElementAxeResults[],
+            ] as HtmlElementAxeResults[],
             featureFlagStoreData: getDefaultFeatureFlagValues(),
         };
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.

#### Description of changes

So, there are some `tslint:disable` in our code, including some which can be easily removed.

Removing two of such interfaces. 

ITabStopEvent -> TabStopEvent
IHtmlElementAxeResults  -> HtmlElementAxeResults 