### PR TITLE
refactor: ContentScriptInjector without Q

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -11,6 +11,7 @@ import { InsightsFeatureFlags } from '../common/insights-feature-flags';
 import { createDefaultLogger } from '../common/logging/default-logger';
 import { NavigatorUtils } from '../common/navigator-utils';
 import { NotificationCreator } from '../common/notification-creator';
+import { createDefaultPromiseFactory } from '../common/promises/promise-factory';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
 import { UrlValidator } from '../common/url-validator';
 import { WindowUtils } from '../common/window-utils';
@@ -34,7 +35,6 @@ import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
 import { TelemetryLogger } from './telemetry/telemetry-logger';
 import { TelemetryStateListener } from './telemetry/telemetry-state-listener';
 import { UserStoredDataCleaner } from './user-stored-data-cleaner';
-import { createDefaultPromiseFactory } from '../common/promises/promise-factory';
 
 declare var window: Window & InsightsFeatureFlags;
 const browserAdapter = new ChromeAdapter();

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -34,6 +34,7 @@ import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
 import { TelemetryLogger } from './telemetry/telemetry-logger';
 import { TelemetryStateListener } from './telemetry/telemetry-state-listener';
 import { UserStoredDataCleaner } from './user-stored-data-cleaner';
+import { createDefaultPromiseFactory } from '../common/promises/promise-factory';
 
 declare var window: Window & InsightsFeatureFlags;
 const browserAdapter = new ChromeAdapter();
@@ -102,6 +103,8 @@ getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
 
         const targetTabController = new TargetTabController(browserAdapter, visualizationConfigurationFactory);
 
+        const promiseFactory = createDefaultPromiseFactory();
+
         const tabContextFactory = new TabContextFactory(
             visualizationConfigurationFactory,
             telemetryEventHandler,
@@ -109,6 +112,7 @@ getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
             targetTabController,
             globalContext.stores.assessmentStore,
             assessmentsProvider,
+            promiseFactory,
         );
 
         const clientHandler = new TabController(

--- a/src/background/injector-controller.ts
+++ b/src/background/injector-controller.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { autobind } from '@uifabric/utilities';
-import { InspectMode } from '../background/inspect-modes';
-import { WindowUtils } from '../common/window-utils';
 
+import { InspectMode } from '../background/inspect-modes';
 import { Messages } from '../common/messages';
+import { WindowUtils } from '../common/window-utils';
 import { ContentScriptInjector } from './injector/content-script-injector';
 import { Interpreter } from './interpreter';
 import { InspectStore } from './stores/inspect-store';
@@ -61,6 +61,7 @@ export class InjectorController {
                 });
             }, InjectorController.injectionStartedWaitTime);
 
