### PR TITLE
Remove tslint disabled no-reserved-keywords comment

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -42,7 +42,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
     public updateIssuesSelectedTargets(selectedTargets: string[]): void {
         const payload: string[] = selectedTargets;
         const message: Message = {
-            type: messages.Issues.UpdateSelectedTargets,
+            messageType: messages.Issues.UpdateSelectedTargets,
             tabId: this._tabId,
             payload,
         };
@@ -59,7 +59,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });
@@ -74,7 +74,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });
@@ -89,7 +89,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });
@@ -111,7 +111,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload: payload,
         });
@@ -137,7 +137,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
     public updateFocusedInstanceTarget(instanceTarget: string[]): void {
         const payload: string[] = instanceTarget;
         const message: Message = {
-            type: messages.Issues.UpdateFocusedInstance,
+            messageType: messages.Issues.UpdateFocusedInstance,
             tabId: this._tabId,
             payload,
         };
@@ -157,7 +157,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: messages.DetailsView.Select,
+            messageType: messages.DetailsView.Select,
             tabId: this._tabId,
             payload,
         });
@@ -175,7 +175,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.SelectTestRequirement,
+            messageType: Messages.Assessment.SelectTestRequirement,
             tabId: this._tabId,
             payload: payload,
         });
@@ -190,7 +190,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Visualizations.DetailsView.PivotSelect,
+            messageType: Messages.Visualizations.DetailsView.PivotSelect,
             tabId: this._tabId,
             payload: payload,
         });
@@ -203,7 +203,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             telemetry,
         };
         this.dispatchMessage({
-            type: Messages.Tab.Switch,
+            messageType: Messages.Tab.Switch,
             tabId: this._tabId,
             payload,
         });
@@ -218,7 +218,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.StartOver,
+            messageType: Messages.Assessment.StartOver,
             tabId: this._tabId,
             payload,
         });
@@ -233,7 +233,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: shouldScan ? Messages.Assessment.EnableVisualHelper : Messages.Assessment.EnableVisualHelperWithoutScan,
+            messageType: shouldScan ? Messages.Assessment.EnableVisualHelper : Messages.Assessment.EnableVisualHelperWithoutScan,
             tabId: this._tabId,
             payload,
         });
@@ -245,7 +245,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.DisableVisualHelperForTest,
+            messageType: Messages.Assessment.DisableVisualHelperForTest,
             tabId: this._tabId,
             payload,
         });
@@ -259,7 +259,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.DisableVisualHelper,
+            messageType: Messages.Assessment.DisableVisualHelper,
             tabId: this._tabId,
             payload,
         });
@@ -277,7 +277,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.ChangeStatus,
+            messageType: Messages.Assessment.ChangeStatus,
             tabId: this._tabId,
             payload,
         });
@@ -294,7 +294,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.ChangeRequirementStatus,
+            messageType: Messages.Assessment.ChangeRequirementStatus,
             tabId: this._tabId,
             payload,
         });
@@ -311,7 +311,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.Undo,
+            messageType: Messages.Assessment.Undo,
             tabId: this._tabId,
             payload,
         });
@@ -327,7 +327,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.UndoChangeRequirementStatus,
+            messageType: Messages.Assessment.UndoChangeRequirementStatus,
             tabId: this._tabId,
             payload,
         });
@@ -350,7 +350,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.ChangeVisualizationState,
+            messageType: Messages.Assessment.ChangeVisualizationState,
             tabId: this._tabId,
             payload,
         });
@@ -366,7 +366,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.AddFailureInstance,
+            messageType: Messages.Assessment.AddFailureInstance,
             tabId: this._tabId,
             payload,
         });
@@ -383,7 +383,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.RemoveFailureInstance,
+            messageType: Messages.Assessment.RemoveFailureInstance,
             tabId: this._tabId,
             payload,
         });
@@ -406,7 +406,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.EditFailureInstance,
+            messageType: Messages.Assessment.EditFailureInstance,
             tabId: this._tabId,
             payload,
         });
@@ -421,7 +421,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.PassUnmarkedInstances,
+            messageType: Messages.Assessment.PassUnmarkedInstances,
             tabId: this._tabId,
             payload,
         });
@@ -438,7 +438,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatchMessage({
-            type: Messages.Assessment.ChangeVisualizationStateForAll,
+            messageType: Messages.Assessment.ChangeVisualizationStateForAll,
             tabId: this._tabId,
             payload,
         });
@@ -451,7 +451,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             telemetry: telemetry,
         };
         this.dispatchMessage({
-            type: Messages.Assessment.ContinuePreviousAssessment,
+            messageType: Messages.Assessment.ContinuePreviousAssessment,
             tabId: this._tabId,
             payload,
         });
@@ -464,7 +464,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             telemetry: telemetry,
         };
         this.dispatchMessage({
-            type: Messages.Assessment.StartOverAllAssessments,
+            messageType: Messages.Assessment.StartOverAllAssessments,
             tabId: this._tabId,
             payload,
         });
@@ -477,7 +477,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             telemetry: telemetry,
         };
         this.dispatchMessage({
-            type: Messages.Assessment.CancelStartOver,
+            messageType: Messages.Assessment.CancelStartOver,
             tabId: this._tabId,
             payload,
         });
@@ -490,7 +490,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             telemetry: telemetry,
         };
         this.dispatchMessage({
-            type: Messages.Assessment.CancelStartOverAllAssessments,
+            messageType: Messages.Assessment.CancelStartOverAllAssessments,
             tabId: this._tabId,
             payload,
         });
@@ -500,7 +500,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         const payload: DetailsViewRightContentPanelType = viewType;
         const message = {
             tabId: this._tabId,
-            type: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
+            messageType: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
             payload: payload,
         };
 

--- a/src/background/chrome-command-handler.ts
+++ b/src/background/chrome-command-handler.ts
@@ -153,7 +153,7 @@ export class ChromeCommandHandler {
 
         tabContext.interpreter.interpret({
             tabId: tabId,
-            type: action,
+            messageType: action,
             payload,
         });
     }

--- a/src/background/completed-test-step-telemetry-creator.ts
+++ b/src/background/completed-test-step-telemetry-creator.ts
@@ -54,7 +54,7 @@ export class CompletedTestStepTelemetryCreator {
 
             this.interpreter.interpret({
                 tabId: targetTab.id,
-                type: Messages.Telemetry.Send,
+                messageType: Messages.Telemetry.Send,
                 payload,
             });
         }

--- a/src/background/dev-tools-listener.ts
+++ b/src/background/dev-tools-listener.ts
@@ -49,7 +49,7 @@ export class DevToolsListener {
                     status: status,
                 } as OnDevToolOpenPayload,
                 tabId: tabId,
-                type: Messages.DevTools.DevtoolStatus,
+                messageType: Messages.DevTools.DevtoolStatus,
             });
         }
     }

