### PR TITLE
refactor: header icon refactor

### DIFF
--- a/src/common/components/header-icon.tsx
+++ b/src/common/components/header-icon.tsx
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
+import { BrandBlue } from '../../icons/brand/blue/brand-blue';
+import { BrandWhite } from '../../icons/brand/white/brand-white';
 import { NamedSFC } from '../react/named-sfc';
 import { ThemeInnerState } from './theme';
 import { withStoreSubscription, WithStoreSubscriptionDeps, WithStoreSubscriptionProps } from './with-store-subscription';
@@ -13,12 +15,10 @@ export type HeaderIconProps = WithStoreSubscriptionProps<HeaderIconState>;
 export type HeaderIconState = ThemeInnerState;
 
 export const HeaderIconComponent = NamedSFC<HeaderIconProps>('HeaderIconComponent', (props: HeaderIconProps) => {
-    const WHITE_ICON = '../../icons/brand/white/brand-white-48px.png';
-    const BLUE_ICON = '../../icons/brand/blue/brand-blue-48px.png';
     const state = props.storeState.userConfigurationStoreData;
     const enableHighContrast = state && state.enableHighContrast;
-    const iconPath = enableHighContrast ? BLUE_ICON : WHITE_ICON;
-    return <img className="header-icon" src={iconPath} alt="" />;
+
+    return enableHighContrast ? <BrandBlue /> : <BrandWhite />;
 });
 
 export const HeaderIcon = withStoreSubscription<HeaderIconProps, HeaderIconState>(HeaderIconComponent);

