### PR TITLE
refactor: extract header section scss to proper module

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -6,6 +6,7 @@
 @import '../../common/icons/icon.scss';
 @import './components/outcome.scss';
 @import './components/instance-details.scss';
+@import './components/report-sections/header-section.scss';
 
 @mixin contentSize {
     max-width: 960px;
@@ -49,33 +50,6 @@ body {
         line-height: 32px;
         letter-spacing: -0.02em;
     }
-}
-
-.report-header-bar svg {
-    margin-left: 8px;
-}
-
-.report-header-command-bar {
-    height: 40px;
-    width: 100%;
-    display: flex;
-    justify-content: end;
-    min-height: fit-content;
-    align-items: center;
-    background-color: $neutral-0;
-    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
-}
-
-.report-header-command-bar .target-page {
-    margin: 0px 0px 0px 16px;
-    display: inherit;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: $neutral-60;
-    font-family: $fontFamily;
-    font-size: 14px;
-    line-height: 20px;
 }
 
 $outcome-pass-summary-color: $positive-outcome;

--- a/src/DetailsView/reports/components/report-sections/header-section.scss
+++ b/src/DetailsView/reports/components/report-sections/header-section.scss
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../../common/styles/colors.scss';
+@import '../../../../common/styles/fonts.scss';
+
+.report-header-bar svg {
+    margin-left: 8px;
+}
+
+.report-header-command-bar {
+    height: 40px;
+    width: 100%;
+    display: flex;
+    justify-content: end;
+    min-height: fit-content;
+    align-items: center;
+    background-color: $neutral-0;
+    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+}
+
+.report-header-command-bar .target-page {
+    margin: 0px 0px 0px 16px;
+    display: inherit;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: $neutral-60;
+    font-family: $fontFamily;
+    font-size: 14px;
+    line-height: 20px;
+}

--- a/src/DetailsView/reports/components/report-sections/header-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/header-section.tsx
@@ -1,10 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
+
 import { NewTabLink } from '../../../../common/components/new-tab-link';
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { productName } from '../../../../content/strings/application';
 import { BrandWhite } from '../../../../icons/brand/white/brand-white';
+import { reportHeaderBar, reportHeaderCommandBar, targetPage } from './header-section.scss';
 
 export interface HeaderSectionProps {
     pageTitle: string;
@@ -14,12 +16,12 @@ export interface HeaderSectionProps {
 export const HeaderSection = NamedSFC<HeaderSectionProps>('HeaderSection', ({ pageTitle, pageUrl }) => {
     return (
         <header>
-            <div className="report-header-bar">
+            <div className={reportHeaderBar}>
                 <BrandWhite />
                 <div className="ms-font-m header-text ms-fontWeight-semibold">{productName}</div>
             </div>
-            <div className="report-header-command-bar">
-                <div className="target-page">
+            <div className={reportHeaderCommandBar}>
+                <div className={targetPage}>
                     Target page:&nbsp;
                     <NewTabLink href={pageUrl} title={pageTitle}>
                         {pageTitle}

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/header-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/header-section.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HeaderSection renders 1`] = `
 <header>
   <div
-    className="report-header-bar"
+    className="reportHeaderBar"
   >
     <BrandWhite />
     <div
@@ -13,10 +13,10 @@ exports[`HeaderSection renders 1`] = `
     </div>
   </div>
   <div
-    className="report-header-command-bar"
+    className="reportHeaderCommandBar"
   >
     <div
-      className="target-page"
+      className="targetPage"
     >
       Target page: 
       <NewTabLink


### PR DESCRIPTION
#### Description of changes

Move all header section style to it's own scss module

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1552753
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no changes
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - no changes
