### PR TITLE
refactor: extract NoFailedInstancesCongrats scss to its own module

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -4,6 +4,7 @@
 @import '../../common/styles/fonts.scss';
 @import '../../common/styles/common.scss';
 @import '../../common/icons/icon.scss';
+@import './components/report-sections/no-failed-instances-congrats.scss';
 @import './components/outcome.scss';
 @import './components/instance-details.scss';
 @import './components/report-sections/header-section.scss';
@@ -339,34 +340,4 @@ ul.instance-details-list {
     li:last-child {
         margin-bottom: unset;
     }
-}
-
-.report-congrats {
-    position: relative;
-}
-
-.report-congrats-screen {
-    top: 181px;
-    position: absolute;
-    width: 488px;
-    left: 105px;
-    height: 295px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-.report-congrats-message {
-    width: 364px;
-    text-align: center;
-}
-.report-congrats-head {
-    font-size: 48px;
-    font-weight: 600;
-    color: rgba(0, 0, 0, 0.9);
-    padding: 10px 0 10px 0;
-}
-.report-congrats-info {
-    font-size: 40px;
-    color: rgba(0, 0, 0, 0.55);
-    padding: 10px 0 10px 0;
 }

--- a/src/DetailsView/reports/components/report-sections/no-failed-instances-congrats.scss
+++ b/src/DetailsView/reports/components/report-sections/no-failed-instances-congrats.scss
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../../common/styles/colors.scss';
+
+.report-congrats {
+    position: relative;
+}
+
+.report-congrats-screen {
+    top: 181px;
+    position: absolute;
+    width: 488px;
+    left: 105px;
+    height: 295px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.report-congrats-message {
+    width: 364px;
+    text-align: center;
+}
+
+.report-congrats-head {
+    font-size: 48px;
+    font-weight: 600;
+    color: $primary-text;
+    padding: 10px 0 10px 0;
+}
+
+.report-congrats-info {
+    font-size: 40px;
+    color: $secondary-text;
+    padding: 10px 0 10px 0;
+}

--- a/src/DetailsView/reports/components/report-sections/no-failed-instances-congrats.tsx
+++ b/src/DetailsView/reports/components/report-sections/no-failed-instances-congrats.tsx
@@ -4,17 +4,24 @@ import * as React from 'react';
 
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { InlineImage, InlineImageType } from '../inline-image';
+import {
+    reportCongrats,
+    reportCongratsHead,
+    reportCongratsInfo,
+    reportCongratsMessage,
+    reportCongratsScreen,
+} from './no-failed-instances-congrats.scss';
 
 export const NoFailedInstancesCongrats = NamedSFC('NoFailedInstancesCongrats', () => {
     return (
-        <div className="report-congrats" key="report-congrats">
-            <div className="report-congrats-image">
+        <div className={reportCongrats} key="report-congrats">
+            <div>
                 <InlineImage imageType={InlineImageType.AdaLaptop} alt="" />
             </div>
-            <div className="report-congrats-screen">
-                <div className="report-congrats-message">
-                    <div className="report-congrats-head">Congratulations!</div>
-                    <div className="report-congrats-info">No failed automated checks were found.</div>
+            <div className={reportCongratsScreen}>
+                <div className={reportCongratsMessage}>
+                    <div className={reportCongratsHead}>Congratulations!</div>
+                    <div className={reportCongratsInfo}>No failed automated checks were found.</div>
                 </div>
             </div>
         </div>

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/no-failed-instances-congrats.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/no-failed-instances-congrats.test.tsx.snap
@@ -2,29 +2,27 @@
 
 exports[`NoFailedInstancesCongrats renders 1`] = `
 <div
-  className="report-congrats"
+  className="reportCongrats"
 >
-  <div
-    className="report-congrats-image"
-  >
+  <div>
     <InlineImage
       alt=""
       imageType={5}
     />
   </div>
   <div
-    className="report-congrats-screen"
+    className="reportCongratsScreen"
   >
     <div
-      className="report-congrats-message"
+      className="reportCongratsMessage"
     >
       <div
-        className="report-congrats-head"
+        className="reportCongratsHead"
       >
         Congratulations!
       </div>
       <div
-        className="report-congrats-info"
+        className="reportCongratsInfo"
       >
         No failed automated checks were found.
       </div>


### PR DESCRIPTION
#### Description of changes

Move all no failed instances congrats component style to it's own scss module

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1552753
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no changes
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - no changes
