### PR TITLE
refactor: add missing child deps type on parent deps type

### DIFF
--- a/src/DetailsView/components/static-content-details-view.tsx
+++ b/src/DetailsView/components/static-content-details-view.tsx
@@ -5,10 +5,10 @@ import * as React from 'react';
 import { VisualizationToggle } from '../../common/components/visualization-toggle';
 import { NamedSFC } from '../../common/react/named-sfc';
 import { ContentInclude, ContentIncludeDeps } from '../../views/content/content-include';
-import { ContentLink } from '../../views/content/content-link';
+import { ContentLink, ContentLinkDeps } from '../../views/content/content-link';
 import { ContentReference } from '../../views/content/content-page';
 
-export type StaticContentDetailsViewDeps = ContentIncludeDeps;
+export type StaticContentDetailsViewDeps = ContentIncludeDeps & ContentLinkDeps;
 
 export interface StaticContentDetailsViewProps {
     deps: StaticContentDetailsViewDeps;


### PR DESCRIPTION
#### Description of changes

There is a missing child deps type on `StaticContentDetailsViewDeps`.

This PR add the missing deps type.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`) 
   - does not apply
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - does not apply
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
