### PR TITLE
Updated/added high contrast styling for primary text; fixes overview page high contrast issue

### DIFF
--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -107,6 +107,7 @@
         --neutral-100: var(--white);
         --neutral-alpha-8: var(--white);
         --secondary-text: var(--white);
+        --primary-text: var(--white);
 
         // Outcome colors
         --positive-outcome: #4ac94a;


### PR DESCRIPTION
#### Description of changes

Simply adding a variable in css for primary text in high contrast styles.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #624 
- [n/a] Added relevant unit test for your changes. (`npm run test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.

![image](https://user-images.githubusercontent.com/32555133/56929517-af45d380-6a8e-11e9-96e1-7740899ec698.png)

