### PR TITLE
BugFilingSettingContainer gets visible services + issue filing dialog uses bug filing setting container

### DIFF
--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -8,6 +8,7 @@ import { NamedSFC } from '../../common/react/named-sfc';
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { BugServiceProperties } from '../../common/types/store-data/user-configuration-store';
 import { ActionAndCancelButtonsComponent } from './action-and-cancel-buttons-component';
+import { BugFilingSettingsContainer, BugFilingSettingsContainerDeps } from '../../bug-filing/components/bug-filing-settings-container';
 
 export interface IssueFilingDialogProps {
     deps: IssueFilingDialogDeps;
@@ -19,12 +20,20 @@ export interface IssueFilingDialogProps {
     onClose: (ev: React.SyntheticEvent) => void;
 }
 
-export interface IssueFilingDialogDeps {}
+export type IssueFilingDialogDeps = BugFilingSettingsContainerDeps;
 
 const titleLabel = 'Specify issue filing location';
 
 export const IssueFilingDialog = NamedSFC<IssueFilingDialogProps>('IssueFilingDialog', props => {
-    const { selectedBugFilingService, selectedBugFilingServiceData, selectedBugData, bugFileTelemetryCallback, onClose, isOpen } = props;
+    const {
+        deps,
+        selectedBugFilingService,
+        selectedBugFilingServiceData,
+        selectedBugData,
+        bugFileTelemetryCallback,
+        onClose,
+        isOpen,
+    } = props;
 
     return (
         <Dialog
@@ -44,6 +53,11 @@ export const IssueFilingDialog = NamedSFC<IssueFilingDialogProps>('IssueFilingDi
             }}
             onDismiss={onClose}
         >
+            <BugFilingSettingsContainer
+                deps={deps}
+                selectedBugFilingService={selectedBugFilingService}
+                selectedBugFilingServiceData={selectedBugFilingServiceData}
+            />
             <DialogFooter>
                 <ActionAndCancelButtonsComponent
                     isHidden={false}

--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -3,12 +3,12 @@
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import * as React from 'react';
 
+import { BugFilingSettingsContainer, BugFilingSettingsContainerDeps } from '../../bug-filing/components/bug-filing-settings-container';
 import { BugFilingService } from '../../bug-filing/types/bug-filing-service';
 import { NamedSFC } from '../../common/react/named-sfc';
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { BugServiceProperties } from '../../common/types/store-data/user-configuration-store';
 import { ActionAndCancelButtonsComponent } from './action-and-cancel-buttons-component';
-import { BugFilingSettingsContainer, BugFilingSettingsContainerDeps } from '../../bug-filing/components/bug-filing-settings-container';
 
 export interface IssueFilingDialogProps {
     deps: IssueFilingDialogDeps;

--- a/src/bug-filing/bug-filing-service-provider.ts
+++ b/src/bug-filing/bug-filing-service-provider.ts
@@ -1,9 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BugFilingService } from './types/bug-filing-service';
+
 export class BugFilingServiceProvider {
     constructor(private readonly services: BugFilingService[]) {}
     public all(): BugFilingService[] {
         return this.services.slice();
+    }
+
+    public allVisible(): BugFilingService[] {
+        return this.all().filter(service => !service.isHidden);
     }
 }

--- a/src/bug-filing/components/bug-filing-settings-container.tsx
+++ b/src/bug-filing/components/bug-filing-settings-container.tsx
@@ -5,21 +5,25 @@ import * as React from 'react';
 import { NamedSFC } from '../../common/react/named-sfc';
 import { BugServiceProperties } from '../../common/types/store-data/user-configuration-store';
 import { SettingsDeps } from '../../DetailsView/components/settings-panel/settings/settings-props';
+import { BugFilingServiceProvider } from '../bug-filing-service-provider';
 import { BugFilingService } from '../types/bug-filing-service';
 import { BugFilingChoiceGroup, BugFilingChoiceGroupDeps } from './bug-filing-choice-group';
 
 export interface BugFilingSettingsContainerProps {
     deps: BugFilingSettingsContainerDeps;
     selectedBugFilingService: BugFilingService;
-    bugFilingServices: BugFilingService[];
     selectedBugFilingServiceData: BugServiceProperties;
 }
 
-export type BugFilingSettingsContainerDeps = BugFilingChoiceGroupDeps & SettingsDeps;
+export type BugFilingSettingsContainerDeps = {
+    bugServiceProvider: BugFilingServiceProvider;
+} & BugFilingChoiceGroupDeps &
+    SettingsDeps;
 
 export const BugFilingSettingsContainer = NamedSFC<BugFilingSettingsContainerProps>('BugFilingSettingsContainer', props => {
-    const { deps, bugFilingServices, selectedBugFilingService, selectedBugFilingServiceData } = props;
+    const { deps, selectedBugFilingService, selectedBugFilingServiceData } = props;
     const SettingsForm = selectedBugFilingService.renderSettingsForm;
+    const bugFilingServices = deps.bugServiceProvider.allVisible();
 
     return (
         <>

--- a/src/bug-filing/components/bug-filing-settings-container.tsx
+++ b/src/bug-filing/components/bug-filing-settings-container.tsx
@@ -16,14 +16,14 @@ export interface BugFilingSettingsContainerProps {
 }
 
 export type BugFilingSettingsContainerDeps = {
-    bugServiceProvider: BugFilingServiceProvider;
+    bugFilingServiceProvider: BugFilingServiceProvider;
 } & BugFilingChoiceGroupDeps &
     SettingsDeps;
 
 export const BugFilingSettingsContainer = NamedSFC<BugFilingSettingsContainerProps>('BugFilingSettingsContainer', props => {
     const { deps, selectedBugFilingService, selectedBugFilingServiceData } = props;
     const SettingsForm = selectedBugFilingService.renderSettingsForm;
-    const bugFilingServices = deps.bugServiceProvider.allVisible();
+    const bugFilingServices = deps.bugFilingServiceProvider.allVisible();
 
     return (
         <>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
@@ -22,6 +22,24 @@ exports[`IssueFilingDialog render closed 1`] = `
   }
   onDismiss={[Function]}
 >
+  <BugFilingSettingsContainer
+    deps={
+      Object {
+        "bugFilingServiceProvider": null,
+      }
+    }
+    selectedBugFilingService={
+      Object {
+        "createBugFilingUrl": [Function],
+        "isSettingsValid": [Function],
+      }
+    }
+    selectedBugFilingServiceData={
+      Object {
+        "someServiceData": null,
+      }
+    }
+  />
   <StyledDialogFooterBase>
     <ActionAndCancelButtonsComponent
       cancelButtonOnClick={[Function]}
@@ -55,6 +73,24 @@ exports[`IssueFilingDialog render open 1`] = `
   }
   onDismiss={[Function]}
 >
+  <BugFilingSettingsContainer
+    deps={
+      Object {
+        "bugFilingServiceProvider": null,
+      }
+    }
+    selectedBugFilingService={
+      Object {
+        "createBugFilingUrl": [Function],
+        "isSettingsValid": [Function],
+      }
+    }
+    selectedBugFilingServiceData={
+      Object {
+        "someServiceData": null,
+      }
+    }
+  />
   <StyledDialogFooterBase>
     <ActionAndCancelButtonsComponent
       cancelButtonOnClick={[Function]}

--- a/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
@@ -40,7 +40,7 @@ describe('IssueFilingDialog', () => {
         };
         deps = {
             bugFilingServiceProvider: null,
-        };
+        } as IssueFilingDialogDeps;
         bugFilingServiceStub = {
             isSettingsValid: isSettingsValidMock.object,
             createBugFilingUrl: createBugFilingUrlMock.object,

--- a/src/tests/unit/tests/bug-filing/bug-filing-service-provider.test.ts
+++ b/src/tests/unit/tests/bug-filing/bug-filing-service-provider.test.ts
@@ -18,4 +18,22 @@ describe('BugFilingServiceProviderTest', () => {
 
         expect(new BugFilingServiceProvider(testOptions).all()).toEqual(testOptions);
     });
+
+    test('allVisible', () => {
+        const givenTestOptions: BugFilingService[] = [
+            {
+                key: 'github',
+                displayName: 'Github',
+            } as BugFilingService,
+            {
+                key: 'random key',
+                displayName: 'random name',
+                isHidden: true,
+            } as BugFilingService,
+        ];
+
+        const expectedTestOptions = [givenTestOptions[0]];
+
+        expect(new BugFilingServiceProvider(givenTestOptions).allVisible()).toEqual(expectedTestOptions);
+    });
 });

--- a/src/tests/unit/tests/bug-filing/components/__snapshots__/bug-filing-settings-container.test.tsx.snap
+++ b/src/tests/unit/tests/bug-filing/components/__snapshots__/bug-filing-settings-container.test.tsx.snap
@@ -14,6 +14,12 @@ exports[`BugFilingSettingsContainerTest render 1`] = `
     }
     deps={
       Object {
+        "bugServiceProvider": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "all": [Function],
+          "allVisible": [Function],
+          "services": undefined,
+        },
         "userConfigMessageCreator": Object {},
       }
     }
@@ -28,6 +34,12 @@ exports[`BugFilingSettingsContainerTest render 1`] = `
   <renderSettingsForm
     deps={
       Object {
+        "bugServiceProvider": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "all": [Function],
+          "allVisible": [Function],
+          "services": undefined,
+        },
         "userConfigMessageCreator": Object {},
       }
     }

--- a/src/tests/unit/tests/bug-filing/components/__snapshots__/bug-filing-settings-container.test.tsx.snap
+++ b/src/tests/unit/tests/bug-filing/components/__snapshots__/bug-filing-settings-container.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`BugFilingSettingsContainerTest render 1`] = `
     }
     deps={
       Object {
-        "bugServiceProvider": proxy {
+        "bugFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
           "allVisible": [Function],
@@ -34,7 +34,7 @@ exports[`BugFilingSettingsContainerTest render 1`] = `
   <renderSettingsForm
     deps={
       Object {
-        "bugServiceProvider": proxy {
+        "bugFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
           "allVisible": [Function],

--- a/src/tests/unit/tests/bug-filing/components/bug-filing-settings-container.test.tsx
+++ b/src/tests/unit/tests/bug-filing/components/bug-filing-settings-container.test.tsx
@@ -33,7 +33,7 @@ describe('BugFilingSettingsContainerTest', () => {
     const props: BugFilingSettingsContainerProps = {
         deps: {
             userConfigMessageCreator: userConfigMessageCreatorStub,
-            bugServiceProvider: bugFilingServicesProviderMock.object,
+            bugFilingServiceProvider: bugFilingServicesProviderMock.object,
         },
         selectedBugFilingService,
         userConfigurationStoreData,

--- a/src/tests/unit/tests/bug-filing/components/bug-filing-settings-container.test.tsx
+++ b/src/tests/unit/tests/bug-filing/components/bug-filing-settings-container.test.tsx
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { Mock } from 'typemoq';
 
+import { BugFilingServiceProvider } from '../../../../../bug-filing/bug-filing-service-provider';
 import {
     BugFilingSettingsContainer,
     BugFilingSettingsContainerProps,
@@ -12,6 +14,7 @@ import { UserConfigMessageCreator } from '../../../../../common/message-creators
 import { BugServiceProperties, UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 
 describe('BugFilingSettingsContainerTest', () => {
+    const bugFilingServicesProviderMock = Mock.ofType(BugFilingServiceProvider);
     const selectedBugFilingService: BugFilingService = {
         key: 'test',
         displayName: 'TEST',
@@ -30,14 +33,15 @@ describe('BugFilingSettingsContainerTest', () => {
     const props: BugFilingSettingsContainerProps = {
         deps: {
             userConfigMessageCreator: userConfigMessageCreatorStub,
+            bugServiceProvider: bugFilingServicesProviderMock.object,
         },
         selectedBugFilingService,
-        bugFilingServices,
         userConfigurationStoreData,
         selectedBugFilingServiceData,
     };
 
     test('render', () => {
+        bugFilingServicesProviderMock.setup(mock => mock.allVisible()).returns(() => bugFilingServices);
         const wrapper = shallow(<BugFilingSettingsContainer {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

Title says it all. Two main changes here: bug filing setting container uses bug service provider to get all visible services (new change) and then using the container in the issue filing dialog.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [n/a] Added screenshots/GIFs for UI changes.
