### PR TITLE
fix: reduce padding top for help section on overview page

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -1420,7 +1420,6 @@ div.insights-file-issue-details-dialog-container {
                         .help-heading {
                             font-size: 17px;
                             padding: 0px;
-                            margin-block-start: 1em;
                             margin-block-end: 1em;
                             margin-inline-start: 0px;
                             margin-inline-end: 0px;


### PR DESCRIPTION
#### Description of changes

Reduce padding top for help section on overview page. 
Doing this by removing `margin-block-start of 1em` that turns to be added 17px.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #600 
- [ ] Added relevant unit test for your changes. (`npm run test`) - n/a
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` - n/a
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.


#### Screenshot

![image](https://user-images.githubusercontent.com/4496335/56694950-c8b8db00-669c-11e9-8f2a-8b0a0b09fc77.png)
