### PR TITLE
[Refactor] Issue filing handling

### DIFF
--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -3,7 +3,6 @@
 import { cloneDeep, isEqual } from 'lodash';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import * as React from 'react';
-
 import { BugFilingServiceProvider } from '../../bug-filing/bug-filing-service-provider';
 import {
     BugFilingSettingsContainer,
@@ -15,7 +14,6 @@ import { BugFilingService } from '../../bug-filing/types/bug-filing-service';
 import { EnvironmentInfoProvider } from '../../common/environment-info-provider';
 import { BugActionMessageCreator } from '../../common/message-creators/bug-action-message-creator';
 import { UserConfigMessageCreator } from '../../common/message-creators/user-config-message-creator';
-import { FileIssueClickService } from '../../common/telemetry-events';
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { BugServicePropertiesMap } from '../../common/types/store-data/user-configuration-store';
 import { ActionAndCancelButtonsComponent } from './action-and-cancel-buttons-component';
@@ -104,7 +102,7 @@ export class IssueFilingDialog extends React.Component<IssueFilingDialogProps, I
         const newData = this.state.selectedBugFilingService.getSettingsFromStoreData(this.state.bugServicePropertiesMap);
         const service = this.state.selectedBugFilingService.key;
         this.props.deps.userConfigMessageCreator.saveIssueFilingSettings(service, newData);
-        this.props.deps.bugActionMessageCreator.fileIssue(ev, service as FileIssueClickService, this.props.selectedBugData);
+        this.props.deps.bugActionMessageCreator.fileIssue(ev, service, this.props.selectedBugData);
         this.props.onClose(ev);
     };
 

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as TelemetryEvents from '../../common/telemetry-events';
-import { BaseTelemetryData, FileIssueClickService, TelemetryData, ToggleTelemetryData } from '../../common/telemetry-events';
+import { BaseTelemetryData, TelemetryData, ToggleTelemetryData } from '../../common/telemetry-events';
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
 import { ManualTestStatus } from '../../common/types/manual-test-status';
