### PR TITLE
Blob storage edits

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "format": "prettier --config prettier.config.js --write \"**/*\"",
         "format-check": "prettier --config prettier.config.js --check \"**/*\"",
         "generate-scss-typings": "tsm src/**/*.scss",
-        "precheckin": "npm-run-all --serial format-check tslint build:all test test:e2e",
+        "precheckin": "npm-run-all --serial format-check tslint copyrightheaders build:all test test:e2e",
         "start:electron": "electron drop/electron/extension/bundle/main.bundle.js",
         "test": "jest --projects src/tests/unit",
         "test:e2e": "jest --projects src/tests/end-to-end --runInBand",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "format": "prettier --config prettier.config.js --write \"**/*\"",
         "format-check": "prettier --config prettier.config.js --check \"**/*\"",
         "generate-scss-typings": "tsm src/**/*.scss",
-        "precheckin": "npm-run-all --serial format-check tslint copyrightheaders build:all test test:e2e",
+        "precheckin": "npm-run-all --serial format-check tslint build:all test test:e2e",
         "start:electron": "electron drop/electron/extension/bundle/main.bundle.js",
         "test": "jest --projects src/tests/unit",
         "test:e2e": "jest --projects src/tests/end-to-end --runInBand",

--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import { NamedSFC } from '../../common/react/named-sfc';
 import { ExportResultType } from '../../common/telemetry-events';
 import { WindowUtils } from '../../common/window-utils';
