### PR TITLE
Add key to components in groups properly

### DIFF
--- a/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
@@ -13,8 +13,8 @@ export const InstanceDetailsGroup = NamedSFC<InstanceDetailsGroupProps>('Instanc
     return (
         <ul className="instance-details-list" aria-label="failed instances with path, snippet and how to fix information">
             {props.nodeResults.map((node, index) => (
-                <li>
-                    <InstanceDetails key={`instance-details-${index}`} {...{ index, ...node }} />
+                <li key={`instance-details-${index}`}>
+                    <InstanceDetails {...{ index, ...node }} />
                 </li>
             ))}
         </ul>

--- a/src/DetailsView/reports/components/report-sections/outcome-summary-bar.tsx
+++ b/src/DetailsView/reports/components/report-sections/outcome-summary-bar.tsx
@@ -31,8 +31,8 @@ export const OutcomeSummaryBar = NamedSFC<OutcomeSummaryBarProps>('OutcomeSummar
                 const ariaLabel = `${count} ${text}`;
 
                 return (
-                    <div aria-label={ariaLabel} style={{ flexGrow: count }}>
-                        <span key={outcomeType} className={kebabCase(outcomeType)} aria-hidden="true">
+                    <div key={outcomeType} aria-label={ariaLabel} style={{ flexGrow: count }}>
+                        <span className={kebabCase(outcomeType)} aria-hidden="true">
                             {outcomeIcon} {count} <span className="outcome-past-tense">{text}</span>
                         </span>
                     </div>

--- a/src/DetailsView/reports/components/report-sections/rule-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-details-group.tsx
@@ -18,9 +18,10 @@ export type RuleDetailsGroupProps = {
 export const RuleDetailsGroup = NamedSFC<RuleDetailsGroupProps>('RuleDetailsGroup', ({ rules, showDetails, outcomeType }) => {
     return (
         <div className="rule-details-group">
-            {rules.map(rule => {
+            {rules.map((rule, idx) => {
                 return showDetails ? (
                     <SummaryDetails
+                        key={`summary-details-${idx + 1}`}
                         id={rule.id}
                         summaryProps={{ role: 'heading', 'aria-level': 3 }}
                         summaryContent={<RuleDetail key={rule.id} rule={rule} outcomeType={outcomeType} isHeader={false} />}


### PR DESCRIPTION
#### Description of changes
Add key to components in groups properly.
No tests changed since keys does not render in dom.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
