### PR TITLE
Ada congrats component

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -345,3 +345,33 @@ ul.instance-details-list {
         margin-bottom: unset;
     }
 }
+
+.report-congrats {
+    position: relative;
+}
+
+.report-congrats-screen {
+    top: 181px;
+    position: absolute;
+    width: 488px;
+    left: 105px;
+    height: 295px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.report-congrats-message {
+    width: 364px;
+    text-align: center;
+}
+.report-congrats-head {
+    font-size: 48px;
+    font-weight: 600;
+    color: rgba(0, 0, 0, 0.9);
+    padding: 10px 0 10px 0;
+}
+.report-congrats-info {
+    font-size: 40px;
+    color: rgba(0, 0, 0, 0.55);
+    padding: 10px 0 10px 0;
+}

--- a/src/DetailsView/reports/components/report-sections/failed-instances-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/failed-instances-section.tsx
@@ -24,6 +24,7 @@ export const FailedInstancesSection = NamedSFC<FailedInstancesSectionProps>(
                     containerClassName="failed-instances-section"
                     outcomeType="fail"
                     showDetails={true}
+                    showCongratsIfNotInstances={true}
                     badgeCount={count}
                 />
                 <script dangerouslySetInnerHTML={{ __html: getCollapsibleScript() }} />

--- a/src/DetailsView/reports/components/report-sections/no-failed-instances-congrats.tsx
+++ b/src/DetailsView/reports/components/report-sections/no-failed-instances-congrats.tsx
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+import { NamedSFC } from '../../../../common/react/named-sfc';
+import { InlineImage, InlineImageType } from '../inline-image';
+
+export const NoFailedInstancesCongrats = NamedSFC('NoFailedInstancesCongrats', () => {
+    return (
+        <div className="report-congrats" key="report-congrats">
+            <div className="report-congrats-image">
+                <InlineImage imageType={InlineImageType.AdaLaptop} alt="" />
+            </div>
+            <div className="report-congrats-screen">
+                <div className="report-congrats-message">
+                    <div className="report-congrats-head">Congratulations!</div>
+                    <div className="report-congrats-info">No failed automated checks were found.</div>
+                </div>
+            </div>
+        </div>
+    );
+});

--- a/src/DetailsView/reports/components/report-sections/result-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { RuleResult } from '../../../../scanner/iruleresults';
+import { NoFailedInstancesCongrats } from './no-failed-instances-congrats';
 import { InstanceOutcomeType } from './outcome-summary-bar';
 import { ResultSectionTitle } from './result-section-title';
 import { RuleDetailsGroup } from './rule-details-group';
@@ -14,16 +15,23 @@ export type ResultSectionProps = {
     title: string;
     outcomeType: InstanceOutcomeType;
     showDetails?: boolean;
+    showCongratsIfNotInstances?: boolean;
     badgeCount: number;
 };
 
 export const ResultSection = NamedSFC<ResultSectionProps>('ResultSection', props => {
-    const { rules, containerClassName, title, outcomeType, badgeCount } = props;
+    const { rules, containerClassName, title, outcomeType, badgeCount, showCongratsIfNotInstances } = props;
+
+    let content = <RuleDetailsGroup rules={rules} showDetails={props.showDetails} outcomeType={outcomeType} />;
+
+    if (rules.length === 0 && showCongratsIfNotInstances) {
+        content = <NoFailedInstancesCongrats />;
+    }
 
     return (
         <div className={containerClassName}>
             <ResultSectionTitle title={title} count={badgeCount} outcomeType={outcomeType} />
-            <RuleDetailsGroup rules={rules} showDetails={props.showDetails} outcomeType={outcomeType} />
+            {content}
         </div>
     );
 });

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/failed-instances-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/failed-instances-section.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`FailedInstancesSection renders 1`] = `
         },
       ]
     }
+    showCongratsIfNotInstances={true}
     showDetails={true}
     title="Failed instances"
   />

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/no-failed-instances-congrats.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/no-failed-instances-congrats.test.tsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NoFailedInstancesCongrats renders 1`] = `
+<div
+  className="report-congrats"
+>
+  <div
+    className="report-congrats-image"
+  >
+    <InlineImage
+      alt=""
+      imageType={5}
+    />
+  </div>
+  <div
+    className="report-congrats-screen"
+  >
+    <div
+      className="report-congrats-message"
+    >
+      <div
+        className="report-congrats-head"
+      >
+        Congratulations!
+      </div>
+      <div
+        className="report-congrats-info"
+      >
+        No failed automated checks were found.
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section.test.tsx.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`PassedChecksSection renders, no rules and show congrats 1`] = `
+<div
+  className="result-section-class-name"
+>
+  <ResultSectionTitle
+    count={2}
+    outcomeType="pass"
+    title="result section title"
+  />
+  <NoFailedInstancesCongrats />
+</div>
+`;
+
 exports[`PassedChecksSection renders, not showDetails 1`] = `
 <div
   className="result-section-class-name"

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/no-failed-instances-congrats.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/no-failed-instances-congrats.test.tsx
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+import { shallow } from 'enzyme';
+import { NoFailedInstancesCongrats } from '../../../../../../../DetailsView/reports/components/report-sections/no-failed-instances-congrats';
+
+describe('NoFailedInstancesCongrats', () => {
+    it('renders', () => {
+        const wrapper = shallow(<NoFailedInstancesCongrats />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section.test.tsx
@@ -35,4 +35,20 @@ describe('PassedChecksSection', () => {
 
         expect(wrapper.getElement()).toMatchSnapshot();
     });
+
+    it('renders, no rules and show congrats', () => {
+        const props: ResultSectionProps = {
+            title: 'result section title',
+            containerClassName: 'result-section-class-name',
+            rules: [],
+            outcomeType: 'pass',
+            showDetails: true,
+            showCongratsIfNotInstances: true,
+            badgeCount: 2,
+        };
+
+        const wrapper = shallow(<ResultSection {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Description of changes

This PR brings ADA back (if the website has no failures)

![25 - ada congrats](https://user-images.githubusercontent.com/2837582/59305491-315d1680-8c4f-11e9-852c-02d4dcec1894.png)

#### Pull request checklist

- [x] Addresses an existing issue: this finishes WI # 1544731
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
