### PR TITLE
tslint rule no-string-based-set-*

### DIFF
--- a/src/tests/unit/common/is-function.ts
+++ b/src/tests/unit/common/is-function.ts
@@ -1,5 +1,5 @@
-import { It } from 'typemoq';
 import { isFunction as checkIsFunction } from 'lodash';
+import { It } from 'typemoq';
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.

--- a/src/tests/unit/common/is-function.ts
+++ b/src/tests/unit/common/is-function.ts
@@ -1,6 +1,0 @@
-import { isFunction as checkIsFunction } from 'lodash';
-import { It } from 'typemoq';
-
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-export const isFunction = It.is<Function>(checkIsFunction);

--- a/src/tests/unit/common/is-function.ts
+++ b/src/tests/unit/common/is-function.ts
@@ -1,0 +1,6 @@
+import { It } from 'typemoq';
+import { isFunction as checkIsFunction } from 'lodash';
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export const isFunction = It.is<Function>(checkIsFunction);

--- a/src/tests/unit/common/it-is-function.ts
+++ b/src/tests/unit/common/it-is-function.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { isFunction } from 'lodash';
+import { It } from 'typemoq';
+
+export const itIsFunction = It.is<Function>(isFunction);

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -13,7 +13,7 @@ import { VisualizationStore } from '../../../../background/stores/visualization-
 import { Messages } from '../../../../common/messages';
 import { IVisualizationStoreData } from '../../../../common/types/store-data/ivisualization-store-data';
 import { WindowUtils } from '../../../../common/window-utils';
