### PR TITLE
Fix heading levels

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -28,6 +28,12 @@ body {
 .content-container {
     @include contentSize();
     margin-top: 24px;
+
+    h2 {
+        margin: 0px;
+        font-size: 17px;
+        line-height: 24px;
+    }
 }
 
 .title-section {
@@ -80,19 +86,13 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     padding: 25px;
     margin-bottom: 24px;
 
-    h3 {
-        margin: 0px;
-        font-size: 17px;
-        line-height: 24px;
-        margin-bottom: 16px;
-    }
-
     .outcome-summary-bar {
         $outcome-summary-icon-size: 16px;
         flex: 0 0 100%;
         display: flex;
         align-items: center;
         height: 32px;
+        margin-top: 16px;
         margin-bottom: 0px;
         line-height: 24px;
         font-size: 17px;
@@ -201,6 +201,7 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     flex-wrap: nowrap;
     justify-content: flex-start;
     align-items: center;
+    margin-bottom: 16px;
 }
 
 .rule-detail {
@@ -227,4 +228,16 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
             color: $secondary-text !important;
         }
     }
+}
+
+#failed-instances-section {
+    margin-top: 56px;
+}
+
+#passed-checks-section {
+    margin-top: 76px;
+}
+
+#not-applicable-checks-section {
+    margin-top: 56px;
 }

--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -230,14 +230,14 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     }
 }
 
-#failed-instances-section {
+.failed-instances-section {
     margin-top: 56px;
 }
 
-#passed-checks-section {
+.passed-checks-section {
     margin-top: 76px;
 }
 
-#not-applicable-checks-section {
+.not-applicable-checks-section {
     margin-top: 56px;
 }

