### PR TITLE
React-based visualization components for highlight drawer

### DIFF
--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -30,6 +30,8 @@ export interface DetailsDialogWindowMessage {
     featureFlagStoreData: FeatureFlagStoreData;
 }
 
+export type RenderDialog = (data: HtmlElementAxeResults, featureFlagStoreData: FeatureFlagStoreData) => void;
+
 export class DialogRenderer {
     private static readonly renderDetailsDialogCommand = 'insights.detailsDialog';
 
@@ -49,7 +51,7 @@ export class DialogRenderer {
         }
     }
 
-    public render(data: HtmlElementAxeResults, featureFlagStoreData: FeatureFlagStoreData): void {
+    public render: RenderDialog = (data: HtmlElementAxeResults, featureFlagStoreData: FeatureFlagStoreData) => {
         if (this.isInMainWindow()) {
             const mainWindowContext = MainWindowContext.getMainWindowContext();
             mainWindowContext.getTargetPageActionMessageCreator().openIssuesDialog();
@@ -106,7 +108,7 @@ export class DialogRenderer {
             };
             this.frameCommunicator.sendMessage(windowMessageRequest);
         }
-    }
+    };
 
     @autobind
     private processRequest(

--- a/src/injected/visualization/element-highlight.tsx
+++ b/src/injected/visualization/element-highlight.tsx
@@ -29,7 +29,7 @@ export interface ElementHighlightProps {
     getBoundingRect: GetBoundingRect;
 }
 
-export const ElementHighlight = NamedSFC<ElementHighlightProps>('HighlightBox', props => {
+export const ElementHighlight = NamedSFC<ElementHighlightProps>('ElementHighlight', props => {
     const { deps, drawerConfig, featureFlagStoreData, dialogRender, element, elementResult, bodyStyle, docStyle, getBoundingRect } = props;
     const { clientUtils, drawerUtils } = deps;
 

--- a/src/injected/visualization/element-highlight.tsx
+++ b/src/injected/visualization/element-highlight.tsx
@@ -30,7 +30,7 @@ export interface ElementHighlightProps {
 }
 
 export const ElementHighlight = NamedSFC<ElementHighlightProps>('HighlightBox', props => {
-    const { deps, drawerConfig, dialogRender, element, elementResult, bodyStyle, docStyle, getBoundingRect } = props;
+    const { deps, drawerConfig, featureFlagStoreData, dialogRender, element, elementResult, bodyStyle, docStyle, getBoundingRect } = props;
     const { clientUtils, drawerUtils } = deps;
 
     if (!drawerConfig.showVisualization) {
@@ -45,7 +45,7 @@ export const ElementHighlight = NamedSFC<ElementHighlightProps>('HighlightBox', 
     }
 
     const onClickFailureBoxHandler = () => {
-        dialogRender(elementResult, this.featureFlagStoreData);
+        dialogRender(elementResult, featureFlagStoreData);
     };
 
     const offset = clientUtils.getOffset(element);

--- a/src/injected/visualization/element-highlight.tsx
+++ b/src/injected/visualization/element-highlight.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { CSSProperties } from 'react';
+import * as React from 'react';
+
+import { NamedSFC } from '../../common/react/named-sfc';
+import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
+import { ClientUtils } from '../client-utils';
+import { RenderDialog } from '../dialog-renderer';
+import { HtmlElementAxeResults } from '../scanner-utils';
+import { DrawerUtils } from './drawer-utils';
+import { DrawerConfiguration, GetBoundingRect } from './formatter';
+import { HightlightBox, HightlightBoxDeps } from './highlight-box';
+
+export type ElementHighlightDeps = {
+    drawerUtils: DrawerUtils;
+    clientUtils: ClientUtils;
+} & HightlightBoxDeps;
+
+export interface ElementHighlightProps {
+    deps: ElementHighlightDeps;
+    element: Element;
+    elementResult: HtmlElementAxeResults;
+    bodyStyle: CSSStyleDeclaration;
+    docStyle: CSSStyleDeclaration;
+    drawerConfig: DrawerConfiguration;
+    featureFlagStoreData: FeatureFlagStoreData;
+    dialogRender: RenderDialog;
+    getBoundingRect: GetBoundingRect;
+}
+
+export const ElementHighlight = NamedSFC<ElementHighlightProps>('HighlightBox', props => {
+    const { deps, drawerConfig, dialogRender, element, elementResult, bodyStyle, docStyle, getBoundingRect } = props;
+    const { clientUtils, drawerUtils } = deps;
+
+    if (!drawerConfig.showVisualization) {
+        return null;
+    }
+
+    const currentDom = drawerUtils.getDocumentElement();
+    const elementBoundingClientRect = getBoundingRect(element);
+
+    if (drawerUtils.isOutsideOfDocument(elementBoundingClientRect, currentDom, bodyStyle, docStyle)) {
+        return null;
+    }
+
+    const onClickFailureBoxHandler = () => {
+        dialogRender(elementResult, this.featureFlagStoreData);
+    };
+
+    const offset = clientUtils.getOffset(element);
+    const styles: CSSProperties = {
+        outlineStyle: drawerConfig.outlineStyle,
+        outlineColor: drawerConfig.borderColor,
+        top: drawerUtils.getContainerTopOffset(offset),
+        left: drawerUtils.getContainerLeftOffset(offset),
+        minWidth: drawerUtils.getContainerWidth(offset, currentDom, elementBoundingClientRect.width, bodyStyle, docStyle),
+        minHeight: drawerUtils.getContainerHeight(offset, currentDom, elementBoundingClientRect.height, bodyStyle, docStyle),
+    };
+
+    return (
+        <div title={drawerConfig.toolTip} className={'insights-highlight-box'} style={styles}>
+            <HightlightBox deps={deps} drawerConfig={drawerConfig} boxConfig={drawerConfig.textBoxConfig} className={'text-label'} />
+            <HightlightBox
+                deps={deps}
+                drawerConfig={drawerConfig}
+                boxConfig={drawerConfig.failureBoxConfig}
+                className={'failure-label'}
+                onClickHandler={onClickFailureBoxHandler}
+            />
+        </div>
+    );
+});

--- a/src/injected/visualization/formatter.ts
+++ b/src/injected/visualization/formatter.ts
@@ -1,19 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TextAlignProperty } from 'csstype';
 import { DialogRenderer } from '../dialog-renderer';
 import { AxeResultsWithFrameLevel } from '../frameCommunicators/html-element-axe-results-helper';
 
-export interface DrawerConfiguration {
+export interface DrawerConfiguration extends SimpleHighlightDrawerConfiguration {
     outlineStyle?: string;
     outlineWidth?: string;
     borderColor: string;
     showVisualization: boolean;
-    textAlign?: string;
-    cursor?: string;
     failureBoxConfig?: FailureBoxConfig;
     toolTip?: string;
     textBoxConfig?: TextBoxConfig;
     getBoundingRect?: (e: Element) => ClientRect | DOMRect;
+}
+
+export interface SimpleHighlightDrawerConfiguration {
+    textAlign?: TextAlignProperty;
+    cursor?: string;
 }
 
 export interface TextBoxConfig extends BoxConfig {

--- a/src/injected/visualization/formatter.ts
+++ b/src/injected/visualization/formatter.ts
@@ -12,8 +12,10 @@ export interface DrawerConfiguration extends SimpleHighlightDrawerConfiguration 
     failureBoxConfig?: FailureBoxConfig;
     toolTip?: string;
     textBoxConfig?: TextBoxConfig;
-    getBoundingRect?: (e: Element) => ClientRect | DOMRect;
+    getBoundingRect?: GetBoundingRect;
 }
+
+export type GetBoundingRect = (e: Element) => ClientRect;
 
 export interface SimpleHighlightDrawerConfiguration {
     textAlign?: TextAlignProperty;

--- a/src/injected/visualization/highlight-box.tsx
+++ b/src/injected/visualization/highlight-box.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { CSSProperties } from 'react';
+import * as React from 'react';
+
+import { NamedSFC } from '../../common/react/named-sfc';
+import { BoxConfig, SimpleHighlightDrawerConfiguration } from './formatter';
+
+export interface HightlightBoxDeps {}
+export interface HightlightBoxProps {
+    deps: HightlightBoxDeps;
+    className?: string;
+    drawerConfig: SimpleHighlightDrawerConfiguration;
+    boxConfig: BoxConfig;
+    onClickHandler?: () => void;
+}
+
+export const HightlightBox = NamedSFC<HightlightBoxProps>('HighlightBox', props => {
+    const { boxConfig, drawerConfig, className, onClickHandler } = props;
+    if (boxConfig == null) {
+        return null;
+    }
+    const styles: CSSProperties = {
+        background: boxConfig.background,
+        color: boxConfig.fontColor,
+        width: boxConfig.boxWidth,
+        cursor: drawerConfig.cursor,
+        textAlign: drawerConfig.textAlign,
+    };
+
+    const combinedClass = 'insights-highlight-text ' + className;
+
+    return (
+        <div className={combinedClass} onClick={onClickHandler} style={styles}>
+            {boxConfig.text}
+        </div>
+    );
+});

--- a/src/injected/visualization/highlight-box.tsx
+++ b/src/injected/visualization/highlight-box.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { css } from '@uifabric/utilities';
 import { CSSProperties } from 'react';
 import * as React from 'react';
 
@@ -28,7 +29,7 @@ export const HightlightBox = NamedSFC<HightlightBoxProps>('HighlightBox', props 
         textAlign: drawerConfig.textAlign,
     };
 
-    const combinedClass = 'insights-highlight-text ' + className;
+    const combinedClass = css('insights-highlight-text', className);
 
     return (
         <div className={combinedClass} onClick={onClickHandler} style={styles}>

--- a/src/tests/unit/tests/injected/visualization/__snapshots__/element-highlight.test.tsx.snap
+++ b/src/tests/unit/tests/injected/visualization/__snapshots__/element-highlight.test.tsx.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ElementHighlight renders null when drawerConfig showVisualization is false 1`] = `null`;
+
+exports[`ElementHighlight renders null when element is outside of document 1`] = `null`;

--- a/src/tests/unit/tests/injected/visualization/__snapshots__/element-highlight.test.tsx.snap
+++ b/src/tests/unit/tests/injected/visualization/__snapshots__/element-highlight.test.tsx.snap
@@ -1,5 +1,98 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ElementHighlight renders elements appropriately 1`] = `
+<div
+  className="insights-highlight-box"
+  style={
+    Object {
+      "left": 222,
+      "minHeight": 444,
+      "minWidth": 333,
+      "outlineColor": "red",
+      "outlineStyle": "solid",
+      "top": 111,
+    }
+  }
+  title="some tool tip"
+>
+  <HighlightBox
+    boxConfig={Object {}}
+    className="text-label"
+    deps={
+      Object {
+        "clientUtils": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "getOffset": [Function],
+          "matchesSelector": [Function],
+          "scroll": undefined,
+        },
+        "drawerUtils": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "clientWindowOffsetThreshold": 5,
+          "dom": undefined,
+          "getContainerHeight": [Function],
+          "getContainerLeftOffset": [Function],
+          "getContainerTopOffset": [Function],
+          "getContainerWidth": [Function],
+          "getDocumentElement": [Function],
+          "getDocumentHeight": [Function],
+          "getDocumentWidth": [Function],
+          "isOutsideOfDocument": [Function],
+        },
+      }
+    }
+    drawerConfig={
+      Object {
+        "borderColor": "red",
+        "failureBoxConfig": Object {},
+        "outlineStyle": "solid",
+        "showVisualization": true,
+        "textBoxConfig": Object {},
+        "toolTip": "some tool tip",
+      }
+    }
+  />
+  <HighlightBox
+    boxConfig={Object {}}
+    className="failure-label"
+    deps={
+      Object {
+        "clientUtils": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "getOffset": [Function],
+          "matchesSelector": [Function],
+          "scroll": undefined,
+        },
+        "drawerUtils": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "clientWindowOffsetThreshold": 5,
+          "dom": undefined,
+          "getContainerHeight": [Function],
+          "getContainerLeftOffset": [Function],
+          "getContainerTopOffset": [Function],
+          "getContainerWidth": [Function],
+          "getDocumentElement": [Function],
+          "getDocumentHeight": [Function],
+          "getDocumentWidth": [Function],
+          "isOutsideOfDocument": [Function],
+        },
+      }
+    }
+    drawerConfig={
+      Object {
+        "borderColor": "red",
+        "failureBoxConfig": Object {},
+        "outlineStyle": "solid",
+        "showVisualization": true,
+        "textBoxConfig": Object {},
+        "toolTip": "some tool tip",
+      }
+    }
+    onClickHandler={[Function]}
+  />
+</div>
+`;
+
 exports[`ElementHighlight renders null when drawerConfig showVisualization is false 1`] = `null`;
 
 exports[`ElementHighlight renders null when element is outside of document 1`] = `null`;

--- a/src/tests/unit/tests/injected/visualization/__snapshots__/highlight-box.test.tsx.snap
+++ b/src/tests/unit/tests/injected/visualization/__snapshots__/highlight-box.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HighlightBox renders null when boxConfig is null 1`] = `null`;
+
+exports[`HighlightBox renders with appropriate styles/elements when boxConfig is set 1`] = `
+<div
+  className="insights-highlight-text some class name"
+  onClick={[Function]}
+  style={
+    Object {
+      "background": "green",
+      "color": "red",
+      "cursor": "auto",
+      "textAlign": "center",
+      "width": "100",
+    }
+  }
+>
+  some text
+</div>
+`;

--- a/src/tests/unit/tests/injected/visualization/element-highlight.test.tsx
+++ b/src/tests/unit/tests/injected/visualization/element-highlight.test.tsx
@@ -1,0 +1,134 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { IMock, Mock } from 'typemoq';
+
+import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
+import { ClientRectOffset, ClientUtils } from '../../../../../injected/client-utils';
+import { RenderDialog } from '../../../../../injected/dialog-renderer';
+import { HtmlElementAxeResults } from '../../../../../injected/scanner-utils';
+import { DrawerUtils } from '../../../../../injected/visualization/drawer-utils';
+import { ElementHighlight, ElementHighlightDeps, ElementHighlightProps } from '../../../../../injected/visualization/element-highlight';
+import { BoxConfig, DrawerConfiguration, GetBoundingRect } from '../../../../../injected/visualization/formatter';
+
+describe('ElementHighlight', () => {
+    let deps: ElementHighlightDeps;
+    let drawerConfiguration: DrawerConfiguration;
+    let failureBoxConfigStub: BoxConfig;
+    let textBoxConfigStub: BoxConfig;
+    let props: ElementHighlightProps;
+    let drawerUtilsMock: IMock<DrawerUtils>;
+    let clientUtilsMock: IMock<ClientUtils>;
+    let elementStub: Element;
+    let elementResultStub: HtmlElementAxeResults;
+    let bodyStyleStub: CSSStyleDeclaration;
+    let docStyleStub: CSSStyleDeclaration;
+    let featureFlagStoreDataStub: FeatureFlagStoreData;
+    let dialogRenderMock: IMock<RenderDialog>;
+    let getBoundingRect: IMock<GetBoundingRect>;
+    let elementBoundingClientRectStub: ClientRect;
+    let documentMock: IMock<Document>;
+    let offsetStub: ClientRectOffset;
+
+    beforeEach(() => {
+        drawerUtilsMock = Mock.ofType<DrawerUtils>(null);
+        clientUtilsMock = Mock.ofType<ClientUtils>(null);
+        dialogRenderMock = Mock.ofType<RenderDialog>();
+        getBoundingRect = Mock.ofType<GetBoundingRect>();
+        documentMock = Mock.ofType<Document>();
+
+        elementStub = {} as Element;
+        elementBoundingClientRectStub = {
+            bottom: 1,
+            left: 2,
+            height: 3,
+            right: 4,
+            top: 5,
+            width: 6,
+        };
+        offsetStub = {
+            left: 11,
+            top: 22,
+        };
+        bodyStyleStub = {} as CSSStyleDeclaration;
+        docStyleStub = {} as CSSStyleDeclaration;
+        failureBoxConfigStub = {} as BoxConfig;
+        textBoxConfigStub = {} as BoxConfig;
+
+        drawerConfiguration = {
+            showVisualization: true,
+            borderColor: 'red',
+            outlineStyle: 'solid',
+            failureBoxConfig: failureBoxConfigStub,
+            textBoxConfig: textBoxConfigStub,
+            toolTip: 'some tool tip',
+        };
+
+        deps = {
+            clientUtils: clientUtilsMock.object,
+            drawerUtils: drawerUtilsMock.object,
+        } as ElementHighlightDeps;
+
+        props = {
+            deps: deps,
+            drawerConfig: drawerConfiguration,
+            element: elementStub,
+            elementResult: elementResultStub,
+            bodyStyle: bodyStyleStub,
+            docStyle: docStyleStub,
+            featureFlagStoreData: featureFlagStoreDataStub,
+            dialogRender: dialogRenderMock.object,
+            getBoundingRect: getBoundingRect.object,
+        };
+    });
+
+    test('renders null when drawerConfig showVisualization is false', () => {
+        drawerConfiguration.showVisualization = false;
+        const testObject = shallow(<ElementHighlight {...props} />);
+        expect(testObject.getElement()).toMatchSnapshot();
+    });
+
+    test('renders null when element is outside of document', () => {
+        getBoundingRect.setup(mock => mock(elementStub)).returns(() => elementBoundingClientRectStub);
+        drawerUtilsMock.setup(mock => mock.getDocumentElement()).returns(() => documentMock.object);
+        drawerUtilsMock
+            .setup(mock => mock.isOutsideOfDocument(elementBoundingClientRectStub, documentMock.object, bodyStyleStub, docStyleStub))
+            .returns(() => true);
+        const testObject = shallow(<ElementHighlight {...props} />);
+        expect(testObject.getElement()).toMatchSnapshot();
+    });
+
+    test('renders elements appropriately', () => {
+        const styleTopStub = 111;
+        const styleLeftStub = 222;
+        const minWidthStub = 333;
+        const minHeightStub = 444;
+
+        getBoundingRect.setup(mock => mock(elementStub)).returns(() => elementBoundingClientRectStub);
+        drawerUtilsMock.setup(mock => mock.getDocumentElement()).returns(() => documentMock.object);
+
+        drawerUtilsMock
+            .setup(mock => mock.isOutsideOfDocument(elementBoundingClientRectStub, documentMock.object, bodyStyleStub, docStyleStub))
+            .returns(() => false);
+
+        clientUtilsMock.setup(mock => mock.getOffset(elementStub)).returns(() => offsetStub);
+        drawerUtilsMock.setup(mock => mock.getContainerTopOffset(offsetStub)).returns(() => styleTopStub);
+        drawerUtilsMock.setup(mock => mock.getContainerLeftOffset(offsetStub)).returns(() => styleLeftStub);
+
+        drawerUtilsMock
+            .setup(mock =>
+                mock.getContainerWidth(offsetStub, documentMock.object, elementBoundingClientRectStub.width, bodyStyleStub, docStyleStub),
+            )
+            .returns(() => minWidthStub);
+
+        drawerUtilsMock
+            .setup(mock =>
+                mock.getContainerHeight(offsetStub, documentMock.object, elementBoundingClientRectStub.height, bodyStyleStub, docStyleStub),
+            )
+            .returns(() => minHeightStub);
+
+        const testObject = shallow(<ElementHighlight {...props} />);
+        expect(testObject.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/injected/visualization/element-highlight.test.tsx
+++ b/src/tests/unit/tests/injected/visualization/element-highlight.test.tsx
@@ -11,6 +11,7 @@ import { HtmlElementAxeResults } from '../../../../../injected/scanner-utils';
 import { DrawerUtils } from '../../../../../injected/visualization/drawer-utils';
 import { ElementHighlight, ElementHighlightDeps, ElementHighlightProps } from '../../../../../injected/visualization/element-highlight';
 import { BoxConfig, DrawerConfiguration, GetBoundingRect } from '../../../../../injected/visualization/formatter';
+import { HightlightBox } from '../../../../../injected/visualization/highlight-box';
 
 describe('ElementHighlight', () => {
     let deps: ElementHighlightDeps;
@@ -128,7 +129,13 @@ describe('ElementHighlight', () => {
             )
             .returns(() => minHeightStub);
 
+        dialogRenderMock.setup(mock => mock(elementResultStub, featureFlagStoreDataStub)).verifiable();
+
         const testObject = shallow(<ElementHighlight {...props} />);
+        const failureHighlightBox = testObject.findWhere(node => node.prop('onClickHandler') != null);
+        failureHighlightBox.prop('onClickHandler')();
+
         expect(testObject.getElement()).toMatchSnapshot();
+        dialogRenderMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/injected/visualization/element-highlight.test.tsx
+++ b/src/tests/unit/tests/injected/visualization/element-highlight.test.tsx
@@ -11,7 +11,6 @@ import { HtmlElementAxeResults } from '../../../../../injected/scanner-utils';
 import { DrawerUtils } from '../../../../../injected/visualization/drawer-utils';
 import { ElementHighlight, ElementHighlightDeps, ElementHighlightProps } from '../../../../../injected/visualization/element-highlight';
 import { BoxConfig, DrawerConfiguration, GetBoundingRect } from '../../../../../injected/visualization/formatter';
-import { HightlightBox } from '../../../../../injected/visualization/highlight-box';
 
 describe('ElementHighlight', () => {
     let deps: ElementHighlightDeps;
@@ -39,6 +38,8 @@ describe('ElementHighlight', () => {
         getBoundingRect = Mock.ofType<GetBoundingRect>();
         documentMock = Mock.ofType<Document>();
 
+        elementResultStub = {} as HtmlElementAxeResults;
+        featureFlagStoreDataStub = {} as FeatureFlagStoreData;
         elementStub = {} as Element;
         elementBoundingClientRectStub = {
             bottom: 1,

--- a/src/tests/unit/tests/injected/visualization/element-highlight.test.tsx
+++ b/src/tests/unit/tests/injected/visualization/element-highlight.test.tsx
@@ -32,8 +32,8 @@ describe('ElementHighlight', () => {
     let offsetStub: ClientRectOffset;
 
     beforeEach(() => {
-        drawerUtilsMock = Mock.ofType<DrawerUtils>(null);
-        clientUtilsMock = Mock.ofType<ClientUtils>(null);
+        drawerUtilsMock = Mock.ofType(DrawerUtils);
+        clientUtilsMock = Mock.ofType(ClientUtils);
         dialogRenderMock = Mock.ofType<RenderDialog>();
         getBoundingRect = Mock.ofType<GetBoundingRect>();
         documentMock = Mock.ofType<Document>();

--- a/src/tests/unit/tests/injected/visualization/highlight-box.test.tsx
+++ b/src/tests/unit/tests/injected/visualization/highlight-box.test.tsx
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { BoxConfig, SimpleHighlightDrawerConfiguration } from '../../../../../injected/visualization/formatter';
+import { HightlightBox, HightlightBoxDeps, HightlightBoxProps } from '../../../../../injected/visualization/highlight-box';
+
+describe('HighlightBox', () => {
+    let deps: HightlightBoxDeps;
+    let classNameStub: string;
+    let drawerConfiguration: SimpleHighlightDrawerConfiguration;
+    let boxConfig: BoxConfig;
+    let onClickHandlerStub: () => void;
+    let props: HightlightBoxProps;
+
+    beforeEach(() => {
+        deps = {};
+
+        boxConfig = {
+            background: 'green',
+            fontColor: 'red',
+            boxWidth: '100',
+            text: 'some text',
+        };
+
+        drawerConfiguration = {
+            cursor: 'auto',
+            textAlign: 'center',
+        };
+
+        onClickHandlerStub = () => {};
+        classNameStub = 'some class name';
+        props = {
+            deps: deps,
+            className: classNameStub,
+            drawerConfig: drawerConfiguration,
+            boxConfig: boxConfig,
+            onClickHandler: onClickHandlerStub,
+        };
+    });
+
+    test('renders null when boxConfig is null', () => {
+        props.boxConfig = null;
+        const testObject = shallow(<HightlightBox {...props} />);
+        expect(testObject.getElement()).toMatchSnapshot();
+    });
+
+    test('renders with appropriate styles/elements when boxConfig is set', () => {
+        const testObject = shallow(<HightlightBox {...props} />);
+        expect(testObject.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

I would like to use more React components for our injected content scripts. As such, this is a start for that effort; **please refer to highlight-box-drawer.ts** to see the re-factor work done here. These components are not being used anywhere (future PR for that).

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
