### PR TITLE
refactor: improve details dialog handler tests

### DIFF
--- a/src/injected/details-dialog-handler.ts
+++ b/src/injected/details-dialog-handler.ts
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
-
 import { FeatureFlags } from '../common/feature-flags';
 import { HTMLElementUtils } from '../common/html-element-utils';
-import { UserConfigurationStoreData } from './../common/types/store-data/user-configuration-store';
 import { DetailsDialog } from './components/details-dialog';
 
 export class DetailsDialogHandler {

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -41,6 +41,7 @@ export class DialogRenderer {
         private readonly shadowUtils: ShadowUtils,
         private readonly clientBrowserAdapter: ClientBrowserAdapter,
         private readonly getRTLFunc: typeof getRTL,
+        private readonly detailsDialogHandler: DetailsDialogHandler,
     ) {
         if (this.isInMainWindow()) {
             this.frameCommunicator.subscribe(DialogRenderer.renderDetailsDialogCommand, this.processRequest);
@@ -84,7 +85,7 @@ export class DialogRenderer {
                     failedRules={failedRules}
                     elementSelector={elementSelector}
                     target={target}
-                    dialogHandler={new DetailsDialogHandler(this.htmlElementUtils)}
+                    dialogHandler={this.detailsDialogHandler}
                     devToolStore={mainWindowContext.getDevToolStore()}
                     userConfigStore={mainWindowContext.getUserConfigStore()}
                     devToolsShortcut={getPlatform(this.windowUtils).devToolsShortcut}

--- a/src/injected/visualization/drawer-provider.ts
+++ b/src/injected/visualization/drawer-provider.ts
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { getRTL } from '@uifabric/utilities';
+
 import { ClientBrowserAdapter } from '../../common/client-browser-adapter';
 import { HTMLElementUtils } from '../../common/html-element-utils';
 import { TabbableElementsHelper } from '../../common/tabbable-elements-helper';
 import { DeepPartial } from '../../common/types/deep-partial';
 import { WindowUtils } from '../../common/window-utils';
 import { ClientUtils } from '../client-utils';
+import { DetailsDialogHandler } from '../details-dialog-handler';
 import { FrameCommunicator } from '../frameCommunicators/frame-communicator';
 import { ShadowUtils } from '../shadow-utils';
 import { CenterPositionCalculator } from './center-position-calculator';
@@ -41,6 +43,7 @@ export class DrawerProvider {
         private readonly frameCommunicator: FrameCommunicator,
         private readonly clientBrowserAdapter: ClientBrowserAdapter,
         private readonly getRTLFunc: typeof getRTL,
+        private readonly detailsDialogHandler: DetailsDialogHandler,
     ) {}
 
     public createNullDrawer(): Drawer {
@@ -96,6 +99,7 @@ export class DrawerProvider {
             this.shadowUtils,
             this.clientBrowserAdapter,
             this.getRTLFunc,
+            this.detailsDialogHandler,
         );
         return this.createDrawer('insights-issues', formatter);
     }

--- a/src/injected/visualization/issues-formatter.ts
+++ b/src/injected/visualization/issues-formatter.ts
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 import { getRTL } from '@uifabric/utilities';
 import * as ReactDOM from 'react-dom';
+
 import { ClientBrowserAdapter } from '../../common/client-browser-adapter';
 import { HTMLElementUtils } from '../../common/html-element-utils';
 import { WindowUtils } from '../../common/window-utils';
+import { DetailsDialogHandler } from '../details-dialog-handler';
 import { DialogRenderer } from '../dialog-renderer';
 import { FrameCommunicator } from '../frameCommunicators/frame-communicator';
 import { HtmlElementAxeResults } from '../scanner-utils';
@@ -22,6 +24,7 @@ export class IssuesFormatter implements Formatter {
         shadowUtils: ShadowUtils,
         clientBrowserAdapter: ClientBrowserAdapter,
         getRTLFunc: typeof getRTL,
+        detailsDialogHandler: DetailsDialogHandler,
     ) {
         this.dialogRenderer = new DialogRenderer(
             document,
@@ -32,6 +35,7 @@ export class IssuesFormatter implements Formatter {
             shadowUtils,
             clientBrowserAdapter,
             getRTLFunc,
+            detailsDialogHandler,
         );
     }
 

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -14,6 +14,7 @@ import { scan } from '../scanner/exposed-apis';
 import { Assessments } from './../assessments/assessments';
 import { ClientUtils } from './client-utils';
 import { rootContainerId } from './constants';
+import { DetailsDialogHandler } from './details-dialog-handler';
 import { DrawingController } from './drawing-controller';
 import { ElementFinderByPosition } from './element-finder-by-position';
 import { FrameUrlFinder } from './frame-url-finder';
@@ -89,6 +90,7 @@ export class WindowInitializer {
             this.frameCommunicator,
             this.clientChromeAdapter,
             getRTL,
+            new DetailsDialogHandler(htmlElementUtils),
         );
         this.drawingController = new DrawingController(
             this.frameCommunicator,

--- a/src/tests/unit/tests/injected/details-dialog-handler.test.ts
+++ b/src/tests/unit/tests/injected/details-dialog-handler.test.ts
@@ -277,9 +277,8 @@ describe('DetailsDialogHandlerTest', () => {
         expect(testSubject.isBackButtonDisabled(detailsDialogMock.object)).toBe(false);
     });
 
-    test('isInspectButtonDisabled', () => {
-        testIsInspectButtonDisabledShouldReflectCanInspect(true);
-        testIsInspectButtonDisabledShouldReflectCanInspect(false);
+    describe('isInspectButtonDisabled', () => {
+        it.each([true, false])('canInspect %s', testIsInspectButtonDisabledShouldReflectCanInspect);
     });
 
     describe('onDevToolChanged', () => {

--- a/src/tests/unit/tests/injected/details-dialog-handler.test.ts
+++ b/src/tests/unit/tests/injected/details-dialog-handler.test.ts
@@ -444,7 +444,7 @@ describe('DetailsDialogHandlerTest', () => {
             .setup(dialog => dialog.setState(It.isValue({ userConfigurationStoreData: userConfigStoreData })))
             .verifiable(Times.once());
 
-        setupDetailsDialogMockForShadowComponents(detailsDialogMock);
+        setupDetailsDialogMockForShadowComponents();
 
         setupDialogContainerQuerySelector(shadowRootMock, clickableMock);
         setupCloseButtonQuerySelector(shadowRootMock, clickableMock);
@@ -577,8 +577,6 @@ describe('DetailsDialogHandlerTest', () => {
     }
 
     function testIsInspectButtonDisabledShouldReflectCanInspect(canInspect: boolean): void {
-        const detailsDialogMock = Mock.ofType(DetailsDialog, MockBehavior.Strict);
-
         detailsDialogMock
             .setup(dialog => dialog.state)
             .returns(() => {
@@ -702,13 +700,13 @@ describe('DetailsDialogHandlerTest', () => {
         return parentLayer;
     }
 
-    function setupDetailsDialogMockForShadowComponents(detailsDialogMock: IMock<DetailsDialog>): void {
-        setupVerificationForBackButton(detailsDialogMock);
-        setupVerificationForNextButton(detailsDialogMock);
-        setupVerificationForInspectButton(detailsDialogMock);
+    function setupDetailsDialogMockForShadowComponents(): void {
+        setupVerificationForBackButton();
+        setupVerificationForNextButton();
+        setupVerificationForInspectButton();
     }
 
-    function setupVerificationForBackButton(detailsDialogMock: IMock<DetailsDialog>): void {
+    function setupVerificationForBackButton(): void {
         detailsDialogMock
             .setup(dialog => dialog.isBackButtonDisabled())
             .returns(() => false)
@@ -717,7 +715,7 @@ describe('DetailsDialogHandlerTest', () => {
         detailsDialogMock.setup(dialog => dialog.onClickBackButton()).verifiable(Times.once());
     }
 
-    function setupVerificationForNextButton(detailsDialogMock: IMock<DetailsDialog>): void {
+    function setupVerificationForNextButton(): void {
         detailsDialogMock
             .setup(dialog => dialog.isNextButtonDisabled())
             .returns(() => false)
@@ -726,7 +724,7 @@ describe('DetailsDialogHandlerTest', () => {
         detailsDialogMock.setup(dialog => dialog.onClickNextButton()).verifiable(Times.once());
     }
 
-    function setupVerificationForInspectButton(detailsDialogMock: IMock<DetailsDialog>): void {
+    function setupVerificationForInspectButton(): void {
         detailsDialogMock
             .setup(dialog => dialog.isInspectButtonDisabled())
             .returns(() => false)

--- a/src/tests/unit/tests/injected/dialog-renderer.test.tsx
+++ b/src/tests/unit/tests/injected/dialog-renderer.test.tsx
@@ -16,6 +16,7 @@ import { UserConfigMessageCreator } from '../../../../common/message-creators/us
 import { FeatureFlagStoreData } from '../../../../common/types/store-data/feature-flag-store-data';
 import { WindowUtils } from '../../../../common/window-utils';
 import { rootContainerId } from '../../../../injected/constants';
+import { DetailsDialogHandler } from '../../../../injected/details-dialog-handler';
 import { DetailsDialogWindowMessage, DialogRenderer } from '../../../../injected/dialog-renderer';
 import { ErrorMessageContent } from '../../../../injected/frameCommunicators/error-message-content';
 import { FrameCommunicator, MessageRequest } from '../../../../injected/frameCommunicators/frame-communicator';
@@ -40,6 +41,8 @@ describe('DialogRendererTests', () => {
     let shadowRootMock: IMock<Element>;
     let getRTLMock: IMock<typeof getRTL>;
     let renderMock: IMock<typeof ReactDOM.render>;
+    let detailsDialogHandlerMock: IMock<DetailsDialogHandler>;
+
     let subscribeCallback: (
         message: DetailsDialogWindowMessage,
         error: ErrorMessageContent,
@@ -53,6 +56,7 @@ describe('DialogRendererTests', () => {
         windowUtilsMock = Mock.ofType(WindowUtils);
         shadowUtilMock = Mock.ofType(ShadowUtils);
         clientBrowserAdapter = Mock.ofType<ClientBrowserAdapter>();
+        detailsDialogHandlerMock = Mock.ofType<DetailsDialogHandler>();
 
         getMainWindoContextMock = GlobalMock.ofInstance(MainWindowContext.getMainWindowContext, 'getMainWindowContext', MainWindowContext);
         frameCommunicator = Mock.ofType(FrameCommunicator);
@@ -548,6 +552,7 @@ describe('DialogRendererTests', () => {
             shadowUtilMock.object,
             clientBrowserAdapter.object,
             getRTLMock.object,
+            detailsDialogHandlerMock.object,
         );
     }
 });

--- a/src/tests/unit/tests/injected/visualization/drawer-provider.test.ts
+++ b/src/tests/unit/tests/injected/visualization/drawer-provider.test.ts
@@ -5,6 +5,7 @@ import { ClientBrowserAdapter } from '../../../../../common/client-browser-adapt
 import { HTMLElementUtils } from '../../../../../common/html-element-utils';
 import { WindowUtils } from '../../../../../common/window-utils';
 import { ClientUtils } from '../../../../../injected/client-utils';
+import { DetailsDialogHandler } from '../../../../../injected/details-dialog-handler';
 import { FrameCommunicator } from '../../../../../injected/frameCommunicators/frame-communicator';
 import { ShadowUtils } from '../../../../../injected/shadow-utils';
 import { DrawerProvider } from '../../../../../injected/visualization/drawer-provider';
@@ -24,6 +25,7 @@ describe('DrawerProviderTests', () => {
     let domStub: Document;
     let frameCommunicator: IMock<FrameCommunicator>;
     const clientBrowserAdapter = Mock.ofType<ClientBrowserAdapter>();
+    let detailsDialogHandlerMock: IMock<DetailsDialogHandler>;
 
     beforeEach(() => {
         htmlElementUtils = Mock.ofType(HTMLElementUtils);
@@ -31,6 +33,7 @@ describe('DrawerProviderTests', () => {
         shadowUtils = Mock.ofType(ShadowUtils);
         drawerUtils = Mock.ofType(DrawerUtils);
         clientUtils = Mock.ofType(ClientUtils);
+        detailsDialogHandlerMock = Mock.ofType<DetailsDialogHandler>();
         domStub = {} as Document;
         frameCommunicator = Mock.ofType(FrameCommunicator);
         const getRTLMock = Mock.ofInstance(() => null);
@@ -45,6 +48,7 @@ describe('DrawerProviderTests', () => {
             frameCommunicator.object,
             clientBrowserAdapter.object,
             getRTLMock.object,
+            detailsDialogHandlerMock.object,
         );
     });
 

--- a/src/tests/unit/tests/injected/visualization/issues-formatter.test.ts
+++ b/src/tests/unit/tests/injected/visualization/issues-formatter.test.ts
@@ -5,6 +5,7 @@ import { IMock, Mock } from 'typemoq';
 import { ClientBrowserAdapter } from '../../../../../common/client-browser-adapter';
 import { HTMLElementUtils } from '../../../../../common/html-element-utils';
 import { WindowUtils } from '../../../../../common/window-utils';
+import { DetailsDialogHandler } from '../../../../../injected/details-dialog-handler';
 import { FrameCommunicator } from '../../../../../injected/frameCommunicators/frame-communicator';
 import { HtmlElementAxeResults } from '../../../../../injected/scanner-utils';
 import { ShadowUtils } from '../../../../../injected/shadow-utils';
@@ -24,6 +25,7 @@ describe('IssuesFormatterTests', () => {
         const shadowUtils: IMock<ShadowUtils> = Mock.ofType(ShadowUtils);
         const clientBrowserAdapter = Mock.ofType<ClientBrowserAdapter>();
         const getRTLMock = Mock.ofInstance(() => null);
+        const detailsDialogHandlerMock = Mock.ofType<DetailsDialogHandler>();
         testSubject = new IssuesFormatter(
             frameCommunicator.object,
             htmlElementUtilsMock.object,
@@ -31,6 +33,7 @@ describe('IssuesFormatterTests', () => {
             shadowUtils.object,
             clientBrowserAdapter.object,
             getRTLMock.object,
+            detailsDialogHandlerMock.object,
         );
     });
 


### PR DESCRIPTION
#### Description of changes

- Move `DetailsDialogHandler` instance creation closer to the composition root
- Change all the `DetailsDialog` mocks (used for testing `DetailsDialogHandler`) to be dynamic mocks and thus decoupling the test from its dependencies (I being doing some refactoring around the `DetailsDialog` and notice that some changes in this class break the tests for the handler too; this change on the mocks should break that dependency)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not apply
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
