### PR TITLE
refactor: update ua-parser-js + small refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
         "react-dom": "^16.8.6",
         "react-helmet": "^5.2.0",
         "react-router-dom": "^4.3.1",
-        "ua-parser-js": "^0.7.19",
+        "ua-parser-js": "^0.7.20",
         "uuid": "^3.3.2"
     }
 }

--- a/src/common/is-supported-browser.ts
+++ b/src/common/is-supported-browser.ts
@@ -6,6 +6,6 @@ export type IsSupportedBrowser = () => boolean;
 
 export const createSupportedBrowserChecker = (uaParser: UAParser): IsSupportedBrowser => {
     return () => {
-        return !(uaParser.getBrowser().name === 'Edge' && uaParser.getEngine().name == 'EdgeHTML');
+        return !(uaParser.getBrowser().name === 'Edge' && uaParser.getEngine().name === 'EdgeHTML');
     };
 };

--- a/src/common/is-supported-browser.ts
+++ b/src/common/is-supported-browser.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UAParser } from 'ua-parser-js';
+
+export type IsSupportedBrowser = () => boolean;
+
+export const createSupportedBrowserChecker = (uaParser: UAParser): IsSupportedBrowser => {
+    return () => {
+        return !(uaParser.getBrowser().name === 'Edge' && uaParser.getEngine().name == 'EdgeHTML');
+    };
+};

--- a/src/popup/popup-init.ts
+++ b/src/popup/popup-init.ts
@@ -4,6 +4,7 @@ import { UAParser } from 'ua-parser-js';
 
 import { ChromeAdapter } from '../background/browser-adapters/chrome-adapter';
 import { initializeFabricIcons } from '../common/fabric-icons';
+import { createSupportedBrowserChecker } from '../common/is-supported-browser';
 import { UrlParser } from '../common/url-parser';
 import { UrlValidator } from '../common/url-validator';
 import { PopupInitializer } from './popup-initializer';
@@ -14,7 +15,8 @@ const browserAdapter = new ChromeAdapter();
 const urlValidator = new UrlValidator(browserAdapter);
 const targetTabFinder = new TargetTabFinder(window, browserAdapter, urlValidator, new UrlParser());
 const userAgentParser = new UAParser(window.navigator.userAgent);
-const popupInitializer: PopupInitializer = new PopupInitializer(browserAdapter, targetTabFinder, userAgentParser.getBrowser());
+const isSupportedBrowser = createSupportedBrowserChecker(userAgentParser);
+const popupInitializer: PopupInitializer = new PopupInitializer(browserAdapter, targetTabFinder, isSupportedBrowser);
 
 // tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
 popupInitializer.initialize();

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -11,6 +11,7 @@ import { VisualizationConfigurationFactory } from '../common/configs/visualizati
 import { DropdownClickHandler } from '../common/dropdown-click-handler';
 import { EnumHelper } from '../common/enum-helper';
 import { HTMLElementUtils } from '../common/html-element-utils';
+import { IsSupportedBrowser } from '../common/is-supported-browser';
 import { createDefaultLogger } from '../common/logging/default-logger';
 import { Logger } from '../common/logging/logger';
 import { ActionMessageDispatcher } from '../common/message-creators/action-message-dispatcher';
