### PR TITLE
fix: forcing to inject immediately when we try to inject files

### DIFF
--- a/src/background/browser-adapters/chrome-adapter.ts
+++ b/src/background/browser-adapters/chrome-adapter.ts
@@ -65,6 +65,7 @@ export class ChromeAdapter extends ClientChromeAdapter implements BrowserAdapter
             {
                 allFrames: true,
                 file: file,
+                runAt: 'document_start',
             },
             callback,
         );


### PR DESCRIPTION
#### Description of changes

We need to test this. This change could mean, if the page is still loading, we may inject it before it completes loading. You can use the latest playground extension to validate this. (Wait for few min to see the today's version in chrome store) I am meanwhile using that to validate on more sites.
I have validated this on https://codepen.io/dbjorge/pen/Kjpmja , slow loading pages. The user experience is same in the slow loading pages as well.


more info on the property can be found here - https://developer.chrome.com/extensions/content_scripts

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #786
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
