### PR TITLE
fix: automated-checks-report; make comment section optional based on description entered

### DIFF
--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -18,6 +18,7 @@ export interface ExportDialogProps {
     onClose: () => void;
     onDescriptionChange: (value: string) => void;
     exportResultsType: ExportResultType;
+    onExportDialogFooterClick: () => void;
 }
 
 export interface ExportDialogDeps {
@@ -34,6 +35,7 @@ export const ExportDialog = NamedSFC<ExportDialogProps>('ExportDialog', props =>
     const onExportLinkClick = (event: React.MouseEvent<HTMLDivElement>): void => {
         const { detailsViewActionMessageCreator } = props.deps;
         detailsViewActionMessageCreator.exportResultsClicked(props.exportResultsType, props.html, event);
+        props.onExportDialogFooterClick();
         props.onClose();
     };
 

--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -18,7 +18,7 @@ export interface ExportDialogProps {
     onClose: () => void;
     onDescriptionChange: (value: string) => void;
     exportResultsType: ExportResultType;
-    onExportDialogFooterClick: () => void;
+    onExportClick: () => void;
 }
 
 export interface ExportDialogDeps {
@@ -35,7 +35,7 @@ export const ExportDialog = NamedSFC<ExportDialogProps>('ExportDialog', props =>
     const onExportLinkClick = (event: React.MouseEvent<HTMLDivElement>): void => {
         const { detailsViewActionMessageCreator } = props.deps;
         detailsViewActionMessageCreator.exportResultsClicked(props.exportResultsType, props.html, event);
-        props.onExportDialogFooterClick();
+        props.onExportClick();
         props.onClose();
     };
 

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -72,7 +72,7 @@ export class ReportExportComponent extends React.Component<ReportExportComponent
                     onClose={this.onDismissExportDialog}
                     onDescriptionChange={this.onExportDescriptionChange}
                     exportResultsType={exportResultsType}
-                    onExportDialogFooterClick={this.generateHtml}
+                    onExportClick={this.generateHtml}
                 />
             </>
         );

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -20,21 +20,16 @@ export interface ReportExportComponentState {
     isOpen: boolean;
     exportName: string;
     exportDescription: string;
-    exportDataWithPlaceholder: string;
     exportData: string;
 }
 
 export class ReportExportComponent extends React.Component<ReportExportComponentProps, ReportExportComponentState> {
-    private descriptionPlaceholder: string = 'd68d50a0-8249-464d-b2fd-709049c89ee4';
-    private replaceRegex: RegExp = new RegExp(this.descriptionPlaceholder, 'g');
-
     constructor(props) {
         super(props);
         this.state = {
             isOpen: false,
             exportName: '',
             exportDescription: '',
-            exportDataWithPlaceholder: '',
             exportData: '',
         };
     }
@@ -44,16 +39,20 @@ export class ReportExportComponent extends React.Component<ReportExportComponent
     };
 
     private onExportDescriptionChange = (value: string) => {
-        const exportData = this.state.exportDataWithPlaceholder.replace(this.replaceRegex, escape(value));
-        this.setState({ exportDescription: value, exportData });
+        const escapedExportDescription = escape(value);
+        this.setState({ exportDescription: escapedExportDescription });
+    };
+
+    private generateHtml = () => {
+        const { htmlGenerator } = this.props;
+        const exportData = htmlGenerator(this.state.exportDescription);
+        this.setState({ exportDescription: '', exportData });
     };
 
     private onExportButtonClick = () => {
-        const { reportGenerator, exportResultsType, scanDate, pageTitle, htmlGenerator } = this.props;
+        const { reportGenerator, exportResultsType, scanDate, pageTitle } = this.props;
         const exportName = reportGenerator.generateName(exportResultsType, scanDate, pageTitle);
-        const exportDataWithPlaceholder = htmlGenerator(this.descriptionPlaceholder);
-        const exportData = exportDataWithPlaceholder.replace(this.replaceRegex, '');
-        this.setState({ exportDescription: '', exportName, exportDataWithPlaceholder, exportData, isOpen: true });
+        this.setState({ exportName, isOpen: true });
     };
 
     public render(): JSX.Element {
@@ -73,6 +72,7 @@ export class ReportExportComponent extends React.Component<ReportExportComponent
                     onClose={this.onDismissExportDialog}
                     onDescriptionChange={this.onExportDescriptionChange}
                     exportResultsType={exportResultsType}
+                    onExportDialogFooterClick={this.generateHtml}
                 />
             </>
         );

--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -32,7 +32,7 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
         scanDate: `Scan date: ${scanDateUTC}`,
         comment: `Comment: ${description}`,
     };
-    const showCommentRow = description !== '';
+    const showCommentRow = !!description && description !== '';
     return (
         <div className="scan-details-section">
             <h2>Scan details</h2>

--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -10,6 +10,20 @@ import { SectionProps } from './report-section-factory';
 
 export type DetailsSectionProps = Pick<SectionProps, 'pageUrl' | 'description' | 'scanDate' | 'toUtcString'>;
 
+const createCommentRow = (description: string, screenReaderText: string) => (
+    <tr>
+        <td className="icon" aria-hidden="true">
+            <CommentIcon />
+        </td>
+        <td className="screen-reader-only" id="comment-text">
+            {screenReaderText}
+        </td>
+        <td className="text description-text" aria-labelledby="comment-text" aria-hidden="true">
+            {description}
+        </td>
+    </tr>
+);
+
 export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', props => {
     const { pageUrl, description, scanDate, toUtcString } = props;
     const scanDateUTC: string = toUtcString(scanDate);
@@ -18,6 +32,7 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
         scanDate: `Scan date: ${scanDateUTC}`,
         comment: `Comment: ${description}`,
     };
+    const showCommentRow = description !== '';
     return (
         <div className="scan-details-section">
             <h2>Scan details</h2>
@@ -47,17 +62,7 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
                             {scanDateUTC}
                         </td>
                     </tr>
-                    <tr>
-                        <td className="icon" aria-hidden="true">
-                            <CommentIcon />
-                        </td>
-                        <td className="screen-reader-only" id="comment-text">
-                            {screenReaderTexts.comment}
-                        </td>
-                        <td className="text description-text" aria-labelledby="comment-text" aria-hidden="true">
-                            {description}
-                        </td>
-                    </tr>
+                    {showCommentRow ? createCommentRow(description, screenReaderTexts.comment) : null}
                 </tbody>
             </table>
         </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
@@ -21,6 +21,7 @@ exports[`ReportExportComponentTest render 1`] = `
     isOpen={false}
     onClose={[Function]}
     onDescriptionChange={[Function]}
+    onExportDialogFooterClick={[Function]}
   />
 </React.Fragment>
 `;
@@ -41,10 +42,11 @@ exports[`ReportExportComponentTest user interactions click export button: dialog
     deps={Object {}}
     description=""
     exportResultsType="Assessment"
-    html="test html"
+    html=""
     isOpen={true}
     onClose={[Function]}
     onDescriptionChange={[Function]}
+    onExportDialogFooterClick={[Function]}
   />
 </React.Fragment>
 `;
@@ -65,10 +67,11 @@ exports[`ReportExportComponentTest user interactions dismiss dialog: dialog shou
     deps={Object {}}
     description=""
     exportResultsType="Assessment"
-    html="test html"
+    html=""
     isOpen={false}
     onClose={[Function]}
     onDescriptionChange={[Function]}
+    onExportDialogFooterClick={[Function]}
   />
 </React.Fragment>
 `;
@@ -94,6 +97,7 @@ exports[`ReportExportComponentTest user interactions edit text field: user input
     isOpen={false}
     onClose={[Function]}
     onDescriptionChange={[Function]}
+    onExportDialogFooterClick={[Function]}
   />
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`ReportExportComponentTest render 1`] = `
     isOpen={false}
     onClose={[Function]}
     onDescriptionChange={[Function]}
-    onExportDialogFooterClick={[Function]}
+    onExportClick={[Function]}
   />
 </React.Fragment>
 `;
@@ -46,7 +46,7 @@ exports[`ReportExportComponentTest user interactions click export button: dialog
     isOpen={true}
     onClose={[Function]}
     onDescriptionChange={[Function]}
-    onExportDialogFooterClick={[Function]}
+    onExportClick={[Function]}
   />
 </React.Fragment>
 `;
@@ -71,7 +71,7 @@ exports[`ReportExportComponentTest user interactions dismiss dialog: dialog shou
     isOpen={false}
     onClose={[Function]}
     onDescriptionChange={[Function]}
-    onExportDialogFooterClick={[Function]}
+    onExportClick={[Function]}
   />
 </React.Fragment>
 `;
@@ -97,7 +97,7 @@ exports[`ReportExportComponentTest user interactions edit text field: user input
     isOpen={false}
     onClose={[Function]}
     onDescriptionChange={[Function]}
-    onExportDialogFooterClick={[Function]}
+    onExportClick={[Function]}
   />
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -42,6 +42,7 @@ describe('ExportDialog', () => {
             onDescriptionChange: onDescriptionChangeMock.object,
             actionMessageCreator: actionMessageCreatorMock.object,
             exportResultsType: 'Assessment',
+            onExportDialogFooterClick: () => {},
         };
     });
 

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -18,6 +18,7 @@ describe('ExportDialog', () => {
     const provideBlobMock = Mock.ofType<(blobParts?: any[], mimeType?: string) => Blob>();
     const eventStub = 'event stub' as any;
     const blobStub = {} as Blob;
+    const onExportClickMock = Mock.ofInstance(() => {});
     let props: ExportDialogProps;
 
     beforeEach(() => {
@@ -25,6 +26,7 @@ describe('ExportDialog', () => {
         onDescriptionChangeMock.reset();
         actionMessageCreatorMock.reset();
         provideBlobMock.reset();
+        onExportClickMock.reset();
 
         const deps = {
             detailsViewActionMessageCreator: actionMessageCreatorMock.object,
@@ -42,7 +44,7 @@ describe('ExportDialog', () => {
             onDescriptionChange: onDescriptionChangeMock.object,
             actionMessageCreator: actionMessageCreatorMock.object,
             exportResultsType: 'Assessment',
-            onExportDialogFooterClick: () => {},
+            onExportClick: onExportClickMock.object,
         };
     });
 
@@ -74,7 +76,7 @@ describe('ExportDialog', () => {
                 .setup(w => w.createObjectURL(blobStub))
                 .returns(() => 'fake-url')
                 .verifiable(Times.once());
-
+            onExportClickMock.setup(getter => getter()).verifiable(Times.never());
             const wrapper = shallow(<ExportDialog {...props} />);
 
             wrapper.find(Dialog).prop('onDismiss')();
@@ -82,10 +84,12 @@ describe('ExportDialog', () => {
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();
             actionMessageCreatorMock.verifyAll();
+            onExportClickMock.verifyAll();
         });
 
         it('handles click on export button', () => {
             onCloseMock.setup(oc => oc()).verifiable(Times.once());
+            onExportClickMock.setup(getter => getter()).verifiable(Times.once());
             provideBlobMock
                 .setup(p => p(It.isAny(), It.isAnyString()))
                 .returns(() => blobStub)
@@ -106,6 +110,7 @@ describe('ExportDialog', () => {
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();
             actionMessageCreatorMock.verifyAll();
+            onExportClickMock.verifyAll();
         });
 
         it('handles text changes for the description', () => {
@@ -129,6 +134,7 @@ describe('ExportDialog', () => {
             onCloseMock.verifyAll();
             onDescriptionChangeMock.verifyAll();
             actionMessageCreatorMock.verifyAll();
+            onExportClickMock.verifyAll();
         });
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
@@ -38,10 +38,10 @@ describe('ReportExportComponentTest', () => {
             reportGeneratorMock
                 .setup(rgm => rgm.generateName(props.exportResultsType, props.scanDate, props.pageTitle))
                 .verifiable(Times.once());
-            // htmlGeneratorMock
-            //     .setup(hgm => hgm(It.isAnyString()))
-            //     .returns(() => 'test html')
-            //     .verifiable(Times.never());
+            htmlGeneratorMock
+                .setup(hgm => hgm(It.isAnyString()))
+                .returns(() => 'test html')
+                .verifiable(Times.never());
             const wrapper = shallow(<ReportExportComponent {...props} />);
             const exportButton = wrapper.find(ActionButton);
 
@@ -53,24 +53,27 @@ describe('ReportExportComponentTest', () => {
             dialog.props().onClose();
 
             reportGeneratorMock.verifyAll();
-            // htmlGeneratorMock.verifyAll();
+            htmlGeneratorMock.verifyAll();
         });
 
         test('dismiss dialog', () => {
+            const wrapper = shallow(<ReportExportComponent {...props} />);
             reportGeneratorMock
                 .setup(rgm => rgm.generateName(props.exportResultsType, props.scanDate, props.pageTitle))
                 .verifiable(Times.once());
             htmlGeneratorMock
                 .setup(hgm => hgm(It.isAnyString()))
                 .returns(() => 'test html')
-                .verifiable(Times.once());
-            const wrapper = shallow(<ReportExportComponent {...props} />);
+                .verifiable(Times.never());
+
             const exportButton = wrapper.find(ActionButton);
             exportButton.simulate('click');
             const dialog = wrapper.find(ExportDialog);
             dialog.props().onClose();
 
             expect(wrapper.getElement()).toMatchSnapshot('dialog should be dismissed');
+            reportGeneratorMock.verifyAll();
+            htmlGeneratorMock.verifyAll();
         });
 
         test('edit text field', () => {
@@ -80,6 +83,29 @@ describe('ReportExportComponentTest', () => {
             dialog.props().onDescriptionChange('new discription');
 
             expect(wrapper.getElement()).toMatchSnapshot('user input new discription');
+        });
+
+        test('clicking export on the dialog should trigger the generateHtml', () => {
+            const wrapper = shallow(<ReportExportComponent {...props} />);
+
+            reportGeneratorMock
+                .setup(rgm => rgm.generateName(props.exportResultsType, props.scanDate, props.pageTitle))
+                .verifiable(Times.once());
+
+            htmlGeneratorMock
+                .setup(hgm => hgm(wrapper.state('exportDescription')))
+                .returns(() => 'test html')
+                .verifiable(Times.once());
+
+            const exportButton = wrapper.find(ActionButton);
+
+            exportButton.simulate('click');
+
+            const dialog = wrapper.find(ExportDialog);
+
+            dialog.props().onExportClick();
+
+            htmlGeneratorMock.verifyAll();
         });
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
@@ -4,7 +4,6 @@ import { shallow } from 'enzyme';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { ExportDialog, ExportDialogDeps } from '../../../../../DetailsView/components/export-dialog';
 import { ReportExportComponent, ReportExportComponentProps } from '../../../../../DetailsView/components/report-export-component';
 import { ReportGenerator } from '../../../../../DetailsView/reports/report-generator';
@@ -39,10 +38,10 @@ describe('ReportExportComponentTest', () => {
             reportGeneratorMock
                 .setup(rgm => rgm.generateName(props.exportResultsType, props.scanDate, props.pageTitle))
                 .verifiable(Times.once());
-            htmlGeneratorMock
-                .setup(hgm => hgm(It.isAnyString()))
-                .returns(() => 'test html')
-                .verifiable(Times.once());
+            // htmlGeneratorMock
+            //     .setup(hgm => hgm(It.isAnyString()))
+            //     .returns(() => 'test html')
+            //     .verifiable(Times.never());
             const wrapper = shallow(<ReportExportComponent {...props} />);
             const exportButton = wrapper.find(ActionButton);
 
@@ -54,7 +53,7 @@ describe('ReportExportComponentTest', () => {
             dialog.props().onClose();
 
             reportGeneratorMock.verifyAll();
-            htmlGeneratorMock.verifyAll();
+            // htmlGeneratorMock.verifyAll();
         });
 
         test('dismiss dialog', () => {

--- a/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
@@ -38,10 +38,9 @@ describe('ReportExportComponentTest', () => {
             reportGeneratorMock
                 .setup(rgm => rgm.generateName(props.exportResultsType, props.scanDate, props.pageTitle))
                 .verifiable(Times.once());
-            htmlGeneratorMock
-                .setup(hgm => hgm(It.isAnyString()))
-                .returns(() => 'test html')
-                .verifiable(Times.never());
+
+            htmlGeneratorMock.setup(hgm => hgm(It.isAnyString())).verifiable(Times.never());
+
             const wrapper = shallow(<ReportExportComponent {...props} />);
             const exportButton = wrapper.find(ActionButton);
 
@@ -61,10 +60,8 @@ describe('ReportExportComponentTest', () => {
             reportGeneratorMock
                 .setup(rgm => rgm.generateName(props.exportResultsType, props.scanDate, props.pageTitle))
                 .verifiable(Times.once());
-            htmlGeneratorMock
-                .setup(hgm => hgm(It.isAnyString()))
-                .returns(() => 'test html')
-                .verifiable(Times.never());
+
+            htmlGeneratorMock.setup(hgm => hgm(It.isAnyString())).verifiable(Times.never());
 
             const exportButton = wrapper.find(ActionButton);
             exportButton.simulate('click');
@@ -88,18 +85,10 @@ describe('ReportExportComponentTest', () => {
         test('clicking export on the dialog should trigger the generateHtml', () => {
             const wrapper = shallow(<ReportExportComponent {...props} />);
 
-            reportGeneratorMock
-                .setup(rgm => rgm.generateName(props.exportResultsType, props.scanDate, props.pageTitle))
-                .verifiable(Times.once());
-
             htmlGeneratorMock
                 .setup(hgm => hgm(wrapper.state('exportDescription')))
                 .returns(() => 'test html')
                 .verifiable(Times.once());
-
-            const exportButton = wrapper.find(ActionButton);
-
-            exportButton.simulate('click');
 
             const dialog = wrapper.find(ExportDialog);
 

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
@@ -1,6 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DetailsSection renders 1`] = `
+exports[`DetailsSection rendering of comment row is dependent on description value renders and matches saved snapshot for description value:  1`] = `
+<div
+  className="scan-details-section"
+>
+  <h2>
+    Scan details
+  </h2>
+  <table>
+    <tbody>
+      <tr>
+        <td
+          aria-hidden="true"
+          className="icon"
+        >
+          <UrlIcon />
+        </td>
+        <td
+          className="screen-reader-only"
+          id="target-page-text"
+        >
+          Target Page: https://page-url/
+        </td>
+        <td
+          aria-hidden="true"
+          aria-labelledby="target-page-text"
+          className="text"
+        >
+          <NewTabLink
+            href="https://page-url/"
+            title="Navigate to target page"
+          >
+            https://page-url/
+          </NewTabLink>
+        </td>
+      </tr>
+      <tr>
+        <td
+          aria-hidden="true"
+          className="icon"
+        >
+          <DateIcon />
+        </td>
+        <td
+          className="screen-reader-only"
+          id="scan-date-text"
+        >
+          Scan date: 2018-03-12 11:24 PM UTC
+        </td>
+        <td
+          aria-hidden="true"
+          aria-labelledby="scan-date-text"
+          className="text"
+        >
+          2018-03-12 11:24 PM UTC
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DetailsSection rendering of comment row is dependent on description value renders and matches saved snapshot for description value: description-text 1`] = `
 <div
   className="scan-details-section"
 >
@@ -75,6 +136,128 @@ exports[`DetailsSection renders 1`] = `
           className="text description-text"
         >
           description-text
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DetailsSection rendering of comment row is dependent on description value renders and matches saved snapshot for description value: null 1`] = `
+<div
+  className="scan-details-section"
+>
+  <h2>
+    Scan details
+  </h2>
+  <table>
+    <tbody>
+      <tr>
+        <td
+          aria-hidden="true"
+          className="icon"
+        >
+          <UrlIcon />
+        </td>
+        <td
+          className="screen-reader-only"
+          id="target-page-text"
+        >
+          Target Page: https://page-url/
+        </td>
+        <td
+          aria-hidden="true"
+          aria-labelledby="target-page-text"
+          className="text"
+        >
+          <NewTabLink
+            href="https://page-url/"
+            title="Navigate to target page"
+          >
+            https://page-url/
+          </NewTabLink>
+        </td>
+      </tr>
+      <tr>
+        <td
+          aria-hidden="true"
+          className="icon"
+        >
+          <DateIcon />
+        </td>
+        <td
+          className="screen-reader-only"
+          id="scan-date-text"
+        >
+          Scan date: 2018-03-12 11:24 PM UTC
+        </td>
+        <td
+          aria-hidden="true"
+          aria-labelledby="scan-date-text"
+          className="text"
+        >
+          2018-03-12 11:24 PM UTC
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+`;
+
+exports[`DetailsSection rendering of comment row is dependent on description value renders and matches saved snapshot for description value: undefined 1`] = `
+<div
+  className="scan-details-section"
+>
+  <h2>
+    Scan details
+  </h2>
+  <table>
+    <tbody>
+      <tr>
+        <td
+          aria-hidden="true"
+          className="icon"
+        >
+          <UrlIcon />
+        </td>
+        <td
+          className="screen-reader-only"
+          id="target-page-text"
+        >
+          Target Page: https://page-url/
+        </td>
+        <td
+          aria-hidden="true"
+          aria-labelledby="target-page-text"
+          className="text"
+        >
+          <NewTabLink
+            href="https://page-url/"
+            title="Navigate to target page"
+          >
+            https://page-url/
+          </NewTabLink>
+        </td>
+      </tr>
+      <tr>
+        <td
+          aria-hidden="true"
+          className="icon"
+        >
+          <DateIcon />
+        </td>
+        <td
+          className="screen-reader-only"
+          id="scan-date-text"
+        >
+          Scan date: 2018-03-12 11:24 PM UTC
+        </td>
+        <td
+          aria-hidden="true"
+          aria-labelledby="scan-date-text"
+          className="text"
+        >
+          2018-03-12 11:24 PM UTC
         </td>
       </tr>
     </tbody>

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/details-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/details-section.test.tsx
@@ -7,31 +7,34 @@ import { DateProvider } from '../../../../../../../common/date-provider';
 import { DetailsSection, DetailsSectionProps } from '../../../../../../../DetailsView/reports/components/report-sections/details-section';
 
 describe('DetailsSection', () => {
-    it('renders', () => {
-        const scanDate = new Date(Date.UTC(2018, 2, 9, 9, 48));
+    describe('rendering of comment row is dependent on description value', () => {
+        const descriptionValues = ['description-text', '', undefined, null];
+        test.each(descriptionValues)('renders and matches saved snapshot for description value: %s', description => {
+            const scanDate = new Date(Date.UTC(2018, 2, 9, 9, 48));
 
-        const toUtcStringMock: IMock<(date: Date) => string> = Mock.ofInstance(DateProvider.getUTCStringFromDate, MockBehavior.Strict);
+            const toUtcStringMock: IMock<(date: Date) => string> = Mock.ofInstance(DateProvider.getUTCStringFromDate, MockBehavior.Strict);
 
-        toUtcStringMock
-            .setup(getter => getter(scanDate))
-            .returns(() => '2018-03-12 11:24 PM UTC')
-            .verifiable();
+            toUtcStringMock
+                .setup(getter => getter(scanDate))
+                .returns(() => '2018-03-12 11:24 PM UTC')
+                .verifiable();
 
-        const props: DetailsSectionProps = {
-            scanDate,
-            pageTitle: 'page-title',
-            pageUrl: 'https://page-url/',
-            description: 'description-text',
-            environmentInfo: {
-                browserSpec: 'environment-version',
-                extensionVersion: 'extension-version',
-                axeCoreVersion: 'axe-version',
-            },
-            toUtcString: toUtcStringMock.object,
-        };
+            const props: DetailsSectionProps = {
+                scanDate,
+                pageTitle: 'page-title',
+                pageUrl: 'https://page-url/',
+                description,
+                environmentInfo: {
+                    browserSpec: 'environment-version',
+                    extensionVersion: 'extension-version',
+                    axeCoreVersion: 'axe-version',
+                },
+                toUtcString: toUtcStringMock.object,
+            };
 
-        const wrapper = shallow(<DetailsSection {...props} />);
-        expect(wrapper.getElement()).toMatchSnapshot();
-        toUtcStringMock.verifyAll();
+            const wrapper = shallow(<DetailsSection {...props} />);
+            expect(wrapper.getElement()).toMatchSnapshot();
+            toUtcStringMock.verifyAll();
+        });
     });
 });


### PR DESCRIPTION
#### Description of changes

This PR makes the comment section optional based on the value of the description. The way I have achieved this is by calling the report html generator on `Export` button click for Export Dialog box.

WIP: need some feedback on how to test the `export dialog for props calling`

#### Pull request checklist

- [x] Addresses an existing issue: Fixes WI # 1554293
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS

#### GIF:
![test](https://user-images.githubusercontent.com/4496335/59392972-7015ce00-8d2e-11e9-9221-e643140bb915.gif)


