### PR TITLE
[Refactor] DropdownActionMessageCreator to use ActionMessageDispatcher

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -141,11 +141,7 @@ if (isNaN(tabId) === false) {
                 telemetryFactory,
                 TelemetryEventSource.DetailsView,
             );
-            const dropdownActionMessageCreator = new DropdownActionMessageCreator(
-                chromeAdapter.sendMessageToFrames,
-                tab.id,
-                telemetryFactory,
-            );
+            const dropdownActionMessageCreator = new DropdownActionMessageCreator(telemetryFactory, actionMessageDispatcher);
 
             const bugActionMessageCreator = new BugActionMessageCreator(
                 actionMessageDispatcher,

--- a/src/common/message-creators/dropdown-action-message-creator.ts
+++ b/src/common/message-creators/dropdown-action-message-creator.ts
@@ -5,15 +5,10 @@ import { Message } from '../message';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
 import { TelemetryEventSource } from '../telemetry-events';
-import { BaseActionMessageCreator } from './base-action-message-creator';
+import { ActionMessageDispatcher } from './action-message-dispatcher';
 
-export class DropdownActionMessageCreator extends BaseActionMessageCreator {
-    private telemetryFactory: TelemetryDataFactory;
-
-    constructor(postMessage: (message: Message) => void, tabId: number, telemetryFactory: TelemetryDataFactory) {
-        super(postMessage, tabId);
-        this.telemetryFactory = telemetryFactory;
-    }
+export class DropdownActionMessageCreator {
+    constructor(private readonly telemetryFactory: TelemetryDataFactory, private readonly dispatcher: ActionMessageDispatcher) {}
 
     public openPreviewFeaturesPanel(event: React.MouseEvent<HTMLElement>, source: TelemetryEventSource): void {
         const messageType = Messages.PreviewFeatures.OpenPanel;
@@ -21,11 +16,11 @@ export class DropdownActionMessageCreator extends BaseActionMessageCreator {
         const payload: BaseActionPayload = {
             telemetry,
         };
-        this.dispatchMessage({
+        const message: Message = {
             messageType: messageType,
-            tabId: this._tabId,
             payload,
-        });
+        };
+        this.dispatcher.dispatchMessage(message);
     }
 
     public openScopingPanel(event: React.MouseEvent<HTMLElement>, source: TelemetryEventSource): void {
@@ -34,11 +29,11 @@ export class DropdownActionMessageCreator extends BaseActionMessageCreator {
         const payload: BaseActionPayload = {
             telemetry,
         };
-        this.dispatchMessage({
+        const message = {
             messageType: messageType,
-            tabId: this._tabId,
             payload,
-        });
+        };
+        this.dispatcher.dispatchMessage(message);
     }
 
     public openSettingsPanel(event: React.MouseEvent<HTMLElement>, source: TelemetryEventSource): void {
@@ -47,10 +42,10 @@ export class DropdownActionMessageCreator extends BaseActionMessageCreator {
         const payload: BaseActionPayload = {
             telemetry,
         };
-        this.dispatchMessage({
+        const message = {
             messageType: messageType,
-            tabId: this._tabId,
             payload,
-        });
+        };
+        this.dispatcher.dispatchMessage(message);
     }
 }

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -93,11 +93,7 @@ export class PopupInitializer {
             actionMessageDispatcher,
         );
 
-        const dropdownActionMessageCreator = new DropdownActionMessageCreator(
-            this.chromeAdapter.sendMessageToFrames,
-            this.targetTabInfo.tab.id,
-            telemetryFactory,
-        );
+        const dropdownActionMessageCreator = new DropdownActionMessageCreator(telemetryFactory, actionMessageDispatcher);
 
         const visualizationStoreName = StoreNames[StoreNames.VisualizationStore];
         const commandStoreName = StoreNames[StoreNames.CommandStore];

--- a/src/tests/unit/tests/common/message-creators/dropdown-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/dropdown-action-message-creator.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock, Times } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 import { Message } from '../../../../../common/message';
+import { ActionMessageDispatcher } from '../../../../../common/message-creators/action-message-dispatcher';
 import { DropdownActionMessageCreator } from '../../../../../common/message-creators/dropdown-action-message-creator';
 import { Messages } from '../../../../../common/messages';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
@@ -11,67 +12,58 @@ import { EventStubFactory } from './../../../common/event-stub-factory';
 describe('DropdownActionMessageCreatorTest', () => {
     const eventStubFactory = new EventStubFactory();
     const testSource: TelemetryEventSource = -1 as TelemetryEventSource;
-    let postMessageMock: IMock<(message) => {}>;
     let telemetryFactoryMock: IMock<TelemetryDataFactory>;
-    let testObject: DropdownActionMessageCreator;
-    const tabId: number = -1;
+    const dispatcherMock = Mock.ofType<ActionMessageDispatcher>();
     let event: any;
     let telemetryData: any;
 
+    let testObject: DropdownActionMessageCreator;
+
     beforeEach(() => {
-        postMessageMock = Mock.ofInstance(message => {
-            return null;
-        });
+        dispatcherMock.reset();
         telemetryFactoryMock = Mock.ofType(TelemetryDataFactory);
         event = eventStubFactory.createMouseClickEvent() as any;
         telemetryData = {
             triggeredBy: 'mouseclick',
             source: testSource,
         };
-        testObject = new DropdownActionMessageCreator(postMessageMock.object, tabId, telemetryFactoryMock.object);
+        testObject = new DropdownActionMessageCreator(telemetryFactoryMock.object, dispatcherMock.object);
     });
 
-    test('openPreviewFeatures', () => {
+    it('dispatches message for openPreviewFeaturesPanel', () => {
         const expectedMessage = getExpectedMessage(Messages.PreviewFeatures.OpenPanel);
 
         setupTelemetryFactoryWithTriggeredByAndSourceCall();
-        setupPostMessage(expectedMessage);
 
         testObject.openPreviewFeaturesPanel(event, testSource);
 
-        postMessageMock.verifyAll();
-        telemetryFactoryMock.verifyAll();
+        dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });
 
-    test('openSettings', () => {
+    it('dispatches message for openScopingPanel', () => {
+        const expectedMessage = getExpectedMessage(Messages.Scoping.OpenPanel);
+
+        setupTelemetryFactoryWithTriggeredByAndSourceCall();
+
+        testObject.openScopingPanel(event, testSource);
+
+        dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
+    });
+
+    it('dispatches message foropenSettingsPanel', () => {
         const expectedMessage = getExpectedMessage(Messages.SettingsPanel.OpenPanel);
         const sourceItem: SettingsOpenSourceItem = 'menu';
         expectedMessage.payload.telemetry.sourceItem = sourceItem;
 
         setupTelemetryFactoryForSettingsPanelOpenCall(sourceItem);
-        setupPostMessage(expectedMessage);
 
         testObject.openSettingsPanel(event, testSource);
 
-        postMessageMock.verifyAll();
-        telemetryFactoryMock.verifyAll();
-    });
-
-    it('dispatch message for openScopingPanel', () => {
-        const expectedMessage = getExpectedMessage(Messages.Scoping.OpenPanel);
-
-        setupTelemetryFactoryWithTriggeredByAndSourceCall();
-        setupPostMessage(expectedMessage);
-
-        testObject.openScopingPanel(event, testSource);
-
-        postMessageMock.verifyAll();
-        telemetryFactoryMock.verifyAll();
+        dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });
 
     function getExpectedMessage(messageType: string): Message {
         return {
-            tabId: tabId,
             messageType: messageType,
             payload: {
                 telemetry: telemetryData,
@@ -80,10 +72,7 @@ describe('DropdownActionMessageCreatorTest', () => {
     }
 
     function setupTelemetryFactoryWithTriggeredByAndSourceCall(): void {
-        telemetryFactoryMock
-            .setup(tf => tf.withTriggeredByAndSource(event, testSource))
-            .returns(() => telemetryData)
-            .verifiable(Times.once());
+        telemetryFactoryMock.setup(tf => tf.withTriggeredByAndSource(event, testSource)).returns(() => telemetryData);
     }
 
     function setupTelemetryFactoryForSettingsPanelOpenCall(sourceItem: SettingsOpenSourceItem): void {
@@ -91,9 +80,5 @@ describe('DropdownActionMessageCreatorTest', () => {
             .setup(tf => tf.forSettingsPanelOpen(event, testSource, sourceItem))
             .returns(() => telemetryData)
             .verifiable(Times.once());
-    }
-
-    function setupPostMessage(expectedMessage: Message): void {
-        postMessageMock.setup(post => post(It.isValue(expectedMessage))).verifiable(Times.once());
     }
 });


### PR DESCRIPTION
#### Description of changes

Refactor ContentActionMessageCreator to use ActionMessageDispatcher
Some minor cleanup 
 
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.