### PR TITLE
[Bug Fix] Switcher change between Assessment and FastPass doesn't announce changes correctly

### DIFF
--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { autobind } from '@uifabric/utilities';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ResponsiveMode } from 'office-ui-fabric-react/lib/utilities/decorators/withResponsiveMode';
 import * as React from 'react';
 
 import { DetailsViewPivotType } from '../../../src/common/types/details-view-pivot-type';
-import { NamedSFC } from '../../common/react/named-sfc';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 
 export type SwitcherDeps = {
@@ -18,17 +18,26 @@ export interface SwitcherProps {
     pivotKey: DetailsViewPivotType;
 }
 
-export const Switcher = NamedSFC<SwitcherProps>('Switcher', props => {
-    const onRenderOption = (option: IDropdownOption): JSX.Element => {
+export interface SwitcherState {
+    selectedKey: DetailsViewPivotType;
+}
+
+export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
+    constructor(props: SwitcherProps) {
+        super(props);
+        this.state = { selectedKey: props.pivotKey };
+    }
+
+    private onRenderOption(option: IDropdownOption): JSX.Element {
         return (
             <div className="switcher-dropdown-option" aria-hidden="true">
                 {option.data && option.data.icon && <Icon iconName={option.data.icon} />}
                 <span>{option.text}</span>
             </div>
         );
-    };
+    }
 
-    const onRenderTitle = (options: IDropdownOption[]): JSX.Element => {
+    private onRenderTitle(options: IDropdownOption[]): JSX.Element {
         const option = options[0];
 
         return (
@@ -37,41 +46,46 @@ export const Switcher = NamedSFC<SwitcherProps>('Switcher', props => {
                 <span>{option.text}</span>
             </div>
         );
-    };
+    }
 
-    const { deps, pivotKey } = props;
-    const { detailsViewActionMessageCreator } = deps;
+    @autobind
+    private onOptionChange(event, option?: IDropdownOption): void {
+        this.setState({ selectedKey: option.key as any });
+        this.props.deps.detailsViewActionMessageCreator.sendPivotItemClicked(DetailsViewPivotType[option.data.key]);
+    }
 
-    const onOptionClick = (event, option?: IDropdownOption): void => {
-        detailsViewActionMessageCreator.sendPivotItemClicked(DetailsViewPivotType[option.data.key]);
-    };
-
-    return (
-        <Dropdown
-            ariaLabel="select workflow"
-            responsiveMode={ResponsiveMode.large}
-            selectedKey={pivotKey}
-            onRenderOption={onRenderOption}
-            onRenderTitle={onRenderTitle}
-            onChange={onOptionClick}
-            options={[
-                {
+    private getOptions(): IDropdownOption[] {
+        return [
+            {
+                key: DetailsViewPivotType.fastPass,
+                text: 'FastPass',
+                data: {
+                    icon: 'Rocket',
                     key: DetailsViewPivotType.fastPass,
-                    text: 'FastPass',
-                    data: {
-                        icon: 'Rocket',
-                        key: DetailsViewPivotType.fastPass,
-                    },
                 },
-                {
+            },
+            {
+                key: DetailsViewPivotType.assessment,
+                text: 'Assessment',
+                data: {
+                    icon: 'testBeaker',
                     key: DetailsViewPivotType.assessment,
-                    text: 'Assessment',
-                    data: {
-                        icon: 'testBeaker',
-                        key: DetailsViewPivotType.assessment,
-                    },
                 },
-            ]}
-        />
-    );
-});
+            },
+        ];
+    }
+
+    public render() {
+        return (
+            <Dropdown
+                ariaLabel="select workflow"
+                responsiveMode={ResponsiveMode.large}
+                selectedKey={this.state.selectedKey}
+                onRenderOption={this.onRenderOption}
+                onRenderTitle={this.onRenderTitle}
+                onChange={this.onOptionChange}
+                options={this.getOptions()}
+            />
+        );
+    }
+}

--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -51,7 +51,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
     @autobind
     private onOptionChange(event, option?: IDropdownOption): void {
         this.setState({ selectedKey: option.key as any });
-        this.props.deps.detailsViewActionMessageCreator.sendPivotItemClicked(DetailsViewPivotType[option.data.key]);
+        this.props.deps.detailsViewActionMessageCreator.sendPivotItemClicked(DetailsViewPivotType[option.key]);
     }
 
     private getOptions(): IDropdownOption[] {
@@ -61,7 +61,6 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
                 text: 'FastPass',
                 data: {
                     icon: 'Rocket',
-                    key: DetailsViewPivotType.fastPass,
                 },
             },
             {
@@ -69,13 +68,12 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
                 text: 'Assessment',
                 data: {
                     icon: 'testBeaker',
-                    key: DetailsViewPivotType.assessment,
                 },
             },
         ];
     }
 
-    public render() {
+    public render(): JSX.Element {
         return (
             <Dropdown
                 ariaLabel="select workflow"

--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ResponsiveMode } from 'office-ui-fabric-react/lib/utilities/decorators/withResponsiveMode';
@@ -28,16 +27,16 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
         this.state = { selectedKey: props.pivotKey };
     }
 
-    private onRenderOption(option: IDropdownOption): JSX.Element {
+    private onRenderOption = (option: IDropdownOption): JSX.Element => {
         return (
             <div className="switcher-dropdown-option" aria-hidden="true">
                 {option.data && option.data.icon && <Icon iconName={option.data.icon} />}
                 <span>{option.text}</span>
             </div>
         );
-    }
+    };
 
-    private onRenderTitle(options: IDropdownOption[]): JSX.Element {
+    private onRenderTitle = (options: IDropdownOption[]): JSX.Element => {
         const option = options[0];
 
         return (
@@ -46,15 +45,14 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
                 <span>{option.text}</span>
             </div>
         );
-    }
+    };
 
-    @autobind
-    private onOptionChange(event, option?: IDropdownOption): void {
+    private onOptionChange = (event, option?: IDropdownOption): void => {
         this.setState({ selectedKey: option.key as any });
         this.props.deps.detailsViewActionMessageCreator.sendPivotItemClicked(DetailsViewPivotType[option.key]);
-    }
+    };
 
-    private getOptions(): IDropdownOption[] {
+    private getOptions = (): IDropdownOption[] => {
         return [
             {
                 key: DetailsViewPivotType.fastPass,
@@ -71,7 +69,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
                 },
             },
         ];
-    }
+    };
 
     public render(): JSX.Element {
         return (

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Switcher render 1`] = `"<StyledWithResponsiveMode ariaLabel=\\"select workflow\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function]} onRenderTitle={[Function]} onChange={[Function: bound ]} options={{...}} />"`;
+exports[`Switcher render 1`] = `"<StyledWithResponsiveMode ariaLabel=\\"select workflow\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function]} onRenderTitle={[Function]} onChange={[Function]} options={{...}} />"`;
 
-exports[`Switcher render options 1`] = `"<StyledWithResponsiveMode ariaLabel=\\"select workflow\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function]} onRenderTitle={[Function]} onChange={[Function: bound ]} options={{...}} />"`;
+exports[`Switcher render options 1`] = `"<StyledWithResponsiveMode ariaLabel=\\"select workflow\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function]} onRenderTitle={[Function]} onChange={[Function]} options={{...}} />"`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Switcher render 1`] = `"<StyledWithResponsiveMode ariaLabel=\\"select workflow\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function: onRenderOption]} onRenderTitle={[Function: onRenderTitle]} onChange={[Function: onOptionClick]} options={{...}} />"`;
+exports[`Switcher render 1`] = `"<StyledWithResponsiveMode ariaLabel=\\"select workflow\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function]} onRenderTitle={[Function]} onChange={[Function: bound ]} options={{...}} />"`;
 
