### PR TITLE
using proper data for instance details

### DIFF
--- a/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
@@ -3,11 +3,10 @@
 import * as React from 'react';
 
 import { NamedSFC } from '../../../../common/react/named-sfc';
-import { DecoratedAxeNodeResult } from '../../../../injected/scanner-utils';
 import { InstanceDetails } from './instance-details';
 
 export type InstanceDetailsGroupProps = {
-    nodeResults: DecoratedAxeNodeResult[];
+    nodeResults: AxeNodeResult[];
 };
 
 export const InstanceDetailsGroup = NamedSFC<InstanceDetailsGroupProps>('InstanceDetailsGroup', props => {

--- a/src/DetailsView/reports/components/report-sections/instance-details.tsx
+++ b/src/DetailsView/reports/components/report-sections/instance-details.tsx
@@ -4,12 +4,11 @@ import * as classNames from 'classnames';
 import * as React from 'react';
 
 import { NamedSFC } from '../../../../common/react/named-sfc';
-import { DecoratedAxeNodeResult } from '../../../../injected/scanner-utils';
 
-export type InstanceDetailsProps = Pick<DecoratedAxeNodeResult, 'selector' | 'snippet' | 'failureSummary'> & { index: number };
+export type InstanceDetailsProps = Pick<AxeNodeResult, 'failureSummary' | 'html' | 'target'> & { index: number };
 
 export const InstanceDetails = NamedSFC<InstanceDetailsProps>('InstanceDetail', props => {
-    const { selector, snippet, failureSummary, index } = props;
+    const { failureSummary, html, target, index } = props;
 
     const createTableRow = (label: string, content: string, rowKey: string, needsExtraClassname?: boolean) => {
         const contentStyling = classNames({
@@ -26,8 +25,8 @@ export const InstanceDetails = NamedSFC<InstanceDetailsProps>('InstanceDetail', 
     return (
         <table className="report-instance-table">
             <tbody>
-                {createTableRow('Path', selector, `path-row-${index}`)}
-                {createTableRow('Snippet', snippet, `snippet-row-${index}`, true)}
+                {createTableRow('Path', target.join(', '), `path-row-${index}`)}
+                {createTableRow('Snippet', html, `snippet-row-${index}`, true)}
                 {createTableRow('How to fix', failureSummary, `how-to-fix-row-${index}`)}
             </tbody>
         </table>

--- a/src/DetailsView/reports/components/report-sections/rule-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-details-group.tsx
@@ -18,7 +18,7 @@ export const RuleDetailsGroup = NamedSFC<RuleDetailsGroupProps>('RuleDetailsGrou
             {rules.map(rule => (
                 <>
                     <RuleDetail key={rule.id} rule={rule}>
-                        {showDetails ? <InstanceDetailsGroup nodeResults={rule.nodes as any} /> : null}
+                        {showDetails ? <InstanceDetailsGroup nodeResults={rule.nodes} /> : null}
                     </RuleDetail>
                 </>
             ))}

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/instance-details-group.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/instance-details-group.test.tsx.snap
@@ -4,15 +4,23 @@ exports[`InstanceDetailsGroup renders 1`] = `
 <React.Fragment>
   <InstanceDetail
     failureSummary="fix the error on html"
+    html="<html>"
     index={0}
-    selector="<html>"
-    snippet="<html>"
+    target={
+      Array [
+        "<html>",
+      ]
+    }
   />
   <InstanceDetail
     failureSummary="fix the error on body"
+    html="<body >"
     index={1}
-    selector="<body>"
-    snippet="<body >"
+    target={
+      Array [
+        "<body>",
+      ]
+    }
   />
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/instance-details-group.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/instance-details-group.test.tsx
@@ -2,25 +2,25 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
+
 import {
     InstanceDetailsGroup,
     InstanceDetailsGroupProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/instance-details-group';
-import { DecoratedAxeNodeResult } from '../../../../../../../injected/scanner-utils';
 
 describe('InstanceDetailsGroup', () => {
     it('renders', () => {
-        const nodes: DecoratedAxeNodeResult[] = [
+        const nodes: AxeNodeResult[] = [
             {
-                selector: '<html>',
-                snippet: '<html>',
+                target: ['<html>'],
+                html: '<html>',
                 failureSummary: 'fix the error on html',
-            } as DecoratedAxeNodeResult,
+            } as AxeNodeResult,
             {
-                selector: '<body>',
-                snippet: '<body >',
+                target: ['<body>'],
+                html: '<body >',
                 failureSummary: 'fix the error on body',
-            } as DecoratedAxeNodeResult,
+            } as AxeNodeResult,
         ];
 
         const props: InstanceDetailsGroupProps = {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/instance-details.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/instance-details.test.tsx
@@ -11,8 +11,8 @@ import {
 describe('InstanceDetails', () => {
     it('renders', () => {
         const props: InstanceDetailsProps = {
-            selector: '<html>',
-            snippet: '<html>',
+            target: ['<html>'],
+            html: '<html>',
             failureSummary: 'fix the error',
             index: 0,
         };


### PR DESCRIPTION
#### Description of changes

Using `AxeNodeResult` type to wire up instance details data on the report

![18 - proper data for instance details](https://user-images.githubusercontent.com/2837582/58991080-442da200-879c-11e9-9fdc-52874ecdfa65.png)


#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1544731
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