--- a/src/icons/brand/blue/brand-blue.tsx
+++ b/src/icons/brand/blue/brand-blue.tsx
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+import { NamedSFC } from '../../../common/react/named-sfc';
+
+export const BrandBlue = NamedSFC('BrandBlue', () => (
+    <svg className="header-icon" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="3" width="48" height="43">
+            <path
+                d="M43.8309 27.1383C49.3148 21.6544 49.3148 12.7632 43.8309 7.27931C38.347 1.7954 29.4558 1.7954 23.9719 7.27931C18.488 1.79541 9.59684 1.7954 4.11293 7.27931C-1.37098 12.7632 -1.37098 21.6544 4.11293 27.1383L21.986 45.0114C23.0828 46.1082 24.861 46.1082 25.9578 45.0114L43.8309 27.1383Z"
+                fill="white"
+            />
+        </mask>
+        <g mask="url(#mask0)">
+            <path
+                d="M43.8309 27.1383C49.3148 21.6544 49.3148 12.7632 43.8309 7.27931C38.347 1.7954 29.4558 1.7954 23.9719 7.27931C18.488 1.79541 9.59684 1.7954 4.11293 7.27931C-1.37098 12.7632 -1.37098 21.6544 4.11293 27.1383L21.986 45.0114C23.0828 46.1082 24.861 46.1082 25.9578 45.0114L43.8309 27.1383Z"
+                fill="#004880"
+            />
+            <rect x="43.9494" y="7.24561" width="14.0948" height="42.2726" transform="rotate(45 43.9494 7.24561)" fill="#003064" />
+            <mask id="mask1" mask-type="alpha" maskUnits="userSpaceOnUse" x="-1" y="3" width="25" height="25">
+                <path
+                    d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79473 18.4879 1.79473 23.9718 7.27863Z"
+                    fill="#CFEBFF"
+                />
+                <path
+                    d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79473 18.4879 1.79473 23.9718 7.27863Z"
+                    fill="url(#paint0_linear)"
+                />
+            </mask>
+            <g mask="url(#mask1)">
+                <path
+                    d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79473 18.4879 1.79473 23.9718 7.27863Z"
+                    fill="#004880"
+                />
+                <path
+                    d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79473 18.4879 1.79473 23.9718 7.27863Z"
+                    fill="url(#paint1_linear)"
+                />
+                <rect x="4.54834" y="6.88208" width="16.3577" height="42.2726" transform="rotate(-45 4.54834 6.88208)" fill="#003064" />
+                <rect
+                    x="4.54834"
+                    y="6.88208"
+                    width="16.3577"
+                    height="42.2726"
+                    transform="rotate(-45 4.54834 6.88208)"
+                    fill="url(#paint2_linear)"
+                />
+            </g>
+            <g filter="url(#filter0_d)">
+                <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="M34.0759 26.9786C39.5979 26.9708 44.0681 22.488 44.0603 16.966C44.0525 11.444 39.5697 6.97389 34.0477 6.98168C28.5258 6.98947 24.0556 11.4722 24.0634 16.9942C24.0665 19.2178 24.7953 21.2709 26.0254 22.9297L23.5401 25.423C23.0339 25.438 22.5322 25.6392 22.1465 26.0261L17.2291 30.9595C16.5257 31.6651 16.5275 32.8074 17.2332 33.5107L17.588 33.8644C18.2936 34.5678 19.4358 34.5659 20.1392 33.8603L25.0567 28.9269C25.4427 28.5397 25.6422 28.0369 25.6553 27.5303L28.1403 25.0373C29.8016 26.2603 31.8547 26.9817 34.0759 26.9786ZM34.0356 23.5423C37.66 23.5569 40.61 20.6306 40.6246 17.0063C40.6392 13.3819 37.713 10.4319 34.0886 10.4173C30.4642 10.4027 27.5142 13.3289 27.4996 16.9533C27.485 20.5777 30.4112 23.5276 34.0356 23.5423Z"
+                    fill="white"
+                />
+            </g>
+        </g>
+        <defs>
+            <filter
+                id="filter0_d"
+                x="15.8964"
+                y="6.90106"
+                width="28.9702"
+                height="29.0217"
+                filterUnits="userSpaceOnUse"
+                color-interpolation-filters="sRGB"
+            >
+                <feFlood flood-opacity="0" result="BackgroundImageFix" />
+                <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" />
+                <feOffset dy="0.725705" />
+                <feGaussianBlur stdDeviation="0.40317" />
+                <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0.027451 0 0 0 0 0.0470588 0 0 0 0.3 0" />
+                <feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow" />
+                <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
+            </filter>
+            <linearGradient id="paint0_linear" x1="14.3166" y1="16.8744" x2="5.92409" y2="8.23504" gradientUnits="userSpaceOnUse">
+                <stop stop-color="#073A5F" stop-opacity="0.3" />
+                <stop offset="1" stop-color="#CFEBFF" stop-opacity="0" />
+            </linearGradient>
+            <linearGradient id="paint1_linear" x1="14.3166" y1="16.8744" x2="4.4082" y2="6.85716" gradientUnits="userSpaceOnUse">
+                <stop stop-color="#00070C" stop-opacity="0.29" />
+                <stop offset="1" stop-color="#004880" stop-opacity="0" />
+            </linearGradient>
+            <linearGradient id="paint2_linear" x1="11.3179" y1="20.1024" x2="11.2867" y2="7.1103" gradientUnits="userSpaceOnUse">
+                <stop stop-color="#00070C" stop-opacity="0.29" />
+                <stop offset="1" stop-color="#003064" stop-opacity="0" />
+            </linearGradient>
+        </defs>
+    </svg>
+));

--- a/src/tests/unit/tests/common/components/__snapshots__/header-icon.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/header-icon.test.tsx.snap
@@ -1,17 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HeaderIconComponent is high contrast mode enabled: false 1`] = `
-<img
-  alt=""
-  className="header-icon"
-  src="../../icons/brand/white/brand-white-48px.png"
-/>
-`;
+exports[`HeaderIconComponent is high contrast mode enabled: false 1`] = `<BrandWhite />`;
 
-exports[`HeaderIconComponent is high contrast mode enabled: true 1`] = `
-<img
-  alt=""
-  className="header-icon"
-  src="../../icons/brand/blue/brand-blue-48px.png"
-/>
-`;
+exports[`HeaderIconComponent is high contrast mode enabled: true 1`] = `<BrandBlue />`;


### PR DESCRIPTION
#### Description of changes

We're currently using a `<img>` element with a `src` attribute and passing the path to the proper icon for the details view header icon (also on the insights guidance content).

We already have a white version of our heart as a react component (wrapping a svg version of the image).

On this PR:
 - Add blue version of our heart
- Using both, blue and white, react components for the icons on the header

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - there is no issue filed
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply as it looks the same
- [x] (UI changes only) Verified usability with NVDA/JAWS **=>** _icon is not being read (before, the img tag had an empty alt attribute, svg's don't have alt property but are not announced neither)_
