### PR TITLE
refactor: Remove circular dependencies of imports relying on ScanOptions and AxeOptions

### DIFF
--- a/src/injected/analyzers/rule-analyzer.ts
+++ b/src/injected/analyzers/rule-analyzer.ts
@@ -8,8 +8,8 @@ import { VisualizationConfigurationFactory } from '../../common/configs/visualiz
 import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
 import { ForRuleAnalyzerScanCallback } from '../../common/types/analyzer-telemetry-callbacks';
 import { ScopingStoreData } from '../../common/types/store-data/scoping-store-data';
-import { ScanOptions } from '../../scanner/exposed-apis';
 import { ScanResults } from '../../scanner/iruleresults';
+import { ScanOptions } from '../../scanner/scan-options';
 import { ScannerUtils } from '../scanner-utils';
 import { AxeAnalyzerResult, RuleAnalyzerConfiguration } from './analyzer';
 import { BaseAnalyzer } from './base-analyzer';

--- a/src/injected/scanner-utils.ts
+++ b/src/injected/scanner-utils.ts
@@ -4,8 +4,9 @@ import { autobind } from '@uifabric/utilities';
 
 import { createDefaultLogger } from '../common/logging/default-logger';
 import { Logger } from '../common/logging/logger';
-import { scan as scanRunner, ScanOptions } from '../scanner/exposed-apis';
+import { scan as scanRunner } from '../scanner/exposed-apis';
 import { RuleResult, ScanResults } from '../scanner/iruleresults';
+import { ScanOptions } from '../scanner/scan-options';
 import { DictionaryStringTo } from '../types/common-types';
 import { HyperlinkDefinition } from '../views/content/content-page';
 

--- a/src/scanner/axe-options.ts
+++ b/src/scanner/axe-options.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as Axe from 'axe-core';
+
+export interface AxeOptions {
+    runOnly?: Axe.RunOnly;
+    restoreScroll?: Boolean; // missing from axe options.
+}
+export type AxeScanContext = string | NodeSelector & Node | IncludeExcludeOptions | NodeList;
+export interface IncludeExcludeOptions {
+    include: string[][];
+    exclude: string[][];
+}

--- a/src/scanner/exposed-apis.ts
+++ b/src/scanner/exposed-apis.ts
@@ -16,16 +16,9 @@ import { MessageDecorator } from './message-decorator';
 import { ResultDecorator } from './result-decorator';
 import { RuleSifter } from './rule-sifter';
 import { ruleToLinkConfiguration } from './rule-to-links-mappings';
+import { ScanOptions } from './scan-options';
 import { ScanParameterGenerator } from './scan-parameter-generator';
 import { ScannerRuleInfo } from './scanner-rule-info';
