### PR TITLE
fix: issue details dialog on shadow dom

### DIFF
--- a/src/injected/components/details-dialog.tsx
+++ b/src/injected/components/details-dialog.tsx
@@ -114,7 +114,7 @@ export class DetailsDialog extends React.Component<DetailsDialogProps, DetailsDi
             showDialog: true,
             currentRuleIndex: 0,
             canInspect: true,
-            userConfigurationStoreData: null,
+            userConfigurationStoreData: props.userConfigStore.getState(),
         };
     }
 

--- a/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
@@ -180,7 +180,6 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
             }
           }
           needsSettingsContentRenderer={[Function]}
-          userConfigurationStoreData={null}
         />
       </React.Fragment>
       <div
@@ -268,7 +267,9 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
               "shadowDialog": false,
             },
             "target": Array [],
-            "userConfigStore": Object {},
+            "userConfigStore": Object {
+              "getState": [Function],
+            },
           },
           "refs": Object {},
           "setState": [Function],
@@ -276,7 +277,7 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
             "canInspect": true,
             "currentRuleIndex": 0,
             "showDialog": true,
-            "userConfigurationStoreData": null,
+            "userConfigurationStoreData": undefined,
           },
           "updater": Updater {
             "_callbacks": Array [],
@@ -355,7 +356,11 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
                   }
                 }
                 target={Array []}
-                userConfigStore={Object {}}
+                userConfigStore={
+                  Object {
+                    "getState": [Function],
+                  }
+                }
               />,
               "_firstWorkInProgressHook": null,
               "_forcedUpdate": false,
@@ -543,7 +548,6 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
                           }
                         }
                         needsSettingsContentRenderer={[Function]}
-                        userConfigurationStoreData={null}
                       />
                     </React.Fragment>
                     <div
@@ -674,7 +678,7 @@ Object {
   "canInspect": true,
   "currentRuleIndex": 0,
   "showDialog": true,
-  "userConfigurationStoreData": null,
+  "userConfigurationStoreData": undefined,
 }
 `;
 
@@ -862,7 +866,6 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: true }
               }
             }
             needsSettingsContentRenderer={[Function]}
-            userConfigurationStoreData={null}
           />
         </React.Fragment>
         <div
@@ -950,7 +953,9 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: true }
                 "shadowDialog": true,
               },
               "target": Array [],
-              "userConfigStore": Object {},
+              "userConfigStore": Object {
+                "getState": [Function],
+              },
             },
             "refs": Object {},
             "setState": [Function],
@@ -958,7 +963,7 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: true }
               "canInspect": true,
               "currentRuleIndex": 0,
               "showDialog": true,
-              "userConfigurationStoreData": null,
+              "userConfigurationStoreData": undefined,
             },
             "updater": Updater {
               "_callbacks": Array [],
@@ -1037,7 +1042,11 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: true }
                     }
                   }
                   target={Array []}
-                  userConfigStore={Object {}}
+                  userConfigStore={
+                    Object {
+                      "getState": [Function],
+                    }
+                  }
                 />,
                 "_firstWorkInProgressHook": null,
                 "_forcedUpdate": false,
@@ -1229,7 +1238,6 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: true }
                               }
                             }
                             needsSettingsContentRenderer={[Function]}
-                            userConfigurationStoreData={null}
                           />
                         </React.Fragment>
                         <div
@@ -1360,7 +1368,7 @@ Object {
   "canInspect": true,
   "currentRuleIndex": 0,
   "showDialog": true,
-  "userConfigurationStoreData": null,
+  "userConfigurationStoreData": undefined,
 }
 `;
 
@@ -1544,7 +1552,6 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
             }
           }
           needsSettingsContentRenderer={[Function]}
-          userConfigurationStoreData={null}
         />
       </React.Fragment>
     </div>
@@ -1627,7 +1634,9 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
               "shadowDialog": false,
             },
             "target": Array [],
-            "userConfigStore": Object {},
+            "userConfigStore": Object {
+              "getState": [Function],
+            },
           },
           "refs": Object {},
           "setState": [Function],
@@ -1635,7 +1644,7 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
             "canInspect": true,
             "currentRuleIndex": 0,
             "showDialog": true,
-            "userConfigurationStoreData": null,
+            "userConfigurationStoreData": undefined,
           },
           "updater": Updater {
             "_callbacks": Array [],
@@ -1714,7 +1723,11 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
                   }
                 }
                 target={Array []}
-                userConfigStore={Object {}}
+                userConfigStore={
+                  Object {
+                    "getState": [Function],
+                  }
+                }
               />,
               "_firstWorkInProgressHook": null,
               "_forcedUpdate": false,
@@ -1902,7 +1915,6 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
                           }
                         }
                         needsSettingsContentRenderer={[Function]}
-                        userConfigurationStoreData={null}
                       />
                     </React.Fragment>
                   </div>
@@ -2028,7 +2040,7 @@ Object {
   "canInspect": true,
   "currentRuleIndex": 0,
   "showDialog": true,
-  "userConfigurationStoreData": null,
+  "userConfigurationStoreData": undefined,
 }
 `;
 
@@ -2216,7 +2228,6 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: true } 
               }
             }
             needsSettingsContentRenderer={[Function]}
-            userConfigurationStoreData={null}
           />
         </React.Fragment>
       </div>
@@ -2299,7 +2310,9 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: true } 
                 "shadowDialog": true,
               },
               "target": Array [],
-              "userConfigStore": Object {},
+              "userConfigStore": Object {
+                "getState": [Function],
+              },
             },
             "refs": Object {},
             "setState": [Function],
@@ -2307,7 +2320,7 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: true } 
               "canInspect": true,
               "currentRuleIndex": 0,
               "showDialog": true,
-              "userConfigurationStoreData": null,
+              "userConfigurationStoreData": undefined,
             },
             "updater": Updater {
               "_callbacks": Array [],
@@ -2386,7 +2399,11 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: true } 
                     }
                   }
                   target={Array []}
-                  userConfigStore={Object {}}
+                  userConfigStore={
+                    Object {
+                      "getState": [Function],
+                    }
+                  }
                 />,
                 "_firstWorkInProgressHook": null,
                 "_forcedUpdate": false,
@@ -2578,7 +2595,6 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: true } 
                               }
                             }
                             needsSettingsContentRenderer={[Function]}
-                            userConfigurationStoreData={null}
                           />
                         </React.Fragment>
                       </div>
@@ -2704,7 +2720,7 @@ Object {
   "canInspect": true,
   "currentRuleIndex": 0,
   "showDialog": true,
-  "userConfigurationStoreData": null,
+  "userConfigurationStoreData": undefined,
 }
 `;
 
@@ -2888,7 +2904,6 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
             }
           }
           needsSettingsContentRenderer={[Function]}
-          userConfigurationStoreData={null}
         />
       </React.Fragment>
       <div
@@ -2976,7 +2991,9 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
               "shadowDialog": false,
             },
             "target": Array [],
-            "userConfigStore": Object {},
+            "userConfigStore": Object {
+              "getState": [Function],
+            },
           },
           "refs": Object {},
           "setState": [Function],
@@ -2984,7 +3001,7 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
             "canInspect": true,
             "currentRuleIndex": 0,
             "showDialog": true,
-            "userConfigurationStoreData": null,
+            "userConfigurationStoreData": undefined,
           },
           "updater": Updater {
             "_callbacks": Array [],
@@ -3063,7 +3080,11 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
                   }
                 }
                 target={Array []}
-                userConfigStore={Object {}}
+                userConfigStore={
+                  Object {
+                    "getState": [Function],
+                  }
+                }
               />,
               "_firstWorkInProgressHook": null,
               "_forcedUpdate": false,
@@ -3251,7 +3272,6 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
                           }
                         }
                         needsSettingsContentRenderer={[Function]}
