### PR TITLE
[Bug] update app bar styling and finish

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -327,6 +327,7 @@ div.insights-file-issue-details-dialog-container {
         z-index: 1000;
         .gear-options-button-component {
             float: right;
+            margin-right: 12px;
             .sign-in-link {
                 color: $neutral-0;
                 margin-top: 11px;

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -327,7 +327,7 @@ div.insights-file-issue-details-dialog-container {
         z-index: 1000;
         .gear-options-button-component {
             float: right;
-            margin-right: 12px;
+            margin-right: 16px;
             .sign-in-link {
                 color: $neutral-0;
                 margin-top: 11px;


### PR DESCRIPTION
#### Description of changes

Bug fix for remaining fix on WI 1421040 where the settings gear drop down was not aligned to Start over button. Aligning that button.
#### Pull request checklist

- [x] Addresses an existing issue: Fixes 1421040
- [n/a] Added relevant unit test for your changes. (`npm run test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.


##### Screenshots
Production:

![image](https://user-images.githubusercontent.com/4496335/55840486-6084c980-5ae0-11e9-93c5-fbdede69577f.png)

With new change:

![image](https://user-images.githubusercontent.com/4496335/55840635-f3256880-5ae0-11e9-9f9d-85127aa55070.png)
