### PR TITLE
fix: remove NaN from fastpass report by removing concatenation in OutcomeSummaryBar

### DIFF
--- a/src/DetailsView/reports/components/outcome-summary-bar.tsx
+++ b/src/DetailsView/reports/components/outcome-summary-bar.tsx
@@ -22,12 +22,12 @@ export const OutcomeSummaryBar = NamedSFC<OutcomeSummaryBarProps>('OutcomeSummar
                 const iconMap = iconStyleInverted === true ? outcomeIconMapInverted : outcomeIconMap;
                 const outcomeIcon = iconMap[outcomeType];
                 const count = props.outcomeStats[outcomeType];
-                const suffix = countSuffix || '';
 
                 return (
                     <div key={outcomeType} style={{ flexGrow: count }}>
                         <span className={kebabCase(outcomeType)}>
-                            {outcomeIcon} {count + suffix} <span className="outcome-past-tense">{text}</span>
+                            {outcomeIcon} {count}
+                            {countSuffix} <span className="outcome-past-tense">{text}</span>
                         </span>
                     </div>
                 );

--- a/src/DetailsView/reports/components/outcome-summary-bar.tsx
+++ b/src/DetailsView/reports/components/outcome-summary-bar.tsx
@@ -22,11 +22,12 @@ export const OutcomeSummaryBar = NamedSFC<OutcomeSummaryBarProps>('OutcomeSummar
                 const iconMap = iconStyleInverted === true ? outcomeIconMapInverted : outcomeIconMap;
                 const outcomeIcon = iconMap[outcomeType];
                 const count = props.outcomeStats[outcomeType];
+                const suffix = countSuffix || '';
 
                 return (
                     <div key={outcomeType} style={{ flexGrow: count }}>
                         <span className={kebabCase(outcomeType)}>
-                            {outcomeIcon} {count + countSuffix} <span className="outcome-past-tense">{text}</span>
+                            {outcomeIcon} {count + suffix} <span className="outcome-past-tense">{text}</span>
                         </span>
                     </div>
                 );

--- a/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
@@ -86,7 +86,8 @@ exports[`OutcomeSummaryBar show by percentage 1`] = `
     >
       <CheckIcon />
        
-      42%
+      42
+      %
        
       <span
         className="outcome-past-tense"
@@ -107,7 +108,8 @@ exports[`OutcomeSummaryBar show by percentage 1`] = `
     >
       <CrossIcon />
        
-      13%
+      13
+      %
        
       <span
         className="outcome-past-tense"
@@ -128,7 +130,8 @@ exports[`OutcomeSummaryBar show by percentage 1`] = `
     >
       <CircleIcon />
        
-      7%
+      7
+      %
        
       <span
         className="outcome-past-tense"

--- a/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`OutcomeSummaryBar render inverted badges 1`] = `
     >
       <CheckIconInverted />
        
-      NaN
+      42
        
       <span
         className="outcome-past-tense"
@@ -37,7 +37,7 @@ exports[`OutcomeSummaryBar render inverted badges 1`] = `
     >
       <CrossIconInverted />
        
-      NaN
+      13
        
       <span
         className="outcome-past-tense"
@@ -58,7 +58,7 @@ exports[`OutcomeSummaryBar render inverted badges 1`] = `
     >
       <CircleIcon />
        
-      NaN
+      7
        
       <span
         className="outcome-past-tense"
@@ -156,7 +156,7 @@ exports[`OutcomeSummaryBar show by percentage 2`] = `
     >
       <CheckIcon />
        
-      NaN
+      42
        
       <span
         className="outcome-past-tense"
@@ -177,7 +177,7 @@ exports[`OutcomeSummaryBar show by percentage 2`] = `
     >
       <CrossIcon />
        
-      NaN
+      13
        
       <span
         className="outcome-past-tense"
@@ -198,7 +198,7 @@ exports[`OutcomeSummaryBar show by percentage 2`] = `
     >
       <CircleIcon />
        
-      NaN
+      7
        
       <span
         className="outcome-past-tense"


### PR DESCRIPTION
#### Description of changes

If the `countSuffix` property isn't provided (like in the FastPass report), concatenating a number with an `undefined` `countSuffix` results in `NaN`, leading to issue #852. This PR removes the concatenation and instead lets React render the undefined (no-op) value.

#### Pull request checklist

- [x] Addresses an existing issue: #852 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS

![screenshot of outcome bar](https://user-images.githubusercontent.com/7775527/60127534-42c11b00-9745-11e9-83b0-f516f4f2a456.png)

