### PR TITLE
Clean up unused variables/imports - Part 4

### DIFF
--- a/src/background/message-distributor.ts
+++ b/src/background/message-distributor.ts
@@ -3,7 +3,7 @@
 import { autobind } from '@uifabric/utilities';
 import { createDefaultLogger } from '../common/logging/default-logger';
 import { Logger } from '../common/logging/logger';
-import { InterpreterMessage, Message } from '../common/message';
+import { InterpreterMessage } from '../common/message';
 import { Tab } from './../common/itab.d';
 import { BrowserAdapter } from './browser-adapter';
 import { GlobalContext } from './global-context';

--- a/src/common/components/collapsible-component.tsx
+++ b/src/common/components/collapsible-component.tsx
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { autobind, css } from '@uifabric/utilities';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import * as React from 'react';
 
 export interface CollapsibleComponentProps {

--- a/src/common/components/file-issue-details-button.tsx
+++ b/src/common/components/file-issue-details-button.tsx
@@ -63,20 +63,10 @@ export class FileIssueDetailsButton extends React.Component<FileIssueDetailsButt
         this.setState({ showingFileIssueDialog: false });
     }
 
-    private openDialog(): void {
-        this.setState({ showingFileIssueDialog: true });
-    }
-
     @autobind
     private openSettings(event: React.MouseEvent<HTMLDivElement | HTMLAnchorElement | HTMLButtonElement>): void {
         this.props.deps.bugActionMessageCreator.openSettingsPanel(event);
         this.closeDialog();
-    }
-
-    @autobind
-    private onClickOpenSettingsButton(event: React.MouseEvent<HTMLDivElement | HTMLAnchorElement | HTMLButtonElement>): void {
-        this.props.deps.bugActionMessageCreator.trackFileIssueClick(event, 'none');
-        this.openDialog();
     }
 
     @autobind

--- a/src/common/components/selector-input-list.tsx
+++ b/src/common/components/selector-input-list.tsx
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as _ from 'lodash/index';
-import * as React from 'react';
-
 import { autobind } from '@uifabric/utilities';
+import * as _ from 'lodash/index';
 import { DefaultButton, IconButton } from 'office-ui-fabric-react/lib/Button';
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 import { List } from 'office-ui-fabric-react/lib/List';
 import { ITextField, TextField } from 'office-ui-fabric-react/lib/TextField';
