### PR TITLE
fix: accessible instance table

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -286,3 +286,73 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
         @include transform(rotate(-45deg));
     }
 }
+
+.a11y-report-instance-table {
+    table,
+    thead,
+    tbody,
+    th,
+    td,
+    tr {
+        display: block;
+    }
+
+    table {
+        font-size: 14px;
+        line-height: 20px;
+    }
+
+    thead tr {
+        position: absolute;
+        top: -9999px;
+        left: -9999px;
+    }
+
+    tr {
+        box-shadow: 0px 0.6px 1.8px rgba(0, 0, 0, 0.108), 0px 3.2px 7.2px rgba(0, 0, 0, 0.132);
+        border-radius: 4px;
+        margin-bottom: 16px;
+        background: $neutral-0;
+    }
+
+    td {
+        border: none;
+        position: relative;
+        padding-left: 110px;
+        padding-top: 14px;
+        padding-right: 14px;
+        padding-bottom: 14px;
+
+        border-bottom: 0.5px solid $neutral-10;
+
+        color: $secondary-text;
+    }
+
+    td:nth-of-type(2) {
+        font-family: Consolas, Segoe UI, Courier New, monospace;
+    }
+
+    td:before {
+        position: absolute;
+        top: 14px;
+        left: 20px;
+        width: 66px;
+        padding-right: 10px;
+        white-space: nowrap;
+
+        font-family: $semiBoldFontFamily;
+        color: $primary-text;
+    }
+
+    td:nth-of-type(1):before {
+        content: 'Path';
+    }
+
+    td:nth-of-type(2):before {
+        content: 'Snippet';
+    }
+
+    td:nth-of-type(3):before {
+        content: 'How to fix';
+    }
+}

--- a/src/DetailsView/reports/components/report-sections/accessible-instance-details/instance-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/accessible-instance-details/instance-details-group.tsx
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+import { NamedSFC } from '../../../../../common/react/named-sfc';
+
+export type InstanceDetailsGroupProps = {
+    nodeResults: AxeNodeResult[];
+};
+
+export const InstanceDetailsGroup = NamedSFC<InstanceDetailsGroupProps>('InstanceDetailsGroup', props => {
+    return (
+        <div className="a11y-report-instance-table">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Path</th>
+                        <th>Snippet</th>
+                        <th>How to fix</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {props.nodeResults.map((node, index) => {
+                        return (
+                            <tr>
+                                <td>{node.target.join(', ')}</td>
+                                <td>{node.html}</td>
+                                <td>{node.failureSummary}</td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        </div>
+    );
+});

--- a/src/DetailsView/reports/components/report-sections/rule-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-details-group.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { RuleResult } from '../../../../scanner/iruleresults';
-import { InstanceDetailsGroup } from './instance-details-group';
+import { InstanceDetailsGroup } from './accessible-instance-details/instance-details-group';
 import { InstanceOutcomeType } from './outcome-summary-bar';
 import { RuleDetail } from './rule-detail';
 


### PR DESCRIPTION
#### Description of changes

Right now, we're using one table per failed instance (1 table of 3 rows -path, snippet, how to fix, and 2 columns -header and value-).

From Rob feedback on the first draft of the report: "it would be nice [better accessibility] to have all the failed instances [grouped by rule] in one table".

This is an attempt to implement Rob's feedback on the failed instance list.

I'm going to run some more test using JAWS and NVDA to see if this make sense and/or if we are missing anything on the new table (aria properties come to mind). I also send an example to Rob to get his feedback.

![20 - accessible failed instance list](https://user-images.githubusercontent.com/2837582/59073080-744b7280-887a-11e9-9b01-9038794fafff.png)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
