### PR TITLE
fix: new report styles on bundled extensions

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -7,6 +7,7 @@
 @import '../../DetailsView/reports/components/assessment-report-summary.scss';
 @import '../../DetailsView/reports/components/assessment-summary-details.scss';
 @import '../../common/components/toast.scss';
+@import '../../common/components//guidance-tags.scss';
 
 body {
     margin: 0;

--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -34,7 +34,7 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
             <ul className="details-section-list">
                 {createListItem(<UrlIcon />, 'target page:', <NewTabLink href={pageUrl}>{pageUrl}</NewTabLink>)}
                 {createListItem(<DateIcon />, 'scan date:', scanDateUTC)}
-                {showCommentRow && createListItem(<CommentIcon />, 'comment:', description)}
+                {showCommentRow && createListItem(<CommentIcon />, 'comment:', description, 'description-text')}
             </ul>
         </div>
     );

--- a/src/DetailsView/reports/components/report-sections/header-section.scss
+++ b/src/DetailsView/reports/components/report-sections/header-section.scss
@@ -16,16 +16,16 @@
     align-items: center;
     background-color: $neutral-0;
     box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
-}
 
-.report-header-command-bar .target-page {
-    margin: 0px 0px 0px 16px;
-    display: inherit;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: $neutral-60;
-    font-family: $fontFamily;
-    font-size: 14px;
-    line-height: 20px;
+    .target-page {
+        margin: 0px 0px 0px 16px;
+        display: inherit;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        color: $neutral-60;
+        font-family: $fontFamily;
+        font-size: 14px;
+        line-height: 20px;
+    }
 }

--- a/src/DetailsView/reports/components/report-sections/header-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/header-section.tsx
@@ -6,7 +6,6 @@ import { NewTabLink } from '../../../../common/components/new-tab-link';
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { productName } from '../../../../content/strings/application';
 import { BrandWhite } from '../../../../icons/brand/white/brand-white';
-import { reportHeaderBar, reportHeaderCommandBar, targetPage } from './header-section.scss';
 
 export interface HeaderSectionProps {
     pageTitle: string;
@@ -16,12 +15,12 @@ export interface HeaderSectionProps {
 export const HeaderSection = NamedSFC<HeaderSectionProps>('HeaderSection', ({ pageTitle, pageUrl }) => {
     return (
         <header>
-            <div className={reportHeaderBar}>
+            <div className="report-header-bar">
                 <BrandWhite />
                 <div className="ms-font-m header-text ms-fontWeight-semibold">{productName}</div>
             </div>
-            <div className={reportHeaderCommandBar}>
-                <div className={targetPage}>
+            <div className="report-header-command-bar">
+                <div className="target-page">
                     Target page:&nbsp;
                     <NewTabLink href={pageUrl} title={pageTitle}>
                         {pageTitle}

--- a/src/common/components/guidance-tags.tsx
+++ b/src/common/components/guidance-tags.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 import { GuidanceLink } from '../../scanner/rule-to-links-mappings';
 import { GetGuidanceTagsFromGuidanceLinks } from '../get-guidance-tags-from-guidance-links';
 import { NamedSFC } from '../react/named-sfc';
-import { guidanceTags } from './guidance-tags.scss';
 
 export interface GuidanceTagsDeps {
     getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks;
@@ -33,5 +32,5 @@ export const GuidanceTags = NamedSFC<GuidanceTagsProps>('GuidanceTags', props =>
         return <div key={index}>{tag.displayText}</div>;
     });
 
-    return <div className={guidanceTags}>{tagElements}</div>;
+    return <div className="guidance-tags">{tagElements}</div>;
 });

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`DetailsSection rendering of comment row is dependent on description val
         comment:
       </span>
       <span
-        className="text"
+        className="text description-text"
       >
         description-text
       </span>

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/header-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/header-section.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HeaderSection renders 1`] = `
 <header>
   <div
-    className="reportHeaderBar"
+    className="report-header-bar"
   >
     <BrandWhite />
     <div
@@ -13,10 +13,10 @@ exports[`HeaderSection renders 1`] = `
     </div>
   </div>
   <div
-    className="reportHeaderCommandBar"
+    className="report-header-command-bar"
   >
     <div
-      className="targetPage"
+      className="target-page"
     >
       Target page: 
       <NewTabLink

--- a/src/tests/unit/tests/common/components/__snapshots__/guidance-tags.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/guidance-tags.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`GuidanceTags renders tags 1`] = `
 <div
-  className="guidanceTags"
+  className="guidance-tags"
 >
   <div>
     some display text


### PR DESCRIPTION
#### Description of changes

Modular scss is not properly working on the report on the bundle versions of the extension. 
For now, let's roll back to "normal" scss.
We should have a second look onto how to make modular scss work on the reports too.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #804 and #803 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
