### PR TITLE
Fix a11y issues in report

### DIFF
--- a/src/DetailsView/reports/components/instance-list-group-header.tsx
+++ b/src/DetailsView/reports/components/instance-list-group-header.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { kebabCase } from 'lodash';
 import * as React from 'react';
 
 import { GuidanceLinks } from '../../../common/components/guidance-links';
@@ -7,6 +8,7 @@ import { NewTabLink } from '../../../common/components/new-tab-link';
 import { NamedSFC } from '../../../common/react/named-sfc';
 import { RuleResult } from '../../../scanner/iruleresults';
 import { OutcomeChip } from './outcome-chip';
+import { outcomeTypeSemantics } from './outcome-type';
 import { InstanceOutcomeType } from './report-sections/outcome-summary-bar';
 
 export interface InstanceListGroupHeaderProps {
@@ -15,6 +17,9 @@ export interface InstanceListGroupHeaderProps {
 }
 
 export const InstanceListGroupHeader = NamedSFC<InstanceListGroupHeaderProps>('InstaceListGroupHeader', props => {
+    const outcomeText = outcomeTypeSemantics[props.outcomeType].pastTense;
+    const ariaDescribedBy = `${kebabCase(outcomeText)}-rule-${props.ruleResult.id}-description`;
+
     const renderCountBadge = () => {
         const { outcomeType, ruleResult } = props;
 
@@ -31,7 +36,7 @@ export const InstanceListGroupHeader = NamedSFC<InstanceListGroupHeaderProps>('I
         const ruleUrl = ruleResult.helpUrl;
         return (
             <span className="rule-details-id">
-                <NewTabLink href={ruleUrl} aria-label={`rule ${ruleId}`} aria-describedby={`${ruleId}-rule-description`}>
+                <NewTabLink href={ruleUrl} aria-label={`rule ${ruleId}`} aria-describedby={ariaDescribedBy}>
                     {ruleId}
                 </NewTabLink>
             </span>
@@ -43,11 +48,15 @@ export const InstanceListGroupHeader = NamedSFC<InstanceListGroupHeaderProps>('I
     };
 
     const renderDescription = () => {
-        return <span className="rule-details-description">{props.ruleResult.description}</span>;
+        return (
+            <span className="rule-details-description" id={ariaDescribedBy}>
+                {props.ruleResult.description}
+            </span>
+        );
     };
 
     return (
-        <div role="heading">
+        <div role="heading" aria-level={4}>
             {renderCountBadge()} {renderRuleLink()}: {renderDescription()} ({renderGuidanceLinks()})
         </div>
     );

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/instance-list-group-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/instance-list-group-header.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`InstanceListGroupHeaderTest render for fail instances 1`] = `
 <div
+  aria-level={4}
   role="heading"
 >
   <OutcomeChip
@@ -13,16 +14,17 @@ exports[`InstanceListGroupHeaderTest render for fail instances 1`] = `
     className="rule-details-id"
   >
     <NewTabLink
-      aria-describedby="ruleid-rule-description"
-      aria-label="rule ruleid"
+      aria-describedby="failed-rule-image-alt-description"
+      aria-label="rule image-alt"
       href="help url"
     >
-      ruleid
+      image-alt
     </NewTabLink>
   </span>
   : 
   <span
     className="rule-details-description"
+    id="failed-rule-image-alt-description"
   >
     rule description
   </span>
@@ -34,6 +36,7 @@ exports[`InstanceListGroupHeaderTest render for fail instances 1`] = `
 
 exports[`InstanceListGroupHeaderTest render for incomplete instances 1`] = `
 <div
+  aria-level={4}
   role="heading"
 >
    
@@ -41,16 +44,17 @@ exports[`InstanceListGroupHeaderTest render for incomplete instances 1`] = `
     className="rule-details-id"
   >
     <NewTabLink
-      aria-describedby="ruleid-rule-description"
-      aria-label="rule ruleid"
+      aria-describedby="incomplete-rule-image-alt-description"
+      aria-label="rule image-alt"
       href="help url"
     >
-      ruleid
+      image-alt
     </NewTabLink>
   </span>
   : 
   <span
     className="rule-details-description"
+    id="incomplete-rule-image-alt-description"
   >
     rule description
   </span>
@@ -62,6 +66,7 @@ exports[`InstanceListGroupHeaderTest render for incomplete instances 1`] = `
 
 exports[`InstanceListGroupHeaderTest render for pass instances 1`] = `
 <div
+  aria-level={4}
   role="heading"
 >
    
@@ -69,16 +74,17 @@ exports[`InstanceListGroupHeaderTest render for pass instances 1`] = `
     className="rule-details-id"
   >
     <NewTabLink
-      aria-describedby="ruleid-rule-description"
-      aria-label="rule ruleid"
+      aria-describedby="passed-rule-image-alt-description"
+      aria-label="rule image-alt"
       href="help url"
     >
-      ruleid
+      image-alt
     </NewTabLink>
   </span>
   : 
   <span
     className="rule-details-description"
+    id="passed-rule-image-alt-description"
   >
     rule description
   </span>

--- a/src/tests/unit/tests/DetailsView/components/instance-list-group-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/instance-list-group-header.test.tsx
@@ -10,7 +10,7 @@ import { RuleResult } from '../../../../../scanner/iruleresults';
 describe('InstanceListGroupHeaderTest', () => {
     const getSampleRuleResult = () => {
         const ruleResult: RuleResult = {
-            id: 'ruleid',
+            id: 'image-alt',
             nodes: [{} as AxeNodeResult],
             description: 'rule description',
             helpUrl: 'help url',


### PR DESCRIPTION
#### Description of changes
Before:
![image](https://user-images.githubusercontent.com/15974344/58994940-20bc2480-87a7-11e9-8966-ee67f76cc405.png)

We have two a11y issues in the new report currently: 
1. group header doesn't have a valid heading level;
2. rule link does not have a valid aria description.

This PR fixes both of them.

After: 
![image](https://user-images.githubusercontent.com/15974344/58998296-efe2ec00-87b4-11e9-83fa-989e06fcf8e7.png)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
