### PR TITLE
Overall responsive layout 

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -34,6 +34,10 @@ body {
         font-size: 17px;
         line-height: 24px;
     }
+
+    @media only screen and (max-width: 1000px) {
+        margin: 0 16px 0 16px;
+    }
 }
 
 .title-section {
@@ -91,6 +95,7 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     background-color: $neutral-0;
     padding: 25px;
     margin-bottom: 24px;
+    white-space: pre-wrap;
 
     .outcome-summary-bar {
         $outcome-summary-icon-size: 16px;
@@ -121,7 +126,6 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
             @include cross-icon-styles($outcome-summary-icon-size, 0px, $outcome-fail-summary-color);
             .check-container {
                 bottom: -1px;
-                margin-right: 8px;
                 background: $neutral-0;
             }
             background-color: $outcome-fail-summary-color;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
@@ -180,6 +180,7 @@ exports[`ReportBody renders 1`] = `
         "violations": Array [],
       }
     }
+    toUtcString={[Function]}
   />
 </body-section>
 `;


### PR DESCRIPTION
#### Description of changes

make the report responsive according to Figma:

1. Add 16px margins to both side of the content when the screen is very narrow.
2. Fix the issue where white space is collapsed in the summary bar. 

![image](https://user-images.githubusercontent.com/15974344/59223700-67cc6000-8b81-11e9-9884-1e2f8cd2e58f.png)

![image](https://user-images.githubusercontent.com/15974344/59223707-71ee5e80-8b81-11e9-91a5-22a876fff86c.png)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
