### PR TITLE
refactor: move file issue behavior to the service

### DIFF
--- a/src/issue-filing/common/create-file-issue-handler.ts
+++ b/src/issue-filing/common/create-file-issue-handler.ts
@@ -7,8 +7,8 @@ import { IssueFilingServicePropertiesMap } from '../../common/types/store-data/u
 import { IssueFilingUrlProvider } from '../types/issue-filing-service';
 
 export const createFileIssueHandler = <Settings>(
-    urlProvider: IssueFilingUrlProvider<Settings>,
-    settingsGetter: (data: IssueFilingServicePropertiesMap) => Settings,
+    getUrl: IssueFilingUrlProvider<Settings>,
+    getSettings: (data: IssueFilingServicePropertiesMap) => Settings,
 ) => {
     return (
         browserAdapter: BrowserAdapter,
@@ -16,9 +16,9 @@ export const createFileIssueHandler = <Settings>(
         issueData: CreateIssueDetailsTextData,
         environmentInfo: EnvironmentInfo,
     ): void => {
-        const serviceConfig = settingsGetter(servicePropertiesMap);
+        const serviceConfig = getSettings(servicePropertiesMap);
 
-        const url = urlProvider(serviceConfig, issueData, environmentInfo);
+        const url = getUrl(serviceConfig, issueData, environmentInfo);
         browserAdapter.createTab(url);
     };
 };

--- a/src/issue-filing/common/create-file-issue-handler.ts
+++ b/src/issue-filing/common/create-file-issue-handler.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BrowserAdapter } from '../../background/browser-adapters/browser-adapter';
+import { EnvironmentInfo } from '../../common/environment-info-provider';
+import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
+import { IssueFilingServicePropertiesMap } from '../../common/types/store-data/user-configuration-store';
+import { IssueFilingUrlProvider } from '../types/issue-filing-service';
+
+export const createFileIssueHandler = <Settings>(
+    urlProvider: IssueFilingUrlProvider<Settings>,
+    settingsGetter: (data: IssueFilingServicePropertiesMap) => Settings,
+) => {
+    return (
+        browserAdapter: BrowserAdapter,
+        servicePropertiesMap: IssueFilingServicePropertiesMap,
+        issueData: CreateIssueDetailsTextData,
+        environmentInfo: EnvironmentInfo,
+    ): void => {
+        const serviceConfig = settingsGetter(servicePropertiesMap);
+
+        const url = urlProvider(serviceConfig, issueData, environmentInfo);
+        browserAdapter.createTab(url);
+    };
+};

--- a/src/issue-filing/common/issue-filing-controller-impl.ts
+++ b/src/issue-filing/common/issue-filing-controller-impl.ts
@@ -4,7 +4,7 @@ import { BrowserAdapter } from '../../background/browser-adapters/browser-adapte
 import { BaseStore } from '../../common/base-store';
 import { EnvironmentInfo } from '../../common/environment-info-provider';
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
-import { IssueFilingServiceProperties, UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
+import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { IssueFilingServiceProvider } from '../issue-filing-service-provider';
 
 export type IssueFilingController = {
@@ -23,11 +23,6 @@ export class IssueFilingControllerImpl implements IssueFilingController {
         const service = this.provider.forKey(serviceKey);
         const userConfigurationStoreData = this.userConfigurationStore.getState();
 
-        const serviceConfig: IssueFilingServiceProperties = service.getSettingsFromStoreData(
-            userConfigurationStoreData.bugServicePropertiesMap,
-        );
-
-        const url = service.issueFilingUrlProvider(serviceConfig, issueData, this.environmentInfo);
-        this.browserAdapter.createTab(url);
+        service.fileIssue(this.browserAdapter, userConfigurationStoreData.bugServicePropertiesMap, issueData, this.environmentInfo);
     };
 }

--- a/src/issue-filing/services/azure-boards/azure-boards-issue-filing-service.tsx
+++ b/src/issue-filing/services/azure-boards/azure-boards-issue-filing-service.tsx
@@ -3,6 +3,7 @@
 import { isEmpty } from 'lodash';
 import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 
+import { createFileIssueHandler } from '../../common/create-file-issue-handler';
 import { createSettingsGetter } from '../../common/create-settings-getter';
 import { IssueFilingService } from '../../types/issue-filing-service';
 import { AzureBoardsSettingsForm } from './azure-boards-settings-form';
@@ -36,12 +37,14 @@ function isStringValid(stringToCheck: string): boolean {
     return !isEmpty(stringToCheck) && !isEmpty(stringToCheck.trim());
 }
 
+const settingsGetter = createSettingsGetter<AzureBoardsIssueFilingSettings>(AzureBoardsIssueFilingServiceKey);
+
 export const AzureBoardsIssueFilingService: IssueFilingService<AzureBoardsIssueFilingSettings> = {
     key: AzureBoardsIssueFilingServiceKey,
     displayName: 'Azure Boards',
     settingsForm: AzureBoardsSettingsForm,
     buildStoreData,
-    getSettingsFromStoreData: createSettingsGetter(AzureBoardsIssueFilingServiceKey),
+    getSettingsFromStoreData: settingsGetter,
     isSettingsValid,
-    issueFilingUrlProvider: azureBoardsIssueFilingUrlProvider,
+    fileIssue: createFileIssueHandler(azureBoardsIssueFilingUrlProvider, settingsGetter),
 };

--- a/src/issue-filing/services/github/github-issue-filing-service.tsx
+++ b/src/issue-filing/services/github/github-issue-filing-service.tsx
@@ -5,6 +5,7 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 
 import { NamedSFC } from '../../../common/react/named-sfc';
+import { createFileIssueHandler } from '../../common/create-file-issue-handler';
 import { createSettingsGetter } from '../../common/create-settings-getter';
 import { IssueFilingService } from '../../types/issue-filing-service';
 import { SettingsFormProps } from '../../types/settings-form-props';
@@ -43,12 +44,14 @@ const settingsForm = NamedSFC<SettingsFormProps<GitHubIssueFilingSettings>>('Iss
     );
 });
 
