### PR TITLE
Make the footer in the automated check report responsive

### DIFF
--- a/src/DetailsView/reports/components/report-sections/footer-section.scss
+++ b/src/DetailsView/reports/components/report-sections/footer-section.scss
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../../../common/styles/colors.scss';
+@import './common-mixins.scss';
 
 .report-footer-container {
-    max-width: 960px;
-    margin: 0 auto;
-
-    margin-bottom: 96px;
+    @include contentSize();
+    margin-bottom: 68px;
 
     .report-footer {
         margin-top: 34px;
@@ -18,5 +17,9 @@
         .tool-name-link {
             color: $secondary-text !important;
         }
+    }
+
+    @media only screen and (max-width: 1000px) {
+        margin: 0px 16px 68px 16px;
     }
 }


### PR DESCRIPTION
#### Description of changes

Sets specific margins (like normal content-container) when not enough width on the view port.
![responsive_footer](https://user-images.githubusercontent.com/32555133/59643533-e85d0480-911d-11e9-8bb1-897e5bf7717e.gif)


#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
