### PR TITLE
refactor: extract footer section scss to proper module

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -7,6 +7,7 @@
 @import './components/outcome.scss';
 @import './components/instance-details.scss';
 @import './components/report-sections/header-section.scss';
+@import './components/report-sections/footer-section.scss';
 
 @mixin contentSize {
     max-width: 960px;
@@ -173,24 +174,6 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
 
     .description-text {
         white-space: pre-wrap;
-    }
-}
-
-.report-footer-container {
-    @include contentSize();
-
-    margin-bottom: 96px;
-
-    .report-footer {
-        margin-top: 24px;
-
-        line-height: 20px;
-
-        color: $secondary-text;
-
-        .tool-name-link {
-            color: $secondary-text !important;
-        }
     }
 }
 

--- a/src/DetailsView/reports/components/report-sections/footer-section.scss
+++ b/src/DetailsView/reports/components/report-sections/footer-section.scss
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../../common/styles/colors.scss';
+
+.report-footer-container {
+    max-width: 960px;
+    margin: 0 auto;
+
+    margin-bottom: 96px;
+
+    .report-footer {
+        margin-top: 24px;
+
+        line-height: 20px;
+
+        color: $secondary-text;
+
+        .tool-name-link {
+            color: $secondary-text !important;
+        }
+    }
+}

--- a/src/DetailsView/reports/components/report-sections/footer-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/footer-section.tsx
@@ -6,10 +6,12 @@ import { NewTabLink } from '../../../../common/components/new-tab-link';
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { toolName } from '../../../../content/strings/application';
 
+import { reportFooter, reportFooterContainer } from './footer-section.scss';
+
 export const FooterSection = NamedSFC('FooterSection', () => {
     return (
-        <div className="report-footer-container">
-            <div className="report-footer" role="contentinfo">
+        <div className={reportFooterContainer}>
+            <div className={reportFooter} role="contentinfo">
                 This automated checks result was generated using <b id="tool-name">{toolName}</b>, a tool that helps debug and find
                 accessibility issues earlier. Get more information & download this tool at{' '}
                 <NewTabLink

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/footer-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/footer-section.test.tsx.snap
@@ -2,10 +2,10 @@
 
 exports[`FooterSection renders 1`] = `
 <div
-  className="report-footer-container"
+  className="reportFooterContainer"
 >
   <div
-    className="report-footer"
+    className="reportFooter"
     role="contentinfo"
   >
     This automated checks result was generated using 


### PR DESCRIPTION
#### Description of changes

Move all footer section style to it's own scss module

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1552753
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no changes
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - no changes
