### PR TITLE
Remove unneded type

### DIFF
--- a/src/common/components/issue-filing-button.tsx
+++ b/src/common/components/issue-filing-button.tsx
@@ -10,7 +10,6 @@ import { IssueFilingService } from '../../issue-filing/types/issue-filing-servic
 import { EnvironmentInfo, EnvironmentInfoProvider } from '../environment-info-provider';
 import { LadyBugSolidIcon } from '../icons/lady-bug-solid-icon';
 import { BugActionMessageCreator } from '../message-creators/bug-action-message-creator';
-import { FileIssueClickService } from '../telemetry-events';
 import { CreateIssueDetailsTextData } from '../types/create-issue-details-text-data';
 import { IssueFilingNeedsSettingsContentProps, IssueFilingNeedsSettingsContentRenderer } from '../types/issue-filing-needs-setting-content';
 import { IssueFilingServiceProperties, UserConfigurationStoreData } from '../types/store-data/user-configuration-store';
@@ -85,7 +84,7 @@ export class IssueFilingButton extends React.Component<IssueFilingButtonProps, I
     @autobind
     private trackFileIssueClick(event: React.MouseEvent<any>): void {
         const bugServiceKey = this.props.userConfigurationStoreData.bugService;
-        this.props.deps.bugActionMessageCreator.trackFileIssueClick(event, bugServiceKey as FileIssueClickService);
+        this.props.deps.bugActionMessageCreator.trackFileIssueClick(event, bugServiceKey);
     }
 
     @autobind

--- a/src/common/message-creators/bug-action-message-creator.ts
+++ b/src/common/message-creators/bug-action-message-creator.ts
@@ -3,7 +3,7 @@
 import { BaseActionPayload } from '../../background/actions/action-payloads';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
-import { FILE_ISSUE_CLICK, FileIssueClickService, TelemetryEventSource } from '../telemetry-events';
+import { FILE_ISSUE_CLICK, TelemetryEventSource } from '../telemetry-events';
 import { ActionMessageDispatcher } from './action-message-dispatcher';
 
 export class BugActionMessageCreator {
@@ -25,7 +25,7 @@ export class BugActionMessageCreator {
         });
     }
 
-    public trackFileIssueClick(event: React.MouseEvent<HTMLElement>, service: FileIssueClickService): void {
+    public trackFileIssueClick(event: React.MouseEvent<HTMLElement>, service: string): void {
         const telemetry = this.telemetryFactory.forFileIssueClick(event, this.source, service);
         this.dispatcher.sendTelemetry(FILE_ISSUE_CLICK, telemetry);
     }

--- a/src/common/telemetry-data-factory.ts
+++ b/src/common/telemetry-data-factory.ts
@@ -13,7 +13,6 @@ import {
     ExportResultsTelemetryData,
     ExportResultType,
     FeatureFlagToggleTelemetryData,
-    FileIssueClickService,
     FileIssueClickTelemetryData,
     InspectTelemetryData,
     IssuesAnalyzerScanTelemetryData,
@@ -160,11 +159,7 @@ export class TelemetryDataFactory {
         };
     }
 
-    public forFileIssueClick(
-        event: SupportedMouseEvent,
-        source: TelemetryEventSource,
-        service: FileIssueClickService,
-    ): FileIssueClickTelemetryData {
+    public forFileIssueClick(event: SupportedMouseEvent, source: TelemetryEventSource, service: string): FileIssueClickTelemetryData {
         return {
             ...this.withTriggeredByAndSource(event, source),
             service,

--- a/src/common/telemetry-events.ts
+++ b/src/common/telemetry-events.ts
@@ -110,9 +110,8 @@ export type SettingsOpenTelemetryData = {
 export type SettingsOpenSourceItem = 'fileIssueSettingsPrompt' | 'menu';
 
 export type FileIssueClickTelemetryData = {
-    service: FileIssueClickService;
+    service: string;
 } & BaseTelemetryData;
-export type FileIssueClickService = 'none' | 'gitHub';
 
 export type RequirementSelectTelemetryData = {
     selectedTest: string;

--- a/src/tests/unit/tests/common/message-creators/bug-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/bug-action-message-creator.test.ts
@@ -8,7 +8,6 @@ import { TelemetryDataFactory } from '../../../../../common/telemetry-data-facto
 import {
     BaseTelemetryData,
     FILE_ISSUE_CLICK,
-    FileIssueClickService,
     SettingsOpenSourceItem,
     TelemetryEventSource,
     TriggeredBy,
@@ -58,7 +57,7 @@ describe('BugActionMessageCreator', () => {
     });
 
     it('dispatch message for trackFileIssueClick', () => {
-        const testService: FileIssueClickService = 'test file issue service' as FileIssueClickService;
+        const testService: string = 'test file issue service';
         const telemetry = { ...telemetryStub, service: testService };
 
         telemetryFactoryMock.setup(factory => factory.forFileIssueClick(eventStub, source, testService)).returns(() => telemetry);

--- a/src/tests/unit/tests/issue-filing/issue-filing-service-provider-impl.test.ts
+++ b/src/tests/unit/tests/issue-filing/issue-filing-service-provider-impl.test.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { uniq } from 'lodash';
+import { IssueFilingServiceProviderImpl } from '../../../../issue-filing/issue-filing-service-provider-impl';
+
+describe('Name of the group', () => {
+    test('unique key across issue filing services', () => {
+        const all = IssueFilingServiceProviderImpl.all();
+
+        const keys = all.map(current => current.key);
+
+        expect(uniq(keys)).toEqual(keys);
+    });
+});


### PR DESCRIPTION
#### Description of changes

Remove `FileIssueClickService`, using `string` instead. The main reason to do this is we are not getting any value from the custom type. Also, if we were to properly use it, every time someone adds a new issue filing service this will be one more place to change.

Also, add test to make sure the key that identify each issue filing service is unique.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
