### PR TITLE
refactor: update url-validator constructor params

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -37,7 +37,7 @@ import { UserStoredDataCleaner } from './user-stored-data-cleaner';
 
 declare var window: Window & InsightsFeatureFlags;
 const browserAdapter = new ChromeAdapter();
-const urlValidator = new UrlValidator();
+const urlValidator = new UrlValidator(browserAdapter);
 const backgroundInitCleaner = new UserStoredDataCleaner(browserAdapter);
 
 const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil();

--- a/src/background/chrome-command-handler.ts
+++ b/src/background/chrome-command-handler.ts
@@ -95,7 +95,7 @@ export class ChromeCommandHandler {
     }
 
     private async checkAccessUrl(): Promise<boolean> {
-        return await this.urlValidator.isSupportedUrl(this.targetTabUrl, this.browserAdapter);
+        return await this.urlValidator.isSupportedUrl(this.targetTabUrl);
     }
 
     private queryTabs(tabQueryParams: chrome.tabs.QueryInfo): Promise<chrome.tabs.Tab[]> {

--- a/src/common/url-validator.ts
+++ b/src/common/url-validator.ts
@@ -3,12 +3,14 @@
 import { BrowserAdapter } from '../background/browser-adapter';
 
 export class UrlValidator {
-    public async isSupportedUrl(url: string, chromeAdapter: BrowserAdapter): Promise<boolean> {
+    constructor(private readonly browserAdapter: BrowserAdapter) {}
+
+    public async isSupportedUrl(url: string): Promise<boolean> {
         const lowerCasedUrl: string = url.toLowerCase();
         if (lowerCasedUrl.startsWith('http://') || lowerCasedUrl.startsWith('https://')) {
             return this.hasSupportedPrefix(lowerCasedUrl);
         } else if (UrlValidator.isFileUrl(lowerCasedUrl)) {
-            return await this.checkAccessToFileUrl(chromeAdapter);
+            return await this.checkAccessToFileUrl();
         } else {
             return false;
         }
@@ -23,9 +25,9 @@ export class UrlValidator {
         return url.toLowerCase().startsWith('file://');
     }
 
-    private checkAccessToFileUrl(chromeAdapter: BrowserAdapter): Promise<boolean> {
+    private checkAccessToFileUrl(): Promise<boolean> {
         return new Promise<boolean>(resolve => {
-            chromeAdapter.isAllowedFileSchemeAccess(resolve);
+            this.browserAdapter.isAllowedFileSchemeAccess(resolve);
         });
     }
 }

--- a/src/popup/popup-init.ts
+++ b/src/popup/popup-init.ts
@@ -11,7 +11,7 @@ import { TargetTabFinder } from './target-tab-finder';
 
 initializeFabricIcons();
 const browserAdapter = new ChromeAdapter();
-const urlValidator = new UrlValidator();
+const urlValidator = new UrlValidator(browserAdapter);
 const targetTabFinder = new TargetTabFinder(window, browserAdapter, urlValidator, new UrlParser());
 const userAgentParser = new UAParser(window.navigator.userAgent);
 const popupInitializer: PopupInitializer = new PopupInitializer(browserAdapter, targetTabFinder, userAgentParser.getBrowser());

--- a/src/popup/target-tab-finder.ts
+++ b/src/popup/target-tab-finder.ts
@@ -55,7 +55,7 @@ export class TargetTabFinder {
 
     @autobind
     private async createTargetTabInfo(tab: Tab): Promise<TargetTabInfo> {
-        const hasAccess = await this.urlValidator.isSupportedUrl(tab.url, this.browserAdapter);
+        const hasAccess = await this.urlValidator.isSupportedUrl(tab.url);
         const targetTab: TargetTabInfo = {
             tab: tab,
             hasAccess,

--- a/src/tests/unit/tests/background/chrome-command-handler.test.ts
+++ b/src/tests/unit/tests/background/chrome-command-handler.test.ts
@@ -74,7 +74,7 @@ describe('ChromeCommandHandlerTest', () => {
 
         urlValidatorMock = Mock.ofType(UrlValidator);
         urlValidatorMock
-            .setup(uV => uV.isSupportedUrl(It.isAny(), browserAdapterMock.object))
+            .setup(uV => uV.isSupportedUrl(It.isAny()))
             .returns(async () => simulatedIsSupportedUrlResponse)
             .verifiable();
 

--- a/src/tests/unit/tests/common/url-validator.test.ts
+++ b/src/tests/unit/tests/common/url-validator.test.ts
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { isFunction } from 'lodash';
-import { It, Mock } from 'typemoq';
-import { ChromeAdapter } from '../../../../background/browser-adapter';
+import { IMock, It, Mock } from 'typemoq';
+
+import { BrowserAdapter } from '../../../../background/browser-adapter';
 import { UrlValidator } from '../../../../common/url-validator';
 
 describe('UrlValidatorTest', () => {
+    let browserAdapterMock: IMock<BrowserAdapter>;
+
     let testSubject: UrlValidator;
 
     const supportedUrlCases = [
@@ -21,16 +24,19 @@ describe('UrlValidatorTest', () => {
         ['oops_http://example.com', false],
     ];
 
+    beforeEach(() => {
+        browserAdapterMock = Mock.ofType<BrowserAdapter>();
+
+        testSubject = new UrlValidator(browserAdapterMock.object);
+    });
+
     test.each(supportedUrlCases)('isSupportedUrl: %s should be %s', async (url: string, expected: boolean) => {
-        testSubject = new UrlValidator();
-        const isSupported = await testSubject.isSupportedUrl(url, It.isAny());
+        const isSupported = await testSubject.isSupportedUrl(url);
         expect(isSupported).toBe(expected);
     });
 
     test('isSupportedUrl: file', async () => {
         const url: string = 'file://test';
-        testSubject = new UrlValidator();
-        const browserAdapterMock = Mock.ofType(ChromeAdapter);
         browserAdapterMock
             .setup(b => b.isAllowedFileSchemeAccess(It.is(isFunction)))
             .callback(callback => {
@@ -38,7 +44,7 @@ describe('UrlValidatorTest', () => {
             })
             .verifiable();
 
-        const isSupported = await testSubject.isSupportedUrl(url, browserAdapterMock.object);
+        const isSupported = await testSubject.isSupportedUrl(url);
         expect(isSupported).toBe(true);
 
         browserAdapterMock.verifyAll();
@@ -46,8 +52,6 @@ describe('UrlValidatorTest', () => {
 
     test('isFileUrl, but have no access, so isNotSupportedUrl', async () => {
         const url: string = 'file://yes/I/am!';
-        testSubject = new UrlValidator();
-        const browserAdapterMock = Mock.ofType(ChromeAdapter);
         browserAdapterMock
             .setup(b => b.isAllowedFileSchemeAccess(It.is(isFunction)))
             .callback(callback => {
@@ -55,7 +59,7 @@ describe('UrlValidatorTest', () => {
             })
             .verifiable();
 
-        const isSupported = await testSubject.isSupportedUrl(url, browserAdapterMock.object);
+        const isSupported = await testSubject.isSupportedUrl(url);
         expect(isSupported).toBe(false);
 
         browserAdapterMock.verifyAll();

--- a/src/tests/unit/tests/popup/target-tab-finder.test.ts
+++ b/src/tests/unit/tests/popup/target-tab-finder.test.ts
@@ -119,6 +119,6 @@ describe('TargetTabFinderTest', () => {
     }
 
     function setupIsSupportedCall(isSupported: boolean): void {
-        urlValidatorMock.setup(v => v.isSupportedUrl(tabStub.url, browserAdapterMock.object)).returns(() => Promise.resolve(isSupported));
+        urlValidatorMock.setup(v => v.isSupportedUrl(tabStub.url)).returns(() => Promise.resolve(isSupported));
     }
 });


### PR DESCRIPTION
#### Description of changes

Promote `browserAdapter` from function param to constructor param.

`browserAdapter` is a "precondition" for the `UrlValidator` to work and it should not be pass to the functions that use it as this reveals some implementation details the user class doesn't need to know. As a "precondition" it should be pass through the constructor as this more clearly inform how `browserAdapter` is actually being used inside `UrlValidator`

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not apply
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
