### PR TITLE
fix: banner title

### DIFF
--- a/src/tests/unit/tests/views/page/__snapshots__/page.test.tsx.snap
+++ b/src/tests/unit/tests/views/page/__snapshots__/page.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`page view renders 1`] = `
     <div
       className="ms-font-m header-text"
     >
-      EXTENSION_NAME
+      Accessibility Insights for Web
     </div>
   </header>
   <main>

--- a/src/tests/unit/tests/views/page/page.test.tsx
+++ b/src/tests/unit/tests/views/page/page.test.tsx
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { configMutator } from '../../../../../common/configuration';
-import { Page, PageDeps } from '../../../../../views/page/page';
 
-configMutator.setOption('extensionFullName', 'EXTENSION_NAME');
+import { Page, PageDeps } from '../../../../../views/page/page';
 
 describe('page view', () => {
     it('renders', () => {

--- a/src/views/page/page.tsx
+++ b/src/views/page/page.tsx
@@ -3,8 +3,8 @@
 import * as React from 'react';
 
 import { HeaderIcon, HeaderIconDeps } from '../../common/components/header-icon';
-import { config } from '../../common/configuration';
 import { NamedSFC } from '../../common/react/named-sfc';
+import { title } from '../../content/strings/application';
 
 export type PageProps = {
     deps: PageDeps;
@@ -13,13 +13,11 @@ export type PageProps = {
 export type PageDeps = HeaderIconDeps;
 
 export const Page = NamedSFC<PageProps>('Page', ({ deps, children }) => {
-    const extensionFullName = config.getOption('extensionFullName');
-
     return (
         <>
             <header className="header-bar">
                 <HeaderIcon deps={deps} />
-                <div className="ms-font-m header-text">{extensionFullName}</div>
+                <div className="ms-font-m header-text">{title}</div>
             </header>
             <main>{children}</main>
         </>


### PR DESCRIPTION
#### Description of changes

We were getting the extension name from the config using the `extensionFullName` property, which is a different value per "environment". To solve this issue, I update the `Page` component to use the `title` const from `src\content\strings\application.ts`

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #625 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
