### PR TITLE
fix: extra special character on target page title for automated check report on edge

### DIFF
--- a/src/DetailsView/reports/components/report-head-v2.tsx
+++ b/src/DetailsView/reports/components/report-head-v2.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-
 import { NamedSFC } from '../../../common/react/named-sfc';
 import { title } from '../../../content/strings/application';
 import * as reportStyles from '../automated-checks-report.styles';
@@ -9,6 +8,7 @@ import * as reportStyles from '../automated-checks-report.styles';
 export const ReportHeadV2 = NamedSFC('ReportHead', () => {
     return (
         <head>
+            <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
             <title>{title} automated checks result</title>
             <style dangerouslySetInnerHTML={{ __html: reportStyles.styleSheet }} />
         </head>

--- a/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/report-head-v2.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/report-head-v2.test.tsx.snap
@@ -2,6 +2,10 @@
 
 exports[`ReportHeadV2 renders 1`] = `
 <head>
+  <meta
+    content="text/html;charset=utf-8"
+    http-equiv="Content-Type"
+  />
   <title>
     Accessibility Insights for Web
      automated checks result


### PR DESCRIPTION
#### Description of changes

Fix extra special character on target page title for automated check report on edge

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes WI # 1552602
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS


#### Screenshot

![image](https://user-images.githubusercontent.com/4496335/59133165-fcd61b80-892b-11e9-95ff-fe6c315d6ffe.png)
