### PR TITLE
bug: fix color contrast a11y issue with disabled visualization toggle

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -552,6 +552,11 @@ div.insights-file-issue-details-dialog-container {
                 .no-matching-elements {
                     font-weight: bold;
                 }
+                .is-disabled.visual-helper-toggle {
+                    .ms-Toggle-stateText {
+                        color: $secondary-text;
+                    }
+                }
                 .no-failure-view {
                     font-size: 15px;
                     font-weight: normal;


### PR DESCRIPTION
#### Description of changes

Fix the color-contrast issue on Visualization toggle state text when the toggle is in disabled state.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #643 
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS

#### Screenshot:

![image](https://user-images.githubusercontent.com/4496335/57258300-e2e5a800-7010-11e9-9f7f-842363bef975.png)

