### PR TITLE
Updates to the semantic CSS content test

### DIFF
--- a/src/assessments/semantics/test-steps/css-content.tsx
+++ b/src/assessments/semantics/test-steps/css-content.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
+import { NewTabLink } from '../../../common/components/new-tab-link';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { link } from '../../../content/link';
 import * as content from '../../../content/test/semantics/css-content';
@@ -10,7 +11,6 @@ import { ManualTestRecordYourResults } from '../../common/manual-test-record-you
 import * as Markup from '../../markup';
 import { Requirement } from '../../types/requirement';
 import { SemanticsTestStep } from './test-steps';
-import { NewTabLink } from '../../../common/components/new-tab-link';
 
 const cssContentHowToTest: JSX.Element = (
     <div>

--- a/src/assessments/semantics/test-steps/css-content.tsx
+++ b/src/assessments/semantics/test-steps/css-content.tsx
@@ -10,20 +10,62 @@ import { ManualTestRecordYourResults } from '../../common/manual-test-record-you
 import * as Markup from '../../markup';
 import { Requirement } from '../../types/requirement';
 import { SemanticsTestStep } from './test-steps';
+import { NewTabLink } from '../../../common/components/new-tab-link';
 
 const cssContentHowToTest: JSX.Element = (
     <div>
         <p>
             The visual helper for this requirement highlights content inserted in the page using CSS <Markup.Term>:before</Markup.Term> or{' '}
-            <Markup.Term>:after</Markup.Term>.
+            <Markup.Term>:after</Markup.Term>. This procedure uses the{' '}
+            <NewTabLink href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">
+                Web Developer
+            </NewTabLink>{' '}
+            browser extension.
         </p>
         <ol>
             <li>
-                In the target page, examine each highlighted item to verify that it is decorative. An element is{' '}
-                <Markup.Emphasis>decorative</Markup.Emphasis> if it could be removed from the page with{' '}
-                <Markup.Emphasis>no</Markup.Emphasis> impact on meaning or function.
+                In the target page, examine each highlighted item to determine whether it is meaningful or decorative.
+                <ul>
+                    <li>
+                        An element is <Markup.Emphasis>meaningful</Markup.Emphasis> if it conveys information that isn't available through
+                        other page content.
+                    </li>
+                    <li>
+                        An element is <Markup.Emphasis>decorative</Markup.Emphasis> if it could be removed from the page with{' '}
+                        <Markup.Emphasis>no</Markup.Emphasis> impact on meaning or function.
+                    </li>
+                </ul>
             </li>
+            <li>
+                If inserted content is meaningful:
+                <ul>
+                    <li>
+                        Determine whether the information in inserted content is available to assistive technologies:
+                        <ul>
+                            <li>
+                                Open the{' '}
+                                <NewTabLink href="https://developers.google.com/web/updates/2018/01/devtools#a11y-pane">
+                                    Accessibility pane
+                                </NewTabLink>{' '}
+                                in the browser Developer Tools.
+                            </li>
+                            <li>In the accessibility tree, examine the element with inserted content and its ancestors.</li>
+                            <li>Verify that any information conveyed by the inserted content is shown in the accessibility tree.</li>
+                        </ul>
+                    </li>
 
+                    <li>
+                        Determine whether the information in inserted content is visible when CSS is turned off:
+                        <ul>
+                            <li>
+                                Use the Web Developer browser extension <Markup.Term>(CSS > Disable All Styles)</Markup.Term> to turn off
+                                CSS.
+                            </li>
+                            <li>Verify that any information conveyed by the inserted content is visible in the target page.</li>
+                        </ul>
+                    </li>
+                </ul>
+            </li>
             <ManualTestRecordYourResults isMultipleFailurePossible={true} />
         </ol>
     </div>
@@ -31,7 +73,7 @@ const cssContentHowToTest: JSX.Element = (
 
 const cssContentDescription: JSX.Element = (
     <span>
-        Meaningful content must not be inserted using CSS <Markup.Term>:before</Markup.Term> or <Markup.Term>:after</Markup.Term>.
+        Meaningful content must not be implemented using only CSS <Markup.Term>:before</Markup.Term> or <Markup.Term>:after</Markup.Term>.
     </span>
 );
 

--- a/src/content/test/semantics/css-content.tsx
+++ b/src/content/test/semantics/css-content.tsx
@@ -6,7 +6,8 @@ export const infoAndExamples = create(({ Markup, Link }) => (
     <>
         <h1>CSS content</h1>
         <p>
-            Meaningful content must not be inserted using CSS <Markup.Code>:before</Markup.Code> or <Markup.Code>:after</Markup.Code>.
+            Meaningful content must not be implemented using only CSS <Markup.Code>:before</Markup.Code> or{' '}
+            <Markup.Code>:after</Markup.Code>.
         </p>
 
         <h2>Why it matters</h2>
@@ -17,9 +18,17 @@ export const infoAndExamples = create(({ Markup, Link }) => (
         </p>
 
         <h2>How to fix</h2>
-        <p>
-            Avoid inserting meaningful page content using CSS <Markup.Code>:before</Markup.Code> or <Markup.Code>:after</Markup.Code>.
-        </p>
+        <ul>
+            <li>
+                Good: Ensure that any information in inserted content is (1) available to assistive technologies, and (2) visible when CSS
+                is turned off.
+            </li>
+            <li>
+                Better: Avoid inserting meaningful page content using CSS <Markup.Code>:before</Markup.Code> or{' '}
+                <Markup.Code>:after</Markup.Code>.
+            </li>
+        </ul>
+        <p />
 
         <h2>Example</h2>
         <Markup.PassFail

--- a/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
@@ -22034,7 +22034,7 @@ exports[`A11Y for content pages High Contrast mode test/semantics/cssContent/inf
         CSS content
       </h1>
       <p>
-        Meaningful content must not be inserted using CSS 
+        Meaningful content must not be implemented using only CSS 
         <span
           class="insights-code"
         >
@@ -22069,21 +22069,27 @@ exports[`A11Y for content pages High Contrast mode test/semantics/cssContent/inf
       <h2>
         How to fix
       </h2>
-      <p>
-        Avoid inserting meaningful page content using CSS 
-        <span
-          class="insights-code"
-        >
-          :before
-        </span>
-         or 
-        <span
-          class="insights-code"
-        >
-          :after
-        </span>
-        .
-      </p>
+      <ul>
+        <li>
+          Good: Ensure that any information in inserted content is (1) available to assistive technologies, and (2) visible when CSS is turned off.
+        </li>
+        <li>
+          Better: Avoid inserting meaningful page content using CSS 
+          <span
+            class="insights-code"
+          >
+            :before
+          </span>
+           or 
+          <span
+            class="insights-code"
+          >
+            :after
+          </span>
+          .
+        </li>
+      </ul>
+      <p />
       <h2>
         Example
       </h2>
@@ -51435,7 +51441,7 @@ exports[`A11Y for content pages Normal mode test/semantics/cssContent/infoAndExa
         CSS content
       </h1>
       <p>
-        Meaningful content must not be inserted using CSS 
+        Meaningful content must not be implemented using only CSS 
         <span
           class="insights-code"
         >
@@ -51470,21 +51476,27 @@ exports[`A11Y for content pages Normal mode test/semantics/cssContent/infoAndExa
       <h2>
         How to fix
       </h2>
-      <p>
-        Avoid inserting meaningful page content using CSS 
-        <span
-          class="insights-code"
-        >
-          :before
-        </span>
-         or 
-        <span
-          class="insights-code"
-        >
-          :after
-        </span>
-        .
-      </p>
+      <ul>
+        <li>
+          Good: Ensure that any information in inserted content is (1) available to assistive technologies, and (2) visible when CSS is turned off.
+        </li>
+        <li>
+          Better: Avoid inserting meaningful page content using CSS 
+          <span
+            class="insights-code"
+          >
+            :before
+          </span>
+           or 
+          <span
+            class="insights-code"
+          >
+            :after
+          </span>
+          .
+        </li>
+      </ul>
+      <p />
       <h2>
         Example
       </h2>


### PR DESCRIPTION
#### Description of changes
This PR updates some text in our CSS content test to reduce potential confusion for the user. More info is in issue #697 

#### Pull request checklist

- [x] Addresses an existing issue: this is addressing #697 
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS

![css content text changes](https://user-images.githubusercontent.com/7775527/59311235-a9cad400-8c5d-11e9-9953-c116b500d054.png)

![guidance text changes](https://user-images.githubusercontent.com/7775527/59311250-b4856900-8c5d-11e9-8c60-572ed7520fac.png)