--- a/src/background/feature-flags-controller.ts
+++ b/src/background/feature-flags-controller.ts
@@ -30,7 +30,7 @@ export class FeatureFlagsController {
             enabled: false,
         };
         const message: Message = {
-            type: Messages.FeatureFlags.SetFeatureFlag,
+            messageType: Messages.FeatureFlags.SetFeatureFlag,
             payload: payload,
             tabId: null,
         };
@@ -43,7 +43,7 @@ export class FeatureFlagsController {
             enabled: true,
         };
         const message: Message = {
-            type: Messages.FeatureFlags.SetFeatureFlag,
+            messageType: Messages.FeatureFlags.SetFeatureFlag,
             payload: payload,
             tabId: null,
         };
@@ -52,7 +52,7 @@ export class FeatureFlagsController {
 
     public resetFeatureFlags(): void {
         const message: Message = {
-            type: Messages.FeatureFlags.ResetFeatureFlag,
+            messageType: Messages.FeatureFlags.ResetFeatureFlag,
             tabId: null,
         };
         this.interpreter.interpret(message);

--- a/src/background/injector-controller.ts
+++ b/src/background/injector-controller.ts
@@ -56,14 +56,14 @@ export class InjectorController {
         ) {
             this._windowUtils.setTimeout(() => {
                 this._interpreter.interpret({
-                    type: Messages.Visualizations.State.InjectionStarted,
+                    messageType: Messages.Visualizations.State.InjectionStarted,
                     tabId: tabId,
                 });
             }, InjectorController.injectionStartedWaitTime);
 
             this._injector.injectScripts(tabId).then(() => {
                 this._interpreter.interpret({
-                    type: Messages.Visualizations.State.InjectionCompleted,
+                    messageType: Messages.Visualizations.State.InjectionCompleted,
                     tabId: tabId,
                 });
             });

--- a/src/background/interpreter.ts
+++ b/src/background/interpreter.ts
@@ -13,8 +13,8 @@ export class Interpreter {
     }
 
     public interpret(message: Message): boolean {
-        if (this.messageToActionMapping[message.type]) {
-            this.messageToActionMapping[message.type](message.payload, message.tabId);
+        if (this.messageToActionMapping[message.messageType]) {
+            this.messageToActionMapping[message.messageType](message.payload, message.tabId);
             return true;
         }
         return false;

--- a/src/background/scanner-utility.ts
+++ b/src/background/scanner-utility.ts
@@ -19,7 +19,7 @@ export class ScannerUtility {
         };
 
         const message = {
-            type: Messages.Assessment.EnableVisualHelper,
+            messageType: Messages.Assessment.EnableVisualHelper,
             tabId: tabId,
             payload: payload,
         };

--- a/src/background/tab-controller.ts
+++ b/src/background/tab-controller.ts
@@ -118,7 +118,7 @@ export class TabController {
                 if (tabContext) {
                     const interpreter = tabContext.interpreter;
                     interpreter.interpret({
-                        type: Messages.Tab.Change,
+                        messageType: Messages.Tab.Change,
                         payload: tab,
                         tabId: tabId,
                     });
@@ -138,7 +138,7 @@ export class TabController {
                 if (tabContext) {
                     const interpreter = tabContext.interpreter;
                     interpreter.interpret({
-                        type: Messages.Tab.Update,
+                        messageType: Messages.Tab.Update,
                         payload: tab,
                         tabId: tabId,
                     });
@@ -163,7 +163,7 @@ export class TabController {
             hidden: isHidden,
         };
         const message: Message = {
-            type: Messages.Tab.VisibilityChange,
+            messageType: Messages.Tab.VisibilityChange,
             payload: payload,
             tabId: tabId,
         };
@@ -185,7 +185,7 @@ export class TabController {
         if (tabContext) {
             const interpreter = tabContext.interpreter;
             interpreter.interpret({
-                type: messageType,
+                messageType: messageType,
                 payload: null,
                 tabId: tabId,
             });

--- a/src/common/message-creators/base-action-message-creator.ts
+++ b/src/common/message-creators/base-action-message-creator.ts
@@ -20,7 +20,7 @@ export abstract class BaseActionMessageCreator {
 
     protected dispatchType(messageType: string): void {
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
         });
     }
@@ -32,7 +32,7 @@ export abstract class BaseActionMessageCreator {
         };
 
         const message: Message = {
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
             payload,
         };
 

--- a/src/common/message-creators/bug-action-message-creator.ts
+++ b/src/common/message-creators/bug-action-message-creator.ts
@@ -24,7 +24,7 @@ export class BugActionMessageCreator extends BaseActionMessageCreator {
             telemetry,
         };
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });

--- a/src/common/message-creators/content-action-message-creator.ts
+++ b/src/common/message-creators/content-action-message-creator.ts
@@ -35,7 +35,7 @@ export class ContentActionMessageCreator extends BaseActionMessageCreator {
             telemetry: { ...telemetry, contentPath },
         };
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });
@@ -55,7 +55,7 @@ export class ContentActionMessageCreator extends BaseActionMessageCreator {
             telemetry: { ...telemetry, href },
         };
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });
@@ -70,7 +70,7 @@ export class ContentActionMessageCreator extends BaseActionMessageCreator {
             contentPath,
         };
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });
@@ -85,7 +85,7 @@ export class ContentActionMessageCreator extends BaseActionMessageCreator {
         };
 
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });

--- a/src/common/message-creators/dev-tool-action-message-creator.ts
+++ b/src/common/message-creators/dev-tool-action-message-creator.ts
@@ -17,7 +17,7 @@ export class DevToolActionMessageCreator extends BaseActionMessageCreator {
     public setDevToolStatus(status: boolean): void {
         const message: Message = {
             tabId: this._tabId,
-            type: Messages.DevTools.DevtoolStatus,
+            messageType: Messages.DevTools.DevtoolStatus,
             payload: {
                 status: status,
             } as OnDevToolOpenPayload,
@@ -33,7 +33,7 @@ export class DevToolActionMessageCreator extends BaseActionMessageCreator {
         };
         const message: Message = {
             tabId: this._tabId,
-            type: Messages.DevTools.InspectElement,
+            messageType: Messages.DevTools.InspectElement,
             payload,
         };
 
@@ -46,7 +46,7 @@ export class DevToolActionMessageCreator extends BaseActionMessageCreator {
         };
         const message: Message = {
             tabId: this._tabId,
-            type: Messages.DevTools.InspectFrameUrl,
+            messageType: Messages.DevTools.InspectFrameUrl,
             payload,
         };
 

--- a/src/common/message-creators/dropdown-action-message-creator.ts
+++ b/src/common/message-creators/dropdown-action-message-creator.ts
@@ -22,7 +22,7 @@ export class DropdownActionMessageCreator extends BaseActionMessageCreator {
             telemetry,
         };
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });
@@ -35,7 +35,7 @@ export class DropdownActionMessageCreator extends BaseActionMessageCreator {
             telemetry,
         };
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });
@@ -48,7 +48,7 @@ export class DropdownActionMessageCreator extends BaseActionMessageCreator {
             telemetry,
         };
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });

