### PR TITLE
Add url rectifier to add /issues if the base url does not have it

### DIFF
--- a/src/issue-filing/github/create-github-issue-filing-url.ts
+++ b/src/issue-filing/github/create-github-issue-filing-url.ts
@@ -8,18 +8,22 @@ import { EnvironmentInfo } from './../../common/environment-info-provider';
 import { CreateIssueDetailsTextData } from './../../common/types/create-issue-details-text-data';
 import { IssueFilingUrlStringUtils, IssueUrlCreationUtils } from './../common/issue-filing-url-string-utils';
 import { GitHubIssueFilingSettings } from './github-issue-filing-service';
+import { rectify, UrlRectifier } from './github-url-rectifier';
 
 export const createGitHubIssueFilingUrlProvider = (
     stringUtils: IssueUrlCreationUtils,
     issueDetailsBuilder: IssueDetailsBuilder,
     queryBuilderProvider: () => HTTPQueryBuilder,
+    rectify: UrlRectifier,
 ) => {
     return (settingsData: GitHubIssueFilingSettings, issueData: CreateIssueDetailsTextData, environmentInfo: EnvironmentInfo): string => {
         const title = stringUtils.getTitle(issueData);
         const body = issueDetailsBuilder(environmentInfo, issueData);
 
+        const baseUrl = rectify(settingsData.repository);
+
         return queryBuilderProvider()
-            .withBaseUrl(`${settingsData.repository}/new`)
+            .withBaseUrl(`${baseUrl}/new`)
             .withParam('title', title)
             .withParam('body', body)
             .build();
@@ -30,4 +34,5 @@ export const gitHubIssueFilingUrlProvider = createGitHubIssueFilingUrlProvider(
     IssueFilingUrlStringUtils,
     createIssueDetailsBuilder(MarkdownFormatter),
     () => new HTTPQueryBuilder(),
+    rectify,
 );

--- a/src/issue-filing/github/create-github-issue-filing-url.ts
+++ b/src/issue-filing/github/create-github-issue-filing-url.ts
@@ -14,13 +14,13 @@ export const createGitHubIssueFilingUrlProvider = (
     stringUtils: IssueUrlCreationUtils,
     issueDetailsBuilder: IssueDetailsBuilder,
     queryBuilderProvider: () => HTTPQueryBuilder,
-    rectify: UrlRectifier,
+    rectifier: UrlRectifier,
 ) => {
     return (settingsData: GitHubIssueFilingSettings, issueData: CreateIssueDetailsTextData, environmentInfo: EnvironmentInfo): string => {
         const title = stringUtils.getTitle(issueData);
         const body = issueDetailsBuilder(environmentInfo, issueData);
 
-        const baseUrl = rectify(settingsData.repository);
+        const baseUrl = rectifier(settingsData.repository);
 
         return queryBuilderProvider()
             .withBaseUrl(`${baseUrl}/new`)

--- a/src/issue-filing/github/github-url-rectifier.ts
+++ b/src/issue-filing/github/github-url-rectifier.ts
@@ -8,7 +8,7 @@ export const rectify: UrlRectifier = (url: string): string => {
         return `${url}/issues`;
     }
 
-    const ownerAndRepoAndSlash = new RegExp('^https?://github.com/[^/]+/[^/]+/?$');
+    const ownerAndRepoAndSlash = new RegExp('^https?://github.com/[^/]+/[^/]+/$');
     if (ownerAndRepoAndSlash.test(url)) {
         return `${url}issues`;
     }

--- a/src/issue-filing/github/github-url-rectifier.ts
+++ b/src/issue-filing/github/github-url-rectifier.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export type UrlRectifier = (url: string) => string;
+
+export const rectify: UrlRectifier = (url: string): string => {
+    const ownerAndRepo = new RegExp('^https?://github.com/[^/]+/[^/]+$');
+    if (ownerAndRepo.test(url)) {
+        return `${url}/issues`;
+    }
+
+    const ownerAndRepoAndSlash = new RegExp('^https?://github.com/[^/]+/[^/]+/?$');
+    if (ownerAndRepoAndSlash.test(url)) {
+        return `${url}issues`;
+    }
+
+    return url;
+};

--- a/src/tests/unit/tests/issue-filing/github/create-github-issue-filing-url.test.ts
+++ b/src/tests/unit/tests/issue-filing/github/create-github-issue-filing-url.test.ts
@@ -5,11 +5,11 @@ import { IMock, Mock } from 'typemoq';
 import { HTTPQueryBuilder } from '../../../../../issue-filing/common/http-query-builder';
 import { IssueDetailsBuilder } from '../../../../../issue-filing/common/issue-details-builder';
 import { createGitHubIssueFilingUrlProvider } from '../../../../../issue-filing/github/create-github-issue-filing-url';
+import { UrlRectifier } from '../../../../../issue-filing/github/github-url-rectifier';
 import { IssueFilingUrlProvider } from '../../../../../issue-filing/types/issue-filing-service';
 import { EnvironmentInfo } from './../../../../../common/environment-info-provider';
 import { IssueUrlCreationUtils } from './../../../../../issue-filing/common/issue-filing-url-string-utils';
 import { GitHubIssueFilingSettings } from './../../../../../issue-filing/github/github-issue-filing-service';
-import { UrlRectifier } from '../../../../../issue-filing/github/github-url-rectifier';
 
 const buildedUrl = 'https://builded-url';
 describe('createGitHubIssueFilingUrlTest', () => {
@@ -57,7 +57,7 @@ describe('createGitHubIssueFilingUrlTest', () => {
 
         const rectifiedUrl = 'rectified-url';
         rectifyMock = Mock.ofType<UrlRectifier>();
-        rectifyMock.setup(rectify => rectify(settingsData.repository)).returns(() => rectifiedUrl);
+        rectifyMock.setup(rectifier => rectifier(settingsData.repository)).returns(() => rectifiedUrl);
 
         queryBuilderMock = Mock.ofType<HTTPQueryBuilder>();
 

--- a/src/tests/unit/tests/issue-filing/github/github-url-rectifier.test.ts
+++ b/src/tests/unit/tests/issue-filing/github/github-url-rectifier.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { rectify } from '../../../../../issue-filing/github/github-url-rectifier';
+
+describe('Github Url Rectifier', () => {
+    const testSubject = rectify;
+
+    const shouldAddSuffixTestCases = [
+        'https://github.com/me/my-repo',
+        'https://github.com/me/my-repo/',
+        'http://github.com/me/my-repo',
+        'http://github.com/me/my-repo/',
+        // the following 2 cases represent real cases where the repo name is 'issues'
+        // we still want to append the suffix in this cases
+        'http://github.com/me/issues/',
+        'http://github.com/me/issues',
+    ];
+
+    it.each(shouldAddSuffixTestCases)('should append to: %s', (url: string) => {
+        const expected = url + (url[url.length - 1] === '/' ? 'issues' : '/issues');
+        expect(testSubject(url)).toEqual(expected);
+    });
+
+    const shouldNotChangeTestCases = [
+        'this doesnt match',
+        'https://github.com/mine/my-repo/pull-request',
+        'file://my-files/issue.text',
+        'https://my-github-enterprise-url.com',
+    ];
+
+    it.each(shouldNotChangeTestCases)('should not change: %s', url => {
+        expect(testSubject(url)).toEqual(url);
+    });
+});


### PR DESCRIPTION
#### Description of changes

Re-adding some code to ensure the github url ends with `/issues`.
The main reason to do this is the difference in behaviors between the first and second versions of issue file: on the first version, we only ask the user to provider the repo url (without /issues) and we were appending the proper suffix, while the on second version we ask the user for the repo issues url (including /issues).
By updating the extension, and old version of the url will not work as of now. This small PR takes care of it while also supporting non-standard github urls (like in the case of github enterprise)

Original commit [here](https://github.com/Microsoft/accessibility-insights-web/pull/603/commits/f18746d82dba69727de966ee76d4db2567d2f779)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] Added screenshots/GIFs for UI changes.
