### PR TITLE
fix: url ellipse/wrapping

### DIFF
--- a/src/DetailsView/reports/components/report-sections/details-section.scss
+++ b/src/DetailsView/reports/components/report-sections/details-section.scss
@@ -41,9 +41,14 @@
         }
     }
 
+    .text {
+        word-break: break-all;
+    }
+
     .description-text {
         white-space: pre-wrap;
     }
+
     .screen-reader-only {
         position: absolute;
         left: -10000px;

--- a/src/DetailsView/reports/components/report-sections/header-section.scss
+++ b/src/DetailsView/reports/components/report-sections/header-section.scss
@@ -3,6 +3,12 @@
 @import '../../../../common/styles/colors.scss';
 @import '../../../../common/styles/fonts.scss';
 
+@mixin ellipsedText {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .report-header-bar svg {
     margin-left: 8px;
 }
@@ -18,14 +24,18 @@
     box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
 
     .target-page {
+        @include ellipsedText();
+
         margin: 0px 0px 0px 16px;
         display: inherit;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
+
         color: $neutral-60;
         font-family: $fontFamily;
         font-size: 14px;
         line-height: 20px;
+
+        a {
+            @include ellipsedText();
+        }
     }
 }


### PR DESCRIPTION
#### Description of changes

Wrapping long urls on scan details section
![01 - scan details url wrapping](https://user-images.githubusercontent.com/2837582/59631991-fd29a000-90fd-11e9-98cf-1bb78866c677.png)

Cutting text and adding ellipsis on target page url (this follows figma mock)
![02 - target page url ellipsis](https://user-images.githubusercontent.com/2837582/59632005-06b30800-90fe-11e9-86fc-b946e7d110cd.png)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #813
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - css change only
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - no changes
