### PR TITLE
Feature Flag for manual failure instance details

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "format": "prettier --config prettier.config.js --write \"**/*\"",
         "format-check": "prettier --config prettier.config.js --check \"**/*\"",
         "generate-scss-typings": "tsm src/**/*.scss",
-        "precheckin": "npm-run-all --serial format-check tslint build:all test test:e2e",
+        "precheckin": "npm-run-all --serial clean:scss-typings format-check tslint copyrightheaders build:all test test:e2e",
         "start:electron": "electron drop/electron/extension/bundle/main.bundle.js",
         "test": "jest --projects src/tests/unit",
         "test:e2e": "jest --projects src/tests/end-to-end --runInBand",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "format": "prettier --config prettier.config.js --write \"**/*\"",
         "format-check": "prettier --config prettier.config.js --check \"**/*\"",
         "generate-scss-typings": "tsm src/**/*.scss",
-        "precheckin": "npm-run-all --serial format-check tslint copyrightheaders build:all test test:e2e",
+        "precheckin": "npm-run-all --serial format-check tslint build:all test test:e2e",
         "start:electron": "electron drop/electron/extension/bundle/main.bundle.js",
         "test": "jest --projects src/tests/unit",
         "test:e2e": "jest --projects src/tests/end-to-end --runInBand",

--- a/package.json
+++ b/package.json
@@ -22,10 +22,7 @@
         "format": "prettier --config prettier.config.js --write \"**/*\"",
         "format-check": "prettier --config prettier.config.js --check \"**/*\"",
         "generate-scss-typings": "tsm src/**/*.scss",
-<<<<<<< HEAD
-=======
         "clean:scss-typings": "grunt clean:scss",
->>>>>>> 7d23c3d5f758e7417a0d3976de6f1b5529b61955
         "precheckin": "npm-run-all --serial clean:scss-typings format-check tslint copyrightheaders build:all test test:e2e",
         "start:electron": "electron drop/electron/extension/bundle/main.bundle.js",
         "test": "jest --projects src/tests/unit",

--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -12,6 +12,7 @@ export class FeatureFlags {
     public static readonly scoping = 'scoping';
     public static readonly showInstanceVisibility = 'showInstanceVisibility';
     public static readonly newAutomatedChecksReport = 'newAutomatedChecksReport';
+    public static readonly manualInstanceDetails = 'manualInstanceDetails';
 }
 
 export interface FeatureFlagDetail {
@@ -84,6 +85,16 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
             displayableDescription: 'Enable the new FastPass Automated checks report, with new UX and accessibility improvements',
             isPreviewFeature: false,
             forceDefault: true,
+        },
+        {
+            id: FeatureFlags.manualInstanceDetails,
+            defaultValue: false,
+            displayableName: 'Enable manual instance details',
+            displayableDescription:
+                'Allow addition of path (CSS selector) which automatically ' +
+                'populates the corresponding code snippet when adding manual failure instance.',
+            isPreviewFeature: false,
+            forceDefault: false,
         },
     ];
 }

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -21,6 +21,7 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.scoping]: false,
             [FeatureFlags.showInstanceVisibility]: false,
             [FeatureFlags.newAutomatedChecksReport]: true,
+            [FeatureFlags.manualInstanceDetails]: false,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Description of changes

Adds feature flag for enabling the more detailed version of manual failure instances. Will allow users to add the CSS selector (path) of a specific, failure-causing element. Will then automatically populate the code snippet associated with that path. This PR solely adds the feature flag itself.

#### Pull request checklist

- [X] Addresses an existing issue: part of setup for feature #1555720
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [X] (UI changes only) Added screenshots/GIFs to description above- [X] (UI changes only) Verified usability with NVDA/JAWS


<img width="620" alt="FeatureFlag" src="https://user-images.githubusercontent.com/24820607/59885664-d45d1100-9370-11e9-8d42-345a15adba57.PNG">
