### PR TITLE
Update references to Chrome to reflect Edge Insider

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,7 +38,7 @@ If applicable, add screenshots to help explain your problem.
 
 - OS: [e.g. Windows/Mac]
 - Version [e.g. 1.140.1]
-- Chrome Version [e.g 71.0]
+- Browser Version [e.g Chrome 71.0]
 - Target Page [e.g www.bing.com]
 
 ## Are you willing to submit a PR?

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Licensed under the MIT License.
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/users/pbjjkligggfmakdaogkfomddhfmpjeni.svg)](https://chrome.google.com/webstore/detail/accessibility-insights-fo/pbjjkligggfmakdaogkfomddhfmpjeni)
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/stars/pbjjkligggfmakdaogkfomddhfmpjeni.svg)](https://chrome.google.com/webstore/detail/accessibility-insights-fo/pbjjkligggfmakdaogkfomddhfmpjeni/reviews)
 
-Accessibility Insights for Web is a Google Chrome extension for assessing the accessibility of web sites and web applications.
+Accessibility Insights for Web is a Google Chrome and Microsoft Edge Insider browser extension for assessing the accessibility of web sites and web applications.
 
 ### Running the extension
 
@@ -71,7 +71,7 @@ Please ensure that you have at least the **minimum** recommended versions
     ```bash
     npm run build
     ```
--   Add the extension to your Chrome browser
+-   Add the extension to your browser
 
     -   Click on the 3-dotted-menu in the upper right corner and then select "More Tools" and then "Extensions"
     -   Verify that **developer mode** is enabled in the upper right

--- a/src/assessments/custom-widgets/test-steps/cues.tsx
+++ b/src/assessments/custom-widgets/test-steps/cues.tsx
@@ -38,7 +38,7 @@ const cuesHowToTest: JSX.Element = (
                 </ol>
             </li>
             <li>
-                If a widget <Markup.Emphasis>does</Markup.Emphasis> adopt any of these states, inspect its HTML using the Chrome Developer
+                If a widget <Markup.Emphasis>does</Markup.Emphasis> adopt any of these states, inspect its HTML using the browser Developer
                 Tools to verify that the states are appropriately coded.
                 <ol>
                     <li>

--- a/src/assessments/custom-widgets/test-steps/role-state-property.tsx
+++ b/src/assessments/custom-widgets/test-steps/role-state-property.tsx
@@ -38,7 +38,7 @@ const roleStatePropertyHowToTest: JSX.Element = (
             <li>
                 Inspect the widget's HTML using the{' '}
                 <NewTabLink href="https://developers.google.com/web/updates/2018/01/devtools">
-                    Accessibility pane in the Chrome Developer Tools
+                    Accessibility pane in the browser Developer Tools
                 </NewTabLink>{' '}
                 to verify that it supports all of the roles, states, and properties specified by its design pattern:
                 <ul>

--- a/src/assessments/native-widgets/test-steps/cues.tsx
+++ b/src/assessments/native-widgets/test-steps/cues.tsx
@@ -44,7 +44,7 @@ const howToTest: JSX.Element = (
                 </ol>
             </li>
             <li>
-                If a widget <Markup.Emphasis>does</Markup.Emphasis> adopt any of these states, inspect its HTML using the Chrome Developer
+                If a widget <Markup.Emphasis>does</Markup.Emphasis> adopt any of these states, inspect its HTML using the browser Developer
                 Tools to verify that the states are appropriately coded.
                 <ol>
                     <li>

--- a/src/assessments/parsing/test-steps/parsing.tsx
+++ b/src/assessments/parsing/test-steps/parsing.tsx
@@ -28,13 +28,13 @@ const howToTest: JSX.Element = (
                 window.
             </li>
             <li>
-                Add these two bookmarklets to your Chrome bookmarks:
+                Add these two bookmarklets to your browser bookmarks:
                 <ol>
                     <li>Check serialized DOM of current page</li>
                     <li>Check for WCAG 2.0 parsing compliance</li>
                 </ol>
                 <p>
-                    (Mouse users can simply drag the corresponding links from the page to the Chrome bookmarks bar. Keyboard users can
+                    (Mouse users can simply drag the corresponding links from the page to the browser bookmarks bar. Keyboard users can
                     follow <NewTabLink href={keyboardBookmarkletInstructionsURL}>these instructions</NewTabLink>.)
                 </p>
             </li>

--- a/src/assessments/repetitive-content/test-steps/consistent-identification.tsx
+++ b/src/assessments/repetitive-content/test-steps/consistent-identification.tsx
@@ -22,7 +22,7 @@ const consistentIdentificationHowToTest: JSX.Element = (
             <li>
                 Use the{' '}
                 <NewTabLink href="https://developers.google.com/web/updates/2018/01/devtools">
-                    Accessibility pane in the Chrome Developer Tools
+                    Accessibility pane in the browser Developer Tools
                 </NewTabLink>{' '}
                 to verify that the component has the same accessible name each time it appears.
             </li>

--- a/src/assessments/semantics/test-steps/data-tables.tsx
+++ b/src/assessments/semantics/test-steps/data-tables.tsx
@@ -13,15 +13,15 @@ const dataTablesDescription: JSX.Element = <span>Semantic elements in a data tab
 const dataTablesHowToTest: JSX.Element = (
     <div>
         <p>
-            This procedure uses the Chrome{' '}
+            This procedure uses the{' '}
             <NewTabLink href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">
                 Web Developer
             </NewTabLink>{' '}
-            extension.
+            browser extension.
         </p>
         <ol>
             <li>
-                Use the Chrome Web Developer extension (<Markup.Term>Information > Outline tables</Markup.Term>) to highlight tables on the
+                Use the Web Developer browser extension (<Markup.Term>Outline > Outline tables</Markup.Term>) to highlight tables on the
                 page.
             </li>
             <li>
@@ -37,7 +37,7 @@ const dataTablesHowToTest: JSX.Element = (
                 </ol>
             </li>
             <li>
-                Use the Chrome Web Developer extension (<Markup.Term>Information > Display ARIA Roles</Markup.Term>) to verify that none of
+                Use the Web Developer browser extension (<Markup.Term>Information > Display ARIA Roles</Markup.Term>) to verify that none of
                 its elements is coded with <Markup.Term>role="presentation"</Markup.Term>.
             </li>
             <ManualTestRecordYourResults isMultipleFailurePossible={true} />

--- a/src/assessments/semantics/test-steps/emphasis.tsx
+++ b/src/assessments/semantics/test-steps/emphasis.tsx
@@ -14,7 +14,7 @@ const emphasisDescription: JSX.Element = (
 
 const emphasisHowToTest: JSX.Element = (
     <div>
-        <p>This procedure uses the Chrome Developer Tools (F12) to inspect the page's HTML.</p>
+        <p>This procedure uses the browser Developer Tools (F12) to inspect the page's HTML.</p>
         <ol>
             <li>Examine the target page to identify any visually emphasized words or phrases.</li>
             <li>

--- a/src/assessments/semantics/test-steps/letter-spacing.tsx
+++ b/src/assessments/semantics/test-steps/letter-spacing.tsx
@@ -12,7 +12,7 @@ const letterSpacingDescription: JSX.Element = (
 
 const letterSpacingHowToTest: JSX.Element = (
     <div>
-        <p>This procedure uses the Chrome Developer Tools (F12) to inspect the page's HTML.</p>
+        <p>This procedure uses the browser Developer Tools (F12) to inspect the page's HTML.</p>
         <ol>
             <li>Examine the target page to identify any words that appear to have increased spacing between letters.</li>
             <li>

--- a/src/assessments/semantics/test-steps/lists.tsx
+++ b/src/assessments/semantics/test-steps/lists.tsx
@@ -12,7 +12,7 @@ const listsDescription: JSX.Element = <span>Lists must be contained within seman
 
 const listsHowToTest: JSX.Element = (
     <div>
-        <p>This procedure uses the Chrome Developer Tools (F12) to inspect the page's HTML.</p>
+        <p>This procedure uses the browser Developer Tools (F12) to inspect the page's HTML.</p>
         <p>
             <Markup.Emphasis>
                 Note: This requirement applies to list containers. An automated check will fail if list items are incorrectly coded.

--- a/src/assessments/semantics/test-steps/quotes.tsx
+++ b/src/assessments/semantics/test-steps/quotes.tsx
@@ -15,7 +15,7 @@ const quotesDescription: JSX.Element = (
 
 const quotesHowToTest: JSX.Element = (
     <div>
-        <p>This procedure uses the Chrome Developer Tools (F12) to inspect the page's HTML.</p>
+        <p>This procedure uses the browser Developer Tools (F12) to inspect the page's HTML.</p>
         <ol>
             <li>
                 Search the page's HTML to determine whether the page includes any <Markup.Tag tagName="blockquote" /> elements.

--- a/src/assessments/sequence/test-steps/columns.tsx
+++ b/src/assessments/sequence/test-steps/columns.tsx
@@ -11,7 +11,7 @@ const description: JSX.Element = <span>White space characters must not be used t
 
 const howToTest: JSX.Element = (
     <div>
-        <p>This procedure uses the Chrome Developer Tools (F12) to inspect the page's HTML.</p>
+        <p>This procedure uses the browser Developer Tools (F12) to inspect the page's HTML.</p>
         <ol>
             <li>
                 Search the page's HTML to determine whether the page includes any <Markup.Tag tagName="pre" /> elements.

--- a/src/assessments/sequence/test-steps/css-positioning.tsx
+++ b/src/assessments/sequence/test-steps/css-positioning.tsx
@@ -22,11 +22,11 @@ const howToTest: JSX.Element = (
             <Markup.Term>position:absolute</Markup.Term> or <Markup.Term>float:right</Markup.Term>.
         </p>
         <p>
-            This procedure also uses the Chrome{' '}
+            This procedure also uses the{' '}
             <NewTabLink href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">
                 Web Developer
             </NewTabLink>{' '}
-            extension.
+            browser extension.
         </p>
         <ol>
             <li>
@@ -43,7 +43,7 @@ const howToTest: JSX.Element = (
                 </ol>
             </li>
             <li>
-                If the page does have meaningful positioned content, use the Chrome Web Developer extension (
+                If the page does have meaningful positioned content, use the Web Developer browser extension (
                 <Markup.Term>Miscellaneous > Linearize page</Markup.Term>) to show the page in DOM order.
             </li>
             <li>Verify that the positioned content retains its meaning when the page is linearized.</li>

--- a/src/assessments/sequence/test-steps/layout-tables.tsx
+++ b/src/assessments/sequence/test-steps/layout-tables.tsx
@@ -13,15 +13,15 @@ const description: JSX.Element = <span>The content in an HTML layout table must 
 const howToTest: JSX.Element = (
     <div>
         <p>
-            This procedure uses the Chrome{' '}
+            This procedure uses the{' '}
             <NewTabLink href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">
                 Web Developer
             </NewTabLink>{' '}
-            extension.
+            browser extension.
         </p>
         <ol>
             <li>
-                Use the Chrome Web Developer extension (<Markup.Term>Outline > Outline Tables</Markup.Term>) to identify any{' '}
+                Use the Web Developer extension (<Markup.Term>Outline > Outline Tables</Markup.Term>) to identify any{' '}
                 <Markup.Tag tagName="table" /> elements in the target page.
             </li>
             <li>
@@ -37,7 +37,7 @@ const howToTest: JSX.Element = (
                 </ol>
             </li>
             <li>
-                If you find a layout table, use the Chrome Web Developer extension (
+                If you find a layout table, use the Web Developer browser extension (
                 <Markup.Term>Miscellaneous > Linearize page</Markup.Term>) to show the page in DOM order.
             </li>
             <li>Verify that content in layout tables still has the correct reading order when the page is linearized.</li>

--- a/src/assessments/text-legibility/test-steps/high-contrast-mode.tsx
+++ b/src/assessments/text-legibility/test-steps/high-contrast-mode.tsx
@@ -14,7 +14,7 @@ const highContrastModeDescription: JSX.Element = (
 
 const highContrastModeHowToTest: JSX.Element = (
     <div>
-        Chrome does not support Windows' high contrast mode.
+        Chrome and Edge Insider do not support Windows' high contrast mode.
         <ol>
             <li>Open the target page in Microsoft Edge.</li>
             <li>

--- a/src/assessments/text-legibility/test-steps/resize-text.tsx
+++ b/src/assessments/text-legibility/test-steps/resize-text.tsx
@@ -27,7 +27,7 @@ const resizeTextHowToTest: JSX.Element = (
                     <li>Set scaling to 100%.</li>
                 </ol>
             </li>
-            <li>Use Chrome's settings to set the target page's zoom to 200%.</li>
+            <li>Use the browser's settings to set the target page's zoom to 200%.</li>
             <li>
                 Examine the target page to verify that:
                 <ol>

--- a/src/common/constants/displayable-strings.ts
+++ b/src/common/constants/displayable-strings.ts
@@ -5,7 +5,7 @@ import { title } from '../../content/strings/application';
 export class DisplayableStrings {
     public static previewFeaturesDescription: string =
         'The following preview features are available for your evalution. Help us make them better!';
-    public static fileUrlDoesNotHaveAccess: string = `Your Chrome settings don't allow ${title} to run on file URLs.`;
+    public static fileUrlDoesNotHaveAccess: string = `Your browser settings don't allow ${title} to run on file URLs.`;
     public static urlNotScannable: string[] = [`${title} can't run on this URL.`, "You'll need to go to a different page."];
     public static noPreviewFeatureDisplayMessage: string =
         'No preview features are currently available to manage. Follow this page for future cool features.';

--- a/src/common/navigator-utils.ts
+++ b/src/common/navigator-utils.ts
@@ -8,12 +8,26 @@ export class NavigatorUtils {
 
     public getBrowserSpec(): string {
         const userAgent = this.navigatorInfo.userAgent;
-        const versionOffset = userAgent.indexOf('Chrome');
-        if (versionOffset === -1) {
-            return userAgent;
-        }
-        const fullVersion = userAgent.substring(versionOffset + 7).split(' ')[0];
 
-        return `Chrome version ${fullVersion}`;
+        const edgeVersion = this.getVersion(userAgent, 'Edg');
+        if (edgeVersion !== null) {
+            return `Edge version ${edgeVersion}`;
+        }
+
+        const chromeVersion = this.getVersion(userAgent, 'Chrome');
+        if (chromeVersion !== null) {
+            return `Chrome version ${chromeVersion}`;
+        }
+
+        return userAgent;
+    }
+
+    private getVersion(userAgent: string, versionPrefix: string): string {
+        const versionOffset = userAgent.indexOf(versionPrefix);
+        if (versionOffset === -1) {
+            return null;
+        }
+
+        return userAgent.substring(versionOffset + versionPrefix.length + 1).split(' ')[0];
     }
 }

--- a/src/content/test/parsing/keyboard-bookmarklet-instructions.tsx
+++ b/src/content/test/parsing/keyboard-bookmarklet-instructions.tsx
@@ -5,13 +5,14 @@ import { create, React } from '../../common';
 
 export const keyboardBookmarkletInstructions = create(({ Markup }) => (
     <>
-        <Markup.Title>Using a keyboard to add the Nu HTML Checker bookmarklets to Chrome</Markup.Title>
+        <Markup.Title>Using a keyboard to add the Nu HTML Checker bookmarklets</Markup.Title>
+        <h2>Google Chrome instructions</h2>
         <ol>
             <li>
-                Open the Chrome <Markup.Term>Bookmarks Manager</Markup.Term>:
+                Open the Chrome <Markup.Term>Bookmarks</Markup.Term> manager:
                 <ol type="a">
                     <li>
-                        In Chrome, type <Markup.Term>Ctrl + Shift + o</Markup.Term> or <Markup.Term>⌘ + Option + b</Markup.Term>
+                        In Chrome, type <Markup.Term>Ctrl + Shift + o</Markup.Term> or <Markup.Term>⌘ + Option + b</Markup.Term>.
                     </li>
                     <li>
                         A new browser tab called <Markup.Term>Bookmarks</Markup.Term> will open.
@@ -75,7 +76,81 @@ export const keyboardBookmarkletInstructions = create(({ Markup }) => (
             </li>
 
             <li>
-                Close the <Markup.Term>Bookmarks Manager</Markup.Term> tab.
+                Close the <Markup.Term>Bookmarks</Markup.Term> tab.
+            </li>
+        </ol>
+
+        <h2>Microsoft Edge Insider instructions</h2>
+        <ol>
+            <li>
+                Open the Edge Insider <Markup.Term>Favorites</Markup.Term> manager:
+                <ol type="a">
+                    <li>
+                        In Edge Insider, type <Markup.Term>Ctrl + Shift + o</Markup.Term>.
+                    </li>
+                    <li>
+                        A new browser tab called <Markup.Term>Favorites</Markup.Term> will open.
+                    </li>
+                </ol>
+            </li>
+
+            <li>
+                Add the first bookmarklet (<Markup.Term>Check serialized DOM of current page</Markup.Term>):
+                <ol type="a">
+                    <li>
+                        Open the <Markup.Term>Add favorite</Markup.Term> dialog:
+                        <ol type="i">
+                            <li>Navigate to the Add Favorite button and activate it.</li>
+                            <li>The Add favorite dialog will open.</li>
+                        </ol>
+                    </li>
+
+                    <li>
+                        Add the bookmarklet's name to the <Markup.Term>Name</Markup.Term> field.
+                    </li>
+
+                    <li>
+                        Add the bookmarklet's JavaScript code to the <Markup.Term>URL</Markup.Term> field:
+                        <ol type="i">
+                            <li>
+                                Go to{' '}
+                                <NewTabLink href="https://validator.w3.org/nu/about.html">
+                                    https://validator.w3.org/nu/about.html
+                                </NewTabLink>
+                                .
+                            </li>
+                            <li>Navigate to the bookmark link.</li>
+                            <li>
+                                Open the context menu and select <Markup.Term>Copy link</Markup.Term>.
+                            </li>
+                            <li>
+                                Return to the <Markup.Term>Add favorite dialog</Markup.Term> and paste the link address into the{' '}
+                                <Markup.Term>URL</Markup.Term> field.
+                            </li>
+                        </ol>
+                    </li>
+
+                    <li>
+                        Save the new favorite.
+                        <ol type="i">
+                            <li>
+                                Navigate to the <Markup.Term>Save</Markup.Term> button and activate it.
+                            </li>
+                            <li>
+                                The bookmarklet will be added to the end of the <Markup.Term>Favorites</Markup.Term> bar, and the{' '}
+                                <Markup.Term>Add favorite</Markup.Term> dialog will close.
+                            </li>
+                        </ol>
+                    </li>
+                </ol>
+            </li>
+
+            <li>
+                Repeat steps 2a through 2d to add the second bookmarklet (<Markup.Term>Check for WCAG 2.0 parsing compliance</Markup.Term>).
+            </li>
+
+            <li>
+                Close the <Markup.Term>Favorites</Markup.Term> tab.
             </li>
         </ol>
     </>

--- a/src/content/test/parsing/keyboard-bookmarklet-instructions.tsx
+++ b/src/content/test/parsing/keyboard-bookmarklet-instructions.tsx
@@ -9,8 +9,6 @@ export const keyboardBookmarkletInstructions = create(({ Markup }) => (
         <ol>
             <li>
                 Open the Chrome <Markup.Term>Bookmarks Manager</Markup.Term>:
-            </li>
-            <li>
                 <ol type="a">
                     <li>
                         In Chrome, type <Markup.Term>Ctrl + Shift + o</Markup.Term> or <Markup.Term>⌘ + Option + b</Markup.Term>
@@ -23,14 +21,9 @@ export const keyboardBookmarkletInstructions = create(({ Markup }) => (
 
             <li>
                 Add the first bookmarklet (<Markup.Term>Check serialized DOM of current page</Markup.Term>):
-            </li>
-
-            <li>
                 <ol type="a">
                     <li>
                         Open the <Markup.Term>Add bookmark</Markup.Term> dialog:
-                    </li>
-                    <li>
                         <ol type="i">
                             <li>Navigate to the Organize menu button and activate it.</li>
                             <li>Arrow down to Add new bookmark and activate it. The Add bookmark dialog will open.</li>
@@ -43,8 +36,6 @@ export const keyboardBookmarkletInstructions = create(({ Markup }) => (
 
                     <li>
                         Add the bookmarklet's JavaScript code to the <Markup.Term>URL</Markup.Term> field:
-                    </li>
-                    <li>
                         <ol type="i">
                             <li>
                                 Go to{' '}
@@ -64,27 +55,27 @@ export const keyboardBookmarkletInstructions = create(({ Markup }) => (
                         </ol>
                     </li>
 
-                    <li>Save the new bookmark.</li>
-
                     <li>
-                        <ul>
+                        Save the new bookmark.
+                        <ol type="i">
                             <li>
-                                Navigate to the <Markup.Term>Save</Markup.Term> button and activate it. The bookmarklet will be added to the
-                                end of the <Markup.Term>Bookmarks</Markup.Term> bar, and the <Markup.Term>Add bookmark</Markup.Term> dialog
-                                will close.
+                                Navigate to the <Markup.Term>Save</Markup.Term> button and activate it.
                             </li>
-                        </ul>
-                    </li>
-
-                    <li>
-                        Repeat steps 2a through 2d to add the second bookmarklet (
-                        <Markup.Term>Check for WCAG 2.0 parsing compliance</Markup.Term>).
-                    </li>
-
-                    <li>
-                        Close the <Markup.Term>Bookmarks Manager</Markup.Term> tab.
+                            <li>
+                                The bookmarklet will be added to the end of the <Markup.Term>Bookmarks</Markup.Term> bar, and the{' '}
+                                <Markup.Term>Add bookmark</Markup.Term> dialog will close.
+                            </li>
+                        </ol>
                     </li>
                 </ol>
+            </li>
+
+            <li>
+                Repeat steps 2a through 2d to add the second bookmarklet (<Markup.Term>Check for WCAG 2.0 parsing compliance</Markup.Term>).
+            </li>
+
+            <li>
+                Close the <Markup.Term>Bookmarks Manager</Markup.Term> tab.
             </li>
         </ol>
     </>

--- a/src/injected/components/details-dialog.tsx
+++ b/src/injected/components/details-dialog.tsx
@@ -219,7 +219,7 @@ export class DetailsDialog extends React.Component<DetailsDialogProps, DetailsDi
         if (this.props.dialogHandler.isInspectButtonDisabled(this)) {
             return (
                 <div className="insights-dialog-inspect-disabled">
-                    {`To enable the Inspect HTML button, open the Chrome dev tools (${this.props.devToolsShortcut}).`}
+                    {`To enable the Inspect HTML button, open the developer tools (${this.props.devToolsShortcut}).`}
                 </div>
             );
         }

--- a/src/tests/unit/tests/common/navigator-utils.test.ts
+++ b/src/tests/unit/tests/common/navigator-utils.test.ts
@@ -5,8 +5,15 @@ import { NavigatorUtils } from '../../../../common/navigator-utils';
 describe('NavigatorUtilsTest', () => {
     test('getEnvironmentInfo: chrome', () => {
         validateBrowserSpecReturnedWithUserAgent(
-            `Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36`,
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36',
             'Chrome version 65.0.3325.181',
+        );
+    });
+
+    test('getEnvironmentInfo: edge', () => {
+        validateBrowserSpecReturnedWithUserAgent(
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3763.0 Safari/537.36 Edg/75.0.131.0',
+            'Edge version 75.0.131.0',
         );
     });
 

--- a/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
@@ -207,7 +207,7 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
         <div
           className="insights-dialog-inspect-disabled"
         >
-          To enable the Inspect HTML button, open the Chrome dev tools (shortcut).
+          To enable the Inspect HTML button, open the developer tools (shortcut).
         </div>
       </div>
     </div>
@@ -586,7 +586,7 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: true }
           <div
             className="insights-dialog-inspect-disabled"
           >
-            To enable the Inspect HTML button, open the Chrome dev tools (shortcut).
+            To enable the Inspect HTML button, open the developer tools (shortcut).
           </div>
         </div>
       </div>
@@ -1697,7 +1697,7 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
         <div
           className="insights-dialog-inspect-disabled"
         >
-          To enable the Inspect HTML button, open the Chrome dev tools (shortcut).
+          To enable the Inspect HTML button, open the developer tools (shortcut).
         </div>
       </div>
     </div>

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -82,7 +82,7 @@ exports[`PopupView renderFailureMsgPanelForFileUrl 1`] = `
     <div
       className="launch-panel-general-container"
     >
-      Your Chrome settings don't allow Accessibility Insights for Web to run on file URLs.
+      Your browser settings don't allow Accessibility Insights for Web to run on file URLs.
     </div>
     <div>
       <div>


### PR DESCRIPTION
#### Description of changes

- Update references to Chrome in README, the bug report template, How to Test text, bookmarklet instructions, the details dialog, the file URL permission error,

 bug descriptions, and export reports to reflect that our extension can run in Edge Insider as well as Chrome.

#### Pull request checklist

- [X] Addresses an existing issue: Fixes 1517252
- [X] Added relevant unit test for your changes. (`npm run test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`npm run precheckin`)
- [X] Added screenshots/GIFs for UI changes.

#### Screenshots

##### Representative How to Test updates
![image](https://user-images.githubusercontent.com/1752950/56760861-ed6e8a80-6750-11e9-9cbc-a7fc21214b64.png)
![image](https://user-images.githubusercontent.com/1752950/56760988-33c3e980-6751-11e9-9926-5a401b915e91.png)

##### Bookmarklet instructions
![image](https://user-images.githubusercontent.com/1752950/56760904-07a86880-6751-11e9-9159-5b25af064622.png)

##### Details dialog
![image](https://user-images.githubusercontent.com/1752950/56761475-3c68ef80-6752-11e9-81c7-d0d14e704295.png)

##### Export reports
![image](https://user-images.githubusercontent.com/1752950/56761389-17747c80-6752-11e9-9658-7e4dd6c354eb.png)
![image](https://user-images.githubusercontent.com/1752950/56761334-ebf19200-6751-11e9-9db2-d33507beb241.png)

##### Bug descriptions
![image](https://user-images.githubusercontent.com/1752950/56761549-776b2300-6752-11e9-94ed-3ee7d9f652ea.png)


