### PR TITLE
enable new report ux by default

### DIFF
--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -79,11 +79,11 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
         },
         {
             id: FeatureFlags.newAutomatedChecksReport,
-            defaultValue: false,
+            defaultValue: true,
             displayableName: 'Enable new automated checks report',
             displayableDescription: 'Enable the new FastPass Automated checks report, with new UX and accessibility improvements',
             isPreviewFeature: false,
-            forceDefault: false,
+            forceDefault: true,
         },
     ];
 }

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -20,7 +20,7 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.showAllFeatureFlags]: false,
             [FeatureFlags.scoping]: false,
             [FeatureFlags.showInstanceVisibility]: false,
-            [FeatureFlags.newAutomatedChecksReport]: false,
+            [FeatureFlags.newAutomatedChecksReport]: true,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Description of changes

enable new report ux by default


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
