### PR TITLE
[Refactor] Extract buildGithubText

### DIFF
--- a/src/bug-filing/common/get-issue-details-markdown.ts
+++ b/src/bug-filing/common/get-issue-details-markdown.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { EnvironmentInfo } from '../../common/environment-info-provider';
+import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
+import { IssueUrlCreationUtils } from './issue-filing-url-string-utils';
+
+export const getIssueDetailsMarkdown = (
+    stringUtils: IssueUrlCreationUtils,
+    environmentInfo: EnvironmentInfo,
+    data: CreateIssueDetailsTextData,
+): string => {
+    const result = data.ruleResult;
+
+    const text = [
+        `**Issue**: \`${result.help}\` ([\`${result.ruleId}\`](${result.helpUrl}))`,
+        ``,
+        `**Target application**: [${data.pageTitle}](${data.pageUrl})`,
+        ``,
+        `**Element path**: ${data.ruleResult.selector}`,
+        ``,
+        `**Snippet**:`,
+        ``,
+        `    ${stringUtils.collapseConsecutiveSpaces(result.snippet)}`,
+        ``,
+        `**How to fix**:`,
+        ``,
+        `${stringUtils.formatAsMarkdownCodeBlock(result.failureSummary)}`,
+        ``,
+        `**Environment**:`,
+        `${environmentInfo.browserSpec}`,
+        ``,
+        `====`,
+        ``,
+        stringUtils.getFooterContent(environmentInfo),
+    ].join('\n');
+
+    return text;
+};

--- a/src/bug-filing/common/get-issue-details-markdown.ts
+++ b/src/bug-filing/common/get-issue-details-markdown.ts
@@ -4,6 +4,12 @@ import { EnvironmentInfo } from '../../common/environment-info-provider';
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { IssueUrlCreationUtils } from './issue-filing-url-string-utils';
 
