### PR TITLE
refactor: created/moved module specific styles for test status choice group

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -628,7 +628,6 @@ div.insights-file-issue-details-dialog-container {
                 text-overflow: ellipsis;
                 color: $secondary-text;
             }
-
             .remove-button {
                 margin-left: 12px;
                 font-size: 16px;

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -628,47 +628,7 @@ div.insights-file-issue-details-dialog-container {
                 text-overflow: ellipsis;
                 color: $secondary-text;
             }
-            .radio-button-group {
-                float: left;
-                line-height: 24px;
-                .ms-ChoiceField {
-                    float: left;
-                    margin-top: 0px !important;
-                }
-                .ms-Label {
-                    font-size: 14px;
-                    padding: 0 0 0 26px;
-                    display: inline-block;
-                }
-                .ms-ChoiceField:nth-of-type(1) {
-                    margin-right: 8px;
-                }
-                .ms-ChoiceField-input {
-                    position: absolute;
-                }
-                .PASS {
-                    .ms-ChoiceField:nth-of-type(1) {
-                        .ms-ChoiceField-field::before,
-                        .ms-ChoiceField-field::after {
-                            border-color: $positive-outcome;
-                        }
-                    }
-                }
-                .FAIL {
-                    .ms-ChoiceField:nth-of-type(2) {
-                        .ms-ChoiceField-field::before,
-                        .ms-ChoiceField-field::after {
-                            border-color: $negative-outcome;
-                        }
-                    }
-                }
-            }
-            .undo-button {
-                margin-left: 8px;
-                font-size: 16px;
-                line-height: 24px;
-                color: $neutral-100;
-            }
+
             .remove-button {
                 margin-left: 12px;
                 font-size: 16px;

--- a/src/DetailsView/components/test-status-choice-group.scss
+++ b/src/DetailsView/components/test-status-choice-group.scss
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+
+.radio-button-group {
+    float: left;
+    line-height: 24px;
+
+    .radio-label {
+        font-size: 14px;
+        padding: 0 0 0 26px;
+        display: inline-block;
+    }
+
+    :global {
+        .ms-ChoiceField {
+            float: left;
+            margin-top: 0px !important;
+        }
+        .ms-ChoiceField:nth-of-type(1) {
+            margin-right: 8px;
+        }
+        .ms-ChoiceField-input {
+            position: absolute;
+        }
+        .PASS {
+            .ms-ChoiceField:nth-of-type(1) {
+                .ms-ChoiceField-field::before,
+                .ms-ChoiceField-field::after {
+                    border-color: $positive-outcome;
+                }
+            }
+        }
+        .FAIL {
+            .ms-ChoiceField:nth-of-type(2) {
+                .ms-ChoiceField-field::before,
+                .ms-ChoiceField-field::after {
+                    border-color: $negative-outcome;
+                }
+            }
+        }
+    }
+}
+
+.undo-button {
+    margin-left: 8px !important;
+
+    .undo-button-icon {
+        font-size: 16px;
+        line-height: 24px;
+        color: $neutral-100;
+    }
+}

--- a/src/DetailsView/components/test-status-choice-group.tsx
+++ b/src/DetailsView/components/test-status-choice-group.tsx
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
+import { isEqual } from 'lodash';
 import { ChoiceGroup, IChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import * as React from 'react';
 
-import { isEqual } from 'lodash';
 import { ManualTestStatus } from '../../common/types/manual-test-status';
 import { VisualizationType } from '../../common/types/visualization-type';
+import { radioButtonGroup, radioLabel, undoButton, undoButtonIcon } from './test-status-choice-group.scss';
 
 export interface TestStatusChoiceGroupProps {
     test: VisualizationType;
@@ -42,7 +43,7 @@ export class TestStatusChoiceGroup extends React.Component<TestStatusChoiceGroup
     public render(): JSX.Element {
         return (
             <div>
-                <div className="radio-button-group">
+                <div className={radioButtonGroup}>
                     <ChoiceGroup
                         className={ManualTestStatus[this.props.status]}
                         onChange={this.onChange}
@@ -63,7 +64,7 @@ export class TestStatusChoiceGroup extends React.Component<TestStatusChoiceGroup
     @autobind
     private onRenderLabel(option: IChoiceGroupOption): JSX.Element {
         return (
-            <span id={option.labelId} className="ms-Label" aria-label={option.text}>
+            <span id={option.labelId} className={radioLabel} aria-label={option.text}>
                 {this.props.isLabelVisible ? option.text : ''}
             </span>
         );
@@ -75,8 +76,8 @@ export class TestStatusChoiceGroup extends React.Component<TestStatusChoiceGroup
         }
 
         return (
-            <Link className="undo-button" onClick={this.onUndoClicked}>
-                <Icon iconName="undo" ariaLabel={'undo'} />
+            <Link className={undoButton} onClick={this.onUndoClicked}>
+                <Icon className={undoButtonIcon} iconName="undo" ariaLabel={'undo'} />
             </Link>
         );
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/test-status-choice-group.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/test-status-choice-group.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TestStatusChoiceGroup render 1`] = `
 <div>
   <div
-    className="radio-button-group"
+    className="radioButtonGroup"
   >
     <StyledChoiceGroupBase
       className="PASS"
@@ -33,7 +33,7 @@ exports[`TestStatusChoiceGroup render 1`] = `
 exports[`TestStatusChoiceGroup render: selectedKey is not set to undefined as status is PASS 1`] = `
 <div>
   <div
-    className="radio-button-group"
+    className="radioButtonGroup"
   >
     <StyledChoiceGroupBase
       className="PASS"
@@ -63,7 +63,7 @@ exports[`TestStatusChoiceGroup render: selectedKey is not set to undefined as st
 exports[`TestStatusChoiceGroup render: selectedKey is set to UNKNOWN as status is UNKNOWN 1`] = `
 <div>
   <div
-    className="radio-button-group"
+    className="radioButtonGroup"
   >
     <StyledChoiceGroupBase
       className="UNKNOWN"

--- a/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
@@ -8,6 +8,7 @@ import { Mock, Times } from 'typemoq';
 
 import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
 import { TestStatusChoiceGroup, TestStatusChoiceGroupProps } from '../../../../../DetailsView/components/test-status-choice-group';
+import { undoButton } from '../../../../../DetailsView/components/test-status-choice-group.scss';
 
 describe('TestStatusChoiceGroup', () => {
     const options = [
@@ -26,6 +27,7 @@ describe('TestStatusChoiceGroup', () => {
             onUndoClicked: null,
         };
         const component = new TestStatusChoiceGroup(props);
+
         expect(component.state).toMatchObject({ selectedKey: 'PASS' });
     });
 
@@ -137,7 +139,7 @@ describe('TestStatusChoiceGroup', () => {
 
         const component = React.createElement(TestableTestStatusChoiceGroup, props);
         const testObject = TestUtils.renderIntoDocument(component);
-        const link = TestUtils.findRenderedDOMComponentWithClass(testObject, 'undo-button');
+        const link = TestUtils.findRenderedDOMComponentWithClass(testObject, undoButton);
 
         expect(link).toBeDefined();
 

--- a/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
@@ -27,7 +27,6 @@ describe('TestStatusChoiceGroup', () => {
             onUndoClicked: null,
         };
         const component = new TestStatusChoiceGroup(props);
-
         expect(component.state).toMatchObject({ selectedKey: 'PASS' });
     });
 


### PR DESCRIPTION
#### Description of changes

Just moved styles from general details view scss file to module specific scss file.

![image](https://user-images.githubusercontent.com/32555133/59387806-ec081a00-8d1e-11e9-9525-91534612dc1e.png)

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
