### PR TITLE
Clean up unused variables/imports - Part 5

### DIFF
--- a/src/injected/analyzer-controller.ts
+++ b/src/injected/analyzer-controller.ts
@@ -13,13 +13,10 @@ import { DictionaryStringTo } from '../types/common-types';
 import { AnalyzerStateUpdateHandler } from './analyzer-state-update-handler';
 import { Analyzer } from './analyzers/analyzer';
 import { AnalyzerProvider } from './analyzers/analyzer-provider';
-import { TabStopsListener } from './tab-stops-listener';
 
 export class AnalyzerController {
     private analyzerProvider: AnalyzerProvider;
-    private tabStopsListener: TabStopsListener;
     private analyzers: DictionaryStringTo<Analyzer>;
-    private sendMessage: (message) => void;
     private visualizationstore: BaseStore<VisualizationStoreData>;
     private scopingStore: BaseStore<ScopingStoreData>;
     private featureFlagStore: BaseStore<FeatureFlagStoreData>;
@@ -28,22 +25,18 @@ export class AnalyzerController {
     private assessmentsProvider: AssessmentsProvider;
 
     constructor(
-        sendMessage: (message) => void,
         visualizationstore: BaseStore<VisualizationStoreData>,
         featureFlagStore: BaseStore<FeatureFlagStoreData>,
         scopingStore: BaseStore<ScopingStoreData>,
-        tabStopsListener: TabStopsListener,
         visualizationConfigurationFactory: VisualizationConfigurationFactory,
         analyzerProvider: AnalyzerProvider,
         analyzerStateUpdateHandler: AnalyzerStateUpdateHandler,
         assessmentsProvider: AssessmentsProvider,
     ) {
         this.analyzers = {};
-        this.sendMessage = sendMessage;
         this.visualizationstore = visualizationstore;
         this.scopingStore = scopingStore;
         this.featureFlagStore = featureFlagStore;
-        this.tabStopsListener = tabStopsListener;
         this.visualizationConfigurationFactory = visualizationConfigurationFactory;
         this.analyzerProvider = analyzerProvider;
         this.assessmentsProvider = assessmentsProvider;

--- a/src/injected/frame-url-message-dispatcher.ts
+++ b/src/injected/frame-url-message-dispatcher.ts
@@ -1,23 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
-
 import { DevToolActionMessageCreator } from '../common/message-creators/dev-tool-action-message-creator';
-import { WindowUtils } from '../common/window-utils';
 import { FrameUrlFinder, FrameUrlMessage } from './frame-url-finder';
 import { FrameCommunicator } from './frameCommunicators/frame-communicator';
 
 export class FrameUrlMessageDispatcher {
     private devToolActionMessageCreator: DevToolActionMessageCreator;
-    private frameUrlFinder: FrameUrlFinder;
     private frameCommunicator: FrameCommunicator;
-    private windowUtils: WindowUtils;
 
-    constructor(
-        devToolActionMessageCreator: DevToolActionMessageCreator,
-        frameUrlFinder: FrameUrlFinder,
-        frameCommunicator: FrameCommunicator,
-    ) {
+    constructor(devToolActionMessageCreator: DevToolActionMessageCreator, frameCommunicator: FrameCommunicator) {
         this.devToolActionMessageCreator = devToolActionMessageCreator;
         this.frameCommunicator = frameCommunicator;
     }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -156,11 +156,9 @@ export class MainWindowInitializer extends WindowInitializer {
         );
         const analyzerStateUpdateHandler = new AnalyzerStateUpdateHandler(this.visualizationConfigurationFactory);
         this.analyzerController = new AnalyzerController(
-            this.clientChromeAdapter.sendMessageToFrames,
             this.visualizationStoreProxy,
             this.featureFlagStoreProxy,
             this.scopingStoreProxy,
-            this.tabStopsListener,
             this.visualizationConfigurationFactory,
             analyzerProvider,
             analyzerStateUpdateHandler,

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -118,11 +118,7 @@ export class MainWindowInitializer extends WindowInitializer {
 
         const drawingInitiator = new DrawingInitiator(this.drawingController);
         const selectorMapHelper = new SelectorMapHelper(this.visualizationScanResultStoreProxy, this.assessmentStoreProxy, Assessments);
-        const frameUrlMessageDispatcher = new FrameUrlMessageDispatcher(
-            devToolActionMessageCreator,
-            this.frameUrlFinder,
-            this.frameCommunicator,
-        );
+        const frameUrlMessageDispatcher = new FrameUrlMessageDispatcher(devToolActionMessageCreator, this.frameCommunicator);
         frameUrlMessageDispatcher.initialize();
 
         this.clientViewController = new ClientViewController(

--- a/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
@@ -150,7 +150,7 @@ describe('AssessmentViewTest', () => {
             .setup(a => a.enableVisualHelper(firstAssessment.visualizationType, stepName, false, true))
             .verifiable(Times.once());
 
-        const props = builder.setHasScanData(true).buildProps({ selector: {} }, false, true);
+        const props = builder.buildProps({ selector: {} }, false, true);
         const testObject = new AssessmentView(props);
 
         testObject.componentDidMount();
@@ -163,10 +163,7 @@ describe('AssessmentViewTest', () => {
             .setup(a => a.enableVisualHelper(firstAssessment.visualizationType, stepName, false))
             .verifiable(Times.never());
 
-        const props = builder
-            .setHasScanData(true)
-            .setIsEnabled(true)
-            .buildProps({ selector: {} });
+        const props = builder.setIsEnabled(true).buildProps({ selector: {} });
         const testObject = new AssessmentView(props);
 
         testObject.componentDidMount();
@@ -196,7 +193,6 @@ class AssessmentViewPropsBuilder {
     public assessmentInstanceTableHandlerMock: IMock<AssessmentInstanceTableHandler>;
     private assessmentGeneratorInstance: AssessmentDefaultMessageGenerator;
     private content: JSX.Element = <div>AssessmentViewTest content</div>;
-    private hasScanData: boolean = false;
     private isEnabled: boolean = false;
     private provider: AssessmentsProvider;
 
@@ -205,11 +201,6 @@ class AssessmentViewPropsBuilder {
         this.assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
         this.assessmentGeneratorInstance = assessmentGeneratorInstanceMock;
         this.provider = provider;
-    }
-
-    public setHasScanData(hasScanData: true): AssessmentViewPropsBuilder {
-        this.hasScanData = hasScanData;
-        return this;
     }
 
     public setIsEnabled(isEnabled: true): AssessmentViewPropsBuilder {

--- a/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
@@ -119,19 +119,6 @@ describe('TestStepViewTest', () => {
         expect(visualHelper.exists()).toBeFalsy();
     });
 
-    test('render, with visual helper toggle', () => {
-        const props = TestStepViewPropsBuilder.defaultProps(getVisualHelperToggleMock.object)
-            .withIsManual(true)
-            .build();
-        const toggleStub = <div className="toggle-stub">toggle</div>;
-
-        const wrapper = Enzyme.shallow(<TestStepView {...props} />);
-
-        const visualHelper = wrapper.find('.toggle-stub');
-
-        getVisualHelperToggleMock.verifyAll();
-    });
-
     test('render snapshot matches with manual false and scanning is finished', () => {
         const props = TestStepViewPropsBuilder.defaultProps(getVisualHelperToggleMock.object)
             .withIsManual(false)
@@ -238,11 +225,6 @@ class TestStepViewPropsBuilder extends BaseDataBuilder<TestStepViewProps> {
 
     public withScanning(isScanning: boolean): TestStepViewPropsBuilder {
         this.data.isScanning = isScanning;
-        return this;
-    }
-
-    public withoutInstanceMap(): TestStepViewPropsBuilder {
-        this.data.instancesMap = {};
         return this;
     }
 

--- a/src/tests/unit/tests/injected/analyzer-controller.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-controller.test.ts
@@ -20,7 +20,6 @@ import { AnalyzerController } from '../../../../injected/analyzer-controller';
 import { AnalyzerStateUpdateHandler } from '../../../../injected/analyzer-state-update-handler';
 import { Analyzer } from '../../../../injected/analyzers/analyzer';
 import { AnalyzerProvider } from '../../../../injected/analyzers/analyzer-provider';
-import { TabStopsListener } from '../../../../injected/tab-stops-listener';
 import { ScopingStoreDataBuilder } from '../../common/scoping-store-data-builder';
 import { IsSameObject } from '../../common/typemoq-helper';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
@@ -43,8 +42,6 @@ describe('AnalyzerControllerTests', () => {
     let scopingStoreState: ScopingStoreData;
     let analyzerProviderStrictMock: IMock<AnalyzerProvider>;
     let analyzerMock: IMock<Analyzer>;
-    let tabStopsListenerMock: IMock<TabStopsListener>;
-    let sendMessageMock: IMock<(message) => void>;
     let analyzerStateUpdateHandlerStrictMock: IMock<AnalyzerStateUpdateHandler>;
     let assessmentsMock: IMock<AssessmentsProvider>;
     let testObject: AnalyzerController;
@@ -68,7 +65,6 @@ describe('AnalyzerControllerTests', () => {
             getIdentifier: getIdentifierMock.object,
         } as any;
 
-        tabStopsListenerMock = Mock.ofType(TabStopsListener);
         visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
         assessmentsMock = Mock.ofType(AssessmentsProviderImpl);
         visualizationStoreMock = Mock.ofType<VisualizationStore>();
@@ -97,8 +93,6 @@ describe('AnalyzerControllerTests', () => {
         visualizationStoreState = null;
         scopingStoreState = null;
 
-        sendMessageMock = Mock.ofInstance(message => {}, MockBehavior.Strict);
-
         EnumHelper.getNumericValues(VisualizationType).forEach((test: VisualizationType) => {
             setupVisualizationConfigurationFactory(test, configStub);
         });
@@ -109,11 +103,9 @@ describe('AnalyzerControllerTests', () => {
         setupGetAnalyzerMockCalled(times);
 
         testObject = new AnalyzerController(
-            sendMessageMock.object,
             visualizationStoreMock.object,
             featureFlagStoreStoreMock.object,
             scopingStoreMock.object,
-            tabStopsListenerMock.object,
             visualizationConfigurationFactoryMock.object,
             analyzerProviderStrictMock.object,
             analyzerStateUpdateHandlerStrictMock.object,
@@ -126,7 +118,6 @@ describe('AnalyzerControllerTests', () => {
         featureFlagStoreStoreMock.verifyAll();
         scopingStoreMock.verifyAll();
         analyzerProviderStrictMock.verifyAll();
-        sendMessageMock.verifyAll();
         featureFlagStoreState = {};
     });
 

--- a/src/tests/unit/tests/injected/frame-url-message-dispatcher.test.ts
+++ b/src/tests/unit/tests/injected/frame-url-message-dispatcher.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Mock, MockBehavior } from 'typemoq';
-
 import { DevToolActionMessageCreator } from '../../../../common/message-creators/dev-tool-action-message-creator';
 import { FrameUrlFinder, FrameUrlMessage } from '../../../../injected/frame-url-finder';
 import { FrameUrlMessageDispatcher } from '../../../../injected/frame-url-message-dispatcher';
@@ -9,7 +8,7 @@ import { FrameCommunicator } from '../../../../injected/frameCommunicators/frame
 
 describe('FrameUrlMessageDispatcherTest', () => {
     test('constructor', () => {
-        expect(new FrameUrlMessageDispatcher(null, null, null)).toBeDefined();
+        expect(new FrameUrlMessageDispatcher(null, null)).toBeDefined();
     });
 
     test('setTargetFrameUrl', () => {
@@ -20,7 +19,7 @@ describe('FrameUrlMessageDispatcherTest', () => {
 
         devToolActionMessageCreatorMock.setup(acm => acm.setInspectFrameUrl('testUrl')).verifiable();
 
-        const testSubject = new FrameUrlMessageDispatcher(devToolActionMessageCreatorMock.object, null, null);
+        const testSubject = new FrameUrlMessageDispatcher(devToolActionMessageCreatorMock.object, null);
         testSubject.setTargetFrameUrl(targetFrameUrlMessage);
 
         devToolActionMessageCreatorMock.verifyAll();
@@ -28,14 +27,9 @@ describe('FrameUrlMessageDispatcherTest', () => {
 
     test('initialize', () => {
         const devToolActionMessageCreatorMock = Mock.ofType(DevToolActionMessageCreator, MockBehavior.Strict);
-        const frameUrlFinderMock = Mock.ofType(FrameUrlFinder, MockBehavior.Strict);
         const frameCommunicatorMock = Mock.ofType(FrameCommunicator, MockBehavior.Strict);
 
-        const testSubject = new FrameUrlMessageDispatcher(
-            devToolActionMessageCreatorMock.object,
-            frameUrlFinderMock.object,
-            frameCommunicatorMock.object,
-        );
+        const testSubject = new FrameUrlMessageDispatcher(devToolActionMessageCreatorMock.object, frameCommunicatorMock.object);
 
         frameCommunicatorMock.setup(fcm => fcm.subscribe(FrameUrlFinder.SetFrameUrlCommand, testSubject.setTargetFrameUrl)).verifiable();
 

--- a/tslint.json
+++ b/tslint.json
@@ -58,6 +58,7 @@
         "no-this-assignment": true,
         "no-trailing-whitespace": true,
         "no-unused-expression": true,
+        "no-unused-variable": true,
         "no-var-keyword": true,
         "no-var-requires": true,
         "one-line": [true, "check-open-brace", "check-whitespace"],


### PR DESCRIPTION
#### Description of changes

Clean up unused variables/imports. General idea is finish the clean up and then enable `noUnusedParameters` & `noUnusedLocals`  options on tsconfig.json
At this point, we're able to temporary enable 'no-unused-variables' tslint rule. This rule is deprecated so the end goal is to enable tsc check (mentioned before) but adding this rule will prevent us from adding more unused variables/imports. 

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
