### PR TITLE
fix: duplicated header announcement on automated checks report

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -44,6 +44,12 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     justify-content: flex-start;
     align-items: center;
     margin-bottom: 16px;
+
+    .title {
+        font-size: 17px;
+        line-height: 24px;
+        font-weight: 700;
+    }
 }
 
 .failed-instances-section {

--- a/src/DetailsView/reports/components/report-sections/collapsible-container.tsx
+++ b/src/DetailsView/reports/components/report-sections/collapsible-container.tsx
@@ -7,15 +7,24 @@ import { NamedSFC } from '../../../../common/react/named-sfc';
 
 export type CollapsibleContainerProps = {
     id: string;
-    summaryContent: JSX.Element;
-    detailsContent: JSX.Element;
+    accessibleHeadingContent: JSX.Element;
+    visibleHeadingContent: JSX.Element;
+    collapsibleContent: JSX.Element;
     buttonAriaLabel: string;
     titleHeadingLevel?: number;
     containerClassName?: string;
 };
 
 export const CollapsibleContainer = NamedSFC<CollapsibleContainerProps>('CollapsibleContainer', props => {
-    const { id, summaryContent, titleHeadingLevel, detailsContent, buttonAriaLabel, containerClassName } = props;
+    const {
+        id,
+        visibleHeadingContent,
+        titleHeadingLevel,
+        collapsibleContent,
+        buttonAriaLabel,
+        containerClassName,
+        accessibleHeadingContent,
+    } = props;
 
     const contentId = `content-container-${id}`;
 
@@ -26,11 +35,12 @@ export const CollapsibleContainer = NamedSFC<CollapsibleContainerProps>('Collaps
     return (
         <div className={outerDivClassName}>
             <div className="title-container" {...titleContainerProps}>
+                {accessibleHeadingContent}
                 <button className="collapsible-control" aria-expanded="false" aria-controls={contentId} aria-label={buttonAriaLabel} />
-                <div>{summaryContent}</div>
+                <div>{visibleHeadingContent}</div>
             </div>
             <div id={contentId} className="collapsible-content" aria-hidden="true">
-                {detailsContent}
+                {collapsibleContent}
             </div>
         </div>
     );

--- a/src/DetailsView/reports/components/report-sections/collapsible-result-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/collapsible-result-section.tsx
@@ -14,14 +14,23 @@ export type CollapsibleResultSectionProps = ResultSectionProps & {
 };
 
 export const CollapsibleResultSection = NamedSFC<CollapsibleResultSectionProps>('CollapsibleResultSection', props => {
-    const { containerClassName, buttonAriaLabel, containerId } = props;
+    const { containerClassName, buttonAriaLabel, containerId, title, badgeCount } = props;
 
     return (
         <div className={containerClassName}>
             <CollapsibleContainer
                 id={containerId}
-                summaryContent={<ResultSectionTitle {...props} />}
-                detailsContent={<RulesOnly {...props} />}
+                accessibleHeadingContent={
+                    <h2 className="screen-reader-only">
+                        {title} {badgeCount}
+                    </h2>
+                }
+                visibleHeadingContent={
+                    <div aria-hidden="true">
+                        <ResultSectionTitle {...props} />
+                    </div>
+                }
+                collapsibleContent={<RulesOnly {...props} />}
                 buttonAriaLabel={buttonAriaLabel}
             />
         </div>

--- a/src/DetailsView/reports/components/report-sections/result-section-title.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section-title.tsx
@@ -18,7 +18,9 @@ export const ResultSectionTitle = NamedSFC<ResultSectionTitleProps>('ResultSecti
             <h2 className="screen-reader-only">
                 {props.title} {props.badgeCount}
             </h2>
-            <span aria-hidden="true">{props.title}</span>
+            <span className="title" aria-hidden="true">
+                {props.title}
+            </span>
             <div aria-hidden="true">
                 <OutcomeChip outcomeType={props.outcomeType} count={props.badgeCount} />
             </div>

--- a/src/DetailsView/reports/components/report-sections/result-section-title.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section-title.tsx
@@ -15,8 +15,13 @@ export type ResultSectionTitleProps = {
 export const ResultSectionTitle = NamedSFC<ResultSectionTitleProps>('ResultSectionTitle', props => {
     return (
         <div className="result-section-title">
-            <h2>{props.title}</h2>
-            <OutcomeChip outcomeType={props.outcomeType} count={props.badgeCount} />
+            <h2 className="screen-reader-only">
+                {props.title} {props.badgeCount}
+            </h2>
+            <span aria-hidden="true">{props.title}</span>
+            <div aria-hidden="true">
+                <OutcomeChip outcomeType={props.outcomeType} count={props.badgeCount} />
+            </div>
         </div>
     );
 });

--- a/src/DetailsView/reports/components/report-sections/rule-detail.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-detail.tsx
@@ -34,7 +34,11 @@ export const RuleDetail = NamedSFC<RuleDetailProps>('RuleDetails', props => {
             return null;
         }
 
-        return <OutcomeChip count={rule.nodes.length} outcomeType={outcomeType} />;
+        return (
+            <span aria-hidden="true">
+                <OutcomeChip count={rule.nodes.length} outcomeType={outcomeType} />
+            </span>
+        );
     };
 
     const renderRuleLink = () => {
@@ -69,7 +73,7 @@ export const RuleDetail = NamedSFC<RuleDetailProps>('RuleDetails', props => {
         <>
             <div className="rule-detail">
                 <div>
-                    {renderCountBadge()} {renderRuleLink()}: {renderDescription()} ({renderGuidanceLinks()}) {renderGuidanceTags()}
+                    {renderCountBadge()} {renderRuleLink()}: {renderDescription()} ({renderGuidanceLinks()}){renderGuidanceTags()}
                 </div>
             </div>
         </>

--- a/src/DetailsView/reports/components/report-sections/rule-detail.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-detail.tsx
@@ -21,11 +21,10 @@ export type RuleDetailProps = {
     deps: RuleDetailDeps;
     rule: RuleResult;
     outcomeType: InstanceOutcomeType;
-    isHeader: boolean;
 };
 
 export const RuleDetail = NamedSFC<RuleDetailProps>('RuleDetails', props => {
-    const { rule, outcomeType, isHeader, deps } = props;
+    const { rule, outcomeType, deps } = props;
 
     const outcomeText = outcomeTypeSemantics[props.outcomeType].pastTense;
     const ariaDescribedBy = `${kebabCase(outcomeText)}-rule-${rule.id}-description`;
@@ -66,20 +65,10 @@ export const RuleDetail = NamedSFC<RuleDetailProps>('RuleDetails', props => {
         return <GuidanceTags deps={deps} links={rule.guidanceLinks} />;
     };
 
-    const ariaLevel = isHeader ? 3 : undefined;
-
-    const headingProps =
-        ariaLevel != null
-            ? {
-                  role: 'heading',
-                  'aria-level': ariaLevel,
-              }
-            : null;
-
     return (
         <>
             <div className="rule-detail">
-                <div {...headingProps}>
+                <div>
                     {renderCountBadge()} {renderRuleLink()}: {renderDescription()} ({renderGuidanceLinks()}) {renderGuidanceTags()}
                 </div>
             </div>

--- a/src/DetailsView/reports/components/report-sections/rules-only.tsx
+++ b/src/DetailsView/reports/components/report-sections/rules-only.tsx
@@ -19,7 +19,7 @@ export const RulesOnly = NamedSFC<RulesProps>('RulesOnly', ({ rules, outcomeType
     return (
         <div className="rule-details-group">
             {rules.map(rule => {
-                return <RuleDetail deps={deps} key={rule.id} rule={rule} outcomeType={outcomeType} isHeader={false} />;
+                return <RuleDetail deps={deps} key={rule.id} rule={rule} outcomeType={outcomeType} />;
             })}
         </div>
     );

--- a/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
+++ b/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
@@ -29,7 +29,7 @@ export const RulesWithInstances = NamedSFC<RulesWithInstancesProps>(
                         <CollapsibleContainer
                             key={`summary-details-${idx + 1}`}
                             id={rule.id}
-                            summaryContent={<RuleDetail deps={deps} key={rule.id} rule={rule} outcomeType={outcomeType} isHeader={false} />}
+                            summaryContent={<RuleDetail deps={deps} key={rule.id} rule={rule} outcomeType={outcomeType} />}
                             detailsContent={
                                 <InstanceDetailsGroup
                                     fixInstructionProcessor={fixInstructionProcessor}

--- a/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
+++ b/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
@@ -29,8 +29,13 @@ export const RulesWithInstances = NamedSFC<RulesWithInstancesProps>(
                         <CollapsibleContainer
                             key={`summary-details-${idx + 1}`}
                             id={rule.id}
-                            summaryContent={<RuleDetail deps={deps} key={rule.id} rule={rule} outcomeType={outcomeType} />}
-                            detailsContent={
+                            accessibleHeadingContent={
+                                <h3 className="screen-reader-only">
+                                    rule {rule.id}, {rule.nodes.length} failures
+                                </h3>
+                            }
+                            visibleHeadingContent={<RuleDetail deps={deps} key={rule.id} rule={rule} outcomeType={outcomeType} />}
+                            collapsibleContent={
                                 <InstanceDetailsGroup
                                     fixInstructionProcessor={fixInstructionProcessor}
                                     key={`${rule.id}-rule-group`}
@@ -39,7 +44,6 @@ export const RulesWithInstances = NamedSFC<RulesWithInstancesProps>(
                             }
                             buttonAriaLabel="show failed instance list"
                             containerClassName="collapsible-rule-details-group"
-                            titleHeadingLevel={3}
                         />
                     );
                 })}

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/collapsible-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/collapsible-container.test.tsx.snap
@@ -7,6 +7,9 @@ exports[`CollapsibleContainer renders, no optional fields 1`] = `
   <div
     className="title-container"
   >
+    <div>
+      this is the accessible heading content
+    </div>
     <button
       aria-controls="content-container-test-id"
       aria-expanded="false"
@@ -15,7 +18,7 @@ exports[`CollapsibleContainer renders, no optional fields 1`] = `
     />
     <div>
       <div>
-        this is the summary content
+        this is the visible heading content
       </div>
     </div>
   </div>
@@ -25,7 +28,7 @@ exports[`CollapsibleContainer renders, no optional fields 1`] = `
     id="content-container-test-id"
   >
     <div>
-       this is the details content 
+       this is the collapsible content 
     </div>
   </div>
 </div>
@@ -38,6 +41,9 @@ exports[`CollapsibleContainer renders, with extra class name for the container d
   <div
     className="title-container"
   >
+    <div>
+      this is the accessible heading content
+    </div>
     <button
       aria-controls="content-container-test-id"
       aria-expanded="false"
@@ -46,7 +52,7 @@ exports[`CollapsibleContainer renders, with extra class name for the container d
     />
     <div>
       <div>
-        this is the summary content
+        this is the visible heading content
       </div>
     </div>
   </div>
@@ -56,7 +62,7 @@ exports[`CollapsibleContainer renders, with extra class name for the container d
     id="content-container-test-id"
   >
     <div>
-       this is the details content 
+       this is the collapsible content 
     </div>
   </div>
 </div>
@@ -71,6 +77,9 @@ exports[`CollapsibleContainer renders, with heading level for the title containe
     className="title-container"
     role="heading"
   >
+    <div>
+      this is the accessible heading content
+    </div>
     <button
       aria-controls="content-container-test-id"
       aria-expanded="false"
@@ -79,7 +88,7 @@ exports[`CollapsibleContainer renders, with heading level for the title containe
     />
     <div>
       <div>
-        this is the summary content
+        this is the visible heading content
       </div>
     </div>
   </div>
@@ -89,7 +98,7 @@ exports[`CollapsibleContainer renders, with heading level for the title containe
     id="content-container-test-id"
   >
     <div>
-       this is the details content 
+       this is the collapsible content 
     </div>
   </div>
 </div>

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/collapsible-result-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/collapsible-result-section.test.tsx.snap
@@ -5,8 +5,15 @@ exports[`CollapsibleResultSection renders 1`] = `
   className="result-section-class-name"
 >
   <CollapsibleContainer
+    accessibleHeadingContent={
+      <h2
+        className="screen-reader-only"
+      >
+         
+      </h2>
+    }
     buttonAriaLabel="button aria label test"
-    detailsContent={
+    collapsibleContent={
       <RulesOnly
         buttonAriaLabel="button aria label test"
         containerClassName="result-section-class-name"
@@ -14,12 +21,16 @@ exports[`CollapsibleResultSection renders 1`] = `
       />
     }
     id="container-id"
-    summaryContent={
-      <ResultSectionTitle
-        buttonAriaLabel="button aria label test"
-        containerClassName="result-section-class-name"
-        containerId="container-id"
-      />
+    visibleHeadingContent={
+      <div
+        aria-hidden="true"
+      >
+        <ResultSectionTitle
+          buttonAriaLabel="button aria label test"
+          containerClassName="result-section-class-name"
+          containerId="container-id"
+        />
+      </div>
     }
   />
 </div>

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section-title.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section-title.test.tsx.snap
@@ -4,12 +4,25 @@ exports[`ResultSectionTitle renders 1`] = `
 <div
   className="result-section-title"
 >
-  <h2>
+  <h2
+    className="screen-reader-only"
+  >
     test title
+     
+    10
   </h2>
-  <OutcomeChip
-    count={10}
-    outcomeType="pass"
-  />
+  <span
+    aria-hidden="true"
+  >
+    test title
+  </span>
+  <div
+    aria-hidden="true"
+  >
+    <OutcomeChip
+      count={10}
+      outcomeType="pass"
+    />
+  </div>
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section-title.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section-title.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`ResultSectionTitle renders 1`] = `
   </h2>
   <span
     aria-hidden="true"
+    className="title"
   >
     test title
   </span>

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-detail.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-detail.test.tsx.snap
@@ -6,10 +6,14 @@ exports[`RuleDetail renders 1`] = `
     className="rule-detail"
   >
     <div>
-      <OutcomeChip
-        count={1}
-        outcomeType="fail"
-      />
+      <span
+        aria-hidden="true"
+      >
+        <OutcomeChip
+          count={1}
+          outcomeType="fail"
+        />
+      </span>
        
       <span
         className="rule-details-id"
@@ -44,7 +48,7 @@ exports[`RuleDetail renders 1`] = `
           ]
         }
       />
-      ) 
+      )
       <GuidanceTags
         deps={Object {}}
         links={

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-detail.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-detail.test.tsx.snap
@@ -1,79 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RuleDetail renders, isHeader false 1`] = `
+exports[`RuleDetail renders 1`] = `
 <React.Fragment>
   <div
     className="rule-detail"
   >
     <div>
-      <OutcomeChip
-        count={1}
-        outcomeType="fail"
-      />
-       
-      <span
-        className="rule-details-id"
-      >
-        <NewTabLink
-          aria-describedby="failed-rule-rule id-description"
-          aria-label="rule rule id"
-          href="url://help.url"
-        >
-          rule id
-        </NewTabLink>
-      </span>
-      : 
-      <span
-        className="rule-details-description"
-        id="failed-rule-rule id-description"
-      >
-        rule description
-      </span>
-       (
-      <GuidanceLinks
-        links={
-          Array [
-            Object {
-              "href": "url://guidance-01.link",
-              "text": "guidance-01",
-            },
-            Object {
-              "href": "url://guidance-02.link",
-              "text": "guidance-02",
-            },
-          ]
-        }
-      />
-      ) 
-      <GuidanceTags
-        deps={Object {}}
-        links={
-          Array [
-            Object {
-              "href": "url://guidance-01.link",
-              "text": "guidance-01",
-            },
-            Object {
-              "href": "url://guidance-02.link",
-              "text": "guidance-02",
-            },
-          ]
-        }
-      />
-    </div>
-  </div>
-</React.Fragment>
-`;
-
-exports[`RuleDetail renders, isHeader true 1`] = `
-<React.Fragment>
-  <div
-    className="rule-detail"
-  >
-    <div
-      aria-level={3}
-      role="heading"
-    >
       <OutcomeChip
         count={1}
         outcomeType="fail"

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rules-only.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rules-only.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`RulesOnly renders 1`] = `
 >
   <RuleDetails
     deps={Object {}}
-    isHeader={false}
     outcomeType="pass"
     rule={
       Object {
@@ -16,7 +15,6 @@ exports[`RulesOnly renders 1`] = `
   />
   <RuleDetails
     deps={Object {}}
-    isHeader={false}
     outcomeType="pass"
     rule={
       Object {
@@ -26,7 +24,6 @@ exports[`RulesOnly renders 1`] = `
   />
   <RuleDetails
     deps={Object {}}
-    isHeader={false}
     outcomeType="pass"
     rule={
       Object {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rules-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rules-with-instances.test.tsx.snap
@@ -39,7 +39,6 @@ exports[`RulesWithInstances renders 1`] = `
     summaryContent={
       <RuleDetails
         deps={Object {}}
-        isHeader={false}
         outcomeType="pass"
         rule={
           Object {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rules-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rules-with-instances.test.tsx.snap
@@ -5,9 +5,19 @@ exports[`RulesWithInstances renders 1`] = `
   className="rule-details-group"
 >
   <CollapsibleContainer
+    accessibleHeadingContent={
+      <h3
+        className="screen-reader-only"
+      >
+        rule 
+        1
+        , 
+        1
+         failures
+      </h3>
+    }
     buttonAriaLabel="show failed instance list"
-    containerClassName="collapsible-rule-details-group"
-    detailsContent={
+    collapsibleContent={
       <InstanceDetailsGroup
         fixInstructionProcessor={
           proxy {
@@ -35,8 +45,9 @@ exports[`RulesWithInstances renders 1`] = `
         }
       />
     }
+    containerClassName="collapsible-rule-details-group"
     id="1"
-    summaryContent={
+    visibleHeadingContent={
       <RuleDetails
         deps={Object {}}
         outcomeType="pass"
@@ -54,7 +65,6 @@ exports[`RulesWithInstances renders 1`] = `
         }
       />
     }
-    titleHeadingLevel={3}
   />
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/collapsible-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/collapsible-container.test.tsx
@@ -9,27 +9,32 @@ import {
 } from '../../../../../../../DetailsView/reports/components/report-sections/collapsible-container';
 
 describe('CollapsibleContainer', () => {
-    it('renders, no optional fields', () => {
-        const props: CollapsibleContainerProps = {
+    const getProps = (customProps?: Partial<CollapsibleContainerProps>): CollapsibleContainerProps => {
+        const defaultProps: Partial<CollapsibleContainerProps> = {
             id: 'test-id',
-            summaryContent: <div>this is the summary content</div>,
-            detailsContent: <div> this is the details content </div>,
+            accessibleHeadingContent: <div>this is the accessible heading content</div>,
+            visibleHeadingContent: <div>this is the visible heading content</div>,
+            collapsibleContent: <div> this is the collapsible content </div>,
             buttonAriaLabel: 'button aria label',
         };
 
+        return {
+            ...defaultProps,
+            ...customProps,
+        } as CollapsibleContainerProps;
+    };
+
+    it('renders, no optional fields', () => {
+        const props = getProps();
         const wrapped = shallow(<CollapsibleContainer {...props} />);
 
         expect(wrapped.getElement()).toMatchSnapshot();
     });
 
     it('renders, with extra class name for the container div', () => {
-        const props: CollapsibleContainerProps = {
-            id: 'test-id',
-            summaryContent: <div>this is the summary content</div>,
-            detailsContent: <div> this is the details content </div>,
-            buttonAriaLabel: 'button aria label',
+        const props = getProps({
             containerClassName: 'extra-class-name',
-        };
+        });
 
         const wrapped = shallow(<CollapsibleContainer {...props} />);
 
@@ -37,13 +42,9 @@ describe('CollapsibleContainer', () => {
     });
 
     it('renders, with heading level for the title container', () => {
-        const props: CollapsibleContainerProps = {
-            id: 'test-id',
-            summaryContent: <div>this is the summary content</div>,
-            detailsContent: <div> this is the details content </div>,
-            buttonAriaLabel: 'button aria label',
+        const props = getProps({
             titleHeadingLevel: 5,
-        };
+        });
 
         const wrapped = shallow(<CollapsibleContainer {...props} />);
 

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-detail.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-detail.test.tsx
@@ -29,20 +29,13 @@ describe('RuleDetail', () => {
         nodes: [{} as AxeNodeResult],
     } as RuleResult;
 
-    const partialProps: Partial<RuleDetailProps> = {
+    const props: RuleDetailProps = {
         deps: depsStub,
         rule: rule,
         outcomeType: 'fail',
     };
 
-    const isHeaderValues = [true, false];
-
-    it.each(isHeaderValues)('renders, isHeader %s', isHeader => {
-        const props: RuleDetailProps = {
-            ...partialProps,
-            isHeader,
-        } as RuleDetailProps;
-
+    it('renders', () => {
         const wrapped = shallow(<RuleDetail {...props} />);
 
         expect(wrapped.getElement()).toMatchSnapshot();


### PR DESCRIPTION
#### Description of changes

Fixing accessibility issues with rule details headers.
General strategy is as follow:
- use a visually hidden 'h' tag for the text
   - we use a simpler text here: rule <rule name>, <count> failures/passes/not applicable
   - visible to screen readers -> screen reader user can navigate to it with 'h' shortcut
   - not actually visible on screen
- use a aria-hidden text for the title
   - screen reader skip this on
   - normally visible on screen
- move the original content of the header out of the header
   - this includes:
      - collapse/expand button control
      - link to the rule (with text = rule name) 
      - links to WCAG rules
      - rule description
      - failure count (this is hidden now as we are reading it as part of the header)

This way screen reader user can navigate to the headings either using 'h' shortcut or arrow key navigation and then use arrow keys to navigate to the content below (button to expand the list and other details) or hit 'h' again to get to the next header.

#### Pull request checklist

- [x] Addresses an existing issue: Part of WI # 1558756
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - make sure it has not change
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - make sure the content is accessible, no duplicated header is announce
