### PR TITLE
[Refactor] Issue filing handling

### DIFF
--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -5,6 +5,7 @@ import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dia
 import * as React from 'react';
 
 import { EnvironmentInfoProvider } from '../../common/environment-info-provider';
+import { IssueFilingActionMessageCreator } from '../../common/message-creators/issue-filing-action-message-creator';
 import { UserConfigMessageCreator } from '../../common/message-creators/user-config-message-creator';
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { IssueFilingServicePropertiesMap } from '../../common/types/store-data/user-configuration-store';
@@ -23,7 +24,6 @@ export interface IssueFilingDialogProps {
     isOpen: boolean;
     selectedIssueFilingService: IssueFilingService;
     selectedIssueData: CreateIssueDetailsTextData;
-    fileIssueTelemetryCallback: (ev: React.SyntheticEvent) => void;
     issueFilingServicePropertiesMap: IssueFilingServicePropertiesMap;
     onClose: (ev: React.SyntheticEvent) => void;
 }
@@ -32,6 +32,7 @@ export type IssueFilingDialogDeps = {
     environmentInfoProvider: EnvironmentInfoProvider;
     userConfigMessageCreator: UserConfigMessageCreator;
     issueFilingServiceProvider: IssueFilingServiceProvider;
+    issueFilingActionMessageCreator: IssueFilingActionMessageCreator;
 } & IssueFilingSettingsContainerDeps;
 
 const titleLabel = 'Specify issue filing location';
