### PR TITLE
add reference to the bug that prevents us from using idb-keyval package

### DIFF
--- a/src/common/indexedDB/idb.ts
+++ b/src/common/indexedDB/idb.ts
@@ -1,5 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+// reference: https://github.com/jakearchibald/idb-keyval/blob/master/idb-keyval.ts
+// idb-keyval has an issue which prevents us using the `idb-keyval` npm package
+// https://github.com/jakearchibald/idb-keyval/issues/51
+// using this code till that issue is fixed
+
 export class Store {
     public readonly _dbp: Promise<IDBDatabase>;
 

--- a/src/common/indexedDB/idb.ts
+++ b/src/common/indexedDB/idb.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 // reference: https://github.com/jakearchibald/idb-keyval/blob/master/idb-keyval.ts
-// idb-keyval has an issue which prevents us using the `idb-keyval` npm package
+// uglifyjs has an issue which prevents us from using the `idb-keyval` npm package with uglifyjs
 // https://github.com/jakearchibald/idb-keyval/issues/51
 // using this code till that issue is fixed
 


### PR DESCRIPTION
#### Description of changes

Adds reference and a comment to why we are not able to use `idb-keyval` package and have to rely on the code rather than the package.


#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`npm run test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`npm run precheckin`)
- [n/a] Added screenshots/GIFs for UI changes.
