### PR TITLE
Add new feature flag for new automated checks report

### DIFF
--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -11,6 +11,7 @@ export class FeatureFlags {
     public static readonly showAllFeatureFlags = 'showAllFeatureFlags';
     public static readonly scoping = 'scoping';
     public static readonly showInstanceVisibility = 'showInstanceVisibility';
+    public static readonly newAutomatedChecksReport = 'newAutomatedChecksReport';
 }
 
 export interface FeatureFlagDetail {
@@ -73,6 +74,14 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
             displayableDescription:
                 'Shows visibility of instances in assessment requirement lists. May impact performance. ' +
                 "(You'll need to go to a different requirement and come back for it to take effect.)",
+            isPreviewFeature: false,
+            forceDefault: false,
+        },
+        {
+            id: FeatureFlags.newAutomatedChecksReport,
+            defaultValue: false,
+            displayableName: 'Enable new automated checks report',
+            displayableDescription: 'Enable the new FastPass Automated checks report, with new UX and accessibility improvements',
             isPreviewFeature: false,
             forceDefault: false,
         },

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -20,6 +20,7 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.showAllFeatureFlags]: false,
             [FeatureFlags.scoping]: false,
             [FeatureFlags.showInstanceVisibility]: false,
+            [FeatureFlags.newAutomatedChecksReport]: false,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Description of changes

Add feature flag for the new automated checks report.

![02 - new feature flag](https://user-images.githubusercontent.com/2837582/58354298-d8efe180-7e25-11e9-8ae5-d10a9504f969.png)

Notes: we do not intend to keep the new report behind a feature flag, the main purpose is to allow the feature crew to make incremental progress and check it to master without disrupting the current report. We'll remove the feature flag and the old report when we're done. This means, visible name and description of the feature flag does not need to be user-facing-perfect.

#### Pull request checklist

- [x] Addresses an existing issue: Completes WI# 1544486
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
