### PR TITLE
responsive summary bar

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -79,6 +79,12 @@ $outcome-incomplete-summary-background: $neutral-outcome;
 $outcome-incomplete-border-color: $incomplete-color;
 $outcome-not-applicable-summary-color: $neutral-outcome;
 
+@media screen and (max-width: 640px) {
+    .outcome-past-tense {
+        display: none;
+    }
+}
+
 .summary-section {
     @include boxShadow();
 

--- a/src/DetailsView/reports/components/report-sections/outcome-summary-bar.tsx
+++ b/src/DetailsView/reports/components/report-sections/outcome-summary-bar.tsx
@@ -28,10 +28,14 @@ export const OutcomeSummaryBar = NamedSFC<OutcomeSummaryBarProps>('OutcomeSummar
                 const outcomeIcon = outcomeIconMap[outcomeType];
                 const count = countSummary[outcomeType];
 
+                const ariaLabel = `${count} ${text}`;
+
                 return (
-                    <span key={outcomeType} className={kebabCase(outcomeType)} style={{ flexGrow: count }}>
-                        {outcomeIcon} {count} {text}
-                    </span>
+                    <div aria-label={ariaLabel} style={{ flexGrow: count }}>
+                        <span key={outcomeType} className={kebabCase(outcomeType)} aria-hidden="true">
+                            {outcomeIcon} {count} <span className="outcome-past-tense">{text}</span>
+                        </span>
+                    </div>
                 );
             })}
         </div>

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/outcome-summary-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/outcome-summary-bar.test.tsx.snap
@@ -4,48 +4,75 @@ exports[`OutcomeSummaryBar failure only 1`] = `
 <div
   className="outcome-summary-bar"
 >
-  <span
-    className="fail"
+  <div
+    aria-label="3 Failed"
     style={
       Object {
         "flexGrow": 3,
       }
     }
   >
-    <CrossIcon />
-     
-    3
-     
-    Failed
-  </span>
-  <span
-    className="pass"
+    <span
+      aria-hidden="true"
+      className="fail"
+    >
+      <CrossIcon />
+       
+      3
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Failed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="0 Passed"
     style={
       Object {
         "flexGrow": 0,
       }
     }
   >
-    <CheckIcon />
-     
-    0
-     
-    Passed
-  </span>
-  <span
-    className="inapplicable"
+    <span
+      aria-hidden="true"
+      className="pass"
+    >
+      <CheckIcon />
+       
+      0
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Passed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="0 Not applicable"
     style={
       Object {
         "flexGrow": 0,
       }
     }
   >
-    <InapplicableIcon />
-     
-    0
-     
-    Not applicable
-  </span>
+    <span
+      aria-hidden="true"
+      className="inapplicable"
+    >
+      <InapplicableIcon />
+       
+      0
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Not applicable
+      </span>
+    </span>
+  </div>
 </div>
 `;
 
@@ -53,48 +80,75 @@ exports[`OutcomeSummaryBar failures + not applicable + passes 1`] = `
 <div
   className="outcome-summary-bar"
 >
-  <span
-    className="fail"
+  <div
+    aria-label="3 Failed"
     style={
       Object {
         "flexGrow": 3,
       }
     }
   >
-    <CrossIcon />
-     
-    3
-     
-    Failed
-  </span>
-  <span
-    className="pass"
+    <span
+      aria-hidden="true"
+      className="fail"
+    >
+      <CrossIcon />
+       
+      3
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Failed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="2 Passed"
     style={
       Object {
         "flexGrow": 2,
       }
     }
   >
-    <CheckIcon />
-     
-    2
-     
-    Passed
-  </span>
-  <span
-    className="inapplicable"
+    <span
+      aria-hidden="true"
+      className="pass"
+    >
+      <CheckIcon />
+       
+      2
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Passed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="3 Not applicable"
     style={
       Object {
         "flexGrow": 3,
       }
     }
   >
-    <InapplicableIcon />
-     
-    3
-     
-    Not applicable
-  </span>
+    <span
+      aria-hidden="true"
+      className="inapplicable"
+    >
+      <InapplicableIcon />
+       
+      3
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Not applicable
+      </span>
+    </span>
+  </div>
 </div>
 `;
 
@@ -102,48 +156,75 @@ exports[`OutcomeSummaryBar failures + not applicable only 1`] = `
 <div
   className="outcome-summary-bar"
 >
-  <span
-    className="fail"
+  <div
+    aria-label="3 Failed"
     style={
       Object {
         "flexGrow": 3,
       }
     }
   >
-    <CrossIcon />
-     
-    3
-     
-    Failed
-  </span>
-  <span
-    className="pass"
+    <span
+      aria-hidden="true"
+      className="fail"
+    >
+      <CrossIcon />
+       
+      3
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Failed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="0 Passed"
     style={
       Object {
         "flexGrow": 0,
       }
     }
   >
-    <CheckIcon />
-     
-    0
-     
-    Passed
-  </span>
-  <span
-    className="inapplicable"
+    <span
+      aria-hidden="true"
+      className="pass"
+    >
+      <CheckIcon />
+       
+      0
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Passed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="3 Not applicable"
     style={
       Object {
         "flexGrow": 3,
       }
     }
   >
-    <InapplicableIcon />
-     
-    3
-     
-    Not applicable
-  </span>
+    <span
+      aria-hidden="true"
+      className="inapplicable"
+    >
+      <InapplicableIcon />
+       
+      3
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Not applicable
+      </span>
+    </span>
+  </div>
 </div>
 `;
 