-
-export interface ScanOptions {
-    testsToRun?: string[];
-    dom?: NodeSelector & Node | NodeList;
-    selector?: string;
-    include?: string[][];
-    exclude?: string[][];
-}
 
 export let scan = (options: ScanOptions, successCallback: (results: ScanResults) => void, errorCallback: (results: Error) => void) => {
     options = options || {};

--- a/src/scanner/launcher.ts
+++ b/src/scanner/launcher.ts
@@ -6,18 +6,6 @@ import { AxeResponseHandler } from './axe-response-handler';
 import { ScanOptions } from './scan-options';
 import { ScanParameterGenerator } from './scan-parameter-generator';
 
-export interface AxeOptions {
-    runOnly?: Axe.RunOnly;
-    restoreScroll?: Boolean; // missing from axe options.
-}
-
-export type AxeScanContext = string | NodeSelector & Node | IncludeExcludeOptions | NodeList;
-
-export interface IncludeExcludeOptions {
-    include: string[][];
-    exclude: string[][];
-}
-
 export class Launcher {
     constructor(
         private axe: typeof Axe,

--- a/src/scanner/launcher.ts
+++ b/src/scanner/launcher.ts
@@ -3,7 +3,7 @@
 import * as Axe from 'axe-core';
 
 import { AxeResponseHandler } from './axe-response-handler';
-import { ScanOptions } from './exposed-apis';
+import { ScanOptions } from './scan-options';
 import { ScanParameterGenerator } from './scan-parameter-generator';
 
 export interface AxeOptions {

--- a/src/scanner/scan-options.ts
+++ b/src/scanner/scan-options.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export interface ScanOptions {
+    testsToRun?: string[];
+    dom?: NodeSelector & Node | NodeList;
+    selector?: string;
+    include?: string[][];
+    exclude?: string[][];
+}

--- a/src/scanner/scan-parameter-generator.ts
+++ b/src/scanner/scan-parameter-generator.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { AxeOptions, AxeScanContext } from './axe-options';
 import { RuleSifter } from './rule-sifter';
 import { ScanOptions } from './scan-options';

--- a/src/scanner/scan-parameter-generator.ts
+++ b/src/scanner/scan-parameter-generator.ts
@@ -1,4 +1,4 @@
-import { AxeOptions, AxeScanContext } from './launcher';
+import { AxeOptions, AxeScanContext } from './axe-options';
 import { RuleSifter } from './rule-sifter';
 import { ScanOptions } from './scan-options';
 

--- a/src/scanner/scan-parameter-generator.ts
+++ b/src/scanner/scan-parameter-generator.ts
@@ -1,8 +1,6 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-import { ScanOptions } from './exposed-apis';
 import { AxeOptions, AxeScanContext } from './launcher';
 import { RuleSifter } from './rule-sifter';
+import { ScanOptions } from './scan-options';
 
 export class ScanParameterGenerator {
     constructor(private ruleSifter: RuleSifter) {}

--- a/src/tests/unit/tests/injected/analyzers/batched-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/batched-analyzer.test.ts
@@ -16,8 +16,8 @@ import { VisualizationType } from '../../../../../common/types/visualization-typ
 import { RuleAnalyzerConfiguration } from '../../../../../injected/analyzers/analyzer';
 import { BatchedRuleAnalyzer, IResultRuleFilter } from '../../../../../injected/analyzers/batched-rule-analyzer';
 import { HtmlElementAxeResults, ScannerUtils } from '../../../../../injected/scanner-utils';
-import { ScanOptions } from '../../../../../scanner/exposed-apis';
 import { RuleResult, ScanResults } from '../../../../../scanner/iruleresults';
+import { ScanOptions } from '../../../../../scanner/scan-options';
 import { DictionaryStringTo } from '../../../../../types/common-types';
 
 describe('BatchedRuleAnalyzer', () => {

--- a/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
@@ -16,8 +16,8 @@ import { VisualizationType } from '../../../../../common/types/visualization-typ
 import { RuleAnalyzerConfiguration } from '../../../../../injected/analyzers/analyzer';
 import { RuleAnalyzer } from '../../../../../injected/analyzers/rule-analyzer';
 import { HtmlElementAxeResults, ScannerUtils } from '../../../../../injected/scanner-utils';
-import { ScanOptions } from '../../../../../scanner/exposed-apis';
 import { ScanResults } from '../../../../../scanner/iruleresults';
+import { ScanOptions } from '../../../../../scanner/scan-options';
 import { DictionaryStringTo } from '../../../../../types/common-types';
 
 describe('RuleAnalyzer', () => {

--- a/src/tests/unit/tests/injected/scanner-utils.test.ts
+++ b/src/tests/unit/tests/injected/scanner-utils.test.ts
@@ -7,8 +7,9 @@ import { ScopingStore } from '../../../../background/stores/global/scoping-store
 import { Logger } from '../../../../common/logging/logger';
 import { ScopingStoreData } from '../../../../common/types/store-data/scoping-store-data';
 import { DecoratedAxeNodeResult, HtmlElementAxeResults, ScannerUtils } from '../../../../injected/scanner-utils';
-import { scan, ScanOptions } from '../../../../scanner/exposed-apis';
+import { scan } from '../../../../scanner/exposed-apis';
 import { RuleResult, ScanResults } from '../../../../scanner/iruleresults';
+import { ScanOptions } from '../../../../scanner/scan-options';
 import { DictionaryStringTo } from '../../../../types/common-types';
 
 describe('ScannerUtilsTest', () => {

--- a/src/tests/unit/tests/scanner/scan-parameter-generator.test.ts
+++ b/src/tests/unit/tests/scanner/scan-parameter-generator.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
-import { AxeOptions } from '../../../../scanner/launcher';
+import { AxeOptions } from '../../../../scanner/axe-options';
 import { RuleSifter, RuleWithA11YCriteria } from '../../../../scanner/rule-sifter';
 import { ScanOptions } from '../../../../scanner/scan-options';
 import { ScanParameterGenerator } from '../../../../scanner/scan-parameter-generator';

--- a/src/tests/unit/tests/scanner/scan-parameter-generator.test.ts
+++ b/src/tests/unit/tests/scanner/scan-parameter-generator.test.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
-import { ScanOptions } from '../../../../scanner/exposed-apis';
 import { AxeOptions } from '../../../../scanner/launcher';
 import { RuleSifter, RuleWithA11YCriteria } from '../../../../scanner/rule-sifter';
+import { ScanOptions } from '../../../../scanner/scan-options';
 import { ScanParameterGenerator } from '../../../../scanner/scan-parameter-generator';
 
 describe('ScanParameterGenerator', () => {


### PR DESCRIPTION
#### Description of changes

Using madge, I found that our background files have quite a few circular dependencies. As such I'm removing a few in this PR.

Fix circular dependencies in our imports by extracting interfaces out to separate files.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`npm run test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