+export type IssueDetailsGetter = (
+    stringUtils: IssueUrlCreationUtils,
+    environmentInfo: EnvironmentInfo,
+    data: CreateIssueDetailsTextData,
+) => string;
+
 export const getIssueDetailsMarkdown = (
     stringUtils: IssueUrlCreationUtils,
     environmentInfo: EnvironmentInfo,

--- a/src/bug-filing/github/create-github-bug-filing-url.ts
+++ b/src/bug-filing/github/create-github-bug-filing-url.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { getIssueDetailsMarkdown, IssueDetailsGetter } from '../common/get-issue-details-markdown';
 import { EnvironmentInfo } from './../../common/environment-info-provider';
 import { CreateIssueDetailsTextData } from './../../common/types/create-issue-details-text-data';
 import { IssueFilingUrlStringUtils, IssueUrlCreationUtils } from './../common/issue-filing-url-string-utils';
 import { GitHubBugFilingSettings } from './github-bug-filing-service';
-import { IssueDetailsGetter, getIssueDetailsMarkdown } from '../common/get-issue-details-markdown';
 
 function buildTitle(stringUtils: IssueUrlCreationUtils, data: CreateIssueDetailsTextData): string {
     const standardTags = stringUtils.standardizeTags(data);

--- a/src/tests/unit/tests/bug-filing/common/__snapshots__/get-issue-details-markdown.test.ts.snap
+++ b/src/tests/unit/tests/bug-filing/common/__snapshots__/get-issue-details-markdown.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getIssueDetailsMarkdown returns issue details text as markdown 1`] = `
+"**Issue**: \`RR-help\` ([\`RR-rule-id\`](RR-help-url))
+
+**Target application**: [pageTitle<x>](pageUrl)
+
+**Element path**: RR-selector<x>
+
+**Snippet**:
+
+    collapsed
+
+**How to fix**:
+
+escaped
+
+**Environment**:
+test spec
+
+====
+
+test footer content"
+`;

--- a/src/tests/unit/tests/bug-filing/common/get-issue-details-markdown.test.ts
+++ b/src/tests/unit/tests/bug-filing/common/get-issue-details-markdown.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { IMock, It, Mock } from 'typemoq';
+import { getIssueDetailsMarkdown } from '../../../../../bug-filing/common/get-issue-details-markdown';
+import { IssueUrlCreationUtils } from '../../../../../bug-filing/common/issue-filing-url-string-utils';
+import { EnvironmentInfo } from '../../../../../common/environment-info-provider';
+
+describe('getIssueDetailsMarkdown', () => {
+    let stringUtilsMock: IMock<IssueUrlCreationUtils>;
+    const sampleIssueDetailsData = {
+        pageTitle: 'pageTitle<x>',
+        pageUrl: 'pageUrl',
+        ruleResult: {
+            failureSummary: 'RR-failureSummary',
+            guidanceLinks: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
+            help: 'RR-help',
+            html: 'RR-html',
+            ruleId: 'RR-rule-id',
+            helpUrl: 'RR-help-url',
+            selector: 'RR-selector<x>',
+            snippet: 'RR-snippet   space',
+        } as any,
+    };
+    const environmentInfo: EnvironmentInfo = {
+        extensionVersion: '1.1.1',
+        axeCoreVersion: '2.2.2',
+        browserSpec: 'test spec',
+    };
+    const testObject = getIssueDetailsMarkdown;
+
+    beforeEach(() => {
+        stringUtilsMock = Mock.ofType<IssueUrlCreationUtils>();
+    });
+
+    it('returns issue details text as markdown', () => {
+        stringUtilsMock.setup(utils => utils.collapseConsecutiveSpaces(It.isAnyString())).returns(() => 'collapsed');
+        stringUtilsMock.setup(utils => utils.formatAsMarkdownCodeBlock(It.isAnyString())).returns(() => 'escaped');
+        stringUtilsMock.setup(utils => utils.getFooterContent(environmentInfo)).returns(() => 'test footer content');
+
+        const result = testObject(stringUtilsMock.object, environmentInfo, sampleIssueDetailsData);
+
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/bug-filing/github/__snapshots__/create-github-bug-filing-url.test.ts.snap
+++ b/src/tests/unit/tests/bug-filing/github/__snapshots__/create-github-bug-filing-url.test.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`createGitHubBugFilingUrlTest createGitHubBugFilingUrl: no tag 1`] = `"test appendSuffixToUrl/new?title=RR-help%20(last%20part)&body=**Issue**%3A%20%60RR-help%60%20(%5B%60RR-rule-id%60%5D(RR-help-url))%0A%0A**Target%20application**%3A%20%5BpageTitle%3Cx%3E%5D(pageUrl)%0A%0A**Element%20path**%3A%20RR-selector%3Cx%3E%0A%0A**Snippet**%3A%0A%0A%20%20%20%20collapsed%0A%0A**How%20to%20fix**%3A%0A%0Aescaped%0A%0A**Environment**%3A%0Atest%20spec%0A%0A%3D%3D%3D%3D%0A%0Atest%20getFooterContent"`;
+exports[`createGitHubBugFilingUrlTest createGitHubBugFilingUrl: no tag 1`] = `"test appendSuffixToUrl/new?title=RR-help%20(last%20part)&body=test%20issue%20details"`;
 
-exports[`createGitHubBugFilingUrlTest createGitHubBugFilingUrl: with tag 1`] = `"test appendSuffixToUrl/new?title=TAG1%2CTAG2%3A%20RR-help%20(last%20part)&body=**Issue**%3A%20%60RR-help%60%20(%5B%60RR-rule-id%60%5D(RR-help-url))%0A%0A**Target%20application**%3A%20%5BpageTitle%3Cx%3E%5D(pageUrl)%0A%0A**Element%20path**%3A%20RR-selector%3Cx%3E%0A%0A**Snippet**%3A%0A%0A%20%20%20%20collapsed%0A%0A**How%20to%20fix**%3A%0A%0Aescaped%0A%0A**Environment**%3A%0Atest%20spec%0A%0A%3D%3D%3D%3D%0A%0Atest%20getFooterContent"`;
+exports[`createGitHubBugFilingUrlTest createGitHubBugFilingUrl: with tag 1`] = `"test appendSuffixToUrl/new?title=TAG1%2CTAG2%3A%20RR-help%20(last%20part)&body=test%20issue%20details"`;

--- a/src/tests/unit/tests/bug-filing/github/create-github-bug-filing-url.test.ts
+++ b/src/tests/unit/tests/bug-filing/github/create-github-bug-filing-url.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock } from 'typemoq';
+import { IssueDetailsGetter } from '../../../../../bug-filing/common/get-issue-details-markdown';
 import { createGitHubIssueFilingUrlProvider } from '../../../../../bug-filing/github/create-github-bug-filing-url';
 import { IssueFilingUrlProvider } from '../../../../../bug-filing/types/bug-filing-service';
 import { IssueUrlCreationUtils } from './../../../../../bug-filing/common/issue-filing-url-string-utils';
@@ -12,6 +13,7 @@ describe('createGitHubBugFilingUrlTest', () => {
     let sampleIssueDetailsData;
     let settingsData: GitHubBugFilingSettings;
     let stringUtilsMock: IMock<IssueUrlCreationUtils>;
+    let issueDetailsGetter: IMock<IssueDetailsGetter>;
     let testObject: IssueFilingUrlProvider<GitHubBugFilingSettings>;
 
     beforeEach(() => {
@@ -39,15 +41,16 @@ describe('createGitHubBugFilingUrlTest', () => {
         };
 
         stringUtilsMock = Mock.ofType<IssueUrlCreationUtils>();
-        testObject = createGitHubIssueFilingUrlProvider(stringUtilsMock.object);
+        issueDetailsGetter = Mock.ofType<IssueDetailsGetter>();
+        issueDetailsGetter
+            .setup(getter => getter(stringUtilsMock.object, environmentInfo, sampleIssueDetailsData))
+            .returns(() => 'test issue details');
+        testObject = createGitHubIssueFilingUrlProvider(stringUtilsMock.object, issueDetailsGetter.object);
     });
 
     test('createGitHubBugFilingUrl: no tag', () => {
         stringUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => []);
         stringUtilsMock.setup(utils => utils.getSelectorLastPart(It.isAny())).returns(() => 'last part');
-        stringUtilsMock.setup(utils => utils.collapseConsecutiveSpaces(It.isAnyString())).returns(() => 'collapsed');
-        stringUtilsMock.setup(utils => utils.formatAsMarkdownCodeBlock(It.isAnyString())).returns(() => 'escaped');
-        stringUtilsMock.setup(utils => utils.getFooterContent(environmentInfo)).returns(() => 'test getFooterContent');
         stringUtilsMock.setup(utils => utils.appendSuffixToUrl(settingsData.repository, 'issues')).returns(() => 'test appendSuffixToUrl');
 
         const result = testObject(settingsData, sampleIssueDetailsData, environmentInfo);
@@ -58,9 +61,6 @@ describe('createGitHubBugFilingUrlTest', () => {
     test('createGitHubBugFilingUrl: with tag', () => {
         stringUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => ['TAG1', 'TAG2']);
         stringUtilsMock.setup(utils => utils.getSelectorLastPart(It.isAny())).returns(() => 'last part');
-        stringUtilsMock.setup(utils => utils.collapseConsecutiveSpaces(It.isAnyString())).returns(() => 'collapsed');
-        stringUtilsMock.setup(utils => utils.formatAsMarkdownCodeBlock(It.isAnyString())).returns(() => 'escaped');
-        stringUtilsMock.setup(utils => utils.getFooterContent(environmentInfo)).returns(() => 'test getFooterContent');
         stringUtilsMock.setup(utils => utils.appendSuffixToUrl(settingsData.repository, 'issues')).returns(() => 'test appendSuffixToUrl');
 
         const result = testObject(settingsData, sampleIssueDetailsData, environmentInfo);


### PR DESCRIPTION
#### Description of changes

The markdown we get from `buildGithubText` is not for github only, we are going to use the same markdown for Azure Boards.
In this PR:

- Extract `buildGithubText` to it's own file
- Add unit tests for the new function
- Update `src\bug-filing\github\create-github-bug-filing-url.ts` (and the related tests) to use the new function

#### Pull request checklist

- [ ] Addresses an existing issue: Part of WI #1505514
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
