### PR TITLE
add html code-coverage report locally

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -51,7 +51,7 @@ jobs:
                 # We care most about the summary information; adding the detailed files doesn't give enough extra information
                 # to be worth the 1min it adds to the build.
                 # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.
-                # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/lcov-report
+                reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage
             displayName: publish code coverage
 
           # CI build only

--- a/build.yaml
+++ b/build.yaml
@@ -51,7 +51,7 @@ jobs:
                 # We care most about the summary information; adding the detailed files doesn't give enough extra information
                 # to be worth the 1min it adds to the build.
                 # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.
-                # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage
+                # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/lcov-report
             displayName: publish code coverage
 
           # CI build only

--- a/build.yaml
+++ b/build.yaml
@@ -51,7 +51,7 @@ jobs:
                 # We care most about the summary information; adding the detailed files doesn't give enough extra information
                 # to be worth the 1min it adds to the build.
                 # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.
-                reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage
+                # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage
             displayName: publish code coverage
 
           # CI build only

--- a/src/tests/unit/jest.config.js
+++ b/src/tests/unit/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
     roots: [currentDir],
     collectCoverage: true,
     collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx}', '!<rootDir>/src/tests/**/*', '!<rootDir>/src/**/*.d.ts'],
-    coverageReporters: ['json', 'lcov', 'text', 'cobertura', 'html'],
+    coverageReporters: ['json', 'text', 'cobertura', 'html'],
     testEnvironment: 'jsdom',
     testMatch: [`${currentDir}/**/*.test.(ts|tsx|js)`],
     reporters: ['default', ['jest-junit', { outputDirectory: '.', outputName: '<rootDir>/test-results/unit/junit.xml' }]],

--- a/src/tests/unit/jest.config.js
+++ b/src/tests/unit/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
     roots: [currentDir],
     collectCoverage: true,
     collectCoverageFrom: ['<rootDir>/src/**/*.{ts,tsx}', '!<rootDir>/src/tests/**/*', '!<rootDir>/src/**/*.d.ts'],
-    coverageReporters: ['json', 'lcov', 'text', 'cobertura'],
+    coverageReporters: ['json', 'lcov', 'text', 'cobertura', 'html'],
     testEnvironment: 'jsdom',
     testMatch: [`${currentDir}/**/*.test.(ts|tsx|js)`],
     reporters: ['default', ['jest-junit', { outputDirectory: '.', outputName: '<rootDir>/test-results/unit/junit.xml' }]],


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.

#### Description of changes

Enabling HTML report for code-coverage & not yet pushing the code coverage report to TFS server as its taking 2m alone for that task.
So, just enabling HTML reporting.