--- a/src/common/message-creators/inspect-action-message-creator.ts
+++ b/src/common/message-creators/inspect-action-message-creator.ts
@@ -33,7 +33,7 @@ export class InspectActionMessageCreator extends BaseActionMessageCreator {
             telemetry,
         };
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload: payload,
         });

--- a/src/common/message-creators/scoping-action-message-creator.ts
+++ b/src/common/message-creators/scoping-action-message-creator.ts
@@ -34,7 +34,7 @@ export class ScopingActionMessageCreator extends BaseActionMessageCreator {
         };
 
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload: payload,
         });
@@ -51,7 +51,7 @@ export class ScopingActionMessageCreator extends BaseActionMessageCreator {
         };
 
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload: payload,
         });

--- a/src/common/message-creators/user-config-message-creator.ts
+++ b/src/common/message-creators/user-config-message-creator.ts
@@ -17,7 +17,7 @@ export class UserConfigMessageCreator extends BaseActionMessageCreator {
         };
 
         this.dispatchMessage({
-            type: Messages.UserConfig.SetTelemetryConfig,
+            messageType: Messages.UserConfig.SetTelemetryConfig,
             tabId: this._tabId,
             payload,
         });
@@ -29,7 +29,7 @@ export class UserConfigMessageCreator extends BaseActionMessageCreator {
         };
 
         this.dispatchMessage({
-            type: Messages.UserConfig.SetHighContrastConfig,
+            messageType: Messages.UserConfig.SetHighContrastConfig,
             tabId: this._tabId,
             payload,
         });
@@ -41,7 +41,7 @@ export class UserConfigMessageCreator extends BaseActionMessageCreator {
         };
 
         this.dispatchMessage({
-            type: Messages.UserConfig.SetBugService,
+            messageType: Messages.UserConfig.SetBugService,
             tabId: this._tabId,
             payload,
         });
@@ -55,7 +55,7 @@ export class UserConfigMessageCreator extends BaseActionMessageCreator {
         };
 
         this.dispatchMessage({
-            type: Messages.UserConfig.SetBugServiceProperty,
+            messageType: Messages.UserConfig.SetBugServiceProperty,
             tabId: this._tabId,
             payload,
         });
@@ -67,7 +67,7 @@ export class UserConfigMessageCreator extends BaseActionMessageCreator {
         };
 
         this.dispatchMessage({
-            type: Messages.UserConfig.SetIssueTrackerPath,
+            messageType: Messages.UserConfig.SetIssueTrackerPath,
             tabId: this._tabId,
             payload,
         });

--- a/src/common/message-creators/visualization-action-message-creator.ts
+++ b/src/common/message-creators/visualization-action-message-creator.ts
@@ -17,7 +17,7 @@ export class VisualizationActionMessageCreator extends BaseActionMessageCreator 
 
         const message: Message = {
             tabId: this._tabId,
-            type: Messages.Visualizations.Common.Toggle,
+            messageType: Messages.Visualizations.Common.Toggle,
             payload,
         };
 

--- a/src/common/message.ts
+++ b/src/common/message.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 export interface Message {
-    // tslint:disable-next-line:no-reserved-keywords
-    type: string;
+    messageType: string;
     tabId?: number;
     payload?: any;
 }

--- a/src/injected/instance-visibility-checker.ts
+++ b/src/injected/instance-visibility-checker.ts
@@ -75,7 +75,7 @@ export class InstanceVisibilityChecker {
             });
 
             const message: Message = {
-                type: Messages.Assessment.UpdateInstanceVisibility,
+                messageType: Messages.Assessment.UpdateInstanceVisibility,
                 payload: { payloadBatch },
             };
 

