### PR TITLE
fix: properly style html tags on data tables content

### DIFF
--- a/src/content/test/semantics/data-tables.tsx
+++ b/src/content/test/semantics/data-tables.tsx
@@ -23,16 +23,36 @@ export const infoAndExamples = create(({ Markup, Link }) => (
         <p>
             Do not use <Markup.Code>role="presentation"</Markup.Code> on any of the semantic elements in a data table:
             <ul>
-                <li>{'<table>'}</li>
-                <li>{'<tr>'}</li>
-                <li> {'<th>'}</li>
-                <li> {'<td>'}</li>
-                <li> {'<caption>'}</li>
-                <li> {'<col>'}</li>
-                <li> {'<colgroup>'}</li>
-                <li> {'<thead>'}</li>
-                <li> {'<tfoot>'}</li>
-                <li> {'<tbody>'}</li>
+                <li>
+                    <Markup.Code>{'<table>'}</Markup.Code>
+                </li>
+                <li>
+                    <Markup.Code>{'<tr>'}</Markup.Code>
+                </li>
+                <li>
+                    <Markup.Code> {'<th>'}</Markup.Code>
+                </li>
+                <li>
+                    <Markup.Code> {'<td>'}</Markup.Code>
+                </li>
+                <li>
+                    <Markup.Code> {'<caption>'}</Markup.Code>
+                </li>
+                <li>
+                    <Markup.Code> {'<col>'}</Markup.Code>
+                </li>
+                <li>
+                    <Markup.Code> {'<colgroup>'}</Markup.Code>
+                </li>
+                <li>
+                    <Markup.Code> {'<thead>'}</Markup.Code>
+                </li>
+                <li>
+                    <Markup.Code> {'<tfoot>'}</Markup.Code>
+                </li>
+                <li>
+                    <Markup.Code> {'<tbody>'}</Markup.Code>
+                </li>
             </ul>
         </p>
         <Markup.PassFail

--- a/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
@@ -22327,34 +22327,74 @@ exports[`A11Y for content pages High Contrast mode test/semantics/dataTables/inf
       </p>
       <ul>
         <li>
-          &lt;table&gt;
+          <span
+            class="insights-code"
+          >
+            &lt;table&gt;
+          </span>
         </li>
         <li>
-          &lt;tr&gt;
+          <span
+            class="insights-code"
+          >
+            &lt;tr&gt;
+          </span>
         </li>
         <li>
-           &lt;th&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;th&gt;
+          </span>
         </li>
         <li>
-           &lt;td&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;td&gt;
+          </span>
         </li>
         <li>
-           &lt;caption&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;caption&gt;
+          </span>
         </li>
         <li>
-           &lt;col&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;col&gt;
+          </span>
         </li>
         <li>
-           &lt;colgroup&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;colgroup&gt;
+          </span>
         </li>
         <li>
-           &lt;thead&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;thead&gt;
+          </span>
         </li>
         <li>
-           &lt;tfoot&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;tfoot&gt;
+          </span>
         </li>
         <li>
-           &lt;tbody&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;tbody&gt;
+          </span>
         </li>
       </ul>
       <p />
@@ -51734,34 +51774,74 @@ exports[`A11Y for content pages Normal mode test/semantics/dataTables/infoAndExa
       </p>
       <ul>
         <li>
-          &lt;table&gt;
+          <span
+            class="insights-code"
+          >
+            &lt;table&gt;
+          </span>
         </li>
         <li>
-          &lt;tr&gt;
+          <span
+            class="insights-code"
+          >
+            &lt;tr&gt;
+          </span>
         </li>
         <li>
-           &lt;th&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;th&gt;
+          </span>
         </li>
         <li>
-           &lt;td&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;td&gt;
+          </span>
         </li>
         <li>
-           &lt;caption&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;caption&gt;
+          </span>
         </li>
         <li>
-           &lt;col&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;col&gt;
+          </span>
         </li>
         <li>
-           &lt;colgroup&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;colgroup&gt;
+          </span>
         </li>
         <li>
-           &lt;thead&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;thead&gt;
+          </span>
         </li>
         <li>
-           &lt;tfoot&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;tfoot&gt;
+          </span>
         </li>
         <li>
-           &lt;tbody&gt;
+          <span
+            class="insights-code"
+          >
+             &lt;tbody&gt;
+          </span>
         </li>
       </ul>
       <p />


### PR DESCRIPTION
#### Description of changes

Making each tag on the list to be surrounded by `<Markup.Code>` to style it properly.

![01 - tag list styled as code](https://user-images.githubusercontent.com/2837582/59543309-40e29680-8ebf-11e9-9be9-28eba73d176e.png)

#### Pull request checklist

- [x] Addresses an existing issue: no issue has been filed on this
- [x] Added relevant unit test for your changes. (`yarn test`)
   - no unit test for content
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - does not apply
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