@@ -55,16 +56,12 @@ export class IssueFilingDialog extends React.Component<IssueFilingDialogProps, I
     }
 
     public render(): JSX.Element {
-        const { selectedIssueData, onClose, isOpen, deps } = this.props;
+        const { onClose, isOpen, deps } = this.props;
         const { selectedIssueFilingService } = this.state;
         const selectedIssueFilingServiceData = this.state.selectedIssueFilingService.getSettingsFromStoreData(
             this.state.issueFilingServicePropertiesMap,
         );
-        const environmentInfo = deps.environmentInfoProvider.getEnvironmentInfo();
         const isSettingsValid = selectedIssueFilingService.isSettingsValid(selectedIssueFilingServiceData);
-        const href = isSettingsValid
-            ? selectedIssueFilingService.issueFilingUrlProvider(selectedIssueFilingServiceData, selectedIssueData, environmentInfo)
-            : null;
 
         return (
             <Dialog
@@ -95,7 +92,6 @@ export class IssueFilingDialog extends React.Component<IssueFilingDialogProps, I
                         primaryButtonDisabled={isSettingsValid === false}
                         primaryButtonOnClick={this.onPrimaryButtonClick}
                         cancelButtonOnClick={onClose}
-                        primaryButtonHref={href}
                         primaryButtonText={'File issue'}
                     />
                 </DialogFooter>
@@ -107,7 +103,7 @@ export class IssueFilingDialog extends React.Component<IssueFilingDialogProps, I
         const newData = this.state.selectedIssueFilingService.getSettingsFromStoreData(this.state.issueFilingServicePropertiesMap);
         const service = this.state.selectedIssueFilingService.key;
         this.props.deps.userConfigMessageCreator.saveIssueFilingSettings(service, newData);
-        this.props.fileIssueTelemetryCallback(ev);
+        this.props.deps.issueFilingActionMessageCreator.fileIssue(ev, service, this.props.selectedIssueData);
         this.props.onClose(ev);
     };
 

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -8,6 +8,7 @@ import { IssueFilingServiceProperties } from '../../common/types/store-data/user
 import { VisualizationType } from '../../common/types/visualization-type';
 import { TabStopEvent } from '../../injected/tab-stops-listener';
 import { LaunchPanelType } from '../../popup/components/popup-view';
+import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 
 export interface BaseActionPayload {
     telemetry?: TelemetryData;
@@ -141,4 +142,9 @@ export interface SetIssueFilingServicePropertyPayload extends BaseActionPayload 
 
 export interface SetIssueTrackerPathPayload extends BaseActionPayload {
     issueTrackerPath: string;
+}
+
+export interface FileIssuePayload extends BaseActionPayload {
+    issueData: CreateIssueDetailsTextData;
+    service: string;
 }

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 import * as TelemetryEvents from '../../common/telemetry-events';
 import { BaseTelemetryData, TelemetryData, ToggleTelemetryData } from '../../common/telemetry-events';
+import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
 import { ManualTestStatus } from '../../common/types/manual-test-status';
 import { IssueFilingServiceProperties } from '../../common/types/store-data/user-configuration-store';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { TabStopEvent } from '../../injected/tab-stops-listener';
 import { LaunchPanelType } from '../../popup/components/popup-view';
-import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 
 export interface BaseActionPayload {
     telemetry?: TelemetryData;

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -14,6 +14,7 @@ import { NotificationCreator } from '../common/notification-creator';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
 import { UrlValidator } from '../common/url-validator';
 import { WindowUtils } from '../common/window-utils';
+import { IssueFilingServiceProviderImpl } from '../issue-filing/issue-filing-service-provider-impl';
 import { ChromeAdapter } from './browser-adapter';
 import { ChromeCommandHandler } from './chrome-command-handler';
 import { DetailsViewController } from './details-view-controller';
@@ -33,7 +34,6 @@ import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
 import { TelemetryLogger } from './telemetry/telemetry-logger';
 import { TelemetryStateListener } from './telemetry/telemetry-state-listener';
 import { UserStoredDataCleaner } from './user-stored-data-cleaner';
-import { IssueFilingServiceProviderImpl } from '../issue-filing/issue-filing-service-provider-impl';
 
 declare var window: Window & InsightsFeatureFlags;
 const browserAdapter = new ChromeAdapter();

--- a/src/background/global-action-creators/issue-filing-action-creator.ts
+++ b/src/background/global-action-creators/issue-filing-action-creator.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Messages } from '../../common/messages';
+import { FILE_ISSUE_CLICK } from '../../common/telemetry-events';
+import { IssueFilingController } from '../../issue-filing/common/issue-filing-controller-impl';
+import { FileIssuePayload } from '../actions/action-payloads';
+import { Interpreter } from '../interpreter';
+import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
+
+export class IssueFilingActionCreator {
+    constructor(
+        private readonly interpreter: Interpreter,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly issueFilingController: IssueFilingController,
+    ) {}
+
+    public registerCallbacks(): void {
+        this.interpreter.registerTypeToPayloadCallback(Messages.IssueFiling.FileIssue, this.onFileIssue);
+    }
+
+    private onFileIssue = (payload: FileIssuePayload) => {
+        this.telemetryEventHandler.publishTelemetry(FILE_ISSUE_CLICK, payload);
+        this.issueFilingController.fileIssue(payload.service, payload.issueData);
+    };
+}

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -1,8 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { EnvironmentInfo } from '../common/environment-info-provider';
 import { IndexedDBAPI } from '../common/indexedDB/indexedDB';
 import { StateDispatcher } from '../common/state-dispatcher';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
+import { IssueFilingControllerImpl } from '../issue-filing/common/issue-filing-controller-impl';
+import { IssueFilingServiceProvider } from '../issue-filing/issue-filing-service-provider';
 import { AssessmentsProvider } from './../assessments/types/assessments-provider';
 import { AssessmentActionCreator } from './actions/assessment-action-creator';
 import { GlobalActionHub } from './actions/global-action-hub';
@@ -11,16 +14,13 @@ import { CompletedTestStepTelemetryCreator } from './completed-test-step-telemet
 import { FeatureFlagsController } from './feature-flags-controller';
 import { PersistedData } from './get-persisted-data';
 import { GlobalActionCreator } from './global-action-creators/global-action-creator';
+import { IssueFilingActionCreator } from './global-action-creators/issue-filing-action-creator';
 import { UserConfigurationActionCreator } from './global-action-creators/user-configuration-action-creator';
 import { GlobalContext } from './global-context';
 import { Interpreter } from './interpreter';
 import { LocalStorageData } from './storage-data';
 import { GlobalStoreHub } from './stores/global/global-store-hub';
 import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
-import { IssueFilingServiceProvider } from '../issue-filing/issue-filing-service-provider';
-import { EnvironmentInfo } from '../common/environment-info-provider';
-import { IssueFilingControllerImpl } from '../issue-filing/common/issue-filing-controller-impl';
-import { IssueFilingActionCreator } from './global-action-creators/issue-filing-action-creator';
 
 export class GlobalContextFactory {
     public static createContext(

--- a/src/common/message-creators/issue-filing-action-message-creator.ts
+++ b/src/common/message-creators/issue-filing-action-message-creator.ts
@@ -5,8 +5,8 @@ import { Message } from '../message';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
 import { FILE_ISSUE_CLICK, TelemetryEventSource } from '../telemetry-events';
-import { ActionMessageDispatcher } from './action-message-dispatcher';
 import { CreateIssueDetailsTextData } from '../types/create-issue-details-text-data';
+import { ActionMessageDispatcher } from './action-message-dispatcher';
 
 type SupportedMouseEvent = React.MouseEvent<HTMLElement> | React.SyntheticEvent<Element, Event>;
 

--- a/src/common/message-creators/issue-filing-action-message-creator.ts
+++ b/src/common/message-creators/issue-filing-action-message-creator.ts
@@ -1,10 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseActionPayload } from '../../background/actions/action-payloads';
+import { BaseActionPayload, FileIssuePayload } from '../../background/actions/action-payloads';
+import { Message } from '../message';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
 import { FILE_ISSUE_CLICK, TelemetryEventSource } from '../telemetry-events';
 import { ActionMessageDispatcher } from './action-message-dispatcher';
+import { CreateIssueDetailsTextData } from '../types/create-issue-details-text-data';
+
+type SupportedMouseEvent = React.MouseEvent<HTMLElement> | React.SyntheticEvent<Element, Event>;
 
 export class IssueFilingActionMessageCreator {
     constructor(
@@ -28,5 +32,20 @@ export class IssueFilingActionMessageCreator {
     public trackFileIssueClick(event: React.MouseEvent<HTMLElement>, service: string): void {
         const telemetry = this.telemetryFactory.forFileIssueClick(event, this.source, service);
         this.dispatcher.sendTelemetry(FILE_ISSUE_CLICK, telemetry);
+    }
+
+    public fileIssue(event: SupportedMouseEvent, serviceKey: string, issueData: CreateIssueDetailsTextData): void {
+        const messageType = Messages.IssueFiling.FileIssue;
+        const telemetry = this.telemetryFactory.forFileIssueClick(event, this.source, serviceKey);
+        const payload: FileIssuePayload = {
+            telemetry,
+            issueData,
+            service: serviceKey,
+        };
+        const message: Message = {
+            messageType,
+            payload,
+        };
+        this.dispatcher.dispatchMessage(message);
     }
 }

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -191,4 +191,8 @@ export class Messages {
         GetCurrentState: 'insights/inspect/get',
         SetHoveredOverSelector: 'insights/inspect/setHoveredOverSelector',
     };
+
+    public static readonly IssueFiling = {
+        FileIssue: 'insights/issueFiling/file',
+    };
 }

--- a/src/common/telemetry-data-factory.ts
+++ b/src/common/telemetry-data-factory.ts
@@ -37,7 +37,8 @@ export type SupportedMouseEvent =
     | React.MouseEvent<any>
     | MouseEvent
     | React.MouseEvent<HTMLElement>
-    | React.KeyboardEvent<HTMLElement>;
+    | React.KeyboardEvent<HTMLElement>
+    | React.SyntheticEvent<Element, Event>;
 
 export class TelemetryDataFactory {
     public forVisualizationToggleByCommand(enabled: boolean): ToggleTelemetryData {

--- a/src/issue-filing/common/issue-filing-controller-impl.ts
+++ b/src/issue-filing/common/issue-filing-controller-impl.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BrowserAdapter } from '../../background/browser-adapter';
+import { BaseStore } from '../../common/base-store';
+import { EnvironmentInfo } from '../../common/environment-info-provider';
+import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
+import { IssueFilingServiceProperties, UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
+import { IssueFilingServiceProvider } from '../issue-filing-service-provider';
+
+export type IssueFilingController = {
+    fileIssue: (serviceKey: string, issueData: CreateIssueDetailsTextData) => void;
+};
+
+export class IssueFilingControllerImpl implements IssueFilingController {
+    constructor(
+        private readonly provider: IssueFilingServiceProvider,
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly environmentInfo: EnvironmentInfo,
+        private readonly userConfigurationStore: BaseStore<UserConfigurationStoreData>,
+    ) {}
+
+    public fileIssue = (serviceKey: string, issueData: CreateIssueDetailsTextData): void => {
+        const service = this.provider.forKey(serviceKey);
+        const userConfigurationStoreData = this.userConfigurationStore.getState();
+
+        const serviceConfig: IssueFilingServiceProperties = service.getSettingsFromStoreData(
+            userConfigurationStoreData.bugServicePropertiesMap,
+        );
+
+        const url = service.issueFilingUrlProvider(serviceConfig, issueData, this.environmentInfo);
+        this.browserAdapter.createTab(url);
+    };
+}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
@@ -30,6 +30,15 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have ch
           "extensionVersion": undefined,
           "getEnvironmentInfo": [Function],
         },
+        "issueFilingActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "issueFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -111,6 +120,15 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have no
           "browserSpec": undefined,
           "extensionVersion": undefined,
           "getEnvironmentInfo": [Function],
+        },
+        "issueFilingActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
         },
         "issueFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -194,6 +212,15 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have change
           "extensionVersion": undefined,
           "getEnvironmentInfo": [Function],
         },
+        "issueFilingActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "issueFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -275,6 +302,15 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have not ch
           "browserSpec": undefined,
           "extensionVersion": undefined,
           "getEnvironmentInfo": [Function],
+        },
+        "issueFilingActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
         },
         "issueFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -358,6 +394,15 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
           "extensionVersion": undefined,
           "getEnvironmentInfo": [Function],
         },
