### PR TITLE
Enable WCAG 2.1 rules in Automated Checks

### DIFF
--- a/src/DetailsView/components/overview-content/overview-content-container.tsx
+++ b/src/DetailsView/components/overview-content/overview-content-container.tsx
@@ -29,6 +29,10 @@ const linkDataSource: HyperlinkDefinition[] = [
         href: 'https://go.microsoft.com/fwlink/?linkid=2077941',
         text: 'Ask a question',
     },
+    {
+        href: 'https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/',
+        text: 'New WCAG 2.1 success criteria',
+    },
 ];
 
 export type OverviewContainerDeps = {

--- a/src/scanner/rule-to-links-mappings.ts
+++ b/src/scanner/rule-to-links-mappings.ts
@@ -92,10 +92,10 @@ export const ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]> 
     'get-frame-title': [link.WCAG_4_1_2],
     'page-title': [link.WCAG_2_4_2],
     'aria-allowed-role': [BestPractice],
-    'autocomplete-valid': [BestPractice],
+    'autocomplete-valid': [link.WCAG_1_3_5],
     'css-orientation-lock': [BestPractice],
     'aria-hidden-focus': [link.WCAG_4_1_2],
     'form-field-multiple-labels': [BestPractice],
-    'label-content-name-mismatch': [BestPractice],
+    'label-content-name-mismatch': [link.WCAG_2_5_3],
     'landmark-complementary-is-top-level': [link.WCAG_1_3_1, BestPractice],
 };

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
@@ -67,6 +67,10 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
             "href": "https://go.microsoft.com/fwlink/?linkid=2077941",
             "text": "Ask a question",
           },
+          Object {
+            "href": "https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/",
+            "text": "New WCAG 2.1 success criteria",
+          },
         ]
       }
     />

--- a/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
@@ -39,7 +39,6 @@ describe('OverviewContainer', () => {
     const filteredProvider = {} as AssessmentsProvider;
     const detailsViewActionMessageCreatorStub = {} as DetailsViewActionMessageCreator;
     const assessmentsProviderWithFeaturesEnabledMock = Mock.ofInstance((provider, featureFlagData) => null, MockBehavior.Strict);
-
     const getAssessmentSummaryModelFromProviderAndStoreData = jest.fn();
 
     const deps: OverviewContainerDeps = {

--- a/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
@@ -39,6 +39,7 @@ describe('OverviewContainer', () => {
     const filteredProvider = {} as AssessmentsProvider;
     const detailsViewActionMessageCreatorStub = {} as DetailsViewActionMessageCreator;
     const assessmentsProviderWithFeaturesEnabledMock = Mock.ofInstance((provider, featureFlagData) => null, MockBehavior.Strict);
+
     const getAssessmentSummaryModelFromProviderAndStoreData = jest.fn();
 
     const deps: OverviewContainerDeps = {


### PR DESCRIPTION
#### Description of changes

This sets the correct mapping for WCAG 2.1 rules in automated checks, thus enabling them. It also adds a link to the overview section in assessments.

![image](https://user-images.githubusercontent.com/32555133/59307153-b85fbe00-8c52-11e9-9519-717207f96766.png)


#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
