### PR TITLE
[Refactor] Move global action creator to it's own folder

### DIFF
--- a/src/background/global-action-creators/global-action-creator.ts
+++ b/src/background/global-action-creators/global-action-creator.ts
@@ -4,22 +4,12 @@ import { autobind } from '@uifabric/utilities';
 
 import { Messages } from '../../common/messages';
 import * as TelemetryEvents from '../../common/telemetry-events';
-import {
-    PayloadWithEventName,
-    SaveIssueFilingSettingsPayload,
-    SetHighContrastModePayload,
-    SetIssueFilingServicePayload,
-    SetIssueFilingServicePropertyPayload,
-    SetIssueTrackerPathPayload,
-    SetLaunchPanelState,
-    SetTelemetryStatePayload,
-} from '../actions/action-payloads';
+import { PayloadWithEventName, SetLaunchPanelState } from '../actions/action-payloads';
 import { CommandActions, GetCommandsPayload } from '../actions/command-actions';
 import { FeatureFlagActions } from '../actions/feature-flag-actions';
 import { GlobalActionHub } from '../actions/global-action-hub';
 import { LaunchPanelStateActions } from '../actions/launch-panel-state-action';
 import { ScopingActions } from '../actions/scoping-actions';
-import { UserConfigurationActions } from '../actions/user-configuration-actions';
 import { BrowserAdapter } from '../browser-adapter';
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
@@ -33,7 +23,6 @@ export class GlobalActionCreator {
     private featureFlagActions: FeatureFlagActions;
     private launchPanelStateActions: LaunchPanelStateActions;
     private scopingActions: ScopingActions;
-    private userConfigActions: UserConfigurationActions;
 
     constructor(
         globalActionHub: GlobalActionHub,
@@ -48,7 +37,6 @@ export class GlobalActionCreator {
         this.featureFlagActions = globalActionHub.featureFlagActions;
         this.launchPanelStateActions = globalActionHub.launchPanelStateActions;
         this.scopingActions = globalActionHub.scopingActions;
-        this.userConfigActions = globalActionHub.userConfigurationActions;
     }
 
     public registerCallbacks(): void {
@@ -65,17 +53,6 @@ export class GlobalActionCreator {
         this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.DeleteSelector, this.onDeleteSelector);
 
         this.interpreter.registerTypeToPayloadCallback(Messages.Telemetry.Send, this.onSendTelemetry);
-
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.GetCurrentState, this.onGetUserConfigState);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetTelemetryConfig, this.onSetTelemetryConfiguration);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetHighContrastConfig, this.onSetHighContrastMode);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetIssueFilingService, this.onSetIssueFilingService);
-        this.interpreter.registerTypeToPayloadCallback(
-            Messages.UserConfig.SetIssueFilingServiceProperty,
-            this.onSetIssueFilingServiceProperty,
-        );
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetIssueTrackerPath, this.onSetIssueTrackerPath);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SaveIssueFilingSettings, this.onSaveIssueFilingSettings);
     }
 
     @autobind
@@ -134,40 +111,5 @@ export class GlobalActionCreator {
     private onSendTelemetry(payload: PayloadWithEventName): void {
         const eventName = payload.eventName;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-    }
-
-    @autobind
-    private onGetUserConfigState(): void {
-        this.userConfigActions.getCurrentState.invoke(null);
-    }
-
-    @autobind
-    private onSetTelemetryConfiguration(payload: SetTelemetryStatePayload): void {
-        this.userConfigActions.setTelemetryState.invoke(payload);
-    }
-
-    @autobind
-    private onSetHighContrastMode(payload: SetHighContrastModePayload): void {
-        this.userConfigActions.setHighContrastMode.invoke(payload);
-    }
-
-    @autobind
-    private onSetIssueFilingService(payload: SetIssueFilingServicePayload): void {
-        this.userConfigActions.setIssueFilingService.invoke(payload);
-    }
-
-    @autobind
-    private onSetIssueFilingServiceProperty(payload: SetIssueFilingServicePropertyPayload): void {
-        this.userConfigActions.setIssueFilingServiceProperty.invoke(payload);
-    }
-
-    @autobind
-    private onSetIssueTrackerPath(payload: SetIssueTrackerPathPayload): void {
-        this.userConfigActions.setIssueTrackerPath.invoke(payload);
-    }
-
-    @autobind
-    private onSaveIssueFilingSettings(payload: SaveIssueFilingSettingsPayload): void {
-        this.userConfigActions.saveIssueFilingSettings.invoke(payload);
     }
 }