@@ -146,5 +146,5 @@ export interface SetIssueTrackerPathPayload extends BaseActionPayload {
 
 export interface FileIssuePayload extends BaseActionPayload {
     issueData: CreateIssueDetailsTextData;
-    service: FileIssueClickService;
+    service: string;
 }

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as TelemetryEvents from '../../common/telemetry-events';
-import { BaseTelemetryData, TelemetryData, ToggleTelemetryData, FileIssueClickService } from '../../common/telemetry-events';
+import { BaseTelemetryData, FileIssueClickService, TelemetryData, ToggleTelemetryData } from '../../common/telemetry-events';
+import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
 import { ManualTestStatus } from '../../common/types/manual-test-status';
 import { BugServiceProperties } from '../../common/types/store-data/user-configuration-store';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { TabStopEvent } from '../../injected/tab-stops-listener';
 import { LaunchPanelType } from '../../popup/components/popup-view';
-import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 
 export interface BaseActionPayload {
     telemetry?: TelemetryData;

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as TelemetryEvents from '../../common/telemetry-events';
-import { BaseTelemetryData, TelemetryData, ToggleTelemetryData } from '../../common/telemetry-events';
+import { BaseTelemetryData, TelemetryData, ToggleTelemetryData, FileIssueClickService } from '../../common/telemetry-events';
 import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
 import { ManualTestStatus } from '../../common/types/manual-test-status';
 import { BugServiceProperties } from '../../common/types/store-data/user-configuration-store';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { TabStopEvent } from '../../injected/tab-stops-listener';
 import { LaunchPanelType } from '../../popup/components/popup-view';
+import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 
 export interface BaseActionPayload {
     telemetry?: TelemetryData;
@@ -141,4 +142,9 @@ export interface SetBugServicePropertyPayload extends BaseActionPayload {
 
 export interface SetIssueTrackerPathPayload extends BaseActionPayload {
     issueTrackerPath: string;
+}
+
+export interface FileIssuePayload extends BaseActionPayload {
+    issueData: CreateIssueDetailsTextData;
+    service: FileIssueClickService;
 }

--- a/src/background/global-action-creators/issue-filing-action-creator.ts
+++ b/src/background/global-action-creators/issue-filing-action-creator.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { IssueFilingController } from '../../bug-filing/common/issue-filing-controller-impl';
+import { Messages } from '../../common/messages';
+import { FILE_ISSUE_CLICK } from '../../common/telemetry-events';
+import { FileIssuePayload } from '../actions/action-payloads';
+import { Interpreter } from '../interpreter';
+import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
+
+export class IssueFilingActionCreator {
+    constructor(
+        private readonly interpreter: Interpreter,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly issueFilingController: IssueFilingController,
+    ) {}
+
+    public registerCallbacks(): void {
+        this.interpreter.registerTypeToPayloadCallback(Messages.IssueFiling.FileIssue, this.onFileIssue);
+    }
+
+    private onFileIssue = (payload: FileIssuePayload) => {
+        this.telemetryEventHandler.publishTelemetry(FILE_ISSUE_CLICK, payload);
+        this.issueFilingController.fileIssue(payload.service, payload.issueData);
+    };
+}

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -50,7 +50,12 @@ export class GlobalContextFactory {
 
         globalStoreHub.initialize();
 
-        const issueFilingController = new IssueFilingControllerImpl(issueFilingServiceProvider, browserAdapter, environmentInfo);
+        const issueFilingController = new IssueFilingControllerImpl(
+            issueFilingServiceProvider,
+            browserAdapter,
+            environmentInfo,
+            globalStoreHub.userConfigurationStore,
+        );
 
         const issueFilingActionCreator = new IssueFilingActionCreator(interpreter, telemetryEventHandler, issueFilingController);
         const actionCreator = new GlobalActionCreator(globalActionsHub, interpreter, browserAdapter, telemetryEventHandler);

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BugFilingServiceProvider } from '../bug-filing/bug-filing-service-provider';
+import { IssueFilingControllerImpl } from '../bug-filing/common/issue-filing-controller-impl';
+import { EnvironmentInfo } from '../common/environment-info-provider';
 import { IndexedDBAPI } from '../common/indexedDB/indexedDB';
 import { StateDispatcher } from '../common/state-dispatcher';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
@@ -11,15 +14,12 @@ import { BrowserAdapter } from './browser-adapter';
 import { CompletedTestStepTelemetryCreator } from './completed-test-step-telemetry-creator';
 import { FeatureFlagsController } from './feature-flags-controller';
 import { PersistedData } from './get-persisted-data';
+import { IssueFilingActionCreator } from './global-action-creators/issue-filing-action-creator';
 import { GlobalContext } from './global-context';
 import { Interpreter } from './interpreter';
 import { LocalStorageData } from './storage-data';
 import { GlobalStoreHub } from './stores/global/global-store-hub';
 import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
-import { IssueFilingControllerImpl } from '../bug-filing/common/issue-filing-controller-impl';
-import { IssueFilingActionCreator } from './global-action-creators/issue-filing-action-creator';
-import { BugFilingServiceProvider } from '../bug-filing/bug-filing-service-provider';
-import { EnvironmentInfo } from '../common/environment-info-provider';
 
 export class GlobalContextFactory {
     public static createContext(

--- a/src/bug-filing/common/issue-filing-controller-impl.ts
+++ b/src/bug-filing/common/issue-filing-controller-impl.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { FileIssueClickService } from '../../common/telemetry-events';
+import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
+import { BugFilingServiceProvider } from '../bug-filing-service-provider';
+import { BrowserAdapter } from '../../background/browser-adapter';
+import { EnvironmentInfo } from '../../common/environment-info-provider';
+
+export type IssueFilingController = {
+    fileIssue: (serviceKey: FileIssueClickService, issueData: CreateIssueDetailsTextData) => void;
+};
+
+export class IssueFilingControllerImpl implements IssueFilingController {
+    constructor(
+        private readonly provider: BugFilingServiceProvider,
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly environmentInfo: EnvironmentInfo,
+    ) {}
+
+    public fileIssue = (serviceKey: FileIssueClickService, issueData: CreateIssueDetailsTextData): void => {
+        const service = this.provider.forKey(serviceKey);
+        const url = service.issueFilingUrlProvider(service, issueData, this.environmentInfo);
+        this.browserAdapter.createTab(url);
+    };
+}

--- a/src/bug-filing/common/issue-filing-controller-impl.ts
+++ b/src/bug-filing/common/issue-filing-controller-impl.ts
@@ -3,13 +3,12 @@
 import { BrowserAdapter } from '../../background/browser-adapter';
 import { BaseStore } from '../../common/base-store';
 import { EnvironmentInfo } from '../../common/environment-info-provider';
-import { FileIssueClickService } from '../../common/telemetry-events';
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { BugServiceProperties, UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { BugFilingServiceProvider } from '../bug-filing-service-provider';
 
 export type IssueFilingController = {
-    fileIssue: (serviceKey: FileIssueClickService, issueData: CreateIssueDetailsTextData) => void;
+    fileIssue: (serviceKey: string, issueData: CreateIssueDetailsTextData) => void;
 };
 
 export class IssueFilingControllerImpl implements IssueFilingController {
@@ -20,7 +19,7 @@ export class IssueFilingControllerImpl implements IssueFilingController {
         private readonly userConfigurationStore: BaseStore<UserConfigurationStoreData>,
     ) {}
 
-    public fileIssue = (serviceKey: FileIssueClickService, issueData: CreateIssueDetailsTextData): void => {
+    public fileIssue = (serviceKey: string, issueData: CreateIssueDetailsTextData): void => {
         const service = this.provider.forKey(serviceKey);
         const userConfigurationStoreData = this.userConfigurationStore.getState();
 

--- a/src/common/components/issue-filing-button.tsx
+++ b/src/common/components/issue-filing-button.tsx
@@ -10,7 +10,6 @@ import { IssueFilingDialogDeps } from '../../DetailsView/components/issue-filing
 import { EnvironmentInfoProvider } from '../environment-info-provider';
 import { LadyBugSolidIcon } from '../icons/lady-bug-solid-icon';
 import { BugActionMessageCreator } from '../message-creators/bug-action-message-creator';
-import { FileIssueClickService } from '../telemetry-events';
 import { CreateIssueDetailsTextData } from '../types/create-issue-details-text-data';
 import { IssueFilingNeedsSettingsContentProps, IssueFilingNeedsSettingsContentRenderer } from '../types/issue-filing-needs-setting-content';
 import { BugServiceProperties, UserConfigurationStoreData } from '../types/store-data/user-configuration-store';
@@ -91,7 +90,7 @@ export class IssueFilingButton extends React.Component<IssueFilingButtonProps, I
         const isSettingValid = selectedBugFilingService.isSettingsValid(selectedBugFilingServiceData);
 
         if (isSettingValid) {
-            bugActionMessageCreator.fileIssue(event, userConfigurationStoreData.bugService as FileIssueClickService, issueDetailsData);
+            bugActionMessageCreator.fileIssue(event, userConfigurationStoreData.bugService, issueDetailsData);
             this.closeNeedsSettingsContent();
         } else {
             this.openNeedsSettingsContent();

--- a/src/common/insights-feature-flag.ts
+++ b/src/common/insights-feature-flag.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { FeatureFlagsController } from '../background/feature-flags-controller';
+
+export type InsightsFeatureFlags = {
+    insightsFeatureFlags: FeatureFlagsController;
+};

--- a/src/common/message-creators/bug-action-message-creator.ts
+++ b/src/common/message-creators/bug-action-message-creator.ts
@@ -8,6 +8,8 @@ import { FILE_ISSUE_CLICK, FileIssueClickService, TelemetryEventSource } from '.
 import { CreateIssueDetailsTextData } from '../types/create-issue-details-text-data';
 import { ActionMessageDispatcher } from './action-message-dispatcher';
 
+type SupportedMouseEvent = React.MouseEvent<HTMLElement> | React.SyntheticEvent<Element, Event>;
+
 export class BugActionMessageCreator {
     constructor(
         private readonly dispatcher: ActionMessageDispatcher,
@@ -32,7 +34,7 @@ export class BugActionMessageCreator {
         this.dispatcher.sendTelemetry(FILE_ISSUE_CLICK, telemetry);
     }
 
-    public fileIssue(event: React.MouseEvent<HTMLElement>, service: FileIssueClickService, issueData: CreateIssueDetailsTextData): void {
+    public fileIssue(event: SupportedMouseEvent, service: FileIssueClickService, issueData: CreateIssueDetailsTextData): void {
         const messageType = Messages.IssueFiling.FileIssue;
         const telemetry = this.telemetryFactory.forFileIssueClick(event, this.source, service);
         const payload: FileIssuePayload = {

--- a/src/common/message-creators/bug-action-message-creator.ts
+++ b/src/common/message-creators/bug-action-message-creator.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseActionPayload } from '../../background/actions/action-payloads';
+import { BaseActionPayload, FileIssuePayload } from '../../background/actions/action-payloads';
+import { Message } from '../message';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
 import { FILE_ISSUE_CLICK, FileIssueClickService, TelemetryEventSource } from '../telemetry-events';
+import { CreateIssueDetailsTextData } from '../types/create-issue-details-text-data';
 import { ActionMessageDispatcher } from './action-message-dispatcher';
 
 export class BugActionMessageCreator {
@@ -28,5 +30,20 @@ export class BugActionMessageCreator {
     public trackFileIssueClick(event: React.MouseEvent<HTMLElement>, service: FileIssueClickService): void {
         const telemetry = this.telemetryFactory.forFileIssueClick(event, this.source, service);
         this.dispatcher.sendTelemetry(FILE_ISSUE_CLICK, telemetry);
+    }
+
+    public fileIssue(event: React.MouseEvent<HTMLElement>, service: FileIssueClickService, issueData: CreateIssueDetailsTextData): void {
+        const messageType = Messages.IssueFiling.FileIssue;
+        const telemetry = this.telemetryFactory.forFileIssueClick(event, this.source, service);
+        const payload: FileIssuePayload = {
+            telemetry,
+            issueData,
+            service,
+        };
+        const message: Message = {
+            messageType,
+            payload,
+        };
+        this.dispatcher.dispatchMessage(message);
     }
 }

--- a/src/common/message-creators/bug-action-message-creator.ts
+++ b/src/common/message-creators/bug-action-message-creator.ts
@@ -4,7 +4,7 @@ import { BaseActionPayload, FileIssuePayload } from '../../background/actions/ac
 import { Message } from '../message';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
-import { FILE_ISSUE_CLICK, FileIssueClickService, TelemetryEventSource } from '../telemetry-events';
+import { FILE_ISSUE_CLICK, TelemetryEventSource } from '../telemetry-events';
 import { CreateIssueDetailsTextData } from '../types/create-issue-details-text-data';
 import { ActionMessageDispatcher } from './action-message-dispatcher';
 
@@ -29,18 +29,18 @@ export class BugActionMessageCreator {
         });
     }
 
-    public trackFileIssueClick(event: React.MouseEvent<HTMLElement>, service: FileIssueClickService): void {
-        const telemetry = this.telemetryFactory.forFileIssueClick(event, this.source, service);
+    public trackFileIssueClick(event: React.MouseEvent<HTMLElement>, serviceKey: string): void {
+        const telemetry = this.telemetryFactory.forFileIssueClick(event, this.source, serviceKey);
         this.dispatcher.sendTelemetry(FILE_ISSUE_CLICK, telemetry);
     }
 
-    public fileIssue(event: SupportedMouseEvent, service: FileIssueClickService, issueData: CreateIssueDetailsTextData): void {
+    public fileIssue(event: SupportedMouseEvent, serviceKey: string, issueData: CreateIssueDetailsTextData): void {
         const messageType = Messages.IssueFiling.FileIssue;
-        const telemetry = this.telemetryFactory.forFileIssueClick(event, this.source, service);
+        const telemetry = this.telemetryFactory.forFileIssueClick(event, this.source, serviceKey);
         const payload: FileIssuePayload = {
             telemetry,
             issueData,
-            service,
+            service: serviceKey,
         };
         const message: Message = {
             messageType,

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -191,4 +191,8 @@ export class Messages {
         GetCurrentState: 'insights/inspect/get',
         SetHoveredOverSelector: 'insights/inspect/setHoveredOverSelector',
     };
+
+    public static readonly IssueFiling = {
+        FileIssue: 'insights/issueFiling/file',
+    };
 }

--- a/src/common/telemetry-data-factory.ts
+++ b/src/common/telemetry-data-factory.ts
@@ -13,7 +13,6 @@ import {
     ExportResultsTelemetryData,
     ExportResultType,
     FeatureFlagToggleTelemetryData,
-    FileIssueClickService,
     FileIssueClickTelemetryData,
     InspectTelemetryData,
     IssuesAnalyzerScanTelemetryData,
@@ -161,14 +160,10 @@ export class TelemetryDataFactory {
         };
     }
 
-    public forFileIssueClick(
-        event: SupportedMouseEvent,
-        source: TelemetryEventSource,
-        service: FileIssueClickService,
-    ): FileIssueClickTelemetryData {
+    public forFileIssueClick(event: SupportedMouseEvent, source: TelemetryEventSource, serviceKey: string): FileIssueClickTelemetryData {
         return {
             ...this.withTriggeredByAndSource(event, source),
-            service,
+            service: serviceKey,
         };
     }
 

--- a/src/common/telemetry-data-factory.ts
+++ b/src/common/telemetry-data-factory.ts
@@ -38,7 +38,8 @@ export type SupportedMouseEvent =
     | React.MouseEvent<any>
     | MouseEvent
     | React.MouseEvent<HTMLElement>
-    | React.KeyboardEvent<HTMLElement>;
+    | React.KeyboardEvent<HTMLElement>
+    | React.SyntheticEvent<Element, Event>;
 
 export class TelemetryDataFactory {
     public forVisualizationToggleByCommand(enabled: boolean): ToggleTelemetryData {

--- a/src/common/telemetry-events.ts
+++ b/src/common/telemetry-events.ts
@@ -110,9 +110,8 @@ export type SettingsOpenTelemetryData = {
 export type SettingsOpenSourceItem = 'fileIssueSettingsPrompt' | 'menu';
 
 export type FileIssueClickTelemetryData = {
-    service: FileIssueClickService;
+    service: string;
 } & BaseTelemetryData;
-export type FileIssueClickService = 'none' | 'gitHub';
 
 export type RequirementSelectTelemetryData = {
     selectedTest: string;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
@@ -23,6 +23,15 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have ch
   <BugFilingSettingsContainer
     deps={
       Object {
+        "bugActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "bugFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -105,6 +114,15 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have no
   <BugFilingSettingsContainer
     deps={
       Object {
+        "bugActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "bugFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -187,6 +205,15 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have change
   <BugFilingSettingsContainer
     deps={
       Object {
+        "bugActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "bugFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -269,6 +296,15 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have not ch
   <BugFilingSettingsContainer
     deps={
       Object {
+        "bugActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "bugFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -351,6 +387,15 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
   <BugFilingSettingsContainer
     deps={
       Object {
+        "bugActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "bugFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -403,7 +448,6 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
       cancelButtonOnClick={[Function]}
       isHidden={false}
       primaryButtonDisabled={true}
-      primaryButtonHref={null}
       primaryButtonOnClick={[Function]}
       primaryButtonText="File issue"
     />
@@ -434,6 +478,15 @@ exports[`IssueFilingDialog render with isSettingsValid: true 1`] = `
   <BugFilingSettingsContainer
     deps={
       Object {
+        "bugActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "bugFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -516,6 +569,15 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
   <BugFilingSettingsContainer
     deps={
       Object {
+        "bugActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "bugFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -599,6 +661,15 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
   <BugFilingSettingsContainer
     deps={
       Object {
+        "bugActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "bugFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -681,6 +752,15 @@ exports[`IssueFilingDialog render: validate callback (onSelectedServiceChange) s
   <BugFilingSettingsContainer
     deps={
       Object {
+        "bugActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "bugFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],

--- a/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
@@ -8,6 +8,7 @@ import { BugFilingServiceProvider } from '../../../../../bug-filing/bug-filing-s
 import { BugFilingSettingsContainer } from '../../../../../bug-filing/components/bug-filing-settings-container';
 import { BugFilingService } from '../../../../../bug-filing/types/bug-filing-service';
 import { EnvironmentInfo, EnvironmentInfoProvider } from '../../../../../common/environment-info-provider';
+import { BugActionMessageCreator } from '../../../../../common/message-creators/bug-action-message-creator';
 import { UserConfigMessageCreator } from '../../../../../common/message-creators/user-config-message-creator';
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 import { BugServicePropertiesMap } from '../../../../../common/types/store-data/user-configuration-store';
@@ -37,6 +38,7 @@ describe('IssueFilingDialog', () => {
     let bugServicePropertiesMapStub: BugServicePropertiesMap;
     let userConfigMessageCreatorMock: IMock<UserConfigMessageCreator>;
     let bugFilingServiceProviderMock: IMock<BugFilingServiceProvider>;
+    let bugActionMessageCreatorMock: IMock<BugActionMessageCreator>;
 
     beforeEach(() => {
         serviceKey = 'gitHub';
@@ -54,6 +56,7 @@ describe('IssueFilingDialog', () => {
         envInfoProviderMock = Mock.ofType(EnvironmentInfoProvider);
         userConfigMessageCreatorMock = Mock.ofType(UserConfigMessageCreator);
         bugFilingServiceProviderMock = Mock.ofType(BugFilingServiceProvider);
+        bugActionMessageCreatorMock = Mock.ofType(BugActionMessageCreator);
 
         envInfoProviderMock.setup(p => p.getEnvironmentInfo()).returns(() => envInfo);
 
@@ -70,6 +73,7 @@ describe('IssueFilingDialog', () => {
             bugFilingServiceProvider: bugFilingServiceProviderMock.object,
             userConfigMessageCreator: userConfigMessageCreatorMock.object,
             environmentInfoProvider: envInfoProviderMock.object,
+            bugActionMessageCreator: bugActionMessageCreatorMock.object,
         } as IssueFilingDialogDeps;
         bugFilingServiceStub = {
             isSettingsValid: isSettingsValidMock.object,
@@ -83,7 +87,6 @@ describe('IssueFilingDialog', () => {
             onClose: onCloseMock.object,
             selectedBugFilingService: bugFilingServiceStub,
             selectedBugData: selectedBugDataStub,
-            bugFileTelemetryCallback: telemetryCallbackMock.object,
             bugServicePropertiesMap: bugServicePropertiesMapStub,
         };
 
@@ -122,14 +125,12 @@ describe('IssueFilingDialog', () => {
         actionCancelButtons.props().cancelButtonOnClick(null);
 
         isSettingsValidMock.verifyAll();
-        createBugFilingUrlMock.verifyAll();
         telemetryCallbackMock.verifyAll();
         onCloseMock.verifyAll();
     });
 
     it('render: validate correct callbacks to ActionAndCancelButtonsComponent (file issue on click and cancel)', () => {
         userConfigMessageCreatorMock.setup(ucmcm => ucmcm.saveIssueFilingSettings(serviceKey, selectedServiceData)).verifiable();
-        telemetryCallbackMock.setup(telemetryCallback => telemetryCallback(eventStub)).verifiable(Times.once());
         onCloseMock.setup(onClose => onClose(eventStub)).verifiable(Times.once());
 
         const testSubject = shallow(<IssueFilingDialog {...props} />);
@@ -137,8 +138,6 @@ describe('IssueFilingDialog', () => {
         actionCancelButtons.props().primaryButtonOnClick(eventStub);
 
         isSettingsValidMock.verifyAll();
-        createBugFilingUrlMock.verifyAll();
-        telemetryCallbackMock.verifyAll();
         userConfigMessageCreatorMock.verifyAll();
         onCloseMock.verifyAll();
     });

--- a/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { It, Mock, MockBehavior, Times } from 'typemoq';
+
+import { FileIssuePayload } from '../../../../../background/actions/action-payloads';
+import { IssueFilingActionCreator } from '../../../../../background/global-action-creators/issue-filing-action-creator';
+import { Interpreter } from '../../../../../background/interpreter';
+import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';
+import { FILE_ISSUE_CLICK, FileIssueClickService, TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
+import { IssueFilingController } from '../../../../../bug-filing/common/issue-filing-controller-impl';
+
+export { isFunction } from 'lodash';
+
+describe('IssueFilingActionCreator', () => {
+    it('handles FileIssue message', () => {
+        const payload: FileIssuePayload = {
+            issueData: {} as CreateIssueDetailsTextData,
+            service: 'test-service' as FileIssueClickService,
+            telemetry: {
+                triggeredBy: 'test' as TriggeredBy,
+                source: -1 as TelemetryEventSource,
+            },
+        };
+
+        const interpreterMock = Mock.ofType<Interpreter>();
+        interpreterMock
+            .setup(interpreter => interpreter.registerTypeToPayloadCallback(It.isAny(), It.isAny()))
+            .callback((message, handler) => handler(payload));
+
+        const telemetryHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
+        telemetryHandlerMock.setup(handler => handler.publishTelemetry(FILE_ISSUE_CLICK, payload)).verifiable(Times.once());
+
+        const issueFilingControllerMock = Mock.ofType<IssueFilingController>(null, MockBehavior.Strict);
+        issueFilingControllerMock.setup(controller => controller.fileIssue(payload.service, payload.issueData)).verifiable(Times.once());
+
+        const testSubject = new IssueFilingActionCreator(
+            interpreterMock.object,
+            telemetryHandlerMock.object,
+            issueFilingControllerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        telemetryHandlerMock.verifyAll();
+        issueFilingControllerMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
@@ -6,9 +6,9 @@ import { FileIssuePayload } from '../../../../../background/actions/action-paylo
 import { IssueFilingActionCreator } from '../../../../../background/global-action-creators/issue-filing-action-creator';
 import { Interpreter } from '../../../../../background/interpreter';
 import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';
+import { IssueFilingController } from '../../../../../bug-filing/common/issue-filing-controller-impl';
 import { FILE_ISSUE_CLICK, FileIssueClickService, TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
-import { IssueFilingController } from '../../../../../bug-filing/common/issue-filing-controller-impl';
 
 export { isFunction } from 'lodash';
 

--- a/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
@@ -7,7 +7,7 @@ import { IssueFilingActionCreator } from '../../../../../background/global-actio
 import { Interpreter } from '../../../../../background/interpreter';
 import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';
 import { IssueFilingController } from '../../../../../bug-filing/common/issue-filing-controller-impl';
-import { FILE_ISSUE_CLICK, FileIssueClickService, TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
+import { FILE_ISSUE_CLICK, TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 
 export { isFunction } from 'lodash';
@@ -16,7 +16,7 @@ describe('IssueFilingActionCreator', () => {
     it('handles FileIssue message', () => {
         const payload: FileIssuePayload = {
             issueData: {} as CreateIssueDetailsTextData,
-            service: 'test-service' as FileIssueClickService,
+            service: 'test-service',
             telemetry: {
                 triggeredBy: 'test' as TriggeredBy,
                 source: -1 as TelemetryEventSource,

--- a/src/tests/unit/tests/bug-filing/bug-filing-service-provider-impl.test.ts
+++ b/src/tests/unit/tests/bug-filing/bug-filing-service-provider-impl.test.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BugFilingServiceProviderImpl } from '../../../../bug-filing/bug-filing-service-provider-impl';
+import { uniq } from 'lodash';
+
+describe('Name of the group', () => {
+    it('holds unique key services', () => {
+        const all = BugFilingServiceProviderImpl.all();
+
+        const keys = all.map(current => current.key);
+
+        const uniqueKeys = uniq(keys);
+
+        expect(uniqueKeys).toEqual(keys);
+    });
+});

--- a/src/tests/unit/tests/bug-filing/bug-filing-service-provider-impl.test.ts
+++ b/src/tests/unit/tests/bug-filing/bug-filing-service-provider-impl.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { BugFilingServiceProviderImpl } from '../../../../bug-filing/bug-filing-service-provider-impl';
 import { uniq } from 'lodash';
+import { BugFilingServiceProviderImpl } from '../../../../bug-filing/bug-filing-service-provider-impl';
 
 describe('Name of the group', () => {
     it('holds unique key services', () => {

--- a/src/tests/unit/tests/bug-filing/common/issue-filing-controller-impl.test.ts
+++ b/src/tests/unit/tests/bug-filing/common/issue-filing-controller-impl.test.ts
@@ -8,7 +8,6 @@ import { IssueFilingControllerImpl } from '../../../../../bug-filing/common/issu
 import { BugFilingService } from '../../../../../bug-filing/types/bug-filing-service';
 import { BaseStore } from '../../../../../common/base-store';
 import { EnvironmentInfo } from '../../../../../common/environment-info-provider';
-import { FileIssueClickService } from '../../../../../common/telemetry-events';
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 import { BugServicePropertiesMap, UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
@@ -67,7 +66,7 @@ describe('IssueFilingControllerImpl', () => {
             storeMock.object,
         );
 
-        testSubject.fileIssue(serviceKey as FileIssueClickService, issueData);
+        testSubject.fileIssue(serviceKey, issueData);
 
         browserAdapterMock.verifyAll();
     });

--- a/src/tests/unit/tests/bug-filing/common/issue-filing-controller-impl.test.ts
+++ b/src/tests/unit/tests/bug-filing/common/issue-filing-controller-impl.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Mock, Times } from 'typemoq';
+
+import { BrowserAdapter } from '../../../../../background/browser-adapter';
+import { BugFilingServiceProvider } from '../../../../../bug-filing/bug-filing-service-provider';
+import { BugFilingService } from '../../../../../bug-filing/types/bug-filing-service';
+import { EnvironmentInfo } from '../../../../../common/environment-info-provider';
+import { IssueFilingControllerImpl } from '../../../../../bug-filing/common/issue-filing-controller-impl';
+import { FileIssueClickService } from '../../../../../common/telemetry-events';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
+import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
+
+describe('IssueFilingControllerImpl', () => {
+    it('fileUssue', () => {
+        const serviceKey = 'test-service';
+        const issueData: CreateIssueDetailsTextData = {
+            pageTitle: 'pageTitle<x>',
+            pageUrl: 'pageUrl',
+            ruleResult: {
+                failureSummary: 'RR-failureSummary',
+                guidanceLinks: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
+                help: 'RR-help',
+                html: 'RR-html',
+                ruleId: 'RR-rule-id',
+                helpUrl: 'RR-help-url',
+                selector: 'RR-selector<x>',
+                snippet: 'RR-snippet   space',
+            } as DecoratedAxeNodeResult,
+        };
+        const environmentInfoStub: EnvironmentInfo = {
+            axeCoreVersion: 'test axe version',
+            browserSpec: 'test browser spec',
+            extensionVersion: 'test extension version',
+        };
+        const testUrl = 'test-url';
+        const issueFilingServiceMock = Mock.ofType<BugFilingService>();
+        issueFilingServiceMock
+            .setup(service => service.issueFilingUrlProvider(issueFilingServiceMock.object, issueData, environmentInfoStub))
+            .returns(() => testUrl);
+
+        const providerMock = Mock.ofType<BugFilingServiceProvider>();
+        providerMock.setup(provider => provider.forKey(serviceKey)).returns(() => issueFilingServiceMock.object);
+
+        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
+        browserAdapterMock.setup(adapter => adapter.createTab(testUrl)).verifiable(Times.once());
+
+        const testSubject = new IssueFilingControllerImpl(providerMock.object, browserAdapterMock.object, environmentInfoStub);
+
+        testSubject.fileIssue(serviceKey as FileIssueClickService, issueData);
+
+        browserAdapterMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/bug-filing/common/issue-filing-controller-impl.test.ts
+++ b/src/tests/unit/tests/bug-filing/common/issue-filing-controller-impl.test.ts
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Mock, Times, It } from 'typemoq';
+import { It, Mock, Times } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../../background/browser-adapter';
 import { BugFilingServiceProvider } from '../../../../../bug-filing/bug-filing-service-provider';
-import { BugFilingService } from '../../../../../bug-filing/types/bug-filing-service';
-import { EnvironmentInfo } from '../../../../../common/environment-info-provider';
 import { IssueFilingControllerImpl } from '../../../../../bug-filing/common/issue-filing-controller-impl';
+import { BugFilingService } from '../../../../../bug-filing/types/bug-filing-service';
+import { BaseStore } from '../../../../../common/base-store';
+import { EnvironmentInfo } from '../../../../../common/environment-info-provider';
 import { FileIssueClickService } from '../../../../../common/telemetry-events';
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
+import { BugServicePropertiesMap, UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
-import { UserConfigurationStoreData, BugServicePropertiesMap } from '../../../../../common/types/store-data/user-configuration-store';
-import { BaseStore } from '../../../../../common/base-store';
 
 describe('IssueFilingControllerImpl', () => {
     it('fileUssue', () => {

--- a/src/tests/unit/tests/common/components/__snapshots__/issue-filing-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/issue-filing-button.test.tsx.snap
@@ -2,48 +2,48 @@
 
 exports[`IssueFilingButtonTest onclick: invalid settings, %s 1`] = `
 "<Fragment>
-  <CustomizedDefaultButton className=\\"create-bug-button\\" target=\\"_self\\" onClick={[Function: onClick]} href={{...}}>
+  <CustomizedDefaultButton className=\\"create-bug-button\\" onClick={[Function: onClick]}>
     <LadyBugSolidIcon />
     <div className=\\"ms-Button-label\\">
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={true} selectedBugFilingService={{...}} selectedBugData={{...}} selectedBugFilingServiceData={{...}} onClose={[Function: bound ]} bugFileTelemetryCallback={[Function: bound ]} bugServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={true} selectedBugFilingService={{...}} selectedBugData={{...}} selectedBugFilingServiceData={{...}} onClose={[Function: bound ]} bugServicePropertiesMap={{...}} />
 </Fragment>"
 `;
 
 exports[`IssueFilingButtonTest onclick: valid settings, file bug and set %s to false 1`] = `
 "<Fragment>
-  <CustomizedDefaultButton className=\\"create-bug-button\\" target=\\"_blank\\" onClick={[Function: onClick]} href=\\"test url\\">
+  <CustomizedDefaultButton className=\\"create-bug-button\\" onClick={[Function: onClick]}>
     <LadyBugSolidIcon />
     <div className=\\"ms-Button-label\\">
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={false} selectedBugFilingService={{...}} selectedBugData={{...}} selectedBugFilingServiceData={{...}} onClose={[Function: bound ]} bugFileTelemetryCallback={[Function: bound ]} bugServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={false} selectedBugFilingService={{...}} selectedBugData={{...}} selectedBugFilingServiceData={{...}} onClose={[Function: bound ]} bugServicePropertiesMap={{...}} />
 </Fragment>"
 `;
 
 exports[`IssueFilingButtonTest render: isSettingsValid: false 1`] = `
 "<Fragment>
-  <CustomizedDefaultButton className=\\"create-bug-button\\" target=\\"_self\\" onClick={[Function: onClick]} href={{...}}>
+  <CustomizedDefaultButton className=\\"create-bug-button\\" onClick={[Function: onClick]}>
     <LadyBugSolidIcon />
     <div className=\\"ms-Button-label\\">
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={false} selectedBugFilingService={{...}} selectedBugData={{...}} selectedBugFilingServiceData={{...}} onClose={[Function: bound ]} bugFileTelemetryCallback={[Function: bound ]} bugServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={false} selectedBugFilingService={{...}} selectedBugData={{...}} selectedBugFilingServiceData={{...}} onClose={[Function: bound ]} bugServicePropertiesMap={{...}} />
 </Fragment>"
 `;
 
 exports[`IssueFilingButtonTest render: isSettingsValid: true 1`] = `
 "<Fragment>
-  <CustomizedDefaultButton className=\\"create-bug-button\\" target=\\"_blank\\" onClick={[Function: onClick]} href=\\"test url\\">
+  <CustomizedDefaultButton className=\\"create-bug-button\\" onClick={[Function: onClick]}>
     <LadyBugSolidIcon />
     <div className=\\"ms-Button-label\\">
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={false} selectedBugFilingService={{...}} selectedBugData={{...}} selectedBugFilingServiceData={{...}} onClose={[Function: bound ]} bugFileTelemetryCallback={[Function: bound ]} bugServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={false} selectedBugFilingService={{...}} selectedBugData={{...}} selectedBugFilingServiceData={{...}} onClose={[Function: bound ]} bugServicePropertiesMap={{...}} />
 </Fragment>"
 `;

--- a/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
+++ b/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
@@ -11,10 +11,10 @@ import { IssueFilingButton, IssueFilingButtonDeps, IssueFilingButtonProps } from
 import { EnvironmentInfoProvider } from '../../../../../common/environment-info-provider';
 import { BugActionMessageCreator } from '../../../../../common/message-creators/bug-action-message-creator';
 import { NamedSFC } from '../../../../../common/react/named-sfc';
+import { FileIssueClickService } from '../../../../../common/telemetry-events';
 import { IssueFilingNeedsSettingsContentRenderer } from '../../../../../common/types/issue-filing-needs-setting-content';
 import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 import { EventStubFactory } from '../../../common/event-stub-factory';
-import { FileIssueClickService } from '../../../../../common/telemetry-events';
 
 describe('IssueFilingButtonTest', () => {
     const testKey: string = 'test';

--- a/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
+++ b/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
@@ -11,7 +11,6 @@ import { IssueFilingButton, IssueFilingButtonDeps, IssueFilingButtonProps } from
 import { EnvironmentInfoProvider } from '../../../../../common/environment-info-provider';
 import { BugActionMessageCreator } from '../../../../../common/message-creators/bug-action-message-creator';
 import { NamedSFC } from '../../../../../common/react/named-sfc';
-import { FileIssueClickService } from '../../../../../common/telemetry-events';
 import { IssueFilingNeedsSettingsContentRenderer } from '../../../../../common/types/issue-filing-needs-setting-content';
 import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 import { EventStubFactory } from '../../../common/event-stub-factory';
@@ -102,7 +101,7 @@ describe('IssueFilingButtonTest', () => {
             needsSettingsContentRenderer,
         };
         bugActionMessageCreatorMock
-            .setup(creator => creator.fileIssue(eventStub, testKey as FileIssueClickService, props.issueDetailsData))
+            .setup(creator => creator.fileIssue(eventStub, testKey, props.issueDetailsData))
             .verifiable(Times.once());
         const wrapper = shallow(<IssueFilingButton {...props} />);
 

--- a/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
+++ b/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
@@ -14,10 +14,11 @@ import { NamedSFC } from '../../../../../common/react/named-sfc';
 import { IssueFilingNeedsSettingsContentRenderer } from '../../../../../common/types/issue-filing-needs-setting-content';
 import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 import { EventStubFactory } from '../../../common/event-stub-factory';
+import { FileIssueClickService } from '../../../../../common/telemetry-events';
 
 describe('IssueFilingButtonTest', () => {
     const testKey: string = 'test';
-    const eventStub = new EventStubFactory().createNativeMouseClickEvent();
+    const eventStub = new EventStubFactory().createNativeMouseClickEvent() as any;
     let environmentInfoProviderMock: IMock<EnvironmentInfoProvider>;
     let bugFilingServiceProviderMock: IMock<BugFilingServiceProvider>;
     let bugActionMessageCreatorMock: IMock<BugActionMessageCreator>;
@@ -82,14 +83,10 @@ describe('IssueFilingButtonTest', () => {
         const wrapper = shallow(<IssueFilingButton {...props} />);
         expect(wrapper.debug()).toMatchSnapshot();
 
-        environmentInfoProviderMock.verifyAll();
         bugFilingServiceProviderMock.verifyAll();
     });
 
     test('onclick: valid settings, file bug and set %s to false', () => {
-        bugActionMessageCreatorMock
-            .setup(messageCreator => messageCreator.trackFileIssueClick(eventStub as any, testKey as any))
-            .verifiable(Times.once());
         const props: IssueFilingButtonProps = {
             deps: {
                 bugActionMessageCreator: bugActionMessageCreatorMock.object,
@@ -104,6 +101,9 @@ describe('IssueFilingButtonTest', () => {
             userConfigurationStoreData: userConfigurationStoreData,
             needsSettingsContentRenderer,
         };
+        bugActionMessageCreatorMock
+            .setup(creator => creator.fileIssue(eventStub, testKey as FileIssueClickService, props.issueDetailsData))
+            .verifiable(Times.once());
         const wrapper = shallow(<IssueFilingButton {...props} />);
 
         wrapper.find(DefaultButton).simulate('click', eventStub);

--- a/src/tests/unit/tests/common/message-creators/bug-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/bug-action-message-creator.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { ActionMessageDispatcher } from '../../../../../common/message-creators/action-message-dispatcher';
 import { BugActionMessageCreator } from '../../../../../common/message-creators/bug-action-message-creator';
 import { Messages } from '../../../../../common/messages';
@@ -13,6 +14,8 @@ import {
     TelemetryEventSource,
     TriggeredBy,
 } from '../../../../../common/telemetry-events';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
+import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
 import { EventStubFactory } from '../../../common/event-stub-factory';
 
 describe('BugActionMessageCreator', () => {
@@ -30,12 +33,12 @@ describe('BugActionMessageCreator', () => {
 
     beforeEach(() => {
         telemetryFactoryMock = Mock.ofType<TelemetryDataFactory>();
-        dispatcherMock = Mock.ofType<ActionMessageDispatcher>();
+        dispatcherMock = Mock.ofType<ActionMessageDispatcher>(null, MockBehavior.Strict);
 
         testSubject = new BugActionMessageCreator(dispatcherMock.object, telemetryFactoryMock.object, source);
     });
 
-    it('dispatch message for openSettingsPanel', () => {
+    it('dispatches message for openSettingsPanel', () => {
         const telemetry = { ...telemetryStub, sourceItem: 'sourceItem' as SettingsOpenSourceItem };
         telemetryFactoryMock
             .setup(factory => factory.forSettingsPanelOpen(eventStub, source, 'fileIssueSettingsPrompt'))
@@ -57,7 +60,7 @@ describe('BugActionMessageCreator', () => {
         dispatcherMock.verifyAll();
     });
 
-    it('dispatch message for trackFileIssueClick', () => {
+    it('dispatches message for trackFileIssueClick', () => {
         const testService: FileIssueClickService = 'test file issue service' as FileIssueClickService;
         const telemetry = { ...telemetryStub, service: testService };
 
@@ -66,6 +69,44 @@ describe('BugActionMessageCreator', () => {
         dispatcherMock.setup(dispatcher => dispatcher.sendTelemetry(FILE_ISSUE_CLICK, telemetry)).verifiable(Times.once());
 
         testSubject.trackFileIssueClick(eventStub, testService);
+
+        dispatcherMock.verifyAll();
+    });
+
+    it('dispatches message for fileIssue', () => {
+        const testService: FileIssueClickService = 'test file issue service' as FileIssueClickService;
+        const telemetry = { ...telemetryStub, service: testService };
+
+        telemetryFactoryMock.setup(factory => factory.forFileIssueClick(eventStub, source, testService)).returns(() => telemetry);
+        const issueDetailsData: CreateIssueDetailsTextData = {
+            pageTitle: 'pageTitle<x>',
+            pageUrl: 'pageUrl',
+            ruleResult: {
+                failureSummary: 'RR-failureSummary',
+                guidanceLinks: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
+                help: 'RR-help',
+                html: 'RR-html',
+                ruleId: 'RR-rule-id',
+                helpUrl: 'RR-help-url',
+                selector: 'RR-selector<x>',
+                snippet: 'RR-snippet   space',
+            } as DecoratedAxeNodeResult,
+        };
+
+        dispatcherMock.setup(dispatcher =>
+            dispatcher.dispatchMessage(
+                It.isValue({
+                    messageType: Messages.IssueFiling.FileIssue,
+                    payload: {
+                        service: testService,
+                        issueData: issueDetailsData,
+                        telemetry,
+                    },
+                }),
+            ),
+        );
+
+        testSubject.fileIssue(eventStub, testService, issueDetailsData);
 
         dispatcherMock.verifyAll();
     });

--- a/src/tests/unit/tests/common/message-creators/bug-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/bug-action-message-creator.test.ts
@@ -9,7 +9,6 @@ import { TelemetryDataFactory } from '../../../../../common/telemetry-data-facto
 import {
     BaseTelemetryData,
     FILE_ISSUE_CLICK,
-    FileIssueClickService,
     SettingsOpenSourceItem,
     TelemetryEventSource,
     TriggeredBy,
@@ -61,7 +60,7 @@ describe('BugActionMessageCreator', () => {
     });
 
     it('dispatches message for trackFileIssueClick', () => {
-        const testService: FileIssueClickService = 'test file issue service' as FileIssueClickService;
+        const testService: string = 'test file issue service';
         const telemetry = { ...telemetryStub, service: testService };
 
         telemetryFactoryMock.setup(factory => factory.forFileIssueClick(eventStub, source, testService)).returns(() => telemetry);
@@ -74,7 +73,7 @@ describe('BugActionMessageCreator', () => {
     });
 
     it('dispatches message for fileIssue', () => {
-        const testService: FileIssueClickService = 'test file issue service' as FileIssueClickService;
+        const testService: string = 'test file issue service';
         const telemetry = { ...telemetryStub, service: testService };
 
         telemetryFactoryMock.setup(factory => factory.forFileIssueClick(eventStub, source, testService)).returns(() => telemetry);


### PR DESCRIPTION
#### Description of changes

Refactor how we are handling 'file issue' button activation.

Currently, the button has a href property on it and also an onClick property (where we send telemetry).

Instead, the button should only send an action message to the background, which should send telemetry and handle the logic to file the issues against the proper service.

Also: remove unneeded custom string type; add missing test to ensure key uniqueness across issue filing services.

#### Pull request checklist

- [x] Addresses an existing issue: WI 1518658
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
