### PR TITLE
fix: make brand icons decorative images

### DIFF
--- a/src/icons/brand/blue/brand-blue.tsx
+++ b/src/icons/brand/blue/brand-blue.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { NamedSFC } from '../../../common/react/named-sfc';
 
 export const BrandBlue = NamedSFC('BrandBlue', () => (
-    <svg className="header-icon" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg role="image" aria-hidden="true" className="header-icon" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
         <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="3" width="48" height="43">
             <path
                 d="M43.8309 27.1383C49.3148 21.6544 49.3148 12.7632 43.8309 7.27931C38.347 1.7954 29.4558 1.7954 23.9719 7.27931C18.488 1.79541 9.59684 1.7954 4.11293 7.27931C-1.37098 12.7632 -1.37098 21.6544 4.11293 27.1383L21.986 45.0114C23.0828 46.1082 24.861 46.1082 25.9578 45.0114L43.8309 27.1383Z"

--- a/src/icons/brand/white/brand-white.tsx
+++ b/src/icons/brand/white/brand-white.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { NamedSFC } from '../../../common/react/named-sfc';
 
 export const BrandWhite = NamedSFC('BrandWhite', () => (
-    <svg className="header-icon" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg role="image" aria-hidden="true" className="header-icon" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
         <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="3" width="48" height="43">
             <path
                 d="M43.8309 27.1383C49.3148 21.6544 49.3148 12.7633 43.8309 7.27934C38.347 1.79544 29.4558 1.79543 23.9719 7.27934C18.488 1.79544 9.59684 1.79544 4.11293 7.27934C-1.37098 12.7633 -1.37098 21.6544 4.11293 27.1383L21.986 45.0114C23.0828 46.1082 24.861 46.1082 25.9578 45.0114L43.8309 27.1383Z"


### PR DESCRIPTION
#### Description of changes

Explicitly making svg icons decorative images by adding role=image and aria-hidden=true

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - not created
- [x] Added relevant unit test for your changes. (`yarn test`)
   - does not apply
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - does not apply
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
