### PR TITLE
fix: update secondary-text color to match design palette

### DIFF
--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -119,6 +119,7 @@
         --communication-shade-10: #ffff00;
         --communication-tint-30: var(--communication-tint-10);
         --communication-tint-40: #38a9ff;
+        --disabled-text: #c285ff;
         --overview-percent-selected: var(--black);
         --index-circle-background: var(--communication-tint-40);
         --header-bar-title-color: var(--brand-blue);

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -15,11 +15,11 @@
 
     // Text colors
     --primary-text: rgba(0, 0, 0, 0.9);
-    --secondary-text: rgba(0, 0, 0, 0.6);
+    --secondary-text: rgba(0, 0, 0, 0.55);
     --disabled-text: rgba(0, 0, 0, 0.38);
     --primary-text-invert: rgba(255, 255, 255, 1);
-    --secondary-text-invert: rgba(0, 0, 0, 0.55);
-    --disabled-text-invert: rgba(0, 0, 0, 0.38);
+    --secondary-text-invert: rgba(255, 255, 255, 0.65);
+    --disabled-text-invert: rgba(255, 255, 255, 0.32);
 
     // UI colors
     --communication-primary: #0078d4;


### PR DESCRIPTION
#### Description of changes

Went through all of the design specs @cheade sent over and verified the color palettes match our CSS. secondary-text was the only one in use that mismatched (the other updates bring the code in line with the palette but are all for cases that are not used anywhere in the product right now).

**Before**:
![image](https://user-images.githubusercontent.com/376284/56618366-3ac6ec80-65d7-11e9-88c1-357f493677c2.png)

**After** (marginally lighter):
![image](https://user-images.githubusercontent.com/376284/56618836-9180f600-65d8-11e9-8541-076445fede54.png)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #594
- [x] **n/a** Added relevant unit test for your changes. (`npm run test`)
- [x] **n/a** Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.
