### PR TITLE
refactor: extract scoping action creator behavior

### DIFF
--- a/src/background/actions/scoping-panel-action-creator.ts
+++ b/src/background/actions/scoping-panel-action-creator.ts
@@ -8,7 +8,7 @@ import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { BaseActionPayload } from './action-payloads';
 import { ScopingActions } from './scoping-actions';
 
-export class ScopingActionCreator {
+export class ScopingPanelActionCreator {
     private scopingActions: ScopingActions;
     private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
     private telemetryEventHandler: TelemetryEventHandler;

--- a/src/background/global-action-creators/global-action-creator.ts
+++ b/src/background/global-action-creators/global-action-creator.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
-
 import { Messages } from '../../common/messages';
 import * as TelemetryEvents from '../../common/telemetry-events';
 import { PayloadWithEventName, SetLaunchPanelState } from '../actions/action-payloads';
@@ -9,7 +8,6 @@ import { CommandActions, GetCommandsPayload } from '../actions/command-actions';
 import { FeatureFlagActions } from '../actions/feature-flag-actions';
 import { GlobalActionHub } from '../actions/global-action-hub';
 import { LaunchPanelStateActions } from '../actions/launch-panel-state-action';
-import { ScopingActions } from '../actions/scoping-actions';
 import { CommandsAdapter } from '../browser-adapters/commands-adapter';
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
@@ -22,7 +20,6 @@ export class GlobalActionCreator {
     private commandActions: CommandActions;
     private featureFlagActions: FeatureFlagActions;
     private launchPanelStateActions: LaunchPanelStateActions;
-    private scopingActions: ScopingActions;
 
     constructor(
         globalActionHub: GlobalActionHub,
@@ -36,7 +33,6 @@ export class GlobalActionCreator {
         this.commandActions = globalActionHub.commandActions;
         this.featureFlagActions = globalActionHub.featureFlagActions;
         this.launchPanelStateActions = globalActionHub.launchPanelStateActions;
-        this.scopingActions = globalActionHub.scopingActions;
     }
 
     public registerCallbacks(): void {
@@ -47,10 +43,6 @@ export class GlobalActionCreator {
 
         this.interpreter.registerTypeToPayloadCallback(Messages.LaunchPanel.Get, this.onGetLaunchPanelState);
         this.interpreter.registerTypeToPayloadCallback(Messages.LaunchPanel.Set, this.onSetLaunchPanelState);
-
-        this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.GetCurrentState, this.onGetScopingState);
-        this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.AddSelector, this.onAddSelector);
-        this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.DeleteSelector, this.onDeleteSelector);
 
         this.interpreter.registerTypeToPayloadCallback(Messages.Telemetry.Send, this.onSendTelemetry);
     }
@@ -90,21 +82,6 @@ export class GlobalActionCreator {
     @autobind
     private onSetLaunchPanelState(payload: SetLaunchPanelState): void {
         this.launchPanelStateActions.setLaunchPanelType.invoke(payload.launchPanelType);
-    }
-
-    @autobind
-    private onGetScopingState(): void {
-        this.scopingActions.getCurrentState.invoke(null);
-    }
-
-    @autobind
-    private onAddSelector(payload): void {
-        this.scopingActions.addSelector.invoke(payload);
-    }
-
-    @autobind
-    private onDeleteSelector(payload): void {
-        this.scopingActions.deleteSelector.invoke(payload);
     }
 
     @autobind

--- a/src/background/global-action-creators/scoping-action-creator.ts
+++ b/src/background/global-action-creators/scoping-action-creator.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Messages } from '../../common/messages';
+import { ScopingActions, ScopingPayload } from '../actions/scoping-actions';
+import { Interpreter } from '../interpreter';
+
+export class ScopingActionCreator {
+    constructor(private readonly interpreter: Interpreter, private readonly scopingActions: ScopingActions) {}
+
+    public registerCallback(): void {
+        this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.GetCurrentState, this.onGetScopingState);
+        this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.AddSelector, this.onAddSelector);
+        this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.DeleteSelector, this.onDeleteSelector);
+    }
+
+    private onGetScopingState = (): void => {
+        this.scopingActions.getCurrentState.invoke(null);
+    };
+
+    private onAddSelector = (payload: ScopingPayload): void => {
+        this.scopingActions.addSelector.invoke(payload);
+    };
+
+    private onDeleteSelector = (payload: ScopingPayload): void => {
+        this.scopingActions.deleteSelector.invoke(payload);
+    };
+}

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -17,6 +17,7 @@ import { FeatureFlagsController } from './feature-flags-controller';
 import { PersistedData } from './get-persisted-data';
 import { GlobalActionCreator } from './global-action-creators/global-action-creator';
 import { IssueFilingActionCreator } from './global-action-creators/issue-filing-action-creator';