+const settingsGetter = createSettingsGetter<GitHubIssueFilingSettings>(GitHubIssueFilingServiceKey);
+
 export const GitHubIssueFilingService: IssueFilingService<GitHubIssueFilingSettings> = {
     key: GitHubIssueFilingServiceKey,
     displayName: 'GitHub',
     settingsForm,
     buildStoreData,
-    getSettingsFromStoreData: createSettingsGetter(GitHubIssueFilingServiceKey),
+    getSettingsFromStoreData: settingsGetter,
     isSettingsValid,
-    issueFilingUrlProvider: gitHubIssueFilingUrlProvider,
+    fileIssue: createFileIssueHandler(gitHubIssueFilingUrlProvider, settingsGetter),
 };

--- a/src/issue-filing/services/null-issue-filing-service/null-issue-filing-service.tsx
+++ b/src/issue-filing/services/null-issue-filing-service/null-issue-filing-service.tsx
@@ -19,5 +19,5 @@ export const NullIssueFilingService: IssueFilingService = {
     buildStoreData: () => null,
     isSettingsValid: () => false,
     getSettingsFromStoreData: () => null,
-    issueFilingUrlProvider: () => null,
+    fileIssue: () => {},
 };

--- a/src/issue-filing/types/issue-filing-service.ts
+++ b/src/issue-filing/types/issue-filing-service.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BrowserAdapter } from '../../background/browser-adapters/browser-adapter';
 import { IssueFilingServicePropertiesMap } from '../../common/types/store-data/user-configuration-store';
 import { EnvironmentInfo } from './../../common/environment-info-provider';
 import { ReactSFCWithDisplayName } from './../../common/react/named-sfc';
@@ -20,5 +21,10 @@ export interface IssueFilingService<Settings = {}> {
     buildStoreData: (...params: any[]) => Settings;
     isSettingsValid: (data: Settings) => boolean;
     getSettingsFromStoreData: (data: IssueFilingServicePropertiesMap) => Settings;
-    issueFilingUrlProvider: IssueFilingUrlProvider<Settings>;
+    fileIssue: (
+        browserAdapter: BrowserAdapter,
+        servicePropertiesMap: IssueFilingServicePropertiesMap,
+        issueData: CreateIssueDetailsTextData,
+        environmentInfo: EnvironmentInfo,
+    ) => void;
 }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
@@ -63,7 +63,6 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have ch
       Object {
         "getSettingsFromStoreData": [Function],
         "isSettingsValid": [Function],
-        "issueFilingUrlProvider": [Function],
         "key": "gitHub",
       }
     }