@@ -151,48 +232,75 @@ exports[`OutcomeSummaryBar failures + passes only 1`] = `
 <div
   className="outcome-summary-bar"
 >
-  <span
-    className="fail"
+  <div
+    aria-label="3 Failed"
     style={
       Object {
         "flexGrow": 3,
       }
     }
   >
-    <CrossIcon />
-     
-    3
-     
-    Failed
-  </span>
-  <span
-    className="pass"
+    <span
+      aria-hidden="true"
+      className="fail"
+    >
+      <CrossIcon />
+       
+      3
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Failed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="2 Passed"
     style={
       Object {
         "flexGrow": 2,
       }
     }
   >
-    <CheckIcon />
-     
-    2
-     
-    Passed
-  </span>
-  <span
-    className="inapplicable"
+    <span
+      aria-hidden="true"
+      className="pass"
+    >
+      <CheckIcon />
+       
+      2
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Passed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="0 Not applicable"
     style={
       Object {
         "flexGrow": 0,
       }
     }
   >
-    <InapplicableIcon />
-     
-    0
-     
-    Not applicable
-  </span>
+    <span
+      aria-hidden="true"
+      className="inapplicable"
+    >
+      <InapplicableIcon />
+       
+      0
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Not applicable
+      </span>
+    </span>
+  </div>
 </div>
 `;
 
@@ -200,48 +308,75 @@ exports[`OutcomeSummaryBar not applicable + passes only 1`] = `
 <div
   className="outcome-summary-bar"
 >
-  <span
-    className="fail"
+  <div
+    aria-label="0 Failed"
     style={
       Object {
         "flexGrow": 0,
       }
     }
   >
-    <CrossIcon />
-     
-    0
-     
-    Failed
-  </span>
-  <span
-    className="pass"
+    <span
+      aria-hidden="true"
+      className="fail"
+    >
+      <CrossIcon />
+       
+      0
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Failed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="2 Passed"
     style={
       Object {
         "flexGrow": 2,
       }
     }
   >
-    <CheckIcon />
-     
-    2
-     
-    Passed
-  </span>
-  <span
-    className="inapplicable"
+    <span
+      aria-hidden="true"
+      className="pass"
+    >
+      <CheckIcon />
+       
+      2
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Passed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="3 Not applicable"
     style={
       Object {
         "flexGrow": 3,
       }
     }
   >
-    <InapplicableIcon />
-     
-    3
-     
-    Not applicable
-  </span>
+    <span
+      aria-hidden="true"
+      className="inapplicable"
+    >
+      <InapplicableIcon />
+       
+      3
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Not applicable
+      </span>
+    </span>
+  </div>
 </div>
 `;
 
@@ -249,48 +384,75 @@ exports[`OutcomeSummaryBar not applicable only 1`] = `
 <div
   className="outcome-summary-bar"
 >
-  <span
-    className="fail"
+  <div
+    aria-label="0 Failed"
     style={
       Object {
         "flexGrow": 0,
       }
     }
   >
-    <CrossIcon />
-     
-    0
-     
-    Failed
-  </span>
-  <span
-    className="pass"
+    <span
+      aria-hidden="true"
+      className="fail"
+    >
+      <CrossIcon />
+       
+      0
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Failed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="2 Passed"
     style={
       Object {
         "flexGrow": 2,
       }
     }
   >
-    <CheckIcon />
-     
-    2
-     
-    Passed
-  </span>
-  <span
-    className="inapplicable"
+    <span
+      aria-hidden="true"
+      className="pass"
+    >
+      <CheckIcon />
+       
+      2
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Passed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="0 Not applicable"
     style={
       Object {
         "flexGrow": 0,
       }
     }
   >
-    <InapplicableIcon />
-     
-    0
-     
-    Not applicable
-  </span>
+    <span
+      aria-hidden="true"
+      className="inapplicable"
+    >
+      <InapplicableIcon />
+       
+      0
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Not applicable
+      </span>
+    </span>
+  </div>
 </div>
 `;
 
@@ -298,47 +460,74 @@ exports[`OutcomeSummaryBar passes only 1`] = `
 <div
   className="outcome-summary-bar"
 >
-  <span
-    className="fail"
+  <div
+    aria-label="0 Failed"
     style={
       Object {
         "flexGrow": 0,
       }
     }
   >
-    <CrossIcon />
-     
-    0
-     
-    Failed
-  </span>
-  <span
-    className="pass"
+    <span
+      aria-hidden="true"
+      className="fail"
+    >
+      <CrossIcon />
+       
+      0
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Failed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="2 Passed"
     style={
       Object {
         "flexGrow": 2,
       }
     }
   >
-    <CheckIcon />
-     
-    2
-     
-    Passed
-  </span>
-  <span
-    className="inapplicable"
+    <span
+      aria-hidden="true"
+      className="pass"
+    >
+      <CheckIcon />
+       
+      2
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Passed
+      </span>
+    </span>
+  </div>
+  <div
+    aria-label="0 Not applicable"
     style={
       Object {
         "flexGrow": 0,
       }
     }
   >
-    <InapplicableIcon />
-     
-    0
-     
-    Not applicable
-  </span>
+    <span
+      aria-hidden="true"
+      className="inapplicable"
+    >
+      <InapplicableIcon />
+       
+      0
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Not applicable
+      </span>
+    </span>
+  </div>
 </div>
 `;


### PR DESCRIPTION
#### Description of changes

- Make the summary bar responsive by visually hiding the outcome text (failed, passed, not applicable)
- Use aria-label and aria-hidden to maintain accessible text for each outcome on both scenarios (responsive and normal mode).

![22 - responsive summary section](https://user-images.githubusercontent.com/2837582/59132639-9bfa1380-892a-11e9-8a55-0796eface341.png)

#### Pull request checklist

- [x] Addresses an existing issue: completes WI # 1552591
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
