### PR TITLE
fix: inspecting same element twice

### DIFF
--- a/src/background/stores/dev-tools-store.ts
+++ b/src/background/stores/dev-tools-store.ts
@@ -47,6 +47,7 @@ export class DevToolStore extends BaseStoreImpl<DevToolState> {
     private onInspectElement(target: string[]): void {
         this.state.inspectElement = target;
         this.state.frameUrl = null;
+        // we're only using this to make sure the store proxy emit the change when the user inspect the same element twice
         this.state.inspectElementRequestId++;
         this.emitChanged();
     }

--- a/src/background/stores/dev-tools-store.ts
+++ b/src/background/stores/dev-tools-store.ts
@@ -19,7 +19,7 @@ export class DevToolStore extends BaseStoreImpl<DevToolState> {
     public getDefaultState(): DevToolState {
         const defaultValues: DevToolState = {
             isOpen: false,
-            count: 0,
+            inspectElementRequestId: 0,
         };
 
         return defaultValues;
@@ -47,7 +47,7 @@ export class DevToolStore extends BaseStoreImpl<DevToolState> {
     private onInspectElement(target: string[]): void {
         this.state.inspectElement = target;
         this.state.frameUrl = null;
-        this.state.count++;
+        this.state.inspectElementRequestId++;
         this.emitChanged();
     }
 

--- a/src/background/stores/dev-tools-store.ts
+++ b/src/background/stores/dev-tools-store.ts
@@ -47,7 +47,7 @@ export class DevToolStore extends BaseStoreImpl<DevToolState> {
     private onInspectElement(target: string[]): void {
         this.state.inspectElement = target;
         this.state.frameUrl = null;
-        this.state.count = 0 || this.state.count + 1;
+        this.state.count++;
         this.emitChanged();
     }
 

--- a/src/background/stores/dev-tools-store.ts
+++ b/src/background/stores/dev-tools-store.ts
@@ -19,6 +19,7 @@ export class DevToolStore extends BaseStoreImpl<DevToolState> {
     public getDefaultState(): DevToolState {
         const defaultValues: DevToolState = {
             isOpen: false,
+            count: 0,
         };
 
         return defaultValues;
@@ -46,6 +47,7 @@ export class DevToolStore extends BaseStoreImpl<DevToolState> {
     private onInspectElement(target: string[]): void {
         this.state.inspectElement = target;
         this.state.frameUrl = null;
+        this.state.count = 0 || this.state.count + 1;
         this.emitChanged();
     }
 

--- a/src/common/types/store-data/idev-tool-state.d.ts
+++ b/src/common/types/store-data/idev-tool-state.d.ts
@@ -4,4 +4,5 @@ export interface DevToolState {
     isOpen: boolean;
     inspectElement?: string[];
     frameUrl?: string;
+    count?: number;
 }

--- a/src/common/types/store-data/idev-tool-state.d.ts
+++ b/src/common/types/store-data/idev-tool-state.d.ts
@@ -4,5 +4,5 @@ export interface DevToolState {
     isOpen: boolean;
     inspectElement?: string[];
     frameUrl?: string;
-    count?: number;
+    count: number;
 }

--- a/src/common/types/store-data/idev-tool-state.d.ts
+++ b/src/common/types/store-data/idev-tool-state.d.ts
@@ -4,5 +4,5 @@ export interface DevToolState {
     isOpen: boolean;
     inspectElement?: string[];
     frameUrl?: string;
-    count: number;
+    inspectElementRequestId: number;
 }

--- a/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
+++ b/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
@@ -57,6 +57,7 @@ describe('DevToolsStoreTest', () => {
         const exepctedState = getDefaultState();
         exepctedState.inspectElement = payload;
         exepctedState.frameUrl = null;
+        exepctedState.count = 1;
 
         createStoreTesterForDevToolsActions('setInspectElement')
             .withActionParam(payload)

--- a/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
+++ b/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
@@ -57,7 +57,7 @@ describe('DevToolsStoreTest', () => {
         const expectedState = getDefaultState();
         expectedState.inspectElement = payload;
         expectedState.frameUrl = null;
-        expectedState.count = 1;
+        expectedState.inspectElementRequestId = 1;
 
         createStoreTesterForDevToolsActions('setInspectElement')
             .withActionParam(payload)

--- a/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
+++ b/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
@@ -54,14 +54,14 @@ describe('DevToolsStoreTest', () => {
 
         const payload = ['#frame1', '#elem1'];
 
-        const exepctedState = getDefaultState();
-        exepctedState.inspectElement = payload;
-        exepctedState.frameUrl = null;
-        exepctedState.count = 1;
+        const expectedState = getDefaultState();
+        expectedState.inspectElement = payload;
+        expectedState.frameUrl = null;
+        expectedState.count = 1;
 
         createStoreTesterForDevToolsActions('setInspectElement')
             .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, exepctedState);
+            .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     test('on setFrameUrl', () => {

--- a/src/tests/unit/tests/injected/frame-url-search-initiator.test.ts
+++ b/src/tests/unit/tests/injected/frame-url-search-initiator.test.ts
@@ -19,7 +19,7 @@ describe('FrameUrlSearchInitiatorTest', () => {
         const stateStub: DevToolState = {
             isOpen: null,
             inspectElement: ['abc', 'def'],
-            count: 0,
+            inspectElementRequestId: 0,
         };
 
         devToolStoreMock.setupAddChangedListener(1);
@@ -42,7 +42,7 @@ describe('FrameUrlSearchInitiatorTest', () => {
             isOpen: null,
             inspectElement: ['abc', 'def'],
             frameUrl: 'test',
-            count: 0,
+            inspectElementRequestId: 0,
         };
 
         devToolStoreMock.setupAddChangedListener(1);
@@ -64,7 +64,7 @@ describe('FrameUrlSearchInitiatorTest', () => {
         const stateStub: DevToolState = {
             isOpen: null,
             inspectElement: ['abc'],
-            count: 0,
+            inspectElementRequestId: 0,
         };
 
         devToolStoreMock.setupAddChangedListener(1);

--- a/src/tests/unit/tests/injected/frame-url-search-initiator.test.ts
+++ b/src/tests/unit/tests/injected/frame-url-search-initiator.test.ts
@@ -19,6 +19,7 @@ describe('FrameUrlSearchInitiatorTest', () => {
         const stateStub: DevToolState = {
             isOpen: null,
             inspectElement: ['abc', 'def'],
+            count: 0,
         };
 
         devToolStoreMock.setupAddChangedListener(1);
@@ -41,6 +42,7 @@ describe('FrameUrlSearchInitiatorTest', () => {
             isOpen: null,
             inspectElement: ['abc', 'def'],
             frameUrl: 'test',
+            count: 0,
         };
 
         devToolStoreMock.setupAddChangedListener(1);
@@ -62,6 +64,7 @@ describe('FrameUrlSearchInitiatorTest', () => {
         const stateStub: DevToolState = {
             isOpen: null,
             inspectElement: ['abc'],
+            count: 0,
         };
 
         devToolStoreMock.setupAddChangedListener(1);


### PR DESCRIPTION
#### Description of changes

Make sure the state is always different (so we trigger the "emit change" on the store proxy side) by adding an auto increment count property to the dev tools store state.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #627 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no UI/UX changes
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - no UI/UX changes
