### PR TITLE
refactor: small improvements on ResultSection

### DIFF
--- a/src/DetailsView/reports/components/report-sections/collapsible-container.tsx
+++ b/src/DetailsView/reports/components/report-sections/collapsible-container.tsx
@@ -5,26 +5,23 @@ import * as React from 'react';
 
 import { NamedSFC } from '../../../../common/react/named-sfc';
 
-type HeadingProps = {
-    role: string;
-    'aria-level': number;
-};
-
 export type CollapsibleContainerProps = {
-    titleContainerProps: HeadingProps;
     id: string;
     summaryContent: JSX.Element;
     detailsContent: JSX.Element;
     buttonAriaLabel: string;
+    titleHeadingLevel?: number;
     containerClassName?: string;
 };
 
 export const CollapsibleContainer = NamedSFC<CollapsibleContainerProps>('CollapsibleContainer', props => {
-    const { id, summaryContent, titleContainerProps, detailsContent, buttonAriaLabel, containerClassName } = props;
+    const { id, summaryContent, titleHeadingLevel, detailsContent, buttonAriaLabel, containerClassName } = props;
 
     const contentId = `content-container-${id}`;
 
     const outerDivClassName = css('collapsible-container', containerClassName);
+
+    const titleContainerProps = titleHeadingLevel ? { role: 'heading', 'aria-level': titleHeadingLevel } : undefined;
 
     return (
         <div className={outerDivClassName}>

--- a/src/DetailsView/reports/components/report-sections/result-section-content.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section-content.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+import { NamedSFC } from '../../../../common/react/named-sfc';
+import { RuleResult } from '../../../../scanner/iruleresults';
+import { NoFailedInstancesCongrats } from './no-failed-instances-congrats';
+import { InstanceOutcomeType } from './outcome-summary-bar';
+import { RuleDetailsGroup } from './rule-details-group';
+
+export type ResultSectionContentProps = {
+    rules: RuleResult[];
+    outcomeType: InstanceOutcomeType;
+    showDetails?: boolean;
+    showCongratsIfNotInstances?: boolean;
+};
+
+export const ResultSectionContent = NamedSFC<ResultSectionContentProps>(
+    'ResultSectionContent',
+    ({ rules, showDetails, outcomeType, showCongratsIfNotInstances }) => {
+        let content = <RuleDetailsGroup rules={rules} showDetails={showDetails} outcomeType={outcomeType} />;
+
+        if (rules.length === 0 && showCongratsIfNotInstances) {
+            content = <NoFailedInstancesCongrats />;
+        }
+
+        return content;
+    },
+);

--- a/src/DetailsView/reports/components/report-sections/result-section-title.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section-title.tsx
@@ -6,17 +6,17 @@ import { NamedSFC } from '../../../../common/react/named-sfc';
 import { OutcomeChip } from '../outcome-chip';
 import { InstanceOutcomeType } from './outcome-summary-bar';
 
-export type ResultSectionTitlePros = {
+export type ResultSectionTitleProps = {
     title: string;
-    count: number;
+    badgeCount: number;
     outcomeType: InstanceOutcomeType;
 };
 
-export const ResultSectionTitle = NamedSFC<ResultSectionTitlePros>('ResultSectionTitle', props => {
+export const ResultSectionTitle = NamedSFC<ResultSectionTitleProps>('ResultSectionTitle', props => {
     return (
         <div className="result-section-title">
             <h2>{props.title}</h2>
-            <OutcomeChip outcomeType={props.outcomeType} count={props.count} />
+            <OutcomeChip outcomeType={props.outcomeType} count={props.badgeCount} />
         </div>
     );
 });

--- a/src/DetailsView/reports/components/report-sections/result-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section.tsx
@@ -3,35 +3,21 @@
 import * as React from 'react';
 
 import { NamedSFC } from '../../../../common/react/named-sfc';
-import { RuleResult } from '../../../../scanner/iruleresults';
-import { NoFailedInstancesCongrats } from './no-failed-instances-congrats';
-import { InstanceOutcomeType } from './outcome-summary-bar';
-import { ResultSectionTitle } from './result-section-title';
-import { RuleDetailsGroup } from './rule-details-group';
+import { ResultSectionContent, ResultSectionContentProps } from './result-section-content';
+import { ResultSectionTitle, ResultSectionTitleProps } from './result-section-title';
 
-export type ResultSectionProps = {
-    rules: RuleResult[];
-    containerClassName: string;
-    title: string;
-    outcomeType: InstanceOutcomeType;
-    showDetails?: boolean;
-    showCongratsIfNotInstances?: boolean;
-    badgeCount: number;
-};
+export type ResultSectionProps = ResultSectionContentProps &
+    ResultSectionTitleProps & {
+        containerClassName: string;
+    };
 
 export const ResultSection = NamedSFC<ResultSectionProps>('ResultSection', props => {
-    const { rules, containerClassName, title, outcomeType, badgeCount, showCongratsIfNotInstances } = props;
-
-    let content = <RuleDetailsGroup rules={rules} showDetails={props.showDetails} outcomeType={outcomeType} />;
-
-    if (rules.length === 0 && showCongratsIfNotInstances) {
-        content = <NoFailedInstancesCongrats />;
-    }
+    const { containerClassName } = props;
 
     return (
         <div className={containerClassName}>
-            <ResultSectionTitle title={title} count={badgeCount} outcomeType={outcomeType} />
-            {content}
+            <ResultSectionTitle {...props} />
+            <ResultSectionContent {...props} />
         </div>
     );
 });

--- a/src/DetailsView/reports/components/report-sections/rule-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-details-group.tsx
@@ -23,11 +23,11 @@ export const RuleDetailsGroup = NamedSFC<RuleDetailsGroupProps>('RuleDetailsGrou
                     <CollapsibleContainer
                         key={`summary-details-${idx + 1}`}
                         id={rule.id}
-                        titleContainerProps={{ role: 'heading', 'aria-level': 3 }}
                         summaryContent={<RuleDetail key={rule.id} rule={rule} outcomeType={outcomeType} isHeader={false} />}
                         detailsContent={<InstanceDetailsGroup key={`${rule.id}-rule-group`} nodeResults={rule.nodes} />}
                         buttonAriaLabel="show failed instance list"
                         containerClassName="collapsible-rule-details-group"
+                        titleHeadingLevel={3}
                     />
                 ) : (
                     <RuleDetail key={rule.id} rule={rule} outcomeType={outcomeType} isHeader={showDetails} />

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/collapsible-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/collapsible-container.test.tsx.snap
@@ -1,13 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CollapsibleContainer renders 1`] = `
+exports[`CollapsibleContainer renders, no optional fields 1`] = `
 <div
   className="collapsible-container"
 >
   <div
-    aria-level={5}
     className="title-container"
-    role="custom role"
   >
     <button
       aria-controls="content-container-test-id"
@@ -38,9 +36,40 @@ exports[`CollapsibleContainer renders, with extra class name for the container d
   className="collapsible-container extra-class-name"
 >
   <div
+    className="title-container"
+  >
+    <button
+      aria-controls="content-container-test-id"
+      aria-expanded="false"
+      aria-label="button aria label"
+      className="collapsible-control"
+    />
+    <div>
+      <div>
+        this is the summary content
+      </div>
+    </div>
+  </div>
+  <div
+    aria-hidden="true"
+    className="content-container"
+    id="content-container-test-id"
+  >
+    <div>
+       this is the details content 
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollapsibleContainer renders, with heading level for the title container 1`] = `
+<div
+  className="collapsible-container"
+>
+  <div
     aria-level={5}
     className="title-container"
-    role="custom role"
+    role="heading"
   >
     <button
       aria-controls="content-container-test-id"

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section-content.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResultSectionContent renders, no rules and show congrats 1`] = `<NoFailedInstancesCongrats />`;
+
+exports[`ResultSectionContent renders, no rules, do not show congrats 1`] = `
+<RuleDetailsGroup
+  outcomeType="pass"
+  rules={Array []}
+/>
+`;
+
+exports[`ResultSectionContent renders, with some rules 1`] = `
+<RuleDetailsGroup
+  outcomeType="pass"
+  rules={
+    Array [
+      Object {},
+      Object {},
+    ]
+  }
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section.test.tsx.snap
@@ -1,57 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`PassedChecksSection renders, no rules and show congrats 1`] = `
+exports[`ResultSection renders 1`] = `
 <div
   className="result-section-class-name"
 >
   <ResultSectionTitle
-    count={2}
-    outcomeType="pass"
-    title="result section title"
+    containerClassName="result-section-class-name"
   />
-  <NoFailedInstancesCongrats />
-</div>
-`;
-
-exports[`PassedChecksSection renders, not showDetails 1`] = `
-<div
-  className="result-section-class-name"
->
-  <ResultSectionTitle
-    count={2}
-    outcomeType="pass"
-    title="result section title"
-  />
-  <RuleDetailsGroup
-    outcomeType="pass"
-    rules={
-      Array [
-        Object {},
-        Object {},
-      ]
-    }
-  />
-</div>
-`;
-
-exports[`PassedChecksSection renders, with showDetails 1`] = `
-<div
-  className="result-section-class-name"
->
-  <ResultSectionTitle
-    count={2}
-    outcomeType="pass"
-    title="result section title"
-  />
-  <RuleDetailsGroup
-    outcomeType="pass"
-    rules={
-      Array [
-        Object {},
-        Object {},
-      ]
-    }
-    showDetails={true}
+  <ResultSectionContent
+    containerClassName="result-section-class-name"
   />
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-details-group.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-details-group.test.tsx.snap
@@ -70,12 +70,7 @@ exports[`RuleDetailsGroup renders, with details 1`] = `
         }
       />
     }
-    titleContainerProps={
-      Object {
-        "aria-level": 3,
-        "role": "heading",
-      }
-    }
+    titleHeadingLevel={3}
   />
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/collapsible-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/collapsible-container.test.tsx
@@ -9,14 +9,10 @@ import {
 } from '../../../../../../../DetailsView/reports/components/report-sections/collapsible-container';
 
 describe('CollapsibleContainer', () => {
-    it('renders', () => {
+    it('renders, no optional fields', () => {
         const props: CollapsibleContainerProps = {
             id: 'test-id',
             summaryContent: <div>this is the summary content</div>,
-            titleContainerProps: {
-                role: 'custom role',
-                'aria-level': 5,
-            },
             detailsContent: <div> this is the details content </div>,
             buttonAriaLabel: 'button aria label',
         };
@@ -30,13 +26,23 @@ describe('CollapsibleContainer', () => {
         const props: CollapsibleContainerProps = {
             id: 'test-id',
             summaryContent: <div>this is the summary content</div>,
-            titleContainerProps: {
-                role: 'custom role',
-                'aria-level': 5,
-            },
             detailsContent: <div> this is the details content </div>,
             buttonAriaLabel: 'button aria label',
             containerClassName: 'extra-class-name',
+        };
+
+        const wrapped = shallow(<CollapsibleContainer {...props} />);
+
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+
+    it('renders, with heading level for the title container', () => {
+        const props: CollapsibleContainerProps = {
+            id: 'test-id',
+            summaryContent: <div>this is the summary content</div>,
+            detailsContent: <div> this is the details content </div>,
+            buttonAriaLabel: 'button aria label',
+            titleHeadingLevel: 5,
         };
 
         const wrapped = shallow(<CollapsibleContainer {...props} />);

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section-content.test.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import {
+    ResultSectionContent,
+    ResultSectionContentProps,
+} from '../../../../../../../DetailsView/reports/components/report-sections/result-section-content';
+import { RuleResult } from '../../../../../../../scanner/iruleresults';
+
+describe('ResultSectionContent', () => {
+    const emptyRules: RuleResult[] = [];
+    const someRules: RuleResult[] = [{} as RuleResult, {} as RuleResult];
+
+    it('renders, with some rules', () => {
+        const props: ResultSectionContentProps = {
+            rules: someRules,
+            outcomeType: 'pass',
+        };
+
+        const wrapper = shallow(<ResultSectionContent {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    it('renders, no rules, do not show congrats', () => {
+        const props: ResultSectionContentProps = {
+            rules: emptyRules,
+            outcomeType: 'pass',
+            showCongratsIfNotInstances: false,
+        };
+
+        const wrapper = shallow(<ResultSectionContent {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    it('renders, no rules and show congrats', () => {
+        const props: ResultSectionContentProps = {
+            rules: emptyRules,
+            outcomeType: 'pass',
+            showCongratsIfNotInstances: true,
+        };
+
+        const wrapper = shallow(<ResultSectionContent {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section-title.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section-title.test.tsx
@@ -4,14 +4,14 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import {
     ResultSectionTitle,
-    ResultSectionTitlePros,
+    ResultSectionTitleProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/result-section-title';
 
 describe('ResultSectionTitle', () => {
     it('renders', () => {
-        const props: ResultSectionTitlePros = {
+        const props: ResultSectionTitleProps = {
             title: 'test title',
-            count: 10,
+            badgeCount: 10,
             outcomeType: 'pass',
         };
 

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section.test.tsx
@@ -4,48 +4,12 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { ResultSection, ResultSectionProps } from '../../../../../../../DetailsView/reports/components/report-sections/result-section';
-import { RuleResult } from '../../../../../../../scanner/iruleresults';
 
-describe('PassedChecksSection', () => {
-    it('renders, not showDetails', () => {
+describe('ResultSection', () => {
+    it('renders', () => {
         const props: ResultSectionProps = {
-            title: 'result section title',
             containerClassName: 'result-section-class-name',
-            rules: [{} as RuleResult, {} as RuleResult],
-            outcomeType: 'pass',
-            badgeCount: 2,
-        };
-
-        const wrapper = shallow(<ResultSection {...props} />);
-
-        expect(wrapper.getElement()).toMatchSnapshot();
-    });
-
-    it('renders, with showDetails', () => {
-        const props: ResultSectionProps = {
-            title: 'result section title',
-            containerClassName: 'result-section-class-name',
-            rules: [{} as RuleResult, {} as RuleResult],
-            outcomeType: 'pass',
-            showDetails: true,
-            badgeCount: 2,
-        };
-
-        const wrapper = shallow(<ResultSection {...props} />);
-
-        expect(wrapper.getElement()).toMatchSnapshot();
-    });
-
-    it('renders, no rules and show congrats', () => {
-        const props: ResultSectionProps = {
-            title: 'result section title',
-            containerClassName: 'result-section-class-name',
-            rules: [],
-            outcomeType: 'pass',
-            showDetails: true,
-            showCongratsIfNotInstances: true,
-            badgeCount: 2,
-        };
+        } as ResultSectionProps;
 
         const wrapper = shallow(<ResultSection {...props} />);
 


### PR DESCRIPTION
#### Description of changes

This PR is in order to support making the pass/not applicable sections collapsible.

- On `ResultSection`, extract the content portion to it's own component
- Clean up how we handle heading level props on the `CollapsibleContainer`

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no UI changes
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - no UI changes
