### PR TITLE
Show feature flag values when enable/disable feature

### DIFF
--- a/src/background/feature-flags-controller.ts
+++ b/src/background/feature-flags-controller.ts
@@ -24,23 +24,18 @@ export class FeatureFlagsController {
         return this.featureFlagStore.getState();
     }
 
-    public disableFeature(feature: string): void {
-        const payload: FeatureFlagPayload = {
-            feature: feature,
-            enabled: false,
-        };
-        const message: Message = {
-            messageType: Messages.FeatureFlags.SetFeatureFlag,
-            payload: payload,
-            tabId: null,
-        };
-        this.interpreter.interpret(message);
+    public disableFeature(feature: string): FeatureFlagStoreData {
+        return this.toggleFeatureFlag(feature, false);
     }
 
-    public enableFeature(feature: string): void {
+    public enableFeature(feature: string): FeatureFlagStoreData {
+        return this.toggleFeatureFlag(feature, true);
+    }
+
+    private toggleFeatureFlag(feature: string, enabled: boolean): FeatureFlagStoreData {
         const payload: FeatureFlagPayload = {
-            feature: feature,
-            enabled: true,
+            feature,
+            enabled,
         };
         const message: Message = {
             messageType: Messages.FeatureFlags.SetFeatureFlag,
@@ -48,6 +43,8 @@ export class FeatureFlagsController {
             tabId: null,
         };
         this.interpreter.interpret(message);
+
+        return this.listFeatureFlags();
     }
 
     public resetFeatureFlags(): void {

--- a/src/tests/unit/tests/background/feature-flags-controller.test.ts
+++ b/src/tests/unit/tests/background/feature-flags-controller.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, Times } from 'typemoq';
+
 import { FeatureFlagPayload } from '../../../../background/actions/feature-flag-actions';
 import { FeatureFlagsController } from '../../../../background/feature-flags-controller';
 import { Interpreter } from '../../../../background/interpreter';
@@ -57,11 +58,14 @@ describe('FeatureFlagsControllerTest', () => {
         featureFlagStoreMock.verifyAll();
     });
 
-    test('disableFeature', () => {
+    test.each([true, false])('toggle feature flag to enabled: %s', (enabled: boolean) => {
         const feature = FeatureFlags.logTelemetryToConsole;
+        const storeDataStub: FeatureFlagStoreData = {
+            [FeatureFlags[feature]]: enabled,
+        };
         const payload: FeatureFlagPayload = {
-            feature: feature,
-            enabled: false,
+            feature,
+            enabled,
         };
         const message: Message = {
             messageType: Messages.FeatureFlags.SetFeatureFlag,
@@ -70,29 +74,15 @@ describe('FeatureFlagsControllerTest', () => {
         };
 
         interpreterMock.setup(i => i.interpret(It.isObjectWith(message))).verifiable();
-
+        featureFlagStoreMock
+            .setup(f => f.getState())
+            .returns(() => storeDataStub)
+            .verifiable();
         testObject = new FeatureFlagsController(featureFlagStoreMock.object, interpreterMock.object);
-        testObject.disableFeature(feature);
+        const storeState = enabled ? testObject.enableFeature(feature) : testObject.disableFeature(feature);
+        expect(storeState).toEqual(storeDataStub);
         interpreterMock.verifyAll();
-    });
-
-    test('enableFeature', () => {
-        const feature = FeatureFlags.logTelemetryToConsole;
-        const payload: FeatureFlagPayload = {
-            feature: feature,
-            enabled: true,
-        };
-        const message: Message = {
-            messageType: Messages.FeatureFlags.SetFeatureFlag,
-            payload: payload,
-            tabId: null,
-        };
-
-        interpreterMock.setup(i => i.interpret(It.isObjectWith(message))).verifiable();
-
-        testObject = new FeatureFlagsController(featureFlagStoreMock.object, interpreterMock.object);
-        testObject.enableFeature(feature);
-        interpreterMock.verifyAll();
+        featureFlagStoreMock.verifyAll();
     });
 
     test('resetFeatureFlags', () => {


### PR DESCRIPTION
#### Description of changes

Per user feedback, show feature flag values when enable/disable a feature instead of 'undefined'. Confirmed the UX with Fer.

Before:
![image](https://user-images.githubusercontent.com/15974344/56931016-72301000-6a93-11e9-8fa0-dfe16c6619a1.png)


After:
![image](https://user-images.githubusercontent.com/15974344/56930976-5f1d4000-6a93-11e9-9492-5d1032aaca38.png)



#### Pull request checklist

- [x] Addresses an existing issue: Fixes #629 
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] Added screenshots/GIFs for UI changes.
