### PR TITLE
fix: correct typos to make extension not crash on Linux

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -4,7 +4,7 @@ jobs:
     - job: 'unit_tests_and_lints'
 
       pool:
-          vmImage: 'macOS-10.13'
+          vmImage: ${{ parameters.vmImage }}
 
       steps:
           - template: pipeline/prerequisites.yaml
@@ -52,7 +52,7 @@ jobs:
     - job: 'e2e_tests_and_publish_drop'
 
       pool:
-          vmImage: 'macOS-10.13'
+          vmImage: ${{ parameters.vmImage }}
 
       steps:
           - template: pipeline/prerequisites.yaml

--- a/build.yaml
+++ b/build.yaml
@@ -4,7 +4,7 @@ jobs:
     - job: 'unit_tests_and_lints'
 
       pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'macOS-10.13'
 
       steps:
           - template: pipeline/prerequisites.yaml
@@ -52,7 +52,7 @@ jobs:
     - job: 'e2e_tests_and_publish_drop'
 
       pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'macOS-10.13'
 
       steps:
           - template: pipeline/prerequisites.yaml

--- a/build.yaml
+++ b/build.yaml
@@ -4,7 +4,7 @@ jobs:
     - job: 'unit_tests_and_lints'
 
       pool:
-          vmImage: ${{ parameters.vmImage }}
+          vmImage: 'ubuntu-16.04'
 
       steps:
           - template: pipeline/prerequisites.yaml
@@ -52,7 +52,7 @@ jobs:
     - job: 'e2e_tests_and_publish_drop'
 
       pool:
-          vmImage: ${{ parameters.vmImage }}
+          vmImage: 'ubuntu-16.04'
 
       steps:
           - template: pipeline/prerequisites.yaml

--- a/src/DetailsView/detailsView.html
+++ b/src/DetailsView/detailsView.html
@@ -7,7 +7,7 @@ Licensed under the MIT License.
     <head>
         <link rel="shortcut icon" type="image/x-icon" href="../icons/brand/blue/brand-blue-16px.png" />
         <link rel="stylesheet" type="text/css" href="../common/styles/fabric.min.css" />
-        <link rel="stylesheet" type="text/css" href="./styles/default/detailsView.css" />
+        <link rel="stylesheet" type="text/css" href="./styles/default/detailsview.css" />
         <link rel="stylesheet" type="text/css" href="../bundle/detailsView.css" />
         <title>Accessibility Insights for Web</title>
         <script src="../insights.config.js"></script>

--- a/src/DetailsView/detailsView.html
+++ b/src/DetailsView/detailsView.html
@@ -7,8 +7,8 @@ Licensed under the MIT License.
     <head>
         <link rel="shortcut icon" type="image/x-icon" href="../icons/brand/blue/brand-blue-16px.png" />
         <link rel="stylesheet" type="text/css" href="../common/styles/fabric.min.css" />
-        <link rel="stylesheet" type="text/css" href="./styles/default/detailsview.css" />
-        <link rel="stylesheet" type="text/css" href="../bundle/detailsview.css" />
+        <link rel="stylesheet" type="text/css" href="./styles/default/detailsView.css" />
+        <link rel="stylesheet" type="text/css" href="../bundle/detailsView.css" />
         <title>Accessibility Insights for Web</title>
         <script src="../insights.config.js"></script>
     </head>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,7 +21,7 @@
         "page": "background/background.html",
         "persistent": true
     },
-    "devtools_page": "devtools/devtools.html",
+    "devtools_page": "Devtools/devtools.html",
     "web_accessible_resources": ["insights.html", "assessments/*", "injected/*", "background/*", "common/*", "DetailsView/*", "bundle/*"],
     "permissions": ["storage", "webNavigation", "tabs", "notifications", "https://*/*", "http://*/*", "file://*/*"],
     "commands": {


### PR DESCRIPTION
#### Description of changes

Fix typo in a path for devtools.html in manifest.
This is an ongoing step to fix the crash issue in Linux.

#### Pull request checklist

- [x] Addresses an existing issue:  #860 
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