+import { FileURLProvider } from '../../common/file-url-provider';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 
 export interface ExportDialogProps {
@@ -24,7 +25,6 @@ export interface ExportDialogProps {
 export interface ExportDialogDeps {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
     windowUtils: WindowUtils;
-    provideBlob: (blobParts?: any[], mimeType?: string) => Blob;
 }
 
 export const ExportDialog = NamedSFC<ExportDialogProps>('ExportDialog', props => {
@@ -43,8 +43,8 @@ export const ExportDialog = NamedSFC<ExportDialogProps>('ExportDialog', props =>
         props.onDescriptionChange(value);
     };
 
-    const blob = props.deps.provideBlob([props.html], 'text/html');
-    const blobUrl = props.deps.windowUtils.createObjectURL(blob);
+    const fileURLProvider = new FileURLProvider(props.deps.windowUtils);
+    const blobURL = fileURLProvider.provideURL([props.html], 'text/html');
 
     return (
         <Dialog
@@ -70,7 +70,7 @@ export const ExportDialog = NamedSFC<ExportDialogProps>('ExportDialog', props =>
                 ariaLabel="Provide result description"
             />
             <DialogFooter>
-                <PrimaryButton onClick={onExportLinkClick} download={props.fileName} href={blobUrl}>
+                <PrimaryButton onClick={onExportLinkClick} download={props.fileName} href={blobURL}>
                     Export
                 </PrimaryButton>
             </DialogFooter>

--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -4,10 +4,9 @@ import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
+import { FileURLProvider } from '../../common/file-url-provider';
 import { NamedSFC } from '../../common/react/named-sfc';
 import { ExportResultType } from '../../common/telemetry-events';
-import { WindowUtils } from '../../common/window-utils';
-import { FileURLProvider } from '../../common/file-url-provider';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 
 export interface ExportDialogProps {
@@ -24,7 +23,7 @@ export interface ExportDialogProps {
 
 export interface ExportDialogDeps {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-    windowUtils: WindowUtils;
+    fileURLProvider: FileURLProvider;
 }
 
 export const ExportDialog = NamedSFC<ExportDialogProps>('ExportDialog', props => {
@@ -43,8 +42,7 @@ export const ExportDialog = NamedSFC<ExportDialogProps>('ExportDialog', props =>
         props.onDescriptionChange(value);
     };
 
-    const fileURLProvider = new FileURLProvider(props.deps.windowUtils);
-    const blobURL = fileURLProvider.provideURL([props.html], 'text/html');
+    const fileURL = props.deps.fileURLProvider.provideURL([props.html], 'text/html');
 
     return (
         <Dialog
@@ -70,7 +68,7 @@ export const ExportDialog = NamedSFC<ExportDialogProps>('ExportDialog', props =>
                 ariaLabel="Provide result description"
             />
             <DialogFooter>
-                <PrimaryButton onClick={onExportLinkClick} download={props.fileName} href={blobURL}>
+                <PrimaryButton onClick={onExportLinkClick} download={props.fileName} href={fileURL}>
                     Export
                 </PrimaryButton>
             </DialogFooter>

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -10,6 +10,7 @@ import { ChromeAdapter } from '../background/browser-adapters/chrome-adapter';
 import { IssueDetailsTextGenerator } from '../background/issue-details-text-generator';
 import { A11YSelfValidator } from '../common/a11y-self-validator';
 import { AxeInfo } from '../common/axe-info';
+import { provideBlob } from '../common/blob-provider';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { DateProvider } from '../common/date-provider';
 import { DocumentManipulator } from '../common/document-manipulator';
@@ -266,7 +267,7 @@ if (isNaN(tabId) === false) {
 
             const windowUtils = new WindowUtils();
 
-            const fileURLProvider = new FileURLProvider(windowUtils);
+            const fileURLProvider = new FileURLProvider(windowUtils, provideBlob);
 
             const deps: DetailsViewContainerDeps = {
                 fixInstructionProcessor,

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -10,7 +10,6 @@ import { ChromeAdapter } from '../background/browser-adapters/chrome-adapter';
 import { IssueDetailsTextGenerator } from '../background/issue-details-text-generator';
 import { A11YSelfValidator } from '../common/a11y-self-validator';
 import { AxeInfo } from '../common/axe-info';
-import { provideBlob } from '../common/blob-provider';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { DateProvider } from '../common/date-provider';
 import { DocumentManipulator } from '../common/document-manipulator';
@@ -296,7 +295,6 @@ if (isNaN(tabId) === false) {
                 urlParser,
                 getDateFromTimestamp: DateProvider.getDateFromTimestamp,
                 getCurrentDate: DateProvider.getCurrentDate,
-                provideBlob: provideBlob,
                 settingsProvider: SettingsProviderImpl,
                 environmentInfoProvider,
                 issueFilingServiceProvider: IssueFilingServiceProviderImpl,

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -17,6 +17,7 @@ import { DropdownClickHandler } from '../common/dropdown-click-handler';
 import { EnvironmentInfoProvider } from '../common/environment-info-provider';
 import { initializeFabricIcons } from '../common/fabric-icons';
 import { getAllFeatureFlagDetails } from '../common/feature-flags';
+import { FileURLProvider } from '../common/file-url-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from '../common/get-guidance-tags-from-guidance-links';
 import { getInnerTextFromJsxElement } from '../common/get-inner-text-from-jsx-element';
 import { HTMLElementUtils } from '../common/html-element-utils';
@@ -263,6 +264,10 @@ if (isNaN(tabId) === false) {
                 AxeInfo.Default.version,
             );
 
+            const windowUtils = new WindowUtils();
+
+            const fileURLProvider = new FileURLProvider(windowUtils);
+
             const deps: DetailsViewContainerDeps = {
                 fixInstructionProcessor,
                 dropdownClickHandler,
@@ -274,7 +279,8 @@ if (isNaN(tabId) === false) {
                 actionInitiators,
                 assessmentDefaultMessageGenerator: assessmentDefaultMessageGenerator,
                 issueDetailsTextGenerator,
-                windowUtils: new WindowUtils(),
+                windowUtils,
+                fileURLProvider,
                 getAssessmentSummaryModelFromProviderAndStoreData: getAssessmentSummaryModelFromProviderAndStoreData,
                 getAssessmentSummaryModelFromProviderAndStatusData: getAssessmentSummaryModelFromProviderAndStatusData,
                 visualizationConfigurationFactory,

--- a/src/common/blob-provider.ts
+++ b/src/common/blob-provider.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export function provideBlob(blobParts?: any[], mimeType?: string): Blob {
+export function provideBlob(blobParts: any[], mimeType: string): Blob {
     return new Blob(blobParts, { type: mimeType });
 }

--- a/src/common/file-url-provider.ts
+++ b/src/common/file-url-provider.ts
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { provideBlob } from './blob-provider';
 import { WindowUtils } from './window-utils';
 
 export class FileURLProvider {
-    constructor(private windowUtils: WindowUtils) {}
+    constructor(private windowUtils: WindowUtils, private provideBlob: (blobParts?: any[], mimeType?: string) => Blob) {}
 
     public provideURL = (blobParts?: any[], mimeType?: string): string => {
-        const blob = provideBlob(blobParts, mimeType);
+        const blob = this.provideBlob(blobParts, mimeType);
         const blobURL = this.windowUtils.createObjectURL(blob);
         return blobURL;
     };

--- a/src/common/file-url-provider.ts
+++ b/src/common/file-url-provider.ts
@@ -3,9 +3,9 @@
 import { WindowUtils } from './window-utils';
 
 export class FileURLProvider {
-    constructor(private windowUtils: WindowUtils, private provideBlob: (blobParts?: any[], mimeType?: string) => Blob) {}
+    constructor(private windowUtils: WindowUtils, private provideBlob: (blobParts: any[], mimeType: string) => Blob) {}
 
-    public provideURL = (blobParts?: any[], mimeType?: string): string => {
+    public provideURL = (blobParts: any[], mimeType: string): string => {
         const blob = this.provideBlob(blobParts, mimeType);
         const blobURL = this.windowUtils.createObjectURL(blob);
         return blobURL;

--- a/src/common/file-url-provider.ts
+++ b/src/common/file-url-provider.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { WindowUtils } from './window-utils';
 import { provideBlob } from './blob-provider';
+import { WindowUtils } from './window-utils';
 
 export class FileURLProvider {
     constructor(private windowUtils: WindowUtils) {}

--- a/src/common/file-url-provider.ts
+++ b/src/common/file-url-provider.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { WindowUtils } from './window-utils';
+import { provideBlob } from './blob-provider';
+
+export class FileURLProvider {
+    constructor(private windowUtils: WindowUtils) {}
+
+    public provideURL = (blobParts?: any[], mimeType?: string): string => {
+        const blob = provideBlob(blobParts, mimeType);
+        const blobURL = this.windowUtils.createObjectURL(blob);
+        return blobURL;
+    };
+}

--- a/src/common/window-utils.ts
+++ b/src/common/window-utils.ts
@@ -22,8 +22,8 @@ export class WindowUtils {
         return window.setInterval(handler, timeout);
     }
 
-    public createObjectURL(ob: Blob | File | MediaSource): string {
-        return window.URL.createObjectURL(ob);
+    public createObjectURL(sourceObject: Blob | File | MediaSource): string {
+        return window.URL.createObjectURL(sourceObject);
     }
 
     public clearTimeout(timeout: number): void {

--- a/src/tests/unit/common/blob-provider.test.tsx
+++ b/src/tests/unit/common/blob-provider.test.tsx
@@ -5,7 +5,7 @@ import { provideBlob } from '../../../common/blob-provider';
 describe('BlobProviderTest', () => {
     test('provideBlob', () => {
         const mimeType = 'text/html';
-        const oMyBlob = provideBlob(['<a></a>'], mimeType);
-        expect(oMyBlob.type).toEqual(mimeType);
+        const blobProvided = provideBlob(['<a></a>'], mimeType);
+        expect(blobProvided.type).toEqual(mimeType);
     });
 });

--- a/src/tests/unit/common/file-url-provider.test.tsx
+++ b/src/tests/unit/common/file-url-provider.test.tsx
@@ -7,9 +7,8 @@ import { provideBlob } from '../../../common/blob-provider';
 
 describe('FileURLProviderTest', () => {
     it('provideURL', () => {
-        const windowUtilsMock = Mock.ofType<WindowUtils>();
+        const windowUtilsMock = Mock.ofType(WindowUtils);
         const provideBlobMock = Mock.ofType<(blobParts?: any[], mimeType?: string) => Blob>();
-        const blobStub = {} as Blob;
         const content = ['<a></a>'];
         const mimeType = 'text/html';
         const returnedURL = 'returned url';

--- a/src/tests/unit/common/file-url-provider.test.tsx
+++ b/src/tests/unit/common/file-url-provider.test.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Mock, Times } from 'typemoq';
 import { FileURLProvider } from '../../../common/file-url-provider';
 import { WindowUtils } from '../../../common/window-utils';
-import { It, Mock, Times } from 'typemoq';
-import { provideBlob } from '../../../common/blob-provider';
 
 describe('FileURLProviderTest', () => {
     it('provideURL', () => {
@@ -12,15 +11,19 @@ describe('FileURLProviderTest', () => {
         const content = ['<a></a>'];
         const mimeType = 'text/html';
         const returnedURL = 'returned url';
+        const blobStub = {} as Blob;
 
-        const givenBlob = provideBlob(content, mimeType);
+        provideBlobMock
+            .setup(pbm => pbm(content, mimeType))
+            .returns(() => blobStub)
+            .verifiable(Times.once());
 
         windowUtilsMock
-            .setup(w => w.createObjectURL(givenBlob))
+            .setup(w => w.createObjectURL(blobStub))
             .returns(() => returnedURL)
             .verifiable(Times.once());
 
-        const testProvider = new FileURLProvider(windowUtilsMock.object);
+        const testProvider = new FileURLProvider(windowUtilsMock.object, provideBlobMock.object);
         testProvider.provideURL(content, mimeType);
 
         provideBlobMock.verifyAll();

--- a/src/tests/unit/common/file-url-provider.test.tsx
+++ b/src/tests/unit/common/file-url-provider.test.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { FileURLProvider } from '../../../common/file-url-provider';
+import { WindowUtils } from '../../../common/window-utils';
+import { It, Mock, Times } from 'typemoq';
+import { provideBlob } from '../../../common/blob-provider';
+
+describe('FileURLProviderTest', () => {
+    it('provideURL', () => {
+        const windowUtilsMock = Mock.ofType<WindowUtils>();
+        const provideBlobMock = Mock.ofType<(blobParts?: any[], mimeType?: string) => Blob>();
+        const blobStub = {} as Blob;
+        const content = ['<a></a>'];
+        const mimeType = 'text/html';
+        const returnedURL = 'returned url';
+
+        const givenBlob = provideBlob(content, mimeType);
+
+        windowUtilsMock
+            .setup(w => w.createObjectURL(givenBlob))
+            .returns(() => returnedURL)
+            .verifiable(Times.once());
+
+        const testProvider = new FileURLProvider(windowUtilsMock.object);
+        testProvider.provideURL(content, mimeType);
+
+        provideBlobMock.verifyAll();
+        windowUtilsMock.verifyAll();
+    });
+});

--- a/src/tests/unit/common/file-url-provider.test.tsx
+++ b/src/tests/unit/common/file-url-provider.test.tsx
@@ -14,12 +14,12 @@ describe('FileURLProviderTest', () => {
         const blobStub = {} as Blob;
 
         provideBlobMock
-            .setup(pbm => pbm(content, mimeType))
+            .setup(blobProvider => blobProvider(content, mimeType))
             .returns(() => blobStub)
             .verifiable(Times.once());
 
         windowUtilsMock
-            .setup(w => w.createObjectURL(blobStub))
+            .setup(windowUtil => windowUtil.createObjectURL(blobStub))
             .returns(() => returnedURL)
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -75,7 +75,6 @@ describe('DetailsViewCommandBar', () => {
             getCurrentDate: () => theDate,
             reportGeneratorProvider: reportGeneratorProviderMock.object,
             windowUtils: windowUtilsMock.object,
-            provideBlob: () => null,
         } as DetailsViewCommandBarDeps;
 
         return {

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -10,7 +10,6 @@ import { Assessment } from '../../../../../assessments/types/iassessment';
 import { AssessmentStoreData } from '../../../../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../../../../common/types/store-data/tab-store-data';
-import { WindowUtils } from '../../../../../common/window-utils';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import {
     DetailsViewCommandBar,
@@ -36,11 +35,9 @@ describe('DetailsViewCommandBar', () => {
     let reportGeneratorProviderMock: IMock<ReportGeneratorProvider>;
     let descriptionPlaceholder: string;
     let renderExportAndStartOver: boolean;
-    let windowUtilsMock: IMock<WindowUtils>;
 
     beforeEach(() => {
         featureFlagStoreData = {};
-        windowUtilsMock = Mock.ofType<WindowUtils>();
         actionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator, MockBehavior.Loose);
         tabStoreData = {
             title: thePageTitle,
@@ -74,7 +71,6 @@ describe('DetailsViewCommandBar', () => {
             outcomeTypeSemanticsFromTestStatus: { stub: 'outcomeTypeSemanticsFromTestStatus' } as any,
             getCurrentDate: () => theDate,
             reportGeneratorProvider: reportGeneratorProviderMock.object,
-            windowUtils: windowUtilsMock.object,
         } as DetailsViewCommandBarDeps;
 
         return {

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -64,7 +64,7 @@ describe('ExportDialog', () => {
         it('closes the dialog onDismiss', () => {
             onCloseMock.setup(oc => oc()).verifiable(Times.once());
             fileProviderMock
-                .setup(f => f.provideURL(It.isAny(), It.isAnyString()))
+                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
                 .returns(() => 'fake-url')
                 .verifiable(Times.once());
             onExportClickMock.setup(getter => getter()).verifiable(Times.never());
@@ -82,7 +82,7 @@ describe('ExportDialog', () => {
         it('handles click on export button', () => {
             onCloseMock.setup(oc => oc()).verifiable(Times.once());
             fileProviderMock
-                .setup(f => f.provideURL(It.isAny(), It.isAnyString()))
+                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
                 .returns(() => 'fake-url')
                 .verifiable(Times.once());
             onExportClickMock.setup(getter => getter()).verifiable(Times.once());
@@ -105,7 +105,7 @@ describe('ExportDialog', () => {
         it('handles text changes for the description', () => {
             props.isOpen = true;
             fileProviderMock
-                .setup(f => f.provideURL(It.isAny(), It.isAnyString()))
+                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
                 .returns(() => 'fake-url')
                 .verifiable(Times.once());
             const changedDescription = 'changed-description';

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -51,7 +51,7 @@ describe('ExportDialog', () => {
         it.each(isOpenOptions)('with open %p', isOpen => {
             props.isOpen = isOpen;
             fileProviderMock
-                .setup(f => f.provideURL(It.isAny(), It.isAnyString()))
+                .setup(provider => provider.provideURL(It.isAny(), It.isAnyString()))
                 .returns(() => 'fake-url')
                 .verifiable(Times.once());
             const wrapper = shallow(<ExportDialog {...props} />);

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -6,7 +6,7 @@ import { Dialog } from 'office-ui-fabric-react/lib/Dialog';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 import { WindowUtils } from 'src/common/window-utils';
-import { It, Mock, MockBehavior, Times } from 'typemoq';
+import { It, Mock, MockBehavior, Times, IMock } from 'typemoq';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import { ExportDialog, ExportDialogProps } from '../../../../../DetailsView/components/export-dialog';
 
@@ -15,23 +15,21 @@ describe('ExportDialog', () => {
     const onDescriptionChangeMock = Mock.ofInstance((value: string) => {});
     const actionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator, MockBehavior.Strict);
     const windowUtilsMock = Mock.ofType<WindowUtils>();
-    const provideBlobMock = Mock.ofType<(blobParts?: any[], mimeType?: string) => Blob>();
     const eventStub = 'event stub' as any;
-    const blobStub = {} as Blob;
     const onExportClickMock = Mock.ofInstance(() => {});
     let props: ExportDialogProps;
+    let provideURLMock: IMock<(blobParts?: any[], mimeType?: string) => string>;
 
     beforeEach(() => {
         onCloseMock.reset();
         onDescriptionChangeMock.reset();
         actionMessageCreatorMock.reset();
-        provideBlobMock.reset();
         onExportClickMock.reset();
+        provideURLMock = Mock.ofInstance(blobParts, mimeType => '');
 
         const deps = {
             detailsViewActionMessageCreator: actionMessageCreatorMock.object,
             windowUtils: windowUtilsMock.object,
-            provideBlob: provideBlobMock.object,
         };
 
         props = {
@@ -52,15 +50,11 @@ describe('ExportDialog', () => {
         const isOpenOptions = [true, false];
 
         it.each(isOpenOptions)('with open %p', isOpen => {
-            provideBlobMock
-                .setup(p => p(It.isAny(), It.isAnyString()))
-                .returns(() => blobStub)
-                .verifiable(Times.once());
-            windowUtilsMock
-                .setup(w => w.createObjectURL(blobStub))
-                .returns(() => 'fake-url')
-                .verifiable(Times.once());
             props.isOpen = isOpen;
+            provideURLMock
+                .setup(pro => pro(It.isAny(), It.isAnyString()))
+                .returns('fake-url')
+                .verifiable(Times.once());
             const wrapper = shallow(<ExportDialog {...props} />);
             expect(wrapper.getElement()).toMatchSnapshot();
         });
@@ -68,14 +62,6 @@ describe('ExportDialog', () => {
     describe('user interaction', () => {
         it('closes the dialog onDismiss', () => {
             onCloseMock.setup(oc => oc()).verifiable(Times.once());
-            provideBlobMock
-                .setup(p => p(It.isAny(), It.isAnyString()))
-                .returns(() => blobStub)
-                .verifiable(Times.once());
-            windowUtilsMock
-                .setup(w => w.createObjectURL(blobStub))
-                .returns(() => 'fake-url')
-                .verifiable(Times.once());
             onExportClickMock.setup(getter => getter()).verifiable(Times.never());
             const wrapper = shallow(<ExportDialog {...props} />);
 
@@ -90,14 +76,6 @@ describe('ExportDialog', () => {
         it('handles click on export button', () => {
             onCloseMock.setup(oc => oc()).verifiable(Times.once());
             onExportClickMock.setup(getter => getter()).verifiable(Times.once());
-            provideBlobMock
-                .setup(p => p(It.isAny(), It.isAnyString()))
-                .returns(() => blobStub)
-                .verifiable(Times.once());
-            windowUtilsMock
-                .setup(w => w.createObjectURL(blobStub))
-                .returns(() => 'fake-url')
-                .verifiable(Times.once());
 
             actionMessageCreatorMock
                 .setup(a => a.exportResultsClicked(props.exportResultsType, props.html, eventStub))
@@ -117,14 +95,6 @@ describe('ExportDialog', () => {
             props.isOpen = true;
             const changedDescription = 'changed-description';
             onDescriptionChangeMock.setup(handler => handler(It.isValue(changedDescription))).verifiable(Times.once());
-            provideBlobMock
-                .setup(p => p(It.isAny(), It.isAnyString()))
-                .returns(() => blobStub)
-                .verifiable(Times.once());
-            windowUtilsMock
-                .setup(w => w.createObjectURL(blobStub))
-                .returns(() => 'fake-url')
-                .verifiable(Times.once());
 
             const wrapper = shallow(<ExportDialog {...props} />);
 


### PR DESCRIPTION
#### Description of changes

A few organizational/specification changes for the increase in download size using blobs that I merged last week. First, giving more meaningful variable names (in blob-provider and window-utils). Second, abstracting the creation of a blob and extraction of a URL from that blob into a class named file-url-provider.

Mocked the action of this class for all Export Dialog tests.

Removed WindowUtils from deps of Export Dialog since their utility was now handled by the File URL Provider.

#### Pull request checklist

- [X] Addresses an existing issue: Addition to Issue #730 (PR #766)
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [N/A] (UI changes only) Verified usability with NVDA/JAWS
