### PR TITLE
refactor: content script injector (comments from previous PR)

### DIFF
--- a/src/background/injector/content-script-injector.ts
+++ b/src/background/injector/content-script-injector.ts
@@ -12,14 +12,14 @@ export class ContentScriptInjector {
 
     constructor(private readonly chromeAdapter: BrowserAdapter, private readonly promiseFactory: PromiseFactory) {}
 
-    public injectScripts(tabId: number): Promise<null> {
-        const inject = new Promise<null>((resolve, reject) => {
+    public injectScripts(tabId: number): Promise<void> {
+        const inject = new Promise<null>(resolve => {
             ContentScriptInjector.cssFiles.forEach(file => {
                 this.chromeAdapter.injectCss(tabId, file, null);
             });
 
             this.injectJsFiles(tabId, ContentScriptInjector.jsFiles, () => {
-                resolve(null);
+                resolve();
             });
         });
 

--- a/src/common/promises/promise-factory.ts
+++ b/src/common/promises/promise-factory.ts
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-type TimeoutPromise = <T>(promise: Promise<T>, delay: number) => Promise<T>;
+type TimeoutPromise = <T>(promise: Promise<T>, delayInMilliseconds: number) => Promise<T>;
 
 export type PromiseFactory = {
     timeout: TimeoutPromise;
 };
 
-const createTimeout: TimeoutPromise = <T>(promise: Promise<T>, delay: number) => {
+const createTimeout: TimeoutPromise = <T>(promise: Promise<T>, delayInMilliseconds: number) => {
     const timeout = new Promise<T>((resolve, reject) => {
         const timeoutId = setTimeout(() => {
             clearTimeout(timeoutId);
-            reject(`Timed out ${delay} ms`);
-        }, delay);
+            reject(`Timed out ${delayInMilliseconds} ms`);
+        }, delayInMilliseconds);
     });
 
     return Promise.race([promise, timeout]);

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -43,6 +43,6 @@ describe('ContentScriptInjectorTest', () => {
 
         const injected = testSubject.injectScripts(tabId);
 
-        return expect(injected).resolves.toBe(null);
+        return expect(injected).resolves.toBeUndefined();
     });
 });


### PR DESCRIPTION
#### Description of changes

Addressing some comments from PR #844

Out of scope for now:
- Refactor the `PromiseFactory` to be only a function for the timeout promise (waiting until we get rid of `Q` as some other functions may be added to the factory)
- Handling the floating promise that we grandfathered on the previous PR
- Changing the style of the test for the `PromiseFactory` as I would like more team members to look at it and give feedback.
- Waiting on the browser adapter injection API (we don't wait for the CSS right now. only for the javascript)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