+            // tslint:disable-next-line:no-floating-promises - grandfathered
             this._injector.injectScripts(tabId).then(() => {
                 this._interpreter.interpret({
                     messageType: Messages.Visualizations.State.InjectionCompleted,

--- a/src/background/injector/content-script-injector.ts
+++ b/src/background/injector/content-script-injector.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Q from 'q';
-
+import { PromiseFactory } from '../../common/promises/promise-factory';
 import { BrowserAdapter } from '../browser-adapters/browser-adapter';
 
 export class ContentScriptInjector {
@@ -11,7 +11,11 @@ export class ContentScriptInjector {
 
     public static timeoutInMilliSec = 5e4;
 
-    constructor(private readonly chromeAdapter: BrowserAdapter, private readonly q: typeof Q) {}
+    constructor(
+        private readonly chromeAdapter: BrowserAdapter,
+        private readonly q: typeof Q,
+        private readonly promiseFactory: PromiseFactory,
+    ) {}
 
     public injectScripts(tabId: number): Q.IPromise<null> {
         const deferred = this.q.defer<null>();

--- a/src/background/injector/content-script-injector.ts
+++ b/src/background/injector/content-script-injector.ts
@@ -10,31 +10,26 @@ export class ContentScriptInjector {
     public static readonly cssFiles: string[] = ['injected/styles/default/injected.css', 'bundle/injected.css'];
 
     public static timeoutInMilliSec = 5e4;
-    private readonly _chromeAdapter: BrowserAdapter;
-    private readonly _q: typeof Q;
 
-    constructor(chromeAdapter: BrowserAdapter, q: typeof Q) {
-        this._chromeAdapter = chromeAdapter;
-        this._q = q;
-    }
+    constructor(private readonly chromeAdapter: BrowserAdapter, private readonly q: typeof Q) {}
 
     public injectScripts(tabId: number): Q.IPromise<null> {
-        const deferred = this._q.defer<null>();
+        const deferred = this.q.defer<null>();
 
         ContentScriptInjector.cssFiles.forEach(file => {
-            this._chromeAdapter.injectCss(tabId, file, null);
+            this.chromeAdapter.injectCss(tabId, file, null);
         });
 
         this.injectJsFiles(tabId, ContentScriptInjector.jsFiles, () => {
             deferred.resolve(null);
         });
 
-        return this._q.timeout(deferred.promise, ContentScriptInjector.timeoutInMilliSec);
+        return this.q.timeout(deferred.promise, ContentScriptInjector.timeoutInMilliSec);
     }
 
     private injectJsFiles(tabId: number, files: string[], callback: Function): void {
         if (files.length > 0) {
-            this._chromeAdapter.injectJs(tabId, files[0], () => {
+            this.chromeAdapter.injectJs(tabId, files[0], () => {
                 this.injectJsFiles(tabId, files.slice(1, files.length), callback);
             });
         } else {

--- a/src/background/injector/content-script-injector.ts
+++ b/src/background/injector/content-script-injector.ts
@@ -23,7 +23,7 @@ export class ContentScriptInjector {
             });
         });
 
-        return this.promiseFactory.timeout(ContentScriptInjector.timeoutInMilliSec, inject);
+        return this.promiseFactory.timeout(inject, ContentScriptInjector.timeoutInMilliSec);
     }
 
     private injectJsFiles(tabId: number, files: string[], callback: Function): void {

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -4,6 +4,7 @@ import * as Q from 'q';
 import { AssessmentsProvider } from '../assessments/types/assessments-provider';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { NotificationCreator } from '../common/notification-creator';
+import { PromiseFactory } from '../common/promises/promise-factory';
 import { StateDispatcher } from '../common/state-dispatcher';
 import { WindowUtils } from '../common/window-utils';
 import { ActionCreator } from './actions/action-creator';
@@ -37,6 +38,7 @@ export class TabContextFactory {
         private targetTabController: TargetTabController,
         private assessmentStore: AssessmentStore,
         private assessmentsProvider: AssessmentsProvider,
+        private readonly promiseFactory: PromiseFactory,
     ) {}
 
     public createTabContext(

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -106,7 +106,7 @@ export class TabContextFactory {
         );
 
         const injectorController = new InjectorController(
-            new ContentScriptInjector(browserAdapter, Q),
+            new ContentScriptInjector(browserAdapter, Q, this.promiseFactory),
             storeHub.visualizationStore,
             interpreter,
             storeHub.tabStore,

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as Q from 'q';
 import { AssessmentsProvider } from '../assessments/types/assessments-provider';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { NotificationCreator } from '../common/notification-creator';

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -106,7 +106,7 @@ export class TabContextFactory {
         );
 
         const injectorController = new InjectorController(
-            new ContentScriptInjector(browserAdapter, Q, this.promiseFactory),
+            new ContentScriptInjector(browserAdapter, this.promiseFactory),
             storeHub.visualizationStore,
             interpreter,
             storeHub.tabStore,

--- a/src/common/promises/promise-factory.ts
+++ b/src/common/promises/promise-factory.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-type TimeoutPromise = <T>(delay: number, promise: Promise<T>) => Promise<T>;
+type TimeoutPromise = <T>(promise: Promise<T>, delay: number) => Promise<T>;
 
 export type PromiseFactory = {
     timeout: TimeoutPromise;
 };
 
-const createTimeout: TimeoutPromise = <T>(delay: number, promise: Promise<T>) => {
+const createTimeout: TimeoutPromise = <T>(promise: Promise<T>, delay: number) => {
     const timeout = new Promise<T>((resolve, reject) => {
         const timeoutId = setTimeout(() => {
             clearTimeout(timeoutId);

--- a/src/common/promises/promise-factory.ts
+++ b/src/common/promises/promise-factory.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+type TimeoutPromise = <T>(delay: number, promise: Promise<T>) => Promise<T>;
+
+export type PromiseFactory = {
+    timeout: TimeoutPromise;
+};
+
+const createTimeout: TimeoutPromise = <T>(delay: number, promise: Promise<T>) => {
+    const timeout = new Promise<T>((resolve, reject) => {
+        const timeoutId = setTimeout(() => {
+            clearTimeout(timeoutId);
+            reject(`Timed out ${delay} ms`);
+        }, delay);
+    });
+
+    return Promise.race([promise, timeout]);
+};
+
+export const createDefaultPromiseFactory = (): PromiseFactory => {
+    return {
+        timeout: createTimeout,
+    };
+};

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as Q from 'q';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { isFunction } from 'lodash';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../background/browser-adapters/browser-adapter';
 import { ContentScriptInjector } from '../../../../background/injector/content-script-injector';
 import { PromiseFactory } from '../../../../common/promises/promise-factory';
-import { QStub } from '../../stubs/q-stub';
 
 describe('ContentScriptInjectorTest', () => {
     let browserAdapterMock: IMock<BrowserAdapter>;
-    let qMock: IMock<typeof Q>;
     let promiseFactoryMock: IMock<PromiseFactory>;
 
     let testSubject: ContentScriptInjector;
@@ -19,67 +17,32 @@ describe('ContentScriptInjectorTest', () => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
 
         promiseFactoryMock = Mock.ofType<PromiseFactory>();
-        qMock = Mock.ofType(QStub, MockBehavior.Strict) as any;
 
-        qMock.setup(x => x.defer()).returns(() => Q.defer());
+        testSubject = new ContentScriptInjector(browserAdapterMock.object, promiseFactoryMock.object);
     });
 
-    it('test inject content scripts', async done => {
-        const tabId = 2;
+    it('injects content scripts', () => {
+        expect.assertions(1);
 
-        let jsLoadCallback: Function;
-        testSubject = new ContentScriptInjector(browserAdapterMock.object, Q, promiseFactoryMock.object);
+        const tabId = -1;
 
-        ContentScriptInjector.cssFiles.forEach(cssFile => {
-            browserAdapterMock.setup(x => x.injectCss(tabId, cssFile, null)).verifiable(Times.once());
-        });
+        promiseFactoryMock
+            .setup(factory => factory.timeout(ContentScriptInjector.timeoutInMilliSec, It.is(promise => promise instanceof Promise)))
+            .returns((delay, promise) => promise);
+
+        ContentScriptInjector.cssFiles.forEach(cssFile =>
+            browserAdapterMock.setup(adapter => adapter.injectCss(tabId, cssFile, null)).verifiable(Times.once()),
+        );
 
         ContentScriptInjector.jsFiles.forEach(jsFile => {
             browserAdapterMock
-                .setup(x => x.injectJs(tabId, jsFile, It.isAny()))
-                .callback((theTabId, theJsFile, callback) => {
-                    jsLoadCallback = callback;
-                })
+                .setup(adapter => adapter.injectJs(tabId, jsFile, It.is(isFunction)))
+                .callback((theTabId, theJsFile, callback) => callback())
                 .verifiable(Times.once());
         });
 
-        const promise = testSubject.injectScripts(tabId);
+        const injected = testSubject.injectScripts(tabId);
 
-        promise.then(() => {
-            browserAdapterMock.verifyAll();
-            done();
-        });
-        expect(Q.isPending(promise)).toBeTruthy();
-        for (let i = 0; i < ContentScriptInjector.jsFiles.length; i++) {
-            jsLoadCallback();
-        }
-    });
-
-    it('test inject content scripts timeout', async done => {
-        const tabId = 2;
-        testSubject = new ContentScriptInjector(browserAdapterMock.object, qMock.object, promiseFactoryMock.object);
-
-        ContentScriptInjector.cssFiles.forEach(cssFile => {
-            browserAdapterMock.setup(x => x.injectCss(tabId, cssFile, null)).verifiable(Times.once());
-        });
-
-        browserAdapterMock.setup(x => x.injectJs(tabId, ContentScriptInjector.jsFiles[0], It.isAny())).verifiable(Times.once());
-
-        const timeoutDeferred = Q.defer();
-        qMock
-            .setup(x => x.timeout(It.isAny(), ContentScriptInjector.timeoutInMilliSec))
-            .returns(() => timeoutDeferred.promise)
-            .verifiable();
-
-        const promise = testSubject.injectScripts(tabId);
-
-        promise.then(null, () => {
-            browserAdapterMock.verifyAll();
-            done();
-        });
-        qMock.verifyAll();
-        expect(promise).toEqual(timeoutDeferred.promise);
-        expect(Q.isPending(promise)).toBeTruthy();
-        timeoutDeferred.reject(null);
+        return expect(injected).resolves.toBe(null);
     });
 });

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -5,32 +5,37 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../background/browser-adapters/browser-adapter';
 import { ContentScriptInjector } from '../../../../background/injector/content-script-injector';
+import { PromiseFactory } from '../../../../common/promises/promise-factory';
 import { QStub } from '../../stubs/q-stub';
 
-let mockBrowserAdpater: IMock<BrowserAdapter>;
-let mockQ: IMock<typeof Q>;
-let testSubject: ContentScriptInjector;
-
 describe('ContentScriptInjectorTest', () => {
-    beforeEach(() => {
-        mockBrowserAdpater = Mock.ofType<BrowserAdapter>();
-        mockQ = Mock.ofType(QStub, MockBehavior.Strict) as any;
+    let browserAdapterMock: IMock<BrowserAdapter>;
+    let qMock: IMock<typeof Q>;
+    let promiseFactoryMock: IMock<PromiseFactory>;
 
-        mockQ.setup(x => x.defer()).returns(() => Q.defer());
+    let testSubject: ContentScriptInjector;
+
+    beforeEach(() => {
+        browserAdapterMock = Mock.ofType<BrowserAdapter>();
+
+        promiseFactoryMock = Mock.ofType<PromiseFactory>();
+        qMock = Mock.ofType(QStub, MockBehavior.Strict) as any;
+
+        qMock.setup(x => x.defer()).returns(() => Q.defer());
     });
 
     it('test inject content scripts', async done => {
         const tabId = 2;
 
         let jsLoadCallback: Function;
-        testSubject = new ContentScriptInjector(mockBrowserAdpater.object, Q);
+        testSubject = new ContentScriptInjector(browserAdapterMock.object, Q, promiseFactoryMock.object);
 
         ContentScriptInjector.cssFiles.forEach(cssFile => {
-            mockBrowserAdpater.setup(x => x.injectCss(tabId, cssFile, null)).verifiable(Times.once());
+            browserAdapterMock.setup(x => x.injectCss(tabId, cssFile, null)).verifiable(Times.once());
         });
 
         ContentScriptInjector.jsFiles.forEach(jsFile => {
-            mockBrowserAdpater
+            browserAdapterMock
                 .setup(x => x.injectJs(tabId, jsFile, It.isAny()))
                 .callback((theTabId, theJsFile, callback) => {
                     jsLoadCallback = callback;
@@ -41,7 +46,7 @@ describe('ContentScriptInjectorTest', () => {
         const promise = testSubject.injectScripts(tabId);
 
         promise.then(() => {
-            mockBrowserAdpater.verifyAll();
+            browserAdapterMock.verifyAll();
             done();
         });
         expect(Q.isPending(promise)).toBeTruthy();
@@ -52,16 +57,16 @@ describe('ContentScriptInjectorTest', () => {
 
     it('test inject content scripts timeout', async done => {
         const tabId = 2;
-        testSubject = new ContentScriptInjector(mockBrowserAdpater.object, mockQ.object);
+        testSubject = new ContentScriptInjector(browserAdapterMock.object, qMock.object, promiseFactoryMock.object);
 
         ContentScriptInjector.cssFiles.forEach(cssFile => {
-            mockBrowserAdpater.setup(x => x.injectCss(tabId, cssFile, null)).verifiable(Times.once());
+            browserAdapterMock.setup(x => x.injectCss(tabId, cssFile, null)).verifiable(Times.once());
         });
 
-        mockBrowserAdpater.setup(x => x.injectJs(tabId, ContentScriptInjector.jsFiles[0], It.isAny())).verifiable(Times.once());
+        browserAdapterMock.setup(x => x.injectJs(tabId, ContentScriptInjector.jsFiles[0], It.isAny())).verifiable(Times.once());
 
         const timeoutDeferred = Q.defer();
-        mockQ
+        qMock
             .setup(x => x.timeout(It.isAny(), ContentScriptInjector.timeoutInMilliSec))
             .returns(() => timeoutDeferred.promise)
             .verifiable();
@@ -69,10 +74,10 @@ describe('ContentScriptInjectorTest', () => {
         const promise = testSubject.injectScripts(tabId);
 
         promise.then(null, () => {
-            mockBrowserAdpater.verifyAll();
+            browserAdapterMock.verifyAll();
             done();
         });
-        mockQ.verifyAll();
+        qMock.verifyAll();
         expect(promise).toEqual(timeoutDeferred.promise);
         expect(Q.isPending(promise)).toBeTruthy();
         timeoutDeferred.reject(null);

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -27,8 +27,8 @@ describe('ContentScriptInjectorTest', () => {
         const tabId = -1;
 
         promiseFactoryMock
-            .setup(factory => factory.timeout(ContentScriptInjector.timeoutInMilliSec, It.is(promise => promise instanceof Promise)))
-            .returns((delay, promise) => promise);
+            .setup(factory => factory.timeout(It.is(promise => promise instanceof Promise), ContentScriptInjector.timeoutInMilliSec))
+            .returns((promise, delay) => promise);
 
         ContentScriptInjector.cssFiles.forEach(cssFile =>
             browserAdapterMock.setup(adapter => adapter.injectCss(tabId, cssFile, null)).verifiable(Times.once()),

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -24,6 +24,7 @@ import { StoreNames } from '../../../../common/stores/store-names';
 import { StoreUpdateMessage } from '../../../../common/types/store-update-message';
 import { VisualizationType } from '../../../../common/types/visualization-type';
 import { WindowUtils } from '../../../../common/window-utils';
+import { PromiseFactory } from '../../../../common/promises/promise-factory';
 
 function getConfigs(visualizationType: VisualizationType): VisualizationConfiguration {
     return new VisualizationConfigurationFactory().getConfiguration(visualizationType);
@@ -70,6 +71,7 @@ describe('TabContextFactoryTest', () => {
         const visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
         visualizationConfigurationFactoryMock.setup(vcfm => vcfm.getConfiguration(It.isAny())).returns(theType => getConfigs(theType));
 
+        const promiseFactoryMock = Mock.ofType<PromiseFactory>();
         const testObject = new TabContextFactory(
             visualizationConfigurationFactoryMock.object,
             telemetryEventHandlerMock.object,
@@ -77,6 +79,7 @@ describe('TabContextFactoryTest', () => {
             targetTabControllerMock.object,
             assessmentStore.object,
             assessmentProvider.object,
+            promiseFactoryMock.object,
         );
 
         const tabContext = testObject.createTabContext(

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -20,11 +20,11 @@ import { TelemetryEventHandler } from '../../../../background/telemetry/telemetr
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
 import { Messages } from '../../../../common/messages';
+import { PromiseFactory } from '../../../../common/promises/promise-factory';
 import { StoreNames } from '../../../../common/stores/store-names';
 import { StoreUpdateMessage } from '../../../../common/types/store-update-message';
 import { VisualizationType } from '../../../../common/types/visualization-type';
 import { WindowUtils } from '../../../../common/window-utils';
-import { PromiseFactory } from '../../../../common/promises/promise-factory';
 
 function getConfigs(visualizationType: VisualizationType): VisualizationConfiguration {
     return new VisualizationConfigurationFactory().getConfiguration(visualizationType);

--- a/src/tests/unit/tests/common/promises/promise-factory.test.ts
+++ b/src/tests/unit/tests/common/promises/promise-factory.test.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { createDefaultPromiseFactory } from '../../../../../common/promises/promise-factory';
+
+// wrote the test following examples from https://jestjs.io/docs/en/tutorial-async
+describe('PromiseFactory', () => {
+    const testObject = createDefaultPromiseFactory();
+
+    describe('timeout', () => {
+        it('resolves', () => {
+            expect.assertions(1);
+
+            const actual = 'the result';
+            const resolving = Promise.resolve(actual);
+
+            const result = testObject.timeout(10, resolving);
+
+            return expect(result).resolves.toEqual(actual);
+        });
+
+        it('rejects', () => {
+            expect.assertions(1);
+
+            const reason = 'rejecting!';
+            const rejecting = Promise.reject(reason);
+
+            return expect(rejecting).rejects.toEqual(reason);
+        });
+
+        it('times out', () => {
+            expect.assertions(1);
+
+            const notResolving = new Promise(() => {
+                /* never actually resolve, so it will timeout*/
+            });
+
+            const delay = 1;
+
+            const timingOut = testObject.timeout(delay, notResolving);
+
+            return expect(timingOut).rejects.toEqual(`Timed out ${delay} ms`);
+        });
+    });
+});

--- a/src/tests/unit/tests/common/promises/promise-factory.test.ts
+++ b/src/tests/unit/tests/common/promises/promise-factory.test.ts
@@ -13,7 +13,7 @@ describe('PromiseFactory', () => {
             const actual = 'the result';
             const resolving = Promise.resolve(actual);
 
-            const result = testObject.timeout(10, resolving);
+            const result = testObject.timeout(resolving, 10);
 
             return expect(result).resolves.toEqual(actual);
         });
@@ -22,7 +22,7 @@ describe('PromiseFactory', () => {
             expect.assertions(1);
 
             const reason = 'rejecting!';
-            const rejecting = Promise.reject(reason);
+            const rejecting = testObject.timeout(Promise.reject(reason), 10);
 
             return expect(rejecting).rejects.toEqual(reason);
         });
@@ -36,7 +36,7 @@ describe('PromiseFactory', () => {
 
             const delay = 1;
 
-            const timingOut = testObject.timeout(delay, notResolving);
+            const timingOut = testObject.timeout(notResolving, delay);
 
             return expect(timingOut).rejects.toEqual(`Timed out ${delay} ms`);
         });


### PR DESCRIPTION
#### Description of changes

This is part of #801: Use native async, await & promise but it doesn't complete it.

Refactor `ContentScriptInjector` to not use `Q`.
- Introduce `PromiseFactory`
   - Implement `timeout` as a `Promise`-like API
- Update `ContentScriptInjector` to use `PromiseFactory` instead of `Q`
   - Update the creator: `TabContextFactory` (remove global reference to Q and use constructor parameter to receive `PromiseFactory'
   - Update user: `InjectorController`: grandfathered a tslint floating promise issue that showed up after the change to native promise (instead of `Q` promises)

**Notes**
There are more places where we're using `Q`. You can take this PR as a starting point and example for:
- How to refactor `Q.defer` uses
- How to replace `Q.timeout` uses
- How to test promise returning function without explicitly use an `async done => {}` test function (make the code less verbose)

#### Pull request checklist

- [x] Addresses an existing issue: Part of #801 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no changes
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - no changes
