### PR TITLE
feature: automated check report - new outcome badge

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -3,6 +3,7 @@
 @import '../../common/styles/colors.scss';
 @import '../../common/styles/fonts.scss';
 @import '../../common/styles/common.scss';
+@import './components/outcome.scss';
 
 @mixin contentSize {
     max-width: 960px;

--- a/src/DetailsView/reports/components/outcome.scss
+++ b/src/DetailsView/reports/components/outcome.scss
@@ -33,7 +33,7 @@ $outcome-fail-summary-color: $negative-outcome;
 
 @mixin outcome-icon-set-color($color) {
     .check-container {
-        border-color: black;
+        border-color: $color;
         background-color: $color;
     }
 }

--- a/src/DetailsView/reports/components/outcome.scss
+++ b/src/DetailsView/reports/components/outcome.scss
@@ -21,15 +21,19 @@ $outcome-incomplete-summary-consistent-foreground: $always-white;
 $outcome-fail-color: $negative-outcome;
 $outcome-fail-summary-color: $negative-outcome;
 @mixin outcome-chip-color($outcome-color) {
-    .check-container,
-    .count {
+    .check-container {
         background-color: $outcome-color;
+        border: 1px solid $outcome-color;
+    }
+    .count {
+        background-color: transparent;
+        border: 1px solid $outcome-color;
     }
 }
 
 @mixin outcome-icon-set-color($color) {
     .check-container {
-        border-color: $color;
+        border-color: black;
         background-color: $color;
     }
 }
@@ -37,7 +41,7 @@ $outcome-fail-summary-color: $negative-outcome;
 .outcome-chip {
     $outcome-chip-icon-size: 16px;
     height: $outcome-chip-icon-size;
-    color: $neutral-0;
+    color: $neutral-90;
     border-radius: 0px 8px 8px 0px;
     margin: 0 4px 0 4px;
     display: inline-flex;
@@ -53,7 +57,7 @@ $outcome-fail-summary-color: $negative-outcome;
         border-radius: 0 8px 8px 0;
         padding: 0 6px 0 10px;
         font-weight: 700;
-        margin-left: -5px;
+        margin-left: -8px;
         height: $outcome-chip-icon-size - 2;
     }
     &.outcome-chip-pass {

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -55,7 +55,7 @@
     --neutral-alpha-60: rgba(0, 0, 0, 0.6);
     --neutral-alpha-70: rgba(0, 0, 0, 0.7);
     --neutral-alpha-80: rgba(0, 0, 0, 0.8);
-    --neutral-alpha-90: rgba(0, 0, 0, 0.8);
+    --neutral-alpha-90: rgba(0, 0, 0, 0.9);
     // Outcome colors
     --positive-outcome: #107c10;
     --negative-outcome: #e81123;

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -55,6 +55,7 @@
     --neutral-alpha-60: rgba(0, 0, 0, 0.6);
     --neutral-alpha-70: rgba(0, 0, 0, 0.7);
     --neutral-alpha-80: rgba(0, 0, 0, 0.8);
+    --neutral-alpha-90: rgba(0, 0, 0, 0.8);
     // Outcome colors
     --positive-outcome: #107c10;
     --negative-outcome: #e81123;
@@ -106,6 +107,7 @@
         --neutral-80: var(--white);
         --neutral-100: var(--white);
         --neutral-alpha-8: var(--white);
+        --neutral-alpha-90: var(--white);
         --secondary-text: var(--white);
         --primary-text: var(--white);
 
@@ -175,6 +177,7 @@ $neutral-55: var(--neutral-55);
 $neutral-60: var(--neutral-60);
 $neutral-70: var(--neutral-70);
 $neutral-80: var(--neutral-80);
+$neutral-90: var(--neutral-90);
 $neutral-alpha-2: var(--neutral-alpha-2);
 $neutral-alpha-4: var(--neutral-alpha-4);
 $neutral-alpha-6: var(--neutral-alpha-6);


### PR DESCRIPTION
#### Description of changes

Introducing new outcome badge styling according to the mock for the new report.

Fail count badge in new automated checks report:
![fail-in-new-automated-report](https://user-images.githubusercontent.com/15974344/58836424-a6a46800-860d-11e9-8279-7a7bd93687ee.jpg)


in assessment overview: 
![count-badges-in-overview](https://user-images.githubusercontent.com/15974344/58837573-ca1ce200-8610-11e9-91a6-2d87e5cb3499.jpg)
![with-high-contrast-mode](https://user-images.githubusercontent.com/15974344/58837574-ca1ce200-8610-11e9-92c9-3a155c69734a.jpg)

#### Pull request checklist

- [x] Addresses an existing issue: WI#1545861
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
