### PR TITLE
fix: prevent target page button:hover borders from applying to injected dialog

### DIFF
--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -105,7 +105,7 @@
 
     .insights-dialog-main-override button {
         // This is to prevent conflicts with target page CSS, see issue #578
-        border: 0;
+        border: 0 !important;
     }
 
     .insights-dialog-main-override .insights-dialog-button-inspect svg path {

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -62,7 +62,7 @@
         width: 25%;
         max-width: 25%;
         user-select: text;
-        min-width: 520px;
+        min-width: 550px;
     }
 
     div.insights-file-issue-details-dialog-container {
@@ -101,6 +101,11 @@
 
     .insights-dialog-main-override .insights-dialog-main-container .ms-Dialog-inner {
         padding: 0 19px 20px !important;
+    }
+
+    .insights-dialog-main-override button {
+        // This is to prevent conflicts with target page CSS, see issue #578
+        border: 0;
     }
 
     .insights-dialog-main-override .insights-dialog-button-inspect svg path {


### PR DESCRIPTION
#### Description of changes

Without this change, if a target page styles all `button`s with a border, it applies to our content-script placed dialog when it shouldn't. In the pathological case outlined by #578, where the target page specifies a `button:hover` style with a larger border than the non-hover case, this can cause jerky/flashing reflows of the dialog layout.

This change:
* Suppresses border styling from applying to the dialog's buttons
* Slightly increases the minimum width of the dialog (520px to 550px), to make it less likely to see this sort of reflow in the case that a target page happens to introduce some other type of small width bump

**before:**
![image](https://user-images.githubusercontent.com/376284/56538475-ffb1b400-6517-11e9-9508-b67dfddcb0b8.png)

**after:**
![image](https://user-images.githubusercontent.com/376284/56538443-ea3c8a00-6517-11e9-9afb-9ef556ab5709.png)


#### Pull request checklist

- [x] Addresses an existing issue: Fixes #578 
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.
