### PR TITLE
[Refactor] TargetPageActionMessageCreator to use ActionMessageDispatcher

### DIFF
--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -105,11 +105,7 @@ export class MainWindowInitializer extends WindowInitializer {
         );
         const actionMessageDispatcher = new ActionMessageDispatcher(this.clientChromeAdapter.sendMessageToFrames, null);
 
-        const targetPageActionMessageCreator = new TargetPageActionMessageCreator(
-            this.clientChromeAdapter.sendMessageToFrames,
-            null,
-            telemetryDataFactory,
-        );
+        const targetPageActionMessageCreator = new TargetPageActionMessageCreator(telemetryDataFactory, actionMessageDispatcher);
         const bugActionMessageCreator = new BugActionMessageCreator(
             actionMessageDispatcher,
             telemetryDataFactory,

--- a/src/injected/target-page-action-message-creator.ts
+++ b/src/injected/target-page-action-message-creator.ts
@@ -3,45 +3,43 @@
 import { autobind } from '@uifabric/utilities';
 import { BaseActionPayload } from '../background/actions/action-payloads';
 import { Message } from '../common/message';
+import { ActionMessageDispatcher } from '../common/message-creators/action-message-dispatcher';
 import { BaseActionMessageCreator } from '../common/message-creators/base-action-message-creator';
 import { Messages } from '../common/messages';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
 import * as TelemetryEvents from '../common/telemetry-events';
-import { TelemetryEventSource } from '../common/telemetry-events';
+import { TelemetryData, TelemetryEventSource } from '../common/telemetry-events';
 
-export class TargetPageActionMessageCreator extends BaseActionMessageCreator {
-    protected telemetryFactory: TelemetryDataFactory;
-
-    constructor(postMessage: (message: Message) => void, tabId: number, telemetryFactory: TelemetryDataFactory) {
-        super(postMessage, tabId);
-        this.telemetryFactory = telemetryFactory;
-    }
+export class TargetPageActionMessageCreator {
+    constructor(private readonly telemetryFactory: TelemetryDataFactory, private readonly dispatcher: ActionMessageDispatcher) {}
 
     public scrollRequested(): void {
-        this.dispatchMessage({
+        const message: Message = {
             messageType: Messages.Visualizations.Common.ScrollRequested,
-        });
+        };
+        this.dispatcher.dispatchMessage(message);
     }
     public openIssuesDialog(): void {
-        this.sendTelemetry(TelemetryEvents.ISSUES_DIALOG_OPENED, {
+        const eventData: TelemetryData = {
             source: TelemetryEventSource.TargetPage,
             triggeredBy: 'N/A',
-        });
+        };
+        this.dispatcher.sendTelemetry(TelemetryEvents.ISSUES_DIALOG_OPENED, eventData);
     }
 
     @autobind
     public setHoveredOverSelector(selector: string[]): void {
-        this.dispatchMessage({
+        const message: Message = {
             messageType: Messages.Inspect.SetHoveredOverSelector,
-            tabId: this._tabId,
             payload: selector,
-        });
+        };
+        this.dispatcher.dispatchMessage(message);
     }
 
     @autobind
     public copyIssueDetailsClicked(event: React.MouseEvent<any>): void {
         const telemetryData = this.telemetryFactory.withTriggeredByAndSource(event, TelemetryEvents.TelemetryEventSource.TargetPage);
-        this.sendTelemetry(TelemetryEvents.COPY_ISSUE_DETAILS, telemetryData);
+        this.dispatcher.sendTelemetry(TelemetryEvents.COPY_ISSUE_DETAILS, telemetryData);
     }
 
     @autobind
@@ -52,10 +50,10 @@ export class TargetPageActionMessageCreator extends BaseActionMessageCreator {
         const payload: BaseActionPayload = {
             telemetry,
         };
-        this.dispatchMessage({
+        const message: Message = {
             messageType: messageType,
-            tabId: this._tabId,
             payload,
-        });
+        };
+        this.dispatcher.dispatchMessage(message);
     }
 }

--- a/src/injected/target-page-action-message-creator.ts
+++ b/src/injected/target-page-action-message-creator.ts
@@ -4,7 +4,6 @@ import { autobind } from '@uifabric/utilities';
 import { BaseActionPayload } from '../background/actions/action-payloads';
 import { Message } from '../common/message';
 import { ActionMessageDispatcher } from '../common/message-creators/action-message-dispatcher';
-import { BaseActionMessageCreator } from '../common/message-creators/base-action-message-creator';
 import { Messages } from '../common/messages';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
 import * as TelemetryEvents from '../common/telemetry-events';

--- a/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
+++ b/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
@@ -56,6 +56,19 @@ describe('TargetPageActionMessageCreator', () => {
         dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });
 
+    it('sends telemetry for copyIssueDetailsClicked', () => {
+        const event = eventStubFactory.createMouseClickEvent() as any;
+        const eventName = TelemetryEvents.COPY_ISSUE_DETAILS;
+        const eventData: TelemetryEvents.TelemetryData = {
+            source: TelemetryEventSource.TargetPage,
+            triggeredBy: 'mouseclick',
+        };
+
+        testSubject.copyIssueDetailsClicked(event);
+
+        dispatcherMock.verify(dispatcher => dispatcher.sendTelemetry(eventName, eventData), Times.once());
+    });
+
     it('dispatches message for openSettingsPanel', () => {
         const event = eventStubFactory.createMouseClickEvent() as any;
 

--- a/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
+++ b/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock, Times } from 'typemoq';
+import { Mock, Times } from 'typemoq';
 import { BaseActionPayload } from '../../../../background/actions/action-payloads';
 import { Message } from '../../../../common/message';
 import { ActionMessageDispatcher } from '../../../../common/message-creators/action-message-dispatcher';

--- a/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
+++ b/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 import { BaseActionPayload } from '../../../../background/actions/action-payloads';
 import { Message } from '../../../../common/message';
+import { ActionMessageDispatcher } from '../../../../common/message-creators/action-message-dispatcher';
 import { Messages } from '../../../../common/messages';
 import { TelemetryDataFactory } from '../../../../common/telemetry-data-factory';
 import * as TelemetryEvents from '../../../../common/telemetry-events';
@@ -12,67 +13,50 @@ import { EventStubFactory } from '../../common/event-stub-factory';
 
 describe('TargetPageActionMessageCreator', () => {
     const eventStubFactory = new EventStubFactory();
+    const dispatcherMock = Mock.ofType<ActionMessageDispatcher>();
     let testSubject: TargetPageActionMessageCreator;
-    let postMessageMock: IMock<(msg: Message) => void>;
-    let tabId: number;
 
     beforeEach(() => {
-        tabId = -1;
-        postMessageMock = Mock.ofInstance(message => {});
-        testSubject = new TargetPageActionMessageCreator(postMessageMock.object, tabId, new TelemetryDataFactory());
+        dispatcherMock.reset();
+        testSubject = new TargetPageActionMessageCreator(new TelemetryDataFactory(), dispatcherMock.object);
     });
 
-    test('scrollRequested', () => {
-        const expectedMessage = {
+    it('dispatches message for scrollRequested', () => {
+        const expectedMessage: Message = {
             messageType: Messages.Visualizations.Common.ScrollRequested,
         };
 
-        postMessageMock.setup(pm => pm(It.isValue(expectedMessage))).verifiable();
-
         testSubject.scrollRequested();
 
-        postMessageMock.verifyAll();
+        dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });
 
-    test('openIssuesDialog', () => {
-        const payload = {
-            eventName: TelemetryEvents.ISSUES_DIALOG_OPENED,
-            telemetry: {
-                source: TelemetryEventSource.TargetPage,
-                triggeredBy: 'N/A',
-            },
+    it('sends telemetry for openIssuesDialog', () => {
+        const eventName = TelemetryEvents.ISSUES_DIALOG_OPENED;
+        const eventData: TelemetryEvents.TelemetryData = {
+            source: TelemetryEventSource.TargetPage,
+            triggeredBy: 'N/A',
         };
-
-        const expectedMessage = {
-            messageType: Messages.Telemetry.Send,
-            tabId: tabId,
-            payload: payload,
-        };
-
-        postMessageMock.setup(pm => pm(It.isValue(expectedMessage))).verifiable();
 
         testSubject.openIssuesDialog();
 
-        postMessageMock.verifyAll();
+        dispatcherMock.verify(dispatcher => dispatcher.sendTelemetry(eventName, eventData), Times.once());
     });
 
-    test('setHoveredOverSelector', () => {
+    it('dispatches message for setHoveredOverSelector', () => {
         const selector = ['some selector'];
 
         const expectedMessage = {
             messageType: Messages.Inspect.SetHoveredOverSelector,
-            tabId: tabId,
             payload: selector,
         };
 
-        postMessageMock.setup(pm => pm(It.isValue(expectedMessage))).verifiable();
-
         testSubject.setHoveredOverSelector(selector);
 
-        postMessageMock.verifyAll();
+        dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });
 
-    test('openSettingsPanel', () => {
+    it('dispatches message for openSettingsPanel', () => {
         const event = eventStubFactory.createMouseClickEvent() as any;
 
         const telemetry: SettingsOpenTelemetryData = {
@@ -85,14 +69,11 @@ describe('TargetPageActionMessageCreator', () => {
         };
         const expectedMessage: Message = {
             messageType: Messages.SettingsPanel.OpenPanel,
-            tabId,
             payload,
         };
 
-        postMessageMock.setup(pm => pm(It.isValue(expectedMessage))).verifiable();
-
         testSubject.openSettingsPanel(event);
 
-        postMessageMock.verifyAll();
+        dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });
 });


### PR DESCRIPTION
#### Description of changes

- Updated `TargetPageActionMessageCreator` to use `ActionMessageDispatcher` instead of extending from `BaseActionMessageCreator`
- Added a unit test for `copyIssueDetailsClicked` in `target-page-action-message-creator.test.ts` to improve code coverage

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes. **N/A**