+import { ScopingActionCreator } from './global-action-creators/scoping-action-creator';
 import { UserConfigurationActionCreator } from './global-action-creators/user-configuration-action-creator';
 import { GlobalContext } from './global-context';
 import { Interpreter } from './interpreter';
@@ -63,6 +64,7 @@ export class GlobalContextFactory {
             globalStoreHub.userConfigurationStore,
         );
 
+        const scopingActionCreator = new ScopingActionCreator(interpreter, globalActionsHub.scopingActions);
         const issueFilingActionCreator = new IssueFilingActionCreator(interpreter, telemetryEventHandler, issueFilingController);
         const actionCreator = new GlobalActionCreator(globalActionsHub, interpreter, commandsAdapter, telemetryEventHandler);
         const assessmentActionCreator = new AssessmentActionCreator(
@@ -76,6 +78,7 @@ export class GlobalContextFactory {
         actionCreator.registerCallbacks();
         assessmentActionCreator.registerCallbacks();
         userConfigurationActionCreator.registerCallback();
+        scopingActionCreator.registerCallback();
 
         const dispatcher = new StateDispatcher(browserAdapter.sendMessageToAllFramesAndTabs, globalStoreHub);
         dispatcher.initialize();

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -12,7 +12,7 @@ import { ContentActionCreator } from './actions/content-action-creator';
 import { DetailsViewActionCreator } from './actions/details-view-action-creator';
 import { DevToolsActionCreator } from './actions/dev-tools-action-creator';
 import { InspectActionCreator } from './actions/inspect-action-creator';
-import { ScopingActionCreator } from './actions/scoping-action-creator';
+import { ScopingPanelActionCreator } from './actions/scoping-panel-action-creator';
 import { TabActionCreator } from './actions/tab-action-creator';
 import { AssessmentScanPolicyRunner } from './assessment-scan-policy-runner';
 import { BrowserAdapter } from './browser-adapters/browser-adapter';
@@ -89,7 +89,7 @@ export class TabContextFactory {
             interpreter.registerTypeToPayloadCallback,
         );
 
-        const scopingActionCreator = new ScopingActionCreator(
+        const scopingPanelActionCreator = new ScopingPanelActionCreator(
             actionsHub.scopingActions,
             this.telemetryEventHandler,
             interpreter.registerTypeToPayloadCallback,
@@ -127,7 +127,7 @@ export class TabContextFactory {
         devToolsActionCreator.registerCallbacks();
         inspectActionsCreator.registerCallbacks();
         tabActionCreator.registerCallbacks();
-        scopingActionCreator.registerCallbacks();
+        scopingPanelActionCreator.registerCallbacks();
         contentActionCreator.registerCallbacks();
 
         injectorController.initialize();

--- a/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
@@ -3,8 +3,8 @@
 import * as _ from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { BaseActionPayload } from '../../../../../background/actions/action-payloads';
-import { ScopingActionCreator } from '../../../../../background/actions/scoping-action-creator';
 import { ScopingActions } from '../../../../../background/actions/scoping-actions';
+import { ScopingPanelActionCreator } from '../../../../../background/actions/scoping-panel-action-creator';
 import { DetailsViewController } from '../../../../../background/details-view-controller';
 import { TelemetryEventHandler } from '../../../../../background/telemetry/telemetry-event-handler';
 import { Action } from '../../../../../common/flux/action';
@@ -12,13 +12,13 @@ import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
 import { Messages } from '../../../../../common/messages';
 import { SCOPING_CLOSE, SCOPING_OPEN } from '../../../../../common/telemetry-events';
 
-describe('ScopingActionCreatorTest', () => {
+describe('ScopingPanelActionCreatorTest', () => {
     let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
     let scopingActionsMock: IMock<ScopingActions>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let detailsViewControllerStrictMock: IMock<DetailsViewController>;
     const tabId = -1;
-    let testObject: ScopingActionCreator;
+    let testObject: ScopingPanelActionCreator;
 
     beforeEach(() => {
         scopingActionsMock = Mock.ofType(ScopingActions, MockBehavior.Strict);
@@ -26,7 +26,7 @@ describe('ScopingActionCreatorTest', () => {
         detailsViewControllerStrictMock = Mock.ofType<DetailsViewController>(null, MockBehavior.Strict);
         registerTypeToPayloadCallbackMock = Mock.ofInstance((theType, callback) => {});
 
-        testObject = new ScopingActionCreator(
+        testObject = new ScopingPanelActionCreator(
             scopingActionsMock.object,
             telemetryEventHandlerMock.object,
             registerTypeToPayloadCallbackMock.object,

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { SetLaunchPanelState } from '../../../../../background/actions/action-payloads';
 import { AssessmentActions } from '../../../../../background/actions/assessment-actions';
 import { CommandActions } from '../../../../../background/actions/command-actions';
 import { FeatureFlagActions, FeatureFlagPayload } from '../../../../../background/actions/feature-flag-actions';
 import { GlobalActionHub } from '../../../../../background/actions/global-action-hub';
 import { LaunchPanelStateActions } from '../../../../../background/actions/launch-panel-state-action';
-import { ScopingActions, ScopingPayload } from '../../../../../background/actions/scoping-actions';
 import { UserConfigurationActions } from '../../../../../background/actions/user-configuration-actions';
 import { CommandsAdapter } from '../../../../../background/browser-adapters/commands-adapter';
 import { GlobalActionCreator } from '../../../../../background/global-action-creators/global-action-creator';
@@ -128,59 +126,6 @@ describe('GlobalActionCreatorTest', () => {
         validator.verifyAll();
     });
 
-    test('registerCallback for on onGetScopingState', () => {
-        const actionName = 'getCurrentState';
-        const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Scoping.GetCurrentState)
-            .setupActionsOnScoping(actionName)
-            .setupScopingActionWithInvokeParameter(actionName, null);
-
-        const actionCreator = validator.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        validator.verifyAll();
-    });
-
-    test('registerCallback for onAddSelector', () => {
-        const actionName = 'addSelector';
-        const payload: ScopingPayload = {
-            inputType: 'generic',
-            selector: ['iframe', 'selector'],
-        };
-
-        const args = [payload];
-
-        const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Scoping.AddSelector, args)
-            .setupActionsOnScoping(actionName)
-            .setupScopingActionWithInvokeParameter(actionName, payload);
-
-        const actionCreator = validator.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        validator.verifyAll();
-    });
-
-    test('registerCallback for onDeleteSelector', () => {
-        const actionName = 'deleteSelector';
-        const payload: ScopingPayload = {
-            inputType: 'generic',
-            selector: ['iframe', 'selector'],
-        };
-
-        const args = [payload];
-
-        const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Scoping.DeleteSelector, args)
-            .setupActionsOnScoping(actionName)
-            .setupScopingActionWithInvokeParameter(actionName, payload);
-
-        const actionCreator = validator.buildActionCreator();
-        actionCreator.registerCallbacks();
-
-        validator.verifyAll();
-    });
-
     test('registerCallback for on onSendTelemetry', () => {
         const payload = { eventName: 'launch-panel/open', telemetry: {} };
         const args = [payload, 1];
@@ -200,12 +145,10 @@ class GlobalActionCreatorValidator {
     private commandActionMocksMap: DictionaryStringTo<IMock<Action<any>>> = {};
     private featureFlagActionsMockMap: DictionaryStringTo<IMock<Action<any>>> = {};
     private launchPanelActionsMockMap: DictionaryStringTo<IMock<Action<any>>> = {};
-    private scopingActionsMockMap: DictionaryStringTo<IMock<Action<any>>> = {};
 
     private commandActionsContainerMock = Mock.ofType(CommandActions);
     private featureFlagActionsContainerMock = Mock.ofType(FeatureFlagActions);
     private launchPanelStateActionsContainerMock = Mock.ofType(LaunchPanelStateActions);
-    private scopingActionsContainerMock = Mock.ofType(ScopingActions);
     private assessmentActionsContainerMock = Mock.ofType(AssessmentActions);
     private userConfigActionsContainerMock = Mock.ofType(UserConfigurationActions);
     private interpreterMock = Mock.ofType<Interpreter>();
@@ -217,7 +160,7 @@ class GlobalActionCreatorValidator {
         commandActions: this.commandActionsContainerMock.object,
         featureFlagActions: this.featureFlagActionsContainerMock.object,
         launchPanelStateActions: this.launchPanelStateActionsContainerMock.object,
-        scopingActions: this.scopingActionsContainerMock.object,
+        scopingActions: null,
         assessmentActions: this.assessmentActionsContainerMock.object,
         userConfigurationActions: this.userConfigActionsContainerMock.object,
     };
@@ -234,10 +177,6 @@ class GlobalActionCreatorValidator {
 
     public setupActionOnLaunchPanelActions(actionName: string): GlobalActionCreatorValidator {
         return this.setupAction(actionName, this.launchPanelStateActionsContainerMock, this.launchPanelActionsMockMap);
-    }
-
-    public setupActionsOnScoping(actionName: keyof ScopingActions): GlobalActionCreatorValidator {
-        return this.setupAction(actionName, this.scopingActionsContainerMock, this.scopingActionsMockMap);
     }
 
     public setupGetCommandsFromAdapter(commands: chrome.commands.Command[]): GlobalActionCreatorValidator {
@@ -262,10 +201,6 @@ class GlobalActionCreatorValidator {
         expectedInvokeParam: any,
     ): GlobalActionCreatorValidator {
         return this.setupActionWithInvokeParameter(actionName, expectedInvokeParam, this.launchPanelActionsMockMap);
-    }
-
-    public setupScopingActionWithInvokeParameter(actionName: keyof ScopingActions, expectedInvokeParam: any): GlobalActionCreatorValidator {
-        return this.setupActionWithInvokeParameter(actionName, expectedInvokeParam, this.scopingActionsMockMap);
     }
 
     private setupActionWithInvokeParameter(
@@ -350,7 +285,6 @@ class GlobalActionCreatorValidator {
         this.verifyAllActions(this.commandActionMocksMap);
         this.verifyAllActions(this.featureFlagActionsMockMap);
         this.verifyAllActions(this.launchPanelActionsMockMap);
-        this.verifyAllActions(this.scopingActionsMockMap);
     }
 
     private verifyAllActions(actionsMap: DictionaryStringTo<IMock<Action<any>>>): void {

--- a/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
@@ -23,10 +23,10 @@ describe('ScopingActionCreator', () => {
     });
 
     it('handles GetcurrentState', () => {
-        const message = Messages.Scoping.GetCurrentState;
+        const expectedMessage = Messages.Scoping.GetCurrentState;
 
         interpreterMock
-            .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
+            .setup(interpreter => interpreter.registerTypeToPayloadCallback(expectedMessage, It.is(isFunction)))
             .callback((message, handler) => handler());
 
         const getCurrentStateMock = Mock.ofType<Action<void>>();
@@ -40,7 +40,7 @@ describe('ScopingActionCreator', () => {
     });
 
     it('handles AddSelector', () => {
-        const message = Messages.Scoping.AddSelector;
+        const expectedMessage = Messages.Scoping.AddSelector;
 
         const payload: ScopingPayload = {
             inputType: 'include',
@@ -48,7 +48,7 @@ describe('ScopingActionCreator', () => {
         };
 
         interpreterMock
-            .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
+            .setup(interpreter => interpreter.registerTypeToPayloadCallback(expectedMessage, It.is(isFunction)))
             .callback((message, handler) => handler(payload));
 
         const addSelectorMock = Mock.ofType<Action<ScopingPayload>>();
@@ -62,7 +62,7 @@ describe('ScopingActionCreator', () => {
     });
 
     it('handles DeleteSelector', () => {
-        const message = Messages.Scoping.DeleteSelector;
+        const expectedMessage = Messages.Scoping.DeleteSelector;
 
         const payload: ScopingPayload = {
             inputType: 'include',
@@ -70,7 +70,7 @@ describe('ScopingActionCreator', () => {
         };
 
         interpreterMock
-            .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
+            .setup(interpreter => interpreter.registerTypeToPayloadCallback(expectedMessage, It.is(isFunction)))
             .callback((message, handler) => handler(payload));
 
         const deleteSelectorMock = Mock.ofType<Action<ScopingPayload>>();

--- a/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { isFunction } from 'lodash';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+import { ScopingActions, ScopingPayload } from '../../../../../background/actions/scoping-actions';
+import { ScopingActionCreator } from '../../../../../background/global-action-creators/scoping-action-creator';
+import { Interpreter } from '../../../../../background/interpreter';
+import { Action } from '../../../../../common/flux/action';
+import { Messages } from '../../../../../common/messages';
+
+describe('ScopingActionCreator', () => {
+    let interpreterMock: IMock<Interpreter>;
+    let scopingActionsMock: IMock<ScopingActions>;
+
+    let testSubject: ScopingActionCreator;
+
+    beforeEach(() => {
+        interpreterMock = Mock.ofType<Interpreter>();
+        scopingActionsMock = Mock.ofType<ScopingActions>();
+
+        testSubject = new ScopingActionCreator(interpreterMock.object, scopingActionsMock.object);
+    });
+
+    it('handles GetcurrentState', () => {
+        const message = Messages.Scoping.GetCurrentState;
+
+        interpreterMock
+            .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
+            .callback((message, handler) => handler());
+
+        const getCurrentStateMock = Mock.ofType<Action<void>>();
+        getCurrentStateMock.setup(action => action.invoke(null)).verifiable(Times.once());
+
+        scopingActionsMock.setup(actions => actions['getCurrentState']).returns(() => getCurrentStateMock.object);
+
+        testSubject.registerCallback();
+
+        getCurrentStateMock.verifyAll();
+    });
+
+    it('handles AddSelector', () => {
+        const message = Messages.Scoping.AddSelector;
+
+        const payload: ScopingPayload = {
+            inputType: 'include',
+            selector: ['html'],
+        };
+
+        interpreterMock
+            .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
+            .callback((message, handler) => handler(payload));
+
+        const addSelectorMock = Mock.ofType<Action<ScopingPayload>>();
+        addSelectorMock.setup(action => action.invoke(payload)).verifiable(Times.once());
+
+        scopingActionsMock.setup(actions => actions['addSelector']).returns(() => addSelectorMock.object);
+
+        testSubject.registerCallback();
+
+        addSelectorMock.verifyAll();
+    });
+
+    it('handles DeleteSelector', () => {
+        const message = Messages.Scoping.DeleteSelector;
+
+        const payload: ScopingPayload = {
+            inputType: 'include',
+            selector: ['html'],
+        };
+
+        interpreterMock
+            .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
+            .callback((message, handler) => handler(payload));
+
+        const deleteSelectorMock = Mock.ofType<Action<ScopingPayload>>();
+        deleteSelectorMock.setup(action => action.invoke(payload)).verifiable(Times.once());
+
+        scopingActionsMock.setup(actions => actions['deleteSelector']).returns(() => deleteSelectorMock.object);
+
+        testSubject.registerCallback();
+
+        deleteSelectorMock.verifyAll();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Move scoping related functionality out of the `GlobalActionCreator` and into the new `ScopingActionCreator`. Cleaning `GlobalActionCreator` so we get classes/objects that follow Single Responsibility Principle.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not apply
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