-                        userConfigurationStoreData={null}
                       />
                     </React.Fragment>
                     <div
@@ -3382,6 +3402,6 @@ Object {
   "canInspect": true,
   "currentRuleIndex": 0,
   "showDialog": true,
-  "userConfigurationStoreData": null,
+  "userConfigurationStoreData": undefined,
 }
 `;

--- a/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
       "topButtonsProps": Array [
         Object {
           "ariaLabel": "Close",
-          "onClick": Object {},
+          "onClick": [Function],
           "onRenderIcon": [Function],
         },
       ],
@@ -26,11 +26,11 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
       "layerProps": Object {
         "className": "insights-dialog-main-override",
         "hostId": "insights-dialog-layer-host",
-        "onLayerDidMount": Object {},
+        "onLayerDidMount": [Function],
       },
     }
   }
-  onDismiss={Object {}}
+  onDismiss={[Function]}
   title="help"
 >
   <div
@@ -208,15 +208,15 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
         DetailsDialog {
           "componentDidMount": [Function],
           "componentWillUnmount": [Function],
-          "context": undefined,
+          "context": Object {},
           "isBackButtonDisabled": [Function],
           "isInspectButtonDisabled": [Function],
           "isNextButtonDisabled": [Function],
-          "onClickBackButton": Object {},
+          "onClickBackButton": [Function],
           "onClickInspectButton": [Function],
-          "onClickNextButton": Object {},
-          "onHideDialog": Object {},
-          "onLayoutDidMount": Object {},
+          "onClickNextButton": [Function],
+          "onHideDialog": [Function],
+          "onLayoutDidMount": [Function],
           "props": Object {
             "deps": Object {
               "clientBrowserAdapter": Object {
@@ -271,17 +271,326 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
             "userConfigStore": Object {},
           },
           "refs": Object {},
+          "setState": [Function],
           "state": Object {
             "canInspect": true,
             "currentRuleIndex": 0,
             "showDialog": true,
             "userConfigurationStoreData": null,
           },
-          "updater": Object {
-            "enqueueForceUpdate": [Function],
-            "enqueueReplaceState": [Function],
-            "enqueueSetState": [Function],
-            "isMounted": [Function],
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_didScheduleRenderPhaseUpdate": false,
+              "_dispatcher": Object {
+                "readContext": [Function],
+                "useCallback": [Function],
+                "useContext": [Function],
+                "useDebugValue": [Function],
+                "useEffect": [Function],
+                "useImperativeHandle": [Function],
+                "useLayoutEffect": [Function],
+                "useMemo": [Function],
+                "useReducer": [Function],
+                "useRef": [Function],
+                "useState": [Function],
+              },
+              "_element": <DetailsDialog
+                deps={
+                  Object {
+                    "clientBrowserAdapter": Object {
+                      "getUrl": [Function],
+                    },
+                    "issueDetailsTextGenerator": null,
+                    "issueFilingActionMessageCreator": null,
+                    "targetPageActionMessageCreator": Object {
+                      "copyIssueDetailsClicked": [Function],
+                    },
+                    "windowUtils": null,
+                  }
+                }
+                devToolActionMessageCreator={Object {}}
+                devToolStore={Object {}}
+                devToolsShortcut="shortcut"
+                dialogHandler={
+                  Object {
+                    "componentDidMount": [Function],
+                    "getFailureInfo": [Function],
+                    "getRuleUrl": [Function],
+                    "isBackButtonDisabled": [Function],
+                    "isInspectButtonDisabled": [Function],
+                    "isNextButtonDisabled": [Function],
+                  }
+                }
+                elementSelector="ruleId"
+                failedRules={
+                  Object {
+                    "ruleId": Object {
+                      "all": Array [],
+                      "any": Array [],
+                      "failureSummary": "failureSummary",
+                      "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                      "guidanceLinks": Array [
+                        Object {
+                          "href": "http://example.com",
+                          "text": "Guidance Link",
+                        },
+                      ],
+                      "help": "help",
+                      "helpUrl": "http://extension/help1",
+                      "html": "html",
+                      "id": "id1",
+                      "none": Array [],
+                      "ruleId": "ruleId",
+                      "selector": "selector",
+                      "snippet": "html",
+                      "status": false,
+                    },
+                  }
+                }
+                featureFlagStoreData={
+                  Object {
+                    "shadowDialog": false,
+                  }
+                }
+                target={Array []}
+                userConfigStore={Object {}}
+              />,
+              "_firstWorkInProgressHook": null,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_isReRender": false,
+              "_newState": null,
+              "_numberOfReRenders": 0,
+              "_renderPhaseUpdates": null,
+              "_rendered": <StyledWithResponsiveMode
+                dialogContentProps={
+                  Object {
+                    "showCloseButton": false,
+                    "styles": Object {
+                      "title": "insights-dialog-title",
+                    },
+                    "topButtonsProps": Array [
+                      Object {
+                        "ariaLabel": "Close",
+                        "onClick": [Function],
+                        "onRenderIcon": [Function],
+                      },
+                    ],
+                    "type": 0,
+                  }
+                }
+                hidden={false}
+                modalProps={
+                  Object {
+                    "containerClassName": "insights-dialog-main-container",
+                    "isBlocking": false,
+                    "layerProps": Object {
+                      "className": "insights-dialog-main-override",
+                      "hostId": "insights-dialog-layer-host",
+                      "onLayerDidMount": [Function],
+                    },
+                  }
+                }
+                onDismiss={[Function]}
+                title="help"
+              >
+                <div
+                  className="insights-dialog-content"
+                >
+                  <div
+                    className="insights-dialog-rule-name"
+                  >
+                    <h3
+                      className="insights-dialog-section-title"
+                    >
+                      Rule name
+                    </h3>
+                    <NewTabLink
+                      href="http://extension/help1"
+                    >
+                      ruleId
+                    </NewTabLink>
+                  </div>
+                  <div
+                    className="insights-dialog-success-criteria"
+                  >
+                    <h3
+                      className="insights-dialog-section-title"
+                    >
+                      Success criterion
+                    </h3>
+                    <GuidanceLinks
+                      links={
+                        Array [
+                          Object {
+                            "href": "http://example.com",
+                            "text": "Guidance Link",
+                          },
+                        ]
+                      }
+                    />
+                  </div>
+                  <div
+                    className="insights-dialog-path-selector-container"
+                  >
+                    <h3
+                      className="insights-dialog-section-title"
+                    >
+                      Path
+                    </h3>
+                    ruleId
+                  </div>
+                  <div
+                    className="insights-dialog-target-button-container"
+                  >
+                    <CustomizedDefaultButton
+                      className="insights-dialog-button-inspect"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      <FileHTMLIcon />
+                      <div
+                        className="ms-Button-label"
+                      >
+                        Inspect HTML
+                      </div>
+                    </CustomizedDefaultButton>
+                    <React.Fragment>
+                      <CopyIssueDetailsButton
+                        deps={
+                          Object {
+                            "clientBrowserAdapter": Object {
+                              "getUrl": [Function],
+                            },
+                            "issueDetailsTextGenerator": null,
+                            "issueFilingActionMessageCreator": null,
+                            "targetPageActionMessageCreator": Object {
+                              "copyIssueDetailsClicked": [Function],
+                            },
+                            "windowUtils": null,
+                          }
+                        }
+                        issueDetailsData={
+                          Object {
+                            "pageTitle": "",
+                            "pageUrl": "http://localhost/",
+                            "ruleResult": Object {
+                              "all": Array [],
+                              "any": Array [],
+                              "failureSummary": "failureSummary",
+                              "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                              "guidanceLinks": Array [
+                                Object {
+                                  "href": "http://example.com",
+                                  "text": "Guidance Link",
+                                },
+                              ],
+                              "help": "help",
+                              "helpUrl": "http://extension/help1",
+                              "html": "html",
+                              "id": "id1",
+                              "none": Array [],
+                              "ruleId": "ruleId",
+                              "selector": "selector",
+                              "snippet": "html",
+                              "status": false,
+                            },
+                          }
+                        }
+                        onClick={[Function]}
+                      />
+                      <IssueFilingButton
+                        deps={
+                          Object {
+                            "clientBrowserAdapter": Object {
+                              "getUrl": [Function],
+                            },
+                            "issueDetailsTextGenerator": null,
+                            "issueFilingActionMessageCreator": null,
+                            "targetPageActionMessageCreator": Object {
+                              "copyIssueDetailsClicked": [Function],
+                            },
+                            "windowUtils": null,
+                          }
+                        }
+                        issueDetailsData={
+                          Object {
+                            "pageTitle": "",
+                            "pageUrl": "http://localhost/",
+                            "ruleResult": Object {
+                              "all": Array [],
+                              "any": Array [],
+                              "failureSummary": "failureSummary",
+                              "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                              "guidanceLinks": Array [
+                                Object {
+                                  "href": "http://example.com",
+                                  "text": "Guidance Link",
+                                },
+                              ],
+                              "help": "help",
+                              "helpUrl": "http://extension/help1",
+                              "html": "html",
+                              "id": "id1",
+                              "none": Array [],
+                              "ruleId": "ruleId",
+                              "selector": "selector",
+                              "snippet": "html",
+                              "status": false,
+                            },
+                          }
+                        }
+                        needsSettingsContentRenderer={[Function]}
+                        userConfigurationStoreData={null}
+                      />
+                    </React.Fragment>
+                    <div
+                      className="insights-dialog-inspect-disabled"
+                    >
+                      To enable the Inspect HTML button, open the developer tools (shortcut).
+                    </div>
+                  </div>
+                  <div
+                    className="insights-dialog-fix-instruction-container"
+                  >
+                    <FixInstructionPanel
+                      checkType={0}
+                      checks={Array []}
+                      renderTitleElement={[Function]}
+                    />
+                    <FixInstructionPanel
+                      checkType={1}
+                      checks={Array []}
+                      renderTitleElement={[Function]}
+                    />
+                  </div>
+                  <IssueDetailsNavigationControls
+                    container={[Circular]}
+                    dialogHandler={
+                      Object {
+                        "componentDidMount": [Function],
+                        "getFailureInfo": [Function],
+                        "getRuleUrl": [Function],
+                        "isBackButtonDisabled": [Function],
+                        "isInspectButtonDisabled": [Function],
+                        "isNextButtonDisabled": [Function],
+                      }
+                    }
+                    failuresCount={1}
+                    featureFlagStoreData={
+                      Object {
+                        "shadowDialog": false,
+                      }
+                    }
+                  />
+                </div>
+              </StyledWithResponsiveMode>,
+              "_rendering": false,
+              "_updater": [Circular],
+              "_workInProgressHook": null,
+            },
           },
         }
       }
@@ -581,15 +890,15 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: true }
           DetailsDialog {
             "componentDidMount": [Function],
             "componentWillUnmount": [Function],
-            "context": undefined,
+            "context": Object {},
             "isBackButtonDisabled": [Function],
             "isInspectButtonDisabled": [Function],
             "isNextButtonDisabled": [Function],
-            "onClickBackButton": Object {},
+            "onClickBackButton": [Function],
             "onClickInspectButton": [Function],
-            "onClickNextButton": Object {},
-            "onHideDialog": Object {},
-            "onLayoutDidMount": Object {},
+            "onClickNextButton": [Function],
+            "onHideDialog": [Function],
+            "onLayoutDidMount": [Function],
             "props": Object {
               "deps": Object {
                 "clientBrowserAdapter": Object {
@@ -644,17 +953,331 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: true }
               "userConfigStore": Object {},
             },
             "refs": Object {},
+            "setState": [Function],
             "state": Object {
               "canInspect": true,
               "currentRuleIndex": 0,
               "showDialog": true,
               "userConfigurationStoreData": null,
             },
-            "updater": Object {
-              "enqueueForceUpdate": [Function],
-              "enqueueReplaceState": [Function],
-              "enqueueSetState": [Function],
-              "isMounted": [Function],
+            "updater": Updater {
+              "_callbacks": Array [],
+              "_renderer": ReactShallowRenderer {
+                "_context": Object {},
+                "_didScheduleRenderPhaseUpdate": false,
+                "_dispatcher": Object {
+                  "readContext": [Function],
+                  "useCallback": [Function],
+                  "useContext": [Function],
+                  "useDebugValue": [Function],
+                  "useEffect": [Function],
+                  "useImperativeHandle": [Function],
+                  "useLayoutEffect": [Function],
+                  "useMemo": [Function],
+                  "useReducer": [Function],
+                  "useRef": [Function],
+                  "useState": [Function],
+                },
+                "_element": <DetailsDialog
+                  deps={
+                    Object {
+                      "clientBrowserAdapter": Object {
+                        "getUrl": [Function],
+                      },
+                      "issueDetailsTextGenerator": null,
+                      "issueFilingActionMessageCreator": null,
+                      "targetPageActionMessageCreator": Object {
+                        "copyIssueDetailsClicked": [Function],
+                      },
+                      "windowUtils": null,
+                    }
+                  }
+                  devToolActionMessageCreator={Object {}}
+                  devToolStore={Object {}}
+                  devToolsShortcut="shortcut"
+                  dialogHandler={
+                    Object {
+                      "componentDidMount": [Function],
+                      "getFailureInfo": [Function],
+                      "getRuleUrl": [Function],
+                      "isBackButtonDisabled": [Function],
+                      "isInspectButtonDisabled": [Function],
+                      "isNextButtonDisabled": [Function],
+                    }
+                  }
+                  elementSelector="ruleId"
+                  failedRules={
+                    Object {
+                      "ruleId": Object {
+                        "all": Array [],
+                        "any": Array [],
+                        "failureSummary": "failureSummary",
+                        "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                        "guidanceLinks": Array [
+                          Object {
+                            "href": "http://example.com",
+                            "text": "Guidance Link",
+                          },
+                        ],
+                        "help": "help",
+                        "helpUrl": "http://extension/help1",
+                        "html": "html",
+                        "id": "id1",
+                        "none": Array [],
+                        "ruleId": "ruleId",
+                        "selector": "selector",
+                        "snippet": "html",
+                        "status": false,
+                      },
+                    }
+                  }
+                  featureFlagStoreData={
+                    Object {
+                      "shadowDialog": true,
+                    }
+                  }
+                  target={Array []}
+                  userConfigStore={Object {}}
+                />,
+                "_firstWorkInProgressHook": null,
+                "_forcedUpdate": false,
+                "_instance": [Circular],
+                "_isReRender": false,
+                "_newState": null,
+                "_numberOfReRenders": 0,
+                "_renderPhaseUpdates": null,
+                "_rendered": <div
+                  className="insights-dialog-main-override-shadow"
+                  style={
+                    Object {
+                      "visibility": "visible",
+                    }
+                  }
+                >
+                  <div
+                    className="insights-dialog-container"
+                  >
+                    <div
+                      className="insights-dialog-header"
+                    >
+                      <p
+                        className="ms-Dialog-title insights-dialog-title"
+                      >
+                        help
+                      </p>
+                      <div
+                        className="ms-Dialog-topButton"
+                      >
+                        <button
+                          aria-label="Close"
+                          className="ms-Dialog-button ms-Dialog-button--close ms-Button ms-Button--icon insights-dialog-close"
+                          data-is-focusable="true"
+                          type="button"
+                        >
+                          <div
+                            className="ms-button-flex-container"
+                          >
+                            <CancelIcon />
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      className="insights-dialog-content"
+                    >
+                      <div
+                        className="insights-dialog-rule-name"
+                      >
+                        <h3
+                          className="insights-dialog-section-title"
+                        >
+                          Rule name
+                        </h3>
+                        <NewTabLink
+                          href="http://extension/help1"
+                        >
+                          ruleId
+                        </NewTabLink>
+                      </div>
+                      <div
+                        className="insights-dialog-success-criteria"
+                      >
+                        <h3
+                          className="insights-dialog-section-title"
+                        >
+                          Success criterion
+                        </h3>
+                        <GuidanceLinks
+                          links={
+                            Array [
+                              Object {
+                                "href": "http://example.com",
+                                "text": "Guidance Link",
+                              },
+                            ]
+                          }
+                        />
+                      </div>
+                      <div
+                        className="insights-dialog-path-selector-container"
+                      >
+                        <h3
+                          className="insights-dialog-section-title"
+                        >
+                          Path
+                        </h3>
+                        ruleId
+                      </div>
+                      <div
+                        className="insights-dialog-target-button-container"
+                      >
+                        <CustomizedDefaultButton
+                          className="insights-dialog-button-inspect"
+                          disabled={true}
+                          onClick={null}
+                        >
+                          <FileHTMLIcon />
+                          <div
+                            className="ms-Button-label"
+                          >
+                            Inspect HTML
+                          </div>
+                        </CustomizedDefaultButton>
+                        <React.Fragment>
+                          <CopyIssueDetailsButton
+                            deps={
+                              Object {
+                                "clientBrowserAdapter": Object {
+                                  "getUrl": [Function],
+                                },
+                                "issueDetailsTextGenerator": null,
+                                "issueFilingActionMessageCreator": null,
+                                "targetPageActionMessageCreator": Object {
+                                  "copyIssueDetailsClicked": [Function],
+                                },
+                                "windowUtils": null,
+                              }
+                            }
+                            issueDetailsData={
+                              Object {
+                                "pageTitle": "",
+                                "pageUrl": "http://localhost/",
+                                "ruleResult": Object {
+                                  "all": Array [],
+                                  "any": Array [],
+                                  "failureSummary": "failureSummary",
+                                  "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                                  "guidanceLinks": Array [
+                                    Object {
+                                      "href": "http://example.com",
+                                      "text": "Guidance Link",
+                                    },
+                                  ],
+                                  "help": "help",
+                                  "helpUrl": "http://extension/help1",
+                                  "html": "html",
+                                  "id": "id1",
+                                  "none": Array [],
+                                  "ruleId": "ruleId",
+                                  "selector": "selector",
+                                  "snippet": "html",
+                                  "status": false,
+                                },
+                              }
+                            }
+                            onClick={[Function]}
+                          />
+                          <IssueFilingButton
+                            deps={
+                              Object {
+                                "clientBrowserAdapter": Object {
+                                  "getUrl": [Function],
+                                },
+                                "issueDetailsTextGenerator": null,
+                                "issueFilingActionMessageCreator": null,
+                                "targetPageActionMessageCreator": Object {
+                                  "copyIssueDetailsClicked": [Function],
+                                },
+                                "windowUtils": null,
+                              }
+                            }
+                            issueDetailsData={
+                              Object {
+                                "pageTitle": "",
+                                "pageUrl": "http://localhost/",
+                                "ruleResult": Object {
+                                  "all": Array [],
+                                  "any": Array [],
+                                  "failureSummary": "failureSummary",
+                                  "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                                  "guidanceLinks": Array [
+                                    Object {
+                                      "href": "http://example.com",
+                                      "text": "Guidance Link",
+                                    },
+                                  ],
+                                  "help": "help",
+                                  "helpUrl": "http://extension/help1",
+                                  "html": "html",
+                                  "id": "id1",
+                                  "none": Array [],
+                                  "ruleId": "ruleId",
+                                  "selector": "selector",
+                                  "snippet": "html",
+                                  "status": false,
+                                },
+                              }
+                            }
+                            needsSettingsContentRenderer={[Function]}
+                            userConfigurationStoreData={null}
+                          />
+                        </React.Fragment>
+                        <div
+                          className="insights-dialog-inspect-disabled"
+                        >
+                          To enable the Inspect HTML button, open the developer tools (shortcut).
+                        </div>
+                      </div>
+                      <div
+                        className="insights-dialog-fix-instruction-container"
+                      >
+                        <FixInstructionPanel
+                          checkType={0}
+                          checks={Array []}
+                          renderTitleElement={[Function]}
+                        />
+                        <FixInstructionPanel
+                          checkType={1}
+                          checks={Array []}
+                          renderTitleElement={[Function]}
+                        />
+                      </div>
+                      <IssueDetailsNavigationControls
+                        container={[Circular]}
+                        dialogHandler={
+                          Object {
+                            "componentDidMount": [Function],
+                            "getFailureInfo": [Function],
+                            "getRuleUrl": [Function],
+                            "isBackButtonDisabled": [Function],
+                            "isInspectButtonDisabled": [Function],
+                            "isNextButtonDisabled": [Function],
+                          }
+                        }
+                        failuresCount={1}
+                        featureFlagStoreData={
+                          Object {
+                            "shadowDialog": true,
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                </div>,
+                "_rendering": false,
+                "_updater": [Circular],
+                "_workInProgressHook": null,
+              },
             },
           }
         }
@@ -752,7 +1375,7 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
       "topButtonsProps": Array [
         Object {
           "ariaLabel": "Close",
-          "onClick": Object {},
+          "onClick": [Function],
           "onRenderIcon": [Function],
         },
       ],
@@ -767,11 +1390,11 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
       "layerProps": Object {
         "className": "insights-dialog-main-override",
         "hostId": "insights-dialog-layer-host",
-        "onLayerDidMount": Object {},
+        "onLayerDidMount": [Function],
       },
     }
   }
-  onDismiss={Object {}}
+  onDismiss={[Function]}
   title="help"
 >
   <div
@@ -944,15 +1567,15 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
         DetailsDialog {
           "componentDidMount": [Function],
           "componentWillUnmount": [Function],
-          "context": undefined,
+          "context": Object {},
           "isBackButtonDisabled": [Function],
           "isInspectButtonDisabled": [Function],
           "isNextButtonDisabled": [Function],
-          "onClickBackButton": Object {},
+          "onClickBackButton": [Function],
           "onClickInspectButton": [Function],
-          "onClickNextButton": Object {},
-          "onHideDialog": Object {},
-          "onLayoutDidMount": Object {},
+          "onClickNextButton": [Function],
+          "onHideDialog": [Function],
+          "onLayoutDidMount": [Function],
           "props": Object {
             "deps": Object {
               "clientBrowserAdapter": Object {
@@ -1007,17 +1630,321 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
             "userConfigStore": Object {},
           },
           "refs": Object {},
+          "setState": [Function],
           "state": Object {
             "canInspect": true,
             "currentRuleIndex": 0,
             "showDialog": true,
             "userConfigurationStoreData": null,
           },
-          "updater": Object {
-            "enqueueForceUpdate": [Function],
-            "enqueueReplaceState": [Function],
-            "enqueueSetState": [Function],
-            "isMounted": [Function],
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_didScheduleRenderPhaseUpdate": false,
+              "_dispatcher": Object {
+                "readContext": [Function],
+                "useCallback": [Function],
+                "useContext": [Function],
+                "useDebugValue": [Function],
+                "useEffect": [Function],
+                "useImperativeHandle": [Function],
+                "useLayoutEffect": [Function],
+                "useMemo": [Function],
+                "useReducer": [Function],
+                "useRef": [Function],
+                "useState": [Function],
+              },
+              "_element": <DetailsDialog
+                deps={
+                  Object {
+                    "clientBrowserAdapter": Object {
+                      "getUrl": [Function],
+                    },
+                    "issueDetailsTextGenerator": null,
+                    "issueFilingActionMessageCreator": null,
+                    "targetPageActionMessageCreator": Object {
+                      "copyIssueDetailsClicked": [Function],
+                    },
+                    "windowUtils": null,
+                  }
+                }
+                devToolActionMessageCreator={Object {}}
+                devToolStore={Object {}}
+                devToolsShortcut="shortcut"
+                dialogHandler={
+                  Object {
+                    "componentDidMount": [Function],
+                    "getFailureInfo": [Function],
+                    "getRuleUrl": [Function],
+                    "isBackButtonDisabled": [Function],
+                    "isInspectButtonDisabled": [Function],
+                    "isNextButtonDisabled": [Function],
+                  }
+                }
+                elementSelector="ruleId"
+                failedRules={
+                  Object {
+                    "ruleId": Object {
+                      "all": Array [],
+                      "any": Array [],
+                      "failureSummary": "failureSummary",
+                      "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                      "guidanceLinks": Array [
+                        Object {
+                          "href": "http://example.com",
+                          "text": "Guidance Link",
+                        },
+                      ],
+                      "help": "help",
+                      "helpUrl": "http://extension/help1",
+                      "html": "html",
+                      "id": "id1",
+                      "none": Array [],
+                      "ruleId": "ruleId",
+                      "selector": "selector",
+                      "snippet": "html",
+                      "status": false,
+                    },
+                  }
+                }
+                featureFlagStoreData={
+                  Object {
+                    "shadowDialog": false,
+                  }
+                }
+                target={Array []}
+                userConfigStore={Object {}}
+              />,
+              "_firstWorkInProgressHook": null,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_isReRender": false,
+              "_newState": null,
+              "_numberOfReRenders": 0,
+              "_renderPhaseUpdates": null,
+              "_rendered": <StyledWithResponsiveMode
+                dialogContentProps={
+                  Object {
+                    "showCloseButton": false,
+                    "styles": Object {
+                      "title": "insights-dialog-title",
+                    },
+                    "topButtonsProps": Array [
+                      Object {
+                        "ariaLabel": "Close",
+                        "onClick": [Function],
+                        "onRenderIcon": [Function],
+                      },
+                    ],
+                    "type": 0,
+                  }
+                }
+                hidden={false}
+                modalProps={
+                  Object {
+                    "containerClassName": "insights-dialog-main-container",
+                    "isBlocking": false,
+                    "layerProps": Object {
+                      "className": "insights-dialog-main-override",
+                      "hostId": "insights-dialog-layer-host",
+                      "onLayerDidMount": [Function],
+                    },
+                  }
+                }
+                onDismiss={[Function]}
+                title="help"
+              >
+                <div
+                  className="insights-dialog-content"
+                >
+                  <div
+                    className="insights-dialog-rule-name"
+                  >
+                    <h3
+                      className="insights-dialog-section-title"
+                    >
+                      Rule name
+                    </h3>
+                    <NewTabLink
+                      href="http://extension/help1"
+                    >
+                      ruleId
+                    </NewTabLink>
+                  </div>
+                  <div
+                    className="insights-dialog-success-criteria"
+                  >
+                    <h3
+                      className="insights-dialog-section-title"
+                    >
+                      Success criterion
+                    </h3>
+                    <GuidanceLinks
+                      links={
+                        Array [
+                          Object {
+                            "href": "http://example.com",
+                            "text": "Guidance Link",
+                          },
+                        ]
+                      }
+                    />
+                  </div>
+                  <div
+                    className="insights-dialog-path-selector-container"
+                  >
+                    <h3
+                      className="insights-dialog-section-title"
+                    >
+                      Path
+                    </h3>
+                    ruleId
+                  </div>
+                  <div
+                    className="insights-dialog-target-button-container"
+                  >
+                    <CustomizedDefaultButton
+                      className="insights-dialog-button-inspect"
+                      disabled={false}
+                      onClick={[Function]}
+                    >
+                      <FileHTMLIcon />
+                      <div
+                        className="ms-Button-label"
+                      >
+                        Inspect HTML
+                      </div>
+                    </CustomizedDefaultButton>
+                    <React.Fragment>
+                      <CopyIssueDetailsButton
+                        deps={
+                          Object {
+                            "clientBrowserAdapter": Object {
+                              "getUrl": [Function],
+                            },
+                            "issueDetailsTextGenerator": null,
+                            "issueFilingActionMessageCreator": null,
+                            "targetPageActionMessageCreator": Object {
+                              "copyIssueDetailsClicked": [Function],
+                            },
+                            "windowUtils": null,
+                          }
+                        }
+                        issueDetailsData={
+                          Object {
+                            "pageTitle": "",
+                            "pageUrl": "http://localhost/",
+                            "ruleResult": Object {
+                              "all": Array [],
+                              "any": Array [],
+                              "failureSummary": "failureSummary",
+                              "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                              "guidanceLinks": Array [
+                                Object {
+                                  "href": "http://example.com",
+                                  "text": "Guidance Link",
+                                },
+                              ],
+                              "help": "help",
+                              "helpUrl": "http://extension/help1",
+                              "html": "html",
+                              "id": "id1",
+                              "none": Array [],
+                              "ruleId": "ruleId",
+                              "selector": "selector",
+                              "snippet": "html",
+                              "status": false,
+                            },
+                          }
+                        }
+                        onClick={[Function]}
+                      />
+                      <IssueFilingButton
+                        deps={
+                          Object {
+                            "clientBrowserAdapter": Object {
+                              "getUrl": [Function],
+                            },
+                            "issueDetailsTextGenerator": null,
+                            "issueFilingActionMessageCreator": null,
+                            "targetPageActionMessageCreator": Object {
+                              "copyIssueDetailsClicked": [Function],
+                            },
+                            "windowUtils": null,
+                          }
+                        }
+                        issueDetailsData={
+                          Object {
+                            "pageTitle": "",
+                            "pageUrl": "http://localhost/",
+                            "ruleResult": Object {
+                              "all": Array [],
+                              "any": Array [],
+                              "failureSummary": "failureSummary",
+                              "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                              "guidanceLinks": Array [
+                                Object {
+                                  "href": "http://example.com",
+                                  "text": "Guidance Link",
+                                },
+                              ],
+                              "help": "help",
+                              "helpUrl": "http://extension/help1",
+                              "html": "html",
+                              "id": "id1",
+                              "none": Array [],
+                              "ruleId": "ruleId",
+                              "selector": "selector",
+                              "snippet": "html",
+                              "status": false,
+                            },
+                          }
+                        }
+                        needsSettingsContentRenderer={[Function]}
+                        userConfigurationStoreData={null}
+                      />
+                    </React.Fragment>
+                  </div>
+                  <div
+                    className="insights-dialog-fix-instruction-container"
+                  >
+                    <FixInstructionPanel
+                      checkType={0}
+                      checks={Array []}
+                      renderTitleElement={[Function]}
+                    />
+                    <FixInstructionPanel
+                      checkType={1}
+                      checks={Array []}
+                      renderTitleElement={[Function]}
+                    />
+                  </div>
+                  <IssueDetailsNavigationControls
+                    container={[Circular]}
+                    dialogHandler={
+                      Object {
+                        "componentDidMount": [Function],
+                        "getFailureInfo": [Function],
+                        "getRuleUrl": [Function],
+                        "isBackButtonDisabled": [Function],
+                        "isInspectButtonDisabled": [Function],
+                        "isNextButtonDisabled": [Function],
+                      }
+                    }
+                    failuresCount={1}
+                    featureFlagStoreData={
+                      Object {
+                        "shadowDialog": false,
+                      }
+                    }
+                  />
+                </div>
+              </StyledWithResponsiveMode>,
+              "_rendering": false,
+              "_updater": [Circular],
+              "_workInProgressHook": null,
+            },
           },
         }
       }
@@ -1312,15 +2239,15 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: true } 
           DetailsDialog {
             "componentDidMount": [Function],
             "componentWillUnmount": [Function],
-            "context": undefined,
+            "context": Object {},
             "isBackButtonDisabled": [Function],
             "isInspectButtonDisabled": [Function],
             "isNextButtonDisabled": [Function],
-            "onClickBackButton": Object {},
+            "onClickBackButton": [Function],
             "onClickInspectButton": [Function],
-            "onClickNextButton": Object {},
-            "onHideDialog": Object {},
-            "onLayoutDidMount": Object {},
+            "onClickNextButton": [Function],
+            "onHideDialog": [Function],
+            "onLayoutDidMount": [Function],
             "props": Object {
               "deps": Object {
                 "clientBrowserAdapter": Object {
@@ -1375,17 +2302,326 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: true } 
               "userConfigStore": Object {},
             },
             "refs": Object {},
+            "setState": [Function],
             "state": Object {
               "canInspect": true,
               "currentRuleIndex": 0,
               "showDialog": true,
               "userConfigurationStoreData": null,
             },
-            "updater": Object {
-              "enqueueForceUpdate": [Function],
-              "enqueueReplaceState": [Function],
-              "enqueueSetState": [Function],
-              "isMounted": [Function],
+            "updater": Updater {
+              "_callbacks": Array [],
+              "_renderer": ReactShallowRenderer {
+                "_context": Object {},
+                "_didScheduleRenderPhaseUpdate": false,
+                "_dispatcher": Object {
+                  "readContext": [Function],
+                  "useCallback": [Function],
+                  "useContext": [Function],
+                  "useDebugValue": [Function],
+                  "useEffect": [Function],
+                  "useImperativeHandle": [Function],
+                  "useLayoutEffect": [Function],
+                  "useMemo": [Function],
+                  "useReducer": [Function],
+                  "useRef": [Function],
+                  "useState": [Function],
+                },
+                "_element": <DetailsDialog
+                  deps={
+                    Object {
+                      "clientBrowserAdapter": Object {
+                        "getUrl": [Function],
+                      },
+                      "issueDetailsTextGenerator": null,
+                      "issueFilingActionMessageCreator": null,
+                      "targetPageActionMessageCreator": Object {
+                        "copyIssueDetailsClicked": [Function],
+                      },
+                      "windowUtils": null,
+                    }
+                  }
+                  devToolActionMessageCreator={Object {}}
+                  devToolStore={Object {}}
+                  devToolsShortcut="shortcut"
+                  dialogHandler={
+                    Object {
+                      "componentDidMount": [Function],
+                      "getFailureInfo": [Function],
+                      "getRuleUrl": [Function],
+                      "isBackButtonDisabled": [Function],
+                      "isInspectButtonDisabled": [Function],
+                      "isNextButtonDisabled": [Function],
+                    }
+                  }
+                  elementSelector="ruleId"
+                  failedRules={
+                    Object {
+                      "ruleId": Object {
+                        "all": Array [],
+                        "any": Array [],
+                        "failureSummary": "failureSummary",
+                        "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                        "guidanceLinks": Array [
+                          Object {
+                            "href": "http://example.com",
+                            "text": "Guidance Link",
+                          },
+                        ],
+                        "help": "help",
+                        "helpUrl": "http://extension/help1",
+                        "html": "html",
+                        "id": "id1",
+                        "none": Array [],
+                        "ruleId": "ruleId",
+                        "selector": "selector",
+                        "snippet": "html",
+                        "status": false,
+                      },
+                    }
+                  }
+                  featureFlagStoreData={
+                    Object {
+                      "shadowDialog": true,
+                    }
+                  }
+                  target={Array []}
+                  userConfigStore={Object {}}
+                />,
+                "_firstWorkInProgressHook": null,
+                "_forcedUpdate": false,
+                "_instance": [Circular],
+                "_isReRender": false,
+                "_newState": null,
+                "_numberOfReRenders": 0,
+                "_renderPhaseUpdates": null,
+                "_rendered": <div
+                  className="insights-dialog-main-override-shadow"
+                  style={
+                    Object {
+                      "visibility": "visible",
+                    }
+                  }
+                >
+                  <div
+                    className="insights-dialog-container"
+                  >
+                    <div
+                      className="insights-dialog-header"
+                    >
+                      <p
+                        className="ms-Dialog-title insights-dialog-title"
+                      >
+                        help
+                      </p>
+                      <div
+                        className="ms-Dialog-topButton"
+                      >
+                        <button
+                          aria-label="Close"
+                          className="ms-Dialog-button ms-Dialog-button--close ms-Button ms-Button--icon insights-dialog-close"
+                          data-is-focusable="true"
+                          type="button"
+                        >
+                          <div
+                            className="ms-button-flex-container"
+                          >
+                            <CancelIcon />
+                          </div>
+                        </button>
+                      </div>
+                    </div>
+                    <div
+                      className="insights-dialog-content"
+                    >
+                      <div
+                        className="insights-dialog-rule-name"
+                      >
+                        <h3
+                          className="insights-dialog-section-title"
+                        >
+                          Rule name
+                        </h3>
+                        <NewTabLink
+                          href="http://extension/help1"
+                        >
+                          ruleId
+                        </NewTabLink>
+                      </div>
+                      <div
+                        className="insights-dialog-success-criteria"
+                      >
+                        <h3
+                          className="insights-dialog-section-title"
+                        >
+                          Success criterion
+                        </h3>
+                        <GuidanceLinks
+                          links={
+                            Array [
+                              Object {
+                                "href": "http://example.com",
+                                "text": "Guidance Link",
+                              },
+                            ]
+                          }
+                        />
+                      </div>
+                      <div
+                        className="insights-dialog-path-selector-container"
+                      >
+                        <h3
+                          className="insights-dialog-section-title"
+                        >
+                          Path
+                        </h3>
+                        ruleId
+                      </div>
+                      <div
+                        className="insights-dialog-target-button-container"
+                      >
+                        <CustomizedDefaultButton
+                          className="insights-dialog-button-inspect"
+                          disabled={false}
+                          onClick={null}
+                        >
+                          <FileHTMLIcon />
+                          <div
+                            className="ms-Button-label"
+                          >
+                            Inspect HTML
+                          </div>
+                        </CustomizedDefaultButton>
+                        <React.Fragment>
+                          <CopyIssueDetailsButton
+                            deps={
+                              Object {
+                                "clientBrowserAdapter": Object {
+                                  "getUrl": [Function],
+                                },
+                                "issueDetailsTextGenerator": null,
+                                "issueFilingActionMessageCreator": null,
+                                "targetPageActionMessageCreator": Object {
+                                  "copyIssueDetailsClicked": [Function],
+                                },
+                                "windowUtils": null,
+                              }
+                            }
+                            issueDetailsData={
+                              Object {
+                                "pageTitle": "",
+                                "pageUrl": "http://localhost/",
+                                "ruleResult": Object {
+                                  "all": Array [],
+                                  "any": Array [],
+                                  "failureSummary": "failureSummary",
+                                  "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                                  "guidanceLinks": Array [
+                                    Object {
+                                      "href": "http://example.com",
+                                      "text": "Guidance Link",
+                                    },
+                                  ],
+                                  "help": "help",
+                                  "helpUrl": "http://extension/help1",
+                                  "html": "html",
+                                  "id": "id1",
+                                  "none": Array [],
+                                  "ruleId": "ruleId",
+                                  "selector": "selector",
+                                  "snippet": "html",
+                                  "status": false,
+                                },
+                              }
+                            }
+                            onClick={[Function]}
+                          />
+                          <IssueFilingButton
+                            deps={
+                              Object {
+                                "clientBrowserAdapter": Object {
+                                  "getUrl": [Function],
+                                },
+                                "issueDetailsTextGenerator": null,
+                                "issueFilingActionMessageCreator": null,
+                                "targetPageActionMessageCreator": Object {
+                                  "copyIssueDetailsClicked": [Function],
+                                },
+                                "windowUtils": null,
+                              }
+                            }
+                            issueDetailsData={
+                              Object {
+                                "pageTitle": "",
+                                "pageUrl": "http://localhost/",
+                                "ruleResult": Object {
+                                  "all": Array [],
+                                  "any": Array [],
+                                  "failureSummary": "failureSummary",
+                                  "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                                  "guidanceLinks": Array [
+                                    Object {
+                                      "href": "http://example.com",
+                                      "text": "Guidance Link",
+                                    },
+                                  ],
+                                  "help": "help",
+                                  "helpUrl": "http://extension/help1",
+                                  "html": "html",
+                                  "id": "id1",
+                                  "none": Array [],
+                                  "ruleId": "ruleId",
+                                  "selector": "selector",
+                                  "snippet": "html",
+                                  "status": false,
+                                },
+                              }
+                            }
+                            needsSettingsContentRenderer={[Function]}
+                            userConfigurationStoreData={null}
+                          />
+                        </React.Fragment>
+                      </div>
+                      <div
+                        className="insights-dialog-fix-instruction-container"
+                      >
+                        <FixInstructionPanel
+                          checkType={0}
+                          checks={Array []}
+                          renderTitleElement={[Function]}
+                        />
+                        <FixInstructionPanel
+                          checkType={1}
+                          checks={Array []}
+                          renderTitleElement={[Function]}
+                        />
+                      </div>
+                      <IssueDetailsNavigationControls
+                        container={[Circular]}
+                        dialogHandler={
+                          Object {
+                            "componentDidMount": [Function],
+                            "getFailureInfo": [Function],
+                            "getRuleUrl": [Function],
+                            "isBackButtonDisabled": [Function],
+                            "isInspectButtonDisabled": [Function],
+                            "isNextButtonDisabled": [Function],
+                          }
+                        }
+                        failuresCount={1}
+                        featureFlagStoreData={
+                          Object {
+                            "shadowDialog": true,
+                          }
+                        }
+                      />
+                    </div>
+                  </div>
+                </div>,
+                "_rendering": false,
+                "_updater": [Circular],
+                "_workInProgressHook": null,
+              },
             },
           }
         }
@@ -1483,7 +2719,7 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
       "topButtonsProps": Array [
         Object {
           "ariaLabel": "Close",
-          "onClick": Object {},
+          "onClick": [Function],
           "onRenderIcon": [Function],
         },
       ],
@@ -1498,11 +2734,11 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
       "layerProps": Object {
         "className": "insights-dialog-main-override",
         "hostId": "insights-dialog-layer-host",
-        "onLayerDidMount": Object {},
+        "onLayerDidMount": [Function],
       },
     }
   }
-  onDismiss={Object {}}
+  onDismiss={[Function]}
   title="help"
 >
   <div
@@ -1680,15 +2916,15 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
         DetailsDialog {
           "componentDidMount": [Function],
           "componentWillUnmount": [Function],
-          "context": undefined,
+          "context": Object {},
           "isBackButtonDisabled": [Function],
           "isInspectButtonDisabled": [Function],
           "isNextButtonDisabled": [Function],
-          "onClickBackButton": Object {},
+          "onClickBackButton": [Function],
           "onClickInspectButton": [Function],
-          "onClickNextButton": Object {},
-          "onHideDialog": Object {},
-          "onLayoutDidMount": Object {},
+          "onClickNextButton": [Function],
+          "onHideDialog": [Function],
+          "onLayoutDidMount": [Function],
           "props": Object {
             "deps": Object {
               "clientBrowserAdapter": Object {
@@ -1743,17 +2979,326 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
             "userConfigStore": Object {},
           },
           "refs": Object {},
+          "setState": [Function],
           "state": Object {
             "canInspect": true,
             "currentRuleIndex": 0,
             "showDialog": true,
             "userConfigurationStoreData": null,
           },
-          "updater": Object {
-            "enqueueForceUpdate": [Function],
-            "enqueueReplaceState": [Function],
-            "enqueueSetState": [Function],
-            "isMounted": [Function],
+          "updater": Updater {
+            "_callbacks": Array [],
+            "_renderer": ReactShallowRenderer {
+              "_context": Object {},
+              "_didScheduleRenderPhaseUpdate": false,
+              "_dispatcher": Object {
+                "readContext": [Function],
+                "useCallback": [Function],
+                "useContext": [Function],
+                "useDebugValue": [Function],
+                "useEffect": [Function],
+                "useImperativeHandle": [Function],
+                "useLayoutEffect": [Function],
+                "useMemo": [Function],
+                "useReducer": [Function],
+                "useRef": [Function],
+                "useState": [Function],
+              },
+              "_element": <DetailsDialog
+                deps={
+                  Object {
+                    "clientBrowserAdapter": Object {
+                      "getUrl": [Function],
+                    },
+                    "issueDetailsTextGenerator": null,
+                    "issueFilingActionMessageCreator": null,
+                    "targetPageActionMessageCreator": Object {
+                      "copyIssueDetailsClicked": [Function],
+                    },
+                    "windowUtils": null,
+                  }
+                }
+                devToolActionMessageCreator={Object {}}
+                devToolStore={Object {}}
+                devToolsShortcut="shortcut"
+                dialogHandler={
+                  Object {
+                    "componentDidMount": [Function],
+                    "getFailureInfo": [Function],
+                    "getRuleUrl": [Function],
+                    "isBackButtonDisabled": [Function],
+                    "isInspectButtonDisabled": [Function],
+                    "isNextButtonDisabled": [Function],
+                  }
+                }
+                elementSelector="ruleId"
+                failedRules={
+                  Object {
+                    "ruleId": Object {
+                      "all": Array [],
+                      "any": Array [],
+                      "failureSummary": "failureSummary",
+                      "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                      "guidanceLinks": Array [
+                        Object {
+                          "href": "http://example.com",
+                          "text": "Guidance Link",
+                        },
+                      ],
+                      "help": "help",
+                      "helpUrl": "help-relative",
+                      "html": "html",
+                      "id": "id1",
+                      "none": Array [],
+                      "ruleId": "ruleId",
+                      "selector": "selector",
+                      "snippet": "html",
+                      "status": false,
+                    },
+                  }
+                }
+                featureFlagStoreData={
+                  Object {
+                    "shadowDialog": false,
+                  }
+                }
+                target={Array []}
+                userConfigStore={Object {}}
+              />,
+              "_firstWorkInProgressHook": null,
+              "_forcedUpdate": false,
+              "_instance": [Circular],
+              "_isReRender": false,
+              "_newState": null,
+              "_numberOfReRenders": 0,
+              "_renderPhaseUpdates": null,
+              "_rendered": <StyledWithResponsiveMode
+                dialogContentProps={
+                  Object {
+                    "showCloseButton": false,
+                    "styles": Object {
+                      "title": "insights-dialog-title",
+                    },
+                    "topButtonsProps": Array [
+                      Object {
+                        "ariaLabel": "Close",
+                        "onClick": [Function],
+                        "onRenderIcon": [Function],
+                      },
+                    ],
+                    "type": 0,
+                  }
+                }
+                hidden={false}
+                modalProps={
+                  Object {
+                    "containerClassName": "insights-dialog-main-container",
+                    "isBlocking": false,
+                    "layerProps": Object {
+                      "className": "insights-dialog-main-override",
+                      "hostId": "insights-dialog-layer-host",
+                      "onLayerDidMount": [Function],
+                    },
+                  }
+                }
+                onDismiss={[Function]}
+                title="help"
+              >
+                <div
+                  className="insights-dialog-content"
+                >
+                  <div
+                    className="insights-dialog-rule-name"
+                  >
+                    <h3
+                      className="insights-dialog-section-title"
+                    >
+                      Rule name
+                    </h3>
+                    <NewTabLink
+                      href="http://extension/help-relative"
+                    >
+                      ruleId
+                    </NewTabLink>
+                  </div>
+                  <div
+                    className="insights-dialog-success-criteria"
+                  >
+                    <h3
+                      className="insights-dialog-section-title"
+                    >
+                      Success criterion
+                    </h3>
+                    <GuidanceLinks
+                      links={
+                        Array [
+                          Object {
+                            "href": "http://example.com",
+                            "text": "Guidance Link",
+                          },
+                        ]
+                      }
+                    />
+                  </div>
+                  <div
+                    className="insights-dialog-path-selector-container"
+                  >
+                    <h3
+                      className="insights-dialog-section-title"
+                    >
+                      Path
+                    </h3>
+                    ruleId
+                  </div>
+                  <div
+                    className="insights-dialog-target-button-container"
+                  >
+                    <CustomizedDefaultButton
+                      className="insights-dialog-button-inspect"
+                      disabled={true}
+                      onClick={[Function]}
+                    >
+                      <FileHTMLIcon />
+                      <div
+                        className="ms-Button-label"
+                      >
+                        Inspect HTML
+                      </div>
+                    </CustomizedDefaultButton>
+                    <React.Fragment>
+                      <CopyIssueDetailsButton
+                        deps={
+                          Object {
+                            "clientBrowserAdapter": Object {
+                              "getUrl": [Function],
+                            },
+                            "issueDetailsTextGenerator": null,
+                            "issueFilingActionMessageCreator": null,
+                            "targetPageActionMessageCreator": Object {
+                              "copyIssueDetailsClicked": [Function],
+                            },
+                            "windowUtils": null,
+                          }
+                        }
+                        issueDetailsData={
+                          Object {
+                            "pageTitle": "",
+                            "pageUrl": "http://localhost/",
+                            "ruleResult": Object {
+                              "all": Array [],
+                              "any": Array [],
+                              "failureSummary": "failureSummary",
+                              "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                              "guidanceLinks": Array [
+                                Object {
+                                  "href": "http://example.com",
+                                  "text": "Guidance Link",
+                                },
+                              ],
+                              "help": "help",
+                              "helpUrl": "help-relative",
+                              "html": "html",
+                              "id": "id1",
+                              "none": Array [],
+                              "ruleId": "ruleId",
+                              "selector": "selector",
+                              "snippet": "html",
+                              "status": false,
+                            },
+                          }
+                        }
+                        onClick={[Function]}
+                      />
+                      <IssueFilingButton
+                        deps={
+                          Object {
+                            "clientBrowserAdapter": Object {
+                              "getUrl": [Function],
+                            },
+                            "issueDetailsTextGenerator": null,
+                            "issueFilingActionMessageCreator": null,
+                            "targetPageActionMessageCreator": Object {
+                              "copyIssueDetailsClicked": [Function],
+                            },
+                            "windowUtils": null,
+                          }
+                        }
+                        issueDetailsData={
+                          Object {
+                            "pageTitle": "",
+                            "pageUrl": "http://localhost/",
+                            "ruleResult": Object {
+                              "all": Array [],
+                              "any": Array [],
+                              "failureSummary": "failureSummary",
+                              "fingerprint": "12345678-9ABC-1234-1234-123456789ABC",
+                              "guidanceLinks": Array [
+                                Object {
+                                  "href": "http://example.com",
+                                  "text": "Guidance Link",
+                                },
+                              ],
+                              "help": "help",
+                              "helpUrl": "help-relative",
+                              "html": "html",
+                              "id": "id1",
+                              "none": Array [],
+                              "ruleId": "ruleId",
+                              "selector": "selector",
+                              "snippet": "html",
+                              "status": false,
+                            },
+                          }
+                        }
+                        needsSettingsContentRenderer={[Function]}
+                        userConfigurationStoreData={null}
+                      />
+                    </React.Fragment>
+                    <div
+                      className="insights-dialog-inspect-disabled"
+                    >
+                      To enable the Inspect HTML button, open the developer tools (shortcut).
+                    </div>
+                  </div>
+                  <div
+                    className="insights-dialog-fix-instruction-container"
+                  >
+                    <FixInstructionPanel
+                      checkType={0}
+                      checks={Array []}
+                      renderTitleElement={[Function]}
+                    />
+                    <FixInstructionPanel
+                      checkType={1}
+                      checks={Array []}
+                      renderTitleElement={[Function]}
+                    />
+                  </div>
+                  <IssueDetailsNavigationControls
+                    container={[Circular]}
+                    dialogHandler={
+                      Object {
+                        "componentDidMount": [Function],
+                        "getFailureInfo": [Function],
+                        "getRuleUrl": [Function],
+                        "isBackButtonDisabled": [Function],
+                        "isInspectButtonDisabled": [Function],
+                        "isNextButtonDisabled": [Function],
+                      }
+                    }
+                    failuresCount={1}
+                    featureFlagStoreData={
+                      Object {
+                        "shadowDialog": false,
+                      }
+                    }
+                  />
+                </div>
+              </StyledWithResponsiveMode>,
+              "_rendering": false,
+              "_updater": [Circular],
+              "_workInProgressHook": null,
+            },
           },
         }
       }

--- a/src/tests/unit/tests/injected/components/details-dialog.test.tsx
+++ b/src/tests/unit/tests/injected/components/details-dialog.test.tsx
@@ -107,19 +107,9 @@ describe('DetailsDialogTest', () => {
             devToolsShortcut: 'shortcut',
         };
 
-        const onHideDialogMock = {};
-        const onClickNextButtonMock = {};
-        const onClickBackButtonMock = {};
-        const onLayoutDidMountMock = {};
-
-        const testObject = new DetailsDialog(props);
-        (testObject as any).onHideDialog = onHideDialogMock;
-        (testObject as any).onClickNextButton = onClickNextButtonMock;
-        (testObject as any).onClickBackButton = onClickBackButtonMock;
-        (testObject as any).onLayoutDidMount = onLayoutDidMountMock;
-
-        expect(testObject.render()).toMatchSnapshot();
         const wrapper = shallow(<DetailsDialog {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
 
         expect(wrapper.state()).toMatchSnapshot('verify initial state');
 

--- a/src/tests/unit/tests/injected/components/details-dialog.test.tsx
+++ b/src/tests/unit/tests/injected/components/details-dialog.test.tsx
@@ -102,7 +102,9 @@ describe('DetailsDialogTest', () => {
                 [FeatureFlags.shadowDialog]: shadowDialog,
             },
             devToolStore: {} as any,
-            userConfigStore: {} as any,
+            userConfigStore: {
+                getState: () => {},
+            } as any,
             devToolActionMessageCreator: {} as any,
             devToolsShortcut: 'shortcut',
         };


### PR DESCRIPTION
#### Description of changes

Currently, the issue details dialog doesn't show up if "Improve dialog styling" preview feature is enabled.

This PR fix the showing part.

Notes:
The dialog still have other issues but I'm not fixing those as part of this PR, only the showing part.

**Improved dialog styling = true**
![with shadow dom](https://user-images.githubusercontent.com/2837582/57813869-8e37e080-7726-11e9-95b0-be652a5ccb67.png)

**Improved dialog styling = false** (for comparison purposes only)
![without shadow dom](https://user-images.githubusercontent.com/2837582/57813886-96901b80-7726-11e9-9eaf-31e9f783dae9.png)

#### Pull request checklist

- [x] Addresses an existing issue: hasn't been filed
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
