### PR TITLE
refactor: convert layered details dialog component to named sfc

### DIFF
--- a/src/injected/layered-details-dialog-component.tsx
+++ b/src/injected/layered-details-dialog-component.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import { BaseStore } from '../common/base-store';
 import { FeatureFlags } from '../common/feature-flags';
 import { DevToolActionMessageCreator } from '../common/message-creators/dev-tool-action-message-creator';
+import { NamedSFC } from '../common/react/named-sfc';
 import { DevToolState } from '../common/types/store-data/idev-tool-state';
 import { UserConfigurationStoreData } from '../common/types/store-data/user-configuration-store';
 import { DictionaryStringTo } from '../types/common-types';
@@ -31,21 +32,20 @@ export interface LayeredDetailsDialogProps {
     devToolsShortcut: string;
 }
 
-export class LayeredDetailsDialogComponent extends React.Component<LayeredDetailsDialogProps> {
-    public render(): JSX.Element {
-        const detailsDialog = <DetailsDialog {...this.props} />;
+export const LayeredDetailsDialogComponent = NamedSFC<LayeredDetailsDialogProps>('LayeredDetailsDialogComponent', props => {
+    const isShadowDOMDialogEnabled = (): boolean => {
+        return props.featureFlagStoreData[FeatureFlags.shadowDialog];
+    };
 
-        if (this.isShadowDOMDialogEnabled()) {
-            return detailsDialog;
-        }
-        return (
-            <LayerHost id="insights-dialog-layer-host" dir={this.props.deps.getRTL() ? 'rtl' : 'ltr'}>
-                {detailsDialog}
-            </LayerHost>
-        );
+    const detailsDialog = <DetailsDialog {...props} />;
+
+    if (isShadowDOMDialogEnabled()) {
+        return detailsDialog;
     }
 
-    private isShadowDOMDialogEnabled(): boolean {
-        return this.props.featureFlagStoreData[FeatureFlags.shadowDialog];
-    }
-}
+    return (
+        <LayerHost id="insights-dialog-layer-host" dir={props.deps.getRTL() ? 'rtl' : 'ltr'}>
+            {detailsDialog}
+        </LayerHost>
+    );
+});

--- a/src/injected/layered-details-dialog-component.tsx
+++ b/src/injected/layered-details-dialog-component.tsx
@@ -15,9 +15,9 @@ import { DetailsDialog, DetailsDialogDeps } from './components/details-dialog';
 import { DetailsDialogHandler } from './details-dialog-handler';
 import { DecoratedAxeNodeResult } from './scanner-utils';
 
-export interface LayeredDetailsDialogDeps extends DetailsDialogDeps {
+export type LayeredDetailsDialogDeps = DetailsDialogDeps & {
     getRTL: typeof getRTL;
-}
+};
 
 export interface LayeredDetailsDialogProps {
     deps: LayeredDetailsDialogDeps;

--- a/src/tests/unit/tests/injected/__snapshots__/layered-details-dialog-component.test.tsx.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/layered-details-dialog-component.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`render component when shadow dom is disabled 1`] = `
+exports[` render component when shadow dom is disabled 1`] = `
 <LayerHost
   dir="ltr"
   id="insights-dialog-layer-host"
@@ -21,7 +21,7 @@ exports[`render component when shadow dom is disabled 1`] = `
 </LayerHost>
 `;
 
-exports[`render component when shadow dom is enabled - isRTL - false 1`] = `
+exports[` render component when shadow dom is enabled - isRTL - false 1`] = `
 <DetailsDialog
   deps={
     Object {
@@ -37,7 +37,7 @@ exports[`render component when shadow dom is enabled - isRTL - false 1`] = `
 />
 `;
 
-exports[`render component when shadow dom is enabled - isRTL - true 1`] = `
+exports[` render component when shadow dom is enabled - isRTL - true 1`] = `
 <DetailsDialog
   deps={
     Object {

--- a/src/tests/unit/tests/injected/__snapshots__/layered-details-dialog-component.test.tsx.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/layered-details-dialog-component.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` render component when shadow dom is disabled 1`] = `
+exports[`LayeredDetailsDialogComponent render component when shadow dom is disabled 1`] = `
 <LayerHost
   dir="ltr"
   id="insights-dialog-layer-host"
@@ -21,7 +21,7 @@ exports[` render component when shadow dom is disabled 1`] = `
 </LayerHost>
 `;
 
-exports[` render component when shadow dom is enabled - isRTL - false 1`] = `
+exports[`LayeredDetailsDialogComponent render component when shadow dom is enabled - isRTL - false 1`] = `
 <DetailsDialog
   deps={
     Object {
@@ -37,7 +37,7 @@ exports[` render component when shadow dom is enabled - isRTL - false 1`] = `
 />
 `;
 
-exports[` render component when shadow dom is enabled - isRTL - true 1`] = `
+exports[`LayeredDetailsDialogComponent render component when shadow dom is enabled - isRTL - true 1`] = `
 <DetailsDialog
   deps={
     Object {

--- a/src/tests/unit/tests/injected/__snapshots__/layered-details-dialog-component.test.tsx.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/layered-details-dialog-component.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LayeredDetailsDialogComponent render component when shadow dom is disabled 1`] = `
+exports[`render component when shadow dom is disabled 1`] = `
 <LayerHost
   dir="ltr"
   id="insights-dialog-layer-host"
@@ -12,12 +12,16 @@ exports[`LayeredDetailsDialogComponent render component when shadow dom is disab
       }
     }
     devToolActionMessageCreator="devToolActionMessageCreator"
-    featureFlagStoreData={Object {}}
+    featureFlagStoreData={
+      Object {
+        "shadowDialog": false,
+      }
+    }
   />
 </LayerHost>
 `;
 
-exports[`LayeredDetailsDialogComponent render component when shadow dom is enabled - isRTL - false 1`] = `
+exports[`render component when shadow dom is enabled - isRTL - false 1`] = `
 <DetailsDialog
   deps={
     Object {
@@ -33,7 +37,7 @@ exports[`LayeredDetailsDialogComponent render component when shadow dom is enabl
 />
 `;
 
-exports[`LayeredDetailsDialogComponent render component when shadow dom is enabled - isRTL - true 1`] = `
+exports[`render component when shadow dom is enabled - isRTL - true 1`] = `
 <DetailsDialog
   deps={
     Object {

--- a/src/tests/unit/tests/injected/layered-details-dialog-component.test.tsx
+++ b/src/tests/unit/tests/injected/layered-details-dialog-component.test.tsx
@@ -22,6 +22,8 @@ describe(LayeredDetailsDialogComponent, () => {
     });
 
     it('render component when shadow dom is disabled', () => {
+        featureFlagStoreData[FeatureFlags.shadowDialog] = false;
+
         const wrapper = shallow(<LayeredDetailsDialogComponent {...props} />);
 
         expect(wrapper.getElement()).toMatchSnapshot();

--- a/src/tests/unit/tests/injected/layered-details-dialog-component.test.tsx
+++ b/src/tests/unit/tests/injected/layered-details-dialog-component.test.tsx
@@ -1,25 +1,30 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { getRTL } from '@uifabric/utilities';
+import { shallow } from 'enzyme';
+import * as React from 'react';
 import { IMock, Mock } from 'typemoq';
+
 import { FeatureFlags } from '../../../../common/feature-flags';
 import { LayeredDetailsDialogComponent, LayeredDetailsDialogProps } from '../../../../injected/layered-details-dialog-component';
 import { DictionaryStringTo } from '../../../../types/common-types';
 
 describe(LayeredDetailsDialogComponent, () => {
     let featureFlagStoreData: DictionaryStringTo<boolean>;
-    let componentProps: LayeredDetailsDialogProps;
+    let props: LayeredDetailsDialogProps;
     let getRTLMock: IMock<typeof getRTL>;
 
     beforeEach(() => {
         featureFlagStoreData = {};
         getRTLMock = Mock.ofInstance(() => null);
 
-        componentProps = createLayeredDetailsDialogProps();
+        props = createLayeredDetailsDialogProps();
     });
 
     it('render component when shadow dom is disabled', () => {
-        expect(new LayeredDetailsDialogComponent(componentProps).render()).toMatchSnapshot();
+        const wrapper = shallow(<LayeredDetailsDialogComponent {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
     });
 
     test.each([true, false])('render component when shadow dom is enabled - isRTL - %o', isRTL => {
@@ -27,7 +32,9 @@ describe(LayeredDetailsDialogComponent, () => {
 
         getRTLMock.setup(g => g()).returns(() => isRTL);
 
-        expect(new LayeredDetailsDialogComponent(componentProps).render()).toMatchSnapshot();
+        const wrapper = shallow(<LayeredDetailsDialogComponent {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
     });
 
     function createLayeredDetailsDialogProps(): LayeredDetailsDialogProps {

--- a/src/tests/unit/tests/injected/layered-details-dialog-component.test.tsx
+++ b/src/tests/unit/tests/injected/layered-details-dialog-component.test.tsx
@@ -9,7 +9,7 @@ import { FeatureFlags } from '../../../../common/feature-flags';
 import { LayeredDetailsDialogComponent, LayeredDetailsDialogProps } from '../../../../injected/layered-details-dialog-component';
 import { DictionaryStringTo } from '../../../../types/common-types';
 
-describe(LayeredDetailsDialogComponent, () => {
+describe('LayeredDetailsDialogComponent', () => {
     let featureFlagStoreData: DictionaryStringTo<boolean>;
     let props: LayeredDetailsDialogProps;
     let getRTLMock: IMock<typeof getRTL>;


### PR DESCRIPTION
#### Description of changes

Refactor `LayeredDetailsDialogComponent`:

- Update test to use enzyme's `shallow` renderer function
- Update the component to be a `NamedSFC` instead of a `class` extending `React.Component`
- Update the component deps to be a type instead of an interface 

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not apply
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
