### PR TITLE
fix: prevent CSP errors in target page by removing fabric.scss dependency from injected content

### DIFF
--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-@import '../../../node_modules/office-ui-fabric-react/dist/sass/Icon.Definitions';
 @import '../../common/styles/colors.scss';
 
 #accessibility-insights-root-container {
@@ -43,8 +42,6 @@
     height: 100% !important;
 
     .insights-dialog-container {
-        @import '../../../node_modules/office-ui-fabric-react/dist/sass/Fabric.scss';
-
         @include max-z-index();
     }
 


### PR DESCRIPTION
#### Description of changes
fabric.scss & Icons.Definition.scss adds font face defintions. We don't seem to be using them & the styling is not affected by removing these two files.

Updated playground extension with this change for validation

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #529
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
