### PR TITLE
fix: a11y failure on see more info here link

### DIFF
--- a/src/assessments/automated-checks/build-test-steps-from-rules.tsx
+++ b/src/assessments/automated-checks/build-test-steps-from-rules.tsx
@@ -21,7 +21,7 @@ function buildAutomatedCheckStep(rule: ScannerRuleInfo): Requirement {
     const howToTest = (
         <React.Fragment>
             {infoElement}{' '}
-            <NewTabLink href={rule.url} aria-label={`See more info about ${rule.id} rule`}>
+            <NewTabLink href={rule.url} aria-label={`See more info here about ${rule.id} rule`}>
                 See more info here.
             </NewTabLink>
         </React.Fragment>

--- a/src/tests/unit/tests/assessments/automated-checks/build-test-steps-from-rules.test.tsx
+++ b/src/tests/unit/tests/assessments/automated-checks/build-test-steps-from-rules.test.tsx
@@ -39,7 +39,7 @@ describe('buildTestStepsFromRules', () => {
         const expectedHowToTest = (
             <React.Fragment>
                 {expectedDescription}{' '}
-                <NewTabLink href={rule.url} aria-label={`See more info about ${rule.id} rule`}>
+                <NewTabLink href={rule.url} aria-label={`See more info here about ${rule.id} rule`}>
                     See more info here.
                 </NewTabLink>
             </React.Fragment>
@@ -152,6 +152,6 @@ describe('buildTestStepsFromRules', () => {
     }
 
     function expectResultToContainBase(result: Object, base: Object): void {
-        expect(isMatch(result, base)).toBeTruthy();
+        expect(isMatch(result, base)).toBe(true);
     }
 });


### PR DESCRIPTION
#### Description of changes

Fix label-content-name-mismatch failure on automated checks requirement rule link.

#### Pull request checklist

- [x] Addresses an existing issue: related to # 805 (not linking to the issue as this PR doesn't fix all of the failures.
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