-import { isFunction } from '../../common/is-function';
+import { itIsFunction } from '../../common/it-is-function';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 
 describe('InjectorControllerTest', () => {
@@ -177,7 +177,7 @@ class InjectorControllerValidator {
 
     public setupTimeoutHandler(times: number): InjectorControllerValidator {
         this.mockWindowUtils
-            .setup(x => x.setTimeout(isFunction, It.isAnyNumber()))
+            .setup(x => x.setTimeout(itIsFunction, It.isAnyNumber()))
             .callback(handler => {
                 this.setTimeoutHandler = handler;
             })

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
 import * as Q from 'q';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
 
@@ -14,6 +13,7 @@ import { VisualizationStore } from '../../../../background/stores/visualization-
 import { Messages } from '../../../../common/messages';
 import { IVisualizationStoreData } from '../../../../common/types/store-data/ivisualization-store-data';
 import { WindowUtils } from '../../../../common/window-utils';
+import { isFunction } from '../../common/is-function';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 
 describe('InjectorControllerTest', () => {
@@ -177,7 +177,7 @@ class InjectorControllerValidator {
 
     public setupTimeoutHandler(times: number): InjectorControllerValidator {
         this.mockWindowUtils
-            .setup(x => x.setTimeout(It.is(isFunction), It.isAnyNumber()))
+            .setup(x => x.setTimeout(isFunction, It.isAnyNumber()))
             .callback(handler => {
                 this.setTimeoutHandler = handler;
             })

--- a/src/tests/unit/tests/background/scanner-utility.test.ts
+++ b/src/tests/unit/tests/background/scanner-utility.test.ts
@@ -6,7 +6,7 @@ import { Interpreter } from '../../../../background/interpreter';
 import { ScannerUtility } from '../../../../background/scanner-utility';
 import { Messages } from '../../../../common/messages';
 import { WindowUtils } from '../../../../common/window-utils';
-import { isFunction } from '../../common/is-function';
+import { itIsFunction } from '../../common/it-is-function';
 
 describe('ScannerUtility', () => {
     it('constructor', () => {
@@ -36,7 +36,7 @@ describe('ScannerUtility', () => {
         interpreterMock.setup(im => im.interpret(It.isValue(expectedMessage))).verifiable();
 
         windowUtilsMock
-            .setup(wum => wum.setTimeout(isFunction, ScannerUtility.scanTimeoutMilliSeconds))
+            .setup(wum => wum.setTimeout(itIsFunction, ScannerUtility.scanTimeoutMilliSeconds))
             .callback(timeoutCallback => {
                 callback = timeoutCallback;
             });

--- a/src/tests/unit/tests/background/scanner-utility.test.ts
+++ b/src/tests/unit/tests/background/scanner-utility.test.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
 import { It, Mock, MockBehavior } from 'typemoq';
 import { AssessmentToggleActionPayload } from '../../../../background/actions/action-payloads';
 import { Interpreter } from '../../../../background/interpreter';
 import { ScannerUtility } from '../../../../background/scanner-utility';
 import { Messages } from '../../../../common/messages';
 import { WindowUtils } from '../../../../common/window-utils';
+import { isFunction } from '../../common/is-function';
 
 describe('ScannerUtility', () => {
     it('constructor', () => {
@@ -36,7 +36,7 @@ describe('ScannerUtility', () => {
         interpreterMock.setup(im => im.interpret(It.isValue(expectedMessage))).verifiable();
 
         windowUtilsMock
-            .setup(wum => wum.setTimeout(It.is(isFunction), ScannerUtility.scanTimeoutMilliSeconds))
+            .setup(wum => wum.setTimeout(isFunction, ScannerUtility.scanTimeoutMilliSeconds))
             .callback(timeoutCallback => {
                 callback = timeoutCallback;
             });

--- a/src/tests/unit/tests/common/components/toast.test.tsx
+++ b/src/tests/unit/tests/common/components/toast.test.tsx
@@ -6,7 +6,7 @@ import { IMock, It, Mock, Times } from 'typemoq';
 
 import { Toast, ToastProps } from '../../../../../common/components/toast';
 import { WindowUtils } from '../../../../../common/window-utils';
-import { isFunction } from '../../../common/is-function';
+import { itIsFunction } from '../../../common/it-is-function';
 
 describe('ToastTest', () => {
     let windowUtilsMock: IMock<WindowUtils>;
@@ -33,7 +33,7 @@ describe('ToastTest', () => {
     test('setTimeout upon componentDidMount', () => {
         const timeoutId = 1;
         windowUtilsMock
-            .setup(m => m.setTimeout(isFunction, 2000))
+            .setup(m => m.setTimeout(itIsFunction, 2000))
             .returns(() => timeoutId)
             .verifiable(Times.once());
         onTimeoutMock.setup(m => m()).verifiable(Times.never());
@@ -48,7 +48,7 @@ describe('ToastTest', () => {
         const timeoutId = 1;
         let callback;
         windowUtilsMock
-            .setup(m => m.setTimeout(isFunction, 2000))
+            .setup(m => m.setTimeout(itIsFunction, 2000))
             .callback((func, _) => (callback = func))
             .returns(() => timeoutId)
             .verifiable(Times.once());

--- a/src/tests/unit/tests/common/components/toast.test.tsx
+++ b/src/tests/unit/tests/common/components/toast.test.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enzyme from 'enzyme';
-import { isFunction } from 'lodash';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
+
 import { Toast, ToastProps } from '../../../../../common/components/toast';
 import { WindowUtils } from '../../../../../common/window-utils';
+import { isFunction } from '../../../common/is-function';
 
 describe('ToastTest', () => {
     let windowUtilsMock: IMock<WindowUtils>;
@@ -32,7 +33,7 @@ describe('ToastTest', () => {
     test('setTimeout upon componentDidMount', () => {
         const timeoutId = 1;
         windowUtilsMock
-            .setup(m => m.setTimeout(It.is(isFunction), 2000))
+            .setup(m => m.setTimeout(isFunction, 2000))
             .returns(() => timeoutId)
             .verifiable(Times.once());
         onTimeoutMock.setup(m => m()).verifiable(Times.never());
@@ -47,7 +48,7 @@ describe('ToastTest', () => {
         const timeoutId = 1;
         let callback;
         windowUtilsMock
-            .setup(m => m.setTimeout(It.is(isFunction), 2000))
+            .setup(m => m.setTimeout(isFunction, 2000))
             .callback((func, _) => (callback = func))
             .returns(() => timeoutId)
             .verifiable(Times.once());

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { WindowUtils } from '../../../../../common/window-utils';
 import { FocusAnalyzerConfiguration, ScanBasePayload } from '../../../../../injected/analyzers/analyzer';
 import { TabStopsAnalyzer } from '../../../../../injected/analyzers/tab-stops-analyzer';
 import { TabStopEvent, TabStopsListener } from '../../../../../injected/tab-stops-listener';
-import { isFunction } from '../../../common/is-function';
+import { itIsFunction } from '../../../common/it-is-function';
 
 describe('TabStopsAnalyzerTests', () => {
     let windowUtilsMock: IMock<WindowUtils>;
@@ -164,7 +163,7 @@ describe('TabStopsAnalyzerTests', () => {
 
     function setupWindowUtils(): void {
         windowUtilsMock
-            .setup(w => w.setTimeout(isFunction, 50))
+            .setup(w => w.setTimeout(itIsFunction, 50))
             .callback((callback, timeout) => {
                 setTimeOutCallBack = callback;
             })

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { WindowUtils } from '../../../../../common/window-utils';
 import { FocusAnalyzerConfiguration, ScanBasePayload } from '../../../../../injected/analyzers/analyzer';
 import { TabStopsAnalyzer } from '../../../../../injected/analyzers/tab-stops-analyzer';
 import { TabStopEvent, TabStopsListener } from '../../../../../injected/tab-stops-listener';
+import { isFunction } from '../../../common/is-function';
 
 describe('TabStopsAnalyzerTests', () => {
     let windowUtilsMock: IMock<WindowUtils>;
@@ -163,7 +164,7 @@ describe('TabStopsAnalyzerTests', () => {
 
     function setupWindowUtils(): void {
         windowUtilsMock
-            .setup(w => w.setTimeout(It.is(isFunction), 50))
+            .setup(w => w.setTimeout(isFunction, 50))
             .callback((callback, timeout) => {
                 setTimeOutCallBack = callback;
             })

--- a/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
+++ b/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, Times } from 'typemoq';
-
 import { UniquelyIdentifiableInstances } from '../../../../background/instance-identifier-generator';
 import {
     VisualizationConfiguration,
@@ -13,7 +12,7 @@ import { VisualizationType } from '../../../../common/types/visualization-type';
 import { WindowUtils } from '../../../../common/window-utils';
 import { AssessmentVisualizationInstance } from '../../../../injected/frameCommunicators/html-element-axe-results-helper';
 import { InstanceVisibilityChecker } from '../../../../injected/instance-visibility-checker';
-import { isFunction } from '../../common/is-function';
+import { itIsFunction } from '../../common/it-is-function';
 
 describe('InstanceVisibilityCheckerTest', () => {
     let windowUtilsMock: IMock<WindowUtils>;
@@ -105,7 +104,7 @@ describe('InstanceVisibilityCheckerTest', () => {
         ];
 
         windowUtilsMock
-            .setup(wU => wU.setInterval(isFunction, InstanceVisibilityChecker.recalculationTimeInterval))
+            .setup(wU => wU.setInterval(itIsFunction, InstanceVisibilityChecker.recalculationTimeInterval))
             .callback((cb, timeout) => {
                 cb();
             })
@@ -174,7 +173,7 @@ describe('InstanceVisibilityCheckerTest', () => {
         };
 
         windowUtilsMock
-            .setup(wU => wU.setInterval(isFunction, InstanceVisibilityChecker.recalculationTimeInterval))
+            .setup(wU => wU.setInterval(itIsFunction, InstanceVisibilityChecker.recalculationTimeInterval))
             .callback((cb, timeout) => {
                 cb();
             })
@@ -287,7 +286,7 @@ describe('InstanceVisibilityCheckerTest', () => {
         configFactoryMock.setup(cfm => cfm.getConfiguration(testType)).returns(() => configStub);
 
         windowUtilsMock
-            .setup(wU => wU.setInterval(isFunction, InstanceVisibilityChecker.recalculationTimeInterval))
+            .setup(wU => wU.setInterval(itIsFunction, InstanceVisibilityChecker.recalculationTimeInterval))
             .verifiable(Times.never());
 
         testSubject.createVisibilityCheckerInterval(testStepDrawerId, testType, [frameResult]);

--- a/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
+++ b/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
+
 import { UniquelyIdentifiableInstances } from '../../../../background/instance-identifier-generator';
 import {
     VisualizationConfiguration,
@@ -13,6 +13,7 @@ import { VisualizationType } from '../../../../common/types/visualization-type';
 import { WindowUtils } from '../../../../common/window-utils';
 import { AssessmentVisualizationInstance } from '../../../../injected/frameCommunicators/html-element-axe-results-helper';
 import { InstanceVisibilityChecker } from '../../../../injected/instance-visibility-checker';
+import { isFunction } from '../../common/is-function';
 
 describe('InstanceVisibilityCheckerTest', () => {
     let windowUtilsMock: IMock<WindowUtils>;
@@ -104,7 +105,7 @@ describe('InstanceVisibilityCheckerTest', () => {
         ];
 
         windowUtilsMock
-            .setup(wU => wU.setInterval(It.is(isFunction), InstanceVisibilityChecker.recalculationTimeInterval))
+            .setup(wU => wU.setInterval(isFunction, InstanceVisibilityChecker.recalculationTimeInterval))
             .callback((cb, timeout) => {
                 cb();
             })
@@ -173,7 +174,7 @@ describe('InstanceVisibilityCheckerTest', () => {
         };
 
         windowUtilsMock
-            .setup(wU => wU.setInterval(It.is(isFunction), InstanceVisibilityChecker.recalculationTimeInterval))
+            .setup(wU => wU.setInterval(isFunction, InstanceVisibilityChecker.recalculationTimeInterval))
             .callback((cb, timeout) => {
                 cb();
             })
@@ -286,7 +287,7 @@ describe('InstanceVisibilityCheckerTest', () => {
         configFactoryMock.setup(cfm => cfm.getConfiguration(testType)).returns(() => configStub);
 
         windowUtilsMock
-            .setup(wU => wU.setInterval(It.is(isFunction), InstanceVisibilityChecker.recalculationTimeInterval))
+            .setup(wU => wU.setInterval(isFunction, InstanceVisibilityChecker.recalculationTimeInterval))
             .verifiable(Times.never());
 
         testSubject.createVisibilityCheckerInterval(testStepDrawerId, testType, [frameResult]);

--- a/src/tests/unit/tests/injected/scoping-listener.test.ts
+++ b/src/tests/unit/tests/injected/scoping-listener.test.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
+
 import { SingleElementSelector } from '../../../../common/types/store-data/scoping-store-data';
 import { WindowUtils } from '../../../../common/window-utils';
 import { ElementFinderByPosition } from '../../../../injected/element-finder-by-position';
 import { ScopingListener } from '../../../../injected/scoping-listener';
 import { ShadowUtils } from '../../../../injected/shadow-utils';
+import { isFunction } from '../../common/is-function';
 
 class TestableScopingListener extends ScopingListener {
     public getOnClick(): (event: MouseEvent) => void {
@@ -221,7 +222,7 @@ describe('ScopingListenerTest', () => {
 
     function setupOnClickSetTimeout(path: SingleElementSelector, times: number = 1): void {
         windowUtilsMock
-            .setup(wum => wum.setTimeout(It.is(isFunction), ScopingListener.onClickTimeout))
+            .setup(wum => wum.setTimeout(isFunction, ScopingListener.onClickTimeout))
             .callback(handler => {
                 onClickSetTimeoutHandler = handler;
             })
@@ -249,7 +250,7 @@ describe('ScopingListenerTest', () => {
 
     function setupOnHoverSetTimeout(path: SingleElementSelector, times: number = 1): void {
         windowUtilsMock
-            .setup(wum => wum.setTimeout(It.is(isFunction), ScopingListener.onHoverTimeout))
+            .setup(wum => wum.setTimeout(isFunction, ScopingListener.onHoverTimeout))
             .callback(handler => {
                 onHoverSetTimeoutHandler = handler;
             })

--- a/src/tests/unit/tests/injected/scoping-listener.test.ts
+++ b/src/tests/unit/tests/injected/scoping-listener.test.ts
@@ -7,7 +7,7 @@ import { WindowUtils } from '../../../../common/window-utils';
 import { ElementFinderByPosition } from '../../../../injected/element-finder-by-position';
 import { ScopingListener } from '../../../../injected/scoping-listener';
 import { ShadowUtils } from '../../../../injected/shadow-utils';
-import { isFunction } from '../../common/is-function';
+import { itIsFunction } from '../../common/it-is-function';
 
 class TestableScopingListener extends ScopingListener {
     public getOnClick(): (event: MouseEvent) => void {
@@ -222,7 +222,7 @@ describe('ScopingListenerTest', () => {
 
     function setupOnClickSetTimeout(path: SingleElementSelector, times: number = 1): void {
         windowUtilsMock
-            .setup(wum => wum.setTimeout(isFunction, ScopingListener.onClickTimeout))
+            .setup(wum => wum.setTimeout(itIsFunction, ScopingListener.onClickTimeout))
             .callback(handler => {
                 onClickSetTimeoutHandler = handler;
             })
@@ -250,7 +250,7 @@ describe('ScopingListenerTest', () => {
 
     function setupOnHoverSetTimeout(path: SingleElementSelector, times: number = 1): void {
         windowUtilsMock
-            .setup(wum => wum.setTimeout(isFunction, ScopingListener.onHoverTimeout))
+            .setup(wum => wum.setTimeout(itIsFunction, ScopingListener.onHoverTimeout))
             .callback(handler => {
                 onHoverSetTimeoutHandler = handler;
             })

--- a/src/tests/unit/tests/injected/visualization/drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/drawer.test.ts
@@ -12,7 +12,7 @@ import { DrawerInitData } from '../../../../../injected/visualization/drawer';
 import { DrawerUtils } from '../../../../../injected/visualization/drawer-utils';
 import { DrawerConfiguration, Formatter } from '../../../../../injected/visualization/formatter';
 import { HighlightBoxDrawer } from '../../../../../injected/visualization/highlight-box-drawer';
-import { isFunction } from '../../../common/is-function';
+import { itIsFunction } from '../../../common/it-is-function';
 import { TestDocumentCreator } from '../../../common/test-document-creator';
 
 describe('Drawer', () => {
@@ -847,7 +847,7 @@ describe('Drawer', () => {
 
         windowUtilsMock.setup(x => x.clearTimeout(It.isAny())).verifiable(Times.never());
         windowUtilsMock
-            .setup(x => x.setTimeout(isFunction, HighlightBoxDrawer.recalculationTimeout))
+            .setup(x => x.setTimeout(itIsFunction, HighlightBoxDrawer.recalculationTimeout))
             .returns(() => timeOutId)
             .verifiable();
 

--- a/src/tests/unit/tests/injected/visualization/drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/drawer.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { IActionN } from 'typemoq/_all';
 import { getDefaultFeatureFlagValues } from '../../../../../common/feature-flags';
@@ -13,6 +12,7 @@ import { DrawerInitData } from '../../../../../injected/visualization/drawer';
 import { DrawerUtils } from '../../../../../injected/visualization/drawer-utils';
 import { DrawerConfiguration, Formatter } from '../../../../../injected/visualization/formatter';
 import { HighlightBoxDrawer } from '../../../../../injected/visualization/highlight-box-drawer';
+import { isFunction } from '../../../common/is-function';
 import { TestDocumentCreator } from '../../../common/test-document-creator';
 
 describe('Drawer', () => {
@@ -847,7 +847,7 @@ describe('Drawer', () => {
 
         windowUtilsMock.setup(x => x.clearTimeout(It.isAny())).verifiable(Times.never());
         windowUtilsMock
-            .setup(x => x.setTimeout(It.is(isFunction), HighlightBoxDrawer.recalculationTimeout))
+            .setup(x => x.setTimeout(isFunction, HighlightBoxDrawer.recalculationTimeout))
             .returns(() => timeOutId)
             .verifiable();
 

--- a/src/tests/unit/tests/popup/support-link-handler.test.ts
+++ b/src/tests/unit/tests/popup/support-link-handler.test.ts
@@ -6,7 +6,7 @@ import { ChromeAdapter } from '../../../../background/browser-adapter';
 import { configMutator } from '../../../../common/configuration';
 import { WindowUtils } from '../../../../common/window-utils';
 import { SupportLinkHandler } from '../../../../popup/support-link-handler';
-import { isFunction } from '../../common/is-function';
+import { itIsFunction } from '../../common/it-is-function';
 
 describe('SupportLinkHandlerTest', () => {
     afterEach(configMutator.reset);
@@ -34,7 +34,7 @@ describe('SupportLinkHandlerTest', () => {
 
         const windowUtilsMock = Mock.ofType(WindowUtils);
         windowUtilsMock
-            .setup(wu => wu.setTimeout(isFunction, 500))
+            .setup(wu => wu.setTimeout(itIsFunction, 500))
             .callback((cb, timeout) => {
                 cb();
             })

--- a/src/tests/unit/tests/popup/support-link-handler.test.ts
+++ b/src/tests/unit/tests/popup/support-link-handler.test.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
 import { It, Mock } from 'typemoq';
+
 import { ChromeAdapter } from '../../../../background/browser-adapter';
 import { configMutator } from '../../../../common/configuration';
 import { WindowUtils } from '../../../../common/window-utils';
 import { SupportLinkHandler } from '../../../../popup/support-link-handler';
+import { isFunction } from '../../common/is-function';
 
 describe('SupportLinkHandlerTest', () => {
     afterEach(configMutator.reset);
@@ -33,7 +34,7 @@ describe('SupportLinkHandlerTest', () => {
 
         const windowUtilsMock = Mock.ofType(WindowUtils);
         windowUtilsMock
-            .setup(wu => wu.setTimeout(It.is(isFunction), 500))
+            .setup(wu => wu.setTimeout(isFunction, 500))
             .callback((cb, timeout) => {
                 cb();
             })


### PR DESCRIPTION
#### Description of changes

SDT build is flagging our mock setup for `setTimeout` because we're using `It.is(isFunction)` which has a return type of any making tslint to flag this uses. 

On this PR I'm adding a wrapper to check the `setTimeout` parameter is a function and make this wrapper to return type of `Function`.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes **several**
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
