### PR TITLE
Added Azure DevOps bug filing service + minor refactors

### DIFF
--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -5,6 +5,7 @@ import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import * as React from 'react';
 
 import { AssessmentsProvider } from '../assessments/types/assessments-provider';
+import { GitHubBugFilingSettings } from '../bug-filing/github/github-bug-filing-service';
 import { ThemeDeps } from '../common/components/theme';
 import { withStoreSubscription, WithStoreSubscriptionDeps } from '../common/components/with-store-subscription';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -173,7 +174,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
         const issueTrackerPath =
             (storeState.userConfigurationStoreData.bugServicePropertiesMap &&
                 storeState.userConfigurationStoreData.bugServicePropertiesMap.gitHub &&
-                storeState.userConfigurationStoreData.bugServicePropertiesMap.gitHub.repository) ||
+                (storeState.userConfigurationStoreData.bugServicePropertiesMap.gitHub as GitHubBugFilingSettings).repository) ||
             undefined;
         return (
             <DetailsViewMainContent

--- a/src/bug-filing/azure-devops/azure-devops-bug-filing-service.tsx
+++ b/src/bug-filing/azure-devops/azure-devops-bug-filing-service.tsx
@@ -13,14 +13,14 @@ import { SettingsFormProps } from '../types/settings-form-props';
 const AzureDevOpsBugFilingServiceKey = 'azureDevOps';
 
 export type AzureDevOpsBugFilingSettings = {
-    project: string;
-    issueDetailsLocation: string;
+    projectURL: string;
+    issueDetailsLocationField: string;
 };
 
-function buildStoreData(project: string, issueDetailsLocation: string): AzureDevOpsBugFilingSettings {
+function buildStoreData(projectURL: string, issueDetailsLocationField: string): AzureDevOpsBugFilingSettings {
     return {
-        project,
-        issueDetailsLocation,
+        projectURL,
+        issueDetailsLocationField,
     };
 }
 
@@ -29,7 +29,7 @@ function getSettingsFromStoreData(bugServicePropertiesMap: BugServicePropertiesM
 }
 
 function isSettingsValid(data: AzureDevOpsBugFilingSettings): boolean {
-    return !isEmpty(data) && isStringValid(data.project) && isStringValid(data.issueDetailsLocation);
+    return !isEmpty(data) && isStringValid(data.projectURL) && isStringValid(data.issueDetailsLocationField);
 }
 
 function isStringValid(stringToCheck: string): boolean {

--- a/src/bug-filing/azure-devops/azure-devops-bug-filing-service.tsx
+++ b/src/bug-filing/azure-devops/azure-devops-bug-filing-service.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { isEmpty } from 'lodash';
+import * as React from 'react';
+
+import { NamedSFC } from '../../common/react/named-sfc';
+import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
+import { BugServicePropertiesMap } from '../../common/types/store-data/user-configuration-store';
+import { BugFilingService } from '../types/bug-filing-service';
+import { SettingsFormProps } from '../types/settings-form-props';
+
+const AzureDevOpsBugFilingServiceKey = 'azureDevOps';
+
+export type AzureDevOpsBugFilingSettings = {
+    project: string;
+    issueDetailsLocation: string;
+};
+
+function buildStoreData(project: string, issueDetailsLocation: string): AzureDevOpsBugFilingSettings {
+    return {
+        project,
+        issueDetailsLocation,
+    };
+}
+
+function getSettingsFromStoreData(bugServicePropertiesMap: BugServicePropertiesMap): AzureDevOpsBugFilingSettings {
+    return bugServicePropertiesMap[AzureDevOpsBugFilingServiceKey] as AzureDevOpsBugFilingSettings;
+}
+
+function isSettingsValid(data: AzureDevOpsBugFilingSettings): boolean {
+    return !isEmpty(data) && isStringValid(data.project) && isStringValid(data.issueDetailsLocation);
+}
+
+function isStringValid(stringToCheck: string): boolean {
+    return !isEmpty(stringToCheck) && !isEmpty(stringToCheck.trim());
+}
+
+const settingsForm = NamedSFC<SettingsFormProps<AzureDevOpsBugFilingSettings>>('BugFilingSettings', props => {
+    return <div />;
+});
+
+export const AzureDevOpsBugFilingService: BugFilingService<AzureDevOpsBugFilingSettings> = {
+    key: AzureDevOpsBugFilingServiceKey,
+    displayName: 'AzureDevOps',
+    settingsForm,
+    buildStoreData,
+    getSettingsFromStoreData,
+    isSettingsValid,
+    createBugFilingUrl: (data: AzureDevOpsBugFilingSettings, bugData: CreateIssueDetailsTextData) => null,
+};

--- a/src/bug-filing/components/bug-filing-settings-container.tsx
+++ b/src/bug-filing/components/bug-filing-settings-container.tsx
@@ -22,7 +22,7 @@ export type BugFilingSettingsContainerDeps = {
 
 export const BugFilingSettingsContainer = NamedSFC<BugFilingSettingsContainerProps>('BugFilingSettingsContainer', props => {
     const { deps, selectedBugFilingService, selectedBugFilingServiceData } = props;
-    const SettingsForm = selectedBugFilingService.renderSettingsForm;
+    const SettingsForm = selectedBugFilingService.settingsForm;
     const bugFilingServices = deps.bugFilingServiceProvider.allVisible();
 
     return (

--- a/src/bug-filing/github/github-bug-filing-service.tsx
+++ b/src/bug-filing/github/github-bug-filing-service.tsx
@@ -21,11 +21,15 @@ function buildStoreData(repository: string): GitHubBugFilingSettings {
     };
 }
 
+function getSettingsFromStoreData(bugServicePropertiesMap: GitHubBugFilingSettings): GitHubBugFilingSettings {
+    return bugServicePropertiesMap[GitHubBugFilingServiceKey] as GitHubBugFilingSettings;
+}
+
 function isSettingsValid(data: GitHubBugFilingSettings): boolean {
     return !isEmpty(data) && !isEmpty(data.repository) && isString(data.repository) && !isEmpty(data.repository.trim());
 }
 
-const renderSettingsForm = NamedSFC<SettingsFormProps<GitHubBugFilingSettings>>('BugFilingSettings', props => {
+const settingsForm = NamedSFC<SettingsFormProps<GitHubBugFilingSettings>>('BugFilingSettings', props => {
     const onGitHubRepositoryChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const propertyName: keyof GitHubBugFilingSettings = 'repository';
         props.deps.userConfigMessageCreator.setBugServiceProperty(GitHubBugFilingServiceKey, propertyName, newValue);
@@ -45,8 +49,9 @@ const renderSettingsForm = NamedSFC<SettingsFormProps<GitHubBugFilingSettings>>(
 export const GitHubBugFilingService: BugFilingService<GitHubBugFilingSettings> = {
     key: GitHubBugFilingServiceKey,
     displayName: 'GitHub',
-    renderSettingsForm,
+    settingsForm,
     buildStoreData,
+    getSettingsFromStoreData,
     isSettingsValid,
     createBugFilingUrl: (data: GitHubBugFilingSettings, bugData: CreateIssueDetailsTextData) => null,
 };

--- a/src/bug-filing/null-issue-filing-service/null-issue-filing-service.tsx
+++ b/src/bug-filing/null-issue-filing-service/null-issue-filing-service.tsx
@@ -6,15 +6,16 @@ import { SettingsFormProps } from '../types/settings-form-props';
 
 const nullServiceKey = 'none';
 
-const renderSettingsForm = NamedSFC<SettingsFormProps<{}>>('NullIssueFilingService', () => null);
+const settingsForm = NamedSFC<SettingsFormProps<{}>>('NullIssueFilingService', () => null);
 
 export const NullIssueFilingService: BugFilingService = {
     key: nullServiceKey,
     isHidden: true,
     order: 0,
     displayName: 'None',
-    renderSettingsForm,
+    settingsForm,
     buildStoreData: () => null,
     isSettingsValid: () => false,
     createBugFilingUrl: () => null,
+    getSettingsFromStoreData: () => null,
 };

--- a/src/bug-filing/types/bug-filing-service.ts
+++ b/src/bug-filing/types/bug-filing-service.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BugServicePropertiesMap } from '../../common/types/store-data/user-configuration-store';
 import { ReactSFCWithDisplayName } from './../../common/react/named-sfc';
 import { CreateIssueDetailsTextData } from './../../common/types/create-issue-details-text-data';
 import { SettingsFormProps } from './settings-form-props';
@@ -8,8 +9,9 @@ export interface BugFilingService<Settings = {}> {
     key: string;
     isHidden?: boolean;
     displayName: string;
-    renderSettingsForm: ReactSFCWithDisplayName<SettingsFormProps<Settings>>;
+    settingsForm: ReactSFCWithDisplayName<SettingsFormProps<Settings>>;
     buildStoreData: (...params: any[]) => Settings;
     isSettingsValid: (data: Settings) => boolean;
     createBugFilingUrl: (data: Settings, bugData: CreateIssueDetailsTextData) => string;
+    getSettingsFromStoreData: (data: BugServicePropertiesMap) => Settings;
 }

--- a/src/common/types/store-data/user-configuration-store.ts
+++ b/src/common/types/store-data/user-configuration-store.ts
@@ -9,11 +9,8 @@ export interface UserConfigurationStoreData {
     bugServicePropertiesMap: BugServicePropertiesMap;
 }
 
-interface BugServicePropertiesMap {
+export interface BugServicePropertiesMap {
     [service: string]: BugServiceProperties;
 }
 
-interface BugServiceProperties {
-    [name: string]: string;
-    issueTrackerPath?: string;
-}
+export type BugServiceProperties = Object;

--- a/src/injected/details-dialog-handler.ts
+++ b/src/injected/details-dialog-handler.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
 
+import { GitHubBugFilingSettings } from '../bug-filing/github/github-bug-filing-service';
 import { FeatureFlags } from '../common/feature-flags';
 import { HTMLElementUtils } from '../common/html-element-utils';
 import { DetailsDialog } from './components/details-dialog';
@@ -84,7 +85,7 @@ export class DetailsDialogHandler {
             userConfigState &&
             userConfigState.bugServicePropertiesMap &&
             userConfigState.bugServicePropertiesMap.gitHub &&
-            userConfigState.bugServicePropertiesMap.gitHub.repository
+            (userConfigState.bugServicePropertiesMap.gitHub as GitHubBugFilingSettings).repository
         );
     }
 

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -5,6 +5,7 @@ import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
+import { GitHubBugFilingSettings } from '../../../../bug-filing/github/github-bug-filing-service';
 import { DropdownClickHandler } from '../../../../common/dropdown-click-handler';
 import { StoreActionMessageCreator } from '../../../../common/message-creators/store-action-message-creator';
 import { StoreActionMessageCreatorImpl } from '../../../../common/message-creators/store-action-message-creator-impl';
@@ -247,7 +248,8 @@ describe('DetailsViewContainer', () => {
         rightPanelConfiguration: DetailsRightPanelConfiguration,
         switcherNavConfiguration: DetailsViewSwitcherNavConfiguration,
     ): JSX.Element {
-        const issueTrackerPath = storeMocks.userConfigurationStoreData.bugServicePropertiesMap.gitHub.repository;
+        const issueTrackerPath = (storeMocks.userConfigurationStoreData.bugServicePropertiesMap.gitHub as GitHubBugFilingSettings)
+            .repository;
         return (
             <DetailsViewMainContent
                 deps={deps}

--- a/src/tests/unit/tests/bug-filing/azure-devops/__snapshots__/azure-devops-bug-filing-service.test.tsx.snap
+++ b/src/tests/unit/tests/bug-filing/azure-devops/__snapshots__/azure-devops-bug-filing-service.test.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AzureDevOpsBugFilingServiceTest renderSettingsForm 1`] = `<div />`;

--- a/src/tests/unit/tests/bug-filing/azure-devops/azure-devops-bug-filing-service.test.tsx
+++ b/src/tests/unit/tests/bug-filing/azure-devops/azure-devops-bug-filing-service.test.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import * as React from 'react';
+import { IMock, Mock, Times } from 'typemoq';
+
+import {
+    AzureDevOpsBugFilingService,
+    AzureDevOpsBugFilingSettings,
+} from '../../../../../bug-filing/azure-devops/azure-devops-bug-filing-service';
+import { SettingsFormProps } from '../../../../../bug-filing/types/settings-form-props';
+import { UserConfigMessageCreator } from '../../../../../common/message-creators/user-config-message-creator';
+import { BugServicePropertiesMap } from '../../../../../common/types/store-data/user-configuration-store';
+
+describe('AzureDevOpsBugFilingServiceTest', () => {
+    let userConfigMessageCreatorMock: IMock<UserConfigMessageCreator>;
+    let props: SettingsFormProps<AzureDevOpsBugFilingSettings>;
+    let projectStub: string;
+    let issueDetailsLocationStub: string;
+
+    const invalidTestSettings = [
+        null,
+        {},
+        undefined,
+        { random: '' },
+        { project: '' },
+        { project: '', issueDetailsLocation: '' },
+        { project: 'some project', issueDetailsLocation: '' },
+        { project: '', issueDetailsLocation: 'some issue details location' },
+    ];
+
+    beforeEach(() => {
+        projectStub = 'some project';
+        issueDetailsLocationStub = 'some location';
+        userConfigMessageCreatorMock = Mock.ofType(UserConfigMessageCreator);
+        props = {
+            deps: {
+                userConfigMessageCreator: userConfigMessageCreatorMock.object,
+            },
+            settings: {
+                project: 'some project',
+                issueDetailsLocation: 'some location',
+            },
+        };
+    });
+
+    it('static properties', () => {
+        expect(AzureDevOpsBugFilingService.key).toBe('azureDevOps');
+        expect(AzureDevOpsBugFilingService.displayName).toBe('AzureDevOps');
+        expect(AzureDevOpsBugFilingService.isHidden).toBeUndefined();
+    });
+
+    it('buildStoreData', () => {
+        const expectedStoreData: AzureDevOpsBugFilingSettings = {
+            project: projectStub,
+            issueDetailsLocation: issueDetailsLocationStub,
+        };
+        expect(AzureDevOpsBugFilingService.buildStoreData(projectStub, issueDetailsLocationStub)).toEqual(expectedStoreData);
+    });
+
+    it('getSettingsFromStoreData', () => {
+        const expectedStoreData: AzureDevOpsBugFilingSettings = {
+            project: projectStub,
+            issueDetailsLocation: issueDetailsLocationStub,
+        };
+        const givenData: BugServicePropertiesMap = {
+            'some other service': {},
+            [AzureDevOpsBugFilingService.key]: expectedStoreData,
+        };
+        expect(AzureDevOpsBugFilingService.getSettingsFromStoreData(givenData)).toEqual(expectedStoreData);
+    });
+
+    describe('check for invalid settings', () => {
+        it.each(invalidTestSettings)('with %o', settings => {
+            expect(AzureDevOpsBugFilingService.isSettingsValid(settings)).toBe(false);
+        });
+    });
+
+    it('isSettingsValid - valid case', () => {
+        const validSettings: AzureDevOpsBugFilingSettings = {
+            project: 'some project',
+            issueDetailsLocation: 'some issue details location',
+        };
+
+        expect(AzureDevOpsBugFilingService.isSettingsValid(validSettings)).toBe(true);
+    });
+
+    it('renderSettingsForm', () => {
+        const Component = AzureDevOpsBugFilingService.settingsForm;
+        const wrapper = shallow(<Component {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    describe('create bug filing url', () => {
+        it.each(invalidTestSettings)('with %o', settings => {
+            expect(AzureDevOpsBugFilingService.createBugFilingUrl(settings, null)).toBeNull();
+        });
+    });
+});

--- a/src/tests/unit/tests/bug-filing/azure-devops/azure-devops-bug-filing-service.test.tsx
+++ b/src/tests/unit/tests/bug-filing/azure-devops/azure-devops-bug-filing-service.test.tsx
@@ -18,15 +18,14 @@ describe('AzureDevOpsBugFilingServiceTest', () => {
     let projectStub: string;
     let issueDetailsLocationStub: string;
 
-    const invalidTestSettings = [
+    const invalidTestSettings: AzureDevOpsBugFilingSettings[] = [
         null,
-        {},
+        {} as AzureDevOpsBugFilingSettings,
         undefined,
-        { random: '' },
-        { project: '' },
-        { project: '', issueDetailsLocation: '' },
-        { project: 'some project', issueDetailsLocation: '' },
-        { project: '', issueDetailsLocation: 'some issue details location' },
+        { projectURL: '' } as AzureDevOpsBugFilingSettings,
+        { projectURL: '', issueDetailsLocationField: '' },
+        { projectURL: 'some project', issueDetailsLocationField: '' },
+        { projectURL: '', issueDetailsLocationField: 'some issue details location' },
     ];
 
     beforeEach(() => {
@@ -38,8 +37,8 @@ describe('AzureDevOpsBugFilingServiceTest', () => {
                 userConfigMessageCreator: userConfigMessageCreatorMock.object,
             },
             settings: {
-                project: 'some project',
-                issueDetailsLocation: 'some location',
+                projectURL: 'some project',
+                issueDetailsLocationField: 'some location',
             },
         };
     });
@@ -52,16 +51,16 @@ describe('AzureDevOpsBugFilingServiceTest', () => {
 
     it('buildStoreData', () => {
         const expectedStoreData: AzureDevOpsBugFilingSettings = {
-            project: projectStub,
-            issueDetailsLocation: issueDetailsLocationStub,
+            projectURL: projectStub,
+            issueDetailsLocationField: issueDetailsLocationStub,
         };
         expect(AzureDevOpsBugFilingService.buildStoreData(projectStub, issueDetailsLocationStub)).toEqual(expectedStoreData);
     });
 
     it('getSettingsFromStoreData', () => {
         const expectedStoreData: AzureDevOpsBugFilingSettings = {
-            project: projectStub,
-            issueDetailsLocation: issueDetailsLocationStub,
+            projectURL: projectStub,
+            issueDetailsLocationField: issueDetailsLocationStub,
         };
         const givenData: BugServicePropertiesMap = {
             'some other service': {},
@@ -78,8 +77,8 @@ describe('AzureDevOpsBugFilingServiceTest', () => {
 
     it('isSettingsValid - valid case', () => {
         const validSettings: AzureDevOpsBugFilingSettings = {
-            project: 'some project',
-            issueDetailsLocation: 'some issue details location',
+            projectURL: 'some project',
+            issueDetailsLocationField: 'some issue details location',
         };
 
         expect(AzureDevOpsBugFilingService.isSettingsValid(validSettings)).toBe(true);

--- a/src/tests/unit/tests/bug-filing/components/__snapshots__/bug-filing-settings-container.test.tsx.snap
+++ b/src/tests/unit/tests/bug-filing/components/__snapshots__/bug-filing-settings-container.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`BugFilingSettingsContainerTest render 1`] = `
         Object {
           "displayName": "TEST",
           "key": "test",
-          "renderSettingsForm": [Function],
+          "settingsForm": [Function],
         },
       ]
     }
@@ -27,11 +27,11 @@ exports[`BugFilingSettingsContainerTest render 1`] = `
       Object {
         "displayName": "TEST",
         "key": "test",
-        "renderSettingsForm": [Function],
+        "settingsForm": [Function],
       }
     }
   />
-  <renderSettingsForm
+  <settingsForm
     deps={
       Object {
         "bugFilingServiceProvider": proxy {

--- a/src/tests/unit/tests/bug-filing/components/bug-filing-settings-container.test.tsx
+++ b/src/tests/unit/tests/bug-filing/components/bug-filing-settings-container.test.tsx
@@ -18,7 +18,7 @@ describe('BugFilingSettingsContainerTest', () => {
     const selectedBugFilingService: BugFilingService = {
         key: 'test',
         displayName: 'TEST',
-        renderSettingsForm: formProps => {
+        settingsForm: formProps => {
             return <>{formProps}</>;
         },
     } as BugFilingService;

--- a/src/tests/unit/tests/bug-filing/github/github-bug-filing-service.test.tsx
+++ b/src/tests/unit/tests/bug-filing/github/github-bug-filing-service.test.tsx
@@ -8,6 +8,7 @@ import { IMock, Mock, Times } from 'typemoq';
 import { GitHubBugFilingService, GitHubBugFilingSettings } from '../../../../../bug-filing/github/github-bug-filing-service';
 import { SettingsFormProps } from '../../../../../bug-filing/types/settings-form-props';
 import { UserConfigMessageCreator } from '../../../../../common/message-creators/user-config-message-creator';
+import { BugServicePropertiesMap } from '../../../../../common/types/store-data/user-configuration-store';
 
 describe('GithubBugFilingServiceTest', () => {
     let userConfigMessageCreatorMock: IMock<UserConfigMessageCreator>;
@@ -41,6 +42,17 @@ describe('GithubBugFilingServiceTest', () => {
         expect(GitHubBugFilingService.buildStoreData(url)).toEqual(expectedStoreData);
     });
 
+    it('getSettingsFromStoreData', () => {
+        const expectedStoreData: GitHubBugFilingSettings = {
+            repository: 'some url',
+        };
+        const givenData: BugServicePropertiesMap = {
+            'some other service': {},
+            [GitHubBugFilingService.key]: expectedStoreData,
+        };
+        expect(GitHubBugFilingService.getSettingsFromStoreData(givenData)).toEqual(expectedStoreData);
+    });
+
     describe('check for invalid settings', () => {
         it.each(invalidTestSettings)('with %o', settings => {
             expect(GitHubBugFilingService.isSettingsValid(settings)).toBe(false);
@@ -56,13 +68,13 @@ describe('GithubBugFilingServiceTest', () => {
     });
 
     it('renderSettingsForm', () => {
-        const Component = GitHubBugFilingService.renderSettingsForm;
+        const Component = GitHubBugFilingService.settingsForm;
         const wrapper = shallow(<Component {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 
     it('renderSettingsForm: onChange', () => {
-        const Component = GitHubBugFilingService.renderSettingsForm;
+        const Component = GitHubBugFilingService.settingsForm;
         const wrapper = shallow(<Component {...props} />);
         userConfigMessageCreatorMock
             .setup(ucmm => ucmm.setBugServiceProperty('gitHub', 'repository', 'new value'))

--- a/src/tests/unit/tests/bug-filing/null-issue-filing-service/null-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/bug-filing/null-issue-filing-service/null-issue-filing-service.test.tsx
@@ -20,6 +20,10 @@ describe('NullIssueFilingService', () => {
         expect(NullIssueFilingService.buildStoreData()).toBeNull();
     });
 
+    it('getSettingsFromStoreData', () => {
+        expect(NullIssueFilingService.getSettingsFromStoreData(null)).toBeNull();
+    });
+
     describe('check settings', () => {
         it.each(testSettings)('with %o', settings => {
             expect(NullIssueFilingService.isSettingsValid(settings)).toBe(false);
@@ -38,7 +42,7 @@ describe('NullIssueFilingService', () => {
     });
 
     it('renders settings form', () => {
-        const Component = NullIssueFilingService.renderSettingsForm;
+        const Component = NullIssueFilingService.settingsForm;
 
         const props = {
             deps: null,


### PR DESCRIPTION
#### Description of changes

Mainly about adding a new service option for azure dev ops. Also re-factoring to add a "get" API to services (and respective tests).

The properties for ADO are from the UI.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [n/a] Added screenshots/GIFs for UI changes.
