### PR TITLE
Modify text on azure boards settings repro steps option

### DIFF
--- a/src/issue-filing/azure-boards/azure-boards-settings-form.tsx
+++ b/src/issue-filing/azure-boards/azure-boards-settings-form.tsx
@@ -13,11 +13,10 @@ import {
 } from './azure-boards-issue-filing-service';
 
 export const AzureBoardsSettingsForm = NamedSFC<SettingsFormProps<AzureBoardsIssueFilingSettings>>('AzureBoardsSettingsForm', props => {
-    const defaultKey = 'reproSteps';
     const options: AzureBoardsIssueDetailLocationDropdownOption[] = [
         {
-            key: defaultKey,
-            text: 'Repro steps (default)',
+            key: 'reproSteps',
+            text: 'Repro steps',
         },
         {
             key: 'description',

--- a/src/tests/unit/tests/issue-filing/azure-boards/__snapshots__/azure-boards-settings-form.test.tsx.snap
+++ b/src/tests/unit/tests/issue-filing/azure-boards/__snapshots__/azure-boards-settings-form.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`AzureBoardsSettingsForm renders settings is null 1`] = `
       Array [
         Object {
           "key": "reproSteps",
-          "text": "Repro steps (default)",
+          "text": "Repro steps",
         },
         Object {
           "key": "description",
@@ -46,7 +46,7 @@ exports[`AzureBoardsSettingsForm renders with projectUrl and issueDetailsField 1
       Array [
         Object {
           "key": "reproSteps",
-          "text": "Repro steps (default)",
+          "text": "Repro steps",
         },
         Object {
           "key": "description",


### PR DESCRIPTION
#### Description of changes

Removed '(default)' to match the UX. Since currently, if the user has not set up issue filing service at all, we do not provide a default option. 

Before:
![image](https://user-images.githubusercontent.com/15974344/56936141-9b0fcf80-6aaa-11e9-90ff-e017e18703c3.png)

After:
![image](https://user-images.githubusercontent.com/15974344/56936152-a82cbe80-6aaa-11e9-9628-8c6c8e767cee.png)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