+        "issueFilingActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "issueFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -403,7 +448,6 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
       cancelButtonOnClick={[Function]}
       isHidden={false}
       primaryButtonDisabled={true}
-      primaryButtonHref={null}
       primaryButtonOnClick={[Function]}
       primaryButtonText="File issue"
     />
@@ -440,6 +484,15 @@ exports[`IssueFilingDialog render with isSettingsValid: true 1`] = `
           "browserSpec": undefined,
           "extensionVersion": undefined,
           "getEnvironmentInfo": [Function],
+        },
+        "issueFilingActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
         },
         "issueFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -522,6 +575,15 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
           "browserSpec": undefined,
           "extensionVersion": undefined,
           "getEnvironmentInfo": [Function],
+        },
+        "issueFilingActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
         },
         "issueFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -606,6 +668,15 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
           "extensionVersion": undefined,
           "getEnvironmentInfo": [Function],
         },
+        "issueFilingActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
+        },
         "issueFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "all": [Function],
@@ -687,6 +758,15 @@ exports[`IssueFilingDialog render: validate callback (onSelectedServiceChange) s
           "browserSpec": undefined,
           "extensionVersion": undefined,
           "getEnvironmentInfo": [Function],
+        },
+        "issueFilingActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "fileIssue": [Function],
+          "openSettingsPanel": [Function],
+          "source": undefined,
+          "telemetryFactory": undefined,
+          "trackFileIssueClick": [Function],
         },
         "issueFilingServiceProvider": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",

