### PR TITLE
refactor: introduce commands adapter

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -70,6 +70,7 @@ getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
             IssueFilingServiceProviderImpl,
             environmentInfoProvider.getEnvironmentInfo(),
             browserAdapter,
+            browserAdapter,
         );
         telemetryLogger.initialize(globalContext.featureFlagsController);
 
@@ -92,6 +93,7 @@ getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
             visualizationConfigurationFactory,
             telemetryDataFactory,
             globalContext.stores.userConfigurationStore,
+            browserAdapter,
         );
         chromeCommandHandler.initialize();
 

--- a/src/background/browser-adapter.ts
+++ b/src/background/browser-adapter.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ClientBrowserAdapter, ClientChromeAdapter } from '../common/client-browser-adapter';
+import { CommandsAdapter } from './browser-adapters/commands-adapter';
 import { StorageAdapter } from './browser-adapters/storage-adapter';
 
 export interface NotificationOptions {
@@ -35,12 +36,10 @@ export interface BrowserAdapter extends ClientBrowserAdapter {
     getRuntimeLastError(): chrome.runtime.LastError;
     isAllowedFileSchemeAccess(callback: Function): void;
     addListenerToLocalStorage(callback: (changes: object) => void): void;
-    addCommandListener(callback: (command: string) => void): void;
-    getCommands(callback: (commands: chrome.commands.Command[]) => void): void;
     openManageExtensionPage(): void;
 }
 
-export class ChromeAdapter extends ClientChromeAdapter implements BrowserAdapter, StorageAdapter {
+export class ChromeAdapter extends ClientChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAdapter {
     public openManageExtensionPage(): void {
         chrome.tabs.create({
             url: `chrome://extensions/?id=${chrome.runtime.id}`,

--- a/src/background/browser-adapters/commands-adapter.ts
+++ b/src/background/browser-adapters/commands-adapter.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export type CommandsAdapter = {
+    addCommandListener(callback: (command: string) => void): void;
+    getCommands(callback: (commands: chrome.commands.Command[]) => void): void;
+};

--- a/src/background/chrome-command-handler.ts
+++ b/src/background/chrome-command-handler.ts
@@ -18,6 +18,7 @@ import { VisualizationTogglePayload } from './actions/action-payloads';
 import { BrowserAdapter } from './browser-adapter';
 import { UserConfigurationStore } from './stores/global/user-configuration-store';
 import { TabToContextMap } from './tab-context';
+import { CommandsAdapter } from './browser-adapters/commands-adapter';
 
 const VisualizationMessages = Messages.Visualizations;
 
@@ -27,18 +28,19 @@ export class ChromeCommandHandler {
 
     constructor(
         private tabToContextMap: TabToContextMap,
-        private chromeAdapter: BrowserAdapter,
+        private browserAdapter: BrowserAdapter,
         private urlValidator: UrlValidator,
         private notificationCreator: NotificationCreator,
         private visualizationConfigurationFactory: VisualizationConfigurationFactory,
         private telemetryDataFactory: TelemetryDataFactory,
         private userConfigurationStore: UserConfigurationStore,
+        private commandsAdapter: CommandsAdapter,
         private logger: Logger = createDefaultLogger(),
     ) {}
 
     public initialize(): void {
         this.commandToVisualizationType = this.visualizationConfigurationFactory.getChromeCommandToVisualizationTypeMap();
-        this.chromeAdapter.addCommandListener(this.onCommand);
+        this.commandsAdapter.addCommandListener(this.onCommand);
     }
 
     @autobind
@@ -93,11 +95,11 @@ export class ChromeCommandHandler {
     }
 
     private async checkAccessUrl(): Promise<boolean> {
-        return await this.urlValidator.isSupportedUrl(this.targetTabUrl, this.chromeAdapter);
+        return await this.urlValidator.isSupportedUrl(this.targetTabUrl, this.browserAdapter);
     }
 
     private queryTabs(tabQueryParams: chrome.tabs.QueryInfo): Promise<chrome.tabs.Tab[]> {
-        return new Promise(resolve => this.chromeAdapter.tabsQuery(tabQueryParams, resolve));
+        return new Promise(resolve => this.browserAdapter.tabsQuery(tabQueryParams, resolve));
     }
 
     private async queryCurrentActiveTab(): Promise<chrome.tabs.Tab> {

--- a/src/background/chrome-command-handler.ts
+++ b/src/background/chrome-command-handler.ts
@@ -16,9 +16,9 @@ import { UrlValidator } from '../common/url-validator';
 import { DictionaryStringTo } from '../types/common-types';
 import { VisualizationTogglePayload } from './actions/action-payloads';
 import { BrowserAdapter } from './browser-adapter';
+import { CommandsAdapter } from './browser-adapters/commands-adapter';
 import { UserConfigurationStore } from './stores/global/user-configuration-store';
 import { TabToContextMap } from './tab-context';
-import { CommandsAdapter } from './browser-adapters/commands-adapter';
 
 const VisualizationMessages = Messages.Visualizations;
 

--- a/src/background/global-action-creators/global-action-creator.ts
+++ b/src/background/global-action-creators/global-action-creator.ts
@@ -10,13 +10,13 @@ import { FeatureFlagActions } from '../actions/feature-flag-actions';
 import { GlobalActionHub } from '../actions/global-action-hub';
 import { LaunchPanelStateActions } from '../actions/launch-panel-state-action';
 import { ScopingActions } from '../actions/scoping-actions';
-import { BrowserAdapter } from '../browser-adapter';
+import { CommandsAdapter } from '../browser-adapters/commands-adapter';
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 
 export class GlobalActionCreator {
     private interpreter: Interpreter;
-    private browserAdapter: BrowserAdapter;
+    private commandsAdapter: CommandsAdapter;
     private telemetryEventHandler: TelemetryEventHandler;
 
     private commandActions: CommandActions;
@@ -27,11 +27,11 @@ export class GlobalActionCreator {
     constructor(
         globalActionHub: GlobalActionHub,
         interpreter: Interpreter,
-        browserAdapter: BrowserAdapter,
+        commandsAdapter: CommandsAdapter,
         telemetryEventHandler: TelemetryEventHandler,
     ) {
         this.interpreter = interpreter;
-        this.browserAdapter = browserAdapter;
+        this.commandsAdapter = commandsAdapter;
         this.telemetryEventHandler = telemetryEventHandler;
         this.commandActions = globalActionHub.commandActions;
         this.featureFlagActions = globalActionHub.featureFlagActions;
@@ -57,7 +57,7 @@ export class GlobalActionCreator {
 
     @autobind
     private onGetCommands(payload, tabId: number): void {
-        this.browserAdapter.getCommands((commands: chrome.commands.Command[]) => {
+        this.commandsAdapter.getCommands((commands: chrome.commands.Command[]) => {
             const getCommandsPayload: GetCommandsPayload = {
                 commands: commands,
                 tabId: tabId,

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -10,6 +10,7 @@ import { AssessmentsProvider } from './../assessments/types/assessments-provider
 import { AssessmentActionCreator } from './actions/assessment-action-creator';
 import { GlobalActionHub } from './actions/global-action-hub';
 import { BrowserAdapter } from './browser-adapter';
+import { CommandsAdapter } from './browser-adapters/commands-adapter';
 import { StorageAdapter } from './browser-adapters/storage-adapter';
 import { CompletedTestStepTelemetryCreator } from './completed-test-step-telemetry-creator';
 import { FeatureFlagsController } from './feature-flags-controller';
@@ -35,6 +36,7 @@ export class GlobalContextFactory {
         issueFilingServiceProvider: IssueFilingServiceProvider,
         environmentInfo: EnvironmentInfo,
         storageAdapter: StorageAdapter,
+        commandsAdapter: CommandsAdapter,
     ): GlobalContext {
         const interpreter = new Interpreter();
 
@@ -62,7 +64,7 @@ export class GlobalContextFactory {
         );
 
         const issueFilingActionCreator = new IssueFilingActionCreator(interpreter, telemetryEventHandler, issueFilingController);
-        const actionCreator = new GlobalActionCreator(globalActionsHub, interpreter, browserAdapter, telemetryEventHandler);
+        const actionCreator = new GlobalActionCreator(globalActionsHub, interpreter, commandsAdapter, telemetryEventHandler);
         const assessmentActionCreator = new AssessmentActionCreator(
             globalActionsHub.assessmentActions,
             telemetryEventHandler,

--- a/src/tests/unit/tests/background/chrome-command-handler.test.ts
+++ b/src/tests/unit/tests/background/chrome-command-handler.test.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { BrowserAdapter, ChromeAdapter } from '../../../../background/browser-adapter';
+import { CommandsAdapter } from '../../../../background/browser-adapters/commands-adapter';
 import { ChromeCommandHandler } from '../../../../background/chrome-command-handler';
 import { Interpreter } from '../../../../background/interpreter';
 import { UserConfigurationStore } from '../../../../background/stores/global/user-configuration-store';
@@ -22,7 +24,8 @@ import { UrlValidator } from '../../../../common/url-validator';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 
 let testSubject: ChromeCommandHandler;
-let chromeAdapterMock: IMock<BrowserAdapter>;
+let browserAdapterMock: IMock<BrowserAdapter>;
+let commandsAdapterMock: IMock<CommandsAdapter>;
 let urlValidatorMock: IMock<UrlValidator>;
 let tabToContextMap: TabToContextMap;
 let visualizationStoreMock: IMock<BaseStore<VisualizationStoreData>>;
@@ -53,23 +56,25 @@ describe('ChromeCommandHandlerTest', () => {
             visualizationStore: visualizationStoreMock.object,
         } as TabContextStoreHub);
 
-        chromeAdapterMock = Mock.ofType(ChromeAdapter);
-        chromeAdapterMock
-            .setup(ca => ca.addCommandListener(It.isAny()))
-            .callback(callback => {
-                commandCallback = callback;
-            })
-            .verifiable();
-        chromeAdapterMock
+        browserAdapterMock = Mock.ofType(ChromeAdapter);
+        browserAdapterMock
             .setup(ca => ca.tabsQuery(It.isValue({ active: true, currentWindow: true }), It.isAny()))
             .returns((_, callback) => {
                 callback([{ id: simulatedActiveTabId, url: simulatedActiveTabUrl } as chrome.tabs.Tab]);
             })
             .verifiable();
 
+        commandsAdapterMock = Mock.ofType<CommandsAdapter>();
+        commandsAdapterMock
+            .setup(adapter => adapter.addCommandListener(It.isAny()))
+            .callback(callback => {
+                commandCallback = callback;
+            })
+            .verifiable();
+
         urlValidatorMock = Mock.ofType(UrlValidator);
         urlValidatorMock
-            .setup(uV => uV.isSupportedUrl(It.isAny(), chromeAdapterMock.object))
+            .setup(uV => uV.isSupportedUrl(It.isAny(), browserAdapterMock.object))
             .returns(async () => simulatedIsSupportedUrlResponse)
             .verifiable();
 
@@ -90,12 +95,13 @@ describe('ChromeCommandHandlerTest', () => {
 
         testSubject = new ChromeCommandHandler(
             tabToContextMap,
-            chromeAdapterMock.object,
+            browserAdapterMock.object,
             urlValidatorMock.object,
             notificationCreatorMock.object,
             new VisualizationConfigurationFactory(),
             new TelemetryDataFactory(),
             userConfigurationStoreMock.object,
+            commandsAdapterMock.object,
         );
 
         testSubject.initialize();

--- a/src/tests/unit/tests/background/global-context-factory.test.ts
+++ b/src/tests/unit/tests/background/global-context-factory.test.ts
@@ -3,6 +3,7 @@
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
 
 import { BrowserAdapter, ChromeAdapter } from '../../../../background/browser-adapter';
+import { CommandsAdapter } from '../../../../background/browser-adapters/commands-adapter';
 import { StorageAdapter } from '../../../../background/browser-adapters/storage-adapter';
 import { PersistedData } from '../../../../background/get-persisted-data';
 import { GlobalContext } from '../../../../background/global-context';
@@ -21,6 +22,7 @@ import { CreateTestAssessmentProvider } from '../../common/test-assessment-provi
 
 describe('GlobalContextFactoryTest', () => {
     let _mockChromeAdapter: IMock<BrowserAdapter>;
+    let _mockCommandsAdapter: IMock<CommandsAdapter>;
     let _mockStorageAdapter: IMock<StorageAdapter>;
     let _mocktelemetryEventHandler: IMock<TelemetryEventHandler>;
     let _mockTelemetryDataFactory: IMock<TelemetryDataFactory>;
@@ -33,6 +35,7 @@ describe('GlobalContextFactoryTest', () => {
     beforeAll(() => {
         _mockStorageAdapter = Mock.ofType<StorageAdapter>();
         _mockChromeAdapter = Mock.ofType(ChromeAdapter, MockBehavior.Loose);
+        _mockCommandsAdapter = Mock.ofType<CommandsAdapter>();
         _mockChromeAdapter.setup(adapter => adapter.sendMessageToAllFramesAndTabs(It.isAny()));
         _mocktelemetryEventHandler = Mock.ofType(TelemetryEventHandler);
         _mockTelemetryDataFactory = Mock.ofType(TelemetryDataFactory);
@@ -56,6 +59,7 @@ describe('GlobalContextFactoryTest', () => {
             _mockIssueFilingServiceProvider.object,
             environmentInfoStub,
             _mockStorageAdapter.object,
+            _mockCommandsAdapter.object,
         );
 
         expect(globalContext).toBeInstanceOf(GlobalContext);


### PR DESCRIPTION
#### Description of changes

More breaking down `BrowserAdapter` type. In this PR:
- Introduce `CommandsAdapter` to wrap 2 commands related functions

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not apply
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
