### PR TITLE
remove guidance for heading best practice rule

### DIFF
--- a/src/content/test/headings/guidance.tsx
+++ b/src/content/test/headings/guidance.tsx
@@ -65,9 +65,6 @@ export const guidance = create(({ Markup, Link }) => (
                     <li>
                         Top-level (<Markup.Code>h1</Markup.Code>) headings can be similar, or even identical, to the page title.
                     </li>
-                    <li>
-                        If the page uses headings, an automated check will fail if the page does not have exactly one top-level heading.
-                    </li>
                 </ul>
 
                 <h3>Structure multiple headings on a page hierarchically. (best practice) </h3>


### PR DESCRIPTION
#### Description of changes

In reference to #520; since that rule is a best practice. Removing the guidance for `only one h1 element`.

#### Pull request checklist

- [x] Addresses an existing issue: #520 
- [n/a] Added relevant unit test for your changes. (`npm run test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [n/a] Added screenshots/GIFs for UI changes.
