### PR TITLE
refactor: remove git hub text generator

### DIFF
--- a/src/background/issue-details-text-generator.ts
+++ b/src/background/issue-details-text-generator.ts
@@ -36,35 +36,6 @@ export class IssueDetailsTextGenerator {
         return text;
     }
 
-    public buildGithubText(data: CreateIssueDetailsTextData): string {
-        const result = data.ruleResult;
-
-        const text = [
-            `**Issue**: \`${result.help}\` ([\`${result.ruleId}\`](${result.helpUrl}))`,
-            ``,
-            `**Target application**: [${data.pageTitle}](${data.pageUrl})`,
-            ``,
-            `**Element path**: ${data.ruleResult.selector}`,
-            ``,
-            `**Snippet**:`,
-            ``,
-            `    ${this.collapseConsecutiveSpaces(result.snippet)}`,
-            ``,
-            `**How to fix**:`,
-            ``,
-            `${this.markdownEscapeBlock(result.failureSummary)}`,
-            ``,
-            `**Environment**:`,
-            `${this.browserSpec}`,
-            ``,
-            `====`,
-            ``,
-            this.footer,
-        ].join('\n');
-
-        return text;
-    }
-
     private get footer(): string {
         return (
             'This accessibility issue was found using Accessibility Insights for Web ' +
@@ -76,13 +47,6 @@ export class IssueDetailsTextGenerator {
 
     private collapseConsecutiveSpaces(input: string): string {
         return input.replace(/\s+/g, ' ');
-    }
-
-    private markdownEscapeBlock(input: string): string {
-        return input
-            .split('\n')
-            .map(line => `    ${line}`)
-            .join('\n');
     }
 
     public buildTitle(data: CreateIssueDetailsTextData, standardTags?: string[]): string {

--- a/src/tests/unit/tests/background/issue-details-text-generator.test.ts
+++ b/src/tests/unit/tests/background/issue-details-text-generator.test.ts
@@ -56,35 +56,6 @@ describe('Issue details text builder', () => {
         expect(actual).toEqual(expected);
     });
 
-    test('buildGithubText', () => {
-        const actual = testSubject.buildGithubText(sampleIssueDetailsData);
-        const expected = [
-            `**Issue**: \`RR-help\` ([\`RR-rule-id\`](RR-help-url))`,
-            ``,
-            `**Target application**: [pageTitle<x>](pageUrl)`,
-            ``,
-            `**Element path**: RR-selector<x>`,
-            ``,
-            `**Snippet**:`,
-            ``,
-            `    RR-snippet space`,
-            ``,
-            `**How to fix**:`,
-            ``,
-            `    RR-failureSummary`,
-            ``,
-            `**Environment**:`,
-            `browser spec`,
-            ``,
-            `====`,
-            ``,
-            'This accessibility issue was found using Accessibility Insights for Web MY.EXT.VER (axe-core AXE.CORE.VER), ' +
-                'a tool that helps find and fix accessibility issues. Get more information & download ' +
-                'this tool at http://aka.ms/AccessibilityInsights.',
-        ].join('\n');
-        expect(actual).toEqual(expected);
-    });
-
     const noStandardTags = [];
     const oneStandardTag = ['WCAG-1.4.1'];
     const manyStandardTags = ['WCAG-1.4.1', 'WCAG-2.8.2', 'WCAG-4.1.4'];


### PR DESCRIPTION
#### Description of changes

Remove text builder for git hub issues from old class (not really being used anymore)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not apply
- [x] ~~Added~~Updated relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
