### PR TITLE
Restore instance dialog UI by moving css class assignment

### DIFF
--- a/src/injected/components/details-dialog.tsx
+++ b/src/injected/components/details-dialog.tsx
@@ -342,10 +342,9 @@ export class DetailsDialog extends React.Component<DetailsDialogProps, DetailsDi
                 }}
                 modalProps={{
                     isBlocking: false,
-                    containerClassName: 'insights-dialog-main-container',
+                    containerClassName: 'insights-dialog-main-override insights-dialog-main-container',
                     layerProps: {
                         onLayerDidMount: this.onLayoutDidMount,
-                        className: 'insights-dialog-main-override',
                         hostId: 'insights-dialog-layer-host',
                     },
                 }}

--- a/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
@@ -21,10 +21,9 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
   hidden={false}
   modalProps={
     Object {
-      "containerClassName": "insights-dialog-main-container",
+      "containerClassName": "insights-dialog-main-override insights-dialog-main-container",
       "isBlocking": false,
       "layerProps": Object {
-        "className": "insights-dialog-main-override",
         "hostId": "insights-dialog-layer-host",
         "onLayerDidMount": [Function],
       },
@@ -415,10 +414,9 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: false, shadowDialog: false 
                 hidden={false}
                 modalProps={
                   Object {
-                    "containerClassName": "insights-dialog-main-container",
+                    "containerClassName": "insights-dialog-main-override insights-dialog-main-container",
                     "isBlocking": false,
                     "layerProps": Object {
-                      "className": "insights-dialog-main-override",
                       "hostId": "insights-dialog-layer-host",
                       "onLayerDidMount": [Function],
                     },
@@ -1497,10 +1495,9 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
   hidden={false}
   modalProps={
     Object {
-      "containerClassName": "insights-dialog-main-container",
+      "containerClassName": "insights-dialog-main-override insights-dialog-main-container",
       "isBlocking": false,
       "layerProps": Object {
-        "className": "insights-dialog-main-override",
         "hostId": "insights-dialog-layer-host",
         "onLayerDidMount": [Function],
       },
@@ -1886,10 +1883,9 @@ exports[`DetailsDialogTest render: { isDevToolsOpen: true, shadowDialog: false }
                 hidden={false}
                 modalProps={
                   Object {
-                    "containerClassName": "insights-dialog-main-container",
+                    "containerClassName": "insights-dialog-main-override insights-dialog-main-container",
                     "isBlocking": false,
                     "layerProps": Object {
-                      "className": "insights-dialog-main-override",
                       "hostId": "insights-dialog-layer-host",
                       "onLayerDidMount": [Function],
                     },
@@ -2953,10 +2949,9 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
   hidden={false}
   modalProps={
     Object {
-      "containerClassName": "insights-dialog-main-container",
+      "containerClassName": "insights-dialog-main-override insights-dialog-main-container",
       "isBlocking": false,
       "layerProps": Object {
-        "className": "insights-dialog-main-override",
         "hostId": "insights-dialog-layer-host",
         "onLayerDidMount": [Function],
       },
@@ -3347,10 +3342,9 @@ exports[`DetailsDialogTest render: with relative help url 1`] = `
                 hidden={false}
                 modalProps={
                   Object {
-                    "containerClassName": "insights-dialog-main-container",
+                    "containerClassName": "insights-dialog-main-override insights-dialog-main-container",
                     "isBlocking": false,
                     "layerProps": Object {
-                      "className": "insights-dialog-main-override",
                       "hostId": "insights-dialog-layer-host",
                       "onLayerDidMount": [Function],
                     },


### PR DESCRIPTION
#### Description of changes

It seems the recent OfficeFabric update #782 may have led to the UI issues described in #829 . I created this [codepen ](https://codepen.io/anon/pen/zVoLJv) to show that using a css class in `layerProps` to target buttons leads to different behavior in OF versions `6.142.0` and `6.189.4`. OF is now on major version 7.

I'm not sure if the PR change is the best way to address this issue; it aligns with the code in this component & unblocks the UI regression in production: https://github.com/microsoft/accessibility-insights-web/blob/9baf98a369968f5e59182c37ec6072e8702e1960/src/popup/components/telemetry-permission-dialog.tsx#L52

![image](https://user-images.githubusercontent.com/7775527/59809260-9c909380-92b4-11e9-8529-89e8e925fb41.png)


#### Pull request checklist

- [x] Addresses an existing issue: #829 
- [NA] Added relevant unit test for your changes. (`yarn test`)
- [NA] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [unchanged] (UI changes only) Verified usability with NVDA/JAWS