-exports[`Switcher render options 1`] = `"<StyledWithResponsiveMode ariaLabel=\\"select workflow\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function: onRenderOption]} onRenderTitle={[Function: onRenderTitle]} onChange={[Function: onOptionClick]} options={{...}} />"`;
+exports[`Switcher render options 1`] = `"<StyledWithResponsiveMode ariaLabel=\\"select workflow\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function]} onRenderTitle={[Function]} onChange={[Function: bound ]} options={{...}} />"`;

--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
@@ -36,21 +36,21 @@ describe('Switcher', () => {
         expect(renderer.debug()).toMatchSnapshot();
     });
 
-    test('onOptionClick', () => {
+    test('onOptionChange', () => {
         actionCreatorMock
-            .setup(creator => creator.sendPivotItemClicked(DetailsViewPivotType[DetailsViewPivotType.fastPass]))
+            .setup(creator => creator.sendPivotItemClicked(DetailsViewPivotType[DetailsViewPivotType.assessment]))
             .verifiable(Times.once());
-        const renderer = shallow(<Switcher {...defaultProps} />);
+        const wrapper = mount(<Switcher {...defaultProps} />);
 
-        renderer
-            .find(Dropdown)
-            .props()
-            .onChange(null, {
-                data: {
-                    key: DetailsViewPivotType.fastPass,
-                },
-            } as any);
-
+        const dropdown = wrapper.find(Dropdown);
+        expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.fastPass);
+        dropdown.props().onChange(null, {
+            key: DetailsViewPivotType.assessment,
+            data: {
+                key: DetailsViewPivotType.assessment,
+            },
+        } as any);
+        expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.assessment);
         actionCreatorMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -41,15 +41,17 @@ describe('Switcher', () => {
             .setup(creator => creator.sendPivotItemClicked(DetailsViewPivotType[DetailsViewPivotType.assessment]))
             .verifiable(Times.once());
         const wrapper = mount(<Switcher {...defaultProps} />);
-
         const dropdown = wrapper.find(Dropdown);
+
         expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.fastPass);
+
         dropdown.props().onChange(null, {
             key: DetailsViewPivotType.assessment,
             data: {
                 key: DetailsViewPivotType.assessment,
             },
         } as any);
+
         expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.assessment);
         actionCreatorMock.verifyAll();
     });

--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { mount, shallow } from 'enzyme';
-import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
+import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
@@ -47,10 +47,7 @@ describe('Switcher', () => {
 
         dropdown.props().onChange(null, {
             key: DetailsViewPivotType.assessment,
-            data: {
-                key: DetailsViewPivotType.assessment,
-            },
-        } as any);
+        } as IDropdownOption);
 
         expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.assessment);
         actionCreatorMock.verifyAll();

--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { shallow, mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';


### PR DESCRIPTION
#### Description of changes
Currently, the 'selected option' of the switcher does not change immediately after user input. It goes through our flux loop before updating the UI. This makes NVDA anoucing the option change incorrectly. 

Saved switcher state locally to fix the a11y issue.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #570 
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
