### PR TITLE
Typescript version on vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,6 @@
     "files.insertFinalNewline": true,
     "prettier.requireConfig": true,
     "editor.formatOnSave": true,
-    "editor.rulers": [140]
+    "editor.rulers": [140],
+    "typescript.tsdk": "node_modules\\typescript\\lib"
 }


### PR DESCRIPTION
#### Description of changes

Adding setting to ensure vscode is using typescript from node_modules not from global instalation.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 **N/A**
- [ ] Added relevant unit test for your changes. (`npm run test`) **N/A**
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` **N/A**
- [ ] Ran precheckin (`npm run precheckin`) **N/A**
- [ ] Added screenshots/GIFs for UI changes. **N/A**
