### PR TITLE
[Refactor] StoreActionMessageCreator to use ActionMessageDispatcher

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -147,7 +147,7 @@ if (isNaN(tabId) === false) {
                 TelemetryEventSource.DetailsView,
             );
 
-            const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(chromeAdapter.sendMessageToFrames, tab.id);
+            const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(actionMessageDispatcher);
 
             const contentActionMessageCreator = new ContentActionMessageCreator(
                 telemetryFactory,

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -1,18 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Message } from '../message';
 import { Messages } from '../messages';
+import { ActionMessageDispatcher } from './action-message-dispatcher';
 import { StoreActionMessageCreator } from './store-action-message-creator';
 import { StoreActionMessageCreatorImpl } from './store-action-message-creator-impl';
 
 export class StoreActionMessageCreatorFactory {
-    private postMessage: (message: Message) => void;
-    private tabId: number;
-
-    constructor(postMessage: (message: Message) => void, tabId: number) {
-        this.postMessage = postMessage;
-        this.tabId = tabId;
-    }
+    constructor(private readonly dispatcher: ActionMessageDispatcher) {}
 
     public forPopup(): StoreActionMessageCreator {
         const getStateMessages: string[] = [
@@ -23,11 +17,11 @@ export class StoreActionMessageCreatorFactory {
             Messages.UserConfig.GetCurrentState,
         ];
 
-        return new StoreActionMessageCreatorImpl(getStateMessages, this.postMessage, this.tabId);
+        return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
     }
 
     public forDetailsView(): StoreActionMessageCreator {
-        const getStateMessage: string[] = [
+        const getStateMessages: string[] = [
             Messages.Visualizations.DetailsView.GetState,
             Messages.Visualizations.State.GetCurrentVisualizationResultState,
             Messages.Visualizations.State.GetCurrentVisualizationToggleState,
@@ -38,17 +32,17 @@ export class StoreActionMessageCreatorFactory {
             Messages.UserConfig.GetCurrentState,
         ];
 
-        return new StoreActionMessageCreatorImpl(getStateMessage, this.postMessage, this.tabId);
+        return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
     }
 
     public forContent(): StoreActionMessageCreator {
-        const getStateMessage: string[] = [Messages.UserConfig.GetCurrentState];
+        const getStateMessages: string[] = [Messages.UserConfig.GetCurrentState];
 
-        return new StoreActionMessageCreatorImpl(getStateMessage, this.postMessage, this.tabId);
+        return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
     }
 
     public forInjected(): StoreActionMessageCreator {
-        const messages: string[] = [
+        const getStateMessages: string[] = [
             Messages.Visualizations.State.GetCurrentVisualizationToggleState,
             Messages.Scoping.GetCurrentState,
             Messages.Inspect.GetCurrentState,
@@ -60,6 +54,6 @@ export class StoreActionMessageCreatorFactory {
             Messages.UserConfig.GetCurrentState,
         ];
 
-        return new StoreActionMessageCreatorImpl(messages, this.postMessage, this.tabId);
+        return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
     }
 }

--- a/src/common/message-creators/store-action-message-creator-impl.ts
+++ b/src/common/message-creators/store-action-message-creator-impl.ts
@@ -1,18 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Message } from '../message';
-import { BaseActionMessageCreator } from './base-action-message-creator';
+import { ActionMessageDispatcher } from './action-message-dispatcher';
 import { StoreActionMessageCreator } from './store-action-message-creator';
 
-export class StoreActionMessageCreatorImpl extends BaseActionMessageCreator implements StoreActionMessageCreator {
-    private getStateMessages: string[];
-
-    constructor(messages: string[], postMessage: (message: Message) => void, tabId: number) {
-        super(postMessage, tabId);
-        this.getStateMessages = messages;
-    }
+export class StoreActionMessageCreatorImpl implements StoreActionMessageCreator {
+    constructor(private readonly getStateMessages: string[], private readonly dispatcher: ActionMessageDispatcher) {}
 
     public getAllStates(): void {
-        this.getStateMessages.forEach(message => this.dispatchType(message));
+        this.getStateMessages.forEach(message => this.dispatcher.dispatchType(message));
     }
 }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -92,7 +92,9 @@ export class MainWindowInitializer extends WindowInitializer {
         this.devToolStoreProxy = new StoreProxy<DevToolState>(StoreNames[StoreNames.DevToolsStore], this.clientChromeAdapter);
         this.inspectStoreProxy = new StoreProxy<InspectStoreData>(StoreNames[StoreNames.InspectStore], this.clientChromeAdapter);
 
-        const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(this.clientChromeAdapter.sendMessageToFrames, null);
+        const actionMessageDispatcher = new ActionMessageDispatcher(this.clientChromeAdapter.sendMessageToFrames, null);
+
+        const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(actionMessageDispatcher);
 
         const storeActionMessageCreator = storeActionMessageCreatorFactory.forInjected();
         storeActionMessageCreator.getAllStates();
@@ -103,7 +105,6 @@ export class MainWindowInitializer extends WindowInitializer {
             null,
             telemetryDataFactory,
         );
-        const actionMessageDispatcher = new ActionMessageDispatcher(this.clientChromeAdapter.sendMessageToFrames, null);
 
         const targetPageActionMessageCreator = new TargetPageActionMessageCreator(telemetryDataFactory, actionMessageDispatcher);
         const issueFilingActionMessageCreator = new IssueFilingActionMessageCreator(

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -80,10 +80,7 @@ export class PopupInitializer {
 
         const userConfigMessageCreator = new UserConfigMessageCreator(actionMessageDispatcher);
 
-        const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(
-            this.chromeAdapter.sendMessageToFrames,
-            this.targetTabInfo.tab.id,
-        );
+        const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(actionMessageDispatcher);
 
         const storeActionMessageCreator = storeActionMessageCreatorFactory.forPopup();
 

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -1,20 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock, MockBehavior } from 'typemoq';
-import { Message } from '../../../../../common/message';
+import { Mock } from 'typemoq';
+import { ActionMessageDispatcher } from '../../../../../common/message-creators/action-message-dispatcher';
 import { StoreActionMessageCreator } from '../../../../../common/message-creators/store-action-message-creator';
 import { StoreActionMessageCreatorFactory } from '../../../../../common/message-creators/store-action-message-creator-factory';
 import { Messages } from '../../../../../common/messages';
 
 describe('StoreActionMessageCreatorFactoryTest', () => {
-    let postMessageMock: IMock<(_message: Message) => void>;
-    const tabId: number = -1;
+    const dispatcherMock = Mock.ofType<ActionMessageDispatcher>();
 
     beforeEach(() => {
-        postMessageMock = Mock.ofInstance(_message => {}, MockBehavior.Strict);
+        dispatcherMock.reset();
     });
 
-    test('forPopup', () => {
+    it('dispatches message types for forPopup', () => {
         const messages: string[] = [
             Messages.Visualizations.State.GetCurrentVisualizationToggleState,
             Messages.Command.GetCommands,
@@ -26,8 +25,8 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         testWithExpectedMessages(messages, testObject => testObject.forPopup());
     });
 
-    test('forDetailsView', () => {
-        const message: string[] = [
+    it('dispatches message types for forDetailsView', () => {
+        const messages: string[] = [
             Messages.Visualizations.DetailsView.GetState,
             Messages.Visualizations.State.GetCurrentVisualizationResultState,
             Messages.Visualizations.State.GetCurrentVisualizationToggleState,
@@ -38,10 +37,10 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             Messages.UserConfig.GetCurrentState,
         ];
 
-        testWithExpectedMessages(message, testObject => testObject.forDetailsView());
+        testWithExpectedMessages(messages, testObject => testObject.forDetailsView());
     });
 
-    test('forInjected', () => {
+    it('dispatches message types for forInjected', () => {
         const messages: string[] = [
             Messages.Visualizations.State.GetCurrentVisualizationToggleState,
             Messages.Scoping.GetCurrentState,
@@ -57,7 +56,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         testWithExpectedMessages(messages, testObject => testObject.forInjected());
     });
 
-    test('forContent', () => {
+    it('dispatches message types for forContent', () => {
         const messages: string[] = [Messages.UserConfig.GetCurrentState];
 
         testWithExpectedMessages(messages, testObject => testObject.forContent());
@@ -67,25 +66,18 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         messages: string[],
         getter: (testObject: StoreActionMessageCreatorFactory) => StoreActionMessageCreator,
     ): void {
-        messages.forEach(message => setupPostMessageMock(message));
+        messages.forEach(message => setupDispatcherMock(message));
 
-        const testObject = new StoreActionMessageCreatorFactory(postMessageMock.object, tabId);
+        const testObject = new StoreActionMessageCreatorFactory(dispatcherMock.object);
 
         const creator = getter(testObject);
 
         creator.getAllStates();
 
-        postMessageMock.verifyAll();
+        dispatcherMock.verifyAll();
     }
 
-    function setupPostMessageMock(messageType: string): void {
-        postMessageMock.setup(pm =>
-            pm(
-                It.isValue({
-                    messageType,
-                    tabId: tabId,
-                }),
-            ),
-        );
+    function setupDispatcherMock(messageType: string): void {
+        dispatcherMock.setup(dispatcher => dispatcher.dispatchType(messageType));
     }
 });

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator.test.ts
@@ -1,35 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock, MockBehavior } from 'typemoq';
-import { Message } from '../../../../../common/message';
+import { Mock } from 'typemoq';
+import { ActionMessageDispatcher } from '../../../../../common/message-creators/action-message-dispatcher';
 import { StoreActionMessageCreatorImpl } from '../../../../../common/message-creators/store-action-message-creator-impl';
 
-describe('StateActionMessageCreator', () => {
-    const tabId: number = -1;
-    let postMessageMock: IMock<(message: Message) => void>;
+describe('StoreActionMessageCreatorImpl', () => {
+    const dispatcherMock = Mock.ofType<ActionMessageDispatcher>();
 
     test('getAllStates', () => {
         const messages = ['a', 'b', 'c', 'd'];
 
-        postMessageMock = Mock.ofInstance((_message: Message) => {}, MockBehavior.Strict);
+        messages.forEach(message => setupDispatcherMock(message));
 
-        messages.forEach(message => setupPostMessageMock(message));
-
-        const testObject = new StoreActionMessageCreatorImpl(messages, postMessageMock.object, tabId);
+        const testObject = new StoreActionMessageCreatorImpl(messages, dispatcherMock.object);
 
         testObject.getAllStates();
 
-        postMessageMock.verifyAll();
+        dispatcherMock.verifyAll();
     });
 
-    function setupPostMessageMock(message: string): void {
-        postMessageMock.setup(pm =>
-            pm(
-                It.isValue({
-                    messageType: message,
-                    tabId: tabId,
-                }),
-            ),
-        );
+    function setupDispatcherMock(message: string): void {
+        dispatcherMock.setup(dispatcher => dispatcher.dispatchType(message));
     }
 });

--- a/src/views/insights/dependencies.ts
+++ b/src/views/insights/dependencies.ts
@@ -32,7 +32,7 @@ export const rendererDependencies: () => RendererDeps = () => {
 
     const store = new StoreProxy<UserConfigurationStoreData>(StoreNames[StoreNames.UserConfigurationStore], chromeAdapter);
     const storesHub = new BaseClientStoresHub<any>([store]);
-    const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(chromeAdapter.sendMessageToFrames, tabId);
+    const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(actionMessageDispatcher);
     const storeActionMessageCreator = storeActionMessageCreatorFactory.forContent();
 
     return {


### PR DESCRIPTION
#### Description of changes

- StoreActionMessageCreatorImpl uses ActionMessageDispatcher instead of inheriting from BaseActionMessageCreator
- StoreActionMessageCreatorFactory functions updated to reflect changes in StoreActionMessageCreatorImpl constructor
- Various initializers updated to use the modified StoreActionMessageCreatorFactory and StoreActionMessageCreatorImpl constructors
- Updated relevant test cases

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
