### PR TITLE
fix badge count for failed instances section

### DIFF
--- a/src/DetailsView/reports/components/report-sections/failed-instances-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/failed-instances-section.tsx
@@ -8,12 +8,20 @@ import { ResultSection } from './result-section';
 
 export type FailedInstancesSectionProps = Pick<SectionProps, 'scanResult'>;
 
-export const FailedInstancesSection = NamedSFC<FailedInstancesSectionProps>('FailedInstancesSection', ({ scanResult }) => (
-    <ResultSection
-        title="Failed instances"
-        rules={scanResult.violations}
-        containerClassName="failed-instances-section"
-        outcomeType="fail"
-        showDetails={true}
-    />
-));
+export const FailedInstancesSection = NamedSFC<FailedInstancesSectionProps>('FailedInstancesSection', ({ scanResult }) => {
+    const rules = scanResult.violations;
+    const count = rules.reduce((total, rule) => {
+        return total + rule.nodes.length;
+    }, 0);
+
+    return (
+        <ResultSection
+            title="Failed instances"
+            rules={rules}
+            containerClassName="failed-instances-section"
+            outcomeType="fail"
+            showDetails={true}
+            badgeCount={count}
+        />
+    );
+});

--- a/src/DetailsView/reports/components/report-sections/not-applicable-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/not-applicable-section.tsx
@@ -8,11 +8,16 @@ import { ResultSection } from './result-section';
 
 export type NotApplicableChecksSectionProps = Pick<SectionProps, 'scanResult'>;
 
-export const NotApplicableChecksSection = NamedSFC<NotApplicableChecksSectionProps>('NotApplicableChecksSection', ({ scanResult }) => (
-    <ResultSection
-        title="Not applicable"
-        rules={scanResult.inapplicable}
-        containerClassName="not-applicable-checks-section"
-        outcomeType="inapplicable"
-    />
-));
+export const NotApplicableChecksSection = NamedSFC<NotApplicableChecksSectionProps>('NotApplicableChecksSection', ({ scanResult }) => {
+    const rules = scanResult.inapplicable;
+
+    return (
+        <ResultSection
+            title="Not applicable"
+            rules={rules}
+            containerClassName="not-applicable-checks-section"
+            outcomeType="inapplicable"
+            badgeCount={rules.length}
+        />
+    );
+});

--- a/src/DetailsView/reports/components/report-sections/passed-checks-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/passed-checks-section.tsx
@@ -8,6 +8,15 @@ import { ResultSection } from './result-section';
 
 export type PassedChecksSectionProps = Pick<SectionProps, 'scanResult'>;
 
-export const PassedChecksSection = NamedSFC<PassedChecksSectionProps>('PassedChecksSection', ({ scanResult }) => (
-    <ResultSection title="Passed checks" rules={scanResult.passes} containerClassName="passed-checks-section" outcomeType="pass" />
-));
+export const PassedChecksSection = NamedSFC<PassedChecksSectionProps>('PassedChecksSection', ({ scanResult }) => {
+    const rules = scanResult.passes;
+    return (
+        <ResultSection
+            title="Passed checks"
+            rules={rules}
+            containerClassName="passed-checks-section"
+            outcomeType="pass"
+            badgeCount={rules.length}
+        />
+    );
+});

--- a/src/DetailsView/reports/components/report-sections/result-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section.tsx
@@ -14,14 +14,15 @@ export type ResultSectionProps = {
     title: string;
     outcomeType: InstanceOutcomeType;
     showDetails?: boolean;
+    badgeCount: number;
 };
 
 export const ResultSection = NamedSFC<ResultSectionProps>('ResultSection', props => {
-    const { rules, containerClassName, title, outcomeType } = props;
+    const { rules, containerClassName, title, outcomeType, badgeCount } = props;
 
     return (
         <div className={containerClassName}>
-            <ResultSectionTitle title={title} count={rules.length} outcomeType={outcomeType} />
+            <ResultSectionTitle title={title} count={badgeCount} outcomeType={outcomeType} />
             <RuleDetailsGroup rules={rules} showDetails={props.showDetails} outcomeType={outcomeType} />
         </div>
     );

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/failed-instances-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/failed-instances-section.test.tsx.snap
@@ -2,13 +2,29 @@
 
 exports[`FailedInstancesSection renders 1`] = `
 <ResultSection
+  badgeCount={6}
   containerClassName="failed-instances-section"
   outcomeType="fail"
   rules={
     Array [
-      Object {},
-      Object {},
-      Object {},
+      Object {
+        "nodes": Array [
+          Object {},
+          Object {},
+        ],
+      },
+      Object {
+        "nodes": Array [
+          Object {},
+        ],
+      },
+      Object {
+        "nodes": Array [
+          Object {},
+          Object {},
+          Object {},
+        ],
+      },
     ]
   }
   showDetails={true}

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/not-applicable-checks-sections.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/not-applicable-checks-sections.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`PassedChecksSection renders 1`] = `
 <ResultSection
+  badgeCount={3}
   containerClassName="not-applicable-checks-section"
   outcomeType="inapplicable"
   rules={

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/passed-checks-sections.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/passed-checks-sections.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`PassedChecksSection renders 1`] = `
 <ResultSection
+  badgeCount={3}
   containerClassName="passed-checks-section"
   outcomeType="pass"
   rules={

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/failed-instances-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/failed-instances-section.test.tsx
@@ -13,7 +13,7 @@ describe('FailedInstancesSection', () => {
     it('renders', () => {
         const props: FailedInstancesSectionProps = {
             scanResult: {
-                violations: [{} as RuleResult, {} as RuleResult, {} as RuleResult],
+                violations: [{ nodes: [{}, {}] } as RuleResult, { nodes: [{}] } as RuleResult, { nodes: [{}, {}, {}] } as RuleResult],
                 passes: [],
                 inapplicable: [],
                 incomplete: [],

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section.test.tsx
@@ -13,6 +13,7 @@ describe('PassedChecksSection', () => {
             containerClassName: 'result-section-class-name',
             rules: [{} as RuleResult, {} as RuleResult],
             outcomeType: 'pass',
+            badgeCount: 2,
         };
 
         const wrapper = shallow(<ResultSection {...props} />);
@@ -27,6 +28,7 @@ describe('PassedChecksSection', () => {
             rules: [{} as RuleResult, {} as RuleResult],
             outcomeType: 'pass',
             showDetails: true,
+            badgeCount: 2,
         };
 
         const wrapper = shallow(<ResultSection {...props} />);


### PR DESCRIPTION
#### Description of changes

We were using the rule count not the instances count. This PR fix this.

![19 - failed instances badge count](https://user-images.githubusercontent.com/2837582/58999330-296a2600-87ba-11e9-9c52-b6b44fdb86f0.png)

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1544731
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
