### PR TITLE
fix: center rule name

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -214,38 +214,6 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     margin-bottom: 16px;
 }
 
-.rule-detail {
-    font-size: 14px;
-
-    height: 56px;
-    padding: 0 8px;
-    margin-left: 6px;
-
-    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
-
-    .outcome-chip {
-        vertical-align: middle;
-        margin-bottom: 2px;
-    }
-
-    .rule-details-id {
-        a {
-            font-family: $semiBoldFontFamily;
-            color: $primary-text !important;
-        }
-    }
-
-    .rule-detail-description {
-        color: $secondary-text !important;
-    }
-
-    .guidance-links {
-        a {
-            color: $secondary-text !important;
-        }
-    }
-}
-
 .failed-instances-section {
     margin-top: 56px;
 }
@@ -272,10 +240,7 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
         width: 7px;
         height: 7px;
         cursor: hand;
-        margin-right: 8px;
         content: '';
-        position: absolute;
-        margin-top: 6px;
         transform-origin: 50% 50%;
         transition: transform 0.1s linear 0s;
     }
@@ -283,12 +248,66 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     summary::-webkit-details-marker {
         display: none;
     }
-    details[open] summary:before {
-        @extend %common-summary-chevron;
-        @include transform(rotate(45deg));
+
+    details[open] {
+        padding-bottom: 16px;
+
+        summary:before {
+            @extend %common-summary-chevron;
+            @include transform(rotate(45deg));
+        }
     }
+
     summary:before {
         @extend %common-summary-chevron;
         @include transform(rotate(-45deg));
+    }
+
+    details {
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+    }
+
+    summary {
+        display: flex;
+        align-items: center;
+        padding-left: 2px;
+
+        .rule-detail {
+            box-shadow: unset;
+        }
+    }
+
+    .rule-detail {
+        font-size: 14px;
+
+        height: 56px;
+        padding: 0 8px;
+
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+
+        display: flex;
+        align-items: center;
+
+        .outcome-chip {
+            vertical-align: middle;
+            margin-bottom: 2px;
+        }
+
+        .rule-details-id {
+            a {
+                font-family: $semiBoldFontFamily;
+                color: $primary-text !important;
+            }
+        }
+
+        .rule-detail-description {
+            color: $secondary-text !important;
+        }
+
+        .guidance-links {
+            a {
+                color: $secondary-text !important;
+            }
+        }
     }
 }

--- a/src/DetailsView/reports/components/instance-details.scss
+++ b/src/DetailsView/reports/components/instance-details.scss
@@ -9,7 +9,6 @@
     border-radius: 4px;
     box-shadow: 0px 0.6px 1.8px rgba(0, 0, 0, 0.108), 0px 3.2px 7.2px rgba(0, 0, 0, 0.132);
     display: block;
-    margin-bottom: 16px;
     margin-left: 24px;
 
     th {


### PR DESCRIPTION
#### Description of changes

- Center rule name for failed instances (collapsed and expanded)
- Center rule name for passed/not applicable checks

**collapsed**
![23 - center rule name - collapsed](https://user-images.githubusercontent.com/2837582/59136391-cbfbe380-8937-11e9-98b4-4259af963175.png)

**expanded**
![24 - center rule name - expanded](https://user-images.githubusercontent.com/2837582/59136395-d1592e00-8937-11e9-8e02-25b09d7c251d.png)


#### Pull request checklist

- [x] Addresses an existing issue: completes WI # 1552594
- [x] Added relevant unit test for your changes. (`yarn test`)
   - css only change
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - css only change
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - css only change
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
