### PR TITLE
fix: fix screen reader announcement of the details section content

### DIFF
--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -3,7 +3,6 @@
 import { escape } from 'lodash';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
-
 import { ExportResultType } from '../../common/telemetry-events';
 import { ReportGenerator } from '../reports/report-generator';
 import { ExportDialog, ExportDialogDeps } from './export-dialog';
@@ -27,6 +26,7 @@ export interface ReportExportComponentState {
 
 export class ReportExportComponent extends React.Component<ReportExportComponentProps, ReportExportComponentState> {
     private descriptionPlaceholder: string = 'd68d50a0-8249-464d-b2fd-709049c89ee4';
+    private replaceRegex: RegExp = new RegExp(`${this.descriptionPlaceholder}`, 'g');
 
     constructor(props) {
         super(props);
@@ -44,7 +44,7 @@ export class ReportExportComponent extends React.Component<ReportExportComponent
     };
 
     private onExportDescriptionChange = (value: string) => {
-        const exportData = this.state.exportDataWithPlaceholder.replace(this.descriptionPlaceholder, escape(value));
+        const exportData = this.state.exportDataWithPlaceholder.replace(this.replaceRegex, escape(value));
         this.setState({ exportDescription: value, exportData });
     };
 
@@ -52,7 +52,7 @@ export class ReportExportComponent extends React.Component<ReportExportComponent
         const { reportGenerator, exportResultsType, scanDate, pageTitle, htmlGenerator } = this.props;
         const exportName = reportGenerator.generateName(exportResultsType, scanDate, pageTitle);
         const exportDataWithPlaceholder = htmlGenerator(this.descriptionPlaceholder);
-        const exportData = exportDataWithPlaceholder.replace(this.descriptionPlaceholder, '');
+        const exportData = exportDataWithPlaceholder.replace(this.replaceRegex, '');
         this.setState({ exportDescription: '', exportName, exportDataWithPlaceholder, exportData, isOpen: true });
     };
 

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -26,7 +26,7 @@ export interface ReportExportComponentState {
 
 export class ReportExportComponent extends React.Component<ReportExportComponentProps, ReportExportComponentState> {
     private descriptionPlaceholder: string = 'd68d50a0-8249-464d-b2fd-709049c89ee4';
-    private replaceRegex: RegExp = new RegExp(`${this.descriptionPlaceholder}`, 'g');
+    private replaceRegex: RegExp = new RegExp(this.descriptionPlaceholder, 'g');
 
     constructor(props) {
         super(props);

--- a/src/DetailsView/reports/components/report-head-v2.tsx
+++ b/src/DetailsView/reports/components/report-head-v2.tsx
@@ -8,7 +8,7 @@ import * as reportStyles from '../automated-checks-report.styles';
 export const ReportHeadV2 = NamedSFC('ReportHead', () => {
     return (
         <head>
-            <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
+            <meta httpEquiv="Content-Type" content="text/html;charset=utf-8" />
             <title>{title} automated checks result</title>
             <style dangerouslySetInnerHTML={{ __html: reportStyles.styleSheet }} />
         </head>

--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -36,7 +36,6 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
                         <td className="icon" aria-hidden="true">
                             <UrlIcon />
                         </td>
-
                         <td className="text" aria-labelledby="target-page-text" aria-hidden="true">
                             <NewTabLink href={pageUrl} title="Navigate to target page">
                                 {pageUrl}
@@ -47,7 +46,6 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
                         <td className="icon" aria-hidden="true">
                             <DateIcon />
                         </td>
-
                         <td className="text" aria-labelledby="scan-date-text" aria-hidden="true">
                             {scanDateUTC}
                         </td>
@@ -56,7 +54,6 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
                         <td className="icon" aria-hidden="true">
                             <CommentIcon />
                         </td>
-
                         <td className="text description-text" aria-labelledby="comment-text" aria-hidden="true">
                             {description}
                         </td>

--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -21,20 +21,14 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
     return (
         <div className="scan-details-section">
             <h2>Scan details</h2>
-            <span className="screen-reader-only" id="target-page-text">
-                {screenReaderTexts.targetPageLink}
-            </span>
-            <span className="screen-reader-only" id="scan-date-text">
-                {screenReaderTexts.scanDate}
-            </span>
-            <span className="screen-reader-only" id="comment-text">
-                {screenReaderTexts.comment}
-            </span>
             <table>
                 <tbody>
                     <tr>
                         <td className="icon" aria-hidden="true">
                             <UrlIcon />
+                        </td>
+                        <td className="screen-reader-only" id="target-page-text">
+                            {screenReaderTexts.targetPageLink}
                         </td>
                         <td className="text" aria-labelledby="target-page-text" aria-hidden="true">
                             <NewTabLink href={pageUrl} title="Navigate to target page">
@@ -46,6 +40,9 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
                         <td className="icon" aria-hidden="true">
                             <DateIcon />
                         </td>
+                        <td className="screen-reader-only" id="scan-date-text">
+                            {screenReaderTexts.scanDate}
+                        </td>
                         <td className="text" aria-labelledby="scan-date-text" aria-hidden="true">
                             {scanDateUTC}
                         </td>
@@ -53,6 +50,9 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
                     <tr>
                         <td className="icon" aria-hidden="true">
                             <CommentIcon />
+                        </td>
+                        <td className="screen-reader-only" id="comment-text">
+                            {screenReaderTexts.comment}
                         </td>
                         <td className="text description-text" aria-labelledby="comment-text" aria-hidden="true">
                             {description}

--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -21,16 +21,23 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
     return (
         <div className="scan-details-section">
             <h2>Scan details</h2>
+            <span className="screen-reader-only" id="target-page-text">
+                {screenReaderTexts.targetPageLink}
+            </span>
+            <span className="screen-reader-only" id="scan-date-text">
+                {screenReaderTexts.scanDate}
+            </span>
+            <span className="screen-reader-only" id="comment-text">
+                {screenReaderTexts.comment}
+            </span>
             <table>
                 <tbody>
                     <tr>
                         <td className="icon" aria-hidden="true">
                             <UrlIcon />
                         </td>
-                        <span className="screen-reader-only" id="target-page-text">
-                            {screenReaderTexts.targetPageLink}
-                        </span>
-                        <td className="text" aria-labelledby="target-page-text">
+
+                        <td className="text" aria-labelledby="target-page-text" aria-hidden="true">
                             <NewTabLink href={pageUrl} title="Navigate to target page">
                                 {pageUrl}
                             </NewTabLink>
@@ -40,10 +47,8 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
                         <td className="icon" aria-hidden="true">
                             <DateIcon />
                         </td>
-                        <span className="screen-reader-only" id="scan-date-text">
-                            {screenReaderTexts.scanDate}
-                        </span>
-                        <td className="text" aria-labelledby="scan-date-text">
+
+                        <td className="text" aria-labelledby="scan-date-text" aria-hidden="true">
                             {scanDateUTC}
                         </td>
                     </tr>
@@ -51,10 +56,8 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
                         <td className="icon" aria-hidden="true">
                             <CommentIcon />
                         </td>
-                        <span className="screen-reader-only" id="comment-text">
-                            {screenReaderTexts.comment}
-                        </span>
-                        <td className="text description-text" aria-labelledby="comment-text">
+
+                        <td className="text description-text" aria-labelledby="comment-text" aria-hidden="true">
                             {description}
                         </td>
                     </tr>

--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -12,6 +12,12 @@ export type DetailsSectionProps = Pick<SectionProps, 'pageUrl' | 'description' |
 
 export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', props => {
     const { pageUrl, description, scanDate, toUtcString } = props;
+    const scanDateUTC: string = toUtcString(scanDate);
+    const screenReaderTexts = {
+        targetPageLink: `Target Page: ${pageUrl}`,
+        scanDate: `Scan date: ${scanDateUTC}`,
+        comment: `Comment: ${description}`,
+    };
     return (
         <div className="scan-details-section">
             <h2>Scan details</h2>
@@ -21,7 +27,10 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
                         <td className="icon" aria-hidden="true">
                             <UrlIcon />
                         </td>
-                        <td className="text">
+                        <span className="screen-reader-only" id="target-page-text">
+                            {screenReaderTexts.targetPageLink}
+                        </span>
+                        <td className="text" aria-labelledby="target-page-text">
                             <NewTabLink href={pageUrl} title="Navigate to target page">
                                 {pageUrl}
                             </NewTabLink>
@@ -31,13 +40,23 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
                         <td className="icon" aria-hidden="true">
                             <DateIcon />
                         </td>
-                        <td className="text">{toUtcString(scanDate)}</td>
+                        <span className="screen-reader-only" id="scan-date-text">
+                            {screenReaderTexts.scanDate}
+                        </span>
+                        <td className="text" aria-labelledby="scan-date-text">
+                            {scanDateUTC}
+                        </td>
                     </tr>
                     <tr>
                         <td className="icon" aria-hidden="true">
                             <CommentIcon />
                         </td>
-                        <td className="text description-text">{description}</td>
+                        <span className="screen-reader-only" id="comment-text">
+                            {screenReaderTexts.comment}
+                        </span>
+                        <td className="text description-text" aria-labelledby="comment-text">
+                            {description}
+                        </td>
                     </tr>
                 </tbody>
             </table>

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
@@ -7,24 +7,6 @@ exports[`DetailsSection renders 1`] = `
   <h2>
     Scan details
   </h2>
-  <span
-    className="screen-reader-only"
-    id="target-page-text"
-  >
-    Target Page: https://page-url/
-  </span>
-  <span
-    className="screen-reader-only"
-    id="scan-date-text"
-  >
-    Scan date: 2018-03-12 11:24 PM UTC
-  </span>
-  <span
-    className="screen-reader-only"
-    id="comment-text"
-  >
-    Comment: description-text
-  </span>
   <table>
     <tbody>
       <tr>
@@ -33,6 +15,12 @@ exports[`DetailsSection renders 1`] = `
           className="icon"
         >
           <UrlIcon />
+        </td>
+        <td
+          className="screen-reader-only"
+          id="target-page-text"
+        >
+          Target Page: https://page-url/
         </td>
         <td
           aria-hidden="true"
@@ -55,6 +43,12 @@ exports[`DetailsSection renders 1`] = `
           <DateIcon />
         </td>
         <td
+          className="screen-reader-only"
+          id="scan-date-text"
+        >
+          Scan date: 2018-03-12 11:24 PM UTC
+        </td>
+        <td
           aria-hidden="true"
           aria-labelledby="scan-date-text"
           className="text"
@@ -68,6 +62,12 @@ exports[`DetailsSection renders 1`] = `
           className="icon"
         >
           <CommentIcon />
+        </td>
+        <td
+          className="screen-reader-only"
+          id="comment-text"
+        >
+          Comment: description-text
         </td>
         <td
           aria-hidden="true"

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
@@ -16,7 +16,14 @@ exports[`DetailsSection renders 1`] = `
         >
           <UrlIcon />
         </td>
+        <span
+          className="screen-reader-only"
+          id="target-page-text"
+        >
+          Target Page: https://page-url/
+        </span>
         <td
+          aria-labelledby="target-page-text"
           className="text"
         >
           <NewTabLink
@@ -34,7 +41,14 @@ exports[`DetailsSection renders 1`] = `
         >
           <DateIcon />
         </td>
+        <span
+          className="screen-reader-only"
+          id="scan-date-text"
+        >
+          Scan date: 2018-03-12 11:24 PM UTC
+        </span>
         <td
+          aria-labelledby="scan-date-text"
           className="text"
         >
           2018-03-12 11:24 PM UTC
@@ -47,7 +61,14 @@ exports[`DetailsSection renders 1`] = `
         >
           <CommentIcon />
         </td>
+        <span
+          className="screen-reader-only"
+          id="comment-text"
+        >
+          Comment: description-text
+        </span>
         <td
+          aria-labelledby="comment-text"
           className="text description-text"
         >
           description-text

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
@@ -7,6 +7,24 @@ exports[`DetailsSection renders 1`] = `
   <h2>
     Scan details
   </h2>
+  <span
+    className="screen-reader-only"
+    id="target-page-text"
+  >
+    Target Page: https://page-url/
+  </span>
+  <span
+    className="screen-reader-only"
+    id="scan-date-text"
+  >
+    Scan date: 2018-03-12 11:24 PM UTC
+  </span>
+  <span
+    className="screen-reader-only"
+    id="comment-text"
+  >
+    Comment: description-text
+  </span>
   <table>
     <tbody>
       <tr>
@@ -16,13 +34,8 @@ exports[`DetailsSection renders 1`] = `
         >
           <UrlIcon />
         </td>
-        <span
-          className="screen-reader-only"
-          id="target-page-text"
-        >
-          Target Page: https://page-url/
-        </span>
         <td
+          aria-hidden="true"
           aria-labelledby="target-page-text"
           className="text"
         >
@@ -41,13 +54,8 @@ exports[`DetailsSection renders 1`] = `
         >
           <DateIcon />
         </td>
-        <span
-          className="screen-reader-only"
-          id="scan-date-text"
-        >
-          Scan date: 2018-03-12 11:24 PM UTC
-        </span>
         <td
+          aria-hidden="true"
           aria-labelledby="scan-date-text"
           className="text"
         >
@@ -61,13 +69,8 @@ exports[`DetailsSection renders 1`] = `
         >
           <CommentIcon />
         </td>
-        <span
-          className="screen-reader-only"
-          id="comment-text"
-        >
-          Comment: description-text
-        </span>
         <td
+          aria-hidden="true"
           aria-labelledby="comment-text"
           className="text description-text"
         >

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/details-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/details-section.test.tsx
@@ -32,5 +32,6 @@ describe('DetailsSection', () => {
 
         const wrapper = shallow(<DetailsSection {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
+        toUtcStringMock.verifyAll();
     });
 });


### PR DESCRIPTION
#### Description of changes

Adds code that makes the screen reader properly announce the text in the scan details section.

The way Its done is to add a `screen-reader-only` span with properly formatted text, the `css` for that `span` will hide it from user's viewport but the screen-reader will read it since I have put the `ids` of those 
`span` in the `td` of the actual content's `aria-labelledby`.

Also since, now we are using `description` at two places; change the logic a little bit to make the replacement work better.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes WI #1552587
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS

#### Screenshot:
No-change in what we show here.

![image](https://user-images.githubusercontent.com/4496335/59309445-69b52280-8c58-11e9-8f51-82f0dc749cb8.png)

#### NVDA read out:
```
Target Page: https://www.chicos.com/store/
Scan date: 2019-06-11 9:51 PM UTC
Comment: Test
```