@@ -148,7 +147,6 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have no
       Object {
         "getSettingsFromStoreData": [Function],
         "isSettingsValid": [Function],
-        "issueFilingUrlProvider": [Function],
         "key": "gitHub",
       }
     }
@@ -233,7 +231,6 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have change
       Object {
         "getSettingsFromStoreData": [Function],
         "isSettingsValid": [Function],
-        "issueFilingUrlProvider": [Function],
         "key": "gitHub",
       }
     }
@@ -318,7 +315,6 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have not ch
       Object {
         "getSettingsFromStoreData": [Function],
         "isSettingsValid": [Function],
-        "issueFilingUrlProvider": [Function],
         "key": "gitHub",
       }
     }
@@ -403,7 +399,6 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
       Object {
         "getSettingsFromStoreData": [Function],
         "isSettingsValid": [Function],
-        "issueFilingUrlProvider": [Function],
         "key": "gitHub",
       }
     }
@@ -488,7 +483,6 @@ exports[`IssueFilingDialog render with isSettingsValid: true 1`] = `
       Object {
         "getSettingsFromStoreData": [Function],
         "isSettingsValid": [Function],
-        "issueFilingUrlProvider": [Function],
         "key": "gitHub",
       }
     }
@@ -573,7 +567,6 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
       Object {
         "getSettingsFromStoreData": [Function],
         "isSettingsValid": [Function],
-        "issueFilingUrlProvider": [Function],
         "key": "gitHub",
       }
     }
@@ -659,7 +652,6 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
       Object {
         "getSettingsFromStoreData": [Function],
         "isSettingsValid": [Function],
-        "issueFilingUrlProvider": [Function],
         "key": "gitHub",
       }
     }
@@ -744,7 +736,6 @@ exports[`IssueFilingDialog render: validate callback (onSelectedServiceChange) s
       Object {
         "getSettingsFromStoreData": [Function],
         "isSettingsValid": [Function],
-        "issueFilingUrlProvider": [Function],
         "key": "different_service",
       }
     }

