### PR TITLE
add wrap for visual helper text as per design

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -511,8 +511,10 @@ div.insights-file-issue-details-dialog-container {
                     flex-direction: row;
                     padding-top: 1.5vh;
                     padding-bottom: 1.1vh;
+                    flex-wrap: wrap;
                     &-text {
                         padding-right: 0.9vh;
+                        padding-bottom: 0.9vh;
                         font-family: $fontFamily;
                         font-size: 14px;
                         line-height: normal;


### PR DESCRIPTION
#### Description of changes

Fix the wrap for visual helper text to make it look as per design, especially for smaller screens.

Look at the attached screenshot for more.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes WI: 1457433
- [ ] Added relevant unit test for your changes. (`npm run test`) - n/a
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` - n/a
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.


#### Screenshots:
 
##### Full screen:

![image](https://user-images.githubusercontent.com/4496335/56518153-90c26400-64f3-11e9-823c-7aedacef1b25.png)

##### Smaller screen:

![image](https://user-images.githubusercontent.com/4496335/56518180-a5066100-64f3-11e9-81b8-ce5dc334eb73.png)

