### PR TITLE
refactor: Introduce Storage Adapter

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -16,6 +16,7 @@ import { UrlValidator } from '../common/url-validator';
 import { WindowUtils } from '../common/window-utils';
 import { IssueFilingServiceProviderImpl } from '../issue-filing/issue-filing-service-provider-impl';
 import { ChromeAdapter } from './browser-adapter';
+import { StorageAdapter } from './browser-adapters/storage-adapter';
 import { ChromeCommandHandler } from './chrome-command-handler';
 import { DetailsViewController } from './details-view-controller';
 import { DevToolsListener } from './dev-tools-listener';
@@ -37,8 +38,9 @@ import { UserStoredDataCleaner } from './user-stored-data-cleaner';
 
 declare var window: Window & InsightsFeatureFlags;
 const browserAdapter = new ChromeAdapter();
+const storageAdapter = new StorageAdapter();
 const urlValidator = new UrlValidator();
-const backgroundInitCleaner = new UserStoredDataCleaner(browserAdapter);
+const backgroundInitCleaner = new UserStoredDataCleaner(storageAdapter);
 
 const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil();
 

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -54,7 +54,7 @@ getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
         const telemetryDataFactory = new TelemetryDataFactory();
         const telemetryLogger = new TelemetryLogger();
 
-        const telemetryClient = getTelemetryClient(userData, browserAdapter, telemetryLogger, AppInsights);
+        const telemetryClient = getTelemetryClient(userData, browserAdapter, telemetryLogger, AppInsights, storageAdapter);
 
         const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
 

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AppInsights } from 'applicationinsights-js';
-
 import { Assessments } from '../assessments/assessments';
 import { AxeInfo } from '../common/axe-info';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -71,6 +70,7 @@ getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
             persistedData,
             IssueFilingServiceProviderImpl,
             environmentInfoProvider.getEnvironmentInfo(),
+            storageAdapter,
         );
         telemetryLogger.initialize(globalContext.featureFlagsController);
 

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -47,7 +47,7 @@ backgroundInitCleaner.cleanUserData(deprecatedStorageDataKeys);
 
 // tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
 getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
