### PR TITLE
Use "Microsoft Edge" not "Edge" in visible text

### DIFF
--- a/src/assessments/text-legibility/test-steps/high-contrast-mode.tsx
+++ b/src/assessments/text-legibility/test-steps/high-contrast-mode.tsx
@@ -14,7 +14,7 @@ const highContrastModeDescription: JSX.Element = (
 
 const highContrastModeHowToTest: JSX.Element = (
     <div>
-        Chrome and Edge Insider do not support Windows' high contrast mode.
+        Google Chrome and Microsoft Edge Insider do not support Windows' high contrast mode.
         <ol>
             <li>Open the target page in Microsoft Edge.</li>
             <li>

--- a/src/common/navigator-utils.ts
+++ b/src/common/navigator-utils.ts
@@ -9,9 +9,9 @@ export class NavigatorUtils {
     public getBrowserSpec(): string {
         const userAgent = this.navigatorInfo.userAgent;
 
-        const edgeVersion = this.getVersion(userAgent, 'Edg');
-        if (edgeVersion !== null) {
-            return `Edge version ${edgeVersion}`;
+        const edgVersion = this.getVersion(userAgent, 'Edg');
+        if (edgVersion !== null) {
+            return `Microsoft Edge version ${edgVersion}`;
         }
 
         const chromeVersion = this.getVersion(userAgent, 'Chrome');

--- a/src/content/test/parsing/keyboard-bookmarklet-instructions.tsx
+++ b/src/content/test/parsing/keyboard-bookmarklet-instructions.tsx
@@ -83,10 +83,10 @@ export const keyboardBookmarkletInstructions = create(({ Markup }) => (
         <h2>Microsoft Edge Insider instructions</h2>
         <ol>
             <li>
-                Open the Edge Insider <Markup.Term>Favorites</Markup.Term> manager:
+                Open the Microsoft Edge Insider <Markup.Term>Favorites</Markup.Term> manager:
                 <ol type="a">
                     <li>
-                        In Edge Insider, type <Markup.Term>Ctrl + Shift + o</Markup.Term>.
+                        In Microsoft Edge Insider, type <Markup.Term>Ctrl + Shift + o</Markup.Term>.
                     </li>
                     <li>
                         A new browser tab called <Markup.Term>Favorites</Markup.Term> will open.

--- a/src/tests/unit/tests/common/navigator-utils.test.ts
+++ b/src/tests/unit/tests/common/navigator-utils.test.ts
@@ -13,7 +13,7 @@ describe('NavigatorUtilsTest', () => {
     test('getEnvironmentInfo: edge', () => {
         validateBrowserSpecReturnedWithUserAgent(
             'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3763.0 Safari/537.36 Edg/75.0.131.0',
-            'Edge version 75.0.131.0',
+            'Microsoft Edge version 75.0.131.0',
         );
     });
 


### PR DESCRIPTION
#### Description of changes

Following Microsoft brand guidance, change user-visible references to the browser from "Edge" to "Microsoft Edge"

#### Pull request checklist

- [X] Addresses an existing issue: Fixes 1518582, 1518583
- [X] Added relevant unit test for your changes. (`npm run test`) (updated existing tests)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`npm run precheckin`)
- [X] Added screenshots/GIFs for UI changes.

#### Screenshots

##### Export Reports
![image](https://user-images.githubusercontent.com/1752950/56774759-ef4c4400-6778-11e9-9079-ec7b78bae431.png)
![image](https://user-images.githubusercontent.com/1752950/56774807-11de5d00-6779-11e9-9fe2-892eb24d1a62.png)

##### Bug report
![image](https://user-images.githubusercontent.com/1752950/56774855-43efbf00-6779-11e9-8f4c-20482266e5d2.png)

##### High contrast mode
![image](https://user-images.githubusercontent.com/1752950/56774882-5b2eac80-6779-11e9-8a04-3a4873a5464e.png)

##### Bookmarklet instructions
![image](https://user-images.githubusercontent.com/1752950/56774907-739ec700-6779-11e9-83fd-15986efb0f8f.png)

