### PR TITLE
Disable label-content-name-mismatch rule for automated checks

### DIFF
--- a/src/scanner/rule-to-links-mappings.ts
+++ b/src/scanner/rule-to-links-mappings.ts
@@ -96,6 +96,6 @@ export const ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]> 
     'css-orientation-lock': [BestPractice],
     'aria-hidden-focus': [link.WCAG_4_1_2],
     'form-field-multiple-labels': [BestPractice],
-    'label-content-name-mismatch': [link.WCAG_2_5_3],
+    'label-content-name-mismatch': [BestPractice],
     'landmark-complementary-is-top-level': [link.WCAG_1_3_1, BestPractice],
 };


### PR DESCRIPTION
#### Description of changes

Setting this rule as best practice until we are confident in it's quality.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
