### PR TITLE
refactor: move script tag

### DIFF
--- a/src/DetailsView/reports/components/report-sections/failed-instances-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/failed-instances-section.tsx
@@ -6,29 +6,23 @@ import { NamedSFC } from '../../../../common/react/named-sfc';
 import { SectionProps } from './report-section-factory';
 import { ResultSection } from './result-section';
 
-export type FailedInstancesSectionProps = Pick<SectionProps, 'scanResult' | 'getCollapsibleScript'>;
+export type FailedInstancesSectionProps = Pick<SectionProps, 'scanResult'>;
 
-export const FailedInstancesSection = NamedSFC<FailedInstancesSectionProps>(
-    'FailedInstancesSection',
-    ({ scanResult, getCollapsibleScript }) => {
-        const rules = scanResult.violations;
-        const count = rules.reduce((total, rule) => {
-            return total + rule.nodes.length;
-        }, 0);
+export const FailedInstancesSection = NamedSFC<FailedInstancesSectionProps>('FailedInstancesSection', ({ scanResult }) => {
+    const rules = scanResult.violations;
+    const count = rules.reduce((total, rule) => {
+        return total + rule.nodes.length;
+    }, 0);
 
-        return (
-            <>
-                <ResultSection
-                    title="Failed instances"
-                    rules={rules}
-                    containerClassName="failed-instances-section"
-                    outcomeType="fail"
-                    showDetails={true}
-                    showCongratsIfNotInstances={true}
-                    badgeCount={count}
-                />
-                <script dangerouslySetInnerHTML={{ __html: getCollapsibleScript() }} />
-            </>
-        );
-    },
-);
+    return (
+        <ResultSection
+            title="Failed instances"
+            rules={rules}
+            containerClassName="failed-instances-section"
+            outcomeType="fail"
+            showDetails={true}
+            showCongratsIfNotInstances={true}
+            badgeCount={count}
+        />
+    );
+});