--- a/src/background/global-action-creators/global-action-creator.ts
+++ b/src/background/global-action-creators/global-action-creator.ts
@@ -4,9 +4,6 @@ import { autobind } from '@uifabric/utilities';
 
 import { Messages } from '../../common/messages';
 import * as TelemetryEvents from '../../common/telemetry-events';
-import { BrowserAdapter } from '../browser-adapter';
-import { Interpreter } from '../interpreter';
-import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import {
     PayloadWithEventName,
     SaveIssueFilingSettingsPayload,
@@ -16,13 +13,16 @@ import {
     SetIssueTrackerPathPayload,
     SetLaunchPanelState,
     SetTelemetryStatePayload,
-} from './action-payloads';
-import { CommandActions, GetCommandsPayload } from './command-actions';
-import { FeatureFlagActions } from './feature-flag-actions';
-import { GlobalActionHub } from './global-action-hub';
-import { LaunchPanelStateActions } from './launch-panel-state-action';
-import { ScopingActions } from './scoping-actions';
-import { UserConfigurationActions } from './user-configuration-actions';
+} from '../actions/action-payloads';
+import { CommandActions, GetCommandsPayload } from '../actions/command-actions';
+import { FeatureFlagActions } from '../actions/feature-flag-actions';
+import { GlobalActionHub } from '../actions/global-action-hub';
+import { LaunchPanelStateActions } from '../actions/launch-panel-state-action';
+import { ScopingActions } from '../actions/scoping-actions';
+import { UserConfigurationActions } from '../actions/user-configuration-actions';
+import { BrowserAdapter } from '../browser-adapter';
+import { Interpreter } from '../interpreter';
+import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 
 export class GlobalActionCreator {
     private interpreter: Interpreter;

--- a/src/background/global-action-creators/user-configuration-action-creator.ts
+++ b/src/background/global-action-creators/user-configuration-action-creator.ts
@@ -3,9 +3,9 @@
 import { Messages } from '../../common/messages';
 import {
     SaveIssueFilingSettingsPayload,
-    SetBugServicePayload,
-    SetBugServicePropertyPayload,
     SetHighContrastModePayload,
+    SetIssueFilingServicePayload,
+    SetIssueFilingServicePropertyPayload,
     SetIssueTrackerPathPayload,
     SetTelemetryStatePayload,
 } from '../actions/action-payloads';
@@ -19,8 +19,8 @@ export class UserConfigurationActionCreator {
         this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.GetCurrentState, this.onGetUserConfigState);
         this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetTelemetryConfig, this.onSetTelemetryConfiguration);
         this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetHighContrastConfig, this.onSetHighContrastMode);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetBugService, this.onSetBugService);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetBugServiceProperty, this.onSetBugServiceProperty);
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetIssueFilingService, this.onSetBugService);
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetIssueFilingServiceProperty, this.onSetBugServiceProperty);
         this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetIssueTrackerPath, this.onSetIssueTrackerPath);
         this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SaveIssueFilingSettings, this.onSaveIssueFilingSettings);
     }
@@ -37,12 +37,12 @@ export class UserConfigurationActionCreator {
         this.userConfigActions.setHighContrastMode.invoke(payload);
     };
 