-    browserAdapter.getUserData(storageDataKeys, (userData: LocalStorageData) => {
+    storageAdapter.getUserData(storageDataKeys, (userData: LocalStorageData) => {
         const assessmentsProvider = Assessments;
         const windowUtils = new WindowUtils();
         const telemetryDataFactory = new TelemetryDataFactory();

--- a/src/background/browser-adapter.ts
+++ b/src/background/browser-adapter.ts
@@ -27,9 +27,6 @@ export interface BrowserAdapter extends ClientBrowserAdapter {
     sendMessageToFramesAndTab(tabId: number, message: any): void;
     sendMessageToFrames(message: any): void;
     sendMessageToAllFramesAndTabs(message: any): void;
-    setUserData(items: Object, callback?: () => void): void;
-    getUserData(keys: string | string[] | Object, callback: (items: { [key: string]: any }) => void): void;
-    removeUserData(key: string): void;
     injectJs(tabId, file: string, callback: Function): void;
     injectCss(tabId, file: string, callback: Function): void;
     getRunTimeId(): string;
@@ -182,18 +179,6 @@ export class ChromeAdapter extends ClientChromeAdapter implements BrowserAdapter
 
     public sendMessageToFrames(message: any): void {
         chrome.runtime.sendMessage(message);
-    }
-
-    public setUserData(items: Object, callback?: () => void): void {
-        chrome.storage.local.set(items, callback);
-    }
-
-    public getUserData(keys: string | string[] | Object, callback: (items: { [key: string]: any }) => void): void {
-        chrome.storage.local.get(keys, callback);
-    }
-
-    public removeUserData(key: string): void {
-        chrome.storage.local.remove(key);
     }
 
     public getRuntimeLastError(): chrome.runtime.LastError {

--- a/src/background/browser-adapter.ts
+++ b/src/background/browser-adapter.ts
@@ -27,6 +27,9 @@ export interface BrowserAdapter extends ClientBrowserAdapter {
     sendMessageToFramesAndTab(tabId: number, message: any): void;
     sendMessageToFrames(message: any): void;
     sendMessageToAllFramesAndTabs(message: any): void;
+    setUserData(items: Object, callback?: () => void): void;
+    getUserData(keys: string | string[] | Object, callback: (items: { [key: string]: any }) => void): void;
+    removeUserData(key: string): void;
     injectJs(tabId, file: string, callback: Function): void;
     injectCss(tabId, file: string, callback: Function): void;
     getRunTimeId(): string;
@@ -179,6 +182,18 @@ export class ChromeAdapter extends ClientChromeAdapter implements BrowserAdapter
 
     public sendMessageToFrames(message: any): void {
         chrome.runtime.sendMessage(message);
+    }
+
+    public setUserData(items: Object, callback?: () => void): void {
+        chrome.storage.local.set(items, callback);
+    }
+
+    public getUserData(keys: string | string[] | Object, callback: (items: { [key: string]: any }) => void): void {
+        chrome.storage.local.get(keys, callback);
+    }
+
+    public removeUserData(key: string): void {
+        chrome.storage.local.remove(key);
     }
 
     public getRuntimeLastError(): chrome.runtime.LastError {

--- a/src/background/browser-adapter.ts
+++ b/src/background/browser-adapter.ts
@@ -28,9 +28,6 @@ export interface BrowserAdapter extends ClientBrowserAdapter {
     sendMessageToFramesAndTab(tabId: number, message: any): void;
     sendMessageToFrames(message: any): void;
     sendMessageToAllFramesAndTabs(message: any): void;
-    setUserData(items: Object, callback?: () => void): void;
-    getUserData(keys: string | string[] | Object, callback: (items: { [key: string]: any }) => void): void;
-    removeUserData(key: string): void;
     injectJs(tabId, file: string, callback: Function): void;
     injectCss(tabId, file: string, callback: Function): void;
     getRunTimeId(): string;

--- a/src/background/browser-adapter.ts
+++ b/src/background/browser-adapter.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ClientBrowserAdapter, ClientChromeAdapter } from '../common/client-browser-adapter';
+import { StorageAdapter } from './browser-adapters/storage-adapter';
 
 export interface NotificationOptions {
     message: string;
@@ -42,7 +43,7 @@ export interface BrowserAdapter extends ClientBrowserAdapter {
     openManageExtensionPage(): void;
 }
 
-export class ChromeAdapter extends ClientChromeAdapter implements BrowserAdapter {
+export class ChromeAdapter extends ClientChromeAdapter implements BrowserAdapter, StorageAdapter {
     public openManageExtensionPage(): void {
         chrome.tabs.create({
             url: `chrome://extensions/?id=${chrome.runtime.id}`,

--- a/src/background/browser-adapters/storage-adapter.ts
+++ b/src/background/browser-adapters/storage-adapter.ts
@@ -5,17 +5,3 @@ export type StorageAPI = {
     getUserData(keys: string | string[] | Object, callback: (items: { [key: string]: any }) => void): void;
     removeUserData(key: string): void;
 };
-
-export class StorageAdapter implements StorageAPI {
-    public setUserData(items: Object, callback?: () => void): void {
-        chrome.storage.local.set(items, callback);
-    }
-
-    public getUserData(keys: string | string[] | Object, callback: (items: { [key: string]: any }) => void): void {
-        chrome.storage.local.get(keys, callback);
-    }
-
-    public removeUserData(key: string): void {
-        chrome.storage.local.remove(key);
-    }
-}

--- a/src/background/browser-adapters/storage-adapter.ts
+++ b/src/background/browser-adapters/storage-adapter.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export type StorageAPI = {
+    setUserData(items: Object, callback?: () => void): void;
+    getUserData(keys: string | string[] | Object, callback: (items: { [key: string]: any }) => void): void;
+    removeUserData(key: string): void;
+};
+
+export class StorageAdapter implements StorageAPI {
+    public setUserData(items: Object, callback?: () => void): void {
+        chrome.storage.local.set(items, callback);
+    }
+
+    public getUserData(keys: string | string[] | Object, callback: (items: { [key: string]: any }) => void): void {
+        chrome.storage.local.get(keys, callback);
+    }
+
+    public removeUserData(key: string): void {
+        chrome.storage.local.remove(key);
+    }
+}

--- a/src/background/browser-adapters/storage-adapter.ts
+++ b/src/background/browser-adapters/storage-adapter.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-export type StorageAPI = {
+export type StorageAdapter = {
     setUserData(items: Object, callback?: () => void): void;
     getUserData(keys: string | string[] | Object, callback: (items: { [key: string]: any }) => void): void;
     removeUserData(key: string): void;

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -10,6 +10,7 @@ import { AssessmentsProvider } from './../assessments/types/assessments-provider
 import { AssessmentActionCreator } from './actions/assessment-action-creator';
 import { GlobalActionHub } from './actions/global-action-hub';
 import { BrowserAdapter } from './browser-adapter';
+import { StorageAPI } from './browser-adapters/storage-adapter';
 import { CompletedTestStepTelemetryCreator } from './completed-test-step-telemetry-creator';
 import { FeatureFlagsController } from './feature-flags-controller';
 import { PersistedData } from './get-persisted-data';
@@ -33,6 +34,7 @@ export class GlobalContextFactory {
         persistedData: PersistedData,
         issueFilingServiceProvider: IssueFilingServiceProvider,
         environmentInfo: EnvironmentInfo,
+        storageAdapter: StorageAPI,
     ): GlobalContext {
         const interpreter = new Interpreter();
 
@@ -45,6 +47,7 @@ export class GlobalContextFactory {
             assessmentsProvider,
             indexedDBInstance,
             persistedData,
+            storageAdapter,
         );
 
         const featureFlagsController = new FeatureFlagsController(globalStoreHub.featureFlagStore, interpreter);

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -10,7 +10,7 @@ import { AssessmentsProvider } from './../assessments/types/assessments-provider
 import { AssessmentActionCreator } from './actions/assessment-action-creator';
 import { GlobalActionHub } from './actions/global-action-hub';
 import { BrowserAdapter } from './browser-adapter';
-import { StorageAPI } from './browser-adapters/storage-adapter';
+import { StorageAdapter } from './browser-adapters/storage-adapter';
 import { CompletedTestStepTelemetryCreator } from './completed-test-step-telemetry-creator';
 import { FeatureFlagsController } from './feature-flags-controller';
 import { PersistedData } from './get-persisted-data';
@@ -34,7 +34,7 @@ export class GlobalContextFactory {
         persistedData: PersistedData,
         issueFilingServiceProvider: IssueFilingServiceProvider,
         environmentInfo: EnvironmentInfo,
-        storageAdapter: StorageAPI,
+        storageAdapter: StorageAdapter,
     ): GlobalContext {
         const interpreter = new Interpreter();
 

--- a/src/background/install-data-generator.ts
+++ b/src/background/install-data-generator.ts
@@ -5,18 +5,14 @@ import { InstallationData } from './installation-data';
 import { LocalStorageDataKeys } from './local-storage-data-keys';
 
 export class InstallDataGenerator {
-    private generateGuid: () => string;
-    private dateGetter: () => Date;
     private installationData: InstallationData;
 
     constructor(
-        initialInstallationData: InstallationData,
-        generateGuid: () => string,
-        dateGetter: () => Date,
+        readonly initialInstallationData: InstallationData,
+        private readonly generateGuid: () => string,
+        private readonly dateGetter: () => Date,
         private readonly storageAdapter: StorageAdapter,
     ) {
-        this.generateGuid = generateGuid;
-        this.dateGetter = dateGetter;
         this.installationData = initialInstallationData;
     }
 

--- a/src/background/install-data-generator.ts
+++ b/src/background/install-data-generator.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { StorageAPI } from './browser-adapters/storage-adapter';
+import { StorageAdapter } from './browser-adapters/storage-adapter';
 import { InstallationData } from './installation-data';
 import { LocalStorageDataKeys } from './local-storage-data-keys';
 
@@ -13,7 +13,7 @@ export class InstallDataGenerator {
         initialInstallationData: InstallationData,
         generateGuid: () => string,
         dateGetter: () => Date,
-        private readonly storageAdapter: StorageAPI,
+        private readonly storageAdapter: StorageAdapter,
     ) {
         this.generateGuid = generateGuid;
         this.dateGetter = dateGetter;

--- a/src/background/install-data-generator.ts
+++ b/src/background/install-data-generator.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserAdapter } from './browser-adapter';
+import { StorageAPI } from './browser-adapters/storage-adapter';
 import { InstallationData } from './installation-data';
 import { LocalStorageDataKeys } from './local-storage-data-keys';
 
@@ -8,18 +8,16 @@ export class InstallDataGenerator {
     private generateGuid: () => string;
     private dateGetter: () => Date;
     private installationData: InstallationData;
-    private browserAdapter: BrowserAdapter;
 
     constructor(
         initialInstallationData: InstallationData,
         generateGuid: () => string,
         dateGetter: () => Date,
-        browserAdapter: BrowserAdapter,
+        private readonly storageAdapter: StorageAPI,
     ) {
         this.generateGuid = generateGuid;
         this.dateGetter = dateGetter;
         this.installationData = initialInstallationData;
-        this.browserAdapter = browserAdapter;
     }
 
     public getInstallationId(): string {
@@ -46,7 +44,7 @@ export class InstallDataGenerator {
             year: currentDate.getUTCFullYear(),
         };
 
-        this.browserAdapter.setUserData({ [LocalStorageDataKeys.installationData]: this.installationData });
+        this.storageAdapter.setUserData({ [LocalStorageDataKeys.installationData]: this.installationData });
         return this.installationData.id;
     }
 }

--- a/src/background/stores/global/feature-flag-store.ts
+++ b/src/background/stores/global/feature-flag-store.ts
@@ -6,7 +6,7 @@ import { FeatureFlags, getDefaultFeatureFlagValues, getForceDefaultFlags } from 
 import { StoreNames } from '../../../common/stores/store-names';
 import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-flag-store-data';
 import { FeatureFlagActions, FeatureFlagPayload } from '../../actions/feature-flag-actions';
-import { StorageAPI } from '../../browser-adapters/storage-adapter';
+import { StorageAdapter } from '../../browser-adapters/storage-adapter';
 import { LocalStorageDataKeys } from '../../local-storage-data-keys';
 import { LocalStorageData } from '../../storage-data';
 import { BaseStoreImpl } from '../base-store-impl';
@@ -14,7 +14,7 @@ import { BaseStoreImpl } from '../base-store-impl';
 export class FeatureFlagStore extends BaseStoreImpl<FeatureFlagStoreData> {
     constructor(
         private readonly featureFlagActions: FeatureFlagActions,
-        private readonly storageAdapter: StorageAPI,
+        private readonly storageAdapter: StorageAdapter,
         private readonly userData: LocalStorageData,
     ) {
         super(StoreNames.FeatureFlagStore);

--- a/src/background/stores/global/feature-flag-store.ts
+++ b/src/background/stores/global/feature-flag-store.ts
@@ -1,27 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
-import { LocalStorageDataKeys } from '../../local-storage-data-keys';
-import { LocalStorageData } from '../../storage-data';
 
 import { FeatureFlags, getDefaultFeatureFlagValues, getForceDefaultFlags } from '../../../common/feature-flags';
 import { StoreNames } from '../../../common/stores/store-names';
 import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-flag-store-data';
 import { FeatureFlagActions, FeatureFlagPayload } from '../../actions/feature-flag-actions';
+import { StorageAPI } from '../../browser-adapters/storage-adapter';
+import { LocalStorageDataKeys } from '../../local-storage-data-keys';
+import { LocalStorageData } from '../../storage-data';
 import { BaseStoreImpl } from '../base-store-impl';
-import { BrowserAdapter } from './../../browser-adapter';
 
 export class FeatureFlagStore extends BaseStoreImpl<FeatureFlagStoreData> {
-    private featureFlagActions: FeatureFlagActions;
-    private browserAdapter: BrowserAdapter;
-    private userData: LocalStorageData;
-
-    constructor(featureFlagActions: FeatureFlagActions, browserAdapter: BrowserAdapter, userData: LocalStorageData) {
+    constructor(
+        private readonly featureFlagActions: FeatureFlagActions,
+        private readonly storageAdapter: StorageAPI,
+        private readonly userData: LocalStorageData,
+    ) {
         super(StoreNames.FeatureFlagStore);
-
-        this.featureFlagActions = featureFlagActions;
-        this.browserAdapter = browserAdapter;
-        this.userData = userData;
     }
 
     public initialize(): void {
@@ -64,7 +60,7 @@ export class FeatureFlagStore extends BaseStoreImpl<FeatureFlagStoreData> {
     @autobind
     private onSetFeatureFlags(payload: FeatureFlagPayload): void {
         this.state[payload.feature] = payload.enabled;
-        this.browserAdapter.setUserData({ [LocalStorageDataKeys.featureFlags]: this.state });
+        this.storageAdapter.setUserData({ [LocalStorageDataKeys.featureFlags]: this.state });
         this.emitChanged();
     }
 

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -6,7 +6,7 @@ import { StoreType } from '../../../common/types/store-type';
 import { generateUID } from '../../../common/uid-generator';
 import { GlobalActionHub } from '../../actions/global-action-hub';
 import { BrowserAdapter } from '../../browser-adapter';
-import { StorageAPI } from '../../browser-adapters/storage-adapter';
+import { StorageAdapter } from '../../browser-adapters/storage-adapter';
 import { PersistedData } from '../../get-persisted-data';
 import { LocalStorageData } from '../../storage-data';
 import { TelemetryEventHandler } from '../../telemetry/telemetry-event-handler';
@@ -38,7 +38,7 @@ export class GlobalStoreHub implements StoreHub {
         assessmentsProvider: AssessmentsProvider,
         indexedDbInstance: IndexedDBAPI,
         persistedData: PersistedData,
-        storageAdapter: StorageAPI,
+        storageAdapter: StorageAdapter,
     ) {
         this.commandStore = new CommandStore(globalActionHub.commandActions, telemetryEventHandler);
         this.featureFlagStore = new FeatureFlagStore(globalActionHub.featureFlagActions, storageAdapter, userData);

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -42,7 +42,7 @@ export class GlobalStoreHub implements StoreHub {
     ) {
         this.commandStore = new CommandStore(globalActionHub.commandActions, telemetryEventHandler);
         this.featureFlagStore = new FeatureFlagStore(globalActionHub.featureFlagActions, storageAdapter, userData);
-        this.launchPanelStore = new LaunchPanelStore(globalActionHub.launchPanelStateActions, browserAdapter, userData);
+        this.launchPanelStore = new LaunchPanelStore(globalActionHub.launchPanelStateActions, storageAdapter, userData);
         this.scopingStore = new ScopingStore(globalActionHub.scopingActions);
         this.assessmentStore = new AssessmentStore(
             browserAdapter,

--- a/src/background/stores/global/global-store-hub.ts
+++ b/src/background/stores/global/global-store-hub.ts
@@ -6,6 +6,7 @@ import { StoreType } from '../../../common/types/store-type';
 import { generateUID } from '../../../common/uid-generator';
 import { GlobalActionHub } from '../../actions/global-action-hub';
 import { BrowserAdapter } from '../../browser-adapter';
+import { StorageAPI } from '../../browser-adapters/storage-adapter';
 import { PersistedData } from '../../get-persisted-data';
 import { LocalStorageData } from '../../storage-data';
 import { TelemetryEventHandler } from '../../telemetry/telemetry-event-handler';
@@ -37,9 +38,10 @@ export class GlobalStoreHub implements StoreHub {
         assessmentsProvider: AssessmentsProvider,
         indexedDbInstance: IndexedDBAPI,
         persistedData: PersistedData,
+        storageAdapter: StorageAPI,
     ) {
         this.commandStore = new CommandStore(globalActionHub.commandActions, telemetryEventHandler);
-        this.featureFlagStore = new FeatureFlagStore(globalActionHub.featureFlagActions, browserAdapter, userData);
+        this.featureFlagStore = new FeatureFlagStore(globalActionHub.featureFlagActions, storageAdapter, userData);
         this.launchPanelStore = new LaunchPanelStore(globalActionHub.launchPanelStateActions, browserAdapter, userData);
         this.scopingStore = new ScopingStore(globalActionHub.scopingActions);
         this.assessmentStore = new AssessmentStore(

--- a/src/background/stores/global/launch-panel-store.ts
+++ b/src/background/stores/global/launch-panel-store.ts
@@ -4,7 +4,7 @@ import { autobind } from '@uifabric/utilities';
 import { StoreNames } from '../../../common/stores/store-names';
 import { LaunchPanelStoreData } from '../../../common/types/store-data/launch-panel-store-data';
 import { LaunchPanelType } from '../../../popup/components/popup-view';
-import { StorageAPI } from '../../browser-adapters/storage-adapter';
+import { StorageAdapter } from '../../browser-adapters/storage-adapter';
 import { LocalStorageDataKeys } from '../../local-storage-data-keys';
 import { LocalStorageData } from '../../storage-data';
 import { BaseStoreImpl } from '../base-store-impl';
@@ -13,7 +13,7 @@ import { LaunchPanelStateActions } from './../../actions/launch-panel-state-acti
 export class LaunchPanelStore extends BaseStoreImpl<LaunchPanelStoreData> {
     constructor(
         private readonly launchPanelStateActions: LaunchPanelStateActions,
-        private readonly storageAdapter: StorageAPI,
+        private readonly storageAdapter: StorageAdapter,
         private readonly userData: LocalStorageData,
     ) {
         super(StoreNames.LaunchPanelStateStore);

--- a/src/background/stores/global/launch-panel-store.ts
+++ b/src/background/stores/global/launch-panel-store.ts
@@ -4,23 +4,19 @@ import { autobind } from '@uifabric/utilities';
 import { StoreNames } from '../../../common/stores/store-names';
 import { LaunchPanelStoreData } from '../../../common/types/store-data/launch-panel-store-data';
 import { LaunchPanelType } from '../../../popup/components/popup-view';
-import { BrowserAdapter } from '../../browser-adapter';
+import { StorageAPI } from '../../browser-adapters/storage-adapter';
 import { LocalStorageDataKeys } from '../../local-storage-data-keys';
 import { LocalStorageData } from '../../storage-data';
 import { BaseStoreImpl } from '../base-store-impl';
 import { LaunchPanelStateActions } from './../../actions/launch-panel-state-action';
 
 export class LaunchPanelStore extends BaseStoreImpl<LaunchPanelStoreData> {
-    private launchPanelStateActions: LaunchPanelStateActions;
-    private browserAdapter: BrowserAdapter;
-    private userData: LocalStorageData;
-
-    constructor(launchPanelStateActions: LaunchPanelStateActions, browserAdapter: BrowserAdapter, userData: LocalStorageData) {
+    constructor(
+        private readonly launchPanelStateActions: LaunchPanelStateActions,
+        private readonly storageAdapter: StorageAPI,
+        private readonly userData: LocalStorageData,
+    ) {
         super(StoreNames.LaunchPanelStateStore);
-
-        this.launchPanelStateActions = launchPanelStateActions;
-        this.browserAdapter = browserAdapter;
-        this.userData = userData;
     }
 
     public getDefaultState(): LaunchPanelStoreData {
@@ -44,7 +40,7 @@ export class LaunchPanelStore extends BaseStoreImpl<LaunchPanelStoreData> {
     @autobind
     private onSetLaunchPanelType(panelType: LaunchPanelType): void {
         this.state.launchPanelType = panelType;
-        this.browserAdapter.setUserData({ [LocalStorageDataKeys.launchPanelSetting]: panelType });
+        this.storageAdapter.setUserData({ [LocalStorageDataKeys.launchPanelSetting]: panelType });
         this.emitChanged();
     }
 }

--- a/src/background/telemetry/telemetry-client-provider.ts
+++ b/src/background/telemetry/telemetry-client-provider.ts
@@ -5,7 +5,7 @@ import { DateProvider } from '../../common/date-provider';
 import { generateUID } from '../../common/uid-generator';
 import { ApplicationBuildGenerator } from '../application-build-generator';
 import { BrowserAdapter } from '../browser-adapter';
-import { StorageAPI } from '../browser-adapters/storage-adapter';
+import { StorageAdapter } from '../browser-adapters/storage-adapter';
 import { InstallDataGenerator } from '../install-data-generator';
 import { LocalStorageData } from '../storage-data';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
@@ -19,7 +19,7 @@ export const getTelemetryClient = (
     browserAdapter: BrowserAdapter,
     logger: TelemetryLogger,
     appInsights: Microsoft.ApplicationInsights.IAppInsights,
-    storageAdapter: StorageAPI,
+    storageAdapter: StorageAdapter,
 ): TelemetryClient => {
     const appInsightsInstrumentationKey = config.getOption('appInsightsInstrumentationKey');
 

--- a/src/background/telemetry/telemetry-client-provider.ts
+++ b/src/background/telemetry/telemetry-client-provider.ts
@@ -5,6 +5,7 @@ import { DateProvider } from '../../common/date-provider';
 import { generateUID } from '../../common/uid-generator';
 import { ApplicationBuildGenerator } from '../application-build-generator';
 import { BrowserAdapter } from '../browser-adapter';
+import { StorageAPI } from '../browser-adapters/storage-adapter';
 import { InstallDataGenerator } from '../install-data-generator';
 import { LocalStorageData } from '../storage-data';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
@@ -18,6 +19,7 @@ export const getTelemetryClient = (
     browserAdapter: BrowserAdapter,
     logger: TelemetryLogger,
     appInsights: Microsoft.ApplicationInsights.IAppInsights,
+    storageAdapter: StorageAPI,
 ): TelemetryClient => {
     const appInsightsInstrumentationKey = config.getOption('appInsightsInstrumentationKey');
 
@@ -25,7 +27,7 @@ export const getTelemetryClient = (
         return new NullTelemetryClient(logger);
     }
 
-    const installDataGenerator = new InstallDataGenerator(userData.installationData, generateUID, DateProvider.getDate, browserAdapter);
+    const installDataGenerator = new InstallDataGenerator(userData.installationData, generateUID, DateProvider.getDate, storageAdapter);
     const applicationBuildGenerator = new ApplicationBuildGenerator();
     const coreTelemetryDataFactory = new ApplicationTelemetryDataFactory(browserAdapter, applicationBuildGenerator, installDataGenerator);
 

--- a/src/background/user-stored-data-cleaner.ts
+++ b/src/background/user-stored-data-cleaner.ts
@@ -1,20 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as _ from 'lodash/index';
+import { each } from 'lodash';
 
-import { BrowserAdapter } from './browser-adapter';
+import { StorageAPI } from './browser-adapters/storage-adapter';
 
 export class UserStoredDataCleaner {
-    private _browserAdapter: BrowserAdapter;
-
-    constructor(adapter: BrowserAdapter) {
-        this._browserAdapter = adapter;
-    }
+    constructor(private readonly storageAdapter?: StorageAPI) {}
 
     public cleanUserData(userDataKeys: string[], callback?: () => void): void {
-        this._browserAdapter.getUserData(userDataKeys, userDataKeysMap => {
-            _.each(userDataKeysMap, (value, key) => {
-                this._browserAdapter.removeUserData(key);
+        this.storageAdapter.getUserData(userDataKeys, userDataKeysMap => {
+            each(userDataKeysMap, (value, key) => {
+                this.storageAdapter.removeUserData(key);
             });
 
             if (callback) {

--- a/src/background/user-stored-data-cleaner.ts
+++ b/src/background/user-stored-data-cleaner.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 import { each } from 'lodash';
 
-import { StorageAPI } from './browser-adapters/storage-adapter';
+import { StorageAdapter } from './browser-adapters/storage-adapter';
 
 export class UserStoredDataCleaner {
-    constructor(private readonly storageAdapter?: StorageAPI) {}
+    constructor(private readonly storageAdapter?: StorageAdapter) {}
 
     public cleanUserData(userDataKeys: string[], callback?: () => void): void {
         this.storageAdapter.getUserData(userDataKeys, userDataKeysMap => {

--- a/src/background/user-stored-data-cleaner.ts
+++ b/src/background/user-stored-data-cleaner.ts
@@ -5,7 +5,7 @@ import { each } from 'lodash';
 import { StorageAdapter } from './browser-adapters/storage-adapter';
 
 export class UserStoredDataCleaner {
-    constructor(private readonly storageAdapter?: StorageAdapter) {}
+    constructor(private readonly storageAdapter: StorageAdapter) {}
 
     public cleanUserData(userDataKeys: string[], callback?: () => void): void {
         this.storageAdapter.getUserData(userDataKeys, userDataKeysMap => {

--- a/src/tests/unit/tests/background/global-context-factory.test.ts
+++ b/src/tests/unit/tests/background/global-context-factory.test.ts
@@ -3,6 +3,7 @@
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
 
 import { BrowserAdapter, ChromeAdapter } from '../../../../background/browser-adapter';
+import { StorageAPI } from '../../../../background/browser-adapters/storage-adapter';
 import { PersistedData } from '../../../../background/get-persisted-data';
 import { GlobalContext } from '../../../../background/global-context';
 import { GlobalContextFactory } from '../../../../background/global-context-factory';
@@ -20,6 +21,7 @@ import { CreateTestAssessmentProvider } from '../../common/test-assessment-provi
 
 describe('GlobalContextFactoryTest', () => {
     let _mockChromeAdapter: IMock<BrowserAdapter>;
+    let _mockStorageAdapter: IMock<StorageAPI>;
     let _mocktelemetryEventHandler: IMock<TelemetryEventHandler>;
     let _mockTelemetryDataFactory: IMock<TelemetryDataFactory>;
     let _mockIssueFilingServiceProvider: IMock<IssueFilingServiceProvider>;
@@ -29,6 +31,7 @@ describe('GlobalContextFactoryTest', () => {
     let persistedDataStub: PersistedData;
 
     beforeAll(() => {
+        _mockStorageAdapter = Mock.ofType<StorageAPI>();
         _mockChromeAdapter = Mock.ofType(ChromeAdapter, MockBehavior.Loose);
         _mockChromeAdapter.setup(adapter => adapter.sendMessageToAllFramesAndTabs(It.isAny()));
         _mocktelemetryEventHandler = Mock.ofType(TelemetryEventHandler);
@@ -52,6 +55,7 @@ describe('GlobalContextFactoryTest', () => {
             persistedDataStub,
             _mockIssueFilingServiceProvider.object,
             environmentInfoStub,
+            _mockStorageAdapter.object,
         );
 
         expect(globalContext).toBeInstanceOf(GlobalContext);

--- a/src/tests/unit/tests/background/global-context-factory.test.ts
+++ b/src/tests/unit/tests/background/global-context-factory.test.ts
@@ -3,7 +3,7 @@
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
 
 import { BrowserAdapter, ChromeAdapter } from '../../../../background/browser-adapter';
-import { StorageAPI } from '../../../../background/browser-adapters/storage-adapter';
+import { StorageAdapter } from '../../../../background/browser-adapters/storage-adapter';
 import { PersistedData } from '../../../../background/get-persisted-data';
 import { GlobalContext } from '../../../../background/global-context';
 import { GlobalContextFactory } from '../../../../background/global-context-factory';
@@ -21,7 +21,7 @@ import { CreateTestAssessmentProvider } from '../../common/test-assessment-provi
 
 describe('GlobalContextFactoryTest', () => {
     let _mockChromeAdapter: IMock<BrowserAdapter>;
-    let _mockStorageAdapter: IMock<StorageAPI>;
+    let _mockStorageAdapter: IMock<StorageAdapter>;
     let _mocktelemetryEventHandler: IMock<TelemetryEventHandler>;
     let _mockTelemetryDataFactory: IMock<TelemetryDataFactory>;
     let _mockIssueFilingServiceProvider: IMock<IssueFilingServiceProvider>;
@@ -31,7 +31,7 @@ describe('GlobalContextFactoryTest', () => {
     let persistedDataStub: PersistedData;
 
     beforeAll(() => {
-        _mockStorageAdapter = Mock.ofType<StorageAPI>();
+        _mockStorageAdapter = Mock.ofType<StorageAdapter>();
         _mockChromeAdapter = Mock.ofType(ChromeAdapter, MockBehavior.Loose);
         _mockChromeAdapter.setup(adapter => adapter.sendMessageToAllFramesAndTabs(It.isAny()));
         _mocktelemetryEventHandler = Mock.ofType(TelemetryEventHandler);

--- a/src/tests/unit/tests/background/install-data-generator.test.ts
+++ b/src/tests/unit/tests/background/install-data-generator.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
-import { StorageAPI } from '../../../../background/browser-adapters/storage-adapter';
+import { StorageAdapter } from '../../../../background/browser-adapters/storage-adapter';
 import { InstallDataGenerator } from '../../../../background/install-data-generator';
 import { InstallationData } from '../../../../background/installation-data';
 import { LocalStorageDataKeys } from '../../../../background/local-storage-data-keys';
@@ -11,7 +11,7 @@ import { generateUID } from '../../../../common/uid-generator';
 describe('InstallDataGeneratorTest', () => {
     let generateGuidMock: IMock<() => string>;
     let dateGetterMock: IMock<() => Date>;
-    let storageAdapterMock: IMock<StorageAPI>;
+    let storageAdapterMock: IMock<StorageAdapter>;
     let dateStubMock: IMock<Date>;
 
     beforeEach(() => {
@@ -28,7 +28,7 @@ describe('InstallDataGeneratorTest', () => {
         dateGetterMock = Mock.ofInstance<() => Date>(() => {
             return null;
         }, MockBehavior.Strict);
-        storageAdapterMock = Mock.ofType<StorageAPI>();
+        storageAdapterMock = Mock.ofType<StorageAdapter>();
         dateStubMock = Mock.ofInstance(dateStub as Date);
     });
 

--- a/src/tests/unit/tests/background/install-data-generator.test.ts
+++ b/src/tests/unit/tests/background/install-data-generator.test.ts
@@ -210,7 +210,7 @@ describe('InstallDataGeneratorTest', () => {
         dateStubMock.verifyAll();
     }
 
-    function createTestObject(initialInstallationData: InstallationData) {
+    function createTestObject(initialInstallationData: InstallationData): InstallDataGenerator {
         return new InstallDataGenerator(initialInstallationData, generateGuidMock.object, dateGetterMock.object, storageAdapterMock.object);
     }
 });

--- a/src/tests/unit/tests/background/install-data-generator.test.ts
+++ b/src/tests/unit/tests/background/install-data-generator.test.ts
@@ -3,6 +3,7 @@
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { ChromeAdapter } from '../../../../background/browser-adapter';
+import { StorageAPI } from '../../../../background/browser-adapters/storage-adapter';
 import { InstallDataGenerator } from '../../../../background/install-data-generator';
 import { InstallationData } from '../../../../background/installation-data';
 import { LocalStorageDataKeys } from '../../../../background/local-storage-data-keys';
@@ -12,6 +13,7 @@ describe('InstallDataGeneratorTest', () => {
     let generateGuidMock: IMock<() => string>;
     let dateGetterMock: IMock<() => Date>;
     let browserAdapterMock: IMock<ChromeAdapter>;
+    let storageAdapterMock: IMock<StorageAPI>;
     let dateStubMock: IMock<Date>;
 
     beforeEach(() => {
@@ -29,6 +31,7 @@ describe('InstallDataGeneratorTest', () => {
             return null;
         }, MockBehavior.Strict);
         browserAdapterMock = Mock.ofType(ChromeAdapter, MockBehavior.Strict);
+        storageAdapterMock = Mock.ofType<StorageAPI>();
         dateStubMock = Mock.ofInstance(dateStub as Date);
     });
 
@@ -43,12 +46,7 @@ describe('InstallDataGeneratorTest', () => {
             year: yearStub,
         };
 
-        const testSubject = new InstallDataGenerator(
-            initialInstallationData,
-            generateGuidMock.object,
-            dateGetterMock.object,
-            browserAdapterMock.object,
-        );
+        const testSubject = createTestObject(initialInstallationData);
 
         dateStubMock
             .setup(ds => ds.getUTCMonth())
@@ -70,9 +68,9 @@ describe('InstallDataGeneratorTest', () => {
             .returns(() => guidStub)
             .verifiable();
 
-        browserAdapterMock
+        storageAdapterMock
             .setup(bam => bam.setUserData(It.isValue({ [LocalStorageDataKeys.installationData]: installationDataStub })))
-            .verifiable();
+            .verifiable(Times.once());
 
         expect(testSubject.getInstallationId()).toEqual(guidStub);
         verifyMocks();
@@ -94,12 +92,7 @@ describe('InstallDataGeneratorTest', () => {
             year: 1999,
         };
 
-        const testSubject = new InstallDataGenerator(
-            initialInstallationData,
-            generateGuidMock.object,
-            dateGetterMock.object,
-            browserAdapterMock.object,
-        );
+        const testSubject = createTestObject(initialInstallationData);
 
         dateStubMock
             .setup(ds => ds.getUTCMonth())
@@ -121,7 +114,7 @@ describe('InstallDataGeneratorTest', () => {
             .returns(() => guidStub)
             .verifiable();
 
-        browserAdapterMock
+        storageAdapterMock
             .setup(bam => bam.setUserData(It.isValue({ [LocalStorageDataKeys.installationData]: installationDataStub })))
             .verifiable();
 
@@ -145,12 +138,7 @@ describe('InstallDataGeneratorTest', () => {
             year: yearStub,
         };
 
-        const testSubject = new InstallDataGenerator(
-            initialInstallationData,
-            generateGuidMock.object,
-            dateGetterMock.object,
-            browserAdapterMock.object,
-        );
+        const testSubject = createTestObject(initialInstallationData);
 
         dateStubMock
             .setup(ds => ds.getUTCMonth())
@@ -172,7 +160,7 @@ describe('InstallDataGeneratorTest', () => {
             .returns(() => guidStub)
             .verifiable();
 
-        browserAdapterMock
+        storageAdapterMock
             .setup(bam => bam.setUserData(It.isValue({ [LocalStorageDataKeys.installationData]: installationDataStub })))
             .verifiable();
 
@@ -190,12 +178,7 @@ describe('InstallDataGeneratorTest', () => {
             year: yearStub,
         };
 
-        const testSubject = new InstallDataGenerator(
-            initialInstallationData,
-            generateGuidMock.object,
-            dateGetterMock.object,
-            browserAdapterMock.object,
-        );
+        const testSubject = createTestObject(initialInstallationData);
 
         dateStubMock
             .setup(ds => ds.getUTCMonth())
@@ -225,8 +208,13 @@ describe('InstallDataGeneratorTest', () => {
 
     function verifyMocks(): void {
         browserAdapterMock.verifyAll();
+        storageAdapterMock.verifyAll();
         dateGetterMock.verifyAll();
         generateGuidMock.verifyAll();
         dateStubMock.verifyAll();
+    }
+
+    function createTestObject(initialInstallationData: InstallationData) {
+        return new InstallDataGenerator(initialInstallationData, generateGuidMock.object, dateGetterMock.object, storageAdapterMock.object);
     }
 });

--- a/src/tests/unit/tests/background/install-data-generator.test.ts
+++ b/src/tests/unit/tests/background/install-data-generator.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
-import { ChromeAdapter } from '../../../../background/browser-adapter';
 import { StorageAPI } from '../../../../background/browser-adapters/storage-adapter';
 import { InstallDataGenerator } from '../../../../background/install-data-generator';
 import { InstallationData } from '../../../../background/installation-data';
@@ -12,7 +11,6 @@ import { generateUID } from '../../../../common/uid-generator';
 describe('InstallDataGeneratorTest', () => {
     let generateGuidMock: IMock<() => string>;
     let dateGetterMock: IMock<() => Date>;
-    let browserAdapterMock: IMock<ChromeAdapter>;
     let storageAdapterMock: IMock<StorageAPI>;
     let dateStubMock: IMock<Date>;
 
@@ -30,7 +28,6 @@ describe('InstallDataGeneratorTest', () => {
         dateGetterMock = Mock.ofInstance<() => Date>(() => {
             return null;
         }, MockBehavior.Strict);
-        browserAdapterMock = Mock.ofType(ChromeAdapter, MockBehavior.Strict);
         storageAdapterMock = Mock.ofType<StorageAPI>();
         dateStubMock = Mock.ofInstance(dateStub as Date);
     });
@@ -200,14 +197,13 @@ describe('InstallDataGeneratorTest', () => {
             .returns(() => guidStub)
             .verifiable(Times.never());
 
-        browserAdapterMock.setup(bam => bam.setUserData(It.isAny())).verifiable(Times.never());
+        storageAdapterMock.setup(bam => bam.setUserData(It.isAny())).verifiable(Times.never());
 
         expect(testSubject.getInstallationId()).toEqual(guidStub);
         verifyMocks();
     });
 
     function verifyMocks(): void {
-        browserAdapterMock.verifyAll();
         storageAdapterMock.verifyAll();
         dateGetterMock.verifyAll();
         generateGuidMock.verifyAll();

--- a/src/tests/unit/tests/background/stores/global/feature-flag-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/feature-flag-store.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { IMock, It, Mock, Times } from 'typemoq';
 import { FeatureFlagActions, FeatureFlagPayload } from '../../../../../../background/actions/feature-flag-actions';
-import { StorageAPI } from '../../../../../../background/browser-adapters/storage-adapter';
+import { StorageAdapter } from '../../../../../../background/browser-adapters/storage-adapter';
 import { LocalStorageDataKeys } from '../../../../../../background/local-storage-data-keys';
 import { LocalStorageData } from '../../../../../../background/storage-data';
 import { FeatureFlagStore } from '../../../../../../background/stores/global/feature-flag-store';
@@ -13,7 +13,7 @@ import { DictionaryStringTo } from '../../../../../../types/common-types';
 import { createStoreWithNullParams, StoreTester } from '../../../../common/store-tester';
 
 describe('FeatureFlagStoreTest', () => {
-    let storageAdapterMock: IMock<StorageAPI>;
+    let storageAdapterMock: IMock<StorageAdapter>;
     let fakeFeatureFlagDefaultValue: FeatureFlagStoreData;
     let fakeFeatureFlagTestValue: FeatureFlagStoreData;
     const fakeFeature = 'fakeFeature';
@@ -25,7 +25,7 @@ describe('FeatureFlagStoreTest', () => {
         fakeFeatureFlagTestValue = getDefaultFeatureFlagValues();
         fakeFeatureFlagTestValue[fakeFeature] = false;
 
-        storageAdapterMock = Mock.ofType<StorageAPI>();
+        storageAdapterMock = Mock.ofType<StorageAdapter>();
     });
 
     test('constructor, no side effects', () => {

--- a/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
+++ b/src/tests/unit/tests/background/stores/global/global-store-hub.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { cloneDeep } from 'lodash';
 import { IMock, Mock, Times } from 'typemoq';
-
 import { GlobalActionHub } from '../../../../../../background/actions/global-action-hub';
 import { PersistedData } from '../../../../../../background/get-persisted-data';
 import { LocalStorageData } from '../../../../../../background/storage-data';
@@ -58,6 +57,7 @@ describe('GlobalStoreHubTest', () => {
             assessmentProvider,
             idbInstance,
             cloneDeep(persistedDataStub),
+            null,
         );
         const allStores = testSubject.getAllStores();
 
@@ -80,6 +80,7 @@ describe('GlobalStoreHubTest', () => {
             assessmentProvider,
             idbInstance,
             cloneDeep(persistedDataStub),
+            null,
         );
         const allStores = testSubject.getAllStores() as BaseStoreImpl<any>[];
         const initializeMocks: Array<IMock<Function>> = [];

--- a/src/tests/unit/tests/background/stores/global/launch-panel-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/launch-panel-state-store.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { IMock, It, Mock, Times } from 'typemoq';
 import { LaunchPanelStateActions } from '../../../../../../background/actions/launch-panel-state-action';
-import { StorageAPI } from '../../../../../../background/browser-adapters/storage-adapter';
+import { StorageAdapter } from '../../../../../../background/browser-adapters/storage-adapter';
 import { LocalStorageDataKeys } from '../../../../../../background/local-storage-data-keys';
 import { LocalStorageData } from '../../../../../../background/storage-data';
 import { LaunchPanelStore } from '../../../../../../background/stores/global/launch-panel-store';
@@ -13,11 +13,11 @@ import { createStoreWithNullParams, StoreTester } from '../../../../common/store
 
 describe('LaunchPanelStateStoreTest', () => {
     let userDataStub: LocalStorageData;
-    let storageAdapterMock: IMock<StorageAPI>;
+    let storageAdapterMock: IMock<StorageAdapter>;
 
     beforeAll(() => {
         userDataStub = { launchPanelSetting: LaunchPanelType.AdhocToolsPanel };
-        storageAdapterMock = Mock.ofType<StorageAPI>();
+        storageAdapterMock = Mock.ofType<StorageAdapter>();
     });
 
     test('constructor, no side effects', () => {

--- a/src/tests/unit/tests/background/stores/global/launch-panel-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/launch-panel-state-store.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { IMock, It, Mock, Times } from 'typemoq';
 import { LaunchPanelStateActions } from '../../../../../../background/actions/launch-panel-state-action';
-import { ChromeAdapter } from '../../../../../../background/browser-adapter';
+import { StorageAPI } from '../../../../../../background/browser-adapters/storage-adapter';
 import { LocalStorageDataKeys } from '../../../../../../background/local-storage-data-keys';
 import { LocalStorageData } from '../../../../../../background/storage-data';
 import { LaunchPanelStore } from '../../../../../../background/stores/global/launch-panel-store';
@@ -13,11 +13,11 @@ import { createStoreWithNullParams, StoreTester } from '../../../../common/store
 
 describe('LaunchPanelStateStoreTest', () => {
     let userDataStub: LocalStorageData;
-    let browserAdapterMock: IMock<ChromeAdapter>;
+    let storageAdapterMock: IMock<StorageAPI>;
 
     beforeAll(() => {
         userDataStub = { launchPanelSetting: LaunchPanelType.AdhocToolsPanel };
-        browserAdapterMock = Mock.ofType(ChromeAdapter);
+        storageAdapterMock = Mock.ofType<StorageAPI>();
     });
 
     test('constructor, no side effects', () => {
@@ -60,19 +60,19 @@ describe('LaunchPanelStateStoreTest', () => {
             [LocalStorageDataKeys.launchPanelSetting]: payload,
         };
 
-        browserAdapterMock.setup(bA => bA.setUserData(It.isValue(expecetedSetUserData))).verifiable(Times.once());
+        storageAdapterMock.setup(adapter => adapter.setUserData(It.isValue(expecetedSetUserData))).verifiable(Times.once());
 
         createStoreForLaunchPanelStateActions('setLaunchPanelType')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, expectedState);
 
-        browserAdapterMock.verifyAll();
+        storageAdapterMock.verifyAll();
     });
 
     function createStoreForLaunchPanelStateActions(
         actionName: keyof LaunchPanelStateActions,
     ): StoreTester<LaunchPanelStoreData, LaunchPanelStateActions> {
-        const factory = (actions: LaunchPanelStateActions) => new LaunchPanelStore(actions, browserAdapterMock.object, userDataStub);
+        const factory = (actions: LaunchPanelStateActions) => new LaunchPanelStore(actions, storageAdapterMock.object, userDataStub);
 
         return new StoreTester(LaunchPanelStateActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
@@ -3,7 +3,7 @@
 import { Mock } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../../background/browser-adapter';
-import { StorageAPI } from '../../../../../background/browser-adapters/storage-adapter';
+import { StorageAdapter } from '../../../../../background/browser-adapters/storage-adapter';
 import { LocalStorageData } from '../../../../../background/storage-data';
 import { AppInsightsTelemetryClient } from '../../../../../background/telemetry/app-insights-telemetry-client';
 import { NullTelemetryClient } from '../../../../../background/telemetry/null-telemetry-client';
@@ -31,7 +31,7 @@ describe('TelemetryClientProvider', () => {
             browserAdapterMock.object,
             Mock.ofType<TelemetryLogger>().object,
             Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>().object,
-            Mock.ofType<StorageAPI>().object,
+            Mock.ofType<StorageAdapter>().object,
         );
 
         expect(result).toBeInstanceOf(AppInsightsTelemetryClient);
@@ -45,7 +45,7 @@ describe('TelemetryClientProvider', () => {
             Mock.ofType<BrowserAdapter>().object,
             Mock.ofType<TelemetryLogger>().object,
             Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>().object,
-            Mock.ofType<StorageAPI>().object,
+            Mock.ofType<StorageAdapter>().object,
         );
 
         expect(result).toBeInstanceOf(NullTelemetryClient);

--- a/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
@@ -3,6 +3,7 @@
 import { Mock } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../../background/browser-adapter';
+import { StorageAPI } from '../../../../../background/browser-adapters/storage-adapter';
 import { LocalStorageData } from '../../../../../background/storage-data';
 import { AppInsightsTelemetryClient } from '../../../../../background/telemetry/app-insights-telemetry-client';
 import { NullTelemetryClient } from '../../../../../background/telemetry/null-telemetry-client';
@@ -30,6 +31,7 @@ describe('TelemetryClientProvider', () => {
             browserAdapterMock.object,
             Mock.ofType<TelemetryLogger>().object,
             Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>().object,
+            Mock.ofType<StorageAPI>().object,
         );
 
         expect(result).toBeInstanceOf(AppInsightsTelemetryClient);
@@ -43,6 +45,7 @@ describe('TelemetryClientProvider', () => {
             Mock.ofType<BrowserAdapter>().object,
             Mock.ofType<TelemetryLogger>().object,
             Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>().object,
+            Mock.ofType<StorageAPI>().object,
         );
 
         expect(result).toBeInstanceOf(NullTelemetryClient);

--- a/src/tests/unit/tests/background/user-stored-data-cleaner.test.ts
+++ b/src/tests/unit/tests/background/user-stored-data-cleaner.test.ts
@@ -3,15 +3,15 @@
 import { isFunction } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
 
-import { StorageAPI } from '../../../../background/browser-adapters/storage-adapter';
+import { StorageAdapter } from '../../../../background/browser-adapters/storage-adapter';
 import { UserStoredDataCleaner } from '../../../../background/user-stored-data-cleaner';
 
 describe('UserStoredDataCleanerTest', () => {
-    let storageAdapterMock: IMock<StorageAPI>;
+    let storageAdapterMock: IMock<StorageAdapter>;
     let testObject: UserStoredDataCleaner;
 
     beforeEach(() => {
-        storageAdapterMock = Mock.ofType<StorageAPI>();
+        storageAdapterMock = Mock.ofType<StorageAdapter>();
         testObject = new UserStoredDataCleaner(storageAdapterMock.object);
     });
 


### PR DESCRIPTION
#### Description of changes

Currently, we use `BrowserAdapter` to encapsulate our access to the chrome API. Having the adapter is great as it place all `chrome.` calls in a single place. The down side of doing this is: our `BrowserAdapter` type expose 30 different functions. This means we have "user" classes that depend on `BrowesrAdapter` but hardly use 5 of this 30 functions. Additionally, by looking at who is using the adapter, how the adapter is being used and which underlying chrome API each function uses, is possible to see `BrowserAdapter` is not cohesive. In other words, `BrowserAdapter` breaks the [Interface Segregation Principle](https://hackernoon.com/interface-segregation-principle-bdf3f94f1d11).

This is a first step into breaking `BrowserAdapter` into smaller, more cohesive types. I started with the local storage API because:
- all of this functions use `chrome.storage.local`
- all the "user" classes don't use anything else from the `BrowserAdapter`, just need access to the local storage.
- just 3 functions needed to be extracted from `BrowserAdapter`

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
