### PR TITLE
Fix typo for #672 and fix typo in git-branch-setup.md

### DIFF
--- a/docs/git-branch-setup.md
+++ b/docs/git-branch-setup.md
@@ -63,7 +63,7 @@ Create a branch from your fork and start making the code changes. Once you are h
 
 ## Merging upstream master into your fork master
 
-From time to time, your fork will get out of sync with the upstream remote. Use the following commands to get the master branch of your fork up up to date.
+From time to time, your fork will get out of sync with the upstream remote. Use the following commands to get the master branch of your fork up to date.
 
 ```
 > git fetch upstream

--- a/src/assessments/custom-widgets/custom-widgets-column-renderer.tsx
+++ b/src/assessments/custom-widgets/custom-widgets-column-renderer.tsx
@@ -63,7 +63,7 @@ const roleToDesignPatternsMapping: DictionaryStringTo<DesignPattern[]> = {
     ],
     checkbox: [{ designPattern: 'Checkbox', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#checkbox' }],
     combobox: [{ designPattern: 'Combo Box', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#combobox' }],
-    dialog: [{ designPattern: 'Dialog (Model)', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal' }],
+    dialog: [{ designPattern: 'Dialog (Modal)', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal' }],
     feed: [{ designPattern: 'Feed', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#feed' }],
     grid: [{ designPattern: 'Grid', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#grid' }],
     link: [{ designPattern: 'Link', URL: 'https://www.w3.org/TR/wai-aria-practices-1.1/#link' }],


### PR DESCRIPTION
#### Description of changes

Fixes typo as requested by #672 plus one extra typo spotted in `./docs/git-branch-setup.md`

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #672
- [ ] Added relevant unit test for your changes. (`npm run test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`npm run precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