-import { InspectMode } from '../../background/inspect-modes';
-import { ScopingInputTypes } from '../../background/scoping-input-types';
+import * as React from 'react';
 import { SingleElementSelector } from '../types/store-data/scoping-store-data';
 
 export interface SelectorInputListProps {

--- a/src/common/file-issue-details-handler.ts
+++ b/src/common/file-issue-details-handler.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { HTMLElementUtils } from './html-element-utils';
 
 export class FileIssueDetailsHandler {

--- a/src/content/settings/improve-accessibility-insights.tsx
+++ b/src/content/settings/improve-accessibility-insights.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-
 import { NewTabLink } from '../../common/components/new-tab-link';
-import { brand, title } from '../strings/application';
+import { title } from '../strings/application';
 
 export const telemetryPopupTitle = `We need your help`;
 

--- a/src/injected/components/fix-instruction-panel.tsx
+++ b/src/injected/components/fix-instruction-panel.tsx
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-import { Label } from 'office-ui-fabric-react/lib/Label';
 import * as React from 'react';
 import { CheckType } from './details-dialog';
 

--- a/src/injected/details-dialog-handler.ts
+++ b/src/injected/details-dialog-handler.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
-
 import { GitHubBugFilingSettings } from '../bug-filing/github/github-bug-filing-service';
 import { FeatureFlags } from '../common/feature-flags';
 import { HTMLElementUtils } from '../common/html-element-utils';
@@ -16,7 +15,6 @@ export class DetailsDialogHandler {
     @autobind
     public backButtonClickHandler(dialog: DetailsDialog): void {
         const currentRuleIndex = dialog.state.currentRuleIndex;
-        const showDialog = dialog.state.showDialog;
         dialog.setState({
             currentRuleIndex: currentRuleIndex - 1,
         });
@@ -25,7 +23,6 @@ export class DetailsDialogHandler {
     @autobind
     public nextButtonClickHandler(dialog: DetailsDialog): void {
         const currentRuleIndex = dialog.state.currentRuleIndex;
-        const showDialog = dialog.state.showDialog;
         dialog.setState({
             currentRuleIndex: currentRuleIndex + 1,
         });

--- a/src/injected/element-finder-by-position.ts
+++ b/src/injected/element-finder-by-position.ts
@@ -3,7 +3,6 @@
 import { autobind } from '@uifabric/utilities';
 import * as Q from 'q';
 
-import { HTMLElementUtils } from '../common/html-element-utils';
 import { BoundRectAccessor, ClientUtils } from './client-utils';
 import { ErrorMessageContent } from './frameCommunicators/error-message-content';
 import { FrameCommunicator } from './frameCommunicators/frame-communicator';

--- a/src/injected/visualization/drawer-utils.ts
+++ b/src/injected/visualization/drawer-utils.ts
@@ -29,7 +29,6 @@ export class DrawerUtils {
         docStyle: CSSStyleDeclaration,
     ): number {
         const leftOffset = this.getContainerLeftOffset(offset);
-        const documentElement = doc.documentElement;
         let containerWidth = elementBoundingClientRectWidth;
 
         if (leftOffset + containerWidth >= this.getDocumentWidth(doc, bodyStyle, docStyle) - this.clientWindowOffsetThreshold) {
@@ -47,7 +46,6 @@ export class DrawerUtils {
         docStyle: CSSStyleDeclaration,
     ): number {
         const topOffset = this.getContainerTopOffset(offset);
-        const documentElement = doc.documentElement;
         let containerHeight = elementBoundingClientRectHeight;
 
         if (topOffset + containerHeight >= this.getDocumentHeight(doc, bodyStyle, docStyle) - this.clientWindowOffsetThreshold) {
@@ -75,8 +73,6 @@ export class DrawerUtils {
     }
 
     public getDocumentWidth(doc: Document, bodyStyle: CSSStyleDeclaration, docStyle: CSSStyleDeclaration): number {
-        const body = this.dom.querySelector('body');
-
         if (bodyStyle.overflowX === 'hidden' || docStyle.overflowX === 'hidden') {
             return doc.documentElement.clientWidth;
         }
@@ -85,8 +81,6 @@ export class DrawerUtils {
     }
 
     public getDocumentHeight(doc: Document, bodyStyle: CSSStyleDeclaration, docStyle: CSSStyleDeclaration): number {
-        const body = this.dom.querySelector('body');
-
         if (bodyStyle.overflowY === 'hidden' || docStyle.overflowY === 'hidden') {
             return doc.documentElement.clientHeight;
         }

--- a/src/popup/components/header-contextual-menu.tsx
+++ b/src/popup/components/header-contextual-menu.tsx
@@ -27,7 +27,7 @@ export type HeaderContextualMenuProps = {
 const telemetryEventSource = TelemetryEventSource.HamburgerMenu;
 
 export const HeaderContextualMenu = NamedSFC<HeaderContextualMenuProps>('HeaderContextualMenu', props => {
-    const { deps, header, popupWindow, featureFlags } = props;
+    const { deps, header, popupWindow } = props;
     const { popupActionMessageCreator, launchPanelHeaderClickHandler } = deps;
 
     const getItems = (): IContextualMenuItem[] => [

--- a/src/scanner/help-url-getter.ts
+++ b/src/scanner/help-url-getter.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { configuration } from './custom-rule-configurations';
 import { RuleConfiguration } from './iruleresults';
 
 export class HelpUrlGetter {

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
@@ -63,13 +63,6 @@ describe('AssessmentInstanceTableTest', () => {
             assessmentDefaultMessageGeneratorMock.object,
             getDefaultMessageMock.object,
         );
-        const items: AssessmentInstanceRowData[] = [
-            {
-                statusChoiceGroup: null,
-                visualizationButton: null,
-                instance: {} as GeneratedAssessmentInstance,
-            },
-        ];
         const testObject = new AssessmentInstanceTable(props);
         const expected = <Spinner className="details-view-spinner" size={SpinnerSize.large} label={'Scanning'} />;
         expect(testObject.render()).toEqual(expected);
@@ -287,13 +280,6 @@ describe('AssessmentInstanceTableTest', () => {
             .setup(a => a.passUnmarkedInstances(props.assessmentNavState.selectedTestType, props.assessmentNavState.selectedTestStep))
             .verifiable(Times.once());
 
-        const items: AssessmentInstanceRowData[] = [
-            {
-                statusChoiceGroup: null,
-                visualizationButton: null,
-                instance: {} as GeneratedAssessmentInstance,
-            },
-        ];
         const testObject = new TestableAssessmentInstanceTable(props);
         testObject.getOnPassUnmarkedInstances()();
 

--- a/src/tests/unit/tests/DetailsView/components/assessment-table-column-config-handler.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-table-column-config-handler.test.tsx
@@ -89,13 +89,6 @@ describe('AssessmentTableColumnConfigHandlerTest', () => {
             selectedTestStep: step.key,
         };
 
-        const baseConfig = {
-            iconName: 'iconName',
-            name: 'toggle all visualization',
-            ariaLabel: 'toggle all visualization',
-            onColumnClick: () => null,
-        };
-
         masterCheckboxConfigProviderMock.setup(m => m.getMasterCheckBoxProperty(It.isAny(), It.isAny())).verifiable(Times.never());
 
         const testObject = new AssessmentTableColumnConfigHandler(masterCheckboxConfigProviderMock.object, provider);

--- a/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
@@ -2,8 +2,7 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { BugFilingService } from '../../../../../bug-filing/types/bug-filing-service';
 import { EnvironmentInfo, EnvironmentInfoProvider } from '../../../../../common/environment-info-provider';
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';

--- a/src/tests/unit/tests/background/message-distributor.test.ts
+++ b/src/tests/unit/tests/background/message-distributor.test.ts
@@ -7,7 +7,7 @@ import { Interpreter } from '../../../../background/interpreter';
 import { MessageDistributor, Sender } from '../../../../background/message-distributor';
 import { TabContext, TabToContextMap } from '../../../../background/tab-context';
 import { Logger } from '../../../../common/logging/logger';
-import { InterpreterMessage, Message } from '../../../../common/message';
+import { InterpreterMessage } from '../../../../common/message';
 
 describe('MessageDistributorTest', () => {
     let mockBrowserAdapter: IMock<BrowserAdapter>;

--- a/src/tests/unit/tests/bug-filing/bug-filing-service-provider.test.ts
+++ b/src/tests/unit/tests/bug-filing/bug-filing-service-provider.test.ts
@@ -68,8 +68,6 @@ describe('BugFilingServiceProviderTest', () => {
             } as BugFilingService,
         ];
 
-        const expectedTestOption = givenTestOptions[0];
-
         expect(new BugFilingServiceProvider(givenTestOptions).forKey('invalid key')).not.toBeDefined();
     });
 });

--- a/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
+++ b/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
@@ -3,8 +3,7 @@
 import { shallow } from 'enzyme';
 import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { IMock, It, Mock, Times } from 'typemoq';
-
+import { IMock, Mock, Times } from 'typemoq';
 import { BugFilingServiceProvider } from '../../../../../bug-filing/bug-filing-service-provider';
 import { BugFilingService } from '../../../../../bug-filing/types/bug-filing-service';
 import { IssueFilingButton, IssueFilingButtonDeps, IssueFilingButtonProps } from '../../../../../common/components/issue-filing-button';


### PR DESCRIPTION
#### Description of changes

Clean up unused variables/imports. General idea is finish the clean up and then enable `noUnusedParameters` & `noUnusedLocals`  options on tsconfig.json

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