--- a/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { EnvironmentInfo, EnvironmentInfoProvider } from '../../../../../common/environment-info-provider';
+import { IssueFilingActionMessageCreator } from '../../../../../common/message-creators/issue-filing-action-message-creator';
 import { UserConfigMessageCreator } from '../../../../../common/message-creators/user-config-message-creator';
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 import { IssueFilingServicePropertiesMap } from '../../../../../common/types/store-data/user-configuration-store';
@@ -18,7 +19,6 @@ import { IssueFilingSettingsContainer } from '../../../../../issue-filing/compon
 import { IssueFilingServiceProvider } from '../../../../../issue-filing/issue-filing-service-provider';
 import { IssueFilingService } from '../../../../../issue-filing/types/issue-filing-service';
 import { EventStub, EventStubFactory } from '../../../common/event-stub-factory';
-import { IssueFilingActionMessageCreator } from '../../../../../common/message-creators/issue-filing-action-message-creator';
 
 describe('IssueFilingDialog', () => {
     let eventStub: EventStub;

--- a/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
@@ -18,6 +18,7 @@ import { IssueFilingSettingsContainer } from '../../../../../issue-filing/compon
 import { IssueFilingServiceProvider } from '../../../../../issue-filing/issue-filing-service-provider';
 import { IssueFilingService } from '../../../../../issue-filing/types/issue-filing-service';
 import { EventStub, EventStubFactory } from '../../../common/event-stub-factory';
+import { IssueFilingActionMessageCreator } from '../../../../../common/message-creators/issue-filing-action-message-creator';
 
 describe('IssueFilingDialog', () => {
     let eventStub: EventStub;
@@ -25,7 +26,6 @@ describe('IssueFilingDialog', () => {
     let createIssueFilingUrlMock: IMock<Function>;
     let getSettingsFromStoreDataMock: IMock<Function>;
     let onCloseMock: IMock<(ev) => void>;
-    let telemetryCallbackMock: IMock<(ev) => void>;
     let selectedIssueDataStub: CreateIssueDetailsTextData;
     let selectedServiceData;
     let deps: IssueFilingDialogDeps;
@@ -37,6 +37,7 @@ describe('IssueFilingDialog', () => {
     let issueFilingServicePropertiesMapStub: IssueFilingServicePropertiesMap;
     let userConfigMessageCreatorMock: IMock<UserConfigMessageCreator>;
     let issueFilingServiceProviderMock: IMock<IssueFilingServiceProvider>;
+    let issueFilingActionMessageCreatorMock: IMock<IssueFilingActionMessageCreator>;
 
     beforeEach(() => {
         serviceKey = 'gitHub';
@@ -50,10 +51,10 @@ describe('IssueFilingDialog', () => {
         onCloseMock = Mock.ofInstance(() => null, MockBehavior.Strict);
         createIssueFilingUrlMock = Mock.ofInstance((serviceData, issueData, info) => null, MockBehavior.Strict);
         getSettingsFromStoreDataMock = Mock.ofInstance(data => null, MockBehavior.Strict);
-        telemetryCallbackMock = Mock.ofInstance(data => null, MockBehavior.Strict);
         envInfoProviderMock = Mock.ofType(EnvironmentInfoProvider);
         userConfigMessageCreatorMock = Mock.ofType(UserConfigMessageCreator);
         issueFilingServiceProviderMock = Mock.ofType(IssueFilingServiceProvider);
+        issueFilingActionMessageCreatorMock = Mock.ofType(IssueFilingActionMessageCreator);
 
         envInfoProviderMock.setup(p => p.getEnvironmentInfo()).returns(() => envInfo);
 
@@ -70,6 +71,7 @@ describe('IssueFilingDialog', () => {
             issueFilingServiceProvider: issueFilingServiceProviderMock.object,
             userConfigMessageCreator: userConfigMessageCreatorMock.object,
             environmentInfoProvider: envInfoProviderMock.object,
+            issueFilingActionMessageCreator: issueFilingActionMessageCreatorMock.object,
         } as IssueFilingDialogDeps;
         issueFilingServiceStub = {
             isSettingsValid: isSettingsValidMock.object,
@@ -83,7 +85,6 @@ describe('IssueFilingDialog', () => {
             onClose: onCloseMock.object,
             selectedIssueFilingService: issueFilingServiceStub,
             selectedIssueData: selectedIssueDataStub,
-            fileIssueTelemetryCallback: telemetryCallbackMock.object,
             issueFilingServicePropertiesMap: issueFilingServicePropertiesMapStub,
         };
 
@@ -114,7 +115,6 @@ describe('IssueFilingDialog', () => {
     });
 
     it('render: validate correct callbacks to ActionAndCancelButtonsComponent (file issue on click and cancel)', () => {
-        telemetryCallbackMock.setup(telemetryCallback => telemetryCallback(eventStub)).verifiable(Times.never());
         onCloseMock.setup(onClose => onClose(null)).verifiable(Times.once());
 
         const testSubject = shallow(<IssueFilingDialog {...props} />);
@@ -122,14 +122,14 @@ describe('IssueFilingDialog', () => {
         actionCancelButtons.props().cancelButtonOnClick(null);
 
         isSettingsValidMock.verifyAll();
-        createIssueFilingUrlMock.verifyAll();
-        telemetryCallbackMock.verifyAll();
         onCloseMock.verifyAll();
     });
 
     it('render: validate correct callbacks to ActionAndCancelButtonsComponent (file issue on click and cancel)', () => {
         userConfigMessageCreatorMock.setup(ucmcm => ucmcm.saveIssueFilingSettings(serviceKey, selectedServiceData)).verifiable();
-        telemetryCallbackMock.setup(telemetryCallback => telemetryCallback(eventStub)).verifiable(Times.once());
+        issueFilingActionMessageCreatorMock
+            .setup(creator => creator.fileIssue(eventStub as any, serviceKey, It.isValue(props.selectedIssueData)))
+            .verifiable(Times.once());
         onCloseMock.setup(onClose => onClose(eventStub)).verifiable(Times.once());
 
         const testSubject = shallow(<IssueFilingDialog {...props} />);
@@ -137,9 +137,8 @@ describe('IssueFilingDialog', () => {
         actionCancelButtons.props().primaryButtonOnClick(eventStub);
 
         isSettingsValidMock.verifyAll();
-        createIssueFilingUrlMock.verifyAll();
-        telemetryCallbackMock.verifyAll();
         userConfigMessageCreatorMock.verifyAll();
+        issueFilingActionMessageCreatorMock.verifyAll();
         onCloseMock.verifyAll();
     });
 

--- a/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { It, Mock, MockBehavior, Times } from 'typemoq';
+
+import { FileIssuePayload } from '../../../../../background/actions/action-payloads';
+import { IssueFilingActionCreator } from '../../../../../background/global-action-creators/issue-filing-action-creator';
+import { Interpreter } from '../../../../../background/interpreter';
+import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';
+import { FILE_ISSUE_CLICK, TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
+import { IssueFilingController } from '../../../../../issue-filing/common/issue-filing-controller-impl';
+
+export { isFunction } from 'lodash';
+
+describe('IssueFilingActionCreator', () => {
+    it('handles FileIssue message', () => {
+        const payload: FileIssuePayload = {
+            issueData: {} as CreateIssueDetailsTextData,
+            service: 'test-service',
+            telemetry: {
+                triggeredBy: 'test' as TriggeredBy,
+                source: -1 as TelemetryEventSource,
+            },
+        };
+
+        const interpreterMock = Mock.ofType<Interpreter>();
+        interpreterMock
+            .setup(interpreter => interpreter.registerTypeToPayloadCallback(It.isAny(), It.isAny()))
+            .callback((message, handler) => handler(payload));
+
+        const telemetryHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
+        telemetryHandlerMock.setup(handler => handler.publishTelemetry(FILE_ISSUE_CLICK, payload)).verifiable(Times.once());
+
+        const issueFilingControllerMock = Mock.ofType<IssueFilingController>(null, MockBehavior.Strict);
+        issueFilingControllerMock.setup(controller => controller.fileIssue(payload.service, payload.issueData)).verifiable(Times.once());
+
+        const testSubject = new IssueFilingActionCreator(
+            interpreterMock.object,
+            telemetryHandlerMock.object,
+            issueFilingControllerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        telemetryHandlerMock.verifyAll();
+        issueFilingControllerMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/background/global-context-factory.test.ts
+++ b/src/tests/unit/tests/background/global-context-factory.test.ts
@@ -14,21 +14,30 @@ import { LaunchPanelStore } from '../../../../background/stores/global/launch-pa
 import { TelemetryEventHandler } from '../../../../background/telemetry/telemetry-event-handler';
 import { IndexedDBAPI } from '../../../../common/indexedDB/indexedDB';
 import { TelemetryDataFactory } from '../../../../common/telemetry-data-factory';
+import { IssueFilingServiceProvider } from '../../../../issue-filing/issue-filing-service-provider';
 import { CreateTestAssessmentProvider } from '../../common/test-assessment-provider';
+import { EnvironmentInfo } from '../../../../common/environment-info-provider';
 
 describe('GlobalContextFactoryTest', () => {
     let _mockChromeAdapter: IMock<BrowserAdapter>;
     let _mocktelemetryEventHandler: IMock<TelemetryEventHandler>;
     let _mockTelemetryDataFactory: IMock<TelemetryDataFactory>;
+    let _mockIssueFilingServiceProvider: IMock<IssueFilingServiceProvider>;
+    let environmentInfoStub: EnvironmentInfo;
     let userDataStub: LocalStorageData;
     let idbInstance: IndexedDBAPI;
+    let persistedDataStub: PersistedData;
 
     beforeAll(() => {
         _mockChromeAdapter = Mock.ofType(ChromeAdapter, MockBehavior.Loose);
         _mockChromeAdapter.setup(adapter => adapter.sendMessageToAllFramesAndTabs(It.isAny()));
         _mocktelemetryEventHandler = Mock.ofType(TelemetryEventHandler);
         _mockTelemetryDataFactory = Mock.ofType(TelemetryDataFactory);
+        _mockIssueFilingServiceProvider = Mock.ofType(IssueFilingServiceProvider);
+
         userDataStub = {};
+        environmentInfoStub = {} as EnvironmentInfo;
+        persistedDataStub = {} as PersistedData;
         idbInstance = {} as IndexedDBAPI;
     });
 
@@ -40,7 +49,9 @@ describe('GlobalContextFactoryTest', () => {
             CreateTestAssessmentProvider(),
             _mockTelemetryDataFactory.object,
             idbInstance,
-            {} as PersistedData,
+            persistedDataStub,
+            _mockIssueFilingServiceProvider.object,
+            environmentInfoStub,
         );
 
         expect(globalContext).toBeInstanceOf(GlobalContext);

--- a/src/tests/unit/tests/background/global-context-factory.test.ts
+++ b/src/tests/unit/tests/background/global-context-factory.test.ts
@@ -12,11 +12,11 @@ import { CommandStore } from '../../../../background/stores/global/command-store
 import { FeatureFlagStore } from '../../../../background/stores/global/feature-flag-store';
 import { LaunchPanelStore } from '../../../../background/stores/global/launch-panel-store';
 import { TelemetryEventHandler } from '../../../../background/telemetry/telemetry-event-handler';
+import { EnvironmentInfo } from '../../../../common/environment-info-provider';
 import { IndexedDBAPI } from '../../../../common/indexedDB/indexedDB';
 import { TelemetryDataFactory } from '../../../../common/telemetry-data-factory';
 import { IssueFilingServiceProvider } from '../../../../issue-filing/issue-filing-service-provider';
 import { CreateTestAssessmentProvider } from '../../common/test-assessment-provider';
-import { EnvironmentInfo } from '../../../../common/environment-info-provider';
 
 describe('GlobalContextFactoryTest', () => {
     let _mockChromeAdapter: IMock<BrowserAdapter>;

--- a/src/tests/unit/tests/common/components/__snapshots__/issue-filing-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/issue-filing-button.test.tsx.snap
@@ -2,48 +2,48 @@
 
 exports[`IssueFilingButtonTest onclick: invalid settings, %s 1`] = `
 "<Fragment>
-  <CustomizedDefaultButton className=\\"file-issue-button\\" target=\\"_self\\" onClick={[Function: onClick]} href={{...}}>
+  <CustomizedDefaultButton className=\\"file-issue-button\\" onClick={[Function: onClick]}>
     <LadyBugSolidIcon />
     <div className=\\"ms-Button-label\\">
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={true} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} fileIssueTelemetryCallback={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={true} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
 </Fragment>"
 `;
 
 exports[`IssueFilingButtonTest onclick: valid settings, file bug and set %s to false 1`] = `
 "<Fragment>
-  <CustomizedDefaultButton className=\\"file-issue-button\\" target=\\"_blank\\" onClick={[Function: onClick]} href=\\"test url\\">
+  <CustomizedDefaultButton className=\\"file-issue-button\\" onClick={[Function: onClick]}>
     <LadyBugSolidIcon />
     <div className=\\"ms-Button-label\\">
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} fileIssueTelemetryCallback={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
 </Fragment>"
 `;
 
 exports[`IssueFilingButtonTest render: isSettingsValid: false 1`] = `
 "<Fragment>
-  <CustomizedDefaultButton className=\\"file-issue-button\\" target=\\"_self\\" onClick={[Function: onClick]} href={{...}}>
+  <CustomizedDefaultButton className=\\"file-issue-button\\" onClick={[Function: onClick]}>
     <LadyBugSolidIcon />
     <div className=\\"ms-Button-label\\">
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} fileIssueTelemetryCallback={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
 </Fragment>"
 `;
 
 exports[`IssueFilingButtonTest render: isSettingsValid: true 1`] = `
 "<Fragment>
-  <CustomizedDefaultButton className=\\"file-issue-button\\" target=\\"_blank\\" onClick={[Function: onClick]} href=\\"test url\\">
+  <CustomizedDefaultButton className=\\"file-issue-button\\" onClick={[Function: onClick]}>
     <LadyBugSolidIcon />
     <div className=\\"ms-Button-label\\">
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} fileIssueTelemetryCallback={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
 </Fragment>"
 `;

--- a/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
+++ b/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
@@ -17,7 +17,7 @@ import { EventStubFactory } from '../../../common/event-stub-factory';
 
 describe('IssueFilingButtonTest', () => {
     const testKey: string = 'test';
-    const eventStub = new EventStubFactory().createNativeMouseClickEvent();
+    const eventStub = new EventStubFactory().createNativeMouseClickEvent() as any;
     let environmentInfoProviderMock: IMock<EnvironmentInfoProvider>;
     let issueFilingServiceProviderMock: IMock<IssueFilingServiceProvider>;
     let issueFilingActionMessageCreatorMock: IMock<IssueFilingActionMessageCreator>;
@@ -82,14 +82,10 @@ describe('IssueFilingButtonTest', () => {
         const wrapper = shallow(<IssueFilingButton {...props} />);
         expect(wrapper.debug()).toMatchSnapshot();
 
-        environmentInfoProviderMock.verifyAll();
         issueFilingServiceProviderMock.verifyAll();
     });
 
     test('onclick: valid settings, file bug and set %s to false', () => {
-        issueFilingActionMessageCreatorMock
-            .setup(messageCreator => messageCreator.trackFileIssueClick(eventStub as any, testKey as any))
-            .verifiable(Times.once());
         const props: IssueFilingButtonProps = {
             deps: {
                 issueFilingActionMessageCreator: issueFilingActionMessageCreatorMock.object,
@@ -104,6 +100,9 @@ describe('IssueFilingButtonTest', () => {
             userConfigurationStoreData: userConfigurationStoreData,
             needsSettingsContentRenderer,
         };
+        issueFilingActionMessageCreatorMock
+            .setup(creator => creator.fileIssue(eventStub, testKey, props.issueDetailsData))
+            .verifiable(Times.once());
         const wrapper = shallow(<IssueFilingButton {...props} />);
 
         wrapper.find(DefaultButton).simulate('click', eventStub);

--- a/src/tests/unit/tests/common/telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/common/telemetry-data-factory.test.ts
@@ -18,6 +18,7 @@ import {
     TelemetryEventSource,
     ToggleTelemetryData,
     TriggeredByNotApplicable,
+    FileIssueClickTelemetryData,
 } from '../../../../common/telemetry-events';
 import { DetailsViewPivotType } from '../../../../common/types/details-view-pivot-type';
 import { VisualizationType } from '../../../../common/types/visualization-type';
@@ -515,6 +516,20 @@ describe('TelemetryDataFactoryTest', () => {
             exportResultsData: exportedHtml.length,
             triggeredBy: 'mouseclick',
             source: testSource,
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    test('forFileIssueClick', () => {
+        const service = 'test-service';
+
+        const result = testObject.forFileIssueClick(mouseClickEvent, testSource, service);
+
+        const expected: FileIssueClickTelemetryData = {
+            service,
+            source: testSource,
+            triggeredBy: 'mouseclick',
         };
 
         expect(result).toEqual(expected);

--- a/src/tests/unit/tests/common/telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/common/telemetry-data-factory.test.ts
@@ -9,6 +9,7 @@ import {
     DetailsViewPivotSelectedTelemetryData,
     ExportResultsTelemetryData,
     FeatureFlagToggleTelemetryData,
+    FileIssueClickTelemetryData,
     InspectTelemetryData,
     RequirementActionTelemetryData,
     RequirementSelectTelemetryData,
@@ -18,7 +19,6 @@ import {
     TelemetryEventSource,
     ToggleTelemetryData,
     TriggeredByNotApplicable,
-    FileIssueClickTelemetryData,
 } from '../../../../common/telemetry-events';
 import { DetailsViewPivotType } from '../../../../common/types/details-view-pivot-type';
 import { VisualizationType } from '../../../../common/types/visualization-type';

--- a/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { It, Mock, Times } from 'typemoq';
+
+import { BrowserAdapter } from '../../../../../background/browser-adapter';
+import { BaseStore } from '../../../../../common/base-store';
+import { EnvironmentInfo } from '../../../../../common/environment-info-provider';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
+import {
+    IssueFilingServicePropertiesMap,
+    UserConfigurationStoreData,
+} from '../../../../../common/types/store-data/user-configuration-store';
+import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
+import { IssueFilingControllerImpl } from '../../../../../issue-filing/common/issue-filing-controller-impl';
+import { IssueFilingServiceProvider } from '../../../../../issue-filing/issue-filing-service-provider';
+import { IssueFilingService } from '../../../../../issue-filing/types/issue-filing-service';
+
+describe('IssueFilingControllerImpl', () => {
+    it('fileUssue', () => {
+        const serviceKey = 'test-service';
+        const issueData: CreateIssueDetailsTextData = {
+            pageTitle: 'pageTitle<x>',
+            pageUrl: 'pageUrl',
+            ruleResult: {
+                failureSummary: 'RR-failureSummary',
+                guidanceLinks: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
+                help: 'RR-help',
+                html: 'RR-html',
+                ruleId: 'RR-rule-id',
+                helpUrl: 'RR-help-url',
+                selector: 'RR-selector<x>',
+                snippet: 'RR-snippet   space',
+            } as DecoratedAxeNodeResult,
+        };
+        const environmentInfoStub: EnvironmentInfo = {
+            axeCoreVersion: 'test axe version',
+            browserSpec: 'test browser spec',
+            extensionVersion: 'test extension version',
+        };
+        const testUrl = 'test-url';
+        const map: IssueFilingServicePropertiesMap = {
+            [serviceKey]: {
+                repository: testUrl,
+            },
+        };
+        const serviceConfig = { bugServicePropertiesMap: map } as UserConfigurationStoreData;
+
+        const issueFilingServiceMock = Mock.ofType<IssueFilingService>();
+        issueFilingServiceMock
+            .setup(service => service.getSettingsFromStoreData(serviceConfig.bugServicePropertiesMap))
+            .returns(() => serviceConfig);
+        issueFilingServiceMock
+            .setup(service => service.issueFilingUrlProvider(It.isValue(serviceConfig), issueData, environmentInfoStub))
+            .returns(() => testUrl);
+
+        const providerMock = Mock.ofType<IssueFilingServiceProvider>();
+        providerMock.setup(provider => provider.forKey(serviceKey)).returns(() => issueFilingServiceMock.object);
+
+        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
+        browserAdapterMock.setup(adapter => adapter.createTab(testUrl)).verifiable(Times.once());
+
+        const storeMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>();
+        storeMock.setup(store => store.getState()).returns(() => serviceConfig);
+
+        const testSubject = new IssueFilingControllerImpl(
+            providerMock.object,
+            browserAdapterMock.object,
+            environmentInfoStub,
+            storeMock.object,
+        );
+
+        testSubject.fileIssue(serviceKey, issueData);
+
+        browserAdapterMock.verifyAll();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Refactor how we are handling 'file issue' button activation.

Currently, the button has a href property on it and also an onClick property (where we send telemetry).

Instead, the button should only send an action message to the background, which should send telemetry and handle the logic to file the issues against the proper service.

**Out of scope**
Cleaning up href usage on ActionAndCancelButtonsComponents, I'll have a separated PR for this clean up.

#### Pull request checklist

- [x] Addresses an existing issue: WI 1518658
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