-    private onSetBugService = (payload: SetBugServicePayload): void => {
-        this.userConfigActions.setBugService.invoke(payload);
+    private onSetBugService = (payload: SetIssueFilingServicePayload): void => {
+        this.userConfigActions.setIssueFilingService.invoke(payload);
     };
 
-    private onSetBugServiceProperty = (payload: SetBugServicePropertyPayload): void => {
-        this.userConfigActions.setBugServiceProperty.invoke(payload);
+    private onSetBugServiceProperty = (payload: SetIssueFilingServicePropertyPayload): void => {
+        this.userConfigActions.setIssueFilingServiceProperty.invoke(payload);
     };
 
     private onSetIssueTrackerPath = (payload: SetIssueTrackerPathPayload): void => {

--- a/src/background/global-action-creators/user-configuration-action-creator.ts
+++ b/src/background/global-action-creators/user-configuration-action-creator.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Messages } from '../../common/messages';
+import {
+    SaveIssueFilingSettingsPayload,
+    SetBugServicePayload,
+    SetBugServicePropertyPayload,
+    SetHighContrastModePayload,
+    SetIssueTrackerPathPayload,
+    SetTelemetryStatePayload,
+} from '../actions/action-payloads';
+import { UserConfigurationActions } from '../actions/user-configuration-actions';
+import { Interpreter } from '../interpreter';
+
+export class UserConfigurationActionCreator {
+    constructor(private readonly interpreter: Interpreter, private readonly userConfigActions: UserConfigurationActions) {}
+
+    public registerCallback(): void {
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.GetCurrentState, this.onGetUserConfigState);
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetTelemetryConfig, this.onSetTelemetryConfiguration);
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetHighContrastConfig, this.onSetHighContrastMode);
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetBugService, this.onSetBugService);
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetBugServiceProperty, this.onSetBugServiceProperty);
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetIssueTrackerPath, this.onSetIssueTrackerPath);
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SaveIssueFilingSettings, this.onSaveIssueFilingSettings);
+    }
+
+    private onGetUserConfigState = (): void => {
+        this.userConfigActions.getCurrentState.invoke(null);
+    };
+
+    private onSetTelemetryConfiguration = (payload: SetTelemetryStatePayload): void => {
+        this.userConfigActions.setTelemetryState.invoke(payload);
+    };
+
+    private onSetHighContrastMode = (payload: SetHighContrastModePayload): void => {
+        this.userConfigActions.setHighContrastMode.invoke(payload);
+    };
+
+    private onSetBugService = (payload: SetBugServicePayload): void => {
+        this.userConfigActions.setBugService.invoke(payload);
+    };
+
+    private onSetBugServiceProperty = (payload: SetBugServicePropertyPayload): void => {
+        this.userConfigActions.setBugServiceProperty.invoke(payload);
+    };
+
+    private onSetIssueTrackerPath = (payload: SetIssueTrackerPathPayload): void => {
+        this.userConfigActions.setIssueTrackerPath.invoke(payload);
+    };
+
+    private onSaveIssueFilingSettings = (payload: SaveIssueFilingSettingsPayload): void => {
+        this.userConfigActions.saveIssueFilingSettings.invoke(payload);
+    };
+}

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -16,6 +16,7 @@ import { Interpreter } from './interpreter';
 import { LocalStorageData } from './storage-data';
 import { GlobalStoreHub } from './stores/global/global-store-hub';
 import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
