### PR TITLE
Using proper Message type

### DIFF
--- a/src/injected/analyzers/base-analyzer.ts
+++ b/src/injected/analyzers/base-analyzer.ts
@@ -3,18 +3,12 @@
 import { autobind } from '@uifabric/utilities';
 import * as Q from 'q';
 
+import { Message } from '../../common/message';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { Analyzer, AnalyzerConfiguration, AxeAnalyzerResult, ScanCompletedPayload } from './analyzer';
 
-export type ScanCompletedMessageType = MessageType<ScanCompletedPayload<any>>;
-
-export type MessageType<Payload = {}> = {
-    messageType: string;
-    payload: Payload;
-};
-
 export class BaseAnalyzer implements Analyzer {
-    protected sendMessage: (message: MessageType) => void;
+    protected sendMessage: (message: Message) => void;
     protected visualizationType: VisualizationType;
     protected config: AnalyzerConfiguration;
     protected emptyResults: AxeAnalyzerResult = {
@@ -50,7 +44,7 @@ export class BaseAnalyzer implements Analyzer {
         this.sendMessage(this.createBaseMessage(analyzerResult, this.config));
     }
 
-    protected createBaseMessage(analyzerResult: AxeAnalyzerResult, config: AnalyzerConfiguration): ScanCompletedMessageType {
+    protected createBaseMessage(analyzerResult: AxeAnalyzerResult, config: AnalyzerConfiguration): Message {
         const messageType = config.analyzerMessageType;
         const originalAxeResult = analyzerResult.originalResult;
         const payload: ScanCompletedPayload<any> = {
@@ -59,8 +53,9 @@ export class BaseAnalyzer implements Analyzer {
             scanResult: originalAxeResult,
             testType: config.testType,
         };
+
         return {
-            messageType: messageType,
+            messageType,
             payload,
         };
     }

--- a/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, Times } from 'typemoq';
-
+import { Message } from '../../../../../common/message';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { AnalyzerConfiguration } from '../../../../../injected/analyzers/analyzer';
 import { BaseAnalyzer } from '../../../../../injected/analyzers/base-analyzer';
-import { ScanCompletedMessageType } from './../../../../../injected/analyzers/base-analyzer';
 
 describe('BaseAnalyzerTest', () => {
     let testSubject: BaseAnalyzer;
@@ -26,7 +25,7 @@ describe('BaseAnalyzerTest', () => {
 
     test('analyze', async done => {
         const resultsStub = {};
-        const expectedMessage: ScanCompletedMessageType = {
+        const expectedMessage: Message = {
             messageType: configStub.analyzerMessageType,
             payload: {
                 key: configStub.key,

--- a/src/tests/unit/tests/injected/analyzers/batched-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/batched-analyzer.test.ts
@@ -8,12 +8,12 @@ import {
     VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../../common/configs/visualization-configuration-factory';
+import { Message } from '../../../../../common/message';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
 import { RuleAnalyzerScanTelemetryData } from '../../../../../common/telemetry-events';
 import { ScopingStoreData } from '../../../../../common/types/store-data/scoping-store-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { RuleAnalyzerConfiguration } from '../../../../../injected/analyzers/analyzer';
-import { ScanCompletedMessageType } from '../../../../../injected/analyzers/base-analyzer';
 import { BatchedRuleAnalyzer, IResultRuleFilter } from '../../../../../injected/analyzers/batched-rule-analyzer';
 import { HtmlElementAxeResults, ScannerUtils } from '../../../../../injected/scanner-utils';
 import { ScanOptions } from '../../../../../scanner/exposed-apis';
@@ -207,7 +207,7 @@ describe('BatchedRuleAnalyzer', () => {
             .verifiable(times);
     }
 
-    function getExpectedMessage(config: RuleAnalyzerConfiguration, results: ScanResults, expectedTelemetryStub): ScanCompletedMessageType {
+    function getExpectedMessage(config: RuleAnalyzerConfiguration, results: ScanResults, expectedTelemetryStub): Message {
         return {
             messageType: config.analyzerMessageType,
             payload: {

--- a/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 import { isFunction } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
-
 import { ScopingInputTypes } from '../../../../../background/scoping-input-types';
 import { ScopingStore } from '../../../../../background/stores/global/scoping-store';
 import {
     VisualizationConfiguration,
     VisualizationConfigurationFactory,
 } from '../../../../../common/configs/visualization-configuration-factory';
+import { Message } from '../../../../../common/message';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
 import { RuleAnalyzerScanTelemetryData } from '../../../../../common/telemetry-events';
 import { ScopingStoreData } from '../../../../../common/types/store-data/scoping-store-data';
@@ -19,7 +19,6 @@ import { HtmlElementAxeResults, ScannerUtils } from '../../../../../injected/sca
 import { ScanOptions } from '../../../../../scanner/exposed-apis';
 import { ScanResults } from '../../../../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../../../../types/common-types';
-import { MessageType } from './../../../../../injected/analyzers/base-analyzer';
 
 describe('RuleAnalyzer', () => {
     let scannerUtilsMock: IMock<ScannerUtils>;
@@ -122,7 +121,7 @@ describe('RuleAnalyzer', () => {
 
         const scanResults = createTestResults();
 
-        const expectedMessage: MessageType = {
+        const expectedMessage: Message = {
             messageType: configStub.analyzerMessageType,
             payload: {
                 key: configStub.key,

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
+import { Message } from '../../../../../common/message';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { WindowUtils } from '../../../../../common/window-utils';
 import { FocusAnalyzerConfiguration, ScanBasePayload } from '../../../../../injected/analyzers/analyzer';
 import { TabStopsAnalyzer } from '../../../../../injected/analyzers/tab-stops-analyzer';
 import { TabStopEvent, TabStopsListener } from '../../../../../injected/tab-stops-listener';
 import { itIsFunction } from '../../../common/it-is-function';
-import { MessageType } from './../../../../../injected/analyzers/base-analyzer';
 
 describe('TabStopsAnalyzerTests', () => {
     let windowUtilsMock: IMock<WindowUtils>;
@@ -44,7 +43,7 @@ describe('TabStopsAnalyzerTests', () => {
             timestamp: 1,
         };
         const resultsStub = {};
-        const expectedBaseMessage: MessageType = {
+        const expectedBaseMessage: Message = {
             messageType: configStub.analyzerMessageType,
             payload: {
                 key: configStub.key,
@@ -53,7 +52,7 @@ describe('TabStopsAnalyzerTests', () => {
                 testType: typeStub,
             },
         };
-        const expectedOnProgressMessage: MessageType = {
+        const expectedOnProgressMessage: Message = {
             messageType: configStub.analyzerProgressMessageType,
             payload: {
                 key: configStub.key,
@@ -91,7 +90,7 @@ describe('TabStopsAnalyzerTests', () => {
         };
         const onTabbedTimoutIdStub = -1;
         const resultsStub = {};
-        const expectedBaseMessage: MessageType = {
+        const expectedBaseMessage: Message = {
             messageType: configStub.analyzerMessageType,
             payload: {
                 key: configStub.key,
@@ -100,7 +99,7 @@ describe('TabStopsAnalyzerTests', () => {
                 testType: typeStub,
             },
         };
-        const expectedOnProgressMessage: MessageType = {
+        const expectedOnProgressMessage: Message = {
             messageType: configStub.analyzerProgressMessageType,
             payload: {
                 key: configStub.key,


### PR DESCRIPTION
#### Description of changes

Remove "duplicated" type for the messages we send to the background from the analyzers. Using `Message` from `src\common\message.ts` file.

Beside running **precheckin**, manually test all the adhoc tools are working. Also check automated checks, landmarks and headings on Assessment.

Related PR: #534 

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
