### PR TITLE
Introduce null object for issue filing service

### DIFF
--- a/src/bug-filing/bug-filing-service-provider-impl.ts
+++ b/src/bug-filing/bug-filing-service-provider-impl.ts
@@ -2,5 +2,6 @@
 // Licensed under the MIT License.
 import { BugFilingServiceProvider } from './bug-filing-service-provider';
 import { GitHubBugFilingService } from './github/github-bug-filing-service';
+import { NullIssueFilingService } from './null-issue-filing-service/null-issue-filing-service';
 
-export const BugFilingServiceProviderImpl = new BugFilingServiceProvider([GitHubBugFilingService]);
+export const BugFilingServiceProviderImpl = new BugFilingServiceProvider([NullIssueFilingService, GitHubBugFilingService]);

--- a/src/bug-filing/null-issue-filing-service/null-issue-filing-service.tsx
+++ b/src/bug-filing/null-issue-filing-service/null-issue-filing-service.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedSFC } from '../../common/react/named-sfc';
+import { BugFilingService } from '../types/bug-filing-service';
+import { SettingsFormProps } from '../types/settings-form-props';
+
+const nullServiceKey = 'none';
+
+const renderSettingsForm = NamedSFC<SettingsFormProps<{}>>('NullIssueFilingService', () => null);
+
+export const NullIssueFilingService: BugFilingService = {
+    key: nullServiceKey,
+    isHidden: true,
+    order: 0,
+    displayName: 'None',
+    renderSettingsForm,
+    buildStoreData: () => null,
+    isSettingsValid: () => false,
+    createBugFilingUrl: () => null,
+};

--- a/src/bug-filing/types/bug-filing-service.ts
+++ b/src/bug-filing/types/bug-filing-service.ts
@@ -6,6 +6,7 @@ import { SettingsFormProps } from './settings-form-props';
 
 export interface BugFilingService<Settings = {}> {
     key: string;
+    isHidden?: boolean;
     displayName: string;
     renderSettingsForm: ReactSFCWithDisplayName<SettingsFormProps<Settings>>;
     buildStoreData: (...params: any[]) => Settings;

--- a/src/tests/unit/tests/bug-filing/github/github-bug-filing-service.test.tsx
+++ b/src/tests/unit/tests/bug-filing/github/github-bug-filing-service.test.tsx
@@ -12,20 +12,8 @@ import { UserConfigMessageCreator } from '../../../../../common/message-creators
 describe('GithubBugFilingServiceTest', () => {
     let userConfigMessageCreatorMock: IMock<UserConfigMessageCreator>;
     let props: SettingsFormProps<GitHubBugFilingSettings>;
-    const nullSettings: GitHubBugFilingSettings = null;
-    const emptySettings: GitHubBugFilingSettings = {} as GitHubBugFilingSettings;
-    const invalidSettings1: GitHubBugFilingSettings = {
-        random: ' ',
-    } as any;
-    const invalidSettings2: GitHubBugFilingSettings = {
-        repository: '  ',
-    };
-    const invalidSettings3: GitHubBugFilingSettings = {
-        repository: 3,
-    } as any;
-    const validSettings: GitHubBugFilingSettings = {
-        repository: 'repository',
-    };
+
+    const invalidTestSettings = [null, {}, undefined, { random: '' }, { repository: '' }];
 
     beforeEach(() => {
         userConfigMessageCreatorMock = Mock.ofType(UserConfigMessageCreator);
@@ -42,6 +30,7 @@ describe('GithubBugFilingServiceTest', () => {
     it('static properties', () => {
         expect(GitHubBugFilingService.key).toBe('gitHub');
         expect(GitHubBugFilingService.displayName).toBe('GitHub');
+        expect(GitHubBugFilingService.isHidden).toBeUndefined();
     });
 
     it('buildStoreData', () => {
@@ -52,14 +41,17 @@ describe('GithubBugFilingServiceTest', () => {
         expect(GitHubBugFilingService.buildStoreData(url)).toEqual(expectedStoreData);
     });
 
-    it.each([nullSettings, emptySettings, invalidSettings1, invalidSettings2, invalidSettings3])(
-        'isSettingsValid - invalid case',
-        settings => {
+    describe('check for invalid settings', () => {
+        it.each(invalidTestSettings)('with %o', settings => {
             expect(GitHubBugFilingService.isSettingsValid(settings)).toBe(false);
-        },
-    );
+        });
+    });
 
     it('isSettingsValid - valid case', () => {
+        const validSettings: GitHubBugFilingSettings = {
+            repository: 'repository',
+        };
+
         expect(GitHubBugFilingService.isSettingsValid(validSettings)).toBe(true);
     });
 
@@ -82,7 +74,9 @@ describe('GithubBugFilingServiceTest', () => {
         userConfigMessageCreatorMock.verifyAll();
     });
 
-    it('createBugFilingUrl', () => {
-        expect(GitHubBugFilingService.createBugFilingUrl).not.toBeNull();
+    describe('create bug filing url', () => {
+        it.each(invalidTestSettings)('with %o', settings => {
+            expect(GitHubBugFilingService.createBugFilingUrl(settings, null)).toBeNull();
+        });
     });
 });

--- a/src/tests/unit/tests/bug-filing/null-issue-filing-service/__snapshots__/null-issue-filing-service.test.tsx.snap
+++ b/src/tests/unit/tests/bug-filing/null-issue-filing-service/__snapshots__/null-issue-filing-service.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NullIssueFilingService renders settings form 1`] = `null`;

--- a/src/tests/unit/tests/bug-filing/null-issue-filing-service/null-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/bug-filing/null-issue-filing-service/null-issue-filing-service.test.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { NullIssueFilingService } from '../../../../../bug-filing/null-issue-filing-service/null-issue-filing-service';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
+import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
+
+describe('NullIssueFilingService', () => {
+    const testSettings = [null, {}, undefined, { repository: 'test-repository' }];
+
+    it('has correct static properties', () => {
+        expect(NullIssueFilingService.key).toBe('none');
+        expect(NullIssueFilingService.displayName).toBe('None');
+        expect(NullIssueFilingService.isHidden).toBe(true);
+    });
+
+    it('build store data', () => {
+        expect(NullIssueFilingService.buildStoreData()).toBeNull();
+    });
+
+    describe('check settings', () => {
+        it.each(testSettings)('with %o', settings => {
+            expect(NullIssueFilingService.isSettingsValid(settings)).toBe(false);
+        });
+    });
+
+    describe('creates bug filing url', () => {
+        it.each(testSettings)('with %o', settings => {
+            const issuesData: CreateIssueDetailsTextData = {
+                pageTitle: 'test page title',
+                pageUrl: '//test-page-url',
+                ruleResult: {} as DecoratedAxeNodeResult,
+            };
+            expect(NullIssueFilingService.createBugFilingUrl(settings, issuesData)).toBeNull();
+        });
+    });
+
+    it('renders settings form', () => {
+        const Component = NullIssueFilingService.renderSettingsForm;
+
+        const props = {
+            deps: null,
+            settings: null,
+        };
+
+        const wrapper = shallow(<Component {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

 Introduce NullObject for our bug filing services
 Small refactor to the provider to add a `register` public api.

#### Pull request checklist

- [x] Addresses an existing issue: WI related #1506333
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
