### PR TITLE
refactor: introduce notification, runtime & injection adapter

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -83,7 +83,7 @@ getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
         const tabToContextMap: TabToContextMap = {};
 
         const visualizationConfigurationFactory = new VisualizationConfigurationFactory();
-        const notificationCreator = new NotificationCreator(chromeAdapter, visualizationConfigurationFactory);
+        const notificationCreator = new NotificationCreator(chromeAdapter, chromeAdapter, visualizationConfigurationFactory);
 
         const chromeCommandHandler = new ChromeCommandHandler(
             tabToContextMap,

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -78,7 +78,7 @@ getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
         telemetryStateListener.initialize();
 
         const broadcaster = new TabContextBroadcaster(chromeAdapter.sendMessageToFramesAndTab);
-        const detailsViewController = new DetailsViewController(chromeAdapter);
+        const detailsViewController = new DetailsViewController(chromeAdapter, chromeAdapter);
 
         const tabToContextMap: TabToContextMap = {};
 
@@ -114,6 +114,8 @@ getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
         const clientHandler = new TabController(
             tabToContextMap,
             broadcaster,
+            chromeAdapter,
+            chromeAdapter,
             chromeAdapter,
             chromeAdapter,
             detailsViewController,

--- a/src/background/browser-adapters/browser-adapter.ts
+++ b/src/background/browser-adapters/browser-adapter.ts
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ClientBrowserAdapter } from '../../common/client-browser-adapter';
-
-export interface NotificationOptions {
-    message: string;
-    title: string;
-    iconUrl: string;
-    notificationType?: string;
-}
+import { NotificationOptions } from './notification-options';
 
 export interface BrowserAdapter extends ClientBrowserAdapter {
     getAllWindows(getInfo: chrome.windows.GetInfo, callback: (chromeWindows: chrome.windows.Window[]) => void): void;

--- a/src/background/browser-adapters/browser-adapter.ts
+++ b/src/background/browser-adapters/browser-adapter.ts
@@ -27,8 +27,6 @@ export interface BrowserAdapter extends ClientBrowserAdapter {
     sendMessageToFramesAndTab(tabId: number, message: any): void;
     sendMessageToFrames(message: any): void;
     sendMessageToAllFramesAndTabs(message: any): void;
-    injectJs(tabId, file: string, callback: Function): void;
-    injectCss(tabId, file: string, callback: Function): void;
     getRunTimeId(): string;
     createNotification(options: NotificationOptions): void;
     getRuntimeLastError(): chrome.runtime.LastError;

--- a/src/background/browser-adapters/browser-adapter.ts
+++ b/src/background/browser-adapters/browser-adapter.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ClientBrowserAdapter } from '../../common/client-browser-adapter';
-import { NotificationOptions } from './notification-options';
 
 export interface BrowserAdapter extends ClientBrowserAdapter {
     getAllWindows(getInfo: chrome.windows.GetInfo, callback: (chromeWindows: chrome.windows.Window[]) => void): void;
@@ -21,9 +20,6 @@ export interface BrowserAdapter extends ClientBrowserAdapter {
     sendMessageToFramesAndTab(tabId: number, message: any): void;
     sendMessageToFrames(message: any): void;
     sendMessageToAllFramesAndTabs(message: any): void;
-    getRunTimeId(): string;
-    createNotification(options: NotificationOptions): void;
-    getRuntimeLastError(): chrome.runtime.LastError;
     isAllowedFileSchemeAccess(callback: Function): void;
     addListenerToLocalStorage(callback: (changes: object) => void): void;
     openManageExtensionPage(): void;

--- a/src/background/browser-adapters/chrome-adapter.ts
+++ b/src/background/browser-adapters/chrome-adapter.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ClientChromeAdapter } from '../../common/client-browser-adapter';
-import { BrowserAdapter, NotificationOptions } from './browser-adapter';
+import { BrowserAdapter } from './browser-adapter';
 import { CommandsAdapter } from './commands-adapter';
 import { InjectorAdapter } from './injector-adapter';
+import { NotificationOptions } from './notification-options';
 import { StorageAdapter } from './storage-adapter';
 
 export class ChromeAdapter extends ClientChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAdapter, InjectorAdapter {

--- a/src/background/browser-adapters/chrome-adapter.ts
+++ b/src/background/browser-adapters/chrome-adapter.ts
@@ -3,9 +3,10 @@
 import { ClientChromeAdapter } from '../../common/client-browser-adapter';
 import { BrowserAdapter, NotificationOptions } from './browser-adapter';
 import { CommandsAdapter } from './commands-adapter';
+import { InjectorAdapter } from './injector-adapter';
 import { StorageAdapter } from './storage-adapter';
 
-export class ChromeAdapter extends ClientChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAdapter {
+export class ChromeAdapter extends ClientChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAdapter, InjectorAdapter {
     public openManageExtensionPage(): void {
         chrome.tabs.create({
             url: `chrome://extensions/?id=${chrome.runtime.id}`,

--- a/src/background/browser-adapters/chrome-adapter.ts
+++ b/src/background/browser-adapters/chrome-adapter.ts
@@ -6,10 +6,11 @@ import { CommandsAdapter } from './commands-adapter';
 import { InjectorAdapter } from './injector-adapter';
 import { NotificationAdapter } from './notification-adapter';
 import { NotificationOptions } from './notification-options';
+import { RuntimeAdapter } from './runtime-adapter';
 import { StorageAdapter } from './storage-adapter';
 
 export class ChromeAdapter extends ClientChromeAdapter
-    implements BrowserAdapter, StorageAdapter, CommandsAdapter, InjectorAdapter, NotificationAdapter {
+    implements BrowserAdapter, StorageAdapter, CommandsAdapter, InjectorAdapter, NotificationAdapter, RuntimeAdapter {
     public openManageExtensionPage(): void {
         chrome.tabs.create({
             url: `chrome://extensions/?id=${chrome.runtime.id}`,

--- a/src/background/browser-adapters/chrome-adapter.ts
+++ b/src/background/browser-adapters/chrome-adapter.ts
@@ -4,10 +4,12 @@ import { ClientChromeAdapter } from '../../common/client-browser-adapter';
 import { BrowserAdapter } from './browser-adapter';
 import { CommandsAdapter } from './commands-adapter';
 import { InjectorAdapter } from './injector-adapter';
+import { NotificationAdapter } from './notification-adapter';
 import { NotificationOptions } from './notification-options';
 import { StorageAdapter } from './storage-adapter';
 
-export class ChromeAdapter extends ClientChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAdapter, InjectorAdapter {
+export class ChromeAdapter extends ClientChromeAdapter
+    implements BrowserAdapter, StorageAdapter, CommandsAdapter, InjectorAdapter, NotificationAdapter {
     public openManageExtensionPage(): void {
         chrome.tabs.create({
             url: `chrome://extensions/?id=${chrome.runtime.id}`,

--- a/src/background/browser-adapters/chrome-adapter.ts
+++ b/src/background/browser-adapters/chrome-adapter.ts
@@ -47,7 +47,7 @@ export class ChromeAdapter extends ClientChromeAdapter
         chrome.windows.onFocusChanged.addListener(callback);
     }
 
-    public getRunTimeId(): string {
+    public getRuntimeId(): string {
         return chrome.runtime.id;
     }
     public tabsQuery(query: chrome.tabs.QueryInfo, callback: (result: chrome.tabs.Tab[]) => void): void {

--- a/src/background/browser-adapters/injector-adapter.ts
+++ b/src/background/browser-adapters/injector-adapter.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export type InjectorAdapter = {
+    injectJs(tabId, file: string, callback: Function): void;
+    injectCss(tabId, file: string, callback: Function): void;
+};

--- a/src/background/browser-adapters/notification-adapter.ts
+++ b/src/background/browser-adapters/notification-adapter.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NotificationOptions } from './notification-options';
+export type NotificationAdapter = {
+    createNotification(options: NotificationOptions): void;
+};

--- a/src/background/browser-adapters/notification-options.ts
+++ b/src/background/browser-adapters/notification-options.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 export interface NotificationOptions {
     message: string;
     title: string;

--- a/src/background/browser-adapters/notification-options.ts
+++ b/src/background/browser-adapters/notification-options.ts
@@ -1,0 +1,6 @@
+export interface NotificationOptions {
+    message: string;
+    title: string;
+    iconUrl: string;
+    notificationType?: string;
+}

--- a/src/background/browser-adapters/runtime-adapter.ts
+++ b/src/background/browser-adapters/runtime-adapter.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 export type RuntimeAdapter = {
-    getRunTimeId(): string;
+    getRuntimeId(): string;
     getRuntimeLastError(): chrome.runtime.LastError;
 };

--- a/src/background/browser-adapters/runtime-adapter.ts
+++ b/src/background/browser-adapters/runtime-adapter.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export type RuntimeAdapter = {
+    getRunTimeId(): string;
+    getRuntimeLastError(): chrome.runtime.LastError;
+};

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -64,7 +64,7 @@ export class DetailsViewController {
     }
 
     private getDetailsUrlWithExtensionId(tabId: number): string {
-        return `${this.runtimeAdapter.getRunTimeId()}/${this.getDetailsUrl(tabId)}`;
+        return `${this.runtimeAdapter.getRuntimeId()}/${this.getDetailsUrl(tabId)}`;
     }
 
     private getTargetTabIdForDetailsTabId(detailsTabId: number): number {

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -4,16 +4,15 @@ import { autobind } from '@uifabric/utilities';
 
 import { DictionaryStringTo } from '../types/common-types';
 import { BrowserAdapter } from './browser-adapters/browser-adapter';
+import { RuntimeAdapter } from './browser-adapters/runtime-adapter';
 
 export class DetailsViewController {
     private _tabIdToDetailsViewMap: DictionaryStringTo<number> = {};
-    private _browserAdapter: BrowserAdapter;
     private _detailsViewRemovedHandler: (tabId: number) => void;
 
-    constructor(adapter: BrowserAdapter) {
-        this._browserAdapter = adapter;
-        this._browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
-        this._browserAdapter.addListenerToTabsOnUpdated(this.onUpdateTab);
+    constructor(private readonly browserAdapter: BrowserAdapter, private readonly runtimeAdapter: RuntimeAdapter) {
+        this.browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
+        this.browserAdapter.addListenerToTabsOnUpdated(this.onUpdateTab);
     }
 
     public setupDetailsViewTabRemovedHandler(handler: (tabId: number) => void): void {
@@ -24,11 +23,11 @@ export class DetailsViewController {
         const detailsViewTabId = this._tabIdToDetailsViewMap[targetTabId];
 
         if (detailsViewTabId != null) {
-            this._browserAdapter.switchToTab(detailsViewTabId);
+            this.browserAdapter.switchToTab(detailsViewTabId);
             return;
         }
 
-        this._browserAdapter.createTabInNewWindow(this.getDetailsUrl(targetTabId), (tab: chrome.tabs.Tab) => {
+        this.browserAdapter.createTabInNewWindow(this.getDetailsUrl(targetTabId), (tab: chrome.tabs.Tab) => {
             this._tabIdToDetailsViewMap[targetTabId] = tab.id;
         });
     }
@@ -65,7 +64,7 @@ export class DetailsViewController {
     }
 
     private getDetailsUrlWithExtensionId(tabId: number): string {
-        return `${this._browserAdapter.getRunTimeId()}/${this.getDetailsUrl(tabId)}`;
+        return `${this.runtimeAdapter.getRunTimeId()}/${this.getDetailsUrl(tabId)}`;
     }
 
     private getTargetTabIdForDetailsTabId(detailsTabId: number): number {

--- a/src/background/injector/content-script-injector.ts
+++ b/src/background/injector/content-script-injector.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as Q from 'q';
 
-import { BrowserAdapter } from '../browser-adapters/browser-adapter';
+import { InjectorAdapter } from '../browser-adapters/injector-adapter';
 
 export class ContentScriptInjector {
     public static readonly jsFiles: string[] = ['bundle/injected.bundle.js'];
@@ -10,31 +10,26 @@ export class ContentScriptInjector {
     public static readonly cssFiles: string[] = ['injected/styles/default/injected.css'];
 
     public static timeoutInMilliSec = 5e4;
-    private readonly _chromeAdapter: BrowserAdapter;
-    private readonly _q: typeof Q;
 
-    constructor(chromeAdapter: BrowserAdapter, q: typeof Q) {
-        this._chromeAdapter = chromeAdapter;
-        this._q = q;
-    }
+    constructor(private readonly injectorAdapter: InjectorAdapter, private readonly q: typeof Q) {}
 
     public injectScripts(tabId: number): Q.IPromise<null> {
-        const deferred = this._q.defer<null>();
+        const deferred = this.q.defer<null>();
 
         ContentScriptInjector.cssFiles.forEach(file => {
-            this._chromeAdapter.injectCss(tabId, file, null);
+            this.injectorAdapter.injectCss(tabId, file, null);
         });
 
         this.injectJsFiles(tabId, ContentScriptInjector.jsFiles, () => {
             deferred.resolve(null);
         });
 
-        return this._q.timeout(deferred.promise, ContentScriptInjector.timeoutInMilliSec);
+        return this.q.timeout(deferred.promise, ContentScriptInjector.timeoutInMilliSec);
     }
 
     private injectJsFiles(tabId: number, files: string[], callback: Function): void {
         if (files.length > 0) {
-            this._chromeAdapter.injectJs(tabId, files[0], () => {
+            this.injectorAdapter.injectJs(tabId, files[0], () => {
                 this.injectJsFiles(tabId, files.slice(1, files.length), callback);
             });
         } else {

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -17,6 +17,7 @@ import { TabActionCreator } from './actions/tab-action-creator';
 import { AssessmentScanPolicyRunner } from './assessment-scan-policy-runner';
 import { BrowserAdapter } from './browser-adapters/browser-adapter';
 import { InjectorAdapter } from './browser-adapters/injector-adapter';
+import { NotificationAdapter } from './browser-adapters/notification-adapter';
 import { ChromeFeatureController } from './chrome-feature-controller';
 import { DetailsViewController } from './details-view-controller';
 import { InjectorController } from './injector-controller';
@@ -44,13 +45,14 @@ export class TabContextFactory {
         broadcastMessage: (message) => void,
         browserAdapter: BrowserAdapter,
         injectorAdapter: InjectorAdapter,
+        notificationAdapter: NotificationAdapter,
         detailsViewController: DetailsViewController,
         tabId: number,
     ): TabContext {
         const interpreter = new Interpreter();
         const actionsHub = new ActionHub();
         const storeHub = new TabContextStoreHub(actionsHub, this.visualizationConfigurationFactory);
-        const notificationCreator = new NotificationCreator(browserAdapter, this.visualizationConfigurationFactory);
+        const notificationCreator = new NotificationCreator(browserAdapter, notificationAdapter, this.visualizationConfigurationFactory);
         const chromeFeatureController = new ChromeFeatureController(browserAdapter);
 
         const actionCreator = new ActionCreator(

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -16,6 +16,7 @@ import { ScopingActionCreator } from './actions/scoping-action-creator';
 import { TabActionCreator } from './actions/tab-action-creator';
 import { AssessmentScanPolicyRunner } from './assessment-scan-policy-runner';
 import { BrowserAdapter } from './browser-adapters/browser-adapter';
+import { InjectorAdapter } from './browser-adapters/injector-adapter';
 import { ChromeFeatureController } from './chrome-feature-controller';
 import { DetailsViewController } from './details-view-controller';
 import { InjectorController } from './injector-controller';
@@ -42,6 +43,7 @@ export class TabContextFactory {
     public createTabContext(
         broadcastMessage: (message) => void,
         browserAdapter: BrowserAdapter,
+        injectorAdapter: InjectorAdapter,
         detailsViewController: DetailsViewController,
         tabId: number,
     ): TabContext {
@@ -104,7 +106,7 @@ export class TabContextFactory {
         );
 
         const injectorController = new InjectorController(
-            new ContentScriptInjector(browserAdapter, Q),
+            new ContentScriptInjector(injectorAdapter, Q),
             storeHub.visualizationStore,
             interpreter,
             storeHub.tabStore,

--- a/src/background/tab-controller.ts
+++ b/src/background/tab-controller.ts
@@ -8,6 +8,7 @@ import { Logger } from './../common/logging/logger';
 import { PageVisibilityChangeTabPayload } from './actions/action-payloads';
 import { BrowserAdapter } from './browser-adapters/browser-adapter';
 import { InjectorAdapter } from './browser-adapters/injector-adapter';
+import { NotificationAdapter } from './browser-adapters/notification-adapter';
 import { DetailsViewController } from './details-view-controller';
 import { TabToContextMap } from './tab-context';
 import { TabContextBroadcaster } from './tab-context-broadcaster';
@@ -21,6 +22,7 @@ export class TabController {
         private readonly broadcaster: TabContextBroadcaster,
         private readonly chromeAdapter: BrowserAdapter,
         private readonly injectorAdapter: InjectorAdapter,
+        private readonly notificationAdapter: NotificationAdapter,
         private readonly detailsViewController: DetailsViewController,
         private readonly tabContextFactory: TabContextFactory,
         private readonly logger: Logger,
@@ -170,6 +172,7 @@ export class TabController {
             this.broadcaster.getBroadcastMessageDelegate(tabId),
             this.chromeAdapter,
             this.injectorAdapter,
+            this.notificationAdapter,
             this.detailsViewController,
             tabId,
         );

--- a/src/background/tab-controller.ts
+++ b/src/background/tab-controller.ts
@@ -9,6 +9,7 @@ import { PageVisibilityChangeTabPayload } from './actions/action-payloads';
 import { BrowserAdapter } from './browser-adapters/browser-adapter';
 import { InjectorAdapter } from './browser-adapters/injector-adapter';
 import { NotificationAdapter } from './browser-adapters/notification-adapter';
+import { RuntimeAdapter } from './browser-adapters/runtime-adapter';
 import { DetailsViewController } from './details-view-controller';
 import { TabToContextMap } from './tab-context';
 import { TabContextBroadcaster } from './tab-context-broadcaster';
@@ -23,6 +24,7 @@ export class TabController {
         private readonly chromeAdapter: BrowserAdapter,
         private readonly injectorAdapter: InjectorAdapter,
         private readonly notificationAdapter: NotificationAdapter,
+        private readonly runtimeAdapter: RuntimeAdapter,
         private readonly detailsViewController: DetailsViewController,
         private readonly tabContextFactory: TabContextFactory,
         private readonly logger: Logger,
@@ -82,7 +84,7 @@ export class TabController {
             (chromeWindows: chrome.windows.Window[]) => {
                 chromeWindows.forEach((chromeWindow: chrome.windows.Window) => {
                     this.chromeAdapter.getSelectedTabInWindow(chromeWindow.id, (activeTab: chrome.tabs.Tab) => {
-                        if (!this.chromeAdapter.getRuntimeLastError()) {
+                        if (!this.runtimeAdapter.getRuntimeLastError()) {
                             if (activeTab) {
                                 this.sendTabVisibilityChangeAction(activeTab.id, chromeWindow.state === 'minimized');
                             }

--- a/src/background/tab-controller.ts
+++ b/src/background/tab-controller.ts
@@ -1,36 +1,31 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
+
 import { Message } from '../common/message';
 import { Messages } from '../common/messages';
 import { Logger } from './../common/logging/logger';
 import { PageVisibilityChangeTabPayload } from './actions/action-payloads';
 import { BrowserAdapter } from './browser-adapters/browser-adapter';
+import { InjectorAdapter } from './browser-adapters/injector-adapter';
 import { DetailsViewController } from './details-view-controller';
 import { TabToContextMap } from './tab-context';
 import { TabContextBroadcaster } from './tab-context-broadcaster';
 import { TabContextFactory } from './tab-context-factory';
 
 export class TabController {
-    private chromeAdapter: BrowserAdapter;
     private readonly tabIdToContextMap: TabToContextMap;
-    private readonly broadcaster: TabContextBroadcaster;
-    private readonly detailsViewController: DetailsViewController;
-    private tabContextFactory: TabContextFactory;
 
     constructor(
         tabToInterpreterMap: TabToContextMap,
-        broadcaster: TabContextBroadcaster,
-        chromeAdapter: BrowserAdapter,
-        detailsViewController: DetailsViewController,
-        tabContextFactory: TabContextFactory,
+        private readonly broadcaster: TabContextBroadcaster,
+        private readonly chromeAdapter: BrowserAdapter,
+        private readonly injectorAdapter: InjectorAdapter,
+        private readonly detailsViewController: DetailsViewController,
+        private readonly tabContextFactory: TabContextFactory,
         private readonly logger: Logger,
     ) {
         this.tabIdToContextMap = tabToInterpreterMap;
-        this.broadcaster = broadcaster;
-        this.chromeAdapter = chromeAdapter;
-        this.detailsViewController = detailsViewController;
-        this.tabContextFactory = tabContextFactory;
     }
 
     public initialize(): void {
@@ -174,6 +169,7 @@ export class TabController {
         this.tabIdToContextMap[tabId] = this.tabContextFactory.createTabContext(
             this.broadcaster.getBroadcastMessageDelegate(tabId),
             this.chromeAdapter,
+            this.injectorAdapter,
             this.detailsViewController,
             tabId,
         );

--- a/src/common/notification-creator.ts
+++ b/src/common/notification-creator.ts
@@ -3,23 +3,22 @@
 import * as _ from 'lodash';
 
 import { BrowserAdapter } from '../background/browser-adapters/browser-adapter';
+import { NotificationAdapter } from '../background/browser-adapters/notification-adapter';
 import { VisualizationType } from '../common/types/visualization-type';
 import { DictionaryStringTo } from '../types/common-types';
 import { VisualizationConfigurationFactory } from './configs/visualization-configuration-factory';
 
 export class NotificationCreator {
-    private chromeAdapter: BrowserAdapter;
-    private visualizationConfigurationFactory: VisualizationConfigurationFactory;
-
-    constructor(chromeAdapter: BrowserAdapter, visualizationConfigurationFactory: VisualizationConfigurationFactory) {
-        this.chromeAdapter = chromeAdapter;
-        this.visualizationConfigurationFactory = visualizationConfigurationFactory;
-    }
+    constructor(
+        private readonly chromeAdapter: BrowserAdapter,
+        private readonly notificationAdapter: NotificationAdapter,
+        private readonly visualizationConfigurationFactory: VisualizationConfigurationFactory,
+    ) {}
 
     public createNotification(message: string): void {
         if (message) {
             const manifest = this.chromeAdapter.getManifest();
-            this.chromeAdapter.createNotification({
+            this.notificationAdapter.createNotification({
                 message: message,
                 title: manifest.name,
                 iconUrl: '../' + manifest.icons[128],

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -3,35 +3,35 @@
 import * as Q from 'q';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
-import { BrowserAdapter } from '../../../../background/browser-adapters/browser-adapter';
+import { InjectorAdapter } from '../../../../background/browser-adapters/injector-adapter';
 import { ContentScriptInjector } from '../../../../background/injector/content-script-injector';
 import { QStub } from '../../stubs/q-stub';
 
-let mockBrowserAdpater: IMock<BrowserAdapter>;
-let mockQ: IMock<typeof Q>;
-let testSubject: ContentScriptInjector;
-
 describe('ContentScriptInjectorTest', () => {
-    beforeEach(() => {
-        mockBrowserAdpater = Mock.ofType<BrowserAdapter>();
-        mockQ = Mock.ofType(QStub, MockBehavior.Strict) as any;
+    let injectorAdapterMock: IMock<InjectorAdapter>;
+    let qMock: IMock<typeof Q>;
+    let testSubject: ContentScriptInjector;
 
-        mockQ.setup(x => x.defer()).returns(() => Q.defer());
+    beforeEach(() => {
+        injectorAdapterMock = Mock.ofType<InjectorAdapter>();
+        qMock = Mock.ofType(QStub, MockBehavior.Strict) as any;
+
+        qMock.setup(q => q.defer()).returns(() => Q.defer());
     });
 
     it('test inject content scripts', async done => {
         const tabId = 2;
 
         let jsLoadCallback: Function;
-        testSubject = new ContentScriptInjector(mockBrowserAdpater.object, Q);
+        testSubject = new ContentScriptInjector(injectorAdapterMock.object, Q);
 
         ContentScriptInjector.cssFiles.forEach(cssFile => {
-            mockBrowserAdpater.setup(x => x.injectCss(tabId, cssFile, null)).verifiable(Times.once());
+            injectorAdapterMock.setup(adapter => adapter.injectCss(tabId, cssFile, null)).verifiable(Times.once());
         });
 
         ContentScriptInjector.jsFiles.forEach(jsFile => {
-            mockBrowserAdpater
-                .setup(x => x.injectJs(tabId, jsFile, It.isAny()))
+            injectorAdapterMock
+                .setup(adapter => adapter.injectJs(tabId, jsFile, It.isAny()))
                 .callback((theTabId, theJsFile, callback) => {
                     jsLoadCallback = callback;
                 })
@@ -41,7 +41,7 @@ describe('ContentScriptInjectorTest', () => {
         const promise = testSubject.injectScripts(tabId);
 
         promise.then(() => {
-            mockBrowserAdpater.verifyAll();
+            injectorAdapterMock.verifyAll();
             done();
         });
         expect(Q.isPending(promise)).toBeTruthy();
@@ -52,27 +52,30 @@ describe('ContentScriptInjectorTest', () => {
 
     it('test inject content scripts timeout', async done => {
         const tabId = 2;
-        testSubject = new ContentScriptInjector(mockBrowserAdpater.object, mockQ.object);
+        testSubject = new ContentScriptInjector(injectorAdapterMock.object, qMock.object);
 
         ContentScriptInjector.cssFiles.forEach(cssFile => {
-            mockBrowserAdpater.setup(x => x.injectCss(tabId, cssFile, null)).verifiable(Times.once());
+            injectorAdapterMock.setup(adapter => adapter.injectCss(tabId, cssFile, null)).verifiable(Times.once());
         });
 
-        mockBrowserAdpater.setup(x => x.injectJs(tabId, ContentScriptInjector.jsFiles[0], It.isAny())).verifiable(Times.once());
+        injectorAdapterMock
+            .setup(adapter => adapter.injectJs(tabId, ContentScriptInjector.jsFiles[0], It.isAny()))
+            .verifiable(Times.once());
 
         const timeoutDeferred = Q.defer();
-        mockQ
-            .setup(x => x.timeout(It.isAny(), ContentScriptInjector.timeoutInMilliSec))
+        qMock
+            .setup(q => q.timeout(It.isAny(), ContentScriptInjector.timeoutInMilliSec))
             .returns(() => timeoutDeferred.promise)
             .verifiable();
 
         const promise = testSubject.injectScripts(tabId);
 
         promise.then(null, () => {
-            mockBrowserAdpater.verifyAll();
+            injectorAdapterMock.verifyAll();
             done();
         });
-        mockQ.verifyAll();
+
+        qMock.verifyAll();
         expect(promise).toEqual(timeoutDeferred.promise);
         expect(Q.isPending(promise)).toBeTruthy();
         timeoutDeferred.reject(null);

--- a/src/tests/unit/tests/background/details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/details-view-controller.test.ts
@@ -146,7 +146,7 @@ describe('DetailsViewControllerTest', () => {
 
         // update details tab
         runtimeAdapterMock
-            .setup(it => it.getRunTimeId())
+            .setup(it => it.getRuntimeId())
             .returns(() => {
                 return 'ext_id';
             });
@@ -185,7 +185,7 @@ describe('DetailsViewControllerTest', () => {
 
         // update details tab
         const extensionId = 'ext_id';
-        runtimeAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
+        runtimeAdapterMock.setup(adapter => adapter.getRuntimeId()).returns(() => extensionId);
         onUpdateTabCallback(detailsViewTabId, { url: 'chromeExt://ext_id/DetailsView/detailsView.html?tabId=90' }, null);
 
         browserAdpaterMock.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.once());
@@ -221,7 +221,7 @@ describe('DetailsViewControllerTest', () => {
         // update details tab
         const extensionId = 'ext_id';
         runtimeAdapterMock
-            .setup(adapter => adapter.getRunTimeId())
+            .setup(adapter => adapter.getRuntimeId())
             .returns(() => {
                 return extensionId;
             });
@@ -259,7 +259,7 @@ describe('DetailsViewControllerTest', () => {
 
         // update details tab
         const extensionId = 'ext_id';
-        runtimeAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
+        runtimeAdapterMock.setup(adapter => adapter.getRuntimeId()).returns(() => extensionId);
         onUpdateTabCallback(detailsViewTabId, { title: 'issues' }, null);
 
         browserAdpaterMock.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.never());
@@ -294,7 +294,7 @@ describe('DetailsViewControllerTest', () => {
 
         // remove details tab
         const extensionId = 'ext_id';
-        runtimeAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
+        runtimeAdapterMock.setup(adapter => adapter.getRuntimeId()).returns(() => extensionId);
         onUpdateTabCallback(123, { title: 'issues' }, null);
 
         browserAdpaterMock.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.never());

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -5,6 +5,7 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { AssessmentsProviderImpl } from '../../../../assessments/assessments-provider';
 import { BrowserAdapter } from '../../../../background/browser-adapters/browser-adapter';
 import { InjectorAdapter } from '../../../../background/browser-adapters/injector-adapter';
+import { NotificationAdapter } from '../../../../background/browser-adapters/notification-adapter';
 import { DetailsViewController } from '../../../../background/details-view-controller';
 import { Interpreter } from '../../../../background/interpreter';
 import { AssessmentStore } from '../../../../background/stores/assessment-store';
@@ -36,10 +37,12 @@ describe('TabContextFactoryTest', () => {
     let detailsViewControllerMock: IMock<DetailsViewController>;
     let browserAdapterMock: IMock<BrowserAdapter>;
     let injectorAdapterMock: IMock<InjectorAdapter>;
+    let notificationAdapterMock: IMock<NotificationAdapter>;
 
     beforeAll(() => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         injectorAdapterMock = Mock.ofType<InjectorAdapter>();
+        notificationAdapterMock = Mock.ofType<NotificationAdapter>();
 
         detailsViewControllerMock = Mock.ofType<DetailsViewController>();
         browserAdapterMock.reset();
@@ -88,6 +91,7 @@ describe('TabContextFactoryTest', () => {
             broadcastMock.object,
             browserAdapterMock.object,
             injectorAdapterMock.object,
+            notificationAdapterMock.object,
             detailsViewControllerMock.object,
             tabId,
         );

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -4,6 +4,7 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { AssessmentsProviderImpl } from '../../../../assessments/assessments-provider';
 import { BrowserAdapter } from '../../../../background/browser-adapters/browser-adapter';
+import { InjectorAdapter } from '../../../../background/browser-adapters/injector-adapter';
 import { DetailsViewController } from '../../../../background/details-view-controller';
 import { Interpreter } from '../../../../background/interpreter';
 import { AssessmentStore } from '../../../../background/stores/assessment-store';
@@ -32,14 +33,16 @@ function getConfigs(visualizationType: VisualizationType): VisualizationConfigur
 }
 
 describe('TabContextFactoryTest', () => {
-    let mockDetailsViewController: IMock<DetailsViewController>;
-    let mockBrowserAdapter: IMock<BrowserAdapter>;
+    let detailsViewControllerMock: IMock<DetailsViewController>;
+    let browserAdapterMock: IMock<BrowserAdapter>;
+    let injectorAdapterMock: IMock<InjectorAdapter>;
 
     beforeAll(() => {
-        mockBrowserAdapter = Mock.ofType<BrowserAdapter>();
+        browserAdapterMock = Mock.ofType<BrowserAdapter>();
+        injectorAdapterMock = Mock.ofType<InjectorAdapter>();
 
-        mockDetailsViewController = Mock.ofType<DetailsViewController>();
-        mockBrowserAdapter.reset();
+        detailsViewControllerMock = Mock.ofType<DetailsViewController>();
+        browserAdapterMock.reset();
     });
 
     it('createInterpreter', () => {
@@ -66,8 +69,8 @@ describe('TabContextFactoryTest', () => {
                 .verifiable(Times.once());
         });
 
-        mockBrowserAdapter.setup(ba => ba.addListenerToTabsOnRemoved(It.isAny())).verifiable();
-        mockBrowserAdapter.setup(ba => ba.addListenerToTabsOnUpdated(It.isAny())).verifiable();
+        browserAdapterMock.setup(ba => ba.addListenerToTabsOnRemoved(It.isAny())).verifiable();
+        browserAdapterMock.setup(ba => ba.addListenerToTabsOnUpdated(It.isAny())).verifiable();
 
         const visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
         visualizationConfigurationFactoryMock.setup(vcfm => vcfm.getConfiguration(It.isAny())).returns(theType => getConfigs(theType));
@@ -83,8 +86,9 @@ describe('TabContextFactoryTest', () => {
 
         const tabContext = testObject.createTabContext(
             broadcastMock.object,
-            mockBrowserAdapter.object,
-            mockDetailsViewController.object,
+            browserAdapterMock.object,
+            injectorAdapterMock.object,
+            detailsViewControllerMock.object,
             tabId,
         );
 

--- a/src/tests/unit/tests/background/tab-controller.test.ts
+++ b/src/tests/unit/tests/background/tab-controller.test.ts
@@ -5,6 +5,7 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { BrowserAdapter } from '../../../../background/browser-adapters/browser-adapter';
 import { InjectorAdapter } from '../../../../background/browser-adapters/injector-adapter';
 import { NotificationAdapter } from '../../../../background/browser-adapters/notification-adapter';
+import { RuntimeAdapter } from '../../../../background/browser-adapters/runtime-adapter';
 import { DetailsViewController } from '../../../../background/details-view-controller';
 import { Interpreter } from '../../../../background/interpreter';
 import { FeatureFlagStore } from '../../../../background/stores/global/feature-flag-store';
@@ -25,6 +26,7 @@ describe('TabControllerTest', () => {
     let browserAdapterMock: IMock<BrowserAdapter>;
     let injectorAdapterMock: IMock<InjectorAdapter>;
     let notificationAdapterMock: IMock<NotificationAdapter>;
+    let runtimeAdapterMock: IMock<RuntimeAdapter>;
     let detailsViewControllerMock: IMock<DetailsViewController>;
     let tabInterpreterMap: TabToContextMap;
     let featureFlagStoreMock: IMock<FeatureFlagStore>;
@@ -60,6 +62,7 @@ describe('TabControllerTest', () => {
             browserAdapterMock.object,
             injectorAdapterMock.object,
             notificationAdapterMock.object,
+            runtimeAdapterMock.object,
             detailsViewControllerMock.object,
             tabContextFactoryMock.object,
             LoggerStub,
@@ -73,6 +76,7 @@ describe('TabControllerTest', () => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         injectorAdapterMock = Mock.ofType<InjectorAdapter>();
         notificationAdapterMock = Mock.ofType<NotificationAdapter>();
+        runtimeAdapterMock = Mock.ofType<RuntimeAdapter>();
         detailsViewControllerMock = Mock.ofType<DetailsViewController>();
         featureFlagStoreMock = Mock.ofType(FeatureFlagStore);
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler);
@@ -92,6 +96,7 @@ describe('TabControllerTest', () => {
             browserAdapterMock.object,
             injectorAdapterMock.object,
             notificationAdapterMock.object,
+            runtimeAdapterMock.object,
             detailsViewControllerMock.object,
             tabContextFactoryMock.object,
             LoggerStub,
@@ -482,7 +487,7 @@ describe('TabControllerTest', () => {
             })
             .verifiable(Times.once());
 
-        browserAdapterMock
+        runtimeAdapterMock
             .setup(ca => ca.getRuntimeLastError())
             .returns(() => null)
             .verifiable(Times.exactly(2));
@@ -573,9 +578,9 @@ describe('TabControllerTest', () => {
             })
             .verifiable(Times.once());
 
-        browserAdapterMock.setup(ca => ca.getRuntimeLastError()).returns(() => new Error('window closed'));
+        runtimeAdapterMock.setup(ca => ca.getRuntimeLastError()).returns(() => new Error('window closed'));
 
-        browserAdapterMock.setup(ca => ca.getRuntimeLastError()).returns(() => null);
+        runtimeAdapterMock.setup(ca => ca.getRuntimeLastError()).returns(() => null);
 
         const interpreterMock = Mock.ofType(Interpreter);
 

--- a/src/tests/unit/tests/background/tab-controller.test.ts
+++ b/src/tests/unit/tests/background/tab-controller.test.ts
@@ -4,6 +4,7 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../background/browser-adapters/browser-adapter';
 import { InjectorAdapter } from '../../../../background/browser-adapters/injector-adapter';
+import { NotificationAdapter } from '../../../../background/browser-adapters/notification-adapter';
 import { DetailsViewController } from '../../../../background/details-view-controller';
 import { Interpreter } from '../../../../background/interpreter';
 import { FeatureFlagStore } from '../../../../background/stores/global/feature-flag-store';
@@ -23,6 +24,7 @@ describe('TabControllerTest', () => {
     let broadcasterStrictMock: IMock<TabContextBroadcaster>;
     let browserAdapterMock: IMock<BrowserAdapter>;
     let injectorAdapterMock: IMock<InjectorAdapter>;
+    let notificationAdapterMock: IMock<NotificationAdapter>;
     let detailsViewControllerMock: IMock<DetailsViewController>;
     let tabInterpreterMap: TabToContextMap;
     let featureFlagStoreMock: IMock<FeatureFlagStore>;
@@ -42,6 +44,7 @@ describe('TabControllerTest', () => {
                     broadCastDelegate,
                     browserAdapterMock.object,
                     injectorAdapterMock.object,
+                    notificationAdapterMock.object,
                     detailsViewControllerMock.object,
                     tabId,
                 ),
@@ -56,6 +59,7 @@ describe('TabControllerTest', () => {
             broadcasterStrictMock.object,
             browserAdapterMock.object,
             injectorAdapterMock.object,
+            notificationAdapterMock.object,
             detailsViewControllerMock.object,
             tabContextFactoryMock.object,
             LoggerStub,
@@ -68,6 +72,7 @@ describe('TabControllerTest', () => {
         broadcasterStrictMock = Mock.ofType<TabContextBroadcaster>(undefined, MockBehavior.Strict);
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         injectorAdapterMock = Mock.ofType<InjectorAdapter>();
+        notificationAdapterMock = Mock.ofType<NotificationAdapter>();
         detailsViewControllerMock = Mock.ofType<DetailsViewController>();
         featureFlagStoreMock = Mock.ofType(FeatureFlagStore);
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler);
@@ -86,6 +91,7 @@ describe('TabControllerTest', () => {
             broadcasterStrictMock.object,
             browserAdapterMock.object,
             injectorAdapterMock.object,
+            notificationAdapterMock.object,
             detailsViewControllerMock.object,
             tabContextFactoryMock.object,
             LoggerStub,
@@ -197,7 +203,7 @@ describe('TabControllerTest', () => {
             });
 
         tabContextFactoryMock
-            .setup(factory => factory.createTabContext(It.isAny(), It.isAny(), It.isAny(), It.isAny(), It.isAny()))
+            .setup(factory => factory.createTabContext(It.isAny(), It.isAny(), It.isAny(), It.isAny(), It.isAny(), It.isAny()))
             .verifiable(Times.never());
 
         testSubject.initialize();

--- a/src/tests/unit/tests/common/notification-creator.test.ts
+++ b/src/tests/unit/tests/common/notification-creator.test.ts
@@ -3,6 +3,7 @@
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../background/browser-adapters/browser-adapter';
+import { NotificationAdapter } from '../../../../background/browser-adapters/notification-adapter';
 import {
     VisualizationConfiguration,
     VisualizationConfigurationFactory,
@@ -12,6 +13,7 @@ import { VisualizationType } from '../../../../common/types/visualization-type';
 
 describe('NotificationCreator', () => {
     let browserAdapterMock: IMock<BrowserAdapter>;
+    let notificationAdapterMock: IMock<NotificationAdapter>;
     let configFactoryMock: IMock<VisualizationConfigurationFactory>;
     let getNotificationMessageMock: IMock<(selectorMap, key) => string>;
     let testObject: NotificationCreator;
@@ -20,9 +22,10 @@ describe('NotificationCreator', () => {
 
     beforeEach(() => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
+        notificationAdapterMock = Mock.ofType<NotificationAdapter>(undefined, MockBehavior.Strict);
         configFactoryMock = Mock.ofType(VisualizationConfigurationFactory, MockBehavior.Strict);
         getNotificationMessageMock = Mock.ofInstance(selector => null);
-        testObject = new NotificationCreator(browserAdapterMock.object, configFactoryMock.object);
+        testObject = new NotificationCreator(browserAdapterMock.object, notificationAdapterMock.object, configFactoryMock.object);
     });
 
     test('createNotification, no message', () => {
@@ -34,14 +37,14 @@ describe('NotificationCreator', () => {
         const notificationMessage = 'the-message';
 
         browserAdapterMock
-            .setup(x => x.getManifest())
+            .setup(adapter => adapter.getManifest())
             .returns(() => {
                 return { name: 'testname', icons: { 128: 'iconUrl' } } as any;
             })
             .verifiable(Times.once());
 
-        browserAdapterMock
-            .setup(x => x.createNotification(It.isAny()))
+        notificationAdapterMock
+            .setup(adapter => adapter.createNotification(It.isAny()))
             .returns(message => {
                 const expectedMessage = {
                     message: notificationMessage,
@@ -60,14 +63,14 @@ describe('NotificationCreator', () => {
         const notificationMessage = 'the-message';
 
         browserAdapterMock
-            .setup(x => x.getManifest())
+            .setup(adapter => adapter.getManifest())
             .returns(() => {
                 return { name: 'testname', icons: { 128: 'iconUrl' } } as any;
             })
             .verifiable(Times.once());
 
-        browserAdapterMock
-            .setup(x => x.createNotification(It.isAny()))
+        notificationAdapterMock
+            .setup(adapter => adapter.createNotification(It.isAny()))
             .returns(message => {
                 const expectedMessage = {
                     message: notificationMessage,
@@ -100,6 +103,7 @@ describe('NotificationCreator', () => {
 
     function verifyAll(): void {
         browserAdapterMock.verifyAll();
+        notificationAdapterMock.verifyAll();
         configFactoryMock.verifyAll();
     }
 });


### PR DESCRIPTION
#### Description of changes

More refactoring on the browser/chrome adapter.
- introduce notification adapter (to create notification on the task bar)
- introduce runtime adapter (a couple of functions that explicitly use the word 'runtime' in their name)
- introduce injection adapter (to inject javascript and css into the target page)

**next in the list**:
We should keep breaking down `BrowserAdapter`. I can see this adapter as candidates for future refactorings:
- windows & tab adapter (to manage, create and query windows and tabs)
- event listener adapter (to add/remove listeners to specific events)
- communication adapter (to send messages between background, tabs and frames)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not apply
- [x] ~~Added~~Updated relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
