### PR TITLE
fix: switcher state is updated correctly (on component did update)

### DIFF
--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -29,7 +29,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
     }
 
     public componentDidUpdate(prevProps: Readonly<SwitcherProps>): void {
-        if (isEqual(prevProps, this.props) === false) {
+        if (prevProps.pivotKey !== this.props.pivotKey) {
             this.setState(() => ({ selectedKey: this.props.pivotKey }));
         }
     }

--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -5,7 +5,6 @@ import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ResponsiveMode } from 'office-ui-fabric-react/lib/utilities/decorators/withResponsiveMode';
 import * as React from 'react';
 
-import { isEqual } from 'lodash';
 import { DetailsViewPivotType } from '../../../src/common/types/details-view-pivot-type';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 

--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -5,6 +5,7 @@ import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ResponsiveMode } from 'office-ui-fabric-react/lib/utilities/decorators/withResponsiveMode';
 import * as React from 'react';
 
+import { isEqual } from 'lodash';
 import { DetailsViewPivotType } from '../../../src/common/types/details-view-pivot-type';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 
@@ -25,6 +26,12 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
     constructor(props: SwitcherProps) {
         super(props);
         this.state = { selectedKey: props.pivotKey };
+    }
+
+    public componentDidUpdate(prevProps: Readonly<SwitcherProps>): void {
+        if (isEqual(prevProps, this.props) === false) {
+            this.setState(() => ({ selectedKey: this.props.pivotKey }));
+        }
     }
 
     private onRenderOption = (option: IDropdownOption): JSX.Element => {

--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -52,4 +52,20 @@ describe('Switcher', () => {
         expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.assessment);
         actionCreatorMock.verifyAll();
     });
+
+    test('componentDidUpdate: props have changed', () => {
+        const newProps = {
+            ...defaultProps,
+            pivotKey: DetailsViewPivotType.assessment,
+        };
+        const component = shallow(<Switcher {...newProps} />).instance() as Switcher;
+        component.componentDidUpdate(defaultProps);
+        expect(component.state).toMatchObject({ selectedKey: DetailsViewPivotType.assessment });
+    });
+
+    test('componentDidUpdate: props have not changed', () => {
+        const component = shallow(<Switcher {...defaultProps} />).instance() as Switcher;
+        component.componentDidUpdate(defaultProps);
+        expect(component.state).toMatchObject({ selectedKey: DetailsViewPivotType.fastPass });
+    });
 });

--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -53,7 +53,7 @@ describe('Switcher', () => {
         actionCreatorMock.verifyAll();
     });
 
-    test('componentDidUpdate: props have changed', () => {
+    test('componentDidUpdate: pivotKey has changed', () => {
         const newProps = {
             ...defaultProps,
             pivotKey: DetailsViewPivotType.assessment,
@@ -63,7 +63,7 @@ describe('Switcher', () => {
         expect(component.state).toMatchObject({ selectedKey: DetailsViewPivotType.assessment });
     });
 
-    test('componentDidUpdate: props have not changed', () => {
+    test('componentDidUpdate: pivotKey has not changed', () => {
         const component = shallow(<Switcher {...defaultProps} />).instance() as Switcher;
         component.componentDidUpdate(defaultProps);
         expect(component.state).toMatchObject({ selectedKey: DetailsViewPivotType.fastPass });


### PR DESCRIPTION
#### Description of changes

A change was made such that the state is being represented in the control instead of the props for the switcher. This was due to the nature of React Flux and how it works with accessibility concerns. However, a part was missed: when props are updated, the state should be updated (we have this in previous uses of the pattern). This is _that_ change.


![switchernotupdatedbugfix](https://user-images.githubusercontent.com/32555133/58139067-fb97b580-7bed-11e9-88d8-3755a440b258.gif)

#### Pull request checklist


- [x] Addresses an existing issue: Fixes #659
- [x] Added relevant unit test for your changes. (`npm run test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`npm run precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS

