### PR TITLE
Clean up unused variables/imports - Part 2

### DIFF
--- a/src/tests/unit/tests/DetailsView/components/bug-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/bug-button.test.tsx
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { It, Mock, Times } from 'typemoq';
-
+import { It, Mock } from 'typemoq';
 import { IssueDetailsTextGenerator } from '../../../../../background/issue-details-text-generator';
 import { BugButton } from '../../../../../DetailsView/components/bug-button';
 

--- a/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-right-panel.test.tsx
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
-
 import { DetailsViewPivotType } from '../../../../../common/types/details-view-pivot-type';
 import {
     DetailsRightPanelConfiguration,

--- a/src/tests/unit/tests/DetailsView/components/issues-table-handler.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-table-handler.test.tsx
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
-
 import { DetailsGroup, IssuesTableHandler, ListProps } from '../../../../../DetailsView/components/issues-table-handler';
 import { RuleResult } from '../../../../../scanner/iruleresults';
 

--- a/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
@@ -5,7 +5,6 @@ import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 import { It, Mock, Times } from 'typemoq';
 import { VisualizationConfigurationFactory } from '../../../../../common/configs/visualization-configuration-factory';
-import { FeatureFlags } from '../../../../../common/feature-flags';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import { IssuesTable, IssuesTableDeps, IssuesTableProps, IssuesTableState } from '../../../../../DetailsView/components/issues-table';
 import { DetailsRowData, IssuesTableHandler } from '../../../../../DetailsView/components/issues-table-handler';

--- a/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
@@ -4,7 +4,6 @@ import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
-
 import { Theme } from '../../../../common/components/theme';
 import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
 import { configMutator } from '../../../../common/configuration';
@@ -12,7 +11,6 @@ import { DocumentManipulator } from '../../../../common/document-manipulator';
 import { DropdownClickHandler } from '../../../../common/dropdown-click-handler';
 import { InspectActionMessageCreator } from '../../../../common/message-creators/inspect-action-message-creator';
 import { ScopingActionMessageCreator } from '../../../../common/message-creators/scoping-action-message-creator';
-import { StoreActionMessageCreatorImpl } from '../../../../common/message-creators/store-action-message-creator-impl';
 import { IssuesTableHandler } from '../../../../DetailsView/components/issues-table-handler';
 import { DetailsView, DetailsViewContainerDeps } from '../../../../DetailsView/details-view-container';
 import { DetailsViewRenderer } from '../../../../DetailsView/details-view-renderer';
@@ -28,7 +26,6 @@ describe('DetailsViewRendererTest', () => {
 
         const scopingActionMessageCreatorStrictMock = Mock.ofType<ScopingActionMessageCreator>(null, MockBehavior.Strict);
         const inspectActionMessageCreatorStrictMock = Mock.ofType<InspectActionMessageCreator>(null, MockBehavior.Strict);
-        const detailsViewStoreActionCreatorStrictMock = Mock.ofType<StoreActionMessageCreatorImpl>(null, MockBehavior.Strict);
 
         const dom = document.createElement('div');
         const detailsViewContainer = document.createElement('div');

--- a/src/tests/unit/tests/DetailsView/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/DetailsView/reports/report-generator.test.ts
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { AssessmentsProvider } from '../../../../../assessments/types/assessments-provider';
 import { AssessmentStoreData } from '../../../../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../../../../common/types/store-data/tab-store-data';
 import { AssessmentReportHtmlGenerator } from '../../../../../DetailsView/reports/assessment-report-html-generator';
-import { ReportGenerator, ReportGeneratorDeps } from '../../../../../DetailsView/reports/report-generator';
+import { ReportGenerator } from '../../../../../DetailsView/reports/report-generator';
 import { ReportHtmlGenerator } from '../../../../../DetailsView/reports/report-html-generator';
 import { ReportNameGenerator } from '../../../../../DetailsView/reports/report-name-generator';
 import { ScanResults } from '../../../../../scanner/iruleresults';
@@ -22,10 +21,6 @@ describe('ReportGeneratorTest', () => {
     let dataBuilderMock: IMock<ReportHtmlGenerator>;
     let nameBuilderMock: IMock<ReportNameGenerator>;
     let assessmentReportHtmlGeneratorMock: IMock<AssessmentReportHtmlGenerator>;
-
-    const deps: ReportGeneratorDeps = {
-        outcomeTypeSemanticsFromTestStatus: { stub: 'outcomeTypeSemanticsFromTestStatus' } as any,
-    };
 
     beforeEach(() => {
         nameBuilderMock = Mock.ofType(ReportNameGenerator, MockBehavior.Strict);

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -100,7 +100,6 @@ describe('AssessmentBuilderTest', () => {
         expect(requirement.reportInstanceFields).toEqual([comment]);
 
         const config = manual.getVisualizationConfiguration();
-        const key = requirement.key;
         const scanData = { enabled: true, stepStatus: { key: true } } as AssessmentScanData;
         const vizStoreData = { assessments: { manualAssessmentKeyAssessment: scanData } } as any;
         expect(config.getStoreData(vizStoreData)).toEqual(scanData);

--- a/src/tests/unit/tests/background/completed-test-step-telemetry-creator.test.ts
+++ b/src/tests/unit/tests/background/completed-test-step-telemetry-creator.test.ts
@@ -45,15 +45,6 @@ function testBeforeAfterAssessmentData(
         },
     };
 
-    const tabStoreData: TabStoreData = {
-        title: 'DetailsViewContainerTest title',
-        url: 'http://detailsViewContainerTest/url/',
-        id: 1,
-        isClosed: false,
-        isChanged: false,
-        isPageHidden: false,
-    };
-
     interpreterMock.setup(m => m.interpret(It.isValue(expectedMessage))).verifiable(expectedTimes);
 
     telemetryFactoryMock

--- a/src/tests/unit/tests/background/dev-tools-listener.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-listener.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { DevToolsListener } from '../../../../background/dev-tools-listener';
 import { Interpreter } from '../../../../background/interpreter';
 import { TabContext, TabToContextMap } from '../../../../background/tab-context';
@@ -11,12 +10,10 @@ import { DevToolsOpenMessage } from '../../../../common/types/dev-tools-open-mes
 import { ChromeAdapterMock, PortWithTabTabIdStub } from '../../mock-helpers/chrome-adapter-mock';
 import { PortOnDisconnectMock } from '../../mock-helpers/port-on-disconnect-mock';
 import { PortOnMessageMock } from '../../mock-helpers/port-on-message-mock';
-import { PortStub } from '../../stubs/port-stub';
 
 describe('DevToolsListenerTests', () => {
     let _testSubject: DevToolsListener;
     let _chromeAdapterMock: ChromeAdapterMock;
-    let _backgrountConnectionMock: IMock<chrome.runtime.Port>;
     let _tabIdToContextMap: TabToContextMap;
     let _tabId1InterpreterMock: IMock<Interpreter>;
     let _tabId2InterpreterMock: IMock<Interpreter>;
@@ -29,7 +26,6 @@ describe('DevToolsListenerTests', () => {
             2: new TabContext(_tabId2InterpreterMock.object, null),
         };
         _chromeAdapterMock = new ChromeAdapterMock();
-        _backgrountConnectionMock = Mock.ofType(PortStub);
         _testSubject = new DevToolsListener(_tabIdToContextMap, _chromeAdapterMock.getObject());
     });
 

--- a/src/tests/unit/tests/background/feature-flags-controller.test.ts
+++ b/src/tests/unit/tests/background/feature-flags-controller.test.ts
@@ -20,11 +20,6 @@ describe('FeatureFlagsControllerTest', () => {
         interpreterMock = Mock.ofType(Interpreter);
     });
 
-    function testCleanup(): void {
-        featureFlagStoreMock.verifyAll();
-        interpreterMock.verifyAll();
-    }
-
     test('isEnabled', () => {
         const storeDataStub: FeatureFlagStoreData = {
             [FeatureFlags[FeatureFlags.logTelemetryToConsole]]: false,

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -583,8 +583,6 @@ describe('AssessmentStoreTest', () => {
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
-        const currentInstancesMap = null;
-
         assessmentDataRemoverMock
             .setup(a => a.deleteDataFromGeneratedMapWithStepKey(initialInstanceMap, payload.key))
             .callback(() => {

--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { cloneDeep } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
-
 import {
     SetBugServicePayload,
     SetBugServicePropertyPayload,
@@ -10,11 +9,9 @@ import {
     SetIssueTrackerPathPayload,
     SetTelemetryStatePayload,
 } from '../../../../../../background/actions/action-payloads';
-import { FeatureFlagPayload } from '../../../../../../background/actions/feature-flag-actions';
 import { UserConfigurationActions } from '../../../../../../background/actions/user-configuration-actions';
 import { IndexedDBDataKeys } from '../../../../../../background/IndexedDBDataKeys';
 import { UserConfigurationStore } from '../../../../../../background/stores/global/user-configuration-store';
-import { FeatureFlags } from '../../../../../../common/feature-flags';
 import { IndexedDBAPI } from '../../../../../../common/indexedDB/indexedDB';
 import { StoreNames } from '../../../../../../common/stores/store-names';
 import { BugServicePropertiesMap, UserConfigurationStoreData } from '../../../../../../common/types/store-data/user-configuration-store';

--- a/src/tests/unit/tests/background/tab-controller.test.ts
+++ b/src/tests/unit/tests/background/tab-controller.test.ts
@@ -600,9 +600,6 @@ describe('TabControllerTest', () => {
             active: false,
         };
         const tabs = [tabStub1, tabStub2];
-        const windowStub = {
-            id: 1,
-        };
         const interpretInput1: Message = {
             messageType: Messages.Tab.VisibilityChange,
             payload: {

--- a/src/tests/unit/tests/background/telemetry/null-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/null-telemetry-client.test.ts
@@ -1,11 +1,11 @@
-import { IMock, It, Mock, Times } from 'typemoq';
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
+import { IMock, Mock, Times } from 'typemoq';
 import { NullTelemetryClient } from '../../../../../background/telemetry/null-telemetry-client';
 import { TelemetryBaseData } from '../../../../../background/telemetry/telemetry-base-data';
 import { TelemetryLogger } from '../../../../../background/telemetry/telemetry-logger';
 
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
 describe('Null telemetry client', () => {
     let loggerMock: IMock<TelemetryLogger>;
 

--- a/src/tests/unit/tests/bug-filing/components/bug-filing-option-choice-group.test.tsx
+++ b/src/tests/unit/tests/bug-filing/components/bug-filing-option-choice-group.test.tsx
@@ -4,11 +4,9 @@ import { shallow } from 'enzyme';
 import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
-
 import { BugFilingChoiceGroup, BugFilingChoiceGroupProps } from '../../../../../bug-filing/components/bug-filing-choice-group';
 import { BugFilingService } from '../../../../../bug-filing/types/bug-filing-service';
 import { UserConfigMessageCreator } from '../../../../../common/message-creators/user-config-message-creator';
-import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 
 describe('BugFilingChoiceGroupTest', () => {
     let userConfigMessageCreatorMock: IMock<UserConfigMessageCreator>;

--- a/src/tests/unit/tests/common/components/visualization-toggle.test.tsx
+++ b/src/tests/unit/tests/common/components/visualization-toggle.test.tsx
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enzyme from 'enzyme';
-import { IToggle, IToggleProps, Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { IToggleProps, Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
-
 import { VisualizationToggle, VisualizationToggleProps } from '../../../../../common/components/visualization-toggle';
 
 describe('VisualizationToggleTest', () => {
@@ -57,7 +56,7 @@ describe('VisualizationToggleTest', () => {
 
         const wrapper = Enzyme.shallow(<VisualizationToggle {...props} />);
 
-        const toggle = wrapper.find(Toggle).simulate('click', clickEventStub);
+        wrapper.find(Toggle).simulate('click', clickEventStub);
 
         onClickMock.verifyAll();
     });

--- a/src/tests/unit/tests/common/components/with-store-subscription.test.tsx
+++ b/src/tests/unit/tests/common/components/with-store-subscription.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { mount, render, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 import { withStoreSubscription, WithStoreSubscriptionProps } from '../../../../../common/components/with-store-subscription';

--- a/src/tests/unit/tests/common/file-issue-details-handler.test.ts
+++ b/src/tests/unit/tests/common/file-issue-details-handler.test.ts
@@ -1,20 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
+import { IMock, Mock } from 'typemoq';
 import { FileIssueDetailsHandler } from '../../../../common/file-issue-details-handler';
 import { HTMLElementUtils } from '../../../../common/html-element-utils';
 
 describe('FileIssueDetailsHandlerTest', () => {
     let testSubject: FileIssueDetailsHandler;
     let htmlElementUtilsMock: IMock<HTMLElementUtils>;
-    let container: Element;
     let fileIssueDetailsButton: Element;
 
     beforeEach(() => {
         htmlElementUtilsMock = Mock.ofType(HTMLElementUtils);
         testSubject = new FileIssueDetailsHandler(htmlElementUtilsMock.object);
-        container = document.createElement('div');
         fileIssueDetailsButton = document.createElement('div');
         fileIssueDetailsButton.classList.add('.insights-file-issue-details-dialog-override');
     });

--- a/src/tests/unit/tests/injected/analyzer-controller.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-controller.test.ts
@@ -238,10 +238,6 @@ describe('AnalyzerControllerTests', () => {
                 return returnedConfig;
             });
     }
-
-    function setupGetStoreDataMock(tests: TestsEnabledState, scanData: ScanData): void {
-        getStoreDataMock.setup(gcdm => gcdm(tests)).returns(() => scanData);
-    }
 });
 
 class AnalyzerStub implements Analyzer {

--- a/src/tests/unit/tests/injected/details-dialog-handler.test.ts
+++ b/src/tests/unit/tests/injected/details-dialog-handler.test.ts
@@ -669,35 +669,6 @@ describe('DetailsDialogHandlerTest', () => {
         detailsDialogMock.verifyAll();
     }
 
-    function testIssueTrackerPathEqualsITP(itp: string): void {
-        const detailsDialogMock = Mock.ofType(DetailsDialog, MockBehavior.Strict);
-        const userConfigStoreMock = Mock.ofType(UserConfigurationStore, MockBehavior.Strict);
-
-        userConfigStoreMock
-            .setup(store => store.getState())
-            .returns(() => {
-                return {
-                    issueTrackerPath: itp,
-                } as any;
-            })
-            .verifiable(Times.once());
-
-        detailsDialogMock
-            .setup(dialog => dialog.props)
-            .returns(() => {
-                return {
-                    userConfigStore: userConfigStoreMock.object,
-                } as any;
-            })
-            .verifiable(Times.once());
-
-        const result = testSubject.issueTrackerPath(detailsDialogMock.object);
-
-        expect(result).toEqual(itp);
-        userConfigStoreMock.verifyAll();
-        detailsDialogMock.verifyAll();
-    }
-
     function testCanInspectEqualsIsOpen(isOpen: boolean): void {
         const detailsDialogMock = Mock.ofType(DetailsDialog, MockBehavior.Strict);
         const devToolStoreMock = Mock.ofType(DevToolStore, MockBehavior.Strict);


### PR DESCRIPTION
#### Description of changes

Clean up unused variables/imports. General idea is finish the clean up and then enable `noUnusedParameters` & `noUnusedLocals`  options on tsconfig.json

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
