### PR TITLE
refactor: remove analyzerMessageType from VisualizationConfiguration

### DIFF
--- a/src/ad-hoc-visualizations/color/visualization.tsx
+++ b/src/ad-hoc-visualizations/color/visualization.tsx
@@ -33,7 +33,6 @@ export const ColorAdHocVisualization: VisualizationConfiguration = {
     chromeCommand: '05_toggle-color',
     launchPanelDisplayOrder: 5,
     adhocToolsPanelDisplayOrder: 2,
-    analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
     resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
     getAnalyzer: provider =>
         provider.createRuleAnalyzer({

--- a/src/ad-hoc-visualizations/headings/visualization.tsx
+++ b/src/ad-hoc-visualizations/headings/visualization.tsx
@@ -33,7 +33,6 @@ export const HeadingsAdHocVisualization: VisualizationConfiguration = {
     chromeCommand: '03_toggle-headings',
     launchPanelDisplayOrder: 3,
     adhocToolsPanelDisplayOrder: 3,
-    analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
     resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
     getAnalyzer: provider =>
         provider.createRuleAnalyzer({

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -38,7 +38,6 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     chromeCommand: '01_toggle-issues',
     launchPanelDisplayOrder: 1,
     adhocToolsPanelDisplayOrder: 1,
-    analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
     resultProcessor: (scanner: ScannerUtils) => scanner.getFailingInstances,
     getAnalyzer: provider =>
         provider.createRuleAnalyzer({

--- a/src/ad-hoc-visualizations/landmarks/visualization.tsx
+++ b/src/ad-hoc-visualizations/landmarks/visualization.tsx
@@ -32,7 +32,6 @@ export const LandmarksAdHocVisualization: VisualizationConfiguration = {
     chromeCommand: '02_toggle-landmarks',
     launchPanelDisplayOrder: 2,
     adhocToolsPanelDisplayOrder: 4,
-    analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
     resultProcessor: (scanner: ScannerUtils) => scanner.getAllCompletedInstances,
     getAnalyzer: provider =>
         provider.createRuleAnalyzer({

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -30,7 +30,6 @@ export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     chromeCommand: '04_toggle-tabStops',
     launchPanelDisplayOrder: 4,
     adhocToolsPanelDisplayOrder: 5,
-    analyzerMessageType: Messages.Visualizations.Common.ScanCompleted,
     analyzerProgressMessageType: Messages.Visualizations.TabStops.TabbedElementAdded,
     analyzerTerminatedMessageType: Messages.Visualizations.TabStops.TerminateScan,
     getAnalyzer: provider =>

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -143,7 +143,6 @@ export class AssessmentBuilder {
             disableTest: AssessmentBuilder.disableTest,
             getTestStatus: AssessmentBuilder.getTestStatus,
             getAssessmentData: data => data.assessments[key],
-            analyzerMessageType: Messages.Assessment.AssessmentScanCompleted,
             key: `${key}Assessment`,
             getAnalyzer: getAnalyzer,
             getIdentifier: getIdentifier,

--- a/src/assessments/keyboard-interaction/assessment.tsx
+++ b/src/assessments/keyboard-interaction/assessment.tsx
@@ -42,7 +42,6 @@ export const KeyboardInteraction: Assessment = AssessmentBuilder.Assisted({
     storeDataKey: 'keyboardInteractionAssessment',
     visualizationConfiguration: {
         key: key,
-        analyzerMessageType: Messages.Assessment.AssessmentScanCompleted,
         analyzerProgressMessageType: Messages.Assessment.TabbedElementAdded,
     },
 });

--- a/src/assessments/visible-focus-order/assessment.tsx
+++ b/src/assessments/visible-focus-order/assessment.tsx
@@ -39,7 +39,6 @@ export const VisibleFocusOrderAssessment: Assessment = AssessmentBuilder.Assiste
     storeDataKey: 'visibleFocusOrderAssessment',
     visualizationConfiguration: {
         key: key,
-        analyzerMessageType: Messages.Assessment.AssessmentScanCompleted,
         analyzerProgressMessageType: Messages.Assessment.TabbedElementAdded,
     },
 });

--- a/src/common/configs/assesssment-visualization-configuration.ts
+++ b/src/common/configs/assesssment-visualization-configuration.ts
@@ -25,7 +25,6 @@ export interface AssesssmentVisualizationConfiguration {
     getTestStatus: (data: ScanData, step?: string) => boolean;
     getAssessmentData?: (data: AssessmentStoreData) => AssessmentData;
     setAssessmentData?: (data: AssessmentStoreData, selectorMap: DictionaryStringTo<any>, instanceMap?: DictionaryStringTo<any>) => void;
-    analyzerMessageType: string;
     analyzerProgressMessageType?: string;
     resultProcessor?: (scanner: ScannerUtils) => (results: ScanResults) => DictionaryStringTo<HtmlElementAxeResults>;
     telemetryProcessor?: TelemetryProcessor<IAnalyzerTelemetryCallback>;

--- a/src/common/configs/visualization-configuration.ts
+++ b/src/common/configs/visualization-configuration.ts
@@ -21,7 +21,6 @@ export interface VisualizationConfiguration extends AssesssmentVisualizationConf
     chromeCommand: string;
     launchPanelDisplayOrder: number;
     adhocToolsPanelDisplayOrder: number;
-    analyzerMessageType: string;
     analyzerProgressMessageType?: string;
     analyzerTerminatedMessageType?: string;
     guidance?: ContentPageComponent;

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -104,7 +104,6 @@ describe('AssessmentBuilderTest', () => {
         const vizStoreData = { assessments: { manualAssessmentKeyAssessment: scanData } } as any;
         expect(config.getStoreData(vizStoreData)).toEqual(scanData);
 
-        expect(config.analyzerMessageType).toEqual(Messages.Assessment.AssessmentScanCompleted);
         expect(config.getIdentifier(selectedRequirementKey)).toBe(requirement.key);
         expect(config.visualizationInstanceProcessor()).toBe(VisualizationInstanceProcessor.nullProcessor);
         expect(config.getInstanceIdentiferGenerator(selectedRequirementKey)).toBe(getInstanceIdentifierMock.object);
@@ -216,9 +215,7 @@ describe('AssessmentBuilderTest', () => {
             gettingStarted: <span>getting started</span>,
             requirements: [requirement1, requirement2, requirement3, requirement4, requirement5, requirement6],
             storeDataKey: 'headingsAssessment',
-            visualizationConfiguration: {
-                analyzerMessageType: Messages.Assessment.AssessmentScanCompleted,
-            },
+            visualizationConfiguration: {},
             requirementOrder: RequirementComparer.byOutcomeAndName,
         };
 
@@ -268,7 +265,6 @@ describe('AssessmentBuilderTest', () => {
         config.getDrawer(drawerProviderMock.object, requirement5.key);
 
         expect(config.getStoreData(vizStoreData)).toEqual(scanData);
-        expect(config.analyzerMessageType).toEqual(Messages.Assessment.AssessmentScanCompleted);
         expect(config.resultProcessor(scannerStub as ScannerUtils)).toEqual(scannerStub.getAllCompletedInstances);
         expect(config.telemetryProcessor(telemetryFactoryStub as TelemetryDataFactory)).toEqual(
             telemetryFactoryStub.forAssessmentRequirementScan,


### PR DESCRIPTION
#### Description of changes

This property is not being used anymore. It was abandoned in favor of `getAnalyzer` function and configuration per visualization/test

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not apply
- [x] Added relevant unit test for your changes. (`yarn test`)
   - does not apply
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
