### PR TITLE
fix: missing focus ring on collapse/expand button

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -274,17 +274,12 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
         transition: transform 0.1s linear 0s;
     }
 
-    button {
-        outline: -webkit-focus-ring-color auto 5px;
-    }
-
     .collapsible-control {
         font-family: 'Segoe UI Web (West European)', 'Segoe UI', '-apple-system', BlinkMacSystemFont, Roboto, 'Helvetica Neue', Helvetica,
             Ubuntu, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
         background-color: transparent;
         cursor: pointer;
         border: none;
-        outline: none;
     }
 
     .collapsible-control[aria-expanded='false']:before {


### PR DESCRIPTION
#### Description of changes

Focus ring was missing on chrome. Removing all the custom `outline` styles for the button fix this.
Check on chrome, firefox and edge.

#### Pull request checklist

- [x] Addresses an existing issue: haven't been created
- [x] Added relevant unit test for your changes. (`yarn test`)
   - css change only
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - css change only
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - no changes
