### PR TITLE
[Bug Fix] Remove default option for azure boards settings

### DIFF
--- a/src/bug-filing/azure-boards/azure-boards-settings-form.tsx
+++ b/src/bug-filing/azure-boards/azure-boards-settings-form.tsx
@@ -50,9 +50,10 @@ export const AzureBoardsSettingsForm = NamedSFC<SettingsFormProps<AzureBoardsBug
             />
             <Dropdown
                 options={options}
+                placeholder="Select an option"
                 label="File issue details in:"
                 onChange={onIssueDetailLocationChange}
-                selectedKey={props.settings ? props.settings.issueDetailsField : defaultKey}
+                selectedKey={props.settings ? props.settings.issueDetailsField : null}
             />
         </>
     );

--- a/src/tests/unit/tests/bug-filing/azure-boards/__snapshots__/azure-boards-settings-form.test.tsx.snap
+++ b/src/tests/unit/tests/bug-filing/azure-boards/__snapshots__/azure-boards-settings-form.test.tsx.snap
@@ -24,7 +24,8 @@ exports[`AzureBoardsSettingsForm renders settings is null 1`] = `
         },
       ]
     }
-    selectedKey="reproSteps"
+    placeholder="Select an option"
+    selectedKey={null}
   />
 </React.Fragment>
 `;
@@ -53,6 +54,7 @@ exports[`AzureBoardsSettingsForm renders with projectUrl and issueDetailsField 1
         },
       ]
     }
+    placeholder="Select an option"
     selectedKey="description"
   />
 </React.Fragment>


### PR DESCRIPTION
#### Description of changes

Remove default option for azure boards settings, so that the store state is consistent with UI.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
