### PR TITLE
feat: add color box for color contrast fix instructions

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -1369,6 +1369,14 @@ div.insights-file-issue-details-dialog-container {
                                         border: 1px solid $always-black;
                                     }
                                 }
+                                .screen-reader-only {
+                                    position: absolute;
+                                    left: -10000px;
+                                    top: auto;
+                                    width: 1px;
+                                    height: 1px;
+                                    overflow: hidden;
+                                }
                             }
                         }
                     }

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -1364,8 +1364,9 @@ div.insights-file-issue-details-dialog-container {
                                         width: 14px;
                                         height: 14px;
                                         display: inline-block;
-                                        vertical-align: -5%;
+                                        vertical-align: -15%;
                                         margin: 0px 2px;
+                                        border: 1px solid $always-black;
                                     }
                                 }
                             }

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -1357,6 +1357,19 @@ div.insights-file-issue-details-dialog-container {
                             margin: 0px;
                             -webkit-padding-start: 20px;
                         }
+                        .fix-content {
+                            .insights-fix-instruction-list {
+                                li {
+                                    span.fix-instruction-color-box {
+                                        width: 14px;
+                                        height: 14px;
+                                        display: inline-block;
+                                        vertical-align: -5%;
+                                        margin: 0px 2px;
+                                    }
+                                }
+                            }
+                        }
                     }
                     .issue-detail-select-message {
                         padding-top: 10px;

--- a/src/DetailsView/components/Issues-details-pane.tsx
+++ b/src/DetailsView/components/Issues-details-pane.tsx
@@ -12,13 +12,14 @@ import { CreateIssueDetailsTextData } from '../../common/types/create-issue-deta
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { CheckType } from '../../injected/components/details-dialog';
-import { FixInstructionPanel } from '../../injected/components/fix-instruction-panel';
+import { FixInstructionPanel, FixInstructionPanelDeps } from '../../injected/components/fix-instruction-panel';
 import { DecoratedAxeNodeResult } from '../../injected/scanner-utils';
 import { DictionaryStringTo } from '../../types/common-types';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { IssueFilingDialog } from './issue-filing-dialog';
 
 export type IssuesDetailsPaneDeps = ToastDeps &
+    FixInstructionPanelDeps &
     IssueFilingButtonDeps & {
         issueDetailsTextGenerator: IssueDetailsTextGenerator;
         detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
@@ -113,11 +114,13 @@ export class IssuesDetailsPane extends React.Component<IssuesDetailsPaneProps, I
                             <td>How to fix</td>
                             <td className="fix-content">
                                 <FixInstructionPanel
+                                    deps={this.props.deps}
                                     checkType={CheckType.All}
                                     checks={result.all.concat(result.none)}
                                     renderTitleElement={this.renderFixInstructionsTitleElement}
                                 />
                                 <FixInstructionPanel
+                                    deps={this.props.deps}
                                     checkType={CheckType.Any}
                                     checks={result.any}
                                     renderTitleElement={this.renderFixInstructionsTitleElement}

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -47,6 +47,7 @@ import { VisualizationStoreData } from '../common/types/store-data/visualization
 import { UrlParser } from '../common/url-parser';
 import { WindowUtils } from '../common/window-utils';
 import { contentPages } from '../content';
+import { FixInstructionProcessor } from '../injected/fix-instruction-processor';
 import { ScannerUtils } from '../injected/scanner-utils';
 import { getVersion, scan } from '../scanner/exposed-apis';
 import { DictionaryStringTo } from '../types/common-types';
@@ -240,7 +241,10 @@ if (isNaN(tabId) === false) {
                 AxeInfo.Default.version,
             );
 
+            const fixInstructionProcessor = new FixInstructionProcessor();
+
             const deps: DetailsViewContainerDeps = {
+                fixInstructionProcessor,
                 dropdownClickHandler,
                 issueFilingActionMessageCreator,
                 contentProvider: contentPages,

--- a/src/injected/components/details-dialog.tsx
+++ b/src/injected/components/details-dialog.tsx
@@ -25,7 +25,7 @@ import { HyperlinkDefinition } from '../../views/content/content-page';
 import { DetailsDialogHandler } from '../details-dialog-handler';
 import { DecoratedAxeNodeResult } from '../scanner-utils';
 import { TargetPageActionMessageCreator } from '../target-page-action-message-creator';
-import { FixInstructionPanel } from './fix-instruction-panel';
+import { FixInstructionPanel, FixInstructionPanelDeps } from './fix-instruction-panel';
 import { IssueDetailsNavigationControls, IssueDetailsNavigationControlsProps } from './issue-details-navigation-controls';
 
 export enum CheckType {
@@ -38,7 +38,8 @@ export type DetailsDialogDeps = {
     targetPageActionMessageCreator: TargetPageActionMessageCreator;
     clientBrowserAdapter: ClientBrowserAdapter;
 } & CopyIssueDetailsButtonDeps &
-    IssueFilingButtonDeps;
+    IssueFilingButtonDeps &
+    FixInstructionPanelDeps;
 
 export interface DetailsDialogProps {
     deps: DetailsDialogDeps;
@@ -268,11 +269,17 @@ export class DetailsDialog extends React.Component<DetailsDialogProps, DetailsDi
         return (
             <div className="insights-dialog-fix-instruction-container">
                 <FixInstructionPanel
+                    deps={this.props.deps}
                     checkType={CheckType.All}
                     checks={ruleResult.all.concat(ruleResult.none)}
                     renderTitleElement={this.renderSectionTitle}
                 />
-                <FixInstructionPanel checkType={CheckType.Any} checks={ruleResult.any} renderTitleElement={this.renderSectionTitle} />
+                <FixInstructionPanel
+                    deps={this.props.deps}
+                    checkType={CheckType.Any}
+                    checks={ruleResult.any}
+                    renderTitleElement={this.renderSectionTitle}
+                />
             </div>
         );
     }

--- a/src/injected/components/fix-instruction-panel.tsx
+++ b/src/injected/components/fix-instruction-panel.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
+
+import { NamedSFC } from '../../common/react/named-sfc';
 import { CheckType } from './details-dialog';
 
 export interface FixInstructionPanelProps {
@@ -9,22 +11,8 @@ export interface FixInstructionPanelProps {
     renderTitleElement: (titleText: string, className: string) => JSX.Element;
 }
 
-export class FixInstructionPanel extends React.Component<FixInstructionPanelProps, any> {
-    public render(): JSX.Element {
-        if (this.props.checks.length === 0) {
-            return null;
-        }
-        const title: string = this.getPanelTitle(this.props.checkType, this.props.checks.length);
-
-        return (
-            <div>
-                {this.props.renderTitleElement(title, 'insights-fix-instruction-title')}
-                <ul className="insights-fix-instruction-list">{this.renderInstructions(this.props.checkType)}</ul>
-            </div>
-        );
-    }
-
-    private getPanelTitle(checkType: CheckType, checkCount: number): string {
+export const FixInstructionPanel = NamedSFC<FixInstructionPanelProps>('FixInstructionPanel', props => {
+    const getPanelTitle = (checkType: CheckType, checkCount: number): string => {
         if (checkCount === 1) {
             return 'Fix the following:';
         }
@@ -33,12 +21,26 @@ export class FixInstructionPanel extends React.Component<FixInstructionPanelProp
         } else {
             return 'Fix ALL of the following:';
         }
-    }
+    };
 
-    private renderInstructions(checkType: CheckType): JSX.Element[] {
-        const instructionList = this.props.checks.map((check, checkIndex) => {
+    const renderInstructions = (checkType: CheckType): JSX.Element[] => {
+        const instructionList = props.checks.map((check, checkIndex) => {
             return <li key={`instruction-${CheckType[checkType]}-${checkIndex + 1}`}>{check.message}</li>;
         });
+
         return instructionList;
+    };
+
+    if (props.checks.length === 0) {
+        return null;
     }
-}
+
+    const title: string = getPanelTitle(props.checkType, props.checks.length);
+
+    return (
+        <div>
+            {props.renderTitleElement(title, 'insights-fix-instruction-title')}
+            <ul className="insights-fix-instruction-list">{renderInstructions(props.checkType)}</ul>
+        </div>
+    );
+});

--- a/src/injected/components/fix-instruction-panel.tsx
+++ b/src/injected/components/fix-instruction-panel.tsx
@@ -3,15 +3,23 @@
 import * as React from 'react';
 
 import { NamedSFC } from '../../common/react/named-sfc';
+import { FixInstructionProcessor } from '../fix-instruction-processor';
 import { CheckType } from './details-dialog';
 
+export interface FixInstructionPanelDeps {
+    fixInstructionProcessor: FixInstructionProcessor;
+}
+
 export interface FixInstructionPanelProps {
+    deps: FixInstructionPanelDeps;
     checkType: CheckType;
     checks: FormattedCheckResult[];
     renderTitleElement: (titleText: string, className: string) => JSX.Element;
 }
 
 export const FixInstructionPanel = NamedSFC<FixInstructionPanelProps>('FixInstructionPanel', props => {
+    const { fixInstructionProcessor } = props.deps;
+
     const getPanelTitle = (checkType: CheckType, checkCount: number): string => {
         if (checkCount === 1) {
             return 'Fix the following:';
@@ -25,7 +33,7 @@ export const FixInstructionPanel = NamedSFC<FixInstructionPanelProps>('FixInstru
 
     const renderInstructions = (checkType: CheckType): JSX.Element[] => {
         const instructionList = props.checks.map((check, checkIndex) => {
-            return <li key={`instruction-${CheckType[checkType]}-${checkIndex + 1}`}>{check.message}</li>;
+            return <li key={`instruction-${CheckType[checkType]}-${checkIndex + 1}`}>{fixInstructionProcessor.process(check.message)}</li>;
         });
 
         return instructionList;

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -16,6 +16,7 @@ import { WindowUtils } from '../common/window-utils';
 import { DictionaryStringTo } from '../types/common-types';
 import { rootContainerId } from './constants';
 import { DetailsDialogHandler } from './details-dialog-handler';
+import { FixInstructionProcessor } from './fix-instruction-processor';
 import { ErrorMessageContent } from './frameCommunicators/error-message-content';
 import { FrameCommunicator, MessageRequest } from './frameCommunicators/frame-communicator';
 import { FrameMessageResponseCallback } from './frameCommunicators/window-message-handler';
@@ -67,7 +68,10 @@ export class DialogRenderer {
                 AxeInfo.Default.version,
             );
 
+            const fixInstructionProcessor = new FixInstructionProcessor();
+
             const deps: LayeredDetailsDialogDeps = {
+                fixInstructionProcessor,
                 issueDetailsTextGenerator,
                 windowUtils: this.windowUtils,
                 targetPageActionMessageCreator: mainWindowContext.getTargetPageActionMessageCreator(),

--- a/src/injected/fix-instruction-processor.tsx
+++ b/src/injected/fix-instruction-processor.tsx
@@ -66,7 +66,12 @@ export class FixInstructionProcessor {
 
         result.push(<span key={`instruction-split-${keyIndex++}`}>{coda}</span>);
 
-        return <>{result}</>;
+        return (
+            <>
+                <span aria-hidden="true">{result}</span>
+                <span className="screen-reader-only">{fixInstruction}</span>
+            </>
+        );
     }
 
     private createColorBox(colorHexValue: string, keyIndex: number): JSX.Element {

--- a/src/injected/fix-instruction-processor.tsx
+++ b/src/injected/fix-instruction-processor.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+type ColorMatch = {
+    splitIndex: number;
+    colorHexValue: string;
+};
+
+export class FixInstructionProcessor {
+    private readonly colorGroupName = 'color';
+    private readonly colorValueMatcher = `(?<${this.colorGroupName}>#[0-9a-f]{6})`;
+    private readonly foregroundColorText = 'foreground color: ';
+    private readonly foregroundRegExp = new RegExp(`${this.foregroundColorText}${this.colorValueMatcher}`, 'i');
+    private readonly backgroundColorText = 'background color: ';
+    private readonly backgroundRegExp = new RegExp(`${this.backgroundColorText}${this.colorValueMatcher}`, 'i');
+
+    public process(fixInstruction: string): JSX.Element {
+        const foregroundMatch = this.getColorMatch(fixInstruction, this.foregroundRegExp);
+        const backgroundMatch = this.getColorMatch(fixInstruction, this.backgroundRegExp);
+
+        const matches = [foregroundMatch, backgroundMatch];
+
+        return this.splitFixInstruction(fixInstruction, matches);
+    }
+
+    private getColorMatch(fixInstruction: string, colorRegex: RegExp): ColorMatch {
+        if (!colorRegex.test(fixInstruction)) {
+            return null;
+        }
+
+        const match = colorRegex.exec(fixInstruction);
+
+        const groups = match['groups'];
+
+        return {
+            splitIndex: match.index + this.foregroundColorText.length + 7,
+            colorHexValue: groups[this.colorGroupName],
+        };
+    }
+
+    private splitFixInstruction(fixInstruction: string, matches: ColorMatch[]): JSX.Element {
+        const properMatches = matches.filter(current => current != null).sort((a, b) => a.splitIndex - b.splitIndex);
+
+        if (properMatches.length == 0) {
+            return <>{fixInstruction}</>;
+        }
+
+        let insertionIndex = 0;
+
+        const result: JSX.Element[] = [];
+
+        properMatches.forEach(match => {
+            const substring = fixInstruction.substring(insertionIndex, match.splitIndex);
+
+            result.push(<>{substring}</>);
+
+            result.push(this.createColorBox(match.colorHexValue));
+
+            insertionIndex = match.splitIndex;
+        });
+
+        const coda = fixInstruction.substr(insertionIndex);
+
+        result.push(<>{coda}</>);
+
+        return <>{result}</>;
+    }
+
+    private createColorBox(colorHexValue: string): JSX.Element {
+        return <span className="fix-instruction-color-box" style={{ backgroundColor: colorHexValue }} />;
+    }
+}

--- a/src/injected/fix-instruction-processor.tsx
+++ b/src/injected/fix-instruction-processor.tsx
@@ -32,10 +32,11 @@ export class FixInstructionProcessor {
         const match = colorRegex.exec(fixInstruction);
 
         const groups = match['groups'];
+        const colorHexValue = groups[this.colorGroupName];
 
         return {
-            splitIndex: match.index + this.foregroundColorText.length + 7,
-            colorHexValue: groups[this.colorGroupName],
+            splitIndex: match.index + this.foregroundColorText.length + colorHexValue.length,
+            colorHexValue,
         };
     }
 
@@ -52,7 +53,7 @@ export class FixInstructionProcessor {
         const result: JSX.Element[] = [];
 
         properMatches.forEach(match => {
-            const endIndex = match.splitIndex - 7;
+            const endIndex = match.splitIndex - match.colorHexValue.length;
             const substring = fixInstruction.substring(insertionIndex, endIndex);
 
             result.push(<span key={`instruction-split-${keyIndex++}`}>{substring}</span>);

--- a/src/injected/fix-instruction-processor.tsx
+++ b/src/injected/fix-instruction-processor.tsx
@@ -42,32 +42,35 @@ export class FixInstructionProcessor {
     private splitFixInstruction(fixInstruction: string, matches: ColorMatch[]): JSX.Element {
         const properMatches = matches.filter(current => current != null).sort((a, b) => a.splitIndex - b.splitIndex);
 
-        if (properMatches.length == 0) {
+        if (properMatches.length === 0) {
             return <>{fixInstruction}</>;
         }
 
         let insertionIndex = 0;
+        let keyIndex = 0;
 
         const result: JSX.Element[] = [];
 
         properMatches.forEach(match => {
             const substring = fixInstruction.substring(insertionIndex, match.splitIndex);
 
-            result.push(<>{substring}</>);
+            result.push(<span key={`instruction-split-${keyIndex++}`}>{substring}</span>);
 
-            result.push(this.createColorBox(match.colorHexValue));
+            result.push(this.createColorBox(match.colorHexValue, keyIndex++));
 
             insertionIndex = match.splitIndex;
         });
 
         const coda = fixInstruction.substr(insertionIndex);
 
-        result.push(<>{coda}</>);
+        result.push(<span key={`instruction-split-${keyIndex++}`}>{coda}</span>);
 
         return <>{result}</>;
     }
 
-    private createColorBox(colorHexValue: string): JSX.Element {
-        return <span className="fix-instruction-color-box" style={{ backgroundColor: colorHexValue }} />;
+    private createColorBox(colorHexValue: string, keyIndex: number): JSX.Element {
+        return (
+            <span key={`instruction-split-${keyIndex}`} className="fix-instruction-color-box" style={{ backgroundColor: colorHexValue }} />
+        );
     }
 }

--- a/src/injected/fix-instruction-processor.tsx
+++ b/src/injected/fix-instruction-processor.tsx
@@ -52,13 +52,14 @@ export class FixInstructionProcessor {
         const result: JSX.Element[] = [];
 
         properMatches.forEach(match => {
-            const substring = fixInstruction.substring(insertionIndex, match.splitIndex);
+            const endIndex = match.splitIndex - 7;
+            const substring = fixInstruction.substring(insertionIndex, endIndex);
 
             result.push(<span key={`instruction-split-${keyIndex++}`}>{substring}</span>);
 
             result.push(this.createColorBox(match.colorHexValue, keyIndex++));
 
-            insertionIndex = match.splitIndex;
+            insertionIndex = endIndex;
         });
 
         const coda = fixInstruction.substr(insertionIndex);

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -385,6 +385,7 @@
                         display: inline-block;
                         vertical-align: -5%;
                         margin: 0px 2px;
+                        border: 1px solid $always-black;
                     }
                 }
             }

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -376,6 +376,18 @@
                 margin: 8px 8px 0px 8px !important;
                 padding-left: 8px !important;
             }
+
+            .insights-fix-instruction-list {
+                li {
+                    span.fix-instruction-color-box {
+                        width: 14px;
+                        height: 14px;
+                        display: inline-block;
+                        vertical-align: -5%;
+                        margin: 0px 2px;
+                    }
+                }
+            }
         }
 
         .insights-dialog-target-button-container {

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -388,6 +388,14 @@
                         border: 1px solid $always-black;
                     }
                 }
+                .screen-reader-only {
+                    position: absolute;
+                    left: -10000px;
+                    top: auto;
+                    width: 1px;
+                    height: 1px;
+                    overflow: hidden;
+                }
             }
         }
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-details-pane.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-details-pane.test.tsx.snap
@@ -94,8 +94,8 @@ exports[`IssuesDetailsPaneTest render with single selection, test copy to clipbo
             How to fix
           </td>
           <td className=\\"fix-content\\">
-            <FixInstructionPanel checkType={0} checks={{...}} renderTitleElement={[Function]} />
-            <FixInstructionPanel checkType={1} checks={{...}} renderTitleElement={[Function]} />
+            <FixInstructionPanel deps={{...}} checkType={0} checks={{...}} renderTitleElement={[Function]} />
+            <FixInstructionPanel deps={{...}} checkType={1} checks={{...}} renderTitleElement={[Function]} />
           </td>
         </tr>
         <tr>

--- a/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
@@ -2,98 +2,134 @@
 
 exports[`FixInstructionProcessor background and foreground on the message (mind the order) 1`] = `
 <React.Fragment>
-  <span>
-    Element has insufficient color contrast of 2.52 (background color: 
+  <span
+    aria-hidden="true"
+  >
+    <span>
+      Element has insufficient color contrast of 2.52 (background color: 
+    </span>
+    <span
+      className="fix-instruction-color-box"
+      style={
+        Object {
+          "backgroundColor": "#8a94a8",
+        }
+      }
+    />
+    <span>
+      #8a94a8, foreground color: 
+    </span>
+    <span
+      className="fix-instruction-color-box"
+      style={
+        Object {
+          "backgroundColor": "#e7ecd8",
+        }
+      }
+    />
+    <span>
+      #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+    </span>
   </span>
   <span
-    className="fix-instruction-color-box"
-    style={
-      Object {
-        "backgroundColor": "#8a94a8",
-      }
-    }
-  />
-  <span>
-    #8a94a8, foreground color: 
-  </span>
-  <span
-    className="fix-instruction-color-box"
-    style={
-      Object {
-        "backgroundColor": "#e7ecd8",
-      }
-    }
-  />
-  <span>
-    #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+    className="screen-reader-only"
+  >
+    Element has insufficient color contrast of 2.52 (background color: #8a94a8, foreground color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
   </span>
 </React.Fragment>
 `;
 
 exports[`FixInstructionProcessor background color on the message 1`] = `
 <React.Fragment>
-  <span>
-    color contrast of 2.52 (background color: 
+  <span
+    aria-hidden="true"
+  >
+    <span>
+      color contrast of 2.52 (background color: 
+    </span>
+    <span
+      className="fix-instruction-color-box"
+      style={
+        Object {
+          "backgroundColor": "#8a94a8",
+        }
+      }
+    />
+    <span>
+      #8a94a8; nothing else to match here)
+    </span>
   </span>
   <span
-    className="fix-instruction-color-box"
-    style={
-      Object {
-        "backgroundColor": "#8a94a8",
-      }
-    }
-  />
-  <span>
-    #8a94a8; nothing else to match here)
+    className="screen-reader-only"
+  >
+    color contrast of 2.52 (background color: #8a94a8; nothing else to match here)
   </span>
 </React.Fragment>
 `;
 
 exports[`FixInstructionProcessor foreground and background color on the message (mind the order) 1`] = `
 <React.Fragment>
-  <span>
-    Element has insufficient color contrast of 2.52 (foreground color: 
+  <span
+    aria-hidden="true"
+  >
+    <span>
+      Element has insufficient color contrast of 2.52 (foreground color: 
+    </span>
+    <span
+      className="fix-instruction-color-box"
+      style={
+        Object {
+          "backgroundColor": "#8a94a8",
+        }
+      }
+    />
+    <span>
+      #8a94a8, background color: 
+    </span>
+    <span
+      className="fix-instruction-color-box"
+      style={
+        Object {
+          "backgroundColor": "#e7ecd8",
+        }
+      }
+    />
+    <span>
+      #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+    </span>
   </span>
   <span
-    className="fix-instruction-color-box"
-    style={
-      Object {
-        "backgroundColor": "#8a94a8",
-      }
-    }
-  />
-  <span>
-    #8a94a8, background color: 
-  </span>
-  <span
-    className="fix-instruction-color-box"
-    style={
-      Object {
-        "backgroundColor": "#e7ecd8",
-      }
-    }
-  />
-  <span>
-    #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+    className="screen-reader-only"
+  >
+    Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
   </span>
 </React.Fragment>
 `;
 
 exports[`FixInstructionProcessor foreground color on the message 1`] = `
 <React.Fragment>
-  <span>
-    color contrast of 2.52 (foreground color: 
+  <span
+    aria-hidden="true"
+  >
+    <span>
+      color contrast of 2.52 (foreground color: 
+    </span>
+    <span
+      className="fix-instruction-color-box"
+      style={
+        Object {
+          "backgroundColor": "#8a94a8",
+        }
+      }
+    />
+    <span>
+      #8a94a8; nothing else to match here)
+    </span>
   </span>
   <span
-    className="fix-instruction-color-box"
-    style={
-      Object {
-        "backgroundColor": "#8a94a8",
-      }
-    }
-  />
-  <span>
-    #8a94a8; nothing else to match here)
+    className="screen-reader-only"
+  >
+    color contrast of 2.52 (foreground color: #8a94a8; nothing else to match here)
   </span>
 </React.Fragment>
 `;
@@ -106,30 +142,39 @@ exports[`FixInstructionProcessor no background nor foreground on the message 1`]
 
 exports[`FixInstructionProcessor we assume only one instance of fore/background color, second instance will be ignored 1`] = `
 <React.Fragment>
-  <span>
-    first foreground color: 
+  <span
+    aria-hidden="true"
+  >
+    <span>
+      first foreground color: 
+    </span>
+    <span
+      className="fix-instruction-color-box"
+      style={
+        Object {
+          "backgroundColor": "#ffffff",
+        }
+      }
+    />
+    <span>
+      #ffffff, second foreground: #000000, first background color: 
+    </span>
+    <span
+      className="fix-instruction-color-box"
+      style={
+        Object {
+          "backgroundColor": "#AAAAAA",
+        }
+      }
+    />
+    <span>
+      #AAAAAA, second background color: #bbBBbb
+    </span>
   </span>
   <span
-    className="fix-instruction-color-box"
-    style={
-      Object {
-        "backgroundColor": "#ffffff",
-      }
-    }
-  />
-  <span>
-    #ffffff, second foreground: #000000, first background color: 
-  </span>
-  <span
-    className="fix-instruction-color-box"
-    style={
-      Object {
-        "backgroundColor": "#AAAAAA",
-      }
-    }
-  />
-  <span>
-    #AAAAAA, second background color: #bbBBbb
+    className="screen-reader-only"
+  >
+    first foreground color: #ffffff, second foreground: #000000, first background color: #AAAAAA, second background color: #bbBBbb
   </span>
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`FixInstructionProcessor background and foreground on the message (mind the order) 1`] = `
 <React.Fragment>
-  <React.Fragment>
+  <span>
     Element has insufficient color contrast of 2.52 (background color: #8a94a8
-  </React.Fragment>
+  </span>
   <span
     className="fix-instruction-color-box"
     style={
@@ -13,9 +13,9 @@ exports[`FixInstructionProcessor background and foreground on the message (mind 
       }
     }
   />
-  <React.Fragment>
+  <span>
     , foreground color: #e7ecd8
-  </React.Fragment>
+  </span>
   <span
     className="fix-instruction-color-box"
     style={
@@ -24,17 +24,17 @@ exports[`FixInstructionProcessor background and foreground on the message (mind 
       }
     }
   />
-  <React.Fragment>
+  <span>
     , font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
-  </React.Fragment>
+  </span>
 </React.Fragment>
 `;
 
 exports[`FixInstructionProcessor background color on the message 1`] = `
 <React.Fragment>
-  <React.Fragment>
+  <span>
     color contrast of 2.52 (background color: #8a94a8
-  </React.Fragment>
+  </span>
   <span
     className="fix-instruction-color-box"
     style={
@@ -43,17 +43,17 @@ exports[`FixInstructionProcessor background color on the message 1`] = `
       }
     }
   />
-  <React.Fragment>
+  <span>
     ; nothing else to match here)
-  </React.Fragment>
+  </span>
 </React.Fragment>
 `;
 
 exports[`FixInstructionProcessor foreground and background color on the message (mind the order) 1`] = `
 <React.Fragment>
-  <React.Fragment>
+  <span>
     Element has insufficient color contrast of 2.52 (foreground color: #8a94a8
-  </React.Fragment>
+  </span>
   <span
     className="fix-instruction-color-box"
     style={
@@ -62,9 +62,9 @@ exports[`FixInstructionProcessor foreground and background color on the message 
       }
     }
   />
-  <React.Fragment>
+  <span>
     , background color: #e7ecd8
-  </React.Fragment>
+  </span>
   <span
     className="fix-instruction-color-box"
     style={
@@ -73,17 +73,17 @@ exports[`FixInstructionProcessor foreground and background color on the message 
       }
     }
   />
-  <React.Fragment>
+  <span>
     , font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
-  </React.Fragment>
+  </span>
 </React.Fragment>
 `;
 
 exports[`FixInstructionProcessor foreground color on the message 1`] = `
 <React.Fragment>
-  <React.Fragment>
+  <span>
     color contrast of 2.52 (foreground color: #8a94a8
-  </React.Fragment>
+  </span>
   <span
     className="fix-instruction-color-box"
     style={
@@ -92,9 +92,9 @@ exports[`FixInstructionProcessor foreground color on the message 1`] = `
       }
     }
   />
-  <React.Fragment>
+  <span>
     ; nothing else to match here)
-  </React.Fragment>
+  </span>
 </React.Fragment>
 `;
 
@@ -106,9 +106,9 @@ exports[`FixInstructionProcessor no background nor foreground on the message 1`]
 
 exports[`FixInstructionProcessor we assume only one instance of fore/background color, second instance will be ignored 1`] = `
 <React.Fragment>
-  <React.Fragment>
+  <span>
     first foreground color: #ffffff
-  </React.Fragment>
+  </span>
   <span
     className="fix-instruction-color-box"
     style={
@@ -117,9 +117,9 @@ exports[`FixInstructionProcessor we assume only one instance of fore/background 
       }
     }
   />
-  <React.Fragment>
+  <span>
     , second foreground: #000000, first background color: #AAAAAA
-  </React.Fragment>
+  </span>
   <span
     className="fix-instruction-color-box"
     style={
@@ -128,8 +128,8 @@ exports[`FixInstructionProcessor we assume only one instance of fore/background 
       }
     }
   />
-  <React.Fragment>
+  <span>
     , second background color: #bbBBbb
-  </React.Fragment>
+  </span>
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FixInstructionProcessor background and foreground on the message (mind the order) 1`] = `
 <React.Fragment>
   <span>
-    Element has insufficient color contrast of 2.52 (background color: #8a94a8
+    Element has insufficient color contrast of 2.52 (background color: 
   </span>
   <span
     className="fix-instruction-color-box"
@@ -14,7 +14,7 @@ exports[`FixInstructionProcessor background and foreground on the message (mind 
     }
   />
   <span>
-    , foreground color: #e7ecd8
+    #8a94a8, foreground color: 
   </span>
   <span
     className="fix-instruction-color-box"
@@ -25,7 +25,7 @@ exports[`FixInstructionProcessor background and foreground on the message (mind 
     }
   />
   <span>
-    , font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+    #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
   </span>
 </React.Fragment>
 `;
@@ -33,7 +33,7 @@ exports[`FixInstructionProcessor background and foreground on the message (mind 
 exports[`FixInstructionProcessor background color on the message 1`] = `
 <React.Fragment>
   <span>
-    color contrast of 2.52 (background color: #8a94a8
+    color contrast of 2.52 (background color: 
   </span>
   <span
     className="fix-instruction-color-box"
@@ -44,7 +44,7 @@ exports[`FixInstructionProcessor background color on the message 1`] = `
     }
   />
   <span>
-    ; nothing else to match here)
+    #8a94a8; nothing else to match here)
   </span>
 </React.Fragment>
 `;
@@ -52,7 +52,7 @@ exports[`FixInstructionProcessor background color on the message 1`] = `
 exports[`FixInstructionProcessor foreground and background color on the message (mind the order) 1`] = `
 <React.Fragment>
   <span>
-    Element has insufficient color contrast of 2.52 (foreground color: #8a94a8
+    Element has insufficient color contrast of 2.52 (foreground color: 
   </span>
   <span
     className="fix-instruction-color-box"
@@ -63,7 +63,7 @@ exports[`FixInstructionProcessor foreground and background color on the message 
     }
   />
   <span>
-    , background color: #e7ecd8
+    #8a94a8, background color: 
   </span>
   <span
     className="fix-instruction-color-box"
@@ -74,7 +74,7 @@ exports[`FixInstructionProcessor foreground and background color on the message 
     }
   />
   <span>
-    , font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+    #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
   </span>
 </React.Fragment>
 `;
@@ -82,7 +82,7 @@ exports[`FixInstructionProcessor foreground and background color on the message 
 exports[`FixInstructionProcessor foreground color on the message 1`] = `
 <React.Fragment>
   <span>
-    color contrast of 2.52 (foreground color: #8a94a8
+    color contrast of 2.52 (foreground color: 
   </span>
   <span
     className="fix-instruction-color-box"
@@ -93,7 +93,7 @@ exports[`FixInstructionProcessor foreground color on the message 1`] = `
     }
   />
   <span>
-    ; nothing else to match here)
+    #8a94a8; nothing else to match here)
   </span>
 </React.Fragment>
 `;
@@ -107,7 +107,7 @@ exports[`FixInstructionProcessor no background nor foreground on the message 1`]
 exports[`FixInstructionProcessor we assume only one instance of fore/background color, second instance will be ignored 1`] = `
 <React.Fragment>
   <span>
-    first foreground color: #ffffff
+    first foreground color: 
   </span>
   <span
     className="fix-instruction-color-box"
@@ -118,7 +118,7 @@ exports[`FixInstructionProcessor we assume only one instance of fore/background 
     }
   />
   <span>
-    , second foreground: #000000, first background color: #AAAAAA
+    #ffffff, second foreground: #000000, first background color: 
   </span>
   <span
     className="fix-instruction-color-box"
@@ -129,7 +129,7 @@ exports[`FixInstructionProcessor we assume only one instance of fore/background 
     }
   />
   <span>
-    , second background color: #bbBBbb
+    #AAAAAA, second background color: #bbBBbb
   </span>
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
@@ -1,0 +1,135 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FixInstructionProcessor background and foreground on the message (mind the order) 1`] = `
+<React.Fragment>
+  <React.Fragment>
+    Element has insufficient color contrast of 2.52 (background color: #8a94a8
+  </React.Fragment>
+  <span
+    className="fix-instruction-color-box"
+    style={
+      Object {
+        "backgroundColor": "#8a94a8",
+      }
+    }
+  />
+  <React.Fragment>
+    , foreground color: #e7ecd8
+  </React.Fragment>
+  <span
+    className="fix-instruction-color-box"
+    style={
+      Object {
+        "backgroundColor": "#e7ecd8",
+      }
+    }
+  />
+  <React.Fragment>
+    , font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+  </React.Fragment>
+</React.Fragment>
+`;
+
+exports[`FixInstructionProcessor background color on the message 1`] = `
+<React.Fragment>
+  <React.Fragment>
+    color contrast of 2.52 (background color: #8a94a8
+  </React.Fragment>
+  <span
+    className="fix-instruction-color-box"
+    style={
+      Object {
+        "backgroundColor": "#8a94a8",
+      }
+    }
+  />
+  <React.Fragment>
+    ; nothing else to match here)
+  </React.Fragment>
+</React.Fragment>
+`;
+
+exports[`FixInstructionProcessor foreground and background color on the message (mind the order) 1`] = `
+<React.Fragment>
+  <React.Fragment>
+    Element has insufficient color contrast of 2.52 (foreground color: #8a94a8
+  </React.Fragment>
+  <span
+    className="fix-instruction-color-box"
+    style={
+      Object {
+        "backgroundColor": "#8a94a8",
+      }
+    }
+  />
+  <React.Fragment>
+    , background color: #e7ecd8
+  </React.Fragment>
+  <span
+    className="fix-instruction-color-box"
+    style={
+      Object {
+        "backgroundColor": "#e7ecd8",
+      }
+    }
+  />
+  <React.Fragment>
+    , font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
+  </React.Fragment>
+</React.Fragment>
+`;
+
+exports[`FixInstructionProcessor foreground color on the message 1`] = `
+<React.Fragment>
+  <React.Fragment>
+    color contrast of 2.52 (foreground color: #8a94a8
+  </React.Fragment>
+  <span
+    className="fix-instruction-color-box"
+    style={
+      Object {
+        "backgroundColor": "#8a94a8",
+      }
+    }
+  />
+  <React.Fragment>
+    ; nothing else to match here)
+  </React.Fragment>
+</React.Fragment>
+`;
+
+exports[`FixInstructionProcessor no background nor foreground on the message 1`] = `
+<React.Fragment>
+  there is nothing that will trigger the processor to change the fix instruction here
+</React.Fragment>
+`;
+
+exports[`FixInstructionProcessor we assume only one instance of fore/background color, second instance will be ignored 1`] = `
+<React.Fragment>
+  <React.Fragment>
+    first foreground color: #ffffff
+  </React.Fragment>
+  <span
+    className="fix-instruction-color-box"
+    style={
+      Object {
+        "backgroundColor": "#ffffff",
+      }
+    }
+  />
+  <React.Fragment>
+    , second foreground: #000000, first background color: #AAAAAA
+  </React.Fragment>
+  <span
+    className="fix-instruction-color-box"
+    style={
+      Object {
+        "backgroundColor": "#AAAAAA",
+      }
+    }
+  />
+  <React.Fragment>
+    , second background color: #bbBBbb
+  </React.Fragment>
+</React.Fragment>
+`;

--- a/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
@@ -194,11 +194,37 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
       <FixInstructionPanel
         checkType={0}
         checks={Array []}
+        deps={
+          Object {
+            "clientBrowserAdapter": Object {
+              "getUrl": [Function],
+            },
+            "issueDetailsTextGenerator": null,
+            "issueFilingActionMessageCreator": null,
+            "targetPageActionMessageCreator": Object {
+              "copyIssueDetailsClicked": [Function],
+            },
+            "windowUtils": null,
+          }
+        }
         renderTitleElement={[Function]}
       />
       <FixInstructionPanel
         checkType={1}
         checks={Array []}
+        deps={
+          Object {
+            "clientBrowserAdapter": Object {
+              "getUrl": [Function],
+            },
+            "issueDetailsTextGenerator": null,
+            "issueFilingActionMessageCreator": null,
+            "targetPageActionMessageCreator": Object {
+              "copyIssueDetailsClicked": [Function],
+            },
+            "windowUtils": null,
+          }
+        }
         renderTitleElement={[Function]}
       />
     </div>
@@ -562,11 +588,37 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
                     <FixInstructionPanel
                       checkType={0}
                       checks={Array []}
+                      deps={
+                        Object {
+                          "clientBrowserAdapter": Object {
+                            "getUrl": [Function],
+                          },
+                          "issueDetailsTextGenerator": null,
+                          "issueFilingActionMessageCreator": null,
+                          "targetPageActionMessageCreator": Object {
+                            "copyIssueDetailsClicked": [Function],
+                          },
+                          "windowUtils": null,
+                        }
+                      }
                       renderTitleElement={[Function]}
                     />
                     <FixInstructionPanel
                       checkType={1}
                       checks={Array []}
+                      deps={
+                        Object {
+                          "clientBrowserAdapter": Object {
+                            "getUrl": [Function],
+                          },
+                          "issueDetailsTextGenerator": null,
+                          "issueFilingActionMessageCreator": null,
+                          "targetPageActionMessageCreator": Object {
+                            "copyIssueDetailsClicked": [Function],
+                          },
+                          "windowUtils": null,
+                        }
+                      }
                       renderTitleElement={[Function]}
                     />
                   </div>
@@ -880,11 +932,37 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: true }
         <FixInstructionPanel
           checkType={0}
           checks={Array []}
+          deps={
+            Object {
+              "clientBrowserAdapter": Object {
+                "getUrl": [Function],
+              },
+              "issueDetailsTextGenerator": null,
+              "issueFilingActionMessageCreator": null,
+              "targetPageActionMessageCreator": Object {
+                "copyIssueDetailsClicked": [Function],
+              },
+              "windowUtils": null,
+            }
+          }
           renderTitleElement={[Function]}
         />
         <FixInstructionPanel
           checkType={1}
           checks={Array []}
+          deps={
+            Object {
+              "clientBrowserAdapter": Object {
+                "getUrl": [Function],
+              },
+              "issueDetailsTextGenerator": null,
+              "issueFilingActionMessageCreator": null,
+              "targetPageActionMessageCreator": Object {
+                "copyIssueDetailsClicked": [Function],
+              },
+              "windowUtils": null,
+            }
+          }
           renderTitleElement={[Function]}
         />
       </div>
@@ -1252,11 +1330,37 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: true }
                         <FixInstructionPanel
                           checkType={0}
                           checks={Array []}
+                          deps={
+                            Object {
+                              "clientBrowserAdapter": Object {
+                                "getUrl": [Function],
+                              },
+                              "issueDetailsTextGenerator": null,
+                              "issueFilingActionMessageCreator": null,
+                              "targetPageActionMessageCreator": Object {
+                                "copyIssueDetailsClicked": [Function],
+                              },
+                              "windowUtils": null,
+                            }
+                          }
                           renderTitleElement={[Function]}
                         />
                         <FixInstructionPanel
                           checkType={1}
                           checks={Array []}
+                          deps={
+                            Object {
+                              "clientBrowserAdapter": Object {
+                                "getUrl": [Function],
+                              },
+                              "issueDetailsTextGenerator": null,
+                              "issueFilingActionMessageCreator": null,
+                              "targetPageActionMessageCreator": Object {
+                                "copyIssueDetailsClicked": [Function],
+                              },
+                              "windowUtils": null,
+                            }
+                          }
                           renderTitleElement={[Function]}
                         />
                       </div>
@@ -1561,11 +1665,37 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
       <FixInstructionPanel
         checkType={0}
         checks={Array []}
+        deps={
+          Object {
+            "clientBrowserAdapter": Object {
+              "getUrl": [Function],
+            },
+            "issueDetailsTextGenerator": null,
+            "issueFilingActionMessageCreator": null,
+            "targetPageActionMessageCreator": Object {
+              "copyIssueDetailsClicked": [Function],
+            },
+            "windowUtils": null,
+          }
+        }
         renderTitleElement={[Function]}
       />
       <FixInstructionPanel
         checkType={1}
         checks={Array []}
+        deps={
+          Object {
+            "clientBrowserAdapter": Object {
+              "getUrl": [Function],
+            },
+            "issueDetailsTextGenerator": null,
+            "issueFilingActionMessageCreator": null,
+            "targetPageActionMessageCreator": Object {
+              "copyIssueDetailsClicked": [Function],
+            },
+            "windowUtils": null,
+          }
+        }
         renderTitleElement={[Function]}
       />
     </div>
@@ -1924,11 +2054,37 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
                     <FixInstructionPanel
                       checkType={0}
                       checks={Array []}
+                      deps={
+                        Object {
+                          "clientBrowserAdapter": Object {
+                            "getUrl": [Function],
+                          },
+                          "issueDetailsTextGenerator": null,
+                          "issueFilingActionMessageCreator": null,
+                          "targetPageActionMessageCreator": Object {
+                            "copyIssueDetailsClicked": [Function],
+                          },
+                          "windowUtils": null,
+                        }
+                      }
                       renderTitleElement={[Function]}
                     />
                     <FixInstructionPanel
                       checkType={1}
                       checks={Array []}
+                      deps={
+                        Object {
+                          "clientBrowserAdapter": Object {
+                            "getUrl": [Function],
+                          },
+                          "issueDetailsTextGenerator": null,
+                          "issueFilingActionMessageCreator": null,
+                          "targetPageActionMessageCreator": Object {
+                            "copyIssueDetailsClicked": [Function],
+                          },
+                          "windowUtils": null,
+                        }
+                      }
                       renderTitleElement={[Function]}
                     />
                   </div>
@@ -2237,11 +2393,37 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: true } 
         <FixInstructionPanel
           checkType={0}
           checks={Array []}
+          deps={
+            Object {
+              "clientBrowserAdapter": Object {
+                "getUrl": [Function],
+              },
+              "issueDetailsTextGenerator": null,
+              "issueFilingActionMessageCreator": null,
+              "targetPageActionMessageCreator": Object {
+                "copyIssueDetailsClicked": [Function],
+              },
+              "windowUtils": null,
+            }
+          }
           renderTitleElement={[Function]}
         />
         <FixInstructionPanel
           checkType={1}
           checks={Array []}
+          deps={
+            Object {
+              "clientBrowserAdapter": Object {
+                "getUrl": [Function],
+              },
+              "issueDetailsTextGenerator": null,
+              "issueFilingActionMessageCreator": null,
+              "targetPageActionMessageCreator": Object {
+                "copyIssueDetailsClicked": [Function],
+              },
+              "windowUtils": null,
+            }
+          }
           renderTitleElement={[Function]}
         />
       </div>
@@ -2604,11 +2786,37 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: true } 
                         <FixInstructionPanel
                           checkType={0}
                           checks={Array []}
+                          deps={
+                            Object {
+                              "clientBrowserAdapter": Object {
+                                "getUrl": [Function],
+                              },
+                              "issueDetailsTextGenerator": null,
+                              "issueFilingActionMessageCreator": null,
+                              "targetPageActionMessageCreator": Object {
+                                "copyIssueDetailsClicked": [Function],
+                              },
+                              "windowUtils": null,
+                            }
+                          }
                           renderTitleElement={[Function]}
                         />
                         <FixInstructionPanel
                           checkType={1}
                           checks={Array []}
+                          deps={
+                            Object {
+                              "clientBrowserAdapter": Object {
+                                "getUrl": [Function],
+                              },
+                              "issueDetailsTextGenerator": null,
+                              "issueFilingActionMessageCreator": null,
+                              "targetPageActionMessageCreator": Object {
+                                "copyIssueDetailsClicked": [Function],
+                              },
+                              "windowUtils": null,
+                            }
+                          }
                           renderTitleElement={[Function]}
                         />
                       </div>
@@ -2918,11 +3126,37 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
       <FixInstructionPanel
         checkType={0}
         checks={Array []}
+        deps={
+          Object {
+            "clientBrowserAdapter": Object {
+              "getUrl": [Function],
+            },
+            "issueDetailsTextGenerator": null,
+            "issueFilingActionMessageCreator": null,
+            "targetPageActionMessageCreator": Object {
+              "copyIssueDetailsClicked": [Function],
+            },
+            "windowUtils": null,
+          }
+        }
         renderTitleElement={[Function]}
       />
       <FixInstructionPanel
         checkType={1}
         checks={Array []}
+        deps={
+          Object {
+            "clientBrowserAdapter": Object {
+              "getUrl": [Function],
+            },
+            "issueDetailsTextGenerator": null,
+            "issueFilingActionMessageCreator": null,
+            "targetPageActionMessageCreator": Object {
+              "copyIssueDetailsClicked": [Function],
+            },
+            "windowUtils": null,
+          }
+        }
         renderTitleElement={[Function]}
       />
     </div>
@@ -3286,11 +3520,37 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
                     <FixInstructionPanel
                       checkType={0}
                       checks={Array []}
+                      deps={
+                        Object {
+                          "clientBrowserAdapter": Object {
+                            "getUrl": [Function],
+                          },
+                          "issueDetailsTextGenerator": null,
+                          "issueFilingActionMessageCreator": null,
+                          "targetPageActionMessageCreator": Object {
+                            "copyIssueDetailsClicked": [Function],
+                          },
+                          "windowUtils": null,
+                        }
+                      }
                       renderTitleElement={[Function]}
                     />
                     <FixInstructionPanel
                       checkType={1}
                       checks={Array []}
+                      deps={
+                        Object {
+                          "clientBrowserAdapter": Object {
+                            "getUrl": [Function],
+                          },
+                          "issueDetailsTextGenerator": null,
+                          "issueFilingActionMessageCreator": null,
+                          "targetPageActionMessageCreator": Object {
+                            "copyIssueDetailsClicked": [Function],
+                          },
+                          "windowUtils": null,
+                        }
+                      }
                       renderTitleElement={[Function]}
                     />
                   </div>

--- a/src/tests/unit/tests/injected/components/__snapshots__/fix-instruction-panel.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/fix-instruction-panel.test.tsx.snap
@@ -11,10 +11,14 @@ exports[`FixInstructionPanelTests render all checks 1`] = `
     className="insights-fix-instruction-list"
   >
     <li>
-      message
+      <React.Fragment>
+        message
+      </React.Fragment>
     </li>
     <li>
-      message
+      <React.Fragment>
+        message
+      </React.Fragment>
     </li>
   </ul>
 </div>
@@ -31,7 +35,9 @@ exports[`FixInstructionPanelTests render instruction only one check 1`] = `
     className="insights-fix-instruction-list"
   >
     <li>
-      message
+      <React.Fragment>
+        message
+      </React.Fragment>
     </li>
   </ul>
 </div>
@@ -48,10 +54,14 @@ exports[`FixInstructionPanelTests render none checks 1`] = `
     className="insights-fix-instruction-list"
   >
     <li>
-      message
+      <React.Fragment>
+        message
+      </React.Fragment>
     </li>
     <li>
-      message
+      <React.Fragment>
+        message
+      </React.Fragment>
     </li>
   </ul>
 </div>

--- a/src/tests/unit/tests/injected/components/fix-instruction-panel.test.tsx
+++ b/src/tests/unit/tests/injected/components/fix-instruction-panel.test.tsx
@@ -2,13 +2,18 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { IMock, It, Mock, MockBehavior } from 'typemoq';
 import { CheckType } from '../../../../../injected/components/details-dialog';
 import { FixInstructionPanel, FixInstructionPanelProps } from '../../../../../injected/components/fix-instruction-panel';
+import { FixInstructionProcessor } from '../../../../../injected/fix-instruction-processor';
 
 describe('FixInstructionPanelTests', () => {
-    function renderTitleAsDiv(titleText: string, className: string): JSX.Element {
-        return <div className={className}>{titleText}</div>;
-    }
+    let fixInstructionProcessorMock: IMock<FixInstructionProcessor>;
+
+    beforeEach(() => {
+        fixInstructionProcessorMock = Mock.ofType<FixInstructionProcessor>(undefined, MockBehavior.Strict);
+        fixInstructionProcessorMock.setup(processor => processor.process(It.isAnyString())).returns(instruction => <>{instruction}</>);
+    });
 
     test('render all checks', () => {
         const allchecks: FormattedCheckResult[] = [
@@ -28,6 +33,9 @@ describe('FixInstructionPanelTests', () => {
             checkType: CheckType.All,
             checks: allchecks,
             renderTitleElement: renderTitleAsDiv,
+            deps: {
+                fixInstructionProcessor: fixInstructionProcessorMock.object,
+            },
         };
 
         const wrapped = shallow(<FixInstructionPanel {...props} />);
@@ -48,6 +56,9 @@ describe('FixInstructionPanelTests', () => {
             checkType: CheckType.All,
             checks: allchecks,
             renderTitleElement: renderTitleAsDiv,
+            deps: {
+                fixInstructionProcessor: fixInstructionProcessorMock.object,
+            },
         };
 
         const wrapped = shallow(<FixInstructionPanel {...props} />);
@@ -73,6 +84,9 @@ describe('FixInstructionPanelTests', () => {
             checkType: CheckType.None,
             checks: noneChecks,
             renderTitleElement: renderTitleAsDiv,
+            deps: {
+                fixInstructionProcessor: fixInstructionProcessorMock.object,
+            },
         };
 
         const wrapped = shallow(<FixInstructionPanel {...props} />);
@@ -87,10 +101,17 @@ describe('FixInstructionPanelTests', () => {
             checkType: CheckType.None,
             checks: checks,
             renderTitleElement: renderTitleAsDiv,
+            deps: {
+                fixInstructionProcessor: fixInstructionProcessorMock.object,
+            },
         };
 
         const wrapped = shallow(<FixInstructionPanel {...props} />);
 
         expect(wrapped.getElement()).toMatchSnapshot();
     });
+
+    function renderTitleAsDiv(titleText: string, className: string): JSX.Element {
+        return <div className={className}>{titleText}</div>;
+    }
 });

--- a/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
+++ b/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { FixInstructionProcessor } from '../../../../injected/fix-instruction-processor';
+
+describe('FixInstructionProcessor', () => {
+    let testSubject: FixInstructionProcessor;
+
+    beforeEach(() => {
+        testSubject = new FixInstructionProcessor();
+    });
+
+    test('no background nor foreground on the message', () => {
+        const fixInstruction = 'there is nothing that will trigger the processor to change the fix instruction here';
+
+        const result = testSubject.process(fixInstruction);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test('foreground color on the message', () => {
+        const fixInstruction = 'color contrast of 2.52 (foreground color: #8a94a8; nothing else to match here)';
+
+        const result = testSubject.process(fixInstruction);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test('background color on the message', () => {
+        const fixInstruction = 'color contrast of 2.52 (background color: #8a94a8; nothing else to match here)';
+
+        const result = testSubject.process(fixInstruction);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test('foreground and background color on the message (mind the order)', () => {
+        const fixInstruction =
+            'Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1';
+
+        const result = testSubject.process(fixInstruction);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test('background and foreground on the message (mind the order)', () => {
+        const fixInstruction =
+            'Element has insufficient color contrast of 2.52 (background color: #8a94a8, foreground color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1';
+
+        const result = testSubject.process(fixInstruction);
+
+        expect(result).toMatchSnapshot();
+    });
+
+    test('we assume only one instance of fore/background color, second instance will be ignored', () => {
+        const fixInstruction =
+            'first foreground color: #ffffff, second foreground: #000000, first background color: #AAAAAA, second background color: #bbBBbb';
+
+        const result = testSubject.process(fixInstruction);
+
+        expect(result).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Adding a fix instruction "decorator" so we can add a little color box when foreground/background colors are mentioned on the fix instructions.

There are some assumptions for the implemented behavior, check `src\tests\unit\tests\injected\fix-instruction-processor.test.tsx` for more details.

~~**Open question**: should I add a little border around the boxes?~~ Solved on the discussion below.

**On target page**
![01 - on target page issue details dialog](https://user-images.githubusercontent.com/2837582/58667639-71390b00-82eb-11e9-8f8a-614d3e51dd10.png)

**On details view**
![02 - on details view - failure details panel](https://user-images.githubusercontent.com/2837582/58667645-74cc9200-82eb-11e9-8d01-aac4b68cd53d.png)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #579 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