--- a/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
@@ -23,7 +23,6 @@ import { EventStub, EventStubFactory } from '../../../common/event-stub-factory'
 describe('IssueFilingDialog', () => {
     let eventStub: EventStub;
     let isSettingsValidMock: IMock<Function>;
-    let createIssueFilingUrlMock: IMock<Function>;
     let getSettingsFromStoreDataMock: IMock<Function>;
     let onCloseMock: IMock<(ev) => void>;
     let selectedIssueDataStub: CreateIssueDetailsTextData;
@@ -49,7 +48,6 @@ describe('IssueFilingDialog', () => {
         eventStub = new EventStubFactory().createMouseClickEvent();
         isSettingsValidMock = Mock.ofInstance(data => null, MockBehavior.Strict);
         onCloseMock = Mock.ofInstance(() => null, MockBehavior.Strict);
-        createIssueFilingUrlMock = Mock.ofInstance((serviceData, issueData, info) => null, MockBehavior.Strict);
         getSettingsFromStoreDataMock = Mock.ofInstance(data => null, MockBehavior.Strict);
         envInfoProviderMock = Mock.ofType(EnvironmentInfoProvider);
         userConfigMessageCreatorMock = Mock.ofType(UserConfigMessageCreator);
@@ -75,7 +73,6 @@ describe('IssueFilingDialog', () => {
         } as IssueFilingDialogDeps;
         issueFilingServiceStub = {
             isSettingsValid: isSettingsValidMock.object,
-            issueFilingUrlProvider: createIssueFilingUrlMock.object,
             getSettingsFromStoreData: getSettingsFromStoreDataMock.object,
             key: serviceKey,
         } as IssueFilingService;
@@ -96,18 +93,11 @@ describe('IssueFilingDialog', () => {
             .setup(isSettingsValid => isSettingsValid(selectedServiceData))
             .returns(() => true)
             .verifiable(Times.once());
-        createIssueFilingUrlMock
-            .setup(createIssueFilingUrl => createIssueFilingUrl(selectedServiceData, selectedIssueDataStub, envInfo))
-            .verifiable(Times.once());
     });
 
     it.each([true, false])('render with isSettingsValid: %s', isSettingsValid => {
         isSettingsValidMock.reset();
         isSettingsValidMock.setup(isValid => isValid(selectedServiceData)).returns(() => isSettingsValid);
-
-        createIssueFilingUrlMock
-            .setup(createIssueFilingUrl => createIssueFilingUrl(selectedServiceData, selectedIssueDataStub, envInfo))
-            .returns(() => 'test url');
 
         const testSubject = shallow(<IssueFilingDialog {...props} />);
 
@@ -158,9 +148,6 @@ describe('IssueFilingDialog', () => {
         isSettingsValidMock
             .setup(isSettingsValid => isSettingsValid(issueFilingServicePropertiesMapStub[differentServiceKey]))
             .returns(() => true);
-        createIssueFilingUrlMock.setup(createIssueFilingUrl =>
-            createIssueFilingUrl(issueFilingServicePropertiesMapStub[differentServiceKey], selectedIssueDataStub, envInfo),
-        );
 
         issueFilingSettingsContainer.props().onPropertyUpdateCallback(differentServiceKey, propertyStub, propertValueStub);
 
@@ -178,9 +165,6 @@ describe('IssueFilingDialog', () => {
             .setup(mock => mock(It.isValue(issueFilingServicePropertiesMapStub)))
             .returns(() => issueFilingServicePropertiesMapStub[serviceKey]);
         isSettingsValidMock.setup(isSettingsValid => isSettingsValid(issueFilingServicePropertiesMapStub[serviceKey])).returns(() => true);
-        createIssueFilingUrlMock.setup(createIssueFilingUrl =>
-            createIssueFilingUrl(issueFilingServicePropertiesMapStub[serviceKey], selectedIssueDataStub, envInfo),
-        );
 
         issueFilingSettingsContainer.props().onPropertyUpdateCallback(serviceKey, propertyStub, propertValueStub);
 
@@ -190,11 +174,9 @@ describe('IssueFilingDialog', () => {
     it('render: validate callback (onSelectedServiceChange) sent to settings container', () => {
         const differentServiceKey = 'different_service';
         const differentIsSettingsValidMock = Mock.ofInstance(data => null, MockBehavior.Strict);
-        const differentCreateIssueFilingUrlMock = Mock.ofInstance((serviceData, issueData, info) => null, MockBehavior.Strict);
         const differentGetSettingsFromStoreDataMock = Mock.ofInstance(data => null);
         const differentServiceStub = {
             isSettingsValid: differentIsSettingsValidMock.object,
-            issueFilingUrlProvider: differentCreateIssueFilingUrlMock.object,
             getSettingsFromStoreData: differentGetSettingsFromStoreDataMock.object,
             key: differentServiceKey,
         } as IssueFilingService;
@@ -207,9 +189,6 @@ describe('IssueFilingDialog', () => {
             .setup(mock => mock(It.isValue(issueFilingServicePropertiesMapStub)))
             .returns(() => differentServiceData);
         differentIsSettingsValidMock.setup(isSettingsValid => isSettingsValid(differentServiceData)).returns(() => true);
-        differentCreateIssueFilingUrlMock.setup(createIssueFilingUrl =>
-            createIssueFilingUrl(differentServiceData, selectedIssueDataStub, envInfo),
-        );
 
         const testSubject = shallow(<IssueFilingDialog {...props} />);
         const issueFilingSettingsContainer = testSubject.find(IssueFilingSettingsContainer);
@@ -237,7 +216,6 @@ describe('IssueFilingDialog', () => {
         };
 
         isSettingsValidMock.setup(isSettingsValid => isSettingsValid(differentServiceData)).returns(() => true);
-        createIssueFilingUrlMock.setup(createIssueFilingUrl => createIssueFilingUrl(differentServiceData, selectedIssueDataStub, envInfo));
         getSettingsFromStoreDataMock
             .setup(mock => mock(It.isValue(newProps.issueFilingServicePropertiesMap)))
             .returns(() => differentServiceData);

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/settings/issue-filing/__snapshots__/issue-filing-settings.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/settings/issue-filing/__snapshots__/issue-filing-settings.test.tsx.snap
@@ -32,9 +32,9 @@ exports[`IssueFilingSettings renders 1`] = `
       Object {
         "buildStoreData": [Function],
         "displayName": "TEST",
+        "fileIssue": [Function],
         "getSettingsFromStoreData": [Function],
         "isSettingsValid": [Function],
-        "issueFilingUrlProvider": [Function],
         "key": "test",
         "settingsForm": [Function],
       }

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/settings/issue-filing/issue-filing-settings.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/settings/issue-filing/issue-filing-settings.test.tsx
@@ -15,7 +15,7 @@ import { IssueFilingService } from '../../../../../../../../issue-filing/types/i
 describe('IssueFilingSettings', () => {
     let userData: UserConfigurationStoreData;
     let issueFilingServiceProviderMock: IMock<IssueFilingServiceProvider>;
-    let testIssueFilingService: IssueFilingService;
+    let testIssueFilingServiceStub: IssueFilingService;
     const testKey: string = 'test';
     let userConfigMessageCreatorMock: IMock<UserConfigMessageCreator>;
 
@@ -29,7 +29,7 @@ describe('IssueFilingSettings', () => {
             bugService: 'gitHub',
             bugServicePropertiesMap: { gitHub: { repository: 'test-repository' } },
         };
-        testIssueFilingService = {
+        testIssueFilingServiceStub = {
             key: testKey,
             displayName: 'TEST',
             settingsForm: NamedSFC('testForm', () => <>Hello World</>),
@@ -38,10 +38,10 @@ describe('IssueFilingSettings', () => {
                 return { testField };
             },
             getSettingsFromStoreData: data => data[testKey],
-            issueFilingUrlProvider: () => 'test url',
+            fileIssue: () => {},
         };
 
-        issueFilingServiceProviderMock.setup(provider => provider.forKey(userData.bugService)).returns(() => testIssueFilingService);
+        issueFilingServiceProviderMock.setup(provider => provider.forKey(userData.bugService)).returns(() => testIssueFilingServiceStub);
     });
 
     it('renders', () => {

--- a/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
+++ b/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
@@ -22,11 +22,11 @@ describe('IssueFilingButtonTest', () => {
     let issueFilingServiceProviderMock: IMock<IssueFilingServiceProvider>;
     let issueFilingActionMessageCreatorMock: IMock<IssueFilingActionMessageCreator>;
     let userConfigurationStoreData: UserConfigurationStoreData;
-    let testIssueFilingService: IssueFilingService;
+    let testIssueFilingServiceStub: IssueFilingService;
     let needsSettingsContentRenderer: IssueFilingNeedsSettingsContentRenderer;
 
     beforeEach(() => {
-        testIssueFilingService = {
+        testIssueFilingServiceStub = {
             key: testKey,
             displayName: 'TEST',
             settingsForm: NamedSFC('testForm', props => <>Hello World</>),
@@ -35,7 +35,7 @@ describe('IssueFilingButtonTest', () => {
                 return { testField };
             },
             getSettingsFromStoreData: data => data[testKey],
-            issueFilingUrlProvider: () => 'test url',
+            fileIssue: () => {},
         };
         userConfigurationStoreData = {
             bugService: testKey,
@@ -58,13 +58,13 @@ describe('IssueFilingButtonTest', () => {
             .verifiable();
         issueFilingServiceProviderMock
             .setup(bp => bp.forKey(testKey))
-            .returns(() => testIssueFilingService)
+            .returns(() => testIssueFilingServiceStub)
             .verifiable();
         needsSettingsContentRenderer = NamedSFC('testRenderer', () => <>needs settings</>);
     });
 
     test.each([true, false])('render: isSettingsValid: %s', isSettingsValid => {
-        testIssueFilingService.isSettingsValid = () => isSettingsValid;
+        testIssueFilingServiceStub.isSettingsValid = () => isSettingsValid;
         const props: IssueFilingButtonProps = {
             deps: {
                 issueFilingActionMessageCreator: issueFilingActionMessageCreatorMock.object,
@@ -113,7 +113,7 @@ describe('IssueFilingButtonTest', () => {
     });
 
     test('onclick: invalid settings, %s', () => {
-        testIssueFilingService.isSettingsValid = () => false;
+        testIssueFilingServiceStub.isSettingsValid = () => false;
         issueFilingActionMessageCreatorMock
             .setup(messageCreator => messageCreator.trackFileIssueClick(eventStub as any, testKey as any))
             .verifiable(Times.never());

--- a/src/tests/unit/tests/issue-filing/common/create-file-issue-handler.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/create-file-issue-handler.test.ts
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Mock, MockBehavior, Times } from 'typemoq';
+
+import { BrowserAdapter } from '../../../../../background/browser-adapters/browser-adapter';
+import { EnvironmentInfo } from '../../../../../common/environment-info-provider';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
+import { IssueFilingServicePropertiesMap } from '../../../../../common/types/store-data/user-configuration-store';
+import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
+import { createFileIssueHandler } from '../../../../../issue-filing/common/create-file-issue-handler';
+import { IssueFilingUrlProvider } from '../../../../../issue-filing/types/issue-filing-service';
+
+describe('createFileIssueHandler', () => {
+    it('properly files an issue', () => {
+        const serviceMap: IssueFilingServicePropertiesMap = {};
+        const issueData: CreateIssueDetailsTextData = {
+            pageTitle: 'pageTitle<x>',
+            pageUrl: 'pageUrl',
+            ruleResult: {
+                failureSummary: 'RR-failureSummary',
+                guidanceLinks: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
+                help: 'RR-help',
+                html: 'RR-html',
+                ruleId: 'RR-rule-id',
+                helpUrl: 'RR-help-url',
+                selector: 'RR-selector<x>',
+                snippet: 'RR-snippet   space',
+            } as DecoratedAxeNodeResult,
+        };
+        const environmentInfoStub: EnvironmentInfo = {
+            axeCoreVersion: 'test axe version',
+            browserSpec: 'test browser spec',
+            extensionVersion: 'test extension version',
+        };
+        const settingsStub = {
+            repo: 'test-repo',
+        };
+        const urlStub = 'url-stub';
+
+        const settingsGetterMock = Mock.ofType<(data: IssueFilingServicePropertiesMap) => any>(undefined, MockBehavior.Strict);
+        settingsGetterMock.setup(getter => getter(serviceMap)).returns(() => settingsStub);
+
+        const urlProviderMock = Mock.ofType<IssueFilingUrlProvider<any>>(undefined, MockBehavior.Strict);
+        urlProviderMock.setup(provider => provider(settingsStub, issueData, environmentInfoStub)).returns(() => urlStub);
+
+        const browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
+        browserAdapterMock.setup(adapter => adapter.createTab(urlStub)).verifiable(Times.once());
+
+        const testSubject = createFileIssueHandler(urlProviderMock.object, settingsGetterMock.object);
+
+        testSubject(browserAdapterMock.object, serviceMap, issueData, environmentInfoStub);
+
+        browserAdapterMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { It, Mock, Times } from 'typemoq';
+import { Mock, Times } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../../background/browser-adapters/browser-adapter';
 import { BaseStore } from '../../../../../common/base-store';
@@ -45,19 +45,14 @@ describe('IssueFilingControllerImpl', () => {
         };
         const serviceConfig = { bugServicePropertiesMap: map } as UserConfigurationStoreData;
 
+        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
         const issueFilingServiceMock = Mock.ofType<IssueFilingService>();
         issueFilingServiceMock
-            .setup(service => service.getSettingsFromStoreData(serviceConfig.bugServicePropertiesMap))
-            .returns(() => serviceConfig);
-        issueFilingServiceMock
-            .setup(service => service.issueFilingUrlProvider(It.isValue(serviceConfig), issueData, environmentInfoStub))
-            .returns(() => testUrl);
+            .setup(service => service.fileIssue(browserAdapterMock.object, map, issueData, environmentInfoStub))
+            .verifiable(Times.once());
 
         const providerMock = Mock.ofType<IssueFilingServiceProvider>();
         providerMock.setup(provider => provider.forKey(serviceKey)).returns(() => issueFilingServiceMock.object);
-
-        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
-        browserAdapterMock.setup(adapter => adapter.createTab(testUrl)).verifiable(Times.once());
 
         const storeMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>();
         storeMock.setup(store => store.getState()).returns(() => serviceConfig);

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-issue-filing-service.test.tsx
@@ -12,16 +12,6 @@ describe('AzureBoardsIssueFilingServiceTest', () => {
     const projectUrlStub: string = 'some/project/url';
     const issueDetailsLocationStub: AzureBoardsIssueDetailField = 'some location' as AzureBoardsIssueDetailField;
 
-    const invalidTestSettings: AzureBoardsIssueFilingSettings[] = [
-        null,
-        {} as AzureBoardsIssueFilingSettings,
-        undefined,
-        { projectURL: '' } as AzureBoardsIssueFilingSettings,
-        { projectURL: '', issueDetailsField: '' as AzureBoardsIssueDetailField },
-        { projectURL: 'some project', issueDetailsField: '' as AzureBoardsIssueDetailField },
-        { projectURL: '', issueDetailsField: 'some issue details location' as AzureBoardsIssueDetailField },
-    ];
-
     it('static properties', () => {
         expect(AzureBoardsIssueFilingService.key).toBe('azureBoards');
         expect(AzureBoardsIssueFilingService.displayName).toBe('Azure Boards');
@@ -49,6 +39,16 @@ describe('AzureBoardsIssueFilingServiceTest', () => {
     });
 
     describe('isSettingsValid', () => {
+        const invalidTestSettings: AzureBoardsIssueFilingSettings[] = [
+            null,
+            {} as AzureBoardsIssueFilingSettings,
+            undefined,
+            { projectURL: '' } as AzureBoardsIssueFilingSettings,
+            { projectURL: '', issueDetailsField: '' as AzureBoardsIssueDetailField },
+            { projectURL: 'some project', issueDetailsField: '' as AzureBoardsIssueDetailField },
+            { projectURL: '', issueDetailsField: 'some issue details location' as AzureBoardsIssueDetailField },
+        ];
+
         it.each(invalidTestSettings)('handles invalid settings: %o', settings => {
             expect(AzureBoardsIssueFilingService.isSettingsValid(settings)).toBe(false);
         });

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-issue-filing-service.test.tsx
@@ -67,8 +67,4 @@ describe('AzureBoardsIssueFilingServiceTest', () => {
     it('has correct settingsForm', () => {
         expect(AzureBoardsIssueFilingService.settingsForm).toBe(AzureBoardsSettingsForm);
     });
-
-    it('has correct issue filing url property', () => {
-        expect(AzureBoardsIssueFilingService.issueFilingUrlProvider).toBe(azureBoardsIssueFilingUrlProvider);
-    });
 });

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-issue-filing-service.test.tsx
@@ -7,7 +7,6 @@ import {
     AzureBoardsIssueFilingSettings,
 } from '../../../../../../issue-filing/services/azure-boards/azure-boards-issue-filing-service';
 import { AzureBoardsSettingsForm } from '../../../../../../issue-filing/services/azure-boards/azure-boards-settings-form';
-import { azureBoardsIssueFilingUrlProvider } from '../../../../../../issue-filing/services/azure-boards/create-azure-boards-issue-filing-url';
 
 describe('AzureBoardsIssueFilingServiceTest', () => {
     const projectUrlStub: string = 'some/project/url';

--- a/src/tests/unit/tests/issue-filing/services/github/__snapshots__/github-issue-filing-service.test.tsx.snap
+++ b/src/tests/unit/tests/issue-filing/services/github/__snapshots__/github-issue-filing-service.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GithubIssueFilingServiceTest renderSettingsForm 1`] = `
+exports[`GithubIssueFilingServiceTest settingsForm renders 1`] = `
 <StyledTextFieldBase
   className="issue-setting"
   label="Enter desired GitHub issues link:"

--- a/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
@@ -98,8 +98,4 @@ describe('GithubIssueFilingServiceTest', () => {
             .onChange(null, 'new value');
         onPropertyUpdateCallbackMock.verifyAll();
     });
-
-    describe('create bug filing url', () => {
-        expect(GitHubIssueFilingService.issueFilingUrlProvider).toEqual(gitHubIssueFilingUrlProvider);
-    });
 });

--- a/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
@@ -58,43 +58,45 @@ describe('GithubIssueFilingServiceTest', () => {
         expect(GitHubIssueFilingService.getSettingsFromStoreData(givenData)).toEqual(expectedStoreData);
     });
 
-    describe('check for invalid settings', () => {
-        it.each(invalidTestSettings)('with %o', (settings: GitHubIssueFilingSettings) => {
+    describe('isSettingsValid', () => {
+        it.each(invalidTestSettings)('invalid settings with %o', (settings: GitHubIssueFilingSettings) => {
             expect(GitHubIssueFilingService.isSettingsValid(settings)).toBe(false);
+        });
+
+        it('valid settings', () => {
+            const validSettings: GitHubIssueFilingSettings = {
+                repository: 'repository',
+            };
+
+            expect(GitHubIssueFilingService.isSettingsValid(validSettings)).toBe(true);
         });
     });
 
-    it('isSettingsValid - valid case', () => {
-        const validSettings: GitHubIssueFilingSettings = {
-            repository: 'repository',
-        };
+    describe('settingsForm', () => {
+        it('renders', () => {
+            const Component = GitHubIssueFilingService.settingsForm;
+            const wrapper = shallow(<Component {...props} />);
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
 
-        expect(GitHubIssueFilingService.isSettingsValid(validSettings)).toBe(true);
-    });
+        it('renders with no valid settings object', () => {
+            const Component = GitHubIssueFilingService.settingsForm;
+            props.settings = null;
+            const wrapper = shallow(<Component {...props} />);
+            const textField = wrapper.find(TextField);
+            expect(textField.exists()).toBe(true);
+            expect(textField.props().value).toEqual('');
+        });
 
-    it('renderSettingsForm', () => {
-        const Component = GitHubIssueFilingService.settingsForm;
-        const wrapper = shallow(<Component {...props} />);
-        expect(wrapper.getElement()).toMatchSnapshot();
-    });
-
-    it('renderSettingsForm: no valid settings object', () => {
-        const Component = GitHubIssueFilingService.settingsForm;
-        props.settings = null;
-        const wrapper = shallow(<Component {...props} />);
-        const textField = wrapper.find(TextField);
-        expect(textField.exists()).toBe(true);
-        expect(textField.props().value).toEqual('');
-    });
-
-    it('renderSettingsForm: onChange', () => {
-        const Component = GitHubIssueFilingService.settingsForm;
-        const wrapper = shallow(<Component {...props} />);
-        onPropertyUpdateCallbackMock.setup(mock => mock('gitHub', 'repository', 'new value')).verifiable(Times.once());
-        wrapper
-            .find(TextField)
-            .props()
-            .onChange(null, 'new value');
-        onPropertyUpdateCallbackMock.verifyAll();
+        it('onChange', () => {
+            const Component = GitHubIssueFilingService.settingsForm;
+            const wrapper = shallow(<Component {...props} />);
+            onPropertyUpdateCallbackMock.setup(mock => mock('gitHub', 'repository', 'new value')).verifiable(Times.once());
+            wrapper
+                .find(TextField)
+                .props()
+                .onChange(null, 'new value');
+            onPropertyUpdateCallbackMock.verifyAll();
+        });
     });
 });

--- a/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
@@ -8,7 +8,6 @@ import { IMock, Mock, Times } from 'typemoq';
 import { IssueFilingServicePropertiesMap } from '../../../../../../common/types/store-data/user-configuration-store';
 import { SettingsDeps } from '../../../../../../DetailsView/components/settings-panel/settings/settings-props';
 import { OnPropertyUpdateCallback } from '../../../../../../issue-filing/components/issue-filing-settings-container';
-import { gitHubIssueFilingUrlProvider } from '../../../../../../issue-filing/services/github/create-github-issue-filing-url';
 import {
     GitHubIssueFilingService,
     GitHubIssueFilingSettings,

--- a/src/tests/unit/tests/issue-filing/services/null-issue-filing-service/null-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/null-issue-filing-service/null-issue-filing-service.test.tsx
@@ -3,8 +3,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { CreateIssueDetailsTextData } from '../../../../../../common/types/create-issue-details-text-data';
-import { DecoratedAxeNodeResult } from '../../../../../../injected/scanner-utils';
 import {
     NullIssueFilingService,
     NullIssueFilingServiceSettings,

--- a/src/tests/unit/tests/issue-filing/services/null-issue-filing-service/null-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/null-issue-filing-service/null-issue-filing-service.test.tsx
@@ -34,17 +34,6 @@ describe('NullIssueFilingService', () => {
         });
     });
 
-    describe('creates bug filing url', () => {
-        it.each(testSettings)('with %o', settings => {
-            const issuesData: CreateIssueDetailsTextData = {
-                pageTitle: 'test page title',
-                pageUrl: '//test-page-url',
-                ruleResult: {} as DecoratedAxeNodeResult,
-            };
-            expect(NullIssueFilingService.issueFilingUrlProvider(settings, issuesData, null)).toBeNull();
-        });
-    });
-
     it('renders settings form', () => {
         const Component = NullIssueFilingService.settingsForm;
 


### PR DESCRIPTION
#### Description of changes

As part of solving issue 588 (not linking so it doesn't get close automatically), I'm moving the responsibility of filing a bug from `IssueFilingControllerImpl` to each service. This way, we give each service the flexibility of filing issue as they need (as opposed to: each service file issues by generating a url which we -basically- use for an HTTP GET request). This way, we may be able to use HTTP POST request or not even HTTP request but system calls (like open notepad for example)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
   - does not apply
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