--- a/src/injected/target-page-action-message-creator.ts
+++ b/src/injected/target-page-action-message-creator.ts
@@ -19,7 +19,7 @@ export class TargetPageActionMessageCreator extends BaseActionMessageCreator {
 
     public scrollRequested(): void {
         this.dispatchMessage({
-            type: Messages.Visualizations.Common.ScrollRequested,
+            messageType: Messages.Visualizations.Common.ScrollRequested,
         });
     }
     public openIssuesDialog(): void {
@@ -32,7 +32,7 @@ export class TargetPageActionMessageCreator extends BaseActionMessageCreator {
     @autobind
     public setHoveredOverSelector(selector: string[]): void {
         this.dispatchMessage({
-            type: Messages.Inspect.SetHoveredOverSelector,
+            messageType: Messages.Inspect.SetHoveredOverSelector,
             tabId: this._tabId,
             payload: selector,
         });
@@ -53,7 +53,7 @@ export class TargetPageActionMessageCreator extends BaseActionMessageCreator {
             telemetry,
         };
         this.dispatchMessage({
-            type: messageType,
+            messageType: messageType,
             tabId: this._tabId,
             payload,
         });

--- a/src/popup/actions/popup-action-message-creator.ts
+++ b/src/popup/actions/popup-action-message-creator.ts
@@ -57,7 +57,7 @@ export class PopupActionMessageCreator extends BaseActionMessageCreator {
         };
 
         this.dispatchMessage({
-            type: visualizationMessages.DetailsView.Open,
+            messageType: visualizationMessages.DetailsView.Open,
             tabId: this._tabId,
             payload: payload,
         });
@@ -71,7 +71,7 @@ export class PopupActionMessageCreator extends BaseActionMessageCreator {
             telemetry,
         };
         this.dispatchMessage({
-            type: Messages.ChromeFeature.configureCommand,
+            messageType: Messages.ChromeFeature.configureCommand,
             tabId: this._tabId,
             payload,
         });
@@ -82,7 +82,7 @@ export class PopupActionMessageCreator extends BaseActionMessageCreator {
             launchPanelType: panelType,
         };
         this.dispatchMessage({
-            type: Messages.LaunchPanel.Set,
+            messageType: Messages.LaunchPanel.Set,
             tabId: this._tabId,
             payload,
         });

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -32,16 +32,14 @@ describe('DetailsViewActionMessageCreatorTest', () => {
     const eventStubFactory = new EventStubFactory();
     const testSource: TelemetryEventSource = -1 as TelemetryEventSource;
     let windowUtilsMock: IMock<WindowUtils>;
-    let postMessageMock: IMock<(message) => {}>;
+    let postMessageMock: IMock<(message: Message) => void>;
     let telemetryFactoryMock: IMock<TelemetryDataFactory>;
     let testSubject: DetailsViewActionMessageCreator;
     let tabId: number;
 
     beforeEach(() => {
         windowUtilsMock = Mock.ofType(WindowUtils);
-        postMessageMock = Mock.ofInstance(message => {
-            return null;
-        });
+        postMessageMock = Mock.ofInstance(message => {});
         telemetryFactoryMock = Mock.ofType(TelemetryDataFactory);
         tabId = 1;
         testSubject = new DetailsViewActionMessageCreator(
@@ -61,7 +59,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
     test('updateIssuesSelectedTargets', () => {
         const selectedTargets: string[] = ['#headings-1', '#landmark-1'];
         const expectedMessage = {
-            type: Messages.Visualizations.Issues.UpdateSelectedTargets,
+            messageType: Messages.Visualizations.Issues.UpdateSelectedTargets,
             tabId: tabId,
             payload: selectedTargets,
         };
@@ -73,7 +71,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
     test('updateFocusedInstanceTarget', () => {
         const instanceTarget = ['#headings-1'];
         const expectedMessage = {
-            type: Messages.Visualizations.Issues.UpdateFocusedInstance,
+            messageType: Messages.Visualizations.Issues.UpdateFocusedInstance,
             tabId: tabId,
             payload: instanceTarget,
         };
@@ -89,7 +87,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         };
         const eventStub = {};
         const expectedMessage: Message = {
-            type: Messages.Tab.Switch,
+            messageType: Messages.Tab.Switch,
             tabId: tabId,
             payload: {
                 telemetry: telemetryStub,
@@ -113,7 +111,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Visualizations.DetailsView.Select,
+            messageType: Messages.Visualizations.DetailsView.Select,
             payload: {
                 telemetry: telemetry,
                 detailsViewType: view,
@@ -143,7 +141,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.SelectTestRequirement,
+            messageType: Messages.Assessment.SelectTestRequirement,
             payload: {
                 telemetry: telemetry,
                 selectedRequirement: selectedRequirement,
@@ -171,7 +169,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.FeatureFlags.SetFeatureFlag,
+            messageType: Messages.FeatureFlags.SetFeatureFlag,
             payload: {
                 feature: 'test-id',
                 enabled: true,
@@ -203,7 +201,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Visualizations.DetailsView.PivotSelect,
+            messageType: Messages.Visualizations.DetailsView.PivotSelect,
             payload: payload,
         };
         setupPostMessage(expectedMessage);
@@ -225,7 +223,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.PreviewFeatures.ClosePanel,
+            messageType: Messages.PreviewFeatures.ClosePanel,
             payload: {
                 telemetry,
             },
@@ -244,7 +242,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Scoping.ClosePanel,
+            messageType: Messages.Scoping.ClosePanel,
             payload: {
                 telemetry,
             },
@@ -263,7 +261,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.SettingsPanel.ClosePanel,
+            messageType: Messages.SettingsPanel.ClosePanel,
             payload: {
                 telemetry,
             },
@@ -283,7 +281,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
             payload: {
                 eventName: DETAILS_VIEW_OPEN,
                 telemetry,
@@ -307,7 +305,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.StartOver,
+            messageType: Messages.Assessment.StartOver,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 requirement: requirementStub,
@@ -333,7 +331,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.ContinuePreviousAssessment,
+            messageType: Messages.Assessment.ContinuePreviousAssessment,
             payload: {
                 telemetry,
             },
@@ -357,7 +355,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.StartOverAllAssessments,
+            messageType: Messages.Assessment.StartOverAllAssessments,
             payload: {
                 telemetry,
             },
@@ -382,7 +380,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.EnableVisualHelper,
+            messageType: Messages.Assessment.EnableVisualHelper,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 requirement,
@@ -407,7 +405,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.EnableVisualHelperWithoutScan,
+            messageType: Messages.Assessment.EnableVisualHelperWithoutScan,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 requirement,
@@ -427,7 +425,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.EnableVisualHelper,
+            messageType: Messages.Assessment.EnableVisualHelper,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 requirement,
@@ -447,7 +445,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.EnableVisualHelperWithoutScan,
+            messageType: Messages.Assessment.EnableVisualHelperWithoutScan,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 requirement,
@@ -465,7 +463,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
     test('disableVisualHelpersForTest', () => {
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.DisableVisualHelperForTest,
+            messageType: Messages.Assessment.DisableVisualHelperForTest,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
             },
@@ -482,7 +480,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.DisableVisualHelper,
+            messageType: Messages.Assessment.DisableVisualHelper,
             payload: {
                 test: test,
                 telemetry,
@@ -508,7 +506,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.ChangeStatus,
+            messageType: Messages.Assessment.ChangeStatus,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -535,7 +533,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.Undo,
+            messageType: Messages.Assessment.Undo,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -561,7 +559,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.ChangeRequirementStatus,
+            messageType: Messages.Assessment.ChangeRequirementStatus,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -584,7 +582,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.UndoChangeRequirementStatus,
+            messageType: Messages.Assessment.UndoChangeRequirementStatus,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -605,7 +603,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.ChangeVisualizationState,
+            messageType: Messages.Assessment.ChangeVisualizationState,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -630,7 +628,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.AddFailureInstance,
+            messageType: Messages.Assessment.AddFailureInstance,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -657,7 +655,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.RemoveFailureInstance,
+            messageType: Messages.Assessment.RemoveFailureInstance,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -682,7 +680,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         const description = 'des';
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.EditFailureInstance,
+            messageType: Messages.Assessment.EditFailureInstance,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -707,7 +705,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.PassUnmarkedInstances,
+            messageType: Messages.Assessment.PassUnmarkedInstances,
             payload: {
                 test: test,
                 requirement: requirement,
@@ -728,7 +726,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.ChangeVisualizationStateForAll,
+            messageType: Messages.Assessment.ChangeVisualizationStateForAll,
             payload: {
                 test: 1,
                 requirement: 'requirement',
@@ -756,7 +754,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
             payload: {
                 eventName: EXPORT_RESULTS,
                 telemetry,
@@ -787,7 +785,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
             payload: {
                 eventName: COPY_ISSUE_DETAILS,
                 telemetry,
@@ -821,7 +819,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.CancelStartOver,
+            messageType: Messages.Assessment.CancelStartOver,
             payload: {
                 telemetry,
             },
@@ -842,7 +840,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Assessment.CancelStartOverAllAssessments,
+            messageType: Messages.Assessment.CancelStartOverAllAssessments,
             payload: {
                 telemetry,
             },
@@ -859,7 +857,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         const viewTypeStub = 'test view type' as DetailsViewRightContentPanelType;
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
+            messageType: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
             payload: viewTypeStub,
         };
 
@@ -868,7 +866,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         postMessageMock.verifyAll();
     });
 
-    function setupPostMessage(expectedMessage): void {
+    function setupPostMessage(expectedMessage: Message): void {
         postMessageMock.setup(pm => pm(It.isValue(expectedMessage))).verifiable(Times.once());
     }
 

--- a/src/tests/unit/tests/background/chrome-command-handler.test.ts
+++ b/src/tests/unit/tests/background/chrome-command-handler.test.ts
@@ -143,7 +143,7 @@ describe('ChromeCommandHandlerTest', () => {
 
         expect(receivedMessage).toEqual({
             tabId: existingTabId,
-            type: Messages.Visualizations.Common.Toggle,
+            messageType: Messages.Visualizations.Common.Toggle,
             payload: {
                 enabled: true,
                 telemetry: {
@@ -175,7 +175,7 @@ describe('ChromeCommandHandlerTest', () => {
 
         expect(receivedMessage).toEqual({
             tabId: existingTabId,
-            type: Messages.Visualizations.Common.Toggle,
+            messageType: Messages.Visualizations.Common.Toggle,
             payload: {
                 enabled: false,
                 telemetry: {

--- a/src/tests/unit/tests/background/completed-test-step-telemetry-creator.test.ts
+++ b/src/tests/unit/tests/background/completed-test-step-telemetry-creator.test.ts
@@ -37,7 +37,7 @@ function testBeforeAfterAssessmentData(
     );
 
     const expectedMessage: Message = {
-        type: Messages.Telemetry.Send,
+        messageType: Messages.Telemetry.Send,
         tabId: 1,
         payload: {
             eventName: CHANGE_OVERALL_REQUIREMENT_STATUS,
@@ -194,7 +194,7 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
             .verifiable(Times.atLeastOnce());
 
         const expectedMessage: Message = {
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
         };
         interpreterMock.setup(im => im.interpret(It.isValue(expectedMessage))).verifiable(Times.never());
 
@@ -215,7 +215,7 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
         const data = getMockAssessmentStoreDataUnknowns();
         const expectedTelemetry = getMockTelemetryData(-1, 'assessment-1-step-1', true, 1);
         const expectedMessage: Message = {
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
             tabId: 1,
             payload: {
                 eventName: CHANGE_OVERALL_REQUIREMENT_STATUS,

--- a/src/tests/unit/tests/background/dev-tools-listener.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-listener.test.ts
@@ -110,7 +110,7 @@ describe('DevToolsListenerTests', () => {
                             status: true,
                         },
                         tabId: 2,
-                        type: Messages.DevTools.DevtoolStatus,
+                        messageType: Messages.DevTools.DevtoolStatus,
                     }),
                 ),
             )
@@ -160,7 +160,7 @@ describe('DevToolsListenerTests', () => {
                             status: false,
                         },
                         tabId: 2,
-                        type: Messages.DevTools.DevtoolStatus,
+                        messageType: Messages.DevTools.DevtoolStatus,
                     }),
                 ),
             )

--- a/src/tests/unit/tests/background/feature-flags-controller.test.ts
+++ b/src/tests/unit/tests/background/feature-flags-controller.test.ts
@@ -69,7 +69,7 @@ describe('FeatureFlagsControllerTest', () => {
             enabled: false,
         };
         const message: Message = {
-            type: Messages.FeatureFlags.SetFeatureFlag,
+            messageType: Messages.FeatureFlags.SetFeatureFlag,
             payload: payload,
             tabId: null,
         };
@@ -88,7 +88,7 @@ describe('FeatureFlagsControllerTest', () => {
             enabled: true,
         };
         const message: Message = {
-            type: Messages.FeatureFlags.SetFeatureFlag,
+            messageType: Messages.FeatureFlags.SetFeatureFlag,
             payload: payload,
             tabId: null,
         };
@@ -102,7 +102,7 @@ describe('FeatureFlagsControllerTest', () => {
 
     test('resetFeatureFlags', () => {
         const message: Message = {
-            type: Messages.FeatureFlags.ResetFeatureFlag,
+            messageType: Messages.FeatureFlags.ResetFeatureFlag,
             tabId: null,
         };
         interpreterMock.setup(i => i.interpret(It.isObjectWith(message))).verifiable();

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -188,7 +188,7 @@ class InjectorControllerValidator {
 
     public setupVerifyInjectionStartedActionCalled(tabId: number, numTimes: number = 1): InjectorControllerValidator {
         this.mockInterpreter
-            .setup(x => x.interpret(It.isObjectWith({ type: Messages.Visualizations.State.InjectionStarted, tabId: tabId })))
+            .setup(x => x.interpret(It.isObjectWith({ messageType: Messages.Visualizations.State.InjectionStarted, tabId: tabId })))
             .verifiable(Times.exactly(numTimes));
 
         return this;
@@ -196,7 +196,7 @@ class InjectorControllerValidator {
 
     public setupVerifyInjectionCompletedActionCalled(tabId: number, numTimes: number = 1): InjectorControllerValidator {
         this.mockInterpreter
-            .setup(x => x.interpret(It.isObjectWith({ type: Messages.Visualizations.State.InjectionCompleted, tabId: tabId })))
+            .setup(x => x.interpret(It.isObjectWith({ messageType: Messages.Visualizations.State.InjectionCompleted, tabId: tabId })))
             .verifiable(Times.exactly(numTimes));
 
         return this;

--- a/src/tests/unit/tests/background/interpreter.test.ts
+++ b/src/tests/unit/tests/background/interpreter.test.ts
@@ -32,7 +32,7 @@ describe('InterpreterTest', () => {
 
         expect(
             testSubject.interpret({
-                type: 'test',
+                messageType: 'test',
                 tabId: 1,
                 payload: 'payload',
             }),
@@ -50,7 +50,7 @@ describe('InterpreterTest', () => {
 
         expect(
             testSubject.interpret({
-                type: 'test2',
+                messageType: 'test2',
                 tabId: 1,
                 payload: 'payload',
             }),

--- a/src/tests/unit/tests/background/scanner-utility.test.ts
+++ b/src/tests/unit/tests/background/scanner-utility.test.ts
@@ -28,7 +28,7 @@ describe('ScannerUtility', () => {
         };
 
         const expectedMessage = {
-            type: Messages.Assessment.EnableVisualHelper,
+            messageType: Messages.Assessment.EnableVisualHelper,
             tabId: tabId,
             payload: expectedPayload,
         };

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -95,7 +95,7 @@ describe('TabContextFactoryTest', () => {
             .verifiable(Times.once());
 
         tabContext.interpreter.interpret({
-            type: Messages.Visualizations.State.GetCurrentVisualizationResultState,
+            messageType: Messages.Visualizations.State.GetCurrentVisualizationResultState,
             tabId: null,
         });
 

--- a/src/tests/unit/tests/background/tab-controller.test.ts
+++ b/src/tests/unit/tests/background/tab-controller.test.ts
@@ -119,7 +119,7 @@ describe('TabControllerTest', () => {
             data: 'abc',
         };
         const interpretInput: Message = {
-            type: Messages.Tab.Update,
+            messageType: Messages.Tab.Update,
             payload: getTabCallbackInput,
             tabId: tabId,
         };
@@ -200,7 +200,7 @@ describe('TabControllerTest', () => {
         let tabUpdatedCallback: (details: chrome.webNavigation.WebNavigationFramedCallbackDetails) => void = null;
         let tabRemovedCallback: Function = null;
         const interpretInput: Message = {
-            type: Messages.Tab.Remove,
+            messageType: Messages.Tab.Remove,
             payload: null,
             tabId: tabId,
         };
@@ -246,7 +246,7 @@ describe('TabControllerTest', () => {
         let tabUpdatedCallback: (details: chrome.webNavigation.WebNavigationFramedCallbackDetails) => void = null;
         const tabId = 2;
         const interpretInput: Message = {
-            type: Messages.Visualizations.DetailsView.Close,
+            messageType: Messages.Visualizations.DetailsView.Close,
             payload: null,
             tabId: tabId,
         };
@@ -295,7 +295,7 @@ describe('TabControllerTest', () => {
 
         openTabIds.forEach((tabId, index) => {
             const interpretInput: Message = {
-                type: Messages.Tab.Update,
+                messageType: Messages.Tab.Update,
                 payload: tabs[tabId],
                 tabId: tabId,
             };
@@ -360,7 +360,7 @@ describe('TabControllerTest', () => {
         };
 
         const interpretInput: Message = {
-            type: Messages.Tab.Change,
+            messageType: Messages.Tab.Change,
             payload: getTabCallbackInput,
             tabId: tabId,
         };
@@ -421,14 +421,14 @@ describe('TabControllerTest', () => {
             windowTypes: ['normal', 'popup'],
         };
         const interpretInput1: Message = {
-            type: Messages.Tab.VisibilityChange,
+            messageType: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: false,
             },
             tabId: 1,
         };
         const interpretInput2: Message = {
-            type: Messages.Tab.VisibilityChange,
+            messageType: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: true,
             },
@@ -512,14 +512,14 @@ describe('TabControllerTest', () => {
             windowTypes: ['normal', 'popup'],
         };
         const interpretInput1: Message = {
-            type: Messages.Tab.VisibilityChange,
+            messageType: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: false,
             },
             tabId: 1,
         };
         const interpretInput2: Message = {
-            type: Messages.Tab.VisibilityChange,
+            messageType: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: true,
             },
@@ -604,14 +604,14 @@ describe('TabControllerTest', () => {
             id: 1,
         };
         const interpretInput1: Message = {
-            type: Messages.Tab.VisibilityChange,
+            messageType: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: false,
             },
             tabId: 1,
         };
         const interpretInput2: Message = {
-            type: Messages.Tab.VisibilityChange,
+            messageType: Messages.Tab.VisibilityChange,
             payload: {
                 hidden: true,
             },

--- a/src/tests/unit/tests/common/message-creators/bug-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/bug-action-message-creator.test.ts
@@ -39,7 +39,7 @@ describe('BugActionMessageCreator', () => {
             telemetry,
         };
         const expectedMessage: Message = {
-            type: Messages.SettingsPanel.OpenPanel,
+            messageType: Messages.SettingsPanel.OpenPanel,
             tabId,
             payload,
         };
@@ -63,7 +63,7 @@ describe('BugActionMessageCreator', () => {
             telemetry,
         };
         const expectedMessage: Message = {
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
             tabId,
             payload,
         };

--- a/src/tests/unit/tests/common/message-creators/content-panel-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/content-panel-action-message-creator.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Mock } from 'typemoq';
-
+import { Message } from '../../../../../common/message';
 import { ContentActionMessageCreator } from '../../../../../common/message-creators/content-action-message-creator';
 import { Messages } from '../../../../../common/messages';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
@@ -39,13 +39,13 @@ describe('ContentPanelActionMessageCreator', () => {
 
         creator.openContentPanel(event, contentPath);
 
-        const expectedMessage = {
+        const expectedMessage: Message = {
             payload: {
                 contentPath,
                 telemetry,
             },
             tabId,
-            type: Messages.ContentPanel.OpenPanel,
+            messageType: Messages.ContentPanel.OpenPanel,
         };
         expect(messagesPosted).toEqual([expectedMessage]);
     });
@@ -56,12 +56,12 @@ describe('ContentPanelActionMessageCreator', () => {
 
         creator.closeContentPanel();
 
-        const expectedMessage = {
+        const expectedMessage: Message = {
             payload: {
                 telemetry,
             },
             tabId,
-            type: Messages.ContentPanel.ClosePanel,
+            messageType: Messages.ContentPanel.ClosePanel,
         };
         expect(messagesPosted).toEqual([expectedMessage]);
     });
@@ -78,7 +78,7 @@ describe('ContentPanelActionMessageCreator', () => {
                 telemetry,
             },
             tabId,
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
         };
         expect(messagesPosted).toEqual([expectedMessage]);
     });
@@ -95,7 +95,7 @@ describe('ContentPanelActionMessageCreator', () => {
                 telemetry,
             },
             tabId,
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
         };
         expect(messagesPosted).toEqual([expectedMessage]);
     });

--- a/src/tests/unit/tests/common/message-creators/dev-tool-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/dev-tool-action-message-creator.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock } from 'typemoq';
-
 import { InspectElementPayload, InspectFrameUrlPayload, OnDevToolOpenPayload } from '../../../../../background/actions/action-payloads';
+import { Message } from '../../../../../common/message';
 import { DevToolActionMessageCreator } from '../../../../../common/message-creators/dev-tool-action-message-creator';
 import { Messages } from '../../../../../common/messages';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
@@ -12,7 +12,7 @@ describe('DevToolActionMessageCreatorTest', () => {
     let eventStubFactory: EventStubFactory;
     let testSubject: DevToolActionMessageCreator;
     const tabId: number = 10;
-    let postMessageMock: IMock<(msg: any) => void>;
+    let postMessageMock: IMock<(msg: Message) => void>;
 
     beforeEach(() => {
         eventStubFactory = new EventStubFactory();
@@ -23,7 +23,7 @@ describe('DevToolActionMessageCreatorTest', () => {
     test('setDevToolStatus', () => {
         const status = true;
         const expectedMessage = {
-            type: Messages.DevTools.DevtoolStatus,
+            messageType: Messages.DevTools.DevtoolStatus,
             tabId: tabId,
             payload: {
                 status: status,
@@ -43,7 +43,7 @@ describe('DevToolActionMessageCreatorTest', () => {
         const telemetryFactory = new TelemetryDataFactory();
         const telemetry = telemetryFactory.forInspectElement(event, target);
         const expectedMessage = {
-            type: Messages.DevTools.InspectElement,
+            messageType: Messages.DevTools.InspectElement,
             tabId: tabId,
             payload: {
                 target: target,
@@ -61,7 +61,7 @@ describe('DevToolActionMessageCreatorTest', () => {
     test('setInspectFrameUrl', () => {
         const frameUrl = 'frame url';
         const expectedMessage = {
-            type: Messages.DevTools.InspectFrameUrl,
+            messageType: Messages.DevTools.InspectFrameUrl,
             tabId: tabId,
             payload: {
                 frameUrl: frameUrl,

--- a/src/tests/unit/tests/common/message-creators/dropdown-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/dropdown-action-message-creator.test.ts
@@ -72,7 +72,7 @@ describe('DropdownActionMessageCreatorTest', () => {
     function getExpectedMessage(messageType: string): Message {
         return {
             tabId: tabId,
-            type: messageType,
+            messageType: messageType,
             payload: {
                 telemetry: telemetryData,
             },

--- a/src/tests/unit/tests/common/message-creators/inspect-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/inspect-action-message-creator.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { InspectMode } from '../../../../../background/inspect-modes';
+import { Message } from '../../../../../common/message';
 import { InspectActionMessageCreator } from '../../../../../common/message-creators/inspect-action-message-creator';
 import { Messages } from '../../../../../common/messages';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
@@ -12,15 +12,13 @@ import { EventStubFactory } from './../../../common/event-stub-factory';
 describe('InspectActionMessageCreatorTest', () => {
     const eventStubFactory = new EventStubFactory();
     const testSource: TelemetryEventSource = -1 as TelemetryEventSource;
-    let postMessageMock: IMock<(message) => {}>;
+    let postMessageMock: IMock<(message: Message) => void>;
     let telemetryFactoryMock: IMock<TelemetryDataFactory>;
     let testSubject: InspectActionMessageCreator;
     const tabId: number = -1;
 
     beforeEach(() => {
-        postMessageMock = Mock.ofInstance(message => {
-            return null;
-        });
+        postMessageMock = Mock.ofInstance(message => {});
         telemetryFactoryMock = Mock.ofType(TelemetryDataFactory, MockBehavior.Strict);
         testSubject = new InspectActionMessageCreator(postMessageMock.object, tabId, telemetryFactoryMock.object, testSource);
     });
@@ -36,7 +34,7 @@ describe('InspectActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Inspect.ChangeInspectMode,
+            messageType: Messages.Inspect.ChangeInspectMode,
             payload: {
                 inspectMode,
                 telemetry,
@@ -54,7 +52,7 @@ describe('InspectActionMessageCreatorTest', () => {
         telemetryFactoryMock.verifyAll();
     });
 
-    function setupPostMessage(expectedMessage): void {
+    function setupPostMessage(expectedMessage: Message): void {
         postMessageMock.setup(post => post(It.isValue(expectedMessage))).verifiable(Times.once());
     }
 });

--- a/src/tests/unit/tests/common/message-creators/scoping-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/scoping-action-message-creator.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
+import { Message } from '../../../../../common/message';
 import { ScopingActionMessageCreator } from '../../../../../common/message-creators/scoping-action-message-creator';
 import { Messages } from '../../../../../common/messages';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
@@ -11,15 +11,13 @@ import { EventStubFactory } from './../../../common/event-stub-factory';
 describe('ScopingActionMessageCreatorTest', () => {
     const eventStubFactory = new EventStubFactory();
     const testSource: TelemetryEventSource = -1 as TelemetryEventSource;
-    let postMessageMock: IMock<(message) => {}>;
+    let postMessageMock: IMock<(message: Message) => void>;
     let telemetryFactoryMock: IMock<TelemetryDataFactory>;
     let testSubject: ScopingActionMessageCreator;
     const tabId: number = -1;
 
     beforeEach(() => {
-        postMessageMock = Mock.ofInstance(message => {
-            return null;
-        });
+        postMessageMock = Mock.ofInstance(message => {});
         telemetryFactoryMock = Mock.ofType(TelemetryDataFactory, MockBehavior.Strict);
         testSubject = new ScopingActionMessageCreator(postMessageMock.object, tabId, telemetryFactoryMock.object, testSource);
     });
@@ -37,7 +35,7 @@ describe('ScopingActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Scoping.AddSelector,
+            messageType: Messages.Scoping.AddSelector,
             payload: {
                 inputType: inputType,
                 selector: testSelector,
@@ -69,7 +67,7 @@ describe('ScopingActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: tabId,
-            type: Messages.Scoping.DeleteSelector,
+            messageType: Messages.Scoping.DeleteSelector,
             payload: {
                 inputType: inputType,
                 selector: testSelector,
@@ -88,7 +86,7 @@ describe('ScopingActionMessageCreatorTest', () => {
         telemetryFactoryMock.verifyAll();
     });
 
-    function setupPostMessage(expectedMessage): void {
+    function setupPostMessage(expectedMessage: Message): void {
         postMessageMock.setup(post => post(It.isValue(expectedMessage))).verifiable(Times.once());
     }
 });

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -77,11 +77,11 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         postMessageMock.verifyAll();
     }
 
-    function setupPostMessageMock(message: string): void {
+    function setupPostMessageMock(messageType: string): void {
         postMessageMock.setup(pm =>
             pm(
                 It.isValue({
-                    type: message,
+                    messageType,
                     tabId: tabId,
                 }),
             ),

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator.test.ts
@@ -26,7 +26,7 @@ describe('StateActionMessageCreator', () => {
         postMessageMock.setup(pm =>
             pm(
                 It.isValue({
-                    type: message,
+                    messageType: message,
                     tabId: tabId,
                 }),
             ),

--- a/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import {
     SetBugServicePayload,
     SetBugServicePropertyPayload,
@@ -9,11 +8,12 @@ import {
     SetIssueTrackerPathPayload,
     SetTelemetryStatePayload,
 } from '../../../../../background/actions/action-payloads';
+import { Message } from '../../../../../common/message';
 import { UserConfigMessageCreator } from '../../../../../common/message-creators/user-config-message-creator';
 import { Messages } from '../../../../../common/messages';
 
 describe('UserConfigMessageCreator', () => {
-    let postMessageMock: IMock<(message) => void>;
+    let postMessageMock: IMock<(message: Message) => void>;
     let testSubject: UserConfigMessageCreator;
     let tabId: number;
 
@@ -35,7 +35,7 @@ describe('UserConfigMessageCreator', () => {
         };
         const expectedMessage = {
             tabId: 1,
-            type: Messages.UserConfig.SetTelemetryConfig,
+            messageType: Messages.UserConfig.SetTelemetryConfig,
             payload,
         };
 
@@ -53,7 +53,7 @@ describe('UserConfigMessageCreator', () => {
         };
         const expectedMessage = {
             tabId: 1,
-            type: Messages.UserConfig.SetHighContrastConfig,
+            messageType: Messages.UserConfig.SetHighContrastConfig,
             payload,
         };
 
@@ -71,7 +71,7 @@ describe('UserConfigMessageCreator', () => {
         };
         const expectedMessage = {
             tabId: 1,
-            type: Messages.UserConfig.SetIssueTrackerPath,
+            messageType: Messages.UserConfig.SetIssueTrackerPath,
             payload,
         };
 
@@ -89,7 +89,7 @@ describe('UserConfigMessageCreator', () => {
         };
         const expectedMessage = {
             tabId: 1,
-            type: Messages.UserConfig.SetBugService,
+            messageType: Messages.UserConfig.SetBugService,
             payload,
         };
 
@@ -108,7 +108,7 @@ describe('UserConfigMessageCreator', () => {
         };
         const expectedMessage = {
             tabId: 1,
-            type: Messages.UserConfig.SetBugServiceProperty,
+            messageType: Messages.UserConfig.SetBugServiceProperty,
             payload,
         };
 

--- a/src/tests/unit/tests/common/visualization-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/visualization-action-message-creator.test.ts
@@ -38,7 +38,7 @@ describe('VisualizationActionMessageCreatorTest', () => {
 
         const expectedMessage: Message = {
             tabId: tabId,
-            type: Messages.Visualizations.Common.Toggle,
+            messageType: Messages.Visualizations.Common.Toggle,
             payload,
         };
 

--- a/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
+++ b/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
@@ -124,7 +124,7 @@ describe('InstanceVisibilityCheckerTest', () => {
         setupConfigurationFactoryMocks(testType, testStepDrawerId, expectedUniquelyIdentifiableInstances, elementFoundGeneratedIds);
 
         const expectedPayload: Message = {
-            type: Messages.Assessment.UpdateInstanceVisibility,
+            messageType: Messages.Assessment.UpdateInstanceVisibility,
             payload: {
                 payloadBatch: [
                     {
@@ -188,7 +188,7 @@ describe('InstanceVisibilityCheckerTest', () => {
         setupConfigurationFactoryMocks(testType, testStepDrawerId, [expectedUniquelyIdentifiableInstance], [elementFoundGeneratedId]);
 
         const expectedPayload: Message = {
-            type: Messages.Assessment.UpdateInstanceVisibility,
+            messageType: Messages.Assessment.UpdateInstanceVisibility,
             payload: {
                 payloadBatch: [
                     {
@@ -237,7 +237,7 @@ describe('InstanceVisibilityCheckerTest', () => {
             .verifiable(Times.once());
 
         const expectedPayload: Message = {
-            type: Messages.Assessment.UpdateInstanceVisibility,
+            messageType: Messages.Assessment.UpdateInstanceVisibility,
             payload: {
                 payloadBatch: [
                     {

--- a/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
+++ b/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
@@ -13,7 +13,7 @@ import { EventStubFactory } from '../../common/event-stub-factory';
 describe('TargetPageActionMessageCreator', () => {
     const eventStubFactory = new EventStubFactory();
     let testSubject: TargetPageActionMessageCreator;
-    let postMessageMock: IMock<(msg: any) => void>;
+    let postMessageMock: IMock<(msg: Message) => void>;
     let tabId: number;
 
     beforeEach(() => {
@@ -24,7 +24,7 @@ describe('TargetPageActionMessageCreator', () => {
 
     test('scrollRequested', () => {
         const expectedMessage = {
-            type: Messages.Visualizations.Common.ScrollRequested,
+            messageType: Messages.Visualizations.Common.ScrollRequested,
         };
 
         postMessageMock.setup(pm => pm(It.isValue(expectedMessage))).verifiable();
@@ -44,7 +44,7 @@ describe('TargetPageActionMessageCreator', () => {
         };
 
         const expectedMessage = {
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
             tabId: tabId,
             payload: payload,
         };
@@ -60,7 +60,7 @@ describe('TargetPageActionMessageCreator', () => {
         const selector = ['some selector'];
 
         const expectedMessage = {
-            type: Messages.Inspect.SetHoveredOverSelector,
+            messageType: Messages.Inspect.SetHoveredOverSelector,
             tabId: tabId,
             payload: selector,
         };
@@ -84,7 +84,7 @@ describe('TargetPageActionMessageCreator', () => {
             telemetry,
         };
         const expectedMessage: Message = {
-            type: Messages.SettingsPanel.OpenPanel,
+            messageType: Messages.SettingsPanel.OpenPanel,
             tabId,
             payload,
         };

--- a/src/tests/unit/tests/popup/actions/popup-action-message-creator.test.ts
+++ b/src/tests/unit/tests/popup/actions/popup-action-message-creator.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { OnDetailsViewOpenPayload, SetLaunchPanelState } from '../../../../../background/actions/action-payloads';
+import { Message } from '../../../../../common/message';
 import { Messages } from '../../../../../common/messages';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
 import {
@@ -25,7 +26,7 @@ describe('PopupActionMessageCreatorTest', () => {
     const testSource: TelemetryEventSource = -1 as TelemetryEventSource;
 
     let mockWindowUtils: IMock<WindowUtils>;
-    let postMessageMock: IMock<(message) => void>;
+    let postMessageMock: IMock<(message: Message) => void>;
     let testSubject: PopupActionMessageCreator;
     let telemetryFactoryMock: IMock<TelemetryDataFactory>;
     let tabId: number;
@@ -57,7 +58,7 @@ describe('PopupActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: 1,
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
             payload: payload,
         };
 
@@ -81,7 +82,7 @@ describe('PopupActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: 1,
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
             payload: payload,
         };
 
@@ -110,7 +111,7 @@ describe('PopupActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: 1,
-            type: Messages.Visualizations.DetailsView.Open,
+            messageType: Messages.Visualizations.DetailsView.Open,
             payload: expectedPayload,
         };
 
@@ -146,7 +147,7 @@ describe('PopupActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: 1,
-            type: Messages.Visualizations.DetailsView.Open,
+            messageType: Messages.Visualizations.DetailsView.Open,
             payload: expectedPayload,
         };
 
@@ -173,7 +174,7 @@ describe('PopupActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: 1,
-            type: Messages.ChromeFeature.configureCommand,
+            messageType: Messages.ChromeFeature.configureCommand,
             payload: {
                 telemetry,
             },
@@ -199,7 +200,7 @@ describe('PopupActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: 1,
-            type: Messages.Telemetry.Send,
+            messageType: Messages.Telemetry.Send,
             payload: {
                 eventName: TUTORIAL_OPEN,
                 telemetry,
@@ -228,7 +229,7 @@ describe('PopupActionMessageCreatorTest', () => {
 
         const expectedMessage = {
             tabId: 1,
-            type: Messages.LaunchPanel.Set,
+            messageType: Messages.LaunchPanel.Set,
             payload,
         };
 


### PR DESCRIPTION
#### Description of changes

Rename `type` property on our Message interface to `messageType` and remove `tslint:disabled-next-line:no-reserved-keywords` comment
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
