### PR TITLE
refactor: add snapshot testing to some visual helper toggle tests

### DIFF
--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/restart-scan-visual-helper-toggle.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/restart-scan-visual-helper-toggle.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RestartScanVisualHelperToggleTest onClick: step disabled 1`] = `
+exports[`RestartScanVisualHelperToggleTest onClick: step enabled = false 1`] = `
 <div
   className="visual-helper"
 >
@@ -19,7 +19,7 @@ exports[`RestartScanVisualHelperToggleTest onClick: step disabled 1`] = `
 </div>
 `;
 
-exports[`RestartScanVisualHelperToggleTest onClick: step enabled 1`] = `
+exports[`RestartScanVisualHelperToggleTest onClick: step enabled = true 1`] = `
 <div
   className="visual-helper"
 >

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/restart-scan-visual-helper-toggle.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/restart-scan-visual-helper-toggle.test.tsx.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RestartScanVisualHelperToggleTest onClick: step disabled 1`] = `
+<div
+  className="visual-helper"
+>
+  <div
+    className="visual-helper-text"
+  >
+    Visual helper
+  </div>
+  <VisualizationToggle
+    checked={false}
+    className="visual-helper-toggle"
+    disabled={false}
+    onClick={[Function]}
+    visualizationName="Visual helper"
+  />
+</div>
+`;
+
+exports[`RestartScanVisualHelperToggleTest onClick: step enabled 1`] = `
+<div
+  className="visual-helper"
+>
+  <div
+    className="visual-helper-text"
+  >
+    Visual helper
+  </div>
+  <VisualizationToggle
+    checked={true}
+    className="visual-helper-toggle"
+    disabled={false}
+    onClick={[Function]}
+    visualizationName="Visual helper"
+  />
+</div>
+`;
+
+exports[`RestartScanVisualHelperToggleTest render 1`] = `
+<div
+  className="visual-helper"
+>
+  <div
+    className="visual-helper-text"
+  >
+    Visual helper
+  </div>
+  <VisualizationToggle
+    checked={true}
+    className="visual-helper-toggle"
+    disabled={false}
+    onClick={[Function]}
+    visualizationName="Visual helper"
+  />
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/restart-scan-visual-helper-toggle.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/restart-scan-visual-helper-toggle.test.tsx
@@ -45,7 +45,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
             .build();
 
         assertVisualizationToggle(expectedToggleProps, toggle);
-        assertSnapshotMatching(wrapper);
+        assertSnapshotMatch(wrapper);
     });
 
     test.each([true, false])('onClick: step enabled = %s', stepIsEnabled => {
@@ -67,7 +67,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
         wrapper.find(VisualizationToggle).simulate('click');
 
         actionMessageCreatorMock.verifyAll();
-        assertSnapshotMatching(wrapper);
+        assertSnapshotMatch(wrapper);
     });
 
     function assertVisualizationToggle(
@@ -83,7 +83,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
         });
     }
 
-    function assertSnapshotMatching(toggleWrapper: ShallowWrapper): void {
+    function assertSnapshotMatch(toggleWrapper: ShallowWrapper): void {
         expect(toggleWrapper.getElement()).toMatchSnapshot();
     }
 

--- a/src/tests/unit/tests/DetailsView/components/restart-scan-visual-helper-toggle.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/restart-scan-visual-helper-toggle.test.tsx
@@ -48,36 +48,20 @@ describe('RestartScanVisualHelperToggleTest', () => {
         assertSnapshotMatching(wrapper);
     });
 
-    test('onClick: step enabled', () => {
+    test.each([true, false])('onClick: step enabled = %s', stepIsEnabled => {
         const props = new VisualHelperToggleConfigBuilder()
-            .withToggleStepEnabled(true)
+            .withToggleStepEnabled(stepIsEnabled)
             .withToggleStepScanned(false)
             .withActionMessageCreator(actionMessageCreatorMock.object)
             .build();
-
         const wrapper = shallow(<RestartScanVisualHelperToggle {...props} />);
         actionMessageCreatorMock.reset();
         actionMessageCreatorMock
-            .setup(acm => acm.disableVisualHelper(props.assessmentNavState.selectedTestType, props.assessmentNavState.selectedTestStep))
-            .verifiable(Times.once());
-
-        wrapper.find(VisualizationToggle).simulate('click');
-
-        actionMessageCreatorMock.verifyAll();
-        assertSnapshotMatching(wrapper);
-    });
-
-    test('onClick: step disabled', () => {
-        const props = new VisualHelperToggleConfigBuilder()
-            .withToggleStepEnabled(false)
-            .withToggleStepScanned(false)
-            .withActionMessageCreator(actionMessageCreatorMock.object)
-            .build();
-
-        const wrapper = shallow(<RestartScanVisualHelperToggle {...props} />);
-        actionMessageCreatorMock.reset();
-        actionMessageCreatorMock
-            .setup(acm => acm.enableVisualHelper(props.assessmentNavState.selectedTestType, stepKey))
+            .setup(acm => {
+                return stepIsEnabled
+                    ? acm.disableVisualHelper(props.assessmentNavState.selectedTestType, props.assessmentNavState.selectedTestStep)
+                    : acm.enableVisualHelper(props.assessmentNavState.selectedTestType, stepKey);
+            })
             .verifiable(Times.once());
 
         wrapper.find(VisualizationToggle).simulate('click');

--- a/src/tests/unit/tests/DetailsView/components/restart-scan-visual-helper-toggle.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/restart-scan-visual-helper-toggle.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as Enzyme from 'enzyme';
-import * as _ from 'lodash';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { forEach } from 'lodash';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 import { VisualizationToggle, VisualizationToggleProps } from '../../../../../common/components/visualization-toggle';
@@ -26,7 +26,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
             .withActionMessageCreator(actionMessageCreatorMock.object)
             .build();
 
-        const wrapper = Enzyme.shallow(<RestartScanVisualHelperToggle {...props} />);
+        const wrapper = shallow(<RestartScanVisualHelperToggle {...props} />);
 
         const visualHelperClass = 'visual-helper';
         const toggleDiv = wrapper.find(`.${visualHelperClass}`);
@@ -36,7 +36,6 @@ describe('RestartScanVisualHelperToggleTest', () => {
         const textDiv = toggleDiv.find(`.${visualHelperClass}-text`);
 
         expect(textDiv.exists()).toBe(true);
-        expect(textDiv.childAt(0).text()).toBe(visualHelperText);
 
         const toggle = wrapper.find(VisualizationToggle);
 
@@ -46,6 +45,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
             .build();
 
         assertVisualizationToggle(expectedToggleProps, toggle);
+        assertSnapshotMatching(wrapper);
     });
 
     test('onClick: step enabled', () => {
@@ -55,7 +55,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
             .withActionMessageCreator(actionMessageCreatorMock.object)
             .build();
 
-        const wrapper = Enzyme.shallow(<RestartScanVisualHelperToggle {...props} />);
+        const wrapper = shallow(<RestartScanVisualHelperToggle {...props} />);
         actionMessageCreatorMock.reset();
         actionMessageCreatorMock
             .setup(acm => acm.disableVisualHelper(props.assessmentNavState.selectedTestType, props.assessmentNavState.selectedTestStep))
@@ -64,6 +64,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
         wrapper.find(VisualizationToggle).simulate('click');
 
         actionMessageCreatorMock.verifyAll();
+        assertSnapshotMatching(wrapper);
     });
 
     test('onClick: step disabled', () => {
@@ -73,7 +74,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
             .withActionMessageCreator(actionMessageCreatorMock.object)
             .build();
 
-        const wrapper = Enzyme.shallow(<RestartScanVisualHelperToggle {...props} />);
+        const wrapper = shallow(<RestartScanVisualHelperToggle {...props} />);
         actionMessageCreatorMock.reset();
         actionMessageCreatorMock
             .setup(acm => acm.enableVisualHelper(props.assessmentNavState.selectedTestType, stepKey))
@@ -82,19 +83,24 @@ describe('RestartScanVisualHelperToggleTest', () => {
         wrapper.find(VisualizationToggle).simulate('click');
 
         actionMessageCreatorMock.verifyAll();
+        assertSnapshotMatching(wrapper);
     });
 
     function assertVisualizationToggle(
         expectedProps: VisualizationToggleProps,
-        visualizationToggle: Enzyme.ShallowWrapper<VisualizationToggleProps>,
+        visualizationToggle: ShallowWrapper<VisualizationToggleProps>,
     ): void {
         expect(visualizationToggle.exists()).toBe(true);
 
         const actualProps = visualizationToggle.props();
 
-        _.forEach(expectedProps, (value, key) => {
+        forEach(expectedProps, (value, key) => {
             expect(actualProps[key]).toBe(value);
         });
+    }
+
+    function assertSnapshotMatching(toggleWrapper: ShallowWrapper): void {
+        expect(toggleWrapper.getElement()).toMatchSnapshot();
     }
 
     function getDefaultVisualizationTogglePropsBuilder(): VisualizationTogglePropsBuilder {

--- a/src/tests/unit/tests/assessments/automated-checks/__snapshots__/automated-checks-visualization-toggle.test.tsx.snap
+++ b/src/tests/unit/tests/assessments/automated-checks/__snapshots__/automated-checks-visualization-toggle.test.tsx.snap
@@ -1,0 +1,68 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AutomatedChecksVisualizationToggle render with disabled message 1`] = `
+<div
+  className="visual-helper"
+>
+  <div
+    className="visual-helper-text"
+  >
+    Visual helper
+  </div>
+  <VisualizationToggle
+    checked={false}
+    className="visual-helper-toggle"
+    disabled={true}
+    onClick={[Function]}
+    visualizationName="Visual helper"
+  />
+  <span
+    className="no-matching-elements"
+  >
+    No matching/failing instances were found
+  </span>
+</div>
+`;
+
+exports[`AutomatedChecksVisualizationToggle render: toggle disabled when there are no failing instances for automated checks 1`] = `
+<div
+  className="visual-helper"
+>
+  <div
+    className="visual-helper-text"
+  >
+    Visual helper
+  </div>
+  <VisualizationToggle
+    checked={false}
+    className="visual-helper-toggle"
+    disabled={true}
+    onClick={[Function]}
+    visualizationName="Visual helper"
+  />
+  <span
+    className="no-matching-elements"
+  >
+    No matching/failing instances were found
+  </span>
+</div>
+`;
+
+exports[`AutomatedChecksVisualizationToggle render: toggle not disabled 1`] = `
+<div
+  className="visual-helper"
+>
+  <div
+    className="visual-helper-text"
+  >
+    Visual helper
+  </div>
+  <VisualizationToggle
+    checked={false}
+    className="visual-helper-toggle"
+    disabled={false}
+    onClick={[Function]}
+    visualizationName="Visual helper"
+  />
+</div>
+`;

