### PR TITLE
fix: add missing footer line to new automated checks report

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -119,8 +119,12 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     }
 }
 
-.result-section {
+.results-container {
     margin-top: 56px;
+}
+
+.result-section {
+    padding-bottom: 58px;
 }
 
 .rule-details-group {

--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -15,6 +15,7 @@
 @import './components/report-sections/header-section.scss';
 @import './components/report-sections/no-failed-instances-congrats.scss';
 @import './components/report-sections/title-section.scss';
+@import './components/report-sections/results-container.scss';
 
 $outcome-pass-summary-color: $positive-outcome;
 $outcome-fail-summary-color: $negative-outcome;
@@ -117,10 +118,6 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
             }
         }
     }
-}
-
-.results-container {
-    margin-top: 56px;
 }
 
 .result-section {

--- a/src/DetailsView/reports/components/report-sections/content-container.scss
+++ b/src/DetailsView/reports/components/report-sections/content-container.scss
@@ -2,17 +2,21 @@
 // Licensed under the MIT License.
 @import './common-mixins.scss';
 
-.content-container {
-    @include contentSize();
-    margin-top: 24px;
+.outer-container {
+    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
 
-    h2 {
-        margin: 0px;
-        font-size: 17px;
-        line-height: 24px;
-    }
+    .content-container {
+        @include contentSize();
+        margin-top: 24px;
 
-    @media only screen and (max-width: 1000px) {
-        margin: 24px 16px 0 16px;
+        h2 {
+            margin: 0px;
+            font-size: 17px;
+            line-height: 24px;
+        }
+
+        @media only screen and (max-width: 1000px) {
+            margin: 24px 16px 0 16px;
+        }
     }
 }

--- a/src/DetailsView/reports/components/report-sections/content-container.tsx
+++ b/src/DetailsView/reports/components/report-sections/content-container.tsx
@@ -4,5 +4,5 @@ import * as React from 'react';
 import { NamedSFC } from '../../../../common/react/named-sfc';
 
 export const ContentContainer = NamedSFC('ContentSection', ({ children }) => {
-    return <div className="content-container">{children}</div>;
+    return <div className='outer-container'><div className="content-container">{children}</div></div>;
 });

--- a/src/DetailsView/reports/components/report-sections/content-container.tsx
+++ b/src/DetailsView/reports/components/report-sections/content-container.tsx
@@ -4,5 +4,9 @@ import * as React from 'react';
 import { NamedSFC } from '../../../../common/react/named-sfc';
 
 export const ContentContainer = NamedSFC('ContentSection', ({ children }) => {
-    return <div className='outer-container'><div className="content-container">{children}</div></div>;
+    return (
+        <div className="outer-container">
+            <div className="content-container">{children}</div>
+        </div>
+    );
 });

--- a/src/DetailsView/reports/components/report-sections/footer-section.scss
+++ b/src/DetailsView/reports/components/report-sections/footer-section.scss
@@ -6,10 +6,9 @@
 .report-footer-container {
     @include contentSize();
     margin-bottom: 68px;
+    margin-top: 24px;
 
     .report-footer {
-        margin-top: 34px;
-
         line-height: 20px;
 
         color: $secondary-text;

--- a/src/DetailsView/reports/components/report-sections/results-container.scss
+++ b/src/DetailsView/reports/components/report-sections/results-container.scss
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+.results-container {
+    margin-top: 56px;
+}

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/content-container.test.tsx.snap
@@ -2,15 +2,19 @@
 
 exports[`ContentContainer renders 1`] = `
 <div
-  className="content-container"
+  className="outer-container"
 >
-  <div>
-    1
-  </div>
   <div
-    id="2"
+    className="content-container"
   >
-    2
+    <div>
+      1
+    </div>
+    <div
+      id="2"
+    >
+      2
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
#### Description of changes

Add separator line to the new report footer

![01 - footer separation line](https://user-images.githubusercontent.com/2837582/59715661-3844d580-91c9-11e9-96d8-c7613dd159c8.png)


#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - doesn't exist
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not changed
