### PR TITLE
refactor: update ui test to use snapshot

### DIFF
--- a/src/DetailsView/components/issues-details-list.tsx
+++ b/src/DetailsView/components/issues-details-list.tsx
@@ -18,12 +18,12 @@ import { FailureDetails } from './failure-details';
 import { DetailsGroup, DetailsRowData, IssuesTableHandler } from './issues-table-handler';
 
 export interface IssuesDetailsListProps {
-    violations: (RuleResult)[];
+    violations: RuleResult[];
     issuesTableHandler: IssuesTableHandler;
     issuesSelection: ISelection;
 }
 
-export class IssuesDetailsList extends React.Component<IssuesDetailsListProps, {}> {
+export class IssuesDetailsList extends React.Component<IssuesDetailsListProps> {
     private items: DetailsRowData[];
     private groups: DetailsGroup[];
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-details-list.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-details-list.test.tsx.snap
@@ -1,0 +1,142 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`IssuesDetailsListTest render columns 1`] = `
+<div
+  className="issues-details-list"
+>
+  <FailureDetails
+    items={
+      Array [
+        Object {
+          "selector": "testSelector",
+        },
+        Object {
+          "selector": "testSelector",
+        },
+      ]
+    }
+  />
+  <StyledWithViewportComponent
+    ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+    ariaLabelForSelectionColumn="Toggle selection"
+    className="details-list"
+    columns={
+      Array [
+        Object {
+          "ariaLabel": "Path",
+          "className": "content-cell",
+          "fieldName": "selector",
+          "headerClassName": "content-header",
+          "isResizable": true,
+          "key": "target",
+          "maxWidth": 200,
+          "minWidth": 100,
+          "name": "Path",
+        },
+        Object {
+          "ariaLabel": "Snippet",
+          "className": "content-cell insights-code",
+          "fieldName": "html",
+          "isResizable": true,
+          "key": "html",
+          "maxWidth": 400,
+          "minWidth": 200,
+          "name": "Snippet",
+        },
+        Object {
+          "ariaLabel": "How to fix",
+          "className": "content-cell",
+          "fieldName": "failureSummary",
+          "isResizable": true,
+          "key": "fix",
+          "maxWidth": 400,
+          "minWidth": 200,
+          "name": "How to fix",
+        },
+      ]
+    }
+    constrainMode={0}
+    groupProps={
+      Object {
+        "isAllGroupsCollapsed": true,
+        "onRenderHeader": [Function],
+      }
+    }
+    groups={
+      Array [
+        Object {
+          "count": 2,
+          "guidanceLinks": Array [
+            Object {
+              "href": "url",
+              "text": "test text",
+            },
+          ],
+          "key": "rule name",
+          "name": "rule help",
+          "ruleUrl": "url",
+          "startIndex": 0,
+        },
+      ]
+    }
+    items={
+      Array [
+        Object {
+          "selector": "testSelector",
+        },
+        Object {
+          "selector": "testSelector",
+        },
+      ]
+    }
+    layoutMode={0}
+    selection={
+      proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "_anchoredIndex": 0,
+        "_canSelectItem": [Function],
+        "_change": [Function],
+        "_changeEventSuppressionCount": 0,
+        "_exemptedCount": 0,
+        "_exemptedIndices": Object {},
+        "_getKey": [Function],
+        "_isModal": false,
+        "_items": Array [],
+        "_keyToIndexMap": Object {},
+        "_onSelectionChanged": undefined,
+        "_selectedItems": null,
+        "_unselectableCount": 0,
+        "_unselectableIndices": Object {},
+        "_updateCount": [Function],
+        "canSelectItem": [Function],
+        "getItems": [Function],
+        "getKey": [Function],
+        "getSelectedCount": [Function],
+        "getSelectedIndices": [Function],
+        "getSelection": [Function],
+        "isAllSelected": [Function],
+        "isIndexSelected": [Function],
+        "isKeySelected": [Function],
+        "isModal": [Function],
+        "isRangeSelected": [Function],
+        "mode": 2,
+        "selectToIndex": [Function],
+        "selectToKey": [Function],
+        "setAllSelected": [Function],
+        "setChangeEvents": [Function],
+        "setIndexSelected": [Function],
+        "setItems": [Function],
+        "setKeySelected": [Function],
+        "setModal": [Function],
+        "toggleAllSelected": [Function],
+        "toggleIndexSelected": [Function],
+        "toggleKeySelected": [Function],
+        "toggleRangeSelected": [Function],
+      }
+    }
+    selectionMode={2}
+    selectionPreservedOnEmptyClick={true}
+    setKey="key"
+  />
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/issues-details-list.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-details-list.test.tsx
@@ -1,19 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import {
-    ConstrainMode,
-    DetailsList,
-    DetailsListLayoutMode,
-    IColumn,
-    ISelection,
-    Selection,
-    SelectionMode,
-} from 'office-ui-fabric-react/lib/DetailsList';
+import { shallow } from 'enzyme';
+import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 import { Mock } from 'typemoq';
 
 import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { FailureDetails } from '../../../../../DetailsView/components/failure-details';
 import { IssuesDetailsList, IssuesDetailsListProps } from '../../../../../DetailsView/components/issues-details-list';
 import { DetailsGroup, DetailsRowData, IssuesTableHandler } from '../../../../../DetailsView/components/issues-table-handler';
 import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
@@ -22,44 +14,43 @@ import { DictionaryStringTo } from '../../../../../types/common-types';
 import { VisualizationScanResultStoreDataBuilder } from '../../../common/visualization-scan-result-store-data-builder';
 
 describe('IssuesDetailsListTest', () => {
-    const instanceColumns = [
-        {
-            key: 'target',
-            name: 'Path',
-            ariaLabel: 'Path',
-            fieldName: 'selector',
-            minWidth: 100,
-            maxWidth: 200,
-            isResizable: true,
-            className: 'content-cell',
-            headerClassName: 'content-header',
-        },
-        {
-            key: 'html',
-            name: 'Snippet',
-            ariaLabel: 'Snippet',
-            fieldName: 'html',
-            minWidth: 200,
-            maxWidth: 400,
-            isResizable: true,
-            className: 'content-cell insights-code',
-        },
-        {
-            key: 'fix',
-            name: 'How to fix',
-            ariaLabel: 'How to fix',
-            fieldName: 'failureSummary',
-            minWidth: 200,
-            maxWidth: 400,
-            isResizable: true,
-            className: 'content-cell',
-        },
-    ];
-
     const iconClassName = 'details-icon-error';
 
     test('render columns', () => {
-        testRendering(null, instanceColumns);
+        const sampleViolations: AxeRule[] = getSampleViolations();
+        const sampleIdToRuleResultMap: DictionaryStringTo<DecoratedAxeNodeResult> = getSampleIdToRuleResultMap();
+        const items: DetailsRowData[] = getSampleItems();
+        const groups: DetailsGroup[] = getSampleGroups();
+        const issuesData = new VisualizationScanResultStoreDataBuilder()
+            .withScanResult(VisualizationType.Issues, {
+                passes: [],
+                violations: sampleViolations,
+            })
+            .withSelectedIdToRuleResultMapForIssues(sampleIdToRuleResultMap)
+            .build().issues;
+        const issuesTableHandlerMock = Mock.ofType<IssuesTableHandler>(IssuesTableHandler);
+        const listGroups = {
+            groups: groups,
+            items: items,
+        };
+
+        issuesTableHandlerMock.setup(handler => handler.getListProps(issuesData.scanResult.violations)).returns(failedRules => listGroups);
+
+        const selectionMock = Mock.ofType<ISelection>(Selection);
+        const props = new TestPropsBuilder()
+            .setViolations(issuesData.scanResult.violations)
+            .setIssuesTableHandler(issuesTableHandlerMock.object)
+            .setIssuesSelection(selectionMock.object)
+            .build();
+
+        const wrapped = shallow(<IssuesDetailsList {...props} />);
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+
+    test('shouldComponentUpdate', () => {
+        const props = new TestPropsBuilder().build();
+        const testSubject = new IssuesDetailsList(props);
+        expect(testSubject.shouldComponentUpdate()).toBe(false);
     });
 
     test('onRenderGroupHeader', () => {
@@ -153,66 +144,6 @@ describe('IssuesDetailsListTest', () => {
                 ],
             },
         ];
-    }
-
-    function testRendering(sampleItems: DetailsRowData[], columns: IColumn[]): void {
-        const sampleViolations: AxeRule[] = getSampleViolations();
-        const sampleIdToRuleResultMap: DictionaryStringTo<DecoratedAxeNodeResult> = getSampleIdToRuleResultMap();
-        const items: DetailsRowData[] = sampleItems ? sampleItems : getSampleItems();
-        const groups: DetailsGroup[] = getSampleGroups();
-        const issuesData = new VisualizationScanResultStoreDataBuilder()
-            .withScanResult(VisualizationType.Issues, {
-                passes: [],
-                violations: sampleViolations,
-            })
-            .withSelectedIdToRuleResultMapForIssues(sampleIdToRuleResultMap)
-            .build().issues;
-        const issuesTableHandlerMock = Mock.ofType<IssuesTableHandler>(IssuesTableHandler);
-        const listGroups = {
-            groups: groups,
-            items: items,
-        };
-
-        issuesTableHandlerMock
-            .setup(handler => handler.getListProps(issuesData.scanResult.violations))
-            .returns(failedRules => listGroups)
-            .verifiable();
-
-        const selectionMock = Mock.ofType<ISelection>(Selection);
-        const props = new TestPropsBuilder()
-            .setViolations(issuesData.scanResult.violations)
-            .setIssuesTableHandler(issuesTableHandlerMock.object)
-            .setIssuesSelection(selectionMock.object)
-            .build();
-        const testObject = new IssuesDetailsList(props);
-        const expected: JSX.Element = (
-            <div className="issues-details-list">
-                <FailureDetails items={items} />
-                <DetailsList
-                    groupProps={{
-                        isAllGroupsCollapsed: true,
-                        onRenderHeader: (testObject as any).onRenderGroupHeader,
-                    }}
-                    items={items}
-                    groups={groups}
-                    onRenderDetailsHeader={(testObject as any).onRenderDetailsHeader}
-                    columns={columns}
-                    ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-                    ariaLabelForSelectionColumn="Toggle selection"
-                    constrainMode={ConstrainMode.unconstrained}
-                    selectionMode={SelectionMode.multiple}
-                    selection={props.issuesSelection}
-                    selectionPreservedOnEmptyClick={true}
-                    setKey="key"
-                    className="details-list"
-                    layoutMode={DetailsListLayoutMode.fixedColumns}
-                />
-            </div>
-        );
-
-        expect(testObject.render()).toEqual(expected);
-        expect(testObject.shouldComponentUpdate()).toBe(false);
-        issuesTableHandlerMock.verifyAll();
     }
 });
 


### PR DESCRIPTION
#### Description of changes

Update UI test to use snapshot test instead of "double accounting" test.
Some minor clean up on the tested class

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not apply
- [x] ~~Added~~Updated relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
