### PR TITLE
collapse/expand chevron style fixes

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -277,6 +277,8 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
 
             .rule-detail {
                 box-shadow: unset;
+                margin-bottom: 16px;
+                margin-top: 16px;
             }
         }
 

--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -273,6 +273,7 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
 
         .summary-container {
             display: flex;
+            align-items: baseline;
 
             .rule-detail {
                 box-shadow: unset;


### PR DESCRIPTION
#### Description of changes

More fit & finish
- Properly align the chevron to the first line of the rule (when window size is small enough that the text wrap)
- Add top and bottom margins

**before**
![27 - chevron before](https://user-images.githubusercontent.com/2837582/59314012-2e225480-8c68-11e9-8667-78a85b7dd366.png)

**after**
![26 - chevron after](https://user-images.githubusercontent.com/2837582/59314021-324e7200-8c68-11e9-9b32-def893043417.png)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
   - does not apply
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - does not apply
- [x] Ran precheckin (`yarn precheckin`)
   - does not apply
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
