### PR TITLE
chore: update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ## Describe the bug
 
-A clear and concise description of what the bug is.
+<!-- A clear and concise description of what the bug is. -->
 
 **To Reproduce**
 Steps to reproduce the behavior:
@@ -22,17 +22,18 @@ Steps to reproduce the behavior:
 ## CodePen repro example
 
 Please provide a reproduction of the bug in a codepen, if possible. Here’s how
-
+<!--
 * Goto https://codepen.io/ for a starting codepen
 * Create a simple example of the page that you have issues with and Export that codepen or give us a link to that codepen.
+-->
 
 ## Expected behavior
 
-A clear and concise description of what you expected to happen.
+<!-- A clear and concise description of what you expected to happen. -->
 
 ## Screenshots
 
-If applicable, add screenshots to help explain your problem.
+<!-- If applicable, add screenshots to help explain your problem. -->
 
 ## Extension (please complete the following information)
 
@@ -43,12 +44,12 @@ If applicable, add screenshots to help explain your problem.
 
 ## Are you willing to submit a PR?
 
-If asked, will you be willing to submit a PR to fix this bug? Yes/No
+<!-- If asked, will you be willing to submit a PR to fix this bug? -->
 
 ## Did you search for similar existing issues?
 
-Did you search for similar issues in our github issues or on [stackoverflow](https://stackoverflow.com/questions/tagged/accessibility-insights)
+<!-- Did you search for similar issues in our github issues or on [stackoverflow](https://stackoverflow.com/questions/tagged/accessibility-insights) -->
 
 ## Additional context
 
-Add any other context about the problem here.
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,8 +21,9 @@ Steps to reproduce the behavior:
 
 ## CodePen repro example
 
-Please provide a reproduction of the bug in a codepen, if possible. Here’s how
 <!--
+Please provide a reproduction of the bug in a codepen, if possible. Here’s how
+
 * Goto https://codepen.io/ for a starting codepen
 * Create a simple example of the page that you have issues with and Export that codepen or give us a link to that codepen.
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,13 +7,13 @@ assignees: ''
 ---
 
 ## Is your feature request related to a problem? Please describe.
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
 
 ## Describe the desired outcome
-A clear and concise description of what you want to happen.
+<!-- A clear and concise description of what you want to happen. -->
 
 ## Describe alternatives you've considered
-A clear and concise description of any alternative solutions or features you've considered.
+<!-- A clear and concise description of any alternative solutions or features you've considered. -->
 
 ## Additional context
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/general_question.md
+++ b/.github/ISSUE_TEMPLATE/general_question.md
@@ -9,6 +9,7 @@ assignees: ''
 **We encourage tool related questions to be asked on stackoverflow.com and tagged with `accessibility-insights`.**
 
 ## Your question here
-
+<!--
 Make sure to provide enough context. If you have spoken to a team member please mention them here.
 Add any items (screenshots etc) that will help.
+-->


### PR DESCRIPTION
#### Description of changes

Update Issue templates to have the helper text in each heading as a comment rather than proper text. This avoids the helper text to show up for things that was in the template for just help.

I noticed a lot of issues have extra wordings from the template directly, which is not required.

> No checklist item applicable for this PR.