--- a/src/DetailsView/reports/components/instance-list-group-header.tsx
+++ b/src/DetailsView/reports/components/instance-list-group-header.tsx
@@ -12,7 +12,7 @@ import { InstanceOutcomeType } from './report-sections/outcome-summary-bar';
 export interface InstanceListGroupHeaderProps {
     ruleResult: RuleResult;
     outcomeType: InstanceOutcomeType;
-    'aria-level'?: number;
+    ariaLevel?: number;
 }
 
 export const InstanceListGroupHeader = NamedSFC<InstanceListGroupHeaderProps>('InstaceListGroupHeader', props => {
@@ -47,7 +47,7 @@ export const InstanceListGroupHeader = NamedSFC<InstanceListGroupHeaderProps>('I
         return <span className="rule-details-description">{props.ruleResult.description}</span>;
     };
 
-    const ariaLevel = props['aria-level'] || undefined;
+    const ariaLevel = props.ariaLevel || undefined;
 
     return (
         <div role="heading" aria-level={ariaLevel}>

--- a/src/DetailsView/reports/components/instance-list-group-header.tsx
+++ b/src/DetailsView/reports/components/instance-list-group-header.tsx
@@ -12,6 +12,7 @@ import { InstanceOutcomeType } from './report-sections/outcome-summary-bar';
 export interface InstanceListGroupHeaderProps {
     ruleResult: RuleResult;
     outcomeType: InstanceOutcomeType;
+    'aria-level'?: number;
 }
 
 export const InstanceListGroupHeader = NamedSFC<InstanceListGroupHeaderProps>('InstaceListGroupHeader', props => {
@@ -46,8 +47,10 @@ export const InstanceListGroupHeader = NamedSFC<InstanceListGroupHeaderProps>('I
         return <span className="rule-details-description">{props.ruleResult.description}</span>;
     };
 
+    const ariaLevel = props['aria-level'] || undefined;
+
     return (
-        <div role="heading">
+        <div role="heading" aria-level={ariaLevel}>
             {renderCountBadge()} {renderRuleLink()}: {renderDescription()} ({renderGuidanceLinks()})
         </div>
     );

--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -17,7 +17,7 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
 
     return (
         <div className="scan-details-section">
-            <h3>Scan details</h3>
+            <h2>Scan details</h2>
             <table>
                 <tbody>
                     <tr>

--- a/src/DetailsView/reports/components/report-sections/result-section-title.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section-title.tsx
@@ -15,7 +15,7 @@ export type ResultSectionTitlePros = {
 export const ResultSectionTitle = NamedSFC<ResultSectionTitlePros>('ResultSectionTitle', props => {
     return (
         <div className="result-section-title">
-            <h3>{props.title}</h3>
+            <h2>{props.title}</h2>
             <OutcomeChip outcomeType={props.outcomeType} count={props.count} />
         </div>
     );

--- a/src/DetailsView/reports/components/report-sections/result-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section.tsx
@@ -20,7 +20,7 @@ export const ResultSection = NamedSFC<ResultSectionProps>('ResultSection', props
     const { rules, containerClassName, title, outcomeType } = props;
 
     return (
-        <div id={containerClassName}>
+        <div className={containerClassName}>
             <ResultSectionTitle title={title} count={rules.length} outcomeType={outcomeType} />
             <RuleDetailsGroup rules={rules} showDetails={props.showDetails} />
         </div>

--- a/src/DetailsView/reports/components/report-sections/rule-detail.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-detail.tsx
@@ -14,17 +14,12 @@ export type RuleDetailProps = {
 };
 
 export const RuleDetail = NamedSFC<RuleDetailProps>('RuleDetails', ({ rule, children, outcomeType, isHeader }) => {
-    const extraProps = {
-        'aria-level': undefined, // can't name a variable 'aria-level' so we need the container object here
-    };
+    const ariaLabel = isHeader ? 3 : undefined;
 
-    if (isHeader) {
-        extraProps['aria-level'] = 3;
-    }
     return (
         <>
             <div className="rule-detail">
-                <InstanceListGroupHeader ruleResult={rule} outcomeType={outcomeType} {...extraProps} />
+                <InstanceListGroupHeader ruleResult={rule} outcomeType={outcomeType} ariaLevel={ariaLabel} />
             </div>
             {children}
         </>

--- a/src/DetailsView/reports/components/report-sections/rule-detail.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-detail.tsx
@@ -9,9 +9,10 @@ import { RuleResult } from '../../../../scanner/iruleresults';
 
 export type RuleDetailProps = {
     rule: RuleResult;
+    isHeader: boolean;
 };
 
-export const RuleDetail = NamedSFC<RuleDetailProps>('RuleDetails', ({ rule, children }) => {
+export const RuleDetail = NamedSFC<RuleDetailProps>('RuleDetails', ({ rule, children, isHeader }) => {
     const renderRuleName = () => (
         <span className="rule-details-id">
             <NewTabLink href={rule.helpUrl}>{rule.id}</NewTabLink>
@@ -26,9 +27,19 @@ export const RuleDetail = NamedSFC<RuleDetailProps>('RuleDetails', ({ rule, chil
         return <GuidanceLinks links={rule.guidanceLinks} />;
     };
 
+    const extraProps = {
+        role: undefined,
+        ariaLevel: undefined,
+    };
+
+    if (isHeader) {
+        extraProps.role = 'heading';
+        extraProps.ariaLevel = '3';
+    }
+
     return (
         <>
-            <div className="rule-detail">
+            <div className="rule-detail" {...extraProps}>
                 {renderRuleName()}: {renderDescription()} ({renderGuidanceLinks()})
             </div>
             {children}

--- a/src/DetailsView/reports/components/report-sections/rule-detail.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-detail.tsx
@@ -15,18 +15,16 @@ export type RuleDetailProps = {
 
 export const RuleDetail = NamedSFC<RuleDetailProps>('RuleDetails', ({ rule, children, outcomeType, isHeader }) => {
     const extraProps = {
-        role: undefined,
-        ariaLevel: undefined,
+        'aria-level': undefined, // can't name a variable 'aria-level' so we need the container object here
     };
 
     if (isHeader) {
-        extraProps.role = 'heading';
-        extraProps.ariaLevel = '3';
+        extraProps['aria-level'] = 3;
     }
     return (
         <>
-            <div className="rule-detail" {...extraProps}>
-                <InstanceListGroupHeader ruleResult={rule} outcomeType={outcomeType} />
+            <div className="rule-detail">
+                <InstanceListGroupHeader ruleResult={rule} outcomeType={outcomeType} {...extraProps} />
             </div>
             {children}
         </>

--- a/src/DetailsView/reports/components/report-sections/rule-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-details-group.tsx
@@ -17,7 +17,7 @@ export const RuleDetailsGroup = NamedSFC<RuleDetailsGroupProps>('RuleDetailsGrou
         <div className="rule-details-group">
             {rules.map(rule => (
                 <>
-                    <RuleDetail key={rule.id} rule={rule}>
+                    <RuleDetail key={rule.id} rule={rule} isHeader={showDetails}>
                         {showDetails ? <InstanceDetailsGroup nodeResults={rule.nodes as any} /> : null}
                     </RuleDetail>
                 </>

--- a/src/DetailsView/reports/components/report-sections/summary-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/summary-section.tsx
@@ -10,7 +10,7 @@ export type SummarySectionProps = OutcomeSummaryBarProps;
 export const SummarySection = NamedSFC<SummarySectionProps>('SummarySection', props => {
     return (
         <div className="summary-section">
-            <h3>Summary</h3>
+            <h2>Summary</h2>
             <OutcomeSummaryBar {...props} />
         </div>
     );

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/instance-list-group-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/instance-list-group-header.test.tsx.snap
@@ -32,6 +32,39 @@ exports[`InstanceListGroupHeaderTest render for fail instances 1`] = `
 </div>
 `;
 
+exports[`InstanceListGroupHeaderTest render for fail instances and handles aria-level 1`] = `
+<div
+  aria-level={2}
+  role="heading"
+>
+  <OutcomeChip
+    count={1}
+    outcomeType="fail"
+  />
+   
+  <span
+    className="rule-details-id"
+  >
+    <NewTabLink
+      aria-describedby="ruleid-rule-description"
+      aria-label="rule ruleid"
+      href="help url"
+    >
+      ruleid
+    </NewTabLink>
+  </span>
+  : 
+  <span
+    className="rule-details-description"
+  >
+    rule description
+  </span>
+   (
+  <GuidanceLinks />
+  )
+</div>
+`;
+
 exports[`InstanceListGroupHeaderTest render for incomplete instances 1`] = `
 <div
   role="heading"
@@ -60,8 +93,66 @@ exports[`InstanceListGroupHeaderTest render for incomplete instances 1`] = `
 </div>
 `;
 
+exports[`InstanceListGroupHeaderTest render for incomplete instances and handles aria-level 1`] = `
+<div
+  aria-level={2}
+  role="heading"
+>
+   
+  <span
+    className="rule-details-id"
+  >
+    <NewTabLink
+      aria-describedby="ruleid-rule-description"
+      aria-label="rule ruleid"
+      href="help url"
+    >
+      ruleid
+    </NewTabLink>
+  </span>
+  : 
+  <span
+    className="rule-details-description"
+  >
+    rule description
+  </span>
+   (
+  <GuidanceLinks />
+  )
+</div>
+`;
+
 exports[`InstanceListGroupHeaderTest render for pass instances 1`] = `
 <div
+  role="heading"
+>
+   
+  <span
+    className="rule-details-id"
+  >
+    <NewTabLink
+      aria-describedby="ruleid-rule-description"
+      aria-label="rule ruleid"
+      href="help url"
+    >
+      ruleid
+    </NewTabLink>
+  </span>
+  : 
+  <span
+    className="rule-details-description"
+  >
+    rule description
+  </span>
+   (
+  <GuidanceLinks />
+  )
+</div>
+`;
+
+exports[`InstanceListGroupHeaderTest render for pass instances and handles aria-level 1`] = `
+<div
+  aria-level={2}
   role="heading"
 >
    

--- a/src/tests/unit/tests/DetailsView/components/instance-list-group-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/instance-list-group-header.test.tsx
@@ -24,7 +24,7 @@ describe('InstanceListGroupHeaderTest', () => {
     });
 
     test.each(['pass', 'fail', 'incomplete'])('render for %s instances and handles aria-level', (outcome: InstanceOutcomeType) => {
-        const wrapper = shallow(<InstanceListGroupHeader ruleResult={getSampleRuleResult()} outcomeType={outcome} aria-level={2} />);
+        const wrapper = shallow(<InstanceListGroupHeader ruleResult={getSampleRuleResult()} outcomeType={outcome} ariaLevel={2} />);
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/instance-list-group-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/instance-list-group-header.test.tsx
@@ -22,4 +22,9 @@ describe('InstanceListGroupHeaderTest', () => {
         const wrapper = shallow(<InstanceListGroupHeader ruleResult={getSampleRuleResult()} outcomeType={outcome} />);
         expect(wrapper.getElement()).toMatchSnapshot();
     });
+
+    test.each(['pass', 'fail', 'incomplete'])('render for %s instances and handles aria-level', (outcome: InstanceOutcomeType) => {
+        const wrapper = shallow(<InstanceListGroupHeader ruleResult={getSampleRuleResult()} outcomeType={outcome} aria-level={2} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
 });

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
@@ -4,9 +4,9 @@ exports[`DetailsSection renders 1`] = `
 <div
   className="scan-details-section"
 >
-  <h3>
+  <h2>
     Scan details
-  </h3>
+  </h2>
   <table>
     <tbody>
       <tr>

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section-title.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section-title.test.tsx.snap
@@ -4,9 +4,9 @@ exports[`ResultSectionTitle renders 1`] = `
 <div
   className="result-section-title"
 >
-  <h3>
+  <h2>
     test title
-  </h3>
+  </h2>
   <OutcomeChip
     count={10}
     outcomeType="pass"

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PassedChecksSection renders, not showDetails 1`] = `
 <div
-  id="result-section-class-name"
+  className="result-section-class-name"
 >
   <ResultSectionTitle
     count={2}
@@ -22,7 +22,7 @@ exports[`PassedChecksSection renders, not showDetails 1`] = `
 
 exports[`PassedChecksSection renders, with showDetails 1`] = `
 <div
-  id="result-section-class-name"
+  className="result-section-class-name"
 >
   <ResultSectionTitle
     count={2}

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-detail.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-detail.test.tsx.snap
@@ -1,6 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RuleDetailsGroup renders 1`] = `
+exports[`RuleDetailsGroup renders, it is header 1`] = `
+<React.Fragment>
+  <div
+    ariaLevel="3"
+    className="rule-detail"
+    role="heading"
+  >
+    <span
+      className="rule-details-id"
+    >
+      <NewTabLink
+        href="url://help.url"
+      >
+        rule id
+      </NewTabLink>
+    </span>
+    : 
+    <span
+      className="rule-details-description"
+    >
+      rule description
+    </span>
+     (
+    <GuidanceLinks
+      links={
+        Array [
+          Object {
+            "href": "url://guidance-01.link",
+            "text": "guidance-01",
+          },
+          Object {
+            "href": "url://guidance-02.link",
+            "text": "guidance-02",
+          },
+        ]
+      }
+    />
+    )
+  </div>
+  <span>
+    children
+  </span>
+</React.Fragment>
+`;
+
+exports[`RuleDetailsGroup renders, not a header 1`] = `
 <React.Fragment>
   <div
     className="rule-detail"

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-detail.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-detail.test.tsx.snap
@@ -3,41 +3,29 @@
 exports[`RuleDetailsGroup renders, it is header 1`] = `
 <React.Fragment>
   <div
-    ariaLevel="3"
     className="rule-detail"
-    role="heading"
   >
-    <span
-      className="rule-details-id"
-    >
-      <NewTabLink
-        href="url://help.url"
-      >
-        rule id
-      </NewTabLink>
-    </span>
-    : 
-    <span
-      className="rule-details-description"
-    >
-      rule description
-    </span>
-     (
-    <GuidanceLinks
-      links={
-        Array [
-          Object {
-            "href": "url://guidance-01.link",
-            "text": "guidance-01",
-          },
-          Object {
-            "href": "url://guidance-02.link",
-            "text": "guidance-02",
-          },
-        ]
+    <InstaceListGroupHeader
+      aria-level={3}
+      outcomeType="fail"
+      ruleResult={
+        Object {
+          "description": "rule description",
+          "guidanceLinks": Array [
+            Object {
+              "href": "url://guidance-01.link",
+              "text": "guidance-01",
+            },
+            Object {
+              "href": "url://guidance-02.link",
+              "text": "guidance-02",
+            },
+          ],
+          "helpUrl": "url://help.url",
+          "id": "rule id",
+        }
       }
     />
-    )
   </div>
   <span>
     children

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-detail.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-detail.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`RuleDetailsGroup renders, it is header 1`] = `
     className="rule-detail"
   >
     <InstaceListGroupHeader
-      aria-level={3}
+      ariaLevel={3}
       outcomeType="fail"
       ruleResult={
         Object {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-details-group.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-details-group.test.tsx.snap
@@ -40,6 +40,7 @@ exports[`RuleDetailsGroup renders, with details 1`] = `
 >
   <React.Fragment>
     <RuleDetails
+      isHeader={true}
       rule={
         Object {
           "id": "1",

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/summary-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/summary-section.test.tsx.snap
@@ -4,9 +4,9 @@ exports[`SummarySection renders 1`] = `
 <div
   className="summary-section"
 >
-  <h3>
+  <h2>
     Summary
-  </h3>
+  </h2>
   <OutcomeSummaryBar
     description="test description"
     environmentInfo={

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-detail.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-detail.test.tsx
@@ -7,7 +7,7 @@ import { RuleDetail } from '../../../../../../../DetailsView/reports/components/
 import { RuleResult } from '../../../../../../../scanner/iruleresults';
 
 describe('RuleDetailsGroup', () => {
-    it('renders', () => {
+    it('renders, not a header', () => {
         const rule = {
             helpUrl: 'url://help.url',
             id: 'rule id',
@@ -26,7 +26,39 @@ describe('RuleDetailsGroup', () => {
 
         const children = <span>children</span>;
 
-        const wrapped = shallow(<RuleDetail rule={rule}>{children}</RuleDetail>);
+        const wrapped = shallow(
+            <RuleDetail rule={rule} isHeader={false}>
+                {children}
+            </RuleDetail>,
+        );
+
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+
+    it('renders, it is header', () => {
+        const rule = {
+            helpUrl: 'url://help.url',
+            id: 'rule id',
+            description: 'rule description',
+            guidanceLinks: [
+                {
+                    href: 'url://guidance-01.link',
+                    text: 'guidance-01',
+                },
+                {
+                    href: 'url://guidance-02.link',
+                    text: 'guidance-02',
+                },
+            ],
+        } as RuleResult;
+
+        const children = <span>children</span>;
+
+        const wrapped = shallow(
+            <RuleDetail rule={rule} isHeader={true}>
+                {children}
+            </RuleDetail>,
+        );
 
         expect(wrapped.getElement()).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

Using heading levels 1 to 3 as follows:
- Automated checks result (the title just after the header) is H1
- All section titles (summary, scan details, failed instances, passed checks, not applicable checks) are H2
- Each rule group under failed instances is an H3 (so, **only** rules with failed instances is announced as a header, but **no** rule under passed and not applicable checks section is announce)
- Update some stylines (mostly margins)

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1544731
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
