### PR TITLE
Added line breaks to exported results descriptions

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -176,6 +176,10 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
         padding-top: 12px;
     }
 
+    .description-text {
+        white-space: pre-wrap;
+    }
+
     tbody :first-child td {
         padding-top: 16px;
     }

--- a/src/DetailsView/reports/components/assessment-scan-details.scss
+++ b/src/DetailsView/reports/components/assessment-scan-details.scss
@@ -33,3 +33,7 @@
         }
     }
 }
+
+.assessment-scan-details-description {
+    white-space: pre-wrap;
+}

--- a/src/DetailsView/reports/components/assessment-scan-details.tsx
+++ b/src/DetailsView/reports/components/assessment-scan-details.tsx
@@ -43,7 +43,7 @@ export class AssessmentScanDetails extends React.Component<AssessmentScanDetails
                             <td className="icon" aria-hidden="true">
                                 <CommentIcon />
                             </td>
-                            <td>{this.props.description}</td>
+                            <td className="assessment-scan-details-description">{this.props.description}</td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/DetailsView/reports/components/report-head.tsx
+++ b/src/DetailsView/reports/components/report-head.tsx
@@ -73,6 +73,9 @@ export class ReportHead extends React.Component {
         .report-scan-details td {
             font-size: 12px;
         }
+        .report-result-description {
+            white-space: pre-wrap;
+        }
         .report-congrats {
             position: relative;
         }

--- a/src/DetailsView/reports/components/report-scan-details.tsx
+++ b/src/DetailsView/reports/components/report-scan-details.tsx
@@ -35,7 +35,7 @@ export class ReportScanDetails extends React.Component<ReportScanDetailsProps> {
                         </tr>
                         <tr>
                             <td className="label">Description</td>
-                            <td>{this.props.description}</td>
+                            <td className="report-result-description">{this.props.description}</td>
                         </tr>
                         <tr>
                             <td className="label">Scan date/time</td>

--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -42,7 +42,7 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
                         <td className="icon" aria-hidden="true">
                             <CommentIcon />
                         </td>
-                        <td className="text">{description}</td>
+                        <td className="text description-text">{description}</td>
                     </tr>
                 </tbody>
             </table>

--- a/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/assessment-scan-details.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/assessment-scan-details.test.tsx.snap
@@ -45,7 +45,9 @@ exports[`AssessmentScanDetails render Correct composition 1`] = `
         >
           <CommentIcon />
         </td>
-        <td>
+        <td
+          className="assessment-scan-details-description"
+        >
           test-description
         </td>
       </tr>

--- a/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/report-head.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/report-head.test.tsx.snap
@@ -78,6 +78,9 @@ exports[`ReportHeadTest renders 1`] = `
         .report-scan-details td {
             font-size: 12px;
         }
+        .report-result-description {
+            white-space: pre-wrap;
+        }
         .report-congrats {
             position: relative;
         }

--- a/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/report-scan-details.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/report-scan-details.test.tsx.snap
@@ -35,7 +35,9 @@ exports[`ReportScanDetailsTest renders 1`] = `
         >
           Description
         </td>
-        <td>
+        <td
+          className="report-result-description"
+        >
           description-text
         </td>
       </tr>

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`DetailsSection renders 1`] = `
           <CommentIcon />
         </td>
         <td
-          className="text"
+          className="text description-text"
         >
           description-text
         </td>


### PR DESCRIPTION
#### Description of changes

Previously, line breaks in the descriptions included in the downloaded summaries of assessment/snapshot were collapsed. We added a CSS property to the HTML of the descriptions to ensure the line breaks were saved in downloads (property: `white-space`, value: `pre-wrap`). We also updated the following snapshots to reflect this change in unit tests:
`src/tests/unit/tests/DetailsView/reports/components/__snapshots__/assessment-scan-details.test.tsx.snap`
`src/tests/unit/tests/DetailsView/reports/components/__snapshots__/report-head.test.tsx.snap`
`src/tests/unit/tests/DetailsView/reports/components/__snapshots__/report-scan-details.test.tsx.snap`

#### Pull request checklist

- [X] Addresses an existing issue: Related Issue #698 
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [X] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS
Using NVDA the lines were separated when navigating with arrow keys.


<img width="437" alt="LineBreak1" src="https://user-images.githubusercontent.com/24820607/58996898-f8d0bf00-87ae-11e9-94e8-cc069464dbc1.png">
<img width="361" alt="LineBreak2" src="https://user-images.githubusercontent.com/24820607/58996899-f8d0bf00-87ae-11e9-8c82-19ddd1739a7b.png">
<img width="756" alt="LineBreak3" src="https://user-images.githubusercontent.com/24820607/58998636-97145300-87b6-11e9-9c5c-f949031c507f.png">