--- a/src/DetailsView/reports/components/report-sections/report-body.tsx
+++ b/src/DetailsView/reports/components/report-sections/report-body.tsx
@@ -32,7 +32,7 @@ export const ReportBody = NamedSFC<ReportBodyProps>('ReportBody', props => {
                 <TitleSection />
                 <SummarySection {...sectionProps} />
                 <DetailsSection {...sectionProps} />
-                <ResultsContainer>
+                <ResultsContainer {...sectionProps}>
                     <FailedInstancesSection {...sectionProps} />
                     <PassedChecksSection {...sectionProps} />
                     <NotApplicableChecksSection {...sectionProps} />

--- a/src/DetailsView/reports/components/report-sections/report-section-factory.tsx
+++ b/src/DetailsView/reports/components/report-sections/report-section-factory.tsx
@@ -22,7 +22,7 @@ export type ReportSectionFactory = {
     TitleSection: ReactSFCWithDisplayName;
     SummarySection: ReactSFCWithDisplayName<SectionProps>;
     DetailsSection: ReactSFCWithDisplayName<SectionProps>;
-    ResultsContainer: ReactSFCWithDisplayName;
+    ResultsContainer: ReactSFCWithDisplayName<SectionProps>;
     FailedInstancesSection: ReactSFCWithDisplayName<SectionProps>;
     PassedChecksSection: ReactSFCWithDisplayName<SectionProps>;
     NotApplicableChecksSection: ReactSFCWithDisplayName<SectionProps>;

--- a/src/DetailsView/reports/components/report-sections/results-container.tsx
+++ b/src/DetailsView/reports/components/report-sections/results-container.tsx
@@ -2,7 +2,15 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 import { NamedSFC } from '../../../../common/react/named-sfc';
+import { SectionProps } from './report-section-factory';
 
-export const ResultsContainer = NamedSFC('ResultsContainer', ({ children }) => {
-    return <div className="results-container">{children}</div>;
+export type ResultsContainerProps = Pick<SectionProps, 'getCollapsibleScript'>;
+
+export const ResultsContainer = NamedSFC<ResultsContainerProps>('ResultsContainer', ({ children, getCollapsibleScript }) => {
+    return (
+        <>
+            <div className="results-container">{children}</div>
+            <script dangerouslySetInnerHTML={{ __html: getCollapsibleScript() }} />
+        </>
+    );
 });

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/failed-instances-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/failed-instances-section.test.tsx.snap
@@ -1,43 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FailedInstancesSection renders 1`] = `
-<React.Fragment>
-  <ResultSection
-    badgeCount={6}
-    containerClassName="failed-instances-section"
-    outcomeType="fail"
-    rules={
-      Array [
-        Object {
-          "nodes": Array [
-            Object {},
-            Object {},
-          ],
-        },
-        Object {
-          "nodes": Array [
-            Object {},
-          ],
-        },
-        Object {
-          "nodes": Array [
-            Object {},
-            Object {},
-            Object {},
-          ],
-        },
-      ]
-    }
-    showCongratsIfNotInstances={true}
-    showDetails={true}
-    title="Failed instances"
-  />
-  <script
-    dangerouslySetInnerHTML={
+<ResultSection
+  badgeCount={6}
+  containerClassName="failed-instances-section"
+  outcomeType="fail"
+  rules={
+    Array [
       Object {
-        "__html": "test script",
-      }
-    }
-  />
-</React.Fragment>
+        "nodes": Array [
+          Object {},
+          Object {},
+        ],
+      },
+      Object {
+        "nodes": Array [
+          Object {},
+        ],
+      },
+      Object {
+        "nodes": Array [
+          Object {},
+          Object {},
+          Object {},
+        ],
+      },
+    ]
+  }
+  showCongratsIfNotInstances={true}
+  showDetails={true}
+  title="Failed instances"
+/>
 `;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
@@ -82,7 +82,32 @@ exports[`ReportBody renders 1`] = `
       }
       toUtcString={[Function]}
     />
-    <result-section>
+    <result-section
+      description="test description"
+      environmentInfo={
+        Object {
+          "axeCoreVersion": "axe-core-version",
+          "browserSpec": "browser-spec",
+          "extensionVersion": "extension-version",
+        }
+      }
+      getCollapsibleScript={[Function]}
+      pageTitle="page-title"
+      pageUrl="url:target-page"
+      scanDate={2019-05-29T19:12:16.804Z}
+      scanResult={
+        Object {
+          "inapplicable": Array [],
+          "incomplete": Array [],
+          "passes": Array [],
+          "targetPageTitle": "page-title",
+          "targetPageUrl": "url:target-page",
+          "timestamp": "today",
+          "violations": Array [],
+        }
+      }
+      toUtcString={[Function]}
+    >
       <failed-instances-section
         description="test description"
         environmentInfo={

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/results-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/results-container.test.tsx.snap
@@ -1,16 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ResultsContainer renders 1`] = `
-<div
-  className="results-container"
->
-  <div>
-    1
-  </div>
+<React.Fragment>
   <div
-    id="2"
+    className="results-container"
   >
-    2
+    <div>
+      1
+    </div>
+    <div
+      id="2"
+    >
+      2
+    </div>
   </div>
-</div>
+  <script
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "test script",
+      }
+    }
+  />
+</React.Fragment>
 `;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/failed-instances-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/failed-instances-section.test.tsx
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Mock } from 'typemoq';
 
 import {
     FailedInstancesSection,
@@ -12,11 +11,7 @@ import { RuleResult } from '../../../../../../../scanner/iruleresults';
 
 describe('FailedInstancesSection', () => {
     it('renders', () => {
-        const getScriptMock = Mock.ofInstance(() => '');
-        getScriptMock.setup(getScript => getScript()).returns(() => 'test script');
-
         const props: FailedInstancesSectionProps = {
-            getCollapsibleScript: getScriptMock.object,
             scanResult: {
                 violations: [{ nodes: [{}, {}] } as RuleResult, { nodes: [{}] } as RuleResult, { nodes: [{}, {}, {}] } as RuleResult],
                 passes: [],

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/results-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/results-container.test.tsx
@@ -3,13 +3,24 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { ResultsContainer } from '../../../../../../../DetailsView/reports/components/report-sections/results-container';
+import { Mock } from 'typemoq';
+import {
+    ResultsContainer,
+    ResultsContainerProps,
+} from '../../../../../../../DetailsView/reports/components/report-sections/results-container';
 
 describe('ResultsContainer', () => {
     it('renders', () => {
+        const getScriptMock = Mock.ofInstance(() => '');
+        getScriptMock.setup(getScript => getScript()).returns(() => 'test script');
+
+        const props: ResultsContainerProps = {
+            getCollapsibleScript: getScriptMock.object,
+        };
+
         const children: JSX.Element[] = [<div>1</div>, <div id="2">2</div>];
 
-        const wrapped = shallow(<ResultsContainer>{children}</ResultsContainer>);
+        const wrapped = shallow(<ResultsContainer {...props}>{children}</ResultsContainer>);
 
         expect(wrapped.getElement()).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

No new features. Just move the script tag some levels up on the dom hierarchy so we can re-use it on the passed/not applicable checks section to make them collapsible.

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1554732
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no UI/UX changes
- [ ] (UI changes only) Verified usability with NVDA/JAWS
   - no UI/UX changes
