### PR TITLE
fix: remove aria-describedby to avoid reading the same text twice

### DIFF
--- a/src/DetailsView/reports/components/instance-list-group-header.tsx
+++ b/src/DetailsView/reports/components/instance-list-group-header.tsx
@@ -44,7 +44,7 @@ export const InstanceListGroupHeader = NamedSFC<InstanceListGroupHeaderProps>('I
         const ruleUrl = ruleResult.helpUrl;
         return (
             <span className="rule-details-id">
-                <NewTabLink href={ruleUrl} aria-label={`rule ${ruleId}`} aria-describedby={ariaDescribedBy}>
+                <NewTabLink href={ruleUrl} aria-label={`rule ${ruleId}`}>
                     {ruleId}
                 </NewTabLink>
             </span>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/instance-list-group-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/instance-list-group-header.test.tsx.snap
@@ -11,7 +11,6 @@ exports[`InstanceListGroupHeaderTest render for fail instances 1`] = `
     className="rule-details-id"
   >
     <NewTabLink
-      aria-describedby="failed-rule-image-alt-description"
       aria-label="rule image-alt"
       href="help url"
     >
@@ -52,7 +51,6 @@ exports[`InstanceListGroupHeaderTest render for fail instances and handles aria-
     className="rule-details-id"
   >
     <NewTabLink
-      aria-describedby="failed-rule-image-alt-description"
       aria-label="rule image-alt"
       href="help url"
     >
@@ -86,7 +84,6 @@ exports[`InstanceListGroupHeaderTest render for incomplete instances 1`] = `
     className="rule-details-id"
   >
     <NewTabLink
-      aria-describedby="incomplete-rule-image-alt-description"
       aria-label="rule image-alt"
       href="help url"
     >
@@ -123,7 +120,6 @@ exports[`InstanceListGroupHeaderTest render for incomplete instances and handles
     className="rule-details-id"
   >
     <NewTabLink
-      aria-describedby="incomplete-rule-image-alt-description"
       aria-label="rule image-alt"
       href="help url"
     >
@@ -157,7 +153,6 @@ exports[`InstanceListGroupHeaderTest render for pass instances 1`] = `
     className="rule-details-id"
   >
     <NewTabLink
-      aria-describedby="passed-rule-image-alt-description"
       aria-label="rule image-alt"
       href="help url"
     >
@@ -194,7 +189,6 @@ exports[`InstanceListGroupHeaderTest render for pass instances and handles aria-
     className="rule-details-id"
   >
     <NewTabLink
-      aria-describedby="passed-rule-image-alt-description"
       aria-label="rule image-alt"
       href="help url"
     >


### PR DESCRIPTION
#### Description of changes

Each rule details group header (a header level 3) contains the rule id as a link, the rule description as text and a list of wcag links. We have a ària-describedby` property on the rule id link that references the rule description, making the AT to announce the description twice. Since we're reading the whole information at the header level, and the user can navigate to the links separately, we want to remove the described by from the rule link to avoid the duplication.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - no issue filed
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - AT's are not reading the description twice
