### PR TITLE
feat: how to fix instruction color box on new report

### DIFF
--- a/src/DetailsView/reports/components/instance-details.scss
+++ b/src/DetailsView/reports/components/instance-details.scss
@@ -48,6 +48,29 @@
     display: flex;
 }
 
+.how-to-fix-content {
+    .insights-fix-instruction-list {
+        li {
+            span.fix-instruction-color-box {
+                width: 14px;
+                height: 14px;
+                display: inline-block;
+                vertical-align: -5%;
+                margin: 0px 2px;
+                border: 1px solid $always-black;
+            }
+        }
+        .screen-reader-only {
+            position: absolute;
+            left: -10000px;
+            top: auto;
+            width: 1px;
+            height: 1px;
+            overflow: hidden;
+        }
+    }
+}
+
 .report-instance-table .instance-list-row-content.content-snipppet {
     font-family: Consolas, Segoe UI, Courier New, monospace;
 }


### PR DESCRIPTION
#### Description of changes

Adding styles to enable the color box on the how to fix instructions (think color contrast) on the new report.

![01 - color box on new report](https://user-images.githubusercontent.com/2837582/59473540-b3883f00-8df7-11e9-9b14-4ea741ab0f36.png)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
