### PR TITLE
Fix a11y issue on issue filing setting dialog

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -76,7 +76,7 @@ div.insights-dialog-main-override {
 }
 
 .issue-filing-dialog {
-    #issue-filing-dialog-title {
+    .ms-Dialog-title {
         font-size: 21px;
         line-height: 32px;
         letter-spacing: -0.02em;
@@ -84,7 +84,7 @@ div.insights-dialog-main-override {
         padding-bottom: 0;
     }
 
-    #issue-filing-dialog-subtext {
+    .ms-Dialog-subText {
         font-weight: 400;
         font-size: 15px;
         color: $secondary-text;

--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -73,9 +73,7 @@ export class IssueFilingDialog extends React.Component<IssueFilingDialogProps, I
                 dialogContentProps={{
                     type: DialogType.normal,
                     title: titleLabel,
-                    titleId: 'issue-filing-dialog-title',
                     subText: 'This configuration can be changed again in settings.',
-                    subTextId: 'issue-filing-dialog-subtext',
                     showCloseButton: false,
                 }}
                 modalProps={{

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
@@ -7,9 +7,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have ch
     Object {
       "showCloseButton": false,
       "subText": "This configuration can be changed again in settings.",
-      "subTextId": "issue-filing-dialog-subtext",
       "title": "Specify issue filing location",
-      "titleId": "issue-filing-dialog-title",
       "type": 0,
     }
   }
@@ -91,9 +89,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have no
     Object {
       "showCloseButton": false,
       "subText": "This configuration can be changed again in settings.",
-      "subTextId": "issue-filing-dialog-subtext",
       "title": "Specify issue filing location",
-      "titleId": "issue-filing-dialog-title",
       "type": 0,
     }
   }
@@ -175,9 +171,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have change
     Object {
       "showCloseButton": false,
       "subText": "This configuration can be changed again in settings.",
-      "subTextId": "issue-filing-dialog-subtext",
       "title": "Specify issue filing location",
-      "titleId": "issue-filing-dialog-title",
       "type": 0,
     }
   }
@@ -259,9 +253,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have not ch
     Object {
       "showCloseButton": false,
       "subText": "This configuration can be changed again in settings.",
-      "subTextId": "issue-filing-dialog-subtext",
       "title": "Specify issue filing location",
-      "titleId": "issue-filing-dialog-title",
       "type": 0,
     }
   }
@@ -343,9 +335,7 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
     Object {
       "showCloseButton": false,
       "subText": "This configuration can be changed again in settings.",
-      "subTextId": "issue-filing-dialog-subtext",
       "title": "Specify issue filing location",
-      "titleId": "issue-filing-dialog-title",
       "type": 0,
     }
   }
@@ -428,9 +418,7 @@ exports[`IssueFilingDialog render with isSettingsValid: true 1`] = `
     Object {
       "showCloseButton": false,
       "subText": "This configuration can be changed again in settings.",
-      "subTextId": "issue-filing-dialog-subtext",
       "title": "Specify issue filing location",
-      "titleId": "issue-filing-dialog-title",
       "type": 0,
     }
   }
@@ -512,9 +500,7 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
     Object {
       "showCloseButton": false,
       "subText": "This configuration can be changed again in settings.",
-      "subTextId": "issue-filing-dialog-subtext",
       "title": "Specify issue filing location",
-      "titleId": "issue-filing-dialog-title",
       "type": 0,
     }
   }
@@ -597,9 +583,7 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
     Object {
       "showCloseButton": false,
       "subText": "This configuration can be changed again in settings.",
-      "subTextId": "issue-filing-dialog-subtext",
       "title": "Specify issue filing location",
-      "titleId": "issue-filing-dialog-title",
       "type": 0,
     }
   }
@@ -681,9 +665,7 @@ exports[`IssueFilingDialog render: validate callback (onSelectedServiceChange) s
     Object {
       "showCloseButton": false,
       "subText": "This configuration can be changed again in settings.",
-      "subTextId": "issue-filing-dialog-subtext",
       "title": "Specify issue filing location",
-      "titleId": "issue-filing-dialog-title",
       "type": 0,
     }
   }


### PR DESCRIPTION
#### Description of changes

Dialog component from office fabric use title and subtext (props you pass) as the outer most container div aria labeled by and described by elements through their ids, which normally are generated by office fabric.
Dialog component let you override those ids (so you can have your own css for example).
When overriding the ids, the outer most container doesn't use them, it still use the auto-generated id, meaning, they are referencing an element that doesn't exist and thus axe throws 2 invalid aria attribute values for the dialog.

In order to fix this, I remove the overriding ids and update our css to find the title and text by already existing classes from office fabric.

#### Pull request checklist

- [x] Addresses an existing issue: caught during insider validation
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
