### PR TITLE
chore: update @types/enzyme

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "devDependencies": {
         "@types/applicationinsights-js": "^1.0.7",
         "@types/chrome": "0.0.86",
-        "@types/enzyme": "3.1.0",
+        "@types/enzyme": "3.9.4",
         "@types/enzyme-adapter-react-16": "^1.0.5",
         "@types/jest": "^24.0.15",
         "@types/jsdom": "^12.2.3",

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as Enzyme from 'enzyme';
 import { shallow } from 'enzyme';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
+
 import { Assessments } from '../../../../../assessments/assessments';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { ActionAndCancelButtonsComponent } from '../../../../../DetailsView/components/action-and-cancel-buttons-component';
@@ -42,7 +42,7 @@ describe('FailureInstancePanelControlTest', () => {
     test('onFailureDescriptionChange', () => {
         const description = 'abc';
         const props = createPropsWithType(CapturedInstanceActionType.CREATE);
-        const wrapper = shallow(<FailureInstancePanelControl {...props} />);
+        const wrapper = shallow<FailureInstancePanelControl>(<FailureInstancePanelControl {...props} />);
         wrapper
             .find(TextField)
             .props()
@@ -54,7 +54,7 @@ describe('FailureInstancePanelControlTest', () => {
     test('openFailureInstancePanel', () => {
         const props = createPropsWithType(CapturedInstanceActionType.CREATE);
         props.originalText = 'original text';
-        const wrapper = shallow(<FailureInstancePanelControl {...props} />);
+        const wrapper = shallow<FailureInstancePanelControl>(<FailureInstancePanelControl {...props} />);
         wrapper
             .find(TextField)
             .props()
@@ -71,7 +71,7 @@ describe('FailureInstancePanelControlTest', () => {
     test('closeFailureInstancePanel', () => {
         const description = 'description';
         const props = createPropsWithType(CapturedInstanceActionType.CREATE);
-        const wrapper = shallow(<FailureInstancePanelControl {...props} />);
+        const wrapper = shallow<FailureInstancePanelControl>(<FailureInstancePanelControl {...props} />);
         wrapper
             .find(TextField)
             .props()
@@ -96,7 +96,7 @@ describe('FailureInstancePanelControlTest', () => {
 
         editInstanceMock.setup(handler => handler(description, props.test, props.step, props.instanceId)).verifiable(Times.once());
 
-        const wrapper = Enzyme.shallow(<FailureInstancePanelControl {...props} />);
+        const wrapper = shallow<FailureInstancePanelControl>(<FailureInstancePanelControl {...props} />);
 
         wrapper
             .find(TextField)
@@ -120,7 +120,7 @@ describe('FailureInstancePanelControlTest', () => {
         const props = createPropsWithType(CapturedInstanceActionType.CREATE);
 
         addInstanceMock.setup(handler => handler(description, props.test, props.step)).verifiable(Times.once());
-        const wrapper = Enzyme.shallow(<FailureInstancePanelControl {...props} />);
+        const wrapper = shallow<FailureInstancePanelControl>(<FailureInstancePanelControl {...props} />);
 
         wrapper
             .find(TextField)

--- a/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
@@ -40,7 +40,7 @@ describe('StartOverDropdownTest', () => {
     });
 
     it('render ContextualMenu', () => {
-        const rendered = shallow(<StartOverDropdown {...defaultProps} />);
+        const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
         rendered.find(ActionButton).simulate('click', event);
         expect(rendered.getElement()).toMatchSnapshot();
         expect(rendered.state().target).toBe(event.currentTarget);
@@ -50,7 +50,7 @@ describe('StartOverDropdownTest', () => {
         defaultProps.rightPanelConfiguration = {
             GetStartOverContextualMenuItemKeys: () => ['assessment'],
         } as DetailsRightPanelConfiguration;
-        const rendered = shallow(<StartOverDropdown {...defaultProps} />);
+        const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
         rendered.find(ActionButton).simulate('click', event);
         expect(rendered.getElement()).toMatchSnapshot();
         expect(rendered.state().target).toBe(event.currentTarget);
@@ -83,7 +83,7 @@ describe('StartOverDropdownTest', () => {
             .setup(creator => creator.cancelStartOver(event, defaultProps.test, defaultProps.requirementKey))
             .verifiable(Times.once());
 
-        const rendered = shallow(<StartOverDropdown {...defaultProps} />);
+        const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
         rendered.find(ActionButton).simulate('click', event);
         rendered
             .find(ContextualMenu)
@@ -99,7 +99,7 @@ describe('StartOverDropdownTest', () => {
     it('should dismiss the start assessment over dialog', () => {
         actionCreatorMock.setup(creator => creator.cancelStartOverAllAssessments(event)).verifiable(Times.once());
 
-        const rendered = shallow(<StartOverDropdown {...defaultProps} />);
+        const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
         rendered.find(ActionButton).simulate('click', event);
         rendered
             .find(ContextualMenu)
@@ -117,7 +117,7 @@ describe('StartOverDropdownTest', () => {
             .setup(creator => creator.startOverAssessment(event, defaultProps.test, defaultProps.requirementKey))
             .verifiable(Times.once());
 
-        const rendered = shallow(<StartOverDropdown {...defaultProps} />);
+        const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
         rendered.find(ActionButton).simulate('click', event);
         rendered
             .find(ContextualMenu)
@@ -133,7 +133,7 @@ describe('StartOverDropdownTest', () => {
     it('should start over the whole assessment', () => {
         actionCreatorMock.setup(creator => creator.startOverAllAssessments(event)).verifiable(Times.once());
 
-        const rendered = shallow(<StartOverDropdown {...defaultProps} />);
+        const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
         rendered.find(ActionButton).simulate('click', event);
         rendered
             .find(ContextualMenu)
@@ -147,7 +147,7 @@ describe('StartOverDropdownTest', () => {
     });
 
     it('should dismiss the contextMenu', () => {
-        const rendered = shallow(<StartOverDropdown {...defaultProps} />);
+        const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
         rendered.find(ActionButton).simulate('click', event);
         rendered.find(ContextualMenu).prop('onDismiss')();
 

--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -40,7 +40,7 @@ describe('Switcher', () => {
         actionCreatorMock
             .setup(creator => creator.sendPivotItemClicked(DetailsViewPivotType[DetailsViewPivotType.assessment]))
             .verifiable(Times.once());
-        const wrapper = mount(<Switcher {...defaultProps} />);
+        const wrapper = mount<Switcher>(<Switcher {...defaultProps} />);
         const dropdown = wrapper.find(Dropdown);
 
         expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.fastPass);

--- a/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
+++ b/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
@@ -103,7 +103,7 @@ describe('IssueFilingButtonTest', () => {
         issueFilingActionMessageCreatorMock
             .setup(creator => creator.fileIssue(eventStub, testKey, props.issueDetailsData))
             .verifiable(Times.once());
-        const wrapper = shallow(<IssueFilingButton {...props} />);
+        const wrapper = shallow<IssueFilingButton>(<IssueFilingButton {...props} />);
 
         wrapper.find(DefaultButton).simulate('click', eventStub);
 
@@ -131,7 +131,7 @@ describe('IssueFilingButtonTest', () => {
             userConfigurationStoreData: userConfigurationStoreData,
             needsSettingsContentRenderer,
         };
-        const wrapper = shallow(<IssueFilingButton {...props} />);
+        const wrapper = shallow<IssueFilingButton>(<IssueFilingButton {...props} />);
         expect(wrapper.state().showNeedsSettingsContent).toBe(false);
 
         wrapper.find(DefaultButton).simulate('click', eventStub);

--- a/yarn.lock
+++ b/yarn.lock
@@ -364,10 +364,10 @@
     "@types/cheerio" "*"
     "@types/react" "*"
 
-"@types/enzyme@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.1.0.tgz#6b5b2d85232ee4200c78d4fcf19a97921f438c7c"
-  integrity sha512-AVqvXLZOTxyOzB9kE700qxIgT6hOiLi73C5gN9cDuCfh4IDpnkcEymLNZhT2m8IM+1rtoRkyGpezF7olR23PkQ==
+"@types/enzyme@3.9.4":
+  version "3.9.4"
+  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.9.4.tgz#08f3ebfa24aa881021693a0fe615d6d2720c07ad"
+  integrity sha512-bQcwt5gcKnekrbci4hcapfE2J6rkkFbHM1l4VobLtSl4ogOfj0lvSxrdS6FftCakmJqqPBqdQCwb5KnlivL6SQ==
   dependencies:
     "@types/cheerio" "*"
     "@types/react" "*"


### PR DESCRIPTION
#### Description of changes

Update @types/enzyme
Code changes are on tests where we use `wrapper.state()` to get specific properties from the state. Looks like enzyme make the types more strict, meaning you need to be more specific when using `shallow` and `mount` about the component type you're rendering so enzyme knows the props and state types and then let you access their internals.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not apply
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - does not apply
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no changes
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - no changes