--- a/src/tests/unit/tests/assessments/automated-checks/automated-checks-visualization-toggle.test.tsx
+++ b/src/tests/unit/tests/assessments/automated-checks/automated-checks-visualization-toggle.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as Enzyme from 'enzyme';
-import * as _ from 'lodash';
+import { shallow, ShallowWrapper } from 'enzyme';
+import { forEach } from 'lodash';
 import * as React from 'react';
 import { IMock, Mock } from 'typemoq';
 import { AutomatedChecksVisualizationToggle } from '../../../../../assessments/automated-checks/automated-checks-visualization-enabled-toggle';
@@ -22,19 +22,15 @@ describe('AutomatedChecksVisualizationToggle', () => {
             .withEmptyFilteredMap()
             .build();
 
-        const wrapper = Enzyme.shallow(<AutomatedChecksVisualizationToggle {...props} />);
+        const wrapper = shallow(<AutomatedChecksVisualizationToggle {...props} />);
 
         const visualHelperClass = 'visual-helper';
         const toggleDiv = wrapper.find(`.${visualHelperClass}`);
+        const textDiv = toggleDiv.find(`.${visualHelperClass}-text`);
+        const noMatchesWarningClass = 'no-matching-elements';
 
         expect(toggleDiv.exists()).toBeTruthy();
-
-        const textDiv = toggleDiv.find(`.${visualHelperClass}-text`);
-
         expect(textDiv.exists()).toBeTruthy();
-        expect(textDiv.childAt(0).text()).toEqual(visualHelperText);
-
-        const noMatchesWarningClass = 'no-matching-elements';
         expect(wrapper.find(`.${noMatchesWarningClass}`).exists()).toBeTruthy();
 
         const toggle = wrapper.find(VisualizationToggle);
@@ -45,6 +41,8 @@ describe('AutomatedChecksVisualizationToggle', () => {
             .build();
 
         assertVisualizationToggle(expectedToggleProps, toggle);
+
+        assertSnapshotMatch(wrapper);
     });
 
     it('render: toggle not disabled', () => {
@@ -55,7 +53,7 @@ describe('AutomatedChecksVisualizationToggle', () => {
             .withNonEmptyFilteredMap()
             .build();
 
-        const wrapper = Enzyme.shallow(<AutomatedChecksVisualizationToggle {...props} />);
+        const wrapper = shallow(<AutomatedChecksVisualizationToggle {...props} />);
 
         const visualHelperClass = 'visual-helper';
         const toggleDiv = wrapper.find(`.${visualHelperClass}`);
@@ -65,7 +63,7 @@ describe('AutomatedChecksVisualizationToggle', () => {
         const textDiv = toggleDiv.find(`.${visualHelperClass}-text`);
 
         expect(textDiv.exists()).toBeTruthy();
-        expect(textDiv.childAt(0).text()).toEqual(visualHelperText);
+
         expect(wrapper.find('strong').exists()).toBeFalsy();
         const toggle = wrapper.find(VisualizationToggle);
 
@@ -75,6 +73,7 @@ describe('AutomatedChecksVisualizationToggle', () => {
             .build();
 
         assertVisualizationToggle(expectedToggleProps, toggle);
+        assertSnapshotMatch(wrapper);
     });
 
     it('render: toggle disabled when there are no failing instances for automated checks', () => {
@@ -85,7 +84,7 @@ describe('AutomatedChecksVisualizationToggle', () => {
             .withPassingFilteredMap()
             .build();
 
-        const wrapper = Enzyme.shallow(<AutomatedChecksVisualizationToggle {...props} />);
+        const wrapper = shallow(<AutomatedChecksVisualizationToggle {...props} />);
         const visualHelperClass = 'visual-helper';
         const toggleDiv = wrapper.find(`.${visualHelperClass}`);
 
@@ -94,7 +93,6 @@ describe('AutomatedChecksVisualizationToggle', () => {
         const textDiv = toggleDiv.find(`.${visualHelperClass}-text`);
 
         expect(textDiv.exists()).toBeTruthy();
-        expect(textDiv.childAt(0).text()).toEqual(visualHelperText);
 
         const noMatchesWarningClass = 'no-matching-elements';
         expect(wrapper.find(`.${noMatchesWarningClass}`).exists()).toBeTruthy();
@@ -107,19 +105,24 @@ describe('AutomatedChecksVisualizationToggle', () => {
             .build();
 
         assertVisualizationToggle(expectedToggleProps, toggle);
+        assertSnapshotMatch(wrapper);
     });
 
     function assertVisualizationToggle(
         expectedProps: VisualizationToggleProps,
-        visualizationToggle: Enzyme.ShallowWrapper<VisualizationToggleProps>,
+        visualizationToggle: ShallowWrapper<VisualizationToggleProps>,
     ): void {
         expect(visualizationToggle.exists()).toBeTruthy();
 
         const actualProps = visualizationToggle.props();
 
-        _.forEach(expectedProps, (value, key) => {
+        forEach(expectedProps, (value, key) => {
             expect(actualProps[key]).toEqual(value);
         });
+    }
+
+    function assertSnapshotMatch(wrapper: ShallowWrapper): void {
+        expect(wrapper.getElement()).toMatchSnapshot();
     }
 
     function getDefaultVisualizationTogglePropsBuilder(): VisualizationTogglePropsBuilder {

--- a/src/tests/unit/tests/assessments/automated-checks/automated-checks-visualization-toggle.test.tsx
+++ b/src/tests/unit/tests/assessments/automated-checks/automated-checks-visualization-toggle.test.tsx
@@ -29,9 +29,9 @@ describe('AutomatedChecksVisualizationToggle', () => {
         const textDiv = toggleDiv.find(`.${visualHelperClass}-text`);
         const noMatchesWarningClass = 'no-matching-elements';
 
-        expect(toggleDiv.exists()).toBeTruthy();
-        expect(textDiv.exists()).toBeTruthy();
-        expect(wrapper.find(`.${noMatchesWarningClass}`).exists()).toBeTruthy();
+        expect(toggleDiv.exists()).toBe(true);
+        expect(textDiv.exists()).toBe(true);
+        expect(wrapper.find(`.${noMatchesWarningClass}`).exists()).toBe(true);
 
         const toggle = wrapper.find(VisualizationToggle);
 
@@ -41,7 +41,6 @@ describe('AutomatedChecksVisualizationToggle', () => {
             .build();
 
         assertVisualizationToggle(expectedToggleProps, toggle);
-
         assertSnapshotMatch(wrapper);
     });
 
@@ -58,11 +57,11 @@ describe('AutomatedChecksVisualizationToggle', () => {
         const visualHelperClass = 'visual-helper';
         const toggleDiv = wrapper.find(`.${visualHelperClass}`);
 
-        expect(toggleDiv.exists()).toBeTruthy();
+        expect(toggleDiv.exists()).toBe(true);
 
         const textDiv = toggleDiv.find(`.${visualHelperClass}-text`);
 
-        expect(textDiv.exists()).toBeTruthy();
+        expect(textDiv.exists()).toBe(true);
 
         expect(wrapper.find('strong').exists()).toBeFalsy();
         const toggle = wrapper.find(VisualizationToggle);
@@ -88,16 +87,17 @@ describe('AutomatedChecksVisualizationToggle', () => {
         const visualHelperClass = 'visual-helper';
         const toggleDiv = wrapper.find(`.${visualHelperClass}`);
 
-        expect(toggleDiv.exists()).toBeTruthy();
+        expect(toggleDiv.exists()).toBe(true);
 
         const textDiv = toggleDiv.find(`.${visualHelperClass}-text`);
 
-        expect(textDiv.exists()).toBeTruthy();
+        expect(textDiv.exists()).toBe(true);
 
         const noMatchesWarningClass = 'no-matching-elements';
-        expect(wrapper.find(`.${noMatchesWarningClass}`).exists()).toBeTruthy();
 
         const toggle = wrapper.find(VisualizationToggle);
+
+        expect(wrapper.find(`.${noMatchesWarningClass}`).exists()).toBe(true);
 
         const expectedToggleProps = getDefaultVisualizationTogglePropsBuilder()
             .with('checked', false)
@@ -112,7 +112,7 @@ describe('AutomatedChecksVisualizationToggle', () => {
         expectedProps: VisualizationToggleProps,
         visualizationToggle: ShallowWrapper<VisualizationToggleProps>,
     ): void {
-        expect(visualizationToggle.exists()).toBeTruthy();
+        expect(visualizationToggle.exists()).toBe(true);
 
         const actualProps = visualizationToggle.props();
 


### PR DESCRIPTION
#### Description of changes

Refactor some tests to rather match snapshots instead of checking for text of an element directly.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000 
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
