### PR TITLE
[Refactor] ScopingActionMessageCreator to use ActionMessageDispatcher

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -130,10 +130,9 @@ if (isNaN(tabId) === false) {
 
             const actionMessageCreator = new DetailsViewActionMessageCreator(chromeAdapter.sendMessageToFrames, tab.id, telemetryFactory);
             const scopingActionMessageCreator = new ScopingActionMessageCreator(
-                chromeAdapter.sendMessageToFrames,
-                tab.id,
                 telemetryFactory,
                 TelemetryEventSource.DetailsView,
+                actionMessageDispatcher,
             );
             const inspectActionMessageCreator = new InspectActionMessageCreator(
                 chromeAdapter.sendMessageToFrames,

--- a/src/common/message-creators/scoping-action-message-creator.ts
+++ b/src/common/message-creators/scoping-action-message-creator.ts
@@ -1,27 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
-import { Message } from '../message';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
 import { ScopingPayload } from './../../background/actions/scoping-actions';
 import { TelemetryEventSource } from './../telemetry-events';
-import { BaseActionMessageCreator } from './base-action-message-creator';
+import { ActionMessageDispatcher } from './action-message-dispatcher';
 
-export class ScopingActionMessageCreator extends BaseActionMessageCreator {
-    private telemetryFactory: TelemetryDataFactory;
-    private source: TelemetryEventSource;
-
+export class ScopingActionMessageCreator {
     constructor(
-        postMessage: (message: Message) => void,
-        tabId: number,
-        telemetryFactory: TelemetryDataFactory,
-        source: TelemetryEventSource,
-    ) {
-        super(postMessage, tabId);
-        this.telemetryFactory = telemetryFactory;
-        this.source = source;
-    }
+        private readonly telemetryFactory: TelemetryDataFactory,
+        private readonly source: TelemetryEventSource,
+        private readonly dispatcher: ActionMessageDispatcher,
+    ) {}
 
     @autobind
     public addSelector(event: React.MouseEvent<HTMLElement> | MouseEvent, inputType: string, selector: string[]): void {
@@ -33,9 +24,8 @@ export class ScopingActionMessageCreator extends BaseActionMessageCreator {
             telemetry,
         };
 
-        this.dispatchMessage({
+        this.dispatcher.dispatchMessage({
             messageType: messageType,
-            tabId: this._tabId,
             payload: payload,
         });
     }
@@ -50,9 +40,8 @@ export class ScopingActionMessageCreator extends BaseActionMessageCreator {
             telemetry,
         };
 
-        this.dispatchMessage({
+        this.dispatcher.dispatchMessage({
             messageType: messageType,
-            tabId: this._tabId,
             payload: payload,
         });
     }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -192,10 +192,9 @@ export class MainWindowInitializer extends WindowInitializer {
         );
 
         const scopingActionMessageCreator = new ScopingActionMessageCreator(
-            this.clientChromeAdapter.sendMessageToFrames,
-            null,
             telemetryDataFactory,
             TelemetryEventSource.TargetPage,
+            actionMessageDispatcher,
         );
 
         this.inspectController = new InspectController(


### PR DESCRIPTION
#### Description of changes

- Modified `ScopingActionMessageCreator` to use `ActionMessageDispatcher` instead of extending `BaseActionMessageCreator`
- Updated relevant unit tests

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes. **N/A**
