### PR TITLE
refactor: remove some unused dom properties

### DIFF
--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -46,7 +46,6 @@ export type DetailsViewContainerDeps = {
 
 export interface DetailsViewContainerProps {
     deps: DetailsViewContainerDeps;
-    document: Document;
     issuesSelection: ISelection;
     clickHandlerFactory: DetailsViewToggleClickHandlerFactory;
     scopingActionMessageCreator: ScopingActionMessageCreator;

--- a/src/DetailsView/details-view-renderer.tsx
+++ b/src/DetailsView/details-view-renderer.tsx
@@ -75,7 +75,6 @@ export class DetailsViewRenderer {
                 <Theme deps={this.deps} />
                 <DetailsView
                     deps={this.deps}
-                    document={this.dom as Document}
                     issuesSelection={this.issuesSelection}
                     clickHandlerFactory={this.clickHandlerFactory}
                     visualizationConfigurationFactory={this.visualizationConfigurationFactory}

--- a/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
@@ -59,7 +59,6 @@ describe('DetailsViewRendererTest', () => {
                                 deps={deps}
                                 scopingActionMessageCreator={scopingActionMessageCreatorStrictMock.object}
                                 inspectActionMessageCreator={inspectActionMessageCreatorStrictMock.object}
-                                document={dom as any}
                                 issuesSelection={selectionMock.object}
                                 clickHandlerFactory={clickHandlerFactoryMock.object}
                                 visualizationConfigurationFactory={visualizationConfigurationFactoryMock.object}


### PR DESCRIPTION
#### Description of changes

Found some unsued `dom: Document` property not being  used.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - no issue filed for this
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no changes
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - no changes