+import { UserConfigurationActionCreator } from './global-action-creators/user-configuration-action-creator';
 
 export class GlobalContextFactory {
     public static createContext(
@@ -50,9 +51,11 @@ export class GlobalContextFactory {
             telemetryEventHandler,
             interpreter.registerTypeToPayloadCallback,
         );
+        const userConfigurationActionCreator = new UserConfigurationActionCreator(interpreter, globalActionsHub.userConfigurationActions);
 
         actionCreator.registerCallbacks();
         assessmentActionCreator.registerCallbacks();
+        userConfigurationActionCreator.registerCallback();
 
         const dispatcher = new StateDispatcher(browserAdapter.sendMessageToAllFramesAndTabs, globalStoreHub);
         dispatcher.initialize();

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -5,7 +5,7 @@ import { StateDispatcher } from '../common/state-dispatcher';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
 import { AssessmentsProvider } from './../assessments/types/assessments-provider';
 import { AssessmentActionCreator } from './actions/assessment-action-creator';
-import { GlobalActionCreator } from './actions/global-action-creator';
+import { GlobalActionCreator } from './global-action-creators/global-action-creator';
 import { GlobalActionHub } from './actions/global-action-hub';
 import { BrowserAdapter } from './browser-adapter';
 import { CompletedTestStepTelemetryCreator } from './completed-test-step-telemetry-creator';

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -5,18 +5,18 @@ import { StateDispatcher } from '../common/state-dispatcher';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
 import { AssessmentsProvider } from './../assessments/types/assessments-provider';
 import { AssessmentActionCreator } from './actions/assessment-action-creator';
-import { GlobalActionCreator } from './global-action-creators/global-action-creator';
 import { GlobalActionHub } from './actions/global-action-hub';
 import { BrowserAdapter } from './browser-adapter';
 import { CompletedTestStepTelemetryCreator } from './completed-test-step-telemetry-creator';
 import { FeatureFlagsController } from './feature-flags-controller';
 import { PersistedData } from './get-persisted-data';
+import { GlobalActionCreator } from './global-action-creators/global-action-creator';
+import { UserConfigurationActionCreator } from './global-action-creators/user-configuration-action-creator';
 import { GlobalContext } from './global-context';
 import { Interpreter } from './interpreter';
 import { LocalStorageData } from './storage-data';
 import { GlobalStoreHub } from './stores/global/global-store-hub';
 import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
-import { UserConfigurationActionCreator } from './global-action-creators/user-configuration-action-creator';
 
 export class GlobalContextFactory {
     public static createContext(

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -12,7 +12,6 @@ import {
 import { AssessmentActions } from '../../../../../background/actions/assessment-actions';
 import { CommandActions } from '../../../../../background/actions/command-actions';
 import { FeatureFlagActions, FeatureFlagPayload } from '../../../../../background/actions/feature-flag-actions';
-import { GlobalActionCreator } from '../../../../../background/actions/global-action-creator';
 import { GlobalActionHub } from '../../../../../background/actions/global-action-hub';
 import { LaunchPanelStateActions } from '../../../../../background/actions/launch-panel-state-action';
 import { ScopingActions, ScopingPayload } from '../../../../../background/actions/scoping-actions';
@@ -26,6 +25,7 @@ import * as TelemetryEvents from '../../../../../common/telemetry-events';
 import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 import { LaunchPanelType } from '../../../../../popup/components/popup-view';
 import { DictionaryStringTo } from '../../../../../types/common-types';
+import { GlobalActionCreator } from '../../../../../background/global-action-creators/global-action-creator';
 
 describe('GlobalActionCreatorTest', () => {
     test('onGetCommands', () => {

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -1,14 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import {
-    SaveIssueFilingSettingsPayload,
-    SetHighContrastModePayload,
-    SetIssueFilingServicePayload,
-    SetIssueFilingServicePropertyPayload,
-    SetLaunchPanelState,
-    SetTelemetryStatePayload,
-} from '../../../../../background/actions/action-payloads';
+
+import { SetLaunchPanelState } from '../../../../../background/actions/action-payloads';
 import { AssessmentActions } from '../../../../../background/actions/assessment-actions';
 import { CommandActions } from '../../../../../background/actions/command-actions';
 import { FeatureFlagActions, FeatureFlagPayload } from '../../../../../background/actions/feature-flag-actions';
@@ -17,15 +11,14 @@ import { LaunchPanelStateActions } from '../../../../../background/actions/launc
 import { ScopingActions, ScopingPayload } from '../../../../../background/actions/scoping-actions';
 import { UserConfigurationActions } from '../../../../../background/actions/user-configuration-actions';
 import { ChromeAdapter } from '../../../../../background/browser-adapter';
+import { GlobalActionCreator } from '../../../../../background/global-action-creators/global-action-creator';
 import { Interpreter } from '../../../../../background/interpreter';
 import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';
 import { Action } from '../../../../../common/flux/action';
 import { Messages } from '../../../../../common/messages';
 import * as TelemetryEvents from '../../../../../common/telemetry-events';
-import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 import { LaunchPanelType } from '../../../../../popup/components/popup-view';
 import { DictionaryStringTo } from '../../../../../types/common-types';
-import { GlobalActionCreator } from '../../../../../background/global-action-creators/global-action-creator';
 
 describe('GlobalActionCreatorTest', () => {
     test('onGetCommands', () => {
@@ -200,122 +193,6 @@ describe('GlobalActionCreatorTest', () => {
 
         validator.verifyAll();
     });
-
-    test('registerCallback for on UserConfig.GetCurrentState', () => {
-        const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.UserConfig.GetCurrentState)
-            .setupActionsOnUserConfig('getCurrentState')
-            .setupUserConfigActionWithInvokeParameter('getCurrentState', null);
-
-        const actionCreator = validator.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        validator.verifyAll();
-    });
-
-    test('registerCallback for on UserConfig.SetTelemetryConfig', () => {
-        const payload: SetTelemetryStatePayload = {
-            enableTelemetry: true,
-        };
-        const args = [payload];
-        const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.UserConfig.SetTelemetryConfig, args)
-            .setupActionsOnUserConfig('setTelemetryState')
-            .setupUserConfigActionWithInvokeParameter('setTelemetryState', payload);
-
-        const actionCreator = validator.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        validator.verifyAll();
-    });
-
-    test('registerCallback for on UserConfig.SetHighContrastConfig', () => {
-        const payload: SetHighContrastModePayload = {
-            enableHighContrast: true,
-        };
-        const args = [payload];
-        const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.UserConfig.SetHighContrastConfig, args)
-            .setupActionsOnUserConfig('setHighContrastMode')
-            .setupUserConfigActionWithInvokeParameter('setHighContrastMode', payload);
-
-        const actionCreator = validator.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        validator.verifyAll();
-    });
-
-    test('registerCallback for on UserConfig.SetIssueFilingService', () => {
-        const payload: SetIssueFilingServicePayload = {
-            issueFilingServiceName: 'none',
-        };
-        const args = [payload];
-        const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.UserConfig.SetIssueFilingService, args)
-            .setupActionsOnUserConfig('setIssueFilingService')
-            .setupUserConfigActionWithInvokeParameter('setIssueFilingService', payload);
-
-        const actionCreator = validator.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        validator.verifyAll();
-    });
-
-    test('registerCallback for on UserConfig.SetIssueFilingServiceProperty', () => {
-        const payload: SetIssueFilingServicePropertyPayload = {
-            issueFilingServiceName: 'bug-service-name',
-            propertyName: 'property-name',
-            propertyValue: 'property-value',
-        };
-        const args = [payload];
-        const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.UserConfig.SetIssueFilingServiceProperty, args)
-            .setupActionsOnUserConfig('setIssueFilingServiceProperty')
-            .setupUserConfigActionWithInvokeParameter('setIssueFilingServiceProperty', payload);
-
-        const actionCreator = validator.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        validator.verifyAll();
-    });
-
-    test('registerCallback for on UserConfig.SetIssueTrackerPath', () => {
-        const payload: UserConfigurationStoreData = {
-            enableTelemetry: true,
-            isFirstTime: false,
-            enableHighContrast: true,
-            issueTrackerPath: 'example/example',
-            bugService: 'none',
-            bugServicePropertiesMap: {},
-        };
-        const args = [payload];
-        const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.UserConfig.SetIssueTrackerPath, args)
-            .setupActionsOnUserConfig('setIssueTrackerPath')
-            .setupUserConfigActionWithInvokeParameter('setIssueTrackerPath', payload);
-
-        const actionCreator = validator.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        validator.verifyAll();
-    });
-
-    test('registerCallback for on UserConfig.SaveIssueFilingSettings', () => {
-        const payload: SaveIssueFilingSettingsPayload = {
-            issueFilingServiceName: 'test bug service',
-            issueFilingSettings: { name: 'issueFilingSettings' },
-        };
-        const args = [payload];
-        const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.UserConfig.SaveIssueFilingSettings, args)
-            .setupActionsOnUserConfig('saveIssueFilingSettings')
-            .setupUserConfigActionWithInvokeParameter('saveIssueFilingSettings', payload);
-
-        const actionCreator = validator.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        validator.verifyAll();
-    });
 });
 
 class GlobalActionCreatorValidator {
@@ -324,7 +201,6 @@ class GlobalActionCreatorValidator {
     private featureFlagActionsMockMap: DictionaryStringTo<IMock<Action<any>>> = {};
     private launchPanelActionsMockMap: DictionaryStringTo<IMock<Action<any>>> = {};
     private scopingActionsMockMap: DictionaryStringTo<IMock<Action<any>>> = {};
-    private userConfigMockMap: DictionaryStringTo<IMock<Action<any>>> = {};
 
     private commandActionsContainerMock = Mock.ofType(CommandActions);
     private featureFlagActionsContainerMock = Mock.ofType(FeatureFlagActions);
@@ -363,10 +239,6 @@ class GlobalActionCreatorValidator {
         return this.setupAction(actionName, this.scopingActionsContainerMock, this.scopingActionsMockMap);
     }
 
-    public setupActionsOnUserConfig(actionName: keyof UserConfigurationActions): GlobalActionCreatorValidator {
-        return this.setupAction(actionName, this.userConfigActionsContainerMock, this.userConfigMockMap);
-    }
-
     public setupGetCommandsFromBrowser(commands: chrome.commands.Command[]): GlobalActionCreatorValidator {
         this.browserAdapterMock
             .setup(x => x.getCommands(It.isAny()))
@@ -397,13 +269,6 @@ class GlobalActionCreatorValidator {
 
     public setupScopingActionWithInvokeParameter(actionName: keyof ScopingActions, expectedInvokeParam: any): GlobalActionCreatorValidator {
         return this.setupActionWithInvokeParameter(actionName, expectedInvokeParam, this.scopingActionsMockMap);
-    }
-
-    public setupUserConfigActionWithInvokeParameter(
-        actionName: keyof UserConfigurationActions,
-        expectedInvokeParam: any,
-    ): GlobalActionCreatorValidator {
-        return this.setupActionWithInvokeParameter(actionName, expectedInvokeParam, this.userConfigMockMap);
     }
 
     private setupActionWithInvokeParameter(
@@ -490,7 +355,6 @@ class GlobalActionCreatorValidator {
         this.verifyAllActions(this.featureFlagActionsMockMap);
         this.verifyAllActions(this.launchPanelActionsMockMap);
         this.verifyAllActions(this.scopingActionsMockMap);
-        this.verifyAllActions(this.userConfigMockMap);
     }
 
     private verifyAllActions(actionsMap: DictionaryStringTo<IMock<Action<any>>>): void {

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -1,0 +1,180 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { isFunction } from 'lodash';
+import { It, Mock, Times } from 'typemoq';
+
+import {
+    SaveIssueFilingSettingsPayload,
+    SetBugServicePayload,
+    SetBugServicePropertyPayload,
+    SetHighContrastModePayload,
+    SetIssueTrackerPathPayload,
+    SetTelemetryStatePayload,
+} from '../../../../../background/actions/action-payloads';
+import { UserConfigurationActions } from '../../../../../background/actions/user-configuration-actions';
+import { UserConfigurationActionCreator } from '../../../../../background/global-action-creators/user-configuration-action-creator';
+import { Interpreter } from '../../../../../background/interpreter';
+import { Action } from '../../../../../common/flux/action';
+import { Messages } from '../../../../../common/messages';
+import { TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
+
+describe('UserConfigurationActionCreator', () => {
+    it('handles GetCurrentState message', () => {
+        const payload = null;
+
+        const getCurrentStateMock = createActionMock<null>(payload);
+
+        const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
+
+        const interpreterMock = createInterpreterMock(Messages.UserConfig.GetCurrentState, payload);
+
+        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+
+        testSubject.registerCallback();
+
+        getCurrentStateMock.verifyAll();
+    });
+
+    it('should SetTelemetryConfig message', () => {
+        const payload: SetTelemetryStatePayload = {
+            enableTelemetry: true,
+            telemetry: {
+                triggeredBy: 'test' as TriggeredBy,
+                source: -1 as TelemetryEventSource,
+            },
+        };
+
+        const setTelemetryStateMock = createActionMock(payload);
+
+        const actionsMock = createActionsMock('setTelemetryState', setTelemetryStateMock.object);
+
+        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetTelemetryConfig, payload);
+
+        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+
+        testSubject.registerCallback();
+
+        setTelemetryStateMock.verifyAll();
+    });
+
+    it('should SetHighContrastConfig message', () => {
+        const payload: SetHighContrastModePayload = {
+            enableHighContrast: true,
+        };
+
+        const setHighContrastConfigMock = createActionMock(payload);
+
+        const actionsMock = createActionsMock('setHighContrastMode', setHighContrastConfigMock.object);
+
+        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetHighContrastConfig, payload);
+
+        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+
+        testSubject.registerCallback();
+
+        setHighContrastConfigMock.verifyAll();
+    });
+
+    it('should SetBugService message', () => {
+        const payload: SetBugServicePayload = {
+            bugServiceName: 'none',
+        };
+
+        const setBugServiceMock = createActionMock(payload);
+
+        const actionsMock = createActionsMock('setBugService', setBugServiceMock.object);
+
+        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetBugService, payload);
+
+        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+
+        testSubject.registerCallback();
+
+        setBugServiceMock.verifyAll();
+    });
+
+    it('should SetBugServiceProperty message', () => {
+        const payload: SetBugServicePropertyPayload = {
+            bugServiceName: 'bug-service-name',
+            propertyName: 'property-name',
+            propertyValue: 'property-value',
+        };
+
+        const setBugServicePropertyMock = createActionMock(payload);
+
+        const actionsMock = createActionsMock('setBugServiceProperty', setBugServicePropertyMock.object);
+
+        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetBugServiceProperty, payload);
+
+        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+
+        testSubject.registerCallback();
+
+        setBugServicePropertyMock.verifyAll();
+    });
+
+    it('should SetIssueTrackerPath message', () => {
+        const payload: SetIssueTrackerPathPayload = {
+            enableTelemetry: true,
+            isFirstTime: false,
+            enableHighContrast: true,
+            issueTrackerPath: 'example/example',
+            bugService: 'none',
+            bugServicePropertiesMap: {},
+        };
+
+        const setIssueTrackerPath = createActionMock(payload);
+
+        const actionsMock = createActionsMock('setIssueTrackerPath', setIssueTrackerPath.object);
+
+        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetIssueTrackerPath, payload);
+
+        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+
+        testSubject.registerCallback();
+
+        setIssueTrackerPath.verifyAll();
+    });
+
+    it('should SaveIssueFilingSettings message', () => {
+        const payload: SaveIssueFilingSettingsPayload = {
+            bugServiceName: 'test bug service',
+            bugFilingSettings: { name: 'issueFilingSettings' },
+        };
+
+        const setIssueFilingSettings = createActionMock(payload);
+
+        const actionsMock = createActionsMock('saveIssueFilingSettings', setIssueFilingSettings.object);
+
+        const interpreterMock = createInterpreterMock(Messages.UserConfig.SaveIssueFilingSettings, payload);
+
+        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+
+        testSubject.registerCallback();
+
+        setIssueFilingSettings.verifyAll();
+    });
+
+    function createActionMock<Payload>(payload: Payload) {
+        const actionMock = Mock.ofType<Action<Payload>>();
+        actionMock.setup(action => action.invoke(payload)).verifiable(Times.once());
+        return actionMock;
+    }
+
+    function createActionsMock<ActionName extends keyof UserConfigurationActions>(
+        actionName: ActionName,
+        action: UserConfigurationActions[ActionName],
+    ) {
+        const actionsMock = Mock.ofType<UserConfigurationActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
+    }
+
+    function createInterpreterMock<Payload>(message: string, payload: Payload) {
+        const interpreterMock = Mock.ofType<Interpreter>();
+        interpreterMock
+            .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
+            .callback((message, handler) => handler(payload));
+        return interpreterMock;
+    }
+});

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -21,13 +21,9 @@ import { TelemetryEventSource, TriggeredBy } from '../../../../../common/telemet
 describe('UserConfigurationActionCreator', () => {
     it('handles GetCurrentState message', () => {
         const payload = null;
-
         const getCurrentStateMock = createActionMock<null>(payload);
-
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-
         const interpreterMock = createInterpreterMock(Messages.UserConfig.GetCurrentState, payload);
-
         const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallback();
@@ -43,13 +39,9 @@ describe('UserConfigurationActionCreator', () => {
                 source: -1 as TelemetryEventSource,
             },
         };
-
         const setTelemetryStateMock = createActionMock(payload);
-
         const actionsMock = createActionsMock('setTelemetryState', setTelemetryStateMock.object);
-
         const interpreterMock = createInterpreterMock(Messages.UserConfig.SetTelemetryConfig, payload);
-
         const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallback();
@@ -61,13 +53,9 @@ describe('UserConfigurationActionCreator', () => {
         const payload: SetHighContrastModePayload = {
             enableHighContrast: true,
         };
-
         const setHighContrastConfigMock = createActionMock(payload);
-
         const actionsMock = createActionsMock('setHighContrastMode', setHighContrastConfigMock.object);
-
         const interpreterMock = createInterpreterMock(Messages.UserConfig.SetHighContrastConfig, payload);
-
         const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallback();
@@ -79,13 +67,9 @@ describe('UserConfigurationActionCreator', () => {
         const payload: SetIssueFilingServicePayload = {
             issueFilingServiceName: 'none',
         };
-
         const setBugServiceMock = createActionMock(payload);
-
         const actionsMock = createActionsMock('setIssueFilingService', setBugServiceMock.object);
-
         const interpreterMock = createInterpreterMock(Messages.UserConfig.SetIssueFilingService, payload);
-
         const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallback();
@@ -99,13 +83,9 @@ describe('UserConfigurationActionCreator', () => {
             propertyName: 'property-name',
             propertyValue: 'property-value',
         };
-
         const setIssuFilingServicePropertyMock = createActionMock(payload);
-
         const actionsMock = createActionsMock('setIssueFilingServiceProperty', setIssuFilingServicePropertyMock.object);
-
         const interpreterMock = createInterpreterMock(Messages.UserConfig.SetIssueFilingServiceProperty, payload);
-
         const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallback();
@@ -122,13 +102,9 @@ describe('UserConfigurationActionCreator', () => {
             bugService: 'none',
             bugServicePropertiesMap: {},
         };
-
         const setIssueTrackerPath = createActionMock(payload);
-
         const actionsMock = createActionsMock('setIssueTrackerPath', setIssueTrackerPath.object);
-
         const interpreterMock = createInterpreterMock(Messages.UserConfig.SetIssueTrackerPath, payload);
-
         const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallback();
@@ -141,13 +117,9 @@ describe('UserConfigurationActionCreator', () => {
             issueFilingServiceName: 'test bug service',
             issueFilingSettings: { name: 'issueFilingSettings' },
         };
-
         const setIssueFilingSettings = createActionMock(payload);
-
         const actionsMock = createActionsMock('saveIssueFilingSettings', setIssueFilingSettings.object);
-
         const interpreterMock = createInterpreterMock(Messages.UserConfig.SaveIssueFilingSettings, payload);
-
         const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallback();

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { isFunction } from 'lodash';
-import { It, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 import {
     SaveIssueFilingSettingsPayload,
-    SetBugServicePayload,
-    SetBugServicePropertyPayload,
     SetHighContrastModePayload,
+    SetIssueFilingServicePayload,
+    SetIssueFilingServicePropertyPayload,
     SetIssueTrackerPathPayload,
     SetTelemetryStatePayload,
 } from '../../../../../background/actions/action-payloads';
@@ -76,15 +76,15 @@ describe('UserConfigurationActionCreator', () => {
     });
 
     it('should SetBugService message', () => {
-        const payload: SetBugServicePayload = {
-            bugServiceName: 'none',
+        const payload: SetIssueFilingServicePayload = {
+            issueFilingServiceName: 'none',
         };
 
         const setBugServiceMock = createActionMock(payload);
 
-        const actionsMock = createActionsMock('setBugService', setBugServiceMock.object);
+        const actionsMock = createActionsMock('setIssueFilingService', setBugServiceMock.object);
 
-        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetBugService, payload);
+        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetIssueFilingService, payload);
 
         const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
 
@@ -94,23 +94,23 @@ describe('UserConfigurationActionCreator', () => {
     });
 
     it('should SetBugServiceProperty message', () => {
-        const payload: SetBugServicePropertyPayload = {
-            bugServiceName: 'bug-service-name',
+        const payload: SetIssueFilingServicePropertyPayload = {
+            issueFilingServiceName: 'bug-service-name',
             propertyName: 'property-name',
             propertyValue: 'property-value',
         };
 
-        const setBugServicePropertyMock = createActionMock(payload);
+        const setIssuFilingServicePropertyMock = createActionMock(payload);
 
-        const actionsMock = createActionsMock('setBugServiceProperty', setBugServicePropertyMock.object);
+        const actionsMock = createActionsMock('setIssueFilingServiceProperty', setIssuFilingServicePropertyMock.object);
 
-        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetBugServiceProperty, payload);
+        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetIssueFilingServiceProperty, payload);
 
         const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallback();
 
-        setBugServicePropertyMock.verifyAll();
+        setIssuFilingServicePropertyMock.verifyAll();
     });
 
     it('should SetIssueTrackerPath message', () => {
@@ -138,8 +138,8 @@ describe('UserConfigurationActionCreator', () => {
 
     it('should SaveIssueFilingSettings message', () => {
         const payload: SaveIssueFilingSettingsPayload = {
-            bugServiceName: 'test bug service',
-            bugFilingSettings: { name: 'issueFilingSettings' },
+            issueFilingServiceName: 'test bug service',
+            issueFilingSettings: { name: 'issueFilingSettings' },
         };
 
         const setIssueFilingSettings = createActionMock(payload);
@@ -155,7 +155,7 @@ describe('UserConfigurationActionCreator', () => {
         setIssueFilingSettings.verifyAll();
     });
 
-    function createActionMock<Payload>(payload: Payload) {
+    function createActionMock<Payload>(payload: Payload): IMock<Action<Payload>> {
         const actionMock = Mock.ofType<Action<Payload>>();
         actionMock.setup(action => action.invoke(payload)).verifiable(Times.once());
         return actionMock;
@@ -164,17 +164,17 @@ describe('UserConfigurationActionCreator', () => {
     function createActionsMock<ActionName extends keyof UserConfigurationActions>(
         actionName: ActionName,
         action: UserConfigurationActions[ActionName],
-    ) {
+    ): IMock<UserConfigurationActions> {
         const actionsMock = Mock.ofType<UserConfigurationActions>();
         actionsMock.setup(actions => actions[actionName]).returns(() => action);
         return actionsMock;
     }
 
-    function createInterpreterMock<Payload>(message: string, payload: Payload) {
+    function createInterpreterMock<Payload>(message: string, payload: Payload): IMock<Interpreter> {
         const interpreterMock = Mock.ofType<Interpreter>();
         interpreterMock
             .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
-            .callback((message, handler) => handler(payload));
+            .callback((_, handler) => handler(payload));
         return interpreterMock;
     }
 });


### PR DESCRIPTION
#### Description of changes

Move GlobalActionCreator to it's own folder.
Move all user configuration related code on the GlobalActionCreator to the new UserConfigurationActionCreator.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