@@ -57,12 +58,12 @@ export class PopupInitializer {
     constructor(
         private readonly chromeAdapter: BrowserAdapter,
         private readonly targetTabFinder: TargetTabFinder,
-        private readonly userAgentBrowser: IUAParser.IBrowser,
+        private readonly isSupportedBrowser: IsSupportedBrowser,
         private logger: Logger = createDefaultLogger(),
     ) {}
 
     public initialize(): Promise<void> {
-        if (this.userAgentBrowser.name === 'Edge') {
+        if (!this.isSupportedBrowser()) {
             this.useIncompatibleBrowserRenderer();
             return;
         }

--- a/src/tests/miscellaneous/user-agent-manual-tests/user-agent-server.js
+++ b/src/tests/miscellaneous/user-agent-manual-tests/user-agent-server.js
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.var http = require('http');
+
+// based on https://www.npmjs.com/package/ua-parser-js#using-nodejs
+
+// to start the server either
+// run from the root folder: node src\tests\miscellaneous\user-agent-manual-tests\user-agent-server.js
+// run from this folder: node .\user-agent-server.js
+
+const http = require('http');
+const parser = require('ua-parser-js');
+
+const localhost = '127.0.0.1';
+const port = 1337;
+
+http.createServer((req, res) => {
+    let ua = parser(req.headers['user-agent']);
+
+    ua['ua-parser-js'] = { version: parser.VERSION };
+
+    res.end(JSON.stringify(ua, null, 4));
+}).listen(port, localhost);
+
+console.log(`Server running at http://${localhost}:${port}/`);

--- a/src/tests/unit/tests/common/is-supported-browser.test.ts
+++ b/src/tests/unit/tests/common/is-supported-browser.test.ts
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { IMock, Mock } from 'typemoq';
+import { UAParser } from 'ua-parser-js';
+
+import { createSupportedBrowserChecker } from '../../../../common/is-supported-browser';
+
+type TestCase = {
+    testedBrowser: string;
+    browserName: string;
+    engineName: string;
+    isSupported: boolean;
+};
+
+describe('isSupportedBrowser', () => {
+    let uaParserMock: IMock<UAParser>;
+
+    beforeEach(() => {
+        uaParserMock = Mock.ofType<UAParser>();
+    });
+
+    const testCases: TestCase[] = [
+        {
+            testedBrowser: 'Microsoft Edge',
+            browserName: 'Edge',
+            engineName: 'Blink',
+            isSupported: false,
+        },
+    ];
+
+    it.each`
+        testedBrowser                   | browserName    | engineName      | isSupported
+        ${'Microsoft Edge'}             | ${'Edge'}      | ${'EdgeHTML'}   | ${false}
+        ${'Microsoft Edge Insider Dev'} | ${'Edge'}      | ${'Blink'}      | ${true}
+        ${'Chrome'}                     | ${'Chrome'}    | ${'WebKit'}     | ${true}
+        ${'Firefox'}                    | ${'Firefox'}   | ${'Gecko'}      | ${true}
+        ${'Ficticious Browser'}         | ${'Ficticius'} | ${'The Engine'} | ${true}
+    `('checks if $testedBrowser is supported', ({ browserName, engineName, isSupported }) => {
+        setGetBrowser({
+            name: browserName,
+        } as IUAParser.IBrowser);
+
+        setGetEngine({
+            name: engineName,
+        } as IUAParser.IEngine);
+
+        const testObject = createSupportedBrowserChecker(uaParserMock.object);
+
+        const result = testObject();
+
+        expect(result).toBe(isSupported);
+    });
+
+    const setGetBrowser = (browser: IUAParser.IBrowser) => uaParserMock.setup(parser => parser.getBrowser()).returns(() => browser);
+
+    const setGetEngine = (engine: IUAParser.IEngine) => uaParserMock.setup(parser => parser.getEngine()).returns(() => engine);
+});

--- a/src/tests/unit/tests/common/is-supported-browser.test.ts
+++ b/src/tests/unit/tests/common/is-supported-browser.test.ts
@@ -5,28 +5,12 @@ import { UAParser } from 'ua-parser-js';
 
 import { createSupportedBrowserChecker } from '../../../../common/is-supported-browser';
 
-type TestCase = {
-    testedBrowser: string;
-    browserName: string;
-    engineName: string;
-    isSupported: boolean;
-};
-
 describe('isSupportedBrowser', () => {
     let uaParserMock: IMock<UAParser>;
 
     beforeEach(() => {
         uaParserMock = Mock.ofType<UAParser>();
     });
-
-    const testCases: TestCase[] = [
-        {
-            testedBrowser: 'Microsoft Edge',
-            browserName: 'Edge',
-            engineName: 'Blink',
-            isSupported: false,
-        },
-    ];
 
     it.each`
         testedBrowser                   | browserName    | engineName      | isSupported

--- a/src/tests/unit/tests/popup/popup-initializer.test.ts
+++ b/src/tests/unit/tests/popup/popup-initializer.test.ts
@@ -3,6 +3,7 @@
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../background/browser-adapters/browser-adapter';
+import { IsSupportedBrowser } from '../../../../common/is-supported-browser';
 import { Logger } from '../../../../common/logging/logger';
 import { PopupInitializer } from '../../../../popup/popup-initializer';
 import { TargetTabFinder, TargetTabInfo } from '../../../../popup/target-tab-finder';
@@ -11,6 +12,7 @@ describe('PopupInitializerTests', () => {
     let targetTabStub: TargetTabInfo;
     let browserAdapterMock: IMock<BrowserAdapter>;
     let targetTabFinderMock: IMock<TargetTabFinder>;
+    let isSupportedBrowserMock: IMock<IsSupportedBrowser>;
     let loggerMock: IMock<Logger>;
 
     beforeEach(() => {
@@ -25,24 +27,23 @@ describe('PopupInitializerTests', () => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         targetTabFinderMock = Mock.ofType(TargetTabFinder);
         loggerMock = Mock.ofType<Logger>();
+        isSupportedBrowserMock = Mock.ofType<IsSupportedBrowser>();
     });
 
     test('initializePopup: valid browser', async () => {
         const initializePopupMock = Mock.ofInstance(result => {});
-        const validUserAgent: IUAParser.IBrowser = {
-            name: 'Chrome',
-        } as IUAParser.IBrowser;
+        isSupportedBrowserMock.setup(isValid => isValid()).returns(() => true);
 
         targetTabFinderMock
-            .setup(b => b.getTargetTab())
+            .setup(finder => finder.getTargetTab())
             .returns(() => Promise.resolve(targetTabStub))
             .verifiable();
 
-        initializePopupMock.setup(i => i(It.isAny())).verifiable();
+        initializePopupMock.setup(init => init(It.isAny())).verifiable();
         const testSubject: PopupInitializer = new PopupInitializer(
             browserAdapterMock.object,
             targetTabFinderMock.object,
-            validUserAgent,
+            isSupportedBrowserMock.object,
             loggerMock.object,
         );
         (testSubject as any).initializePopup = initializePopupMock.object;
@@ -56,20 +57,18 @@ describe('PopupInitializerTests', () => {
 
     test('initializePopup: invalid browser', async () => {
         const useIncompatibleBrowserRendererMock = Mock.ofInstance(result => {});
-        const invalidUserAgent: IUAParser.IBrowser = {
-            name: 'Edge',
-        } as IUAParser.IBrowser;
+        isSupportedBrowserMock.setup(isValid => isValid()).returns(() => false);
 
         targetTabFinderMock
-            .setup(b => b.getTargetTab())
+            .setup(finder => finder.getTargetTab())
             .returns(() => Promise.resolve(targetTabStub))
             .verifiable(Times.never());
 
-        useIncompatibleBrowserRendererMock.setup(i => i(It.isAny())).verifiable();
+        useIncompatibleBrowserRendererMock.setup(renderer => renderer(It.isAny())).verifiable();
         const testSubject: PopupInitializer = new PopupInitializer(
             browserAdapterMock.object,
             targetTabFinderMock.object,
-            invalidUserAgent,
+            isSupportedBrowserMock.object,
             loggerMock.object,
         );
         (testSubject as any).useIncompatibleBrowserRenderer = useIncompatibleBrowserRendererMock.object;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7469,10 +7469,10 @@ typeson@5.13.0, typeson@^5.8.2:
   resolved "https://registry.yarnpkg.com/typeson/-/typeson-5.13.0.tgz#dc65b23ea1978a315ed4c95e58a5b6936bcc3591"
   integrity sha512-xcSaSt+hY/VcRYcqZuVkJwMjDXXJb4CZd51qDocpYw8waA314ygyOPlKhsGsw4qKuJ0tfLLUrxccrm+xvyS0AQ==
 
-ua-parser-js@^0.7.19:
-  version "0.7.19"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
-  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
+ua-parser-js@^0.7.20:
+  version "0.7.20"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
+  integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
 
 uglify-js@^3.1.4, uglify-js@^3.5.12:
   version "3.6.0"


### PR DESCRIPTION
#### Description of changes

Updating ua-parser-js from 0.7.19 to 0.7.20 break our logic to not support Microsoft Edge (the old browser). The change they made is basically fixing how they where parsing the user agent on Edge Insider: on 0.7.19 they reported Edge Insider to be Chrome, while on 0.7.20 they corrected that and report it to be Edge.

Our logic was using the `.getBrowser().name` value from the UA Parser and check the name but now (on 0.7.20) both Edge and Edge Insider name is the same ('Edge') so we need to also check the engine name to run this validation.

In short:
- Extract supported browser logic to 'IsSupportedBrowser' type
- Update popup-init to use the new type instead of running the check itself
- Update ua-parse-js lib

Additionally, I added a small node script to spin up a localserver which respond with the results from ua-parse-js in case we need to check this on other browser and/or for other purposes in the future (the environment info and the reports ring a bell here)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - n/a
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
