### PR TITLE
chore: remove usage of @autobind to unblock office fabric 7.x upgrade

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import {
     AddFailureInstancePayload,
     AddResultDescriptionPayload,
@@ -42,8 +41,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         this.dispatcher.dispatchMessage(message);
     }
 
-    @autobind
-    public closePreviewFeaturesPanel(): void {
+    public closePreviewFeaturesPanel = (): void => {
         const messageType = Messages.PreviewFeatures.ClosePanel;
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: BaseActionPayload = {
@@ -54,10 +52,9 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: messageType,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public closeScopingPanel(): void {
+    public closeScopingPanel = (): void => {
         const messageType = Messages.Scoping.ClosePanel;
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: BaseActionPayload = {
@@ -68,10 +65,9 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: messageType,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public closeSettingsPanel(): void {
+    public closeSettingsPanel = (): void => {
         const messageType = Messages.SettingsPanel.ClosePanel;
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: BaseActionPayload = {
@@ -82,10 +78,9 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: messageType,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public setFeatureFlag(featureFlagId: string, enabled: boolean, event: React.MouseEvent<HTMLElement>): void {
+    public setFeatureFlag = (featureFlagId: string, enabled: boolean, event: React.MouseEvent<HTMLElement>): void => {
         const messageType = Messages.FeatureFlags.SetFeatureFlag;
         const telemetry = this.telemetryFactory.forFeatureFlagToggle(
             event,
@@ -103,7 +98,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: messageType,
             payload: payload,
         });
-    }
+    };
 
     public exportResultsClicked(exportResultsType: ExportResultType, exportedHtml: string, event: React.MouseEvent<HTMLElement>): void {
         const telemetryData = this.telemetryFactory.forExportedHtml(
@@ -116,11 +111,10 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         this.dispatcher.sendTelemetry(TelemetryEvents.EXPORT_RESULTS, telemetryData);
     }
 
-    @autobind
-    public copyIssueDetailsClicked(event: React.MouseEvent<any>): void {
+    public copyIssueDetailsClicked = (event: React.MouseEvent<any>): void => {
         const telemetryData = this.telemetryFactory.withTriggeredByAndSource(event, TelemetryEvents.TelemetryEventSource.DetailsView);
         this.dispatcher.sendTelemetry(TelemetryEvents.COPY_ISSUE_DETAILS, telemetryData);
-    }
+    };
 
     public updateFocusedInstanceTarget(instanceTarget: string[]): void {
         const payload: string[] = instanceTarget;
@@ -180,8 +174,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
-    @autobind
-    public switchToTargetTab(event: React.MouseEvent<HTMLElement>): void {
+    public switchToTargetTab = (event: React.MouseEvent<HTMLElement>): void => {
         const telemetry = this.telemetryFactory.fromDetailsView(event);
         const payload: SwitchToTargetTabPayload = {
             telemetry,
@@ -191,7 +184,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Tab.Switch,
             payload,
         });
-    }
+    };
 
     public startOverAssessment(event: React.MouseEvent<any>, test: VisualizationType, requirement: string): void {
         const telemetry = this.telemetryFactory.forAssessmentActionFromDetailsView(test, event);
@@ -245,8 +238,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
-    @autobind
-    public changeManualTestStatus(status: ManualTestStatus, test: VisualizationType, requirement: string, selector: string): void {
+    public changeManualTestStatus = (status: ManualTestStatus, test: VisualizationType, requirement: string, selector: string): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: ChangeInstanceStatusPayload = {
             test,
@@ -260,10 +252,9 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Assessment.ChangeStatus,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public changeManualRequirementStatus(status: ManualTestStatus, test: VisualizationType, requirement: string): void {
+    public changeManualRequirementStatus = (status: ManualTestStatus, test: VisualizationType, requirement: string): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: ChangeRequirementStatusPayload = {
             test,
@@ -276,10 +267,9 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Assessment.ChangeRequirementStatus,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public undoManualTestStatusChange(test: VisualizationType, requirement: string, selector: string): void {
+    public undoManualTestStatusChange = (test: VisualizationType, requirement: string, selector: string): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: AssessmentActionInstancePayload = {
             test,
@@ -292,10 +282,9 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Assessment.Undo,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public undoManualRequirementStatusChange(test: VisualizationType, requirement: string): void {
+    public undoManualRequirementStatusChange = (test: VisualizationType, requirement: string): void => {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: ChangeRequirementStatusPayload = {
             test: test,
@@ -307,15 +296,14 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Assessment.UndoChangeRequirementStatus,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public changeAssessmentVisualizationState(
+    public changeAssessmentVisualizationState = (
         isVisualizationEnabled: boolean,
         test: VisualizationType,
         requirement: string,
         selector: string,
-    ): void {
+    ): void => {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: ChangeInstanceSelectionPayload = {
             test,
@@ -329,7 +317,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Assessment.ChangeVisualizationState,
             payload,
         });
-    }
+    };
 
     public addResultDescription(description: string): void {
         const payload: AddResultDescriptionPayload = {
@@ -357,8 +345,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
-    @autobind
-    public removeFailureInstance(test: VisualizationType, requirement: string, id: string): void {
+    public removeFailureInstance = (test: VisualizationType, requirement: string, id: string): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: RemoveFailureInstancePayload = {
             test,
@@ -371,15 +358,14 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Assessment.RemoveFailureInstance,
             payload,
         });
-    }
+    };
 
     public detailsViewOpened(selectedPivot: DetailsViewPivotType): void {
         const telemetryData = this.telemetryFactory.forDetailsViewOpened(selectedPivot);
         this.dispatcher.sendTelemetry(TelemetryEvents.DETAILS_VIEW_OPEN, telemetryData);
     }
 
-    @autobind
-    public editFailureInstance(description: string, test: VisualizationType, requirement: string, id: string): void {
+    public editFailureInstance = (description: string, test: VisualizationType, requirement: string, id: string): void => {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: EditFailureInstancePayload = {
             test,
@@ -393,7 +379,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Assessment.EditFailureInstance,
             payload,
         });
-    }
+    };
 
     public passUnmarkedInstances(test: VisualizationType, requirement: string): void {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
@@ -425,8 +411,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
-    @autobind
-    public continuePreviousAssessment(event: React.MouseEvent<any>): void {
+    public continuePreviousAssessment = (event: React.MouseEvent<any>): void => {
         const telemetry = this.telemetryFactory.fromDetailsView(event);
         const payload: BaseActionPayload = {
             telemetry: telemetry,
@@ -435,10 +420,9 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Assessment.ContinuePreviousAssessment,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public startOverAllAssessments(event: React.MouseEvent<any>): void {
+    public startOverAllAssessments = (event: React.MouseEvent<any>): void => {
         const telemetry = this.telemetryFactory.fromDetailsView(event);
         const payload: BaseActionPayload = {
             telemetry: telemetry,
@@ -447,10 +431,9 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Assessment.StartOverAllAssessments,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public cancelStartOver(event: React.MouseEvent<any>, test: VisualizationType, requirement: string): void {
+    public cancelStartOver = (event: React.MouseEvent<any>, test: VisualizationType, requirement: string): void => {
         const telemetry = this.telemetryFactory.forCancelStartOver(event, test, requirement);
         const payload: BaseActionPayload = {
             telemetry: telemetry,
@@ -460,10 +443,9 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Assessment.CancelStartOver,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public cancelStartOverAllAssessments(event: React.MouseEvent<any>): void {
+    public cancelStartOverAllAssessments = (event: React.MouseEvent<any>): void => {
         const telemetry = this.telemetryFactory.fromDetailsView(event);
         const payload: BaseActionPayload = {
             telemetry: telemetry,
@@ -473,7 +455,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
             messageType: Messages.Assessment.CancelStartOverAllAssessments,
             payload,
         });
-    }
+    };
 
     public changeRightContentPanel(viewType: DetailsViewRightContentPanelType): void {
         const payload: DetailsViewRightContentPanelType = viewType;

--- a/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
+++ b/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import * as React from 'react';
@@ -39,8 +38,7 @@ export class AssessmentInstanceEditAndRemoveControl extends React.Component<Asse
         );
     }
 
-    @autobind
-    protected onRemoveButtonClicked(event?: React.MouseEvent<any>): void {
+    protected onRemoveButtonClicked = (event?: React.MouseEvent<any>): void => {
         this.props.onRemove(this.props.test, this.props.step, this.props.id);
-    }
+    };
 }

--- a/src/DetailsView/components/assessment-instance-selected-button.tsx
+++ b/src/DetailsView/components/assessment-instance-selected-button.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as classNames from 'classnames';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
@@ -46,11 +45,10 @@ export class AssessmentInstanceSelectedButton extends React.Component<Assessment
         );
     }
 
-    @autobind
-    private onButtonClicked(event: React.MouseEvent<any>): void {
+    private onButtonClicked = (event: React.MouseEvent<any>): void => {
         if (this.props.isVisible) {
             const checked = !this.props.isVisualizationEnabled;
             this.props.onSelected(checked, this.props.test, this.props.step, this.props.selector);
         }
-    }
+    };
 }

--- a/src/DetailsView/components/assessment-instance-table.tsx
+++ b/src/DetailsView/components/assessment-instance-table.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind, IRenderFunction } from '@uifabric/utilities';
+import { IRenderFunction } from '@uifabric/utilities';
 import { has } from 'lodash';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import {
@@ -86,20 +86,17 @@ export class AssessmentInstanceTable extends React.Component<AssessmentInstanceT
         );
     }
 
-    @autobind
-    public onItemInvoked(item: AssessmentInstanceRowData): void {
+    public onItemInvoked = (item: AssessmentInstanceRowData): void => {
         this.updateFocusedTarget(item);
-    }
+    };
 
-    @autobind
-    public renderRow(props: IDetailsRowProps, defaultRender: IRenderFunction<IDetailsRowProps>): JSX.Element {
+    public renderRow = (props: IDetailsRowProps, defaultRender: IRenderFunction<IDetailsRowProps>): JSX.Element => {
         return <div onClick={() => this.updateFocusedTarget(props.item)}>{defaultRender(props)}</div>;
-    }
+    };
 
-    @autobind
-    public updateFocusedTarget(item: AssessmentInstanceRowData): void {
+    public updateFocusedTarget = (item: AssessmentInstanceRowData): void => {
         this.props.assessmentInstanceTableHandler.updateFocusedTarget(item.instance.target);
-    }
+    };
 
     public renderDefaultInstanceTableHeader(items: AssessmentInstanceRowData[]): JSX.Element {
         const disabled = !this.isAnyInstanceStatusUnknown(items, this.props.assessmentNavState.selectedTestStep);
@@ -117,11 +114,10 @@ export class AssessmentInstanceTable extends React.Component<AssessmentInstanceT
         );
     }
 
-    @autobind
-    protected onPassUnmarkedInstances(): void {
+    protected onPassUnmarkedInstances = (): void => {
         this.props.assessmentInstanceTableHandler.passUnmarkedInstances(
             this.props.assessmentNavState.selectedTestType,
             this.props.assessmentNavState.selectedTestStep,
         );
-    }
+    };
 }

--- a/src/DetailsView/components/assessment-visualization-enabled-toggle.tsx
+++ b/src/DetailsView/components/assessment-visualization-enabled-toggle.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as _ from 'lodash';
 import { GeneratedAssessmentInstance } from '../../common/types/store-data/assessment-result-data';
 import { BaseVisualHelperToggle } from './base-visual-helper-toggle';
@@ -14,14 +13,13 @@ export class AssessmentVisualizationEnabledToggle extends BaseVisualHelperToggle
         return this.isAnyInstanceVisible(instances);
     }
 
-    @autobind
-    protected onClick(event): void {
+    protected onClick = (event): void => {
         this.props.actionMessageCreator.changeAssessmentVisualizationStateForAll(
             !this.isAnyInstanceVisible(this.filterInstancesByTestStep(this.props.assessmentNavState, this.props.instancesMap)),
             this.props.assessmentNavState.selectedTestType,
             this.props.assessmentNavState.selectedTestStep,
         );
-    }
+    };
 
     private isAnyInstanceVisible(instances: GeneratedAssessmentInstance<{}, {}>[]): boolean {
         return instances.some(instance => instance.testStepResults[this.props.assessmentNavState.selectedTestStep].isVisualizationEnabled);

--- a/src/DetailsView/components/base-left-nav.tsx
+++ b/src/DetailsView/components/base-left-nav.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { INavLink, Nav } from 'office-ui-fabric-react/lib/Nav';
 import * as React from 'react';
 
@@ -44,15 +43,13 @@ export class BaseLeftNav extends React.Component<BaseLeftNavProps> {
         );
     }
 
-    @autobind
-    protected onNavLinkClick(event: React.MouseEvent<HTMLElement>, item: BaseLeftNavLink): void {
+    protected onNavLinkClick = (event: React.MouseEvent<HTMLElement>, item: BaseLeftNavLink): void => {
         if (item) {
             item.onClickNavLink(event, item);
         }
-    }
+    };
 
-    @autobind
-    protected onRenderLink(link: BaseLeftNavLink): JSX.Element {
+    protected onRenderLink = (link: BaseLeftNavLink): JSX.Element => {
         return link.onRenderNavLink(link, this.props.renderIcon);
-    }
+    };
 }

--- a/src/DetailsView/components/base-visual-helper-toggle.tsx
+++ b/src/DetailsView/components/base-visual-helper-toggle.tsx
@@ -60,5 +60,5 @@ export abstract class BaseVisualHelperToggle extends React.Component<VisualHelpe
         return null;
     }
 
-    protected abstract onClick(event): void;
+    protected abstract onClick: (event: any) => void;
 }

--- a/src/DetailsView/components/details-group-header.tsx
+++ b/src/DetailsView/components/details-group-header.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { GroupHeader } from 'office-ui-fabric-react/lib/components/GroupedList/GroupHeader';
 import { IGroupDividerProps } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
@@ -22,8 +21,7 @@ export class DetailsGroupHeader extends React.Component<DetailsGroupHeaderProps>
         return <GroupHeader onRenderTitle={this.onRenderTitle} selectAllButtonProps={selectAllButtonProps} {...this.props} />;
     }
 
-    @autobind
-    private onRenderTitle(): JSX.Element {
+    private onRenderTitle = (): JSX.Element => {
         return (
             <div className="details-group-header-title">
                 {this.renderRuleLink(this.props.group)}
@@ -31,7 +29,7 @@ export class DetailsGroupHeader extends React.Component<DetailsGroupHeaderProps>
                 {this.renderRuleDescription(this.props.group)} {this.renderCount(this.props)} {this.renderGuidanceLinks(this.props.group)}
             </div>
         );
-    }
+    };
 
     private renderRuleDescription(group: DetailsGroup): JSX.Element {
         return <span id={`${group.key}-rule-description`}>{group.name}</span>;
@@ -63,8 +61,7 @@ export class DetailsGroupHeader extends React.Component<DetailsGroupHeaderProps>
         return <GuidanceLinks links={group.guidanceLinks} />;
     }
 
-    @autobind
-    private onRuleLinkClick(event: React.MouseEvent<HTMLElement>): void {
+    private onRuleLinkClick = (event: React.MouseEvent<HTMLElement>): void => {
         event.stopPropagation();
-    }
+    };
 }

--- a/src/DetailsView/components/details-view-dropdown.tsx
+++ b/src/DetailsView/components/details-view-dropdown.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind, IPoint } from '@uifabric/utilities';
+import { IPoint } from '@uifabric/utilities';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
@@ -55,13 +55,11 @@ export class DetailsViewDropDown extends React.Component<DetailsViewDropDownProp
         );
     }
 
-    @autobind
-    protected openDropdown(target: React.MouseEvent<HTMLElement>): void {
+    protected openDropdown = (target: React.MouseEvent<HTMLElement>): void => {
         this.setState({ target: target.currentTarget, isContextMenuVisible: true });
-    }
+    };
 
-    @autobind
-    protected dismissDropdown(): void {
+    protected dismissDropdown = (): void => {
         this.setState({ target: null, isContextMenuVisible: false });
-    }
+    };
 }

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { Link } from 'office-ui-fabric-react/lib/Link';
@@ -116,30 +115,25 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
         );
     }
 
-    @autobind
-    protected onFailureDescriptionChange(event, value: string): void {
+    protected onFailureDescriptionChange = (event, value: string): void => {
         this.setState({ failureDescription: value });
-    }
+    };
 
-    @autobind
-    protected onAddFailureInstance(): void {
+    protected onAddFailureInstance = (): void => {
         this.props.addFailureInstance(this.state.failureDescription, this.props.test, this.props.step);
         this.setState({ isPanelOpen: false });
-    }
+    };
 
-    @autobind
-    protected onSaveEditedFailureInstance(): void {
+    protected onSaveEditedFailureInstance = (): void => {
         this.props.editFailureInstance(this.state.failureDescription, this.props.test, this.props.step, this.props.instanceId);
         this.setState({ isPanelOpen: false });
-    }
+    };
 
-    @autobind
-    protected openFailureInstancePanel(): void {
+    protected openFailureInstancePanel = (): void => {
         this.setState({ isPanelOpen: true, failureDescription: this.props.originalText || '' });
-    }
+    };
 
-    @autobind
-    protected closeFailureInstancePanel(): void {
+    protected closeFailureInstancePanel = (): void => {
         this.setState({ isPanelOpen: false });
-    }
+    };
 }

--- a/src/DetailsView/components/issues-details-list.tsx
+++ b/src/DetailsView/components/issues-details-list.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import {
     ConstrainMode,
     DetailsList,
@@ -96,13 +95,12 @@ export class IssuesDetailsList extends React.Component<IssuesDetailsListProps> {
         );
     }
 
-    @autobind
-    private onRenderGroupHeader(props?: DetailsGroupHeaderProps): JSX.Element {
+    private onRenderGroupHeader = (props?: DetailsGroupHeaderProps): JSX.Element => {
         const groupHeaderProps: DetailsGroupHeaderProps = {
             ...props,
             countIcon: <Icon iconName="statusErrorFull" className="details-icon-error" />,
         };
 
         return <DetailsGroupHeader {...groupHeaderProps} />;
-    }
+    };
 }

--- a/src/DetailsView/components/left-nav/nav-link-handler.ts
+++ b/src/DetailsView/components/left-nav/nav-link-handler.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { DetailsViewPivotType } from '../../../common/types/details-view-pivot-type';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../../actions/details-view-action-message-creator';
@@ -9,10 +8,9 @@ import { BaseLeftNavLink } from '../base-left-nav';
 export class NavLinkHandler {
     constructor(private detailsViewActionMessageCreator: DetailsViewActionMessageCreator) {}
 
-    @autobind
-    public onOverviewClick(): void {
+    public onOverviewClick = (): void => {
         this.detailsViewActionMessageCreator.changeRightContentPanel('Overview');
-    }
+    };
 
     public onFastPassTestClick = (event: React.MouseEvent<HTMLElement>, item: BaseLeftNavLink) => {
         this.detailsViewActionMessageCreator.selectDetailsView(event, VisualizationType[item.key], DetailsViewPivotType.fastPass);

--- a/src/DetailsView/components/restart-scan-visual-helper-toggle.tsx
+++ b/src/DetailsView/components/restart-scan-visual-helper-toggle.tsx
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { GeneratedAssessmentInstance } from '../../common/types/store-data/assessment-result-data';
 import { BaseVisualHelperToggle } from './base-visual-helper-toggle';
 
@@ -14,8 +12,7 @@ export class RestartScanVisualHelperToggle extends BaseVisualHelperToggle {
         return this.props.isStepEnabled;
     }
 
-    @autobind
-    protected onClick(event): void {
+    protected onClick = (event): void => {
         if (this.props.isStepEnabled) {
             this.props.actionMessageCreator.disableVisualHelper(
                 this.props.assessmentNavState.selectedTestType,
@@ -27,5 +24,5 @@ export class RestartScanVisualHelperToggle extends BaseVisualHelperToggle {
                 this.props.assessmentNavState.selectedTestStep,
             );
         }
-    }
+    };
 }

--- a/src/DetailsView/components/start-over-dropdown.tsx
+++ b/src/DetailsView/components/start-over-dropdown.tsx
@@ -103,9 +103,7 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
         }
 
         if (this.state.dialogState === 'test') {
-            messageText = `Starting over will clear all existing results from the ${
-                this.props.testName
-            } test. Are you sure you want to start over?`;
+            messageText = `Starting over will clear all existing results from the ${this.props.testName} test. Are you sure you want to start over?`;
             onPrimaryButtonClick = this.onStartTestOver;
         }
 

--- a/src/DetailsView/components/start-over-dropdown.tsx
+++ b/src/DetailsView/components/start-over-dropdown.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind, IPoint } from '@uifabric/utilities';
+import { IPoint } from '@uifabric/utilities';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import * as React from 'react';
@@ -78,15 +78,13 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
         return rightPanelConfiguration.GetStartOverContextualMenuItemKeys().map(key => items.find(item => item.key === key));
     }
 
-    @autobind
-    private onStartOverTestMenu(): void {
+    private onStartOverTestMenu = (): void => {
         this.setState({ dialogState: 'test' });
-    }
+    };
 
-    @autobind
-    private onStartOverAllTestsMenu(): void {
+    private onStartOverAllTestsMenu = (): void => {
         this.setState({ dialogState: 'assessment' });
-    }
+    };
 
     private renderStartOverDialog(): JSX.Element {
         if (this.state.dialogState === 'none') {
@@ -105,7 +103,9 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
         }
 
         if (this.state.dialogState === 'test') {
-            messageText = `Starting over will clear all existing results from the ${this.props.testName} test. Are you sure you want to start over?`;
+            messageText = `Starting over will clear all existing results from the ${
+                this.props.testName
+            } test. Are you sure you want to start over?`;
             onPrimaryButtonClick = this.onStartTestOver;
         }
 
@@ -120,8 +120,7 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
         );
     }
 
-    @autobind
-    private onDismissStartOverDialog(event: React.MouseEvent<any>): void {
+    private onDismissStartOverDialog = (event: React.MouseEvent<any>): void => {
         const { actionMessageCreator, requirementKey, test } = this.props;
 
         if (this.state.dialogState === 'assessment') {
@@ -133,30 +132,27 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
         }
 
         this.setState({ dialogState: 'none' });
-    }
+    };
 
-    @autobind
-    private onStartTestOver(event: React.MouseEvent<any>): void {
+    private onStartTestOver = (event: React.MouseEvent<any>): void => {
         const { actionMessageCreator, test, requirementKey } = this.props;
 
         actionMessageCreator.startOverAssessment(event, test, requirementKey);
 
         this.setState({ dialogState: 'none' });
-    }
+    };
 
-    @autobind
-    private onStartOverAllTests(event: React.MouseEvent<any>): void {
+    private onStartOverAllTests = (event: React.MouseEvent<any>): void => {
         const { actionMessageCreator } = this.props;
 
         actionMessageCreator.startOverAllAssessments(event);
 
         this.setState({ dialogState: 'none' });
-    }
+    };
 
-    @autobind
-    private openDropdown(event): void {
+    private openDropdown = (event): void => {
         this.setState({ target: event.currentTarget, isContextMenuVisible: true });
-    }
+    };
 
     private dismissDropdown(): void {
         this.setState({ target: null, isContextMenuVisible: false });

--- a/src/DetailsView/components/test-status-choice-group.tsx
+++ b/src/DetailsView/components/test-status-choice-group.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { isEqual } from 'lodash';
 import { ChoiceGroup, IChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
@@ -61,14 +60,13 @@ export class TestStatusChoiceGroup extends React.Component<TestStatusChoiceGroup
         );
     }
 
-    @autobind
-    private onRenderLabel(option: IChoiceGroupOption): JSX.Element {
+    private onRenderLabel = (option: IChoiceGroupOption): JSX.Element => {
         return (
             <span id={option.labelId} className={radioLabel} aria-label={option.text}>
                 {this.props.isLabelVisible ? option.text : ''}
             </span>
         );
-    }
+    };
 
     private renderUndoButton(): JSX.Element {
         if (this.props.originalStatus == null) {
@@ -82,21 +80,18 @@ export class TestStatusChoiceGroup extends React.Component<TestStatusChoiceGroup
         );
     }
 
-    @autobind
-    protected compomentRef(component: IChoiceGroup): void {
+    protected compomentRef = (component: IChoiceGroup): void => {
         this._choiceGroup = component;
-    }
+    };
 
-    @autobind
-    protected onChange(ev: React.FocusEvent<HTMLElement>, option: IChoiceGroupOption): void {
+    protected onChange = (ev: React.FocusEvent<HTMLElement>, option: IChoiceGroupOption): void => {
         this.setState({ selectedKey: option.key });
         this.props.onGroupChoiceChange(ManualTestStatus[option.key], this.props.test, this.props.step, this.props.selector);
-    }
+    };
 
-    @autobind
-    protected onUndoClicked(): void {
+    protected onUndoClicked = (): void => {
         this.setState({ selectedKey: ManualTestStatus[ManualTestStatus.UNKNOWN] });
         this._choiceGroup.focus();
         this.props.onUndoClicked(this.props.test, this.props.step, this.props.selector);
-    }
+    };
 }

--- a/src/DetailsView/components/test-steps-nav.tsx
+++ b/src/DetailsView/components/test-steps-nav.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { INavLink, Nav } from 'office-ui-fabric-react/lib/Nav';
 import * as React from 'react';
 
@@ -52,8 +51,7 @@ export class TestStepsNav extends React.Component<TestStepNavProps> {
         );
     }
 
-    @autobind
-    protected renderNavLink(link: INavLink): JSX.Element {
+    protected renderNavLink = (link: INavLink): JSX.Element => {
         return (
             <RequirementLink
                 link={link}
@@ -61,18 +59,17 @@ export class TestStepsNav extends React.Component<TestStepNavProps> {
                 renderRequirementDescription={link.renderRequirementDescription}
             />
         );
-    }
+    };
 
     private getStepStatus(key: string): ManualTestStatus {
         return this.props.stepStatus[key].stepFinalResult;
     }
 
-    @autobind
-    protected onTestStepSelected(event?: React.MouseEvent<HTMLElement>, item?: INavLink): void {
+    protected onTestStepSelected = (event?: React.MouseEvent<HTMLElement>, item?: INavLink): void => {
         if (item) {
             this.props.deps.detailsViewActionMessageCreator.selectRequirement(event, item.key, this.props.selectedTest);
         }
-    }
+    };
 
     private getLinks(): INavLink[] {
         const { selectedTest, stepStatus } = this.props;

--- a/src/DetailsView/document-title-updater.ts
+++ b/src/DetailsView/document-title-updater.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { BaseStore } from '../common/base-store';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
@@ -31,13 +29,12 @@ export class DocumentTitleUpdater {
         this.assessmentStore.addChangedListener(this.onStoreChange);
     }
 
-    @autobind
-    private onStoreChange(): void {
+    private onStoreChange = (): void => {
         const documentTitle = this.getDocumentTitle();
         const defaultTitle = title;
 
         this.doc.title = documentTitle ? `${documentTitle} - ${defaultTitle}` : defaultTitle;
-    }
+    };
 
     private getDocumentTitle(): string {
         if (!this.hasAllStoreData() || this.tabStore.getState().isClosed) {

--- a/src/DetailsView/handlers/assessment-instance-table-handler.tsx
+++ b/src/DetailsView/handlers/assessment-instance-table-handler.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 
@@ -35,20 +34,17 @@ export class AssessmentInstanceTableHandler {
         this.assessmentsProvider = assessmentsProvider;
     }
 
-    @autobind
-    public changeRequirementStatus(status: ManualTestStatus, test: VisualizationType, step: string): void {
+    public changeRequirementStatus = (status: ManualTestStatus, test: VisualizationType, step: string): void => {
         this.actionMessageCreator.changeManualRequirementStatus(status, test, step);
-    }
+    };
 
-    @autobind
-    public undoRequirementStatusChange(test: VisualizationType, step: string): void {
+    public undoRequirementStatusChange = (test: VisualizationType, step: string): void => {
         this.actionMessageCreator.undoManualRequirementStatusChange(test, step);
-    }
+    };
 
-    @autobind
-    public addFailureInstance(description: string, test: VisualizationType, step: string): void {
+    public addFailureInstance = (description: string, test: VisualizationType, step: string): void => {
         this.actionMessageCreator.addFailureInstance(description, test, step);
-    }
+    };
 
     public passUnmarkedInstances(test: VisualizationType, step: string): void {
         this.actionMessageCreator.passUnmarkedInstances(test, step);
@@ -111,8 +107,11 @@ export class AssessmentInstanceTableHandler {
         return this.assessmentTableColumnConfigHandler.getColumnConfigsForCapturedInstances();
     }
 
-    @autobind
-    private renderChoiceGroup(instance: GeneratedAssessmentInstance, key: string, assessmentNavState: AssessmentNavState): JSX.Element {
+    private renderChoiceGroup = (
+        instance: GeneratedAssessmentInstance,
+        key: string,
+        assessmentNavState: AssessmentNavState,
+    ): JSX.Element => {
         const step = assessmentNavState.selectedTestStep;
         const test = assessmentNavState.selectedTestType;
         return (
@@ -126,10 +125,13 @@ export class AssessmentInstanceTableHandler {
                 onUndoClicked={this.actionMessageCreator.undoManualTestStatusChange}
             />
         );
-    }
+    };
 
-    @autobind
-    private renderSelectedButton(instance: GeneratedAssessmentInstance, key: string, assessmentNavState: AssessmentNavState): JSX.Element {
+    private renderSelectedButton = (
+        instance: GeneratedAssessmentInstance,
+        key: string,
+        assessmentNavState: AssessmentNavState,
+    ): JSX.Element => {
         const step = assessmentNavState.selectedTestStep;
         const test = assessmentNavState.selectedTestType;
 
@@ -143,10 +145,9 @@ export class AssessmentInstanceTableHandler {
                 onSelected={this.actionMessageCreator.changeAssessmentVisualizationState}
             />
         );
-    }
+    };
 
-    @autobind
-    private renderInstanceActionButtons(instance: UserCapturedInstance, test: VisualizationType, step: string): JSX.Element {
+    private renderInstanceActionButtons = (instance: UserCapturedInstance, test: VisualizationType, step: string): JSX.Element => {
         return (
             <AssessmentInstanceEditAndRemoveControl
                 test={test}
@@ -158,7 +159,7 @@ export class AssessmentInstanceTableHandler {
                 assessmentsProvider={this.assessmentsProvider}
             />
         );
-    }
+    };
 
     private getInstanceKeys(
         instancesMap: DictionaryStringTo<GeneratedAssessmentInstance>,

--- a/src/DetailsView/handlers/master-checkbox-config-provider.ts
+++ b/src/DetailsView/handlers/master-checkbox-config-provider.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as classNames from 'classnames';
 import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 
@@ -34,11 +33,10 @@ export class MasterCheckBoxConfigProvider {
         };
     }
 
-    @autobind
-    private getMasterCheckBoxClickHandler(
+    private getMasterCheckBoxClickHandler = (
         assessmentNavState: AssessmentNavState,
         allEnabled: boolean,
-    ): (ev: React.MouseEvent<HTMLElement>, column: IColumn) => void {
+    ): ((ev: React.MouseEvent<HTMLElement>, column: IColumn) => void) => {
         return (ev: React.MouseEvent<HTMLElement>, column: IColumn) => {
             this.actionMessageCreator.changeAssessmentVisualizationStateForAll(
                 !allEnabled,
@@ -46,5 +44,5 @@ export class MasterCheckBoxConfigProvider {
                 assessmentNavState.selectedTestStep,
             );
         };
-    }
+    };
 }

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { TestMode } from '../../common/configs/test-mode';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { RegisterTypeToPayloadCallback } from '../../common/message';
@@ -117,61 +115,51 @@ export class ActionCreator {
         this.registerTypeToPayloadCallback(Messages.Inspect.SetHoveredOverSelector, this.onSetHoveredOverSelector);
     }
 
-    @autobind
-    private onEnableVisualHelperWithoutScan(payload: ToggleActionPayload): void {
+    private onEnableVisualHelperWithoutScan = (payload: ToggleActionPayload): void => {
         this.visualizationActions.enableVisualizationWithoutScan.invoke(payload);
     }
 
-    @autobind
-    private onEnableVisualHelper(payload: ToggleActionPayload): void {
+    private onEnableVisualHelper = (payload: ToggleActionPayload): void => {
         this.visualizationActions.enableVisualization.invoke(payload);
     }
 
-    @autobind
-    private onDisableVisualHelpersForTest(payload: ToggleActionPayload): void {
+    private onDisableVisualHelpersForTest = (payload: ToggleActionPayload): void => {
         this.visualizationActions.disableVisualization.invoke(payload.test);
     }
 
-    @autobind
-    private onDisableVisualHelper(payload: ToggleActionPayload): void {
+    private onDisableVisualHelper = (payload: ToggleActionPayload): void => {
         const eventName = TelemetryEvents.DISABLE_VISUAL_HELPER;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.visualizationActions.disableVisualization.invoke(payload.test);
     }
 
-    @autobind
-    private onStartOver(payload: ToggleActionPayload): void {
+    private onStartOver = (payload: ToggleActionPayload): void => {
         const eventName = TelemetryEvents.START_OVER_TEST;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.visualizationActions.disableVisualization.invoke(payload.test);
     }
 
-    @autobind
-    private onCancelStartOver(payload: BaseActionPayload): void {
+    private onCancelStartOver = (payload: BaseActionPayload): void => {
         const eventName = TelemetryEvents.CANCEL_START_OVER_TEST;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
     }
 
-    @autobind
-    private onStartOverAllAssessments(payload: ToggleActionPayload): void {
+    private onStartOverAllAssessments = (payload: ToggleActionPayload): void => {
         const eventName = TelemetryEvents.START_OVER_ASSESSMENT;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.visualizationActions.disableAssessmentVisualizations.invoke(null);
     }
 
-    @autobind
-    private onCancelStartOverAllAssessments(payload: BaseActionPayload): void {
+    private onCancelStartOverAllAssessments = (payload: BaseActionPayload): void => {
         const eventName = TelemetryEvents.CANCEL_START_OVER_ASSESSMENT;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
     }
 
-    @autobind
-    private onDetailsViewClosed(): void {
+    private onDetailsViewClosed = (): void => {
         this.visualizationActions.disableAssessmentVisualizations.invoke(null);
     }
 
-    @autobind
-    private onAssessmentScanCompleted(payload: ScanCompletedPayload<any>, tabId: number): void {
+    private onAssessmentScanCompleted = (payload: ScanCompletedPayload<any>, tabId: number): void => {
         const eventName = TelemetryEvents.ASSESSMENT_SCAN_COMPLETED;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.visualizationActions.scanCompleted.invoke(null);
@@ -179,52 +167,43 @@ export class ActionCreator {
         this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
     }
 
-    @autobind
-    private onOpenPreviewFeaturesPanel(payload: BaseActionPayload, tabId: number): void {
+    private onOpenPreviewFeaturesPanel = (payload: BaseActionPayload, tabId: number): void => {
         this.previewFeaturesActions.openPreviewFeatures.invoke(null);
         this.showDetailsView(tabId);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PREVIEW_FEATURES_OPEN, payload);
     }
 
-    @autobind
-    private onClosePreviewFeaturesPanel(payload: BaseActionPayload): void {
+    private onClosePreviewFeaturesPanel = (payload: BaseActionPayload): void => {
         this.previewFeaturesActions.closePreviewFeatures.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PREVIEW_FEATURES_CLOSE, payload);
     }
 
-    @autobind
-    private onTabbedElementAdded(payload: AddTabbedElementPayload): void {
+    private onTabbedElementAdded = (payload: AddTabbedElementPayload): void => {
         this.visualizationScanResultActions.addTabbedElement.invoke(payload);
     }
 
-    @autobind
-    private onRecordingCompleted(payload: BaseActionPayload): void {
+    private onRecordingCompleted = (payload: BaseActionPayload): void => {
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.TABSTOPS_RECORDING_COMPLETE, payload);
     }
 
-    @autobind
-    private onRecordingTerminated(payload: BaseActionPayload): void {
+    private onRecordingTerminated = (payload: BaseActionPayload): void => {
         this.visualizationScanResultActions.disableTabStop.invoke(payload);
     }
 
-    @autobind
-    private onOpenConfigureCommandTab(payload: BaseActionPayload): void {
+    private onOpenConfigureCommandTab = (payload: BaseActionPayload): void => {
         this.chromeFeatureController.openCommandConfigureTab();
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.SHORTCUT_CONFIGURE_OPEN, payload);
     }
 
-    @autobind
-    private onUpdateIssuesSelectedTargets(payload: string[]): void {
+    private onUpdateIssuesSelectedTargets = (payload: string[]): void => {
         this.visualizationScanResultActions.updateIssuesSelectedTargets.invoke(payload);
     }
 
-    @autobind
-    private onUpdateFocusedInstance(payload: string[]): void {
+    private onUpdateFocusedInstance = (payload: string[]): void => {
         this.visualizationActions.updateFocusedInstance.invoke(payload);
     }
 
-    @autobind
-    private onScanCompleted(payload: ScanCompletedPayload<any>, tabId: number): void {
+    private onScanCompleted = (payload: ScanCompletedPayload<any>, tabId: number): void => {
         const telemetryEventName = TelemetryEvents.ADHOC_SCAN_COMPLETED;
         this.telemetryEventHandler.publishTelemetry(telemetryEventName, payload);
         this.visualizationScanResultActions.scanCompleted.invoke(payload);
@@ -233,13 +212,11 @@ export class ActionCreator {
         this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
     }
 
-    @autobind
-    private onScrollRequested(payload: BaseActionPayload): void {
+    private onScrollRequested = (payload: BaseActionPayload): void => {
         this.visualizationActions.scrollRequested.invoke(null);
     }
 
-    @autobind
-    private onDetailsViewOpen(payload: OnDetailsViewOpenPayload, tabId: number): void {
+    private onDetailsViewOpen = (payload: OnDetailsViewOpenPayload, tabId: number): void => {
         if (this.shouldEnableToggleOnDetailsViewOpen(payload.detailsViewType)) {
             this.enableToggleOnDetailsViewOpen(payload.detailsViewType, tabId);
         }
@@ -268,27 +245,23 @@ export class ActionCreator {
         };
     }
 
-    @autobind
-    private onPivotChildSelected(payload: OnDetailsViewOpenPayload, tabId: number): void {
+    private onPivotChildSelected = (payload: OnDetailsViewOpenPayload, tabId: number): void => {
         this.previewFeaturesActions.closePreviewFeatures.invoke(null);
         this.visualizationActions.updateSelectedPivotChild.invoke(payload);
         this.showDetailsView(tabId);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PIVOT_CHILD_SELECTED, payload);
     }
 
-    @autobind
-    private onDetailsViewPivotSelected(payload: OnDetailsViewPivotSelected): void {
+    private onDetailsViewPivotSelected = (payload: OnDetailsViewPivotSelected): void => {
         this.visualizationActions.updateSelectedPivot.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.DETAILS_VIEW_PIVOT_ACTIVATED, payload);
     }
 
-    @autobind
-    private showDetailsView(tabId: number): void {
+    private showDetailsView = (tabId: number): void => {
         this.detailsViewController.showDetailsView(tabId);
     }
 
-    @autobind
-    private onVisualizationToggle(payload: VisualizationTogglePayload): void {
+    private onVisualizationToggle = (payload: VisualizationTogglePayload): void => {
         const telemetryEvent = this.adhocTestTypeToTelemetryEvent[payload.test];
         this.telemetryEventHandler.publishTelemetry(telemetryEvent, payload);
 
@@ -299,28 +272,23 @@ export class ActionCreator {
         }
     }
 
-    @autobind
-    private injectionCompleted(): void {
+    private injectionCompleted = (): void => {
         this.visualizationActions.injectionCompleted.invoke(null);
     }
 
-    @autobind
-    private injectionStarted(): void {
+    private injectionStarted = (): void => {
         this.visualizationActions.injectionStarted.invoke(null);
     }
 
-    @autobind
-    private getVisualizationToggleCurrentState(): void {
+    private getVisualizationToggleCurrentState = (): void => {
         this.visualizationActions.getCurrentState.invoke(null);
     }
 
-    @autobind
-    private getScanResultsCurrentState(): void {
+    private getScanResultsCurrentState = (): void => {
         this.visualizationScanResultActions.getCurrentState.invoke(null);
     }
 
-    @autobind
-    private onSetHoveredOverSelector(payload: string[]): void {
+    private onSetHoveredOverSelector = (payload: string[]): void => {
         this.inspectActions.setHoveredOverSelector.invoke(payload);
     }
 }

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -117,47 +117,47 @@ export class ActionCreator {
 
     private onEnableVisualHelperWithoutScan = (payload: ToggleActionPayload): void => {
         this.visualizationActions.enableVisualizationWithoutScan.invoke(payload);
-    }
+    };
 
     private onEnableVisualHelper = (payload: ToggleActionPayload): void => {
         this.visualizationActions.enableVisualization.invoke(payload);
-    }
+    };
 
     private onDisableVisualHelpersForTest = (payload: ToggleActionPayload): void => {
         this.visualizationActions.disableVisualization.invoke(payload.test);
-    }
+    };
 
     private onDisableVisualHelper = (payload: ToggleActionPayload): void => {
         const eventName = TelemetryEvents.DISABLE_VISUAL_HELPER;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.visualizationActions.disableVisualization.invoke(payload.test);
-    }
+    };
 
     private onStartOver = (payload: ToggleActionPayload): void => {
         const eventName = TelemetryEvents.START_OVER_TEST;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.visualizationActions.disableVisualization.invoke(payload.test);
-    }
+    };
 
     private onCancelStartOver = (payload: BaseActionPayload): void => {
         const eventName = TelemetryEvents.CANCEL_START_OVER_TEST;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-    }
+    };
 
     private onStartOverAllAssessments = (payload: ToggleActionPayload): void => {
         const eventName = TelemetryEvents.START_OVER_ASSESSMENT;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.visualizationActions.disableAssessmentVisualizations.invoke(null);
-    }
+    };
 
     private onCancelStartOverAllAssessments = (payload: BaseActionPayload): void => {
         const eventName = TelemetryEvents.CANCEL_START_OVER_ASSESSMENT;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-    }
+    };
 
     private onDetailsViewClosed = (): void => {
         this.visualizationActions.disableAssessmentVisualizations.invoke(null);
-    }
+    };
 
     private onAssessmentScanCompleted = (payload: ScanCompletedPayload<any>, tabId: number): void => {
         const eventName = TelemetryEvents.ASSESSMENT_SCAN_COMPLETED;
@@ -165,43 +165,43 @@ export class ActionCreator {
         this.visualizationActions.scanCompleted.invoke(null);
         this.notificationCreator.createNotificationByVisualizationKey(payload.selectorMap, payload.key, payload.testType);
         this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
-    }
+    };
 
     private onOpenPreviewFeaturesPanel = (payload: BaseActionPayload, tabId: number): void => {
         this.previewFeaturesActions.openPreviewFeatures.invoke(null);
         this.showDetailsView(tabId);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PREVIEW_FEATURES_OPEN, payload);
-    }
+    };
 
     private onClosePreviewFeaturesPanel = (payload: BaseActionPayload): void => {
         this.previewFeaturesActions.closePreviewFeatures.invoke(null);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PREVIEW_FEATURES_CLOSE, payload);
-    }
+    };
 
     private onTabbedElementAdded = (payload: AddTabbedElementPayload): void => {
         this.visualizationScanResultActions.addTabbedElement.invoke(payload);
-    }
+    };
 
     private onRecordingCompleted = (payload: BaseActionPayload): void => {
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.TABSTOPS_RECORDING_COMPLETE, payload);
-    }
+    };
 
     private onRecordingTerminated = (payload: BaseActionPayload): void => {
         this.visualizationScanResultActions.disableTabStop.invoke(payload);
-    }
+    };
 
     private onOpenConfigureCommandTab = (payload: BaseActionPayload): void => {
         this.chromeFeatureController.openCommandConfigureTab();
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.SHORTCUT_CONFIGURE_OPEN, payload);
-    }
+    };
 
     private onUpdateIssuesSelectedTargets = (payload: string[]): void => {
         this.visualizationScanResultActions.updateIssuesSelectedTargets.invoke(payload);
-    }
+    };
 
     private onUpdateFocusedInstance = (payload: string[]): void => {
         this.visualizationActions.updateFocusedInstance.invoke(payload);
-    }
+    };
 
     private onScanCompleted = (payload: ScanCompletedPayload<any>, tabId: number): void => {
         const telemetryEventName = TelemetryEvents.ADHOC_SCAN_COMPLETED;
@@ -210,11 +210,11 @@ export class ActionCreator {
         this.visualizationActions.scanCompleted.invoke(null);
         this.notificationCreator.createNotificationByVisualizationKey(payload.selectorMap, payload.key, payload.testType);
         this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
-    }
+    };
 
     private onScrollRequested = (payload: BaseActionPayload): void => {
         this.visualizationActions.scrollRequested.invoke(null);
-    }
+    };
 
     private onDetailsViewOpen = (payload: OnDetailsViewOpenPayload, tabId: number): void => {
         if (this.shouldEnableToggleOnDetailsViewOpen(payload.detailsViewType)) {
@@ -222,7 +222,7 @@ export class ActionCreator {
         }
 
         this.onPivotChildSelected(payload, tabId);
-    }
+    };
 
     private shouldEnableToggleOnDetailsViewOpen(visualizationType: VisualizationType): boolean {
         return (
@@ -250,16 +250,16 @@ export class ActionCreator {
         this.visualizationActions.updateSelectedPivotChild.invoke(payload);
         this.showDetailsView(tabId);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PIVOT_CHILD_SELECTED, payload);
-    }
+    };
 
     private onDetailsViewPivotSelected = (payload: OnDetailsViewPivotSelected): void => {
         this.visualizationActions.updateSelectedPivot.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.DETAILS_VIEW_PIVOT_ACTIVATED, payload);
-    }
+    };
 
     private showDetailsView = (tabId: number): void => {
         this.detailsViewController.showDetailsView(tabId);
-    }
+    };
 
     private onVisualizationToggle = (payload: VisualizationTogglePayload): void => {
         const telemetryEvent = this.adhocTestTypeToTelemetryEvent[payload.test];
@@ -270,25 +270,25 @@ export class ActionCreator {
         } else {
             this.visualizationActions.disableVisualization.invoke(payload.test);
         }
-    }
+    };
 
     private injectionCompleted = (): void => {
         this.visualizationActions.injectionCompleted.invoke(null);
-    }
+    };
 
     private injectionStarted = (): void => {
         this.visualizationActions.injectionStarted.invoke(null);
-    }
+    };
 
     private getVisualizationToggleCurrentState = (): void => {
         this.visualizationActions.getCurrentState.invoke(null);
-    }
+    };
 
     private getScanResultsCurrentState = (): void => {
         this.visualizationScanResultActions.getCurrentState.invoke(null);
-    }
+    };
 
     private onSetHoveredOverSelector = (payload: string[]): void => {
         this.inspectActions.setHoveredOverSelector.invoke(payload);
-    }
+    };
 }

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { capitalize } from 'lodash';
 import { RegisterTypeToPayloadCallback } from '../../common/message';
 import { Messages } from '../../common/messages';
@@ -64,139 +63,118 @@ export class AssessmentActionCreator {
         this.registerTypeToPayloadCallback(Messages.Visualizations.DetailsView.Select, this.onPivotChildSelected);
     }
 
-    @autobind
-    private onContinuePreviousAssessment(payload: any, tabId: number): void {
+    private onContinuePreviousAssessment = (payload: any, tabId: number): void => {
         const eventName = TelemetryEvents.CONTINUE_PREVIOUS_ASSESSMENT;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.continuePreviousAssessment.invoke(tabId);
-    }
+    };
 
-    @autobind
-    private onPassUnmarkedInstances(payload: ToggleActionPayload, tabId: number): void {
+    private onPassUnmarkedInstances = (payload: ToggleActionPayload, tabId: number): void => {
         const eventName = TelemetryEvents.PASS_UNMARKED_INSTANCES;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.updateTargetTabId.invoke(tabId);
         this.assessmentActions.passUnmarkedInstance.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onEditFailureInstance(payload: EditFailureInstancePayload): void {
+    private onEditFailureInstance = (payload: EditFailureInstancePayload): void => {
         const eventName = TelemetryEvents.EDIT_FAILURE_INSTANCE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.editFailureInstance.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onRemoveFailureInstance(payload: RemoveFailureInstancePayload): void {
+    private onRemoveFailureInstance = (payload: RemoveFailureInstancePayload): void => {
         const eventName = TelemetryEvents.REMOVE_FAILURE_INSTANCE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.removeFailureInstance.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onAddFailureInstance(payload: AddFailureInstancePayload): void {
+    private onAddFailureInstance = (payload: AddFailureInstancePayload): void => {
         const eventName = TelemetryEvents.ADD_FAILURE_INSTANCE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.addFailureInstance.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onAddResultDescription(payload: AddResultDescriptionPayload): void {
+    private onAddResultDescription = (payload: AddResultDescriptionPayload): void => {
         this.assessmentActions.addResultDescription.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onChangeManualRequirementStatus(payload: ChangeRequirementStatusPayload, tabId: number): void {
+    private onChangeManualRequirementStatus = (payload: ChangeRequirementStatusPayload, tabId: number): void => {
         const eventName = TelemetryEvents.CHANGE_INSTANCE_STATUS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.updateTargetTabId.invoke(tabId);
         this.assessmentActions.changeRequirementStatus.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onUndoChangeManualRequirementStatus(payload: ChangeRequirementStatusPayload): void {
+    private onUndoChangeManualRequirementStatus = (payload: ChangeRequirementStatusPayload): void => {
         const eventName = TelemetryEvents.UNDO_REQUIREMENT_STATUS_CHANGE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.undoRequirementStatusChange.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onUndoAssessmentInstanceStatusChange(payload: AssessmentActionInstancePayload): void {
+    private onUndoAssessmentInstanceStatusChange = (payload: AssessmentActionInstancePayload): void => {
         const eventName = TelemetryEvents.UNDO_TEST_STATUS_CHANGE;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.undoInstanceStatusChange.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onChangeAssessmentInstanceStatus(payload: ChangeInstanceStatusPayload, tabId: number): void {
+    private onChangeAssessmentInstanceStatus = (payload: ChangeInstanceStatusPayload, tabId: number): void => {
         const eventName = TelemetryEvents.CHANGE_INSTANCE_STATUS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.updateTargetTabId.invoke(tabId);
         this.assessmentActions.changeInstanceStatus.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onChangeAssessmentVisualizationState(payload: ChangeInstanceSelectionPayload): void {
+    private onChangeAssessmentVisualizationState = (payload: ChangeInstanceSelectionPayload): void => {
         const eventName = TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.changeAssessmentVisualizationState.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onChangeVisualizationStateForAll(payload: ChangeInstanceSelectionPayload): void {
+    private onChangeVisualizationStateForAll = (payload: ChangeInstanceSelectionPayload): void => {
         const eventName = TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS_FOR_ALL;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.assessmentActions.changeAssessmentVisualizationStateForAll.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onStartOverAssessment(payload: ToggleActionPayload): void {
+    private onStartOverAssessment = (payload: ToggleActionPayload): void => {
         this.assessmentActions.resetData.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onStartOverAllAssessments(payload: ToggleActionPayload, tabId: number): void {
+    private onStartOverAllAssessments = (payload: ToggleActionPayload, tabId: number): void => {
         this.assessmentActions.resetAllAssessmentsData.invoke(tabId);
-    }
+    };
 
-    @autobind
-    private onUpdateInstanceVisibility(payload: UpdateVisibilityPayload): void {
+    private onUpdateInstanceVisibility = (payload: UpdateVisibilityPayload): void => {
         this.assessmentActions.updateInstanceVisibility.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onAssessmentScanCompleted(payload: ScanCompletedPayload<any>, tabId: number): void {
+    private onAssessmentScanCompleted = (payload: ScanCompletedPayload<any>, tabId: number): void => {
         this.assessmentActions.updateTargetTabId.invoke(tabId);
         this.assessmentActions.scanCompleted.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onGetAssessmentCurrentState(): void {
+    private onGetAssessmentCurrentState = (): void => {
         this.assessmentActions.getCurrentState.invoke(null);
-    }
+    };
 
-    @autobind
-    private onSelectTestStep(payload: SelectRequirementPayload): void {
+    private onSelectTestStep = (payload: SelectRequirementPayload): void => {
         this.assessmentActions.selectRequirement.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.SELECT_REQUIREMENT, payload);
-    }
+    };
 
-    @autobind
-    private onScanUpdate(payload: ScanUpdatePayload): void {
+    private onScanUpdate = (payload: ScanUpdatePayload): void => {
         const telemetryEventName = 'ScanUpdate' + capitalize(payload.key);
         this.telemetryEventHandler.publishTelemetry(telemetryEventName, payload);
         this.assessmentActions.scanUpdate.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onTrackingCompleted(payload: ScanBasePayload): void {
+    private onTrackingCompleted = (payload: ScanBasePayload): void => {
         const telemetryEventName = 'TrackingCompleted' + capitalize(payload.key);
         this.telemetryEventHandler.publishTelemetry(telemetryEventName, payload);
         this.assessmentActions.trackingCompleted.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onPivotChildSelected(payload: OnDetailsViewOpenPayload): void {
+    private onPivotChildSelected = (payload: OnDetailsViewOpenPayload): void => {
         this.assessmentActions.updateSelectedPivotChild.invoke(payload);
-    }
+    };
 }

--- a/src/background/chrome-command-handler.ts
+++ b/src/background/chrome-command-handler.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { DisplayableStrings } from '../common/constants/displayable-strings';
 import { createDefaultLogger } from '../common/logging/default-logger';
@@ -43,8 +41,7 @@ export class ChromeCommandHandler {
         this.commandsAdapter.addCommandListener(this.onCommand);
     }
 
-    @autobind
-    private async onCommand(commandId: string): Promise<void> {
+    private onCommand = async (commandId: string): Promise<void> => {
         try {
             if (this.userConfigurationStore.getState().isFirstTime) {
                 // Avoid launching functionality until a user has decided whether to allow telemetry
@@ -92,7 +89,7 @@ export class ChromeCommandHandler {
         } catch (err) {
             this.logger.error('Error occurred at chrome command handler:', err);
         }
-    }
+    };
 
     private async checkAccessUrl(): Promise<boolean> {
         return await this.urlValidator.isSupportedUrl(this.targetTabUrl);

--- a/src/background/completed-test-step-telemetry-creator.ts
+++ b/src/background/completed-test-step-telemetry-creator.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as _ from 'lodash';
 
 import { AssessmentsProvider } from '../assessments/types/assessments-provider';
@@ -37,11 +36,10 @@ export class CompletedTestStepTelemetryCreator {
         this.store.addChangedListener(this.onAssessmentChange);
     }
 
-    @autobind
-    private onAssessmentChange(): void {
+    private onAssessmentChange = (): void => {
         this.provider.all().some(assessment => this.sendTelemetryIfNewCompletedTestStep(assessment));
         this.updateOldTestStatusState();
-    }
+    };
 
     private sendTelemetryIfNewCompletedTestStep(assessment: Assessment): boolean {
         const completedStep = assessment.requirements.find(step => this.isNewCompletedTestStep(assessment, step));

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { DictionaryStringTo } from '../types/common-types';
 import { BrowserAdapter } from './browser-adapters/browser-adapter';
 
@@ -33,8 +31,7 @@ export class DetailsViewController {
         });
     }
 
-    @autobind
-    private onUpdateTab(tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab): void {
+    private onUpdateTab = (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab): void => {
         const targetTabId = this.getTargetTabIdForDetailsTabId(tabId);
 
         if (targetTabId == null) {
@@ -47,7 +44,7 @@ export class DetailsViewController {
                 this._detailsViewRemovedHandler(targetTabId);
             }
         }
-    }
+    };
 
     private hasUrlChange(changeInfo: chrome.tabs.TabChangeInfo, targetTabId): boolean {
         return (
@@ -79,8 +76,7 @@ export class DetailsViewController {
         return null;
     }
 
-    @autobind
-    private onRemoveTab(tabId: number, removeInfo: chrome.tabs.TabRemoveInfo): void {
+    private onRemoveTab = (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo): void => {
         if (this._tabIdToDetailsViewMap[tabId]) {
             delete this._tabIdToDetailsViewMap[tabId];
         } else {
@@ -92,5 +88,5 @@ export class DetailsViewController {
                 }
             }
         }
-    }
+    };
 }

--- a/src/background/global-action-creators/global-action-creator.ts
+++ b/src/background/global-action-creators/global-action-creator.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { Messages } from '../../common/messages';
 import * as TelemetryEvents from '../../common/telemetry-events';
 import { PayloadWithEventName, SetLaunchPanelState } from '../actions/action-payloads';
@@ -47,8 +46,7 @@ export class GlobalActionCreator {
         this.interpreter.registerTypeToPayloadCallback(Messages.Telemetry.Send, this.onSendTelemetry);
     }
 
-    @autobind
-    private onGetCommands(payload, tabId: number): void {
+    private onGetCommands = (payload, tabId: number): void => {
         this.commandsAdapter.getCommands((commands: chrome.commands.Command[]) => {
             const getCommandsPayload: GetCommandsPayload = {
                 commands: commands,
@@ -56,37 +54,31 @@ export class GlobalActionCreator {
             };
             this.commandActions.getCommands.invoke(getCommandsPayload);
         });
-    }
+    };
 
-    @autobind
-    private onGetFeatureFlags(payload, tabId: number): void {
+    private onGetFeatureFlags = (payload, tabId: number): void => {
         this.featureFlagActions.getCurrentState.invoke(null);
-    }
+    };
 
-    @autobind
-    private onSetFeatureFlags(payload): void {
+    private onSetFeatureFlags = (payload): void => {
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PREVIEW_FEATURES_TOGGLE, payload);
         this.featureFlagActions.setFeatureFlag.invoke(payload);
-    }
+    };
 
-    @autobind
-    private onResetFeatureFlags(payload, tabId: number): void {
+    private onResetFeatureFlags = (payload, tabId: number): void => {
         this.featureFlagActions.resetFeatureFlags.invoke(null);
-    }
+    };
 
-    @autobind
-    private onGetLaunchPanelState(): void {
+    private onGetLaunchPanelState = (): void => {
         this.launchPanelStateActions.getCurrentState.invoke(null);
-    }
+    };
 
-    @autobind
-    private onSetLaunchPanelState(payload: SetLaunchPanelState): void {
+    private onSetLaunchPanelState = (payload: SetLaunchPanelState): void => {
         this.launchPanelStateActions.setLaunchPanelType.invoke(payload.launchPanelType);
-    }
+    };
 
-    @autobind
-    private onSendTelemetry(payload: PayloadWithEventName): void {
+    private onSendTelemetry = (payload: PayloadWithEventName): void => {
         const eventName = payload.eventName;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
-    }
+    };
 }

--- a/src/background/injector-controller.ts
+++ b/src/background/injector-controller.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { InspectMode } from '../background/inspect-modes';
 import { Messages } from '../common/messages';
 import { WindowUtils } from '../common/window-utils';
@@ -43,8 +41,7 @@ export class InjectorController {
         this._inspectStore.addChangedListener(this.inject);
     }
 
-    @autobind
-    private inject(): void {
+    private inject = (): void => {
         const tabId: number = this._tabStore.getState().id;
         const visualizationStoreState = this._visualizationStore.getState();
         const inspectStoreState = this._inspectStore.getState();
@@ -71,5 +68,5 @@ export class InjectorController {
         }
 
         this._oldInspectType = inspectStoreState.inspectMode;
-    }
+    };
 }

--- a/src/background/interpreter.ts
+++ b/src/background/interpreter.ts
@@ -1,16 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { InterpreterMessage, PayloadCallback } from '../common/message';
 import { DictionaryStringTo } from '../types/common-types';
 
 export class Interpreter {
     protected messageToActionMapping: DictionaryStringTo<PayloadCallback> = {};
 
-    @autobind
-    public registerTypeToPayloadCallback(messageType: string, callback: PayloadCallback): void {
+    public registerTypeToPayloadCallback = (messageType: string, callback: PayloadCallback): void => {
         this.messageToActionMapping[messageType] = callback;
-    }
+    };
 
     public interpret(message: InterpreterMessage): boolean {
         if (this.messageToActionMapping[message.messageType]) {

--- a/src/background/message-distributor.ts
+++ b/src/background/message-distributor.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { createDefaultLogger } from '../common/logging/default-logger';
 import { Logger } from '../common/logging/logger';
 import { InterpreterMessage } from '../common/message';
@@ -25,8 +24,7 @@ export class MessageDistributor {
         this.browserAdapter.addListenerOnMessage(this.distributeMessage);
     }
 
-    @autobind
-    private distributeMessage(message: InterpreterMessage, sender?: Sender): void {
+    private distributeMessage = (message: InterpreterMessage, sender?: Sender): void => {
         message.tabId = this.getTabId(message, sender);
 
         const isInterpretedUsingGlobalContext = this.globalContext.interpreter.interpret(message);
@@ -35,7 +33,7 @@ export class MessageDistributor {
         if (!isInterpretedUsingGlobalContext && !isInterpretedUsingTabContext) {
             this.logger.log('Unable to interpret message - ', message);
         }
-    }
+    };
 
     private getTabId(message: InterpreterMessage, sender?: Sender): number {
         if (message != null && message.tabId != null) {

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { forEach, isEmpty } from 'lodash';
 
 import { AssessmentsProvider } from '../../assessments/types/assessments-provider';
@@ -137,29 +136,25 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         );
     }
 
-    @autobind
-    private onContinuePreviousAssessment(tabId: number): void {
+    private onContinuePreviousAssessment = (tabId: number): void => {
         this.updateTargetTabWithId(tabId);
-    }
+    };
 
-    @autobind
-    private onUpdateTargetTabId(tabId: number): void {
+    private onUpdateTargetTabId = (tabId: number): void => {
         if (this.state.persistedTabInfo == null || this.state.persistedTabInfo.id !== tabId) {
             this.updateTargetTabWithId(tabId);
         }
-    }
+    };
 
-    @autobind
-    private onUpdateSelectedTest(payload: UpdateSelectedDetailsViewPayload): void {
+    private onUpdateSelectedTest = (payload: UpdateSelectedDetailsViewPayload): void => {
         if (payload.pivotType === DetailsViewPivotType.assessment && payload.detailsViewType != null) {
             this.state.assessmentNavState.selectedTestType = payload.detailsViewType;
             this.state.assessmentNavState.selectedTestStep = this.getDefaultTestStepForTest(payload.detailsViewType);
             this.emitChanged();
         }
-    }
+    };
 
-    @autobind
-    private onTrackingCompleted(payload: ScanBasePayload): void {
+    private onTrackingCompleted = (payload: ScanBasePayload): void => {
         const test = payload.testType;
         const step = payload.key;
         const config = this.assessmentsProvider.forType(test).getVisualizationConfiguration();
@@ -167,10 +162,9 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.assessmentDataRemover.deleteDataFromGeneratedMapWithStepKey(assessmentData.generatedAssessmentInstancesMap, step);
 
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onPassUnmarkedInstances(payload: AssessmentActionInstancePayload): void {
+    private onPassUnmarkedInstances = (payload: AssessmentActionInstancePayload): void => {
         const config = this.assessmentsProvider.forType(payload.test).getVisualizationConfiguration();
         const assessmentData = config.getAssessmentData(this.state);
         forEach(Object.keys(assessmentData.generatedAssessmentInstancesMap), key => {
@@ -183,10 +177,9 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
 
         this.updateTestStepStatusForGeneratedInstances(assessmentData, payload.requirement);
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onEditFailureInstance(payload: EditFailureInstancePayload): void {
+    private onEditFailureInstance = (payload: EditFailureInstancePayload): void => {
         const config = this.assessmentsProvider.forType(payload.test).getVisualizationConfiguration();
         const assessmentData = config.getAssessmentData(this.state);
         const instances = assessmentData.manualTestStepResultMap[payload.requirement].instances;
@@ -199,10 +192,9 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         }
 
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onRemoveFailureInstance(payload: RemoveFailureInstancePayload): void {
+    private onRemoveFailureInstance = (payload: RemoveFailureInstancePayload): void => {
         const config = this.assessmentsProvider.forType(payload.test).getVisualizationConfiguration();
         const assessmentData = config.getAssessmentData(this.state);
         assessmentData.manualTestStepResultMap[payload.requirement].instances = assessmentData.manualTestStepResultMap[
@@ -213,10 +205,9 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.updateManualTestStepStatus(assessmentData, payload.requirement, payload.test);
 
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onAddFailureInstance(payload: AddFailureInstancePayload): void {
+    private onAddFailureInstance = (payload: AddFailureInstancePayload): void => {
         const config = this.assessmentsProvider.forType(payload.test).getVisualizationConfiguration();
         const assessmentData = config.getAssessmentData(this.state);
         const newInstance: UserCapturedInstance = this.assessmentDataConverter.generateFailureInstance(payload.description);
@@ -224,16 +215,14 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.updateManualTestStepStatus(assessmentData, payload.requirement, payload.test);
 
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onAddResultDescription(payload: AddResultDescriptionPayload): void {
+    private onAddResultDescription = (payload: AddResultDescriptionPayload): void => {
         this.state.resultDescription = payload.description;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onChangeAssessmentVisualizationStateForAll(payload: ChangeInstanceSelectionPayload): void {
+    private onChangeAssessmentVisualizationStateForAll = (payload: ChangeInstanceSelectionPayload): void => {
         const config = this.assessmentsProvider.forType(payload.test).getVisualizationConfiguration();
         const assessmentDataMap = config.getAssessmentData(this.state).generatedAssessmentInstancesMap;
         forEach(assessmentDataMap, val => {
@@ -245,10 +234,9 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         });
 
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onChangeStepStatus(payload: ChangeRequirementStatusPayload): void {
+    private onChangeStepStatus = (payload: ChangeRequirementStatusPayload): void => {
         const config = this.assessmentsProvider.forType(payload.test).getVisualizationConfiguration();
         const assessmentData = config.getAssessmentData(this.state);
         assessmentData.manualTestStepResultMap[payload.requirement].status = payload.status;
@@ -259,20 +247,18 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
 
         this.updateManualTestStepStatus(assessmentData, payload.requirement, payload.test);
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onUndoStepStatusChange(payload: ChangeRequirementStatusPayload): void {
+    private onUndoStepStatusChange = (payload: ChangeRequirementStatusPayload): void => {
         const config = this.assessmentsProvider.forType(payload.test).getVisualizationConfiguration();
         const assessmentData = config.getAssessmentData(this.state);
         assessmentData.manualTestStepResultMap[payload.requirement].status = ManualTestStatus.UNKNOWN;
         assessmentData.manualTestStepResultMap[payload.requirement].instances = [];
         this.updateManualTestStepStatus(assessmentData, payload.requirement, payload.test);
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onChangeAssessmentVisualizationState(payload: ChangeInstanceSelectionPayload): void {
+    private onChangeAssessmentVisualizationState = (payload: ChangeInstanceSelectionPayload): void => {
         const config = this.assessmentsProvider.forType(payload.test).getVisualizationConfiguration();
         const assessmentData = config.getAssessmentData(this.state);
         const stepResult: TestStepResult =
@@ -280,10 +266,9 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         stepResult.isVisualizationEnabled = payload.isVisualizationEnabled;
 
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onUpdateInstanceVisibility(payload: UpdateVisibilityPayload): void {
+    private onUpdateInstanceVisibility = (payload: UpdateVisibilityPayload): void => {
         const step = this.state.assessmentNavState.selectedTestStep;
         payload.payloadBatch.forEach(updateInstanceVisibilityPayload => {
             const config = this.assessmentsProvider.forType(updateInstanceVisibilityPayload.test).getVisualizationConfiguration();
@@ -297,10 +282,9 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         });
 
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onUndoInstanceStatusChange(payload: AssessmentActionInstancePayload): void {
+    private onUndoInstanceStatusChange = (payload: AssessmentActionInstancePayload): void => {
         const config = this.assessmentsProvider.forType(payload.test).getVisualizationConfiguration();
         const assessmentData = config.getAssessmentData(this.state);
         const stepResult: TestStepResult =
@@ -309,10 +293,9 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         stepResult.originalStatus = null;
         this.updateTestStepStatusForGeneratedInstances(assessmentData, payload.requirement);
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onChangeInstanceStatus(payload: ChangeInstanceStatusPayload): void {
+    private onChangeInstanceStatus = (payload: ChangeInstanceStatusPayload): void => {
         const config = this.assessmentsProvider.forType(payload.test).getVisualizationConfiguration();
         const assessmentData = config.getAssessmentData(this.state);
         const stepResult: TestStepResult =
@@ -323,17 +306,15 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         stepResult.status = payload.status;
         this.updateTestStepStatusForGeneratedInstances(assessmentData, payload.requirement);
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onSelectTestStep(payload: SelectRequirementPayload): void {
+    private onSelectTestStep = (payload: SelectRequirementPayload): void => {
         this.state.assessmentNavState.selectedTestType = payload.selectedTest;
         this.state.assessmentNavState.selectedTestStep = payload.selectedRequirement;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onScanCompleted(payload: ScanCompletedPayload<any>): void {
+    private onScanCompleted = (payload: ScanCompletedPayload<any>): void => {
         const test = payload.testType;
         const step = payload.key;
         const config = this.assessmentsProvider.forType(test).getVisualizationConfiguration();
@@ -351,10 +332,9 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         assessmentData.testStepStatus[step].isStepScanned = true;
         this.updateTestStepStatusOnScanUpdate(assessmentData, step, test);
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onScanUpdate(payload: ScanUpdatePayload): void {
+    private onScanUpdate = (payload: ScanUpdatePayload): void => {
         const test = payload.testType;
         const step = payload.key;
         const config = this.assessmentsProvider.forType(test).getVisualizationConfiguration();
@@ -369,23 +349,21 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         assessmentData.generatedAssessmentInstancesMap = generatedAssessmentInstancesMap;
         this.updateTestStepStatusOnScanUpdate(assessmentData, step, test);
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onResetData(payload: ToggleActionPayload): void {
+    private onResetData = (payload: ToggleActionPayload): void => {
         const test = this.assessmentsProvider.forType(payload.test);
         const config = test.getVisualizationConfiguration();
         const defaultTestStatus: AssessmentData = config.getAssessmentData(this.generateDefaultState());
         this.state.assessments[test.key] = defaultTestStatus;
         this.state.assessmentNavState.selectedTestStep = test.requirements[0].key;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onResetAllAssessmentsData(targetTabId: number): void {
+    private onResetAllAssessmentsData = (targetTabId: number): void => {
         this.state = this.generateDefaultState();
         this.updateTargetTabWithId(targetTabId);
-    }
+    };
 
     private getDefaultTestStepForTest(testType: VisualizationType): string {
         return this.assessmentsProvider.forType(testType).requirements[0].key;

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { StoreNames } from '../../common/stores/store-names';
 import { CurrentPanel } from '../../common/types/store-data/current-panel';
 import { DetailsViewData } from '../../common/types/store-data/details-view-data';
@@ -55,8 +54,7 @@ export class DetailsViewStore extends BaseStoreImpl<DetailsViewData> {
         this.detailsViewActions.getCurrentState.addListener(this.onGetCurrentState);
     }
 
-    @autobind
-    private onOpen(flagName: keyof CurrentPanel, mutator?: (IDetailsViewData) => void): void {
+    private onOpen = (flagName: keyof CurrentPanel, mutator?: (IDetailsViewData) => void): void => {
         Object.keys(this.state.currentPanel).forEach(key => {
             this.state.currentPanel[key] = false;
         });
@@ -67,21 +65,19 @@ export class DetailsViewStore extends BaseStoreImpl<DetailsViewData> {
         }
 
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onClose(flagName: keyof CurrentPanel, mutator?: (IDetailsViewData) => void): void {
+    private onClose = (flagName: keyof CurrentPanel, mutator?: (IDetailsViewData) => void): void => {
         this.state.currentPanel[flagName] = false;
 
         if (mutator != null) {
             mutator(this.state);
         }
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onSetSelectedDetailsViewRightContentPanel(view: DetailsViewRightContentPanelType): void {
+    private onSetSelectedDetailsViewRightContentPanel = (view: DetailsViewRightContentPanelType): void => {
         this.state.detailsViewRightContentPanel = view;
         this.emitChanged();
-    }
+    };
 }

--- a/src/background/stores/dev-tools-store.ts
+++ b/src/background/stores/dev-tools-store.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { StoreNames } from '../../common/stores/store-names';
 import { DevToolState } from '../../common/types/store-data/idev-tool-state';
 import { DevToolActions } from '../actions/dev-tools-actions';
@@ -33,28 +31,25 @@ export class DevToolStore extends BaseStoreImpl<DevToolState> {
         this.devToolActions.getCurrentState.addListener(this.onGetCurrentState);
     }
 
-    @autobind
-    private onDevToolStatusChanged(status: boolean): void {
+    private onDevToolStatusChanged = (status: boolean): void => {
         if (this.state.isOpen !== status) {
             this.state.isOpen = status;
             this.state.frameUrl = null;
             this.state.inspectElement = null;
             this.emitChanged();
         }
-    }
+    };
 
-    @autobind
-    private onInspectElement(target: string[]): void {
+    private onInspectElement = (target: string[]): void => {
         this.state.inspectElement = target;
         this.state.frameUrl = null;
         // we're only using this to make sure the store proxy emit the change when the user inspect the same element twice
         this.state.inspectElementRequestId++;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onSetFrameUrl(frameUrl: string): void {
+    private onSetFrameUrl = (frameUrl: string): void => {
         this.state.frameUrl = frameUrl;
         this.emitChanged();
-    }
+    };
 }

--- a/src/background/stores/global/command-store.ts
+++ b/src/background/stores/global/command-store.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { StoreNames } from '../../../common/stores/store-names';
 import { ModifiedCommandsTelemetryData, SHORTCUT_MODIFIED } from '../../../common/telemetry-events';
 import { CommandStoreData } from '../../../common/types/store-data/command-store-data';
@@ -32,8 +30,7 @@ export class CommandStore extends BaseStoreImpl<CommandStoreData> {
         this.commandActions.getCommands.addListener(this.onGetCommands);
     }
 
-    @autobind
-    private onGetCommands(payload: GetCommandsPayload): void {
+    private onGetCommands = (payload: GetCommandsPayload): void => {
         const modifiedCommands: chrome.commands.Command[] = this.getModifiedCommands(payload.commands);
         if (modifiedCommands.length > 0) {
             const telemetry: ModifiedCommandsTelemetryData = {
@@ -47,7 +44,7 @@ export class CommandStore extends BaseStoreImpl<CommandStoreData> {
 
         this.state.commands = payload.commands;
         this.emitChanged();
-    }
+    };
 
     private getModifiedCommands(currentCommands: chrome.commands.Command[]): chrome.commands.Command[] {
         if (currentCommands.length !== this.state.commands.length) {

--- a/src/background/stores/global/feature-flag-store.ts
+++ b/src/background/stores/global/feature-flag-store.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { FeatureFlags, getDefaultFeatureFlagValues, getForceDefaultFlags } from '../../../common/feature-flags';
 import { StoreNames } from '../../../common/stores/store-names';
 import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-flag-store-data';
@@ -57,16 +55,14 @@ export class FeatureFlagStore extends BaseStoreImpl<FeatureFlagStoreData> {
         return initialState;
     }
 
-    @autobind
-    private onSetFeatureFlags(payload: FeatureFlagPayload): void {
+    private onSetFeatureFlags = (payload: FeatureFlagPayload): void => {
         this.state[payload.feature] = payload.enabled;
         this.storageAdapter.setUserData({ [LocalStorageDataKeys.featureFlags]: this.state });
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onResetFeatureFlags(): void {
+    private onResetFeatureFlags = (): void => {
         this.state = this.getDefaultState();
         this.emitChanged();
-    }
+    };
 }

--- a/src/background/stores/global/launch-panel-store.ts
+++ b/src/background/stores/global/launch-panel-store.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { StoreNames } from '../../../common/stores/store-names';
 import { LaunchPanelStoreData } from '../../../common/types/store-data/launch-panel-store-data';
 import { LaunchPanelType } from '../../../popup/components/popup-view';
@@ -37,10 +36,9 @@ export class LaunchPanelStore extends BaseStoreImpl<LaunchPanelStoreData> {
         this.launchPanelStateActions.getCurrentState.addListener(this.onGetCurrentState);
     }
 
-    @autobind
-    private onSetLaunchPanelType(panelType: LaunchPanelType): void {
+    private onSetLaunchPanelType = (panelType: LaunchPanelType): void => {
         this.state.launchPanelType = panelType;
         this.storageAdapter.setUserData({ [LocalStorageDataKeys.launchPanelSetting]: panelType });
         this.emitChanged();
-    }
+    };
 }

--- a/src/background/stores/global/scoping-store.ts
+++ b/src/background/stores/global/scoping-store.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as _ from 'lodash/index';
 
 import { StoreNames } from '../../../common/stores/store-names';
@@ -39,8 +38,7 @@ export class ScopingStore extends BaseStoreImpl<ScopingStoreData> {
         this.scopingActions.deleteSelector.addListener(this.onDeleteSelector);
     }
 
-    @autobind
-    private onAddSelector(payload: ScopingPayload): void {
+    private onAddSelector = (payload: ScopingPayload): void => {
         let shouldUpdate: boolean = true;
         _.forEach(Object.keys(this.state.selectors[payload.inputType]), key => {
             if (_.isEqual(this.state.selectors[payload.inputType][key], payload.selector)) {
@@ -52,15 +50,14 @@ export class ScopingStore extends BaseStoreImpl<ScopingStoreData> {
             this.state.selectors[payload.inputType].push(payload.selector);
             this.emitChanged();
         }
-    }
+    };
 
-    @autobind
-    private onDeleteSelector(payload: ScopingPayload): void {
+    private onDeleteSelector = (payload: ScopingPayload): void => {
         _.forEach(Object.keys(this.state.selectors[payload.inputType]), key => {
             if (_.isEqual(this.state.selectors[payload.inputType][key], payload.selector)) {
                 this.state.selectors[payload.inputType].splice(key, 1);
                 this.emitChanged();
             }
         });
-    }
+    };
 }

--- a/src/background/stores/global/user-configuration-store.ts
+++ b/src/background/stores/global/user-configuration-store.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { cloneDeep, isPlainObject } from 'lodash';
 import { IndexedDBAPI } from '../../../common/indexedDB/indexedDB';
 import { StoreNames } from '../../../common/stores/store-names';
@@ -52,27 +51,23 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
         this.userConfigActions.saveIssueFilingSettings.addListener(this.onSaveIssueSettings);
     }
 
-    @autobind
-    private onSetTelemetryState(payload: SetTelemetryStatePayload): void {
+    private onSetTelemetryState = (payload: SetTelemetryStatePayload): void => {
         this.state.isFirstTime = false;
         this.state.enableTelemetry = payload.enableTelemetry;
         this.saveAndEmitChanged();
-    }
+    };
 
-    @autobind
-    private onSetHighContrastMode(payload: SetHighContrastModePayload): void {
+    private onSetHighContrastMode = (payload: SetHighContrastModePayload): void => {
         this.state.enableHighContrast = payload.enableHighContrast;
         this.saveAndEmitChanged();
-    }
+    };
 
-    @autobind
-    private onSetIssueFilingService(payload: SetIssueFilingServicePayload): void {
+    private onSetIssueFilingService = (payload: SetIssueFilingServicePayload): void => {
         this.state.bugService = payload.issueFilingServiceName;
         this.saveAndEmitChanged();
-    }
+    };
 
-    @autobind
-    private onSetIssueFilingServiceProperty(payload: SetIssueFilingServicePropertyPayload): void {
+    private onSetIssueFilingServiceProperty = (payload: SetIssueFilingServicePropertyPayload): void => {
         if (!isPlainObject(this.state.bugServicePropertiesMap)) {
             this.state.bugServicePropertiesMap = {};
         }
@@ -83,15 +78,14 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
         this.state.bugServicePropertiesMap[payload.issueFilingServiceName][payload.propertyName] = payload.propertyValue;
 
         this.saveAndEmitChanged();
-    }
+    };
 
-    @autobind
-    private onSaveIssueSettings(payload: SaveIssueFilingSettingsPayload): void {
+    private onSaveIssueSettings = (payload: SaveIssueFilingSettingsPayload): void => {
         const bugService = payload.issueFilingServiceName;
         this.state.bugService = bugService;
         this.state.bugServicePropertiesMap[bugService] = payload.issueFilingSettings;
         this.saveAndEmitChanged();
-    }
+    };
 
     private saveAndEmitChanged(): void {
         // tslint:disable-next-line:no-floating-promises - grandfathered-in pre-existing violation

--- a/src/background/stores/inspect-store.ts
+++ b/src/background/stores/inspect-store.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { StoreNames } from '../../common/stores/store-names';
 import { InspectStoreData } from '../../common/types/store-data/inspect-store-data';
 import { InspectActions, InspectPayload } from '../actions/inspect-actions';
@@ -35,22 +34,19 @@ export class InspectStore extends BaseStoreImpl<InspectStoreData> {
         this.tabActions.tabChange.addListener(this.onTabChange);
     }
 
-    @autobind
-    private onChangeInspectMode(payload: InspectPayload): void {
+    private onChangeInspectMode = (payload: InspectPayload): void => {
         this.state.inspectMode = payload.inspectMode;
         this.state.hoveredOverSelector = null;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onSetHoveredOverSelector(payload: string[]): void {
+    private onSetHoveredOverSelector = (payload: string[]): void => {
         this.state.hoveredOverSelector = payload;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onTabChange(): void {
+    private onTabChange = (): void => {
         this.state = this.getDefaultState();
         this.emitChanged();
-    }
+    };
 }

--- a/src/background/stores/tab-store.ts
+++ b/src/background/stores/tab-store.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { Tab } from '../../common/itab.d';
 import { StoreNames } from '../../common/stores/store-names';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
@@ -46,42 +44,37 @@ export class TabStore extends BaseStoreImpl<TabStoreData> {
         this.visualizationActions.updateSelectedPivot.addListener(this.resetTabChange);
     }
 
-    @autobind
-    private onVisibilityChange(hidden: boolean): void {
+    private onVisibilityChange = (hidden: boolean): void => {
         if (this.state.isPageHidden === hidden) {
             return;
         }
         this.state.isPageHidden = hidden;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onTabUpdate(payload: Tab): void {
+    private onTabUpdate = (payload: Tab): void => {
         this.state.id = payload.id;
         this.state.title = payload.title;
         this.state.url = payload.url;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onTabRemove(): void {
+    private onTabRemove = (): void => {
         this.state.isClosed = true;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onTabChange(payload: Tab): void {
+    private onTabChange = (payload: Tab): void => {
         this.state.title = payload.title;
         this.state.url = payload.url;
         this.state.isChanged = true;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private resetTabChange(): void {
+    private resetTabChange = (): void => {
         if (this.state.isChanged) {
             this.state.isChanged = false;
             this.emitChanged();
         }
-    }
+    };
 }

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { forOwn } from 'lodash';
 import * as _ from 'lodash';
 import { StoreNames } from '../../common/stores/store-names';
@@ -58,14 +57,12 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         this.tabActions.tabChange.addListener(this.onTabChange);
     }
 
-    @autobind
-    private onTabStopsDisabled(): void {
+    private onTabStopsDisabled = (): void => {
         this.state.tabStops.tabbedElements = null;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onAddTabbedElement(payload: AddTabbedElementPayload): void {
+    private onAddTabbedElement = (payload: AddTabbedElementPayload): void => {
         if (!this.state.tabStops.tabbedElements) {
             this.state.tabStops.tabbedElements = [];
         }
@@ -91,10 +88,9 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         });
 
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onScanCompleted(payload: ScanCompletedPayload<any>): void {
+    private onScanCompleted = (payload: ScanCompletedPayload<any>): void => {
         const selectorMap = payload.selectorMap;
         const result = payload.scanResult;
         const selectedRows = this.getRowToRuleResultMap(selectorMap);
@@ -106,10 +102,9 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         this.state[payload.key].scanResult = result;
 
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onUpdateIssuesSelectedTargets(selected: string[]): void {
+    private onUpdateIssuesSelectedTargets = (selected: string[]): void => {
         const newSelectedRows: DictionaryStringTo<DecoratedAxeNodeResult> = {};
 
         selected.forEach(uid => {
@@ -123,19 +118,17 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         this.state.issues.selectedAxeResultsMap = this.getSelectorMap(newSelectedRows);
         this.state.issues.selectedIdToRuleResultMap = newSelectedRows;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onIssuesDisabled(): void {
+    private onIssuesDisabled = (): void => {
         this.state.issues.scanResult = null;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onTabChange(): void {
+    private onTabChange = (): void => {
         this.state = this.getDefaultState();
         this.emitChanged();
-    }
+    };
 
     private getRowToRuleResultMap(selectorMap: DictionaryStringTo<HtmlElementAxeResults>): DictionaryStringTo<DecoratedAxeNodeResult> {
         const selectedRows: DictionaryStringTo<DecoratedAxeNodeResult> = {};

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { TestMode } from '../../common/configs/test-mode';
 import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
@@ -91,12 +89,11 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
         return defaultValues;
     }
 
-    @autobind
-    private onDisableVisualization(test: VisualizationType): void {
+    private onDisableVisualization = (test: VisualizationType): void => {
         if (this.toggleTestOff(test)) {
             this.emitChanged();
         }
-    }
+    };
 
     private toggleTestOff(test: VisualizationType): boolean {
         let isStateChanged = false;
@@ -126,8 +123,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
         return isStateChanged;
     }
 
-    @autobind
-    private onTabChange(payload: Tab): void {
+    private onTabChange = (payload: Tab): void => {
         this.state = {
             ...this.getDefaultState(),
             selectedFastPassDetailsView: this.state.selectedFastPassDetailsView,
@@ -135,7 +131,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
             selectedDetailsViewPivot: this.state.selectedDetailsViewPivot,
         };
         this.emitChanged();
-    }
+    };
 
     private disableAssessmentVisualizationsWithoutEmitting(): void {
         EnumHelper.getNumericValues(VisualizationType).forEach((test: number) => {
@@ -147,21 +143,18 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
         });
     }
 
-    @autobind
-    private onDisableAssessmentVisualizations(): void {
+    private onDisableAssessmentVisualizations = (): void => {
         this.disableAssessmentVisualizationsWithoutEmitting();
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onEnableVisualization(payload: ToggleActionPayload): void {
+    private onEnableVisualization = (payload: ToggleActionPayload): void => {
         this.enableTest(payload, false);
-    }
+    };
 
-    @autobind
-    private onEnableVisualizationWithoutScan(payload: ToggleActionPayload): void {
+    private onEnableVisualizationWithoutScan = (payload: ToggleActionPayload): void => {
         this.enableTest(payload, true);
-    }
+    };
 
     private enableTest(payload: ToggleActionPayload, skipScanning: boolean): void {
         if (this.state.scanning != null) {
@@ -190,8 +183,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
         return config.testMode === TestMode.Assessments;
     }
 
-    @autobind
-    private onUpdateSelectedPivot(payload: UpdateSelectedPivot): void {
+    private onUpdateSelectedPivot = (payload: UpdateSelectedPivot): void => {
         const pivot = payload.pivotKey;
 
         if (this.state.selectedDetailsViewPivot !== pivot) {
@@ -199,7 +191,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
             this.disableAllTests();
             this.emitChanged();
         }
-    }
+    };
 
     private disableAllTests(): void {
         EnumHelper.getNumericValues(VisualizationType).forEach((test: VisualizationType) => {
@@ -207,8 +199,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
         });
     }
 
-    @autobind
-    private onUpdateSelectedPivotChild(payload: UpdateSelectedDetailsViewPayload): void {
+    private onUpdateSelectedPivotChild = (payload: UpdateSelectedDetailsViewPayload): void => {
         const pivot = payload.pivotType;
         const pivotChildUpdated = this.updateSelectedPivotChildUnderPivot(payload);
         const pivotUpdated = this.updateSelectedPivot(pivot);
@@ -216,35 +207,30 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
             this.disableAllTests();
             this.emitChanged();
         }
-    }
+    };
 
-    @autobind
-    private onScanCompleted(): void {
+    private onScanCompleted = (): void => {
         this.state.scanning = null;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onScrollRequested(): void {
+    private onScrollRequested = (): void => {
         this.state.focusedTarget = null;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private onUpdateFocusedInstance(focusedInstanceTarget: string[]): void {
+    private onUpdateFocusedInstance = (focusedInstanceTarget: string[]): void => {
         this.state.focusedTarget = focusedInstanceTarget;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private injectionCompleted(): void {
+    private injectionCompleted = (): void => {
         this.state.injectingInProgress = false;
         this.state.injectingStarted = false;
         this.emitChanged();
-    }
+    };
 
-    @autobind
-    private injectionStarted(): void {
+    private injectionStarted = (): void => {
         if (this.state.injectingStarted) {
             return;
         }
@@ -252,7 +238,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
         this.state.injectingInProgress = true;
         this.state.injectingStarted = true;
         this.emitChanged();
-    }
+    };
 
     private updateSelectedPivotChildUnderPivot(payload: UpdateSelectedDetailsViewPayload): boolean {
         let updated = false;

--- a/src/background/tab-context-broadcaster.ts
+++ b/src/background/tab-context-broadcaster.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { StoreUpdateMessage } from '../common/types/store-update-message';
 
 export class TabContextBroadcaster {
@@ -11,11 +9,10 @@ export class TabContextBroadcaster {
         this._sendMessageToFramesAndTab = sendMessageToFramesAndTabDelegate;
     }
 
-    @autobind
-    public getBroadcastMessageDelegate(tabId): (message: StoreUpdateMessage<any>) => void {
+    public getBroadcastMessageDelegate = (tabId): ((message: StoreUpdateMessage<any>) => void) => {
         return message => {
             message.tabId = tabId;
             this._sendMessageToFramesAndTab(tabId, message);
         };
-    }
+    };
 }

--- a/src/background/tab-controller.ts
+++ b/src/background/tab-controller.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { Message } from '../common/message';
 import { Messages } from '../common/messages';
 import { Logger } from './../common/logging/logger';
@@ -55,15 +54,13 @@ export class TabController {
         this.detailsViewController.setupDetailsViewTabRemovedHandler(this.onDetailsViewTabRemoved);
     }
 
-    @autobind
-    private onTabNavigated(details: chrome.webNavigation.WebNavigationFramedCallbackDetails): void {
+    private onTabNavigated = (details: chrome.webNavigation.WebNavigationFramedCallbackDetails): void => {
         if (details.frameId === 0) {
             this.handleTabUpdate(details.tabId);
         }
-    }
+    };
 
-    @autobind
-    private onTabActivated(activeInfo: chrome.tabs.TabActiveInfo): void {
+    private onTabActivated = (activeInfo: chrome.tabs.TabActiveInfo): void => {
         const activeTabId = activeInfo.tabId;
         const windowId = activeInfo.windowId;
 
@@ -76,10 +73,9 @@ export class TabController {
                 }
             });
         });
-    }
+    };
 
-    @autobind
-    private onWindowFocusChanged(windowId: number): void {
+    private onWindowFocusChanged = (windowId: number): void => {
         this.chromeAdapter.getAllWindows(
             { populate: false, windowTypes: ['normal', 'popup'] },
             (chromeWindows: chrome.windows.Window[]) => {
@@ -94,17 +90,16 @@ export class TabController {
                 });
             },
         );
-    }
+    };
 
-    @autobind
-    private handleTabUpdate(tabId: number): void {
+    private handleTabUpdate = (tabId: number): void => {
         if (this.hasTabContext(tabId)) {
             this.sendTabChangedAction(tabId);
         } else {
             this.addTabContext(tabId);
             this.sendTabUpdateAction(tabId);
         }
-    }
+    };
 
     private hasTabContext(tabId: number): boolean {
         return tabId in this.tabIdToContextMap;
@@ -179,8 +174,7 @@ export class TabController {
         );
     }
 
-    @autobind
-    private onTabRemoved(tabId: number, messageType: string): void {
+    private onTabRemoved = (tabId: number, messageType: string): void => {
         const tabContext = this.tabIdToContextMap[tabId];
         if (tabContext) {
             const interpreter = tabContext.interpreter;
@@ -190,16 +184,14 @@ export class TabController {
                 tabId: tabId,
             });
         }
-    }
+    };
 
-    @autobind
-    private onTargetTabRemoved(tabId: number): void {
+    private onTargetTabRemoved = (tabId: number): void => {
         this.onTabRemoved(tabId, Messages.Tab.Remove);
         delete this.tabIdToContextMap[tabId];
-    }
+    };
 
-    @autobind
-    private onDetailsViewTabRemoved(tabId: number): void {
+    private onDetailsViewTabRemoved = (tabId: number): void => {
         this.onTabRemoved(tabId, Messages.Visualizations.DetailsView.Close);
-    }
+    };
 }

--- a/src/background/telemetry/telemetry-state-listener.ts
+++ b/src/background/telemetry/telemetry-state-listener.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { UserConfigurationStore } from '../stores/global/user-configuration-store';
 import { TelemetryEventHandler } from './telemetry-event-handler';
 
@@ -13,12 +11,11 @@ export class TelemetryStateListener {
         this.onStateChanged();
     }
 
-    @autobind
-    private onStateChanged(): void {
+    private onStateChanged = (): void => {
         if (this.userConfigStore.getState().enableTelemetry) {
             this.telemetryEventHandler.enableTelemetry();
         } else {
             this.telemetryEventHandler.disableTelemetry();
         }
-    }
+    };
 }

--- a/src/common/a11y-self-validator.ts
+++ b/src/common/a11y-self-validator.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { ScannerUtils } from '../injected/scanner-utils';
 import { ScanResults } from '../scanner/iruleresults';
 import { HTMLElementUtils } from './html-element-utils';
@@ -30,8 +28,7 @@ export class A11YSelfValidator {
         this.scannerUtils.scan(null, this.logAxeResults);
     }
 
-    @autobind
-    private logAxeResults(axeResults: ScanResults): void {
+    private logAxeResults = (axeResults: ScanResults): void => {
         const violations = axeResults.violations;
         const loggedViolations: LoggedRule[] = [];
 
@@ -54,5 +51,5 @@ export class A11YSelfValidator {
         }
 
         this.logger.log(loggedViolations);
-    }
+    };
 }

--- a/src/common/components/collapsible-component.tsx
+++ b/src/common/components/collapsible-component.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind, css } from '@uifabric/utilities';
+import { css } from '@uifabric/utilities';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
@@ -24,11 +24,10 @@ export class CollapsibleComponent extends React.Component<CollapsibleComponentPr
         this.state = { showContent: true };
     }
 
-    @autobind
-    private onClick(): void {
+    private onClick = (): void => {
         const newState = !this.state.showContent;
         this.setState({ showContent: newState });
-    }
+    };
 
     public render(): JSX.Element {
         const showContent = this.state.showContent;

--- a/src/common/components/copy-issue-details-button.tsx
+++ b/src/common/components/copy-issue-details-button.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import * as CopyToClipboard from 'react-copy-to-clipboard';
@@ -41,13 +40,12 @@ export class CopyIssueDetailsButton extends React.Component<CopyIssueDetailsButt
         return this.props.deps.issueDetailsTextGenerator.buildText(data);
     }
 
-    @autobind
-    private copyButtonClicked(event: React.MouseEvent<any>): void {
+    private copyButtonClicked = (event: React.MouseEvent<any>): void => {
         if (this.props.onClick) {
             this.props.onClick(event);
         }
         this.setState({ showingCopyToast: true });
-    }
+    };
 
     public render(): JSX.Element {
         return (

--- a/src/common/components/issue-filing-button.tsx
+++ b/src/common/components/issue-filing-button.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
@@ -69,17 +68,15 @@ export class IssueFilingButton extends React.Component<IssueFilingButtonProps, I
         );
     }
 
-    @autobind
-    private closeNeedsSettingsContent(): void {
+    private closeNeedsSettingsContent = (): void => {
         this.setState({ showNeedsSettingsContent: false });
-    }
+    };
 
     private openNeedsSettingsContent(): void {
         this.setState({ showNeedsSettingsContent: true });
     }
 
-    @autobind
-    private onClickFileIssueButton(event: React.MouseEvent<any>): void {
+    private onClickFileIssueButton = (event: React.MouseEvent<any>): void => {
         const { issueDetailsData, userConfigurationStoreData, deps } = this.props;
         const { issueFilingServiceProvider, issueFilingActionMessageCreator } = deps;
 
@@ -95,5 +92,5 @@ export class IssueFilingButton extends React.Component<IssueFilingButtonProps, I
         } else {
             this.openNeedsSettingsContent();
         }
-    }
+    };
 }

--- a/src/common/components/selector-input-list.tsx
+++ b/src/common/components/selector-input-list.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as _ from 'lodash/index';
 import { DefaultButton, IconButton } from 'office-ui-fabric-react/lib/Button';
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
@@ -81,13 +80,11 @@ export class SelectorInputList extends React.Component<SelectorInputListProps, S
         );
     }
 
-    @autobind
-    protected setTextField(textField: ITextField): void {
+    protected setTextField = (textField: ITextField): void => {
         this.textField = textField;
-    }
+    };
 
-    @autobind
-    private onRenderCell(item: string[]): JSX.Element {
+    private onRenderCell = (item: string[]): JSX.Element => {
         return (
             <div className="selector-input-itemCell" data-is-focusable={true}>
                 <div className="selector-input-itemContent">
@@ -100,14 +97,13 @@ export class SelectorInputList extends React.Component<SelectorInputListProps, S
                 </div>
             </div>
         );
-    }
+    };
 
     private renderItemName(selector: string[]): string {
         return selector.join('; ');
     }
 
-    @autobind
-    private updateFieldValueValidState(event, textFieldValue: string): void {
+    private updateFieldValueValidState = (event, textFieldValue: string): void => {
         this.setState({
             value: textFieldValue,
         });
@@ -119,15 +115,14 @@ export class SelectorInputList extends React.Component<SelectorInputListProps, S
             });
 
         this.setState({ isTextFieldValueValid: selectorIsValid });
-    }
+    };
 
-    @autobind
-    private addSelector(event: React.MouseEvent<HTMLButtonElement>): void {
+    private addSelector = (event: React.MouseEvent<HTMLButtonElement>): void => {
         const selector = this.textField.value;
         this.props.onAddSelector(event, this.props.inputType, this.formatSelector(selector));
         this.restore();
         this.refocus();
-    }
+    };
 
     private formatSelector(selector: string): string[] {
         const formattedSelector: string[] = [];
@@ -142,31 +137,27 @@ export class SelectorInputList extends React.Component<SelectorInputListProps, S
         this.props.onDeleteSelector(event, this.props.inputType, item);
     }
 
-    @autobind
-    private getDeleteSelectorHandler(item: string[]): (event: React.MouseEvent<HTMLButtonElement>) => void {
+    private getDeleteSelectorHandler = (item: string[]): ((event: React.MouseEvent<HTMLButtonElement>) => void) => {
         return (event: React.MouseEvent<HTMLButtonElement>) => {
             this.deleteSelector(event, item);
         };
-    }
+    };
 
-    @autobind
-    private onChangeSelectorHandler(event: React.MouseEvent<HTMLButtonElement>): void {
+    private onChangeSelectorHandler = (event: React.MouseEvent<HTMLButtonElement>): void => {
         this.onChangeSelector(event, this.props.inspectMode);
-    }
+    };
 
     private onChangeSelector(event: React.MouseEvent<HTMLButtonElement>, inspectType: string): void {
         this.props.onChangeInspectMode(event, inspectType);
     }
 
-    @autobind
-    private restore(): void {
+    private restore = (): void => {
         this.setState({
             value: this.emptyStringInitialValue,
         });
-    }
+    };
 
-    @autobind
-    private refocus(): void {
+    private refocus = (): void => {
         this.textField.focus();
-    }
+    };
 }

--- a/src/common/configs/inspect-configuration-factory.ts
+++ b/src/common/configs/inspect-configuration-factory.ts
@@ -16,6 +16,14 @@ export class InspectConfigurationFactory {
         this.scopingActionMessageCreator = scopingActionMessageCreator;
     }
 
+    private addIncludeSelector = (event: MouseEvent, selector: string[]): void => {
+        this.scopingActionMessageCreator.addSelector(event, ScopingInputTypes.include, selector);
+    };
+
+    private addExcludeSelector = (event: MouseEvent, selector: string[]): void => {
+        this.scopingActionMessageCreator.addSelector(event, ScopingInputTypes.exclude, selector);
+    };
+
     private configurationByType: DictionaryStringTo<IInspectCallback> = {
         [InspectMode.scopingAddInclude]: this.addIncludeSelector,
         [InspectMode.scopingAddExclude]: this.addExcludeSelector,
@@ -30,12 +38,4 @@ export class InspectConfigurationFactory {
 
         return configuration;
     }
-
-    private addIncludeSelector = (event: MouseEvent, selector: string[]): void => {
-        this.scopingActionMessageCreator.addSelector(event, ScopingInputTypes.include, selector);
-    };
-
-    private addExcludeSelector = (event: MouseEvent, selector: string[]): void => {
-        this.scopingActionMessageCreator.addSelector(event, ScopingInputTypes.exclude, selector);
-    };
 }

--- a/src/common/configs/inspect-configuration-factory.ts
+++ b/src/common/configs/inspect-configuration-factory.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { InspectMode } from '../../background/inspect-modes';
 import { ScopingInputTypes } from '../../background/scoping-input-types';
 import { DictionaryStringTo } from '../../types/common-types';
@@ -32,13 +31,11 @@ export class InspectConfigurationFactory {
         return configuration;
     }
 
-    @autobind
-    private addIncludeSelector(event: MouseEvent, selector: string[]): void {
+    private addIncludeSelector = (event: MouseEvent, selector: string[]): void => {
         this.scopingActionMessageCreator.addSelector(event, ScopingInputTypes.include, selector);
-    }
+    };
 
-    @autobind
-    private addExcludeSelector(event: MouseEvent, selector: string[]): void {
+    private addExcludeSelector = (event: MouseEvent, selector: string[]): void => {
         this.scopingActionMessageCreator.addSelector(event, ScopingInputTypes.exclude, selector);
-    }
+    };
 }

--- a/src/common/dropdown-click-handler.ts
+++ b/src/common/dropdown-click-handler.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { DropdownActionMessageCreator } from './message-creators/dropdown-action-message-creator';
 import { TelemetryEventSource } from './telemetry-events';
 
@@ -14,18 +12,15 @@ export class DropdownClickHandler {
         this.dropdownActionMessageCreator = dropdownActionMessageCreator;
     }
 
-    @autobind
-    public openPreviewFeaturesPanelHandler(event: React.MouseEvent<HTMLElement>): void {
+    public openPreviewFeaturesPanelHandler = (event: React.MouseEvent<HTMLElement>): void => {
         this.dropdownActionMessageCreator.openPreviewFeaturesPanel(event, this.source);
-    }
+    };
 
-    @autobind
-    public openScopingPanelHandler(event: React.MouseEvent<HTMLElement>): void {
+    public openScopingPanelHandler = (event: React.MouseEvent<HTMLElement>): void => {
         this.dropdownActionMessageCreator.openScopingPanel(event, this.source);
-    }
+    };
 
-    @autobind
-    public openSettingsPanelHandler(event: React.MouseEvent<HTMLElement>): void {
+    public openSettingsPanelHandler = (event: React.MouseEvent<HTMLElement>): void => {
         this.dropdownActionMessageCreator.openSettingsPanel(event, this.source);
-    }
+    };
 }

--- a/src/common/message-creators/content-action-message-creator.ts
+++ b/src/common/message-creators/content-action-message-creator.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { BaseActionPayload } from '../../background/actions/action-payloads';
 import { ContentPayload } from '../../background/actions/content-actions';
 import { ActionInitiators } from '../action/action-initiator';
@@ -20,8 +19,7 @@ export class ContentActionMessageCreator {
         private readonly dispatcher: ActionMessageDispatcher,
     ) {}
 
-    @autobind
-    public openContentPage(event: React.MouseEvent<any> | MouseEvent, contentPath: string): void {
+    public openContentPage = (event: React.MouseEvent<any> | MouseEvent, contentPath: string): void => {
         const messageType = Messages.Telemetry.Send;
         const telemetry = this.telemetryFactory.withTriggeredByAndSource(event, this.source);
         const payload = {
@@ -33,10 +31,9 @@ export class ContentActionMessageCreator {
             messageType,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public openContentHyperLink(event: React.MouseEvent<any> | MouseEvent, href: string): void {
+    public openContentHyperLink = (event: React.MouseEvent<any> | MouseEvent, href: string): void => {
         const messageType = Messages.Telemetry.Send;
         const telemetry = this.telemetryFactory.withTriggeredByAndSource(event, this.source);
         const payload = {
@@ -47,10 +44,9 @@ export class ContentActionMessageCreator {
             messageType: messageType,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public openContentPanel(event: React.MouseEvent<HTMLElement> | MouseEvent, contentPath: string): void {
+    public openContentPanel = (event: React.MouseEvent<HTMLElement> | MouseEvent, contentPath: string): void => {
         const messageType = Messages.ContentPanel.OpenPanel;
         const telemetry = this.telemetryFactory.withTriggeredByAndSource(event, this.source);
         const payload: ContentPayload = {
@@ -62,10 +58,9 @@ export class ContentActionMessageCreator {
             messageType,
             payload,
         });
-    }
+    };
 
-    @autobind
-    public closeContentPanel(): void {
+    public closeContentPanel = (): void => {
         const messageType = Messages.ContentPanel.ClosePanel;
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: BaseActionPayload = {
@@ -76,10 +71,9 @@ export class ContentActionMessageCreator {
             messageType: messageType,
             payload,
         });
-    }
+    };
 
-    @autobind
-    private openExternalLink(event: React.MouseEvent<any> | MouseEvent, details: { href: string }): void {
+    private openExternalLink = (event: React.MouseEvent<any> | MouseEvent, details: { href: string }): void => {
         this.openContentHyperLink(event, details.href);
-    }
+    };
 }

--- a/src/common/message-creators/content-action-message-creator.ts
+++ b/src/common/message-creators/content-action-message-creator.ts
@@ -9,10 +9,6 @@ import { CONTENT_HYPERLINK_OPENED, CONTENT_PAGE_OPENED, TelemetryEventSource } f
 import { ActionMessageDispatcher } from './action-message-dispatcher';
 
 export class ContentActionMessageCreator {
-    public initiators: Pick<ActionInitiators, 'openExternalLink'> = {
-        openExternalLink: this.openExternalLink,
-    };
-
     constructor(
         private readonly telemetryFactory: TelemetryDataFactory,
         private readonly source: TelemetryEventSource,
@@ -75,5 +71,9 @@ export class ContentActionMessageCreator {
 
     private openExternalLink = (event: React.MouseEvent<any> | MouseEvent, details: { href: string }): void => {
         this.openContentHyperLink(event, details.href);
+    };
+
+    public initiators: Pick<ActionInitiators, 'openExternalLink'> = {
+        openExternalLink: this.openExternalLink,
     };
 }

--- a/src/common/message-creators/inspect-action-message-creator.ts
+++ b/src/common/message-creators/inspect-action-message-creator.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { InspectMode } from '../../background/inspect-modes';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
@@ -15,8 +14,7 @@ export class InspectActionMessageCreator {
         private readonly dispatcher: ActionMessageDispatcher,
     ) {}
 
-    @autobind
-    public changeInspectMode(event: React.MouseEvent<HTMLElement> | MouseEvent, inspectMode: InspectMode): void {
+    public changeInspectMode = (event: React.MouseEvent<HTMLElement> | MouseEvent, inspectMode: InspectMode): void => {
         const messageType = Messages.Inspect.ChangeInspectMode;
         const telemetry = this.telemetryFactory.withTriggeredByAndSource(event, this.source);
         const payload: InspectPayload = {
@@ -27,5 +25,5 @@ export class InspectActionMessageCreator {
             messageType: messageType,
             payload: payload,
         });
-    }
+    };
 }

--- a/src/common/message-creators/scoping-action-message-creator.ts
+++ b/src/common/message-creators/scoping-action-message-creator.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
 import { ScopingPayload } from './../../background/actions/scoping-actions';
@@ -14,8 +13,7 @@ export class ScopingActionMessageCreator {
         private readonly dispatcher: ActionMessageDispatcher,
     ) {}
 
-    @autobind
-    public addSelector(event: React.MouseEvent<HTMLElement> | MouseEvent, inputType: string, selector: string[]): void {
+    public addSelector = (event: React.MouseEvent<HTMLElement> | MouseEvent, inputType: string, selector: string[]): void => {
         const messageType = Messages.Scoping.AddSelector;
         const telemetry = this.telemetryFactory.forAddSelector(event, inputType, this.source);
         const payload: ScopingPayload = {
@@ -28,10 +26,9 @@ export class ScopingActionMessageCreator {
             messageType: messageType,
             payload: payload,
         });
-    }
+    };
 
-    @autobind
-    public deleteSelector(event: React.MouseEvent<HTMLElement> | MouseEvent, inputType: string, selector: string[]): void {
+    public deleteSelector = (event: React.MouseEvent<HTMLElement> | MouseEvent, inputType: string, selector: string[]): void => {
         const messageType = Messages.Scoping.DeleteSelector;
         const telemetry = this.telemetryFactory.forDeleteSelector(event, inputType, this.source);
         const payload: ScopingPayload = {
@@ -44,5 +41,5 @@ export class ScopingActionMessageCreator {
             messageType: messageType,
             payload: payload,
         });
-    }
+    };
 }

--- a/src/common/state-dispatcher.ts
+++ b/src/common/state-dispatcher.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { StoreHub } from '../background/stores/store-hub';
 import { BaseStore } from './base-store';
 import { GenericStoreMessageTypes } from './constants/generic-store-messages-types';
@@ -25,8 +24,7 @@ export class StateDispatcher {
         dispatchStateUpdateDelegate();
     }
 
-    @autobind
-    private getDispatchStateUpdateEvent(store: BaseStore<any>): () => void {
+    private getDispatchStateUpdateEvent = (store: BaseStore<any>): (() => void) => {
         return () => {
             this.broadcastMessage({
                 isStoreUpdateMessage: true,
@@ -36,5 +34,5 @@ export class StateDispatcher {
                 payload: store.getState(),
             });
         };
-    }
+    };
 }

--- a/src/common/store-proxy.ts
+++ b/src/common/store-proxy.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as _ from 'lodash';
 
 import { BaseStore } from './base-store';
@@ -23,8 +22,7 @@ export class StoreProxy<TState> extends Store implements BaseStore<TState> {
         this._clientChomeAdapter.addListenerOnMessage(this.onChange);
     }
 
-    @autobind
-    private onChange(message: StoreUpdateMessage<TState>): void {
+    private onChange = (message: StoreUpdateMessage<TState>): void => {
         if (!this.isValidMessage(message)) {
             return;
         }
@@ -33,7 +31,7 @@ export class StoreProxy<TState> extends Store implements BaseStore<TState> {
             this._state = message.payload;
             this.emitChanged();
         }
-    }
+    };
 
     private isValidMessage(message: StoreUpdateMessage<TState>): boolean {
         return (
@@ -53,10 +51,9 @@ export class StoreProxy<TState> extends Store implements BaseStore<TState> {
         return message.payload && message.storeId === this.getId();
     }
 
-    @autobind
-    public getState(): TState {
+    public getState = (): TState => {
         return this._state;
-    }
+    };
 
     public getId(): string {
         return this._storeId;

--- a/src/common/tabbable-elements-helper.ts
+++ b/src/common/tabbable-elements-helper.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { HTMLElementUtils } from './html-element-utils';
 
 export class TabbableElementsHelper {
@@ -11,15 +9,14 @@ export class TabbableElementsHelper {
         return this.htmlElementUtils.getCurrentFocusedElement();
     }
 
-    @autobind
-    private isVisible(element: HTMLElement): boolean {
+    private isVisible = (element: HTMLElement): boolean => {
         const style: CSSStyleDeclaration = this.htmlElementUtils.getComputedStyle(element);
         const offsetHeight = this.htmlElementUtils.getOffsetHeight(element);
         const offsetWidth = this.htmlElementUtils.getOffsetWidth(element);
         const clientRects = this.htmlElementUtils.getClientRects(element);
         const result = style.visibility !== 'hidden' && style.display !== 'none' && offsetHeight && offsetWidth && clientRects.length > 0;
         return result;
-    }
+    };
 
     public getAncestorMap(element: HTMLElement): HTMLMapElement {
         if (!element.parentElement || element.parentNode instanceof Document) {

--- a/src/injected/analyzer-controller.ts
+++ b/src/injected/analyzer-controller.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { AssessmentsProvider } from '../assessments/types/assessments-provider';
 import { BaseStore } from '../common/base-store';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -52,26 +51,23 @@ export class AnalyzerController {
         this.onChangedState();
     }
 
-    @autobind
-    private onChangedState(): void {
+    private onChangedState = (): void => {
         if (this.hasInitializedStores() === false) {
             return;
         }
 
         this.analyzerStateUpdateHandler.handleUpdate(this.visualizationstore.getState());
-    }
+    };
 
-    @autobind
-    protected teardown(id: string): void {
+    protected teardown = (id: string): void => {
         const analyzer = this.getAnalyzerByIdentifier(id);
         analyzer.teardown();
-    }
+    };
 
-    @autobind
-    protected startScan(id: string): void {
+    protected startScan = (id: string): void => {
         const analyzer = this.getAnalyzerByIdentifier(id);
         analyzer.analyze();
-    }
+    };
 
     private initializeAnalyzers(): void {
         EnumHelper.getNumericValues(VisualizationType).forEach((test: VisualizationType) => {

--- a/src/injected/analyzers/base-analyzer.ts
+++ b/src/injected/analyzers/base-analyzer.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as Q from 'q';
 
 import { Message } from '../../common/message';
@@ -34,15 +33,13 @@ export class BaseAnalyzer implements Analyzer {
 
     public teardown(): void {}
 
-    @autobind
-    protected getResults(): Q.Promise<AxeAnalyzerResult> {
+    protected getResults = (): Q.Promise<AxeAnalyzerResult> => {
         return Q(this.emptyResults);
-    }
+    };
 
-    @autobind
-    protected onResolve(analyzerResult: AxeAnalyzerResult): void {
+    protected onResolve = (analyzerResult: AxeAnalyzerResult): void => {
         this.sendMessage(this.createBaseMessage(analyzerResult, this.config));
-    }
+    };
 
     protected createBaseMessage(analyzerResult: AxeAnalyzerResult, config: AnalyzerConfiguration): Message {
         const messageType = config.analyzerMessageType;

--- a/src/injected/analyzers/batched-rule-analyzer.ts
+++ b/src/injected/analyzers/batched-rule-analyzer.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { BaseStore } from '../../common/base-store';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { TelemetryDataFactory } from '../../common/telemetry-data-factory';
@@ -34,8 +32,7 @@ export class BatchedRuleAnalyzer extends RuleAnalyzer {
         return null;
     }
 
-    @autobind
-    protected onResolve(results: AxeAnalyzerResult): void {
+    protected onResolve = (results: AxeAnalyzerResult): void => {
         BatchedRuleAnalyzer.batchConfigs.forEach(config => {
             const filteredScannerResult = this.postScanFilter(results.originalResult, config.rules);
             const processResults = config.resultProcessor(this.scanner);
@@ -46,5 +43,5 @@ export class BatchedRuleAnalyzer extends RuleAnalyzer {
             };
             this.sendScanCompleteResolveMessage(filteredAxeAnalyzerResult, config);
         });
-    }
+    };
 }

--- a/src/injected/analyzers/rule-analyzer.ts
+++ b/src/injected/analyzers/rule-analyzer.ts
@@ -29,7 +29,7 @@ export class RuleAnalyzer extends BaseAnalyzer {
         super(config, sendMessageDelegate);
     }
 
-    protected getResults(): Q.Promise<AxeAnalyzerResult> {
+    protected getResults = (): Q.Promise<AxeAnalyzerResult> => {
         const deferred = Q.defer<AxeAnalyzerResult>();
         const scopingState = this.scopingStore.getState().selectors;
         const include = scopingState[ScopingInputTypes.include];
@@ -57,7 +57,7 @@ export class RuleAnalyzer extends BaseAnalyzer {
         this.scanner.scan(scanOptions, scanCallback);
 
         return deferred.promise;
-    }
+    };
 
     protected getRulesToRun(): string[] {
         return this.config.rules;

--- a/src/injected/analyzers/rule-analyzer.ts
+++ b/src/injected/analyzers/rule-analyzer.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as Q from 'q';
 import { ScopingInputTypes } from '../../background/scoping-input-types';
 import { BaseStore } from '../../common/base-store';
@@ -64,10 +63,9 @@ export class RuleAnalyzer extends BaseAnalyzer {
         return this.config.rules;
     }
 
-    @autobind
-    protected onResolve(analyzerResult: AxeAnalyzerResult): void {
+    protected onResolve = (analyzerResult: AxeAnalyzerResult): void => {
         this.sendScanCompleteResolveMessage(analyzerResult, this.config);
-    }
+    };
 
     protected sendScanCompleteResolveMessage(analyzerResult: AxeAnalyzerResult, config: RuleAnalyzerConfiguration): void {
         const endTime = this.dateGetter().getTime();

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -39,7 +39,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         this.getResults().progress(this.onProgress);
     }
 
-    protected getResults(): Q.Promise<AxeAnalyzerResult> {
+    protected getResults = (): Q.Promise<AxeAnalyzerResult> => {
         this.deferred = Q.defer<AxeAnalyzerResult>();
         this.tabStopsListener.setTabEventListenerOnMainWindow((tabEvent: TabStopEvent) => {
             if (this._onTabbedTimeoutId != null) {
@@ -61,7 +61,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         this.tabStopsListener.startListenToTabStops();
         this.analyzerSetupComplete();
         return this.deferred.promise;
-    }
+    };
 
     private analyzerSetupComplete(): void {
         this.onResolve(this.emptyResults);

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as Q from 'q';
 import { WindowUtils } from '../../common/window-utils';
 import { TabStopEvent, TabStopsListener } from '../tab-stops-listener';
@@ -68,8 +67,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         this.onResolve(this.emptyResults);
     }
 
-    @autobind
-    protected onProgress(progressResult: ProgressResult<TabStopEvent[]>): void {
+    protected onProgress = (progressResult: ProgressResult<TabStopEvent[]>): void => {
         const payload: ScanUpdatePayload = {
             key: this.config.key,
             testType: this.config.testType,
@@ -82,7 +80,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
             payload,
         };
         this.sendMessage(message);
-    }
+    };
 
     public teardown(): void {
         this.tabStopsListener.stopListenToTabStops();

--- a/src/injected/client-view-controller.ts
+++ b/src/injected/client-view-controller.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as _ from 'lodash';
 import { BaseStore } from '../common/base-store';
 import { TestMode } from '../common/configs/test-mode';
@@ -82,8 +81,7 @@ export class ClientViewController {
         this.previousVisualizationStates = {};
     }
 
-    @autobind
-    public onChangedState(): void {
+    public onChangedState = (): void => {
         const oldVisualizationState = this.currentVisualizationState;
 
         this.currentVisualizationState = this.visualizationStore.getState();
@@ -101,7 +99,7 @@ export class ClientViewController {
             this.executeUpdates();
             this.handleFocusChanges(oldVisualizationState);
         }
-    }
+    };
 
     private handleFocusChanges(oldVisualizationState: VisualizationStoreData): void {
         if (

--- a/src/injected/details-dialog-handler.ts
+++ b/src/injected/details-dialog-handler.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { FeatureFlags } from '../common/feature-flags';
 import { HTMLElementUtils } from '../common/html-element-utils';
 import { DetailsDialog } from './components/details-dialog';
@@ -11,79 +10,66 @@ export class DetailsDialogHandler {
 
     constructor(private htmlElementUtils: HTMLElementUtils) {}
 
-    @autobind
-    public backButtonClickHandler(dialog: DetailsDialog): void {
+    public backButtonClickHandler = (dialog: DetailsDialog): void => {
         const currentRuleIndex = dialog.state.currentRuleIndex;
         dialog.setState({
             currentRuleIndex: currentRuleIndex - 1,
         });
-    }
+    };
 
-    @autobind
-    public nextButtonClickHandler(dialog: DetailsDialog): void {
+    public nextButtonClickHandler = (dialog: DetailsDialog): void => {
         const currentRuleIndex = dialog.state.currentRuleIndex;
         dialog.setState({
             currentRuleIndex: currentRuleIndex + 1,
         });
-    }
+    };
 
-    @autobind
-    public inspectButtonClickHandler(dialog: DetailsDialog, event: React.SyntheticEvent<MouseEvent>): void {
+    public inspectButtonClickHandler = (dialog: DetailsDialog, event: React.SyntheticEvent<MouseEvent>): void => {
         this.hideDialog(dialog);
         dialog.props.devToolActionMessageCreator.setInspectElement(event, dialog.props.target);
-    }
+    };
 
-    @autobind
-    public showDialog(dialog: DetailsDialog): void {
+    public showDialog = (dialog: DetailsDialog): void => {
         dialog.setState({ showDialog: true });
-    }
+    };
 
-    @autobind
-    public hideDialog(dialog: DetailsDialog): void {
+    public hideDialog = (dialog: DetailsDialog): void => {
         dialog.setState({ showDialog: false });
-    }
+    };
 
-    @autobind
-    public isNextButtonDisabled(dialog: DetailsDialog): boolean {
+    public isNextButtonDisabled = (dialog: DetailsDialog): boolean => {
         return dialog.state.currentRuleIndex >= Object.keys(dialog.props.failedRules).length - 1;
-    }
+    };
 
-    @autobind
-    public isBackButtonDisabled(dialog: DetailsDialog): boolean {
+    public isBackButtonDisabled = (dialog: DetailsDialog): boolean => {
         return dialog.state.currentRuleIndex <= 0;
-    }
+    };
 
-    @autobind
-    public isInspectButtonDisabled(dialog: DetailsDialog): boolean {
+    public isInspectButtonDisabled = (dialog: DetailsDialog): boolean => {
         return !dialog.state.canInspect;
-    }
+    };
 
-    @autobind
-    public onDevToolChanged(dialog: DetailsDialog): void {
+    public onDevToolChanged = (dialog: DetailsDialog): void => {
         dialog.setState({ canInspect: this.canInspect(dialog) });
-    }
+    };
 
-    @autobind
-    public canInspect(dialog: DetailsDialog): boolean {
+    public canInspect = (dialog: DetailsDialog): boolean => {
         const devToolState = dialog.props.devToolStore.getState();
         return devToolState && devToolState.isOpen;
-    }
+    };
 
-    @autobind
-    public onUserConfigChanged(dialog: DetailsDialog): void {
+    public onUserConfigChanged = (dialog: DetailsDialog): void => {
         const storeState = dialog.props.userConfigStore.getState();
         dialog.setState({
             userConfigurationStoreData: storeState,
         });
-    }
+    };
 
-    @autobind
-    public getFailureInfo(dialog: DetailsDialog): string {
+    public getFailureInfo = (dialog: DetailsDialog): string => {
         return `Failure ${dialog.state.currentRuleIndex + 1} of ${Object.keys(dialog.props.failedRules).length} for this target`;
-    }
+    };
 
-    @autobind
-    public onLayoutDidMount(): void {
+    public onLayoutDidMount = (): void => {
         const dialogContainer = this.htmlElementUtils.querySelector('.insights-dialog-main-override') as HTMLElement;
 
         if (dialogContainer == null) {
@@ -99,10 +85,9 @@ export class DetailsDialogHandler {
             }
             parentLayer = parentLayer.parentElement;
         }
-    }
+    };
 
-    @autobind
-    public componentDidMount(dialog: DetailsDialog): void {
+    public componentDidMount = (dialog: DetailsDialog): void => {
         if (!this.hasStore(dialog)) {
             return;
         }
@@ -122,7 +107,7 @@ export class DetailsDialogHandler {
         if (dialog.props.featureFlagStoreData[FeatureFlags.shadowDialog]) {
             this.addListenerForDialogInShadowDom(dialog);
         }
-    }
+    };
 
     private addListenerForDialogInShadowDom(dialog: DetailsDialog): void {
         const shadowRoot = this.htmlElementUtils.querySelector('#insights-shadow-host').shadowRoot;
@@ -176,11 +161,10 @@ export class DetailsDialogHandler {
         this.addShadowClickEventListener(shadowRoot, '.insights-dialog-button-inspect', inspectButtonListener);
     }
 
-    @autobind
-    public componentWillUnmount(dialog: DetailsDialog): void {
+    public componentWillUnmount = (dialog: DetailsDialog): void => {
         dialog.props.devToolStore.removeChangedListener(this._onDevToolChanged);
         dialog.props.userConfigStore.removeChangedListener(this._onUserConfigChanged);
-    }
+    };
 
     private hasStore(dialog: DetailsDialog): boolean {
         return dialog.props != null && dialog.props.devToolStore != null;

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind, getRTL } from '@uifabric/utilities';
+import { getRTL } from '@uifabric/utilities';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
@@ -110,15 +110,14 @@ export class DialogRenderer {
         }
     };
 
-    @autobind
-    private processRequest(
+    private processRequest = (
         message: DetailsDialogWindowMessage,
         error: ErrorMessageContent,
         sourceWin: Window,
         responder?: FrameMessageResponseCallback,
-    ): void {
+    ): void => {
         this.render(message.data, message.featureFlagStoreData);
-    }
+    };
 
     private initializeDialogContainerInShadowDom(): HTMLDivElement {
         const shadowContainer = this.shadowUtils.getShadowContainer();

--- a/src/injected/drawing-controller.ts
+++ b/src/injected/drawing-controller.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { forOwn } from 'lodash';
 
 import { HTMLElementUtils } from '../common/html-element-utils';
@@ -49,8 +48,7 @@ export class DrawingController {
         this.drawers[id] = drawer;
     };
 
-    @autobind
-    public processRequest(message: VisualizationWindowMessage): void {
+    public processRequest = (message: VisualizationWindowMessage): void => {
         this.featureFlagStoreData = message.featureFlagStoreData;
         if (message.isEnabled) {
             const elementResultsByFrames = message.elementResults
@@ -60,18 +58,17 @@ export class DrawingController {
         } else {
             this.disableVisualization(message.configId);
         }
-    }
+    };
 
-    @autobind
-    private onTriggerVisualization(
+    private onTriggerVisualization = (
         result: VisualizationWindowMessage,
         error: ErrorMessageContent,
         sourceWindow: Window,
         responder?: FrameMessageResponseCallback,
-    ): void {
+    ): void => {
         this.processRequest(result);
         this.invokeMethodIfExists(responder, null);
-    }
+    };
 
     private enableVisualization(elementResultsByFrames: HTMLIFrameResult[], configId: string): void {
         if (elementResultsByFrames) {

--- a/src/injected/element-finder-by-position.ts
+++ b/src/injected/element-finder-by-position.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import * as Q from 'q';
 
 import { BoundRectAccessor, ClientUtils } from './client-utils';
@@ -34,13 +33,12 @@ export class ElementFinderByPosition {
         this.frameCommunicator.subscribe(ElementFinderByPosition.findElementByPositionCommand, this.onfindElementByPosition);
     }
 
-    @autobind
-    protected onfindElementByPosition(
+    protected onfindElementByPosition = (
         message: ElementFinderByPositionMessage,
         error: ErrorMessageContent,
         sourceWin: Window,
         responder?: FrameMessageResponseCallback,
-    ): void {
+    ): void => {
         this.processRequest(message).then(
             result => {
                 responder(result, null, sourceWin);
@@ -49,7 +47,7 @@ export class ElementFinderByPosition {
                 responder(null, err, sourceWin);
             },
         );
-    }
+    };
 
     public processRequest(message: ElementFinderByPositionMessage): Q.IPromise<string[]> {
         let path = [];

--- a/src/injected/frame-url-finder.ts
+++ b/src/injected/frame-url-finder.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { HTMLElementUtils } from '../common/html-element-utils';
 import { WindowUtils } from '../common/window-utils';
 import { FrameCommunicator, MessageRequest } from './frameCommunicators/frame-communicator';
@@ -32,8 +30,7 @@ export class FrameUrlFinder {
         this.frameCommunicator.subscribe(FrameUrlFinder.GetTargetFrameUrlCommand, this.processRequest);
     }
 
-    @autobind
-    public processRequest(message: TargetMessage): void {
+    public processRequest = (message: TargetMessage): void => {
         const target = message.target;
 
         if (target.length === 1) {
@@ -53,5 +50,5 @@ export class FrameUrlFinder {
                 },
             } as MessageRequest<TargetMessage>);
         }
-    }
+    };
 }

--- a/src/injected/frame-url-message-dispatcher.ts
+++ b/src/injected/frame-url-message-dispatcher.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { DevToolActionMessageCreator } from '../common/message-creators/dev-tool-action-message-creator';
 import { FrameUrlFinder, FrameUrlMessage } from './frame-url-finder';
 import { FrameCommunicator } from './frameCommunicators/frame-communicator';
@@ -18,8 +17,7 @@ export class FrameUrlMessageDispatcher {
         this.frameCommunicator.subscribe(FrameUrlFinder.SetFrameUrlCommand, this.setTargetFrameUrl);
     }
 
-    @autobind
-    public setTargetFrameUrl(targetFrameUrlMessage: FrameUrlMessage): void {
+    public setTargetFrameUrl = (targetFrameUrlMessage: FrameUrlMessage): void => {
         this.devToolActionMessageCreator.setInspectFrameUrl(targetFrameUrlMessage.frameUrl);
-    }
+    };
 }

--- a/src/injected/frame-url-search-initiator.ts
+++ b/src/injected/frame-url-search-initiator.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { BaseStore } from '../common/base-store';
 import { DevToolState } from '../common/types/store-data/idev-tool-state';
 import { FrameUrlFinder } from './frame-url-finder';
@@ -19,12 +17,11 @@ export class FrameUrlSearchInitiator {
         this.devToolStore.addChangedListener(this.handleDevToolStateChange);
     }
 
-    @autobind
-    private handleDevToolStateChange(): void {
+    private handleDevToolStateChange = (): void => {
         const storeState = this.devToolStore.getState();
 
         if (storeState.inspectElement != null && storeState.inspectElement.length > 1 && storeState.frameUrl == null) {
             this.frameUrlFinder.processRequest({ target: storeState.inspectElement });
         }
-    }
+    };
 }

--- a/src/injected/frameCommunicators/scrolling-controller.ts
+++ b/src/injected/frameCommunicators/scrolling-controller.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { HTMLElementUtils } from './../../common/html-element-utils';
 import { ErrorMessageContent } from './error-message-content';
 import { FrameCommunicator, MessageRequest } from './frame-communicator';
@@ -25,15 +23,14 @@ export class ScrollingController {
         this._frameCommunicator.subscribe(ScrollingController.triggerScrollingCommand, this.onTriggerScrolling);
     }
 
-    @autobind
-    private onTriggerScrolling(
+    private onTriggerScrolling = (
         message: ScrollingWindowMessage,
         error: ErrorMessageContent,
         sourceWin: Window,
         responder?: FrameMessageResponseCallback,
-    ): void {
+    ): void => {
         this.processRequest(message);
-    }
+    };
 
     public processRequest(message: ScrollingWindowMessage): void {
         const selector: string[] = message.focusedTarget;

--- a/src/injected/frameCommunicators/window-message-handler.ts
+++ b/src/injected/frameCommunicators/window-message-handler.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { WindowUtils } from '../../common/window-utils';
 import { DictionaryStringTo } from '../../types/common-types';
 import { ErrorMessageContent } from './error-message-content';
@@ -58,8 +56,7 @@ export class WindowMessageHandler {
         this._windowUtils.postMessage(win, data, '*');
     }
 
-    @autobind
-    private windowMessageHandler(e: MessageEvent): void {
+    private windowMessageHandler = (e: MessageEvent): void => {
         const data: WindowMessage = this._windowMessageParser.parseMessage(e.data);
         if (data == null) {
             return;
@@ -76,7 +73,7 @@ export class WindowMessageHandler {
         } catch (err) {
             this.post(e.source, data.command, err, null, messageId);
         }
-    }
+    };
 
     private updateResponseCallbackMap(messageId, callback): void {
         if (callback) {

--- a/src/injected/inspect-controller.ts
+++ b/src/injected/inspect-controller.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { InspectMode } from '../background/inspect-modes';
 import { BaseStore } from '../common/base-store';
 import { ConfigurationKey, InspectConfigurationFactory } from '../common/configs/inspect-configuration-factory';
@@ -23,8 +22,7 @@ export class InspectController {
         this.onChangedState();
     }
 
-    @autobind
-    private onChangedState(): void {
+    private onChangedState = (): void => {
         if (this.inspectStore.getState() == null) {
             return;
         }
@@ -35,12 +33,11 @@ export class InspectController {
         if (newInspectStoreState != null && this.currentMode !== InspectMode.off) {
             this.scopingListener.start(this.onInspectClick, this.onHover);
         }
-    }
+    };
 
-    @autobind
-    private onInspectClick(event: MouseEvent, selector: string[]): void {
+    private onInspectClick = (event: MouseEvent, selector: string[]): void => {
         this.scopingListener.stop();
         this.inspectConfigurationFactory.getConfigurationByKey(this.currentMode as ConfigurationKey)(event, selector);
         this.changeInspectMode(event, InspectMode.off);
-    }
+    };
 }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { Assessments } from '../assessments/assessments';
 import { AxeInfo } from '../common/axe-info';
 import { InspectConfigurationFactory } from '../common/configs/inspect-configuration-factory';
@@ -206,13 +204,12 @@ export class MainWindowInitializer extends WindowInitializer {
         await Promise.all(asyncInitializationSteps);
     }
 
-    @autobind
-    protected dispose(): void {
+    protected dispose = (): void => {
         super.dispose();
         this.frameCommunicator.dispose();
         this.tabStoreProxy.dispose();
         this.visualizationScanResultStoreProxy.dispose();
         this.visualizationStoreProxy.dispose();
         this.devToolStoreProxy.dispose();
-    }
+    };
 }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -204,12 +204,16 @@ export class MainWindowInitializer extends WindowInitializer {
         await Promise.all(asyncInitializationSteps);
     }
 
-    protected dispose = (): void => {
-        super.dispose();
+    protected dispose(): void {
+        // Using .bind(this) instead of an arrow function because ES5 only supports accessing methods (not properties) of super
+        // When we move to target ES6, this can be simplified to super.dispose()
+        // See https://github.com/microsoft/TypeScript/issues/338
+        super.dispose.bind(this)();
+
         this.frameCommunicator.dispose();
         this.tabStoreProxy.dispose();
         this.visualizationScanResultStoreProxy.dispose();
         this.visualizationStoreProxy.dispose();
         this.devToolStoreProxy.dispose();
-    };
+    }
 }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -205,10 +205,7 @@ export class MainWindowInitializer extends WindowInitializer {
     }
 
     protected dispose(): void {
-        // Using .bind(this) instead of an arrow function because ES5 only supports accessing methods (not properties) of super
-        // When we move to target ES6, this can be simplified to super.dispose()
-        // See https://github.com/microsoft/TypeScript/issues/338
-        super.dispose.bind(this)();
+        super.dispose();
 
         this.frameCommunicator.dispose();
         this.tabStoreProxy.dispose();

--- a/src/injected/scanner-utils.ts
+++ b/src/injected/scanner-utils.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { createDefaultLogger } from '../common/logging/default-logger';
 import { Logger } from '../common/logging/logger';
 import { scan as scanRunner } from '../scanner/exposed-apis';
@@ -66,44 +64,39 @@ export class ScannerUtils {
         return selector;
     }
 
-    @autobind
-    public getIncompleteInstances(results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> {
+    public getIncompleteInstances = (results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> => {
         const resultsMap: DictionaryStringTo<HtmlElementAxeResults> = {};
         this.addIncompletesToDictionary(resultsMap, results.incomplete);
         return resultsMap;
-    }
+    };
 
-    @autobind
-    public getFailingInstances(results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> {
+    public getFailingInstances = (results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> => {
         const resultsMap: DictionaryStringTo<HtmlElementAxeResults> = {};
         this.addFailuresToDictionary(resultsMap, results.violations);
         return resultsMap;
-    }
+    };
 
-    @autobind
-    public getPassingInstances(results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> {
+    public getPassingInstances = (results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> => {
         const resultsMap: DictionaryStringTo<HtmlElementAxeResults> = {};
         this.addPassesToDictionary(resultsMap, results.passes);
         return resultsMap;
-    }
+    };
 
-    @autobind
-    public getAllCompletedInstances(results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> {
+    public getAllCompletedInstances = (results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> => {
         const resultsMap: DictionaryStringTo<HtmlElementAxeResults> = {};
         this.addPassesToDictionary(resultsMap, results.passes);
         this.addFailuresToDictionary(resultsMap, results.violations);
         return resultsMap;
-    }
+    };
 
-    @autobind
-    public getFailingOrPassingInstances(results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> {
+    public getFailingOrPassingInstances = (results: ScanResults): DictionaryStringTo<HtmlElementAxeResults> => {
         const resultsMap: DictionaryStringTo<HtmlElementAxeResults> = {};
         this.addFailuresToDictionary(resultsMap, results.violations);
         if (Object.keys(resultsMap).length === 0) {
             this.addPassesToDictionary(resultsMap, results.passes);
         }
         return resultsMap;
-    }
+    };
 
     private addPassesToDictionary(dictionary: DictionaryStringTo<HtmlElementAxeResults>, axeRules: RuleResult[]): void {
         this.addResultstoDictionary(dictionary, axeRules, true);

--- a/src/injected/scoping-listener.ts
+++ b/src/injected/scoping-listener.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { SingleElementSelector } from '../common/types/store-data/scoping-store-data';
 import { WindowUtils } from '../common/window-utils';
 import { ElementFinderByPosition } from './element-finder-by-position';
@@ -68,8 +67,7 @@ export class ScopingListener {
         shadowContainer.appendChild(scopeLayout);
     }
 
-    @autobind
-    protected onClick(event: MouseEvent): void {
+    protected onClick = (event: MouseEvent): void => {
         if (this.onClickCurrentTimeoutId != null) {
             this.windowUtils.clearTimeout(this.onClickCurrentTimeoutId);
             this.onClickCurrentTimeoutId = null;
@@ -80,10 +78,9 @@ export class ScopingListener {
                 this.onInspectClick(event, path);
             });
         }, ScopingListener.onClickTimeout);
-    }
+    };
 
-    @autobind
-    protected onHover(event: MouseEvent): void {
+    protected onHover = (event: MouseEvent): void => {
         if (this.onHoverCurrentTimeoutId != null) {
             this.windowUtils.clearTimeout(this.onHoverCurrentTimeoutId);
             this.onHoverCurrentTimeoutId = null;
@@ -94,7 +91,7 @@ export class ScopingListener {
                 this.onInspectHover(path);
             });
         }, ScopingListener.onHoverTimeout);
-    }
+    };
 
     private processRequestForEvent(event: MouseEvent): PromiseLike<SingleElementSelector> {
         return this.elementFinderByPosition.processRequest({

--- a/src/injected/tab-stops-listener.ts
+++ b/src/injected/tab-stops-listener.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { DateProvider } from '../common/date-provider';
 import { HTMLElementUtils } from '../common/html-element-utils';
 import { WindowUtils } from '../common/window-utils';
@@ -65,13 +63,12 @@ export class TabStopsListener {
         this.onStopListenToTabStops();
     }
 
-    @autobind
-    private onGetTabbedElements(
+    private onGetTabbedElements = (
         tabStopEvent: TabStopEvent,
         error: ErrorMessageContent,
         messageSourceWin: Window,
         responder?: FrameMessageResponseCallback,
-    ): void {
+    ): void => {
         const messageSourceFrame = this.getFrameElementForWindow(messageSourceWin);
 
         if (messageSourceFrame != null) {
@@ -82,10 +79,9 @@ export class TabStopsListener {
         } else {
             throw new Error('unable to get frame element for the tabbed element');
         }
-    }
+    };
 
-    @autobind
-    private sendTabbedElements(tabStopEvent: TabStopEvent): void {
+    private sendTabbedElements = (tabStopEvent: TabStopEvent): void => {
         if (this.windowUtils.isTopWindow()) {
             if (this.tabEventListener) {
                 this.tabEventListener(tabStopEvent);
@@ -95,17 +91,16 @@ export class TabStopsListener {
         } else {
             this.sendTabbedElementsToParent(tabStopEvent);
         }
-    }
+    };
 
-    @autobind
-    private sendTabbedElementsToParent(tabStopEvent: TabStopEvent): void {
+    private sendTabbedElementsToParent = (tabStopEvent: TabStopEvent): void => {
         const messageRequest: MessageRequest<TabStopEvent> = {
             win: this.windowUtils.getParentWindow(),
             command: TabStopsListener.getTabbedElementsCommand,
             message: tabStopEvent,
         };
         this.frameCommunicator.sendMessage(messageRequest);
-    }
+    };
 
     private getFrameElementForWindow(win: Window): HTMLIFrameElement {
         const frames = this.getAllFrames();
@@ -119,23 +114,21 @@ export class TabStopsListener {
         return null;
     }
 
-    @autobind
-    private onStartListenToTabStops(): void {
+    private onStartListenToTabStops = (): void => {
         this.addListeners();
         const iframes: NodeListOf<HTMLIFrameElement> = this.getAllFrames();
         for (let pos = 0; pos < iframes.length; pos++) {
             this.startListenToTabStopsInFrame(iframes[pos]);
         }
-    }
+    };
 
-    @autobind
-    private onStopListenToTabStops(): void {
+    private onStopListenToTabStops = (): void => {
         this.removeListeners();
         const iframes: NodeListOf<HTMLIFrameElement> = this.getAllFrames();
         for (let pos = 0; pos < iframes.length; pos++) {
             this.stopListenToTabStopsInFrame(iframes[pos]);
         }
-    }
+    };
 
     private startListenToTabStopsInFrame(frame: HTMLIFrameElement): void {
         const message: MessageRequest<VisualizationWindowMessage> = {
@@ -145,14 +138,13 @@ export class TabStopsListener {
         this.frameCommunicator.sendMessage(message);
     }
 
-    @autobind
-    private stopListenToTabStopsInFrame(frame: HTMLIFrameElement): void {
+    private stopListenToTabStopsInFrame = (frame: HTMLIFrameElement): void => {
         const message: MessageRequest<VisualizationWindowMessage> = {
             command: TabStopsListener.stopListeningCommand,
             frame: frame,
         };
         this.frameCommunicator.sendMessage(message);
-    }
+    };
 
     private addListeners(): void {
         this.dom.addEventListener('focusin', this.onFocusIn);
@@ -162,8 +154,7 @@ export class TabStopsListener {
         this.dom.removeEventListener('focusin', this.onFocusIn);
     }
 
-    @autobind
-    private onFocusIn(event: Event): void {
+    private onFocusIn = (event: Event): void => {
         const target: HTMLElement = event.target as HTMLElement;
 
         const timestamp: Date = DateProvider.getCurrentDate();
@@ -175,7 +166,7 @@ export class TabStopsListener {
         };
 
         this.sendTabbedElements(tabStopEvent);
-    }
+    };
 
     private getAllFrames(): NodeListOf<HTMLIFrameElement> {
         return this.htmlElementUtils.getAllElementsByTagName('iframe') as NodeListOf<HTMLIFrameElement>;

--- a/src/injected/target-page-action-message-creator.ts
+++ b/src/injected/target-page-action-message-creator.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { BaseActionPayload } from '../background/actions/action-payloads';
 import { Message } from '../common/message';
 import { ActionMessageDispatcher } from '../common/message-creators/action-message-dispatcher';
@@ -26,23 +25,20 @@ export class TargetPageActionMessageCreator {
         this.dispatcher.sendTelemetry(TelemetryEvents.ISSUES_DIALOG_OPENED, eventData);
     }
 
-    @autobind
-    public setHoveredOverSelector(selector: string[]): void {
+    public setHoveredOverSelector = (selector: string[]): void => {
         const message: Message = {
             messageType: Messages.Inspect.SetHoveredOverSelector,
             payload: selector,
         };
         this.dispatcher.dispatchMessage(message);
-    }
+    };
 
-    @autobind
-    public copyIssueDetailsClicked(event: React.MouseEvent<any>): void {
+    public copyIssueDetailsClicked = (event: React.MouseEvent<any>): void => {
         const telemetryData = this.telemetryFactory.withTriggeredByAndSource(event, TelemetryEvents.TelemetryEventSource.TargetPage);
         this.dispatcher.sendTelemetry(TelemetryEvents.COPY_ISSUE_DETAILS, telemetryData);
-    }
+    };
 
-    @autobind
-    public openSettingsPanel(event: React.MouseEvent<HTMLElement>): void {
+    public openSettingsPanel = (event: React.MouseEvent<HTMLElement>): void => {
         const messageType = Messages.SettingsPanel.OpenPanel;
         const source = TelemetryEventSource.TargetPage;
         const telemetry = this.telemetryFactory.forSettingsPanelOpen(event, source, 'fileIssueSettingsPrompt');
@@ -54,5 +50,5 @@ export class TargetPageActionMessageCreator {
             payload,
         };
         this.dispatcher.dispatchMessage(message);
-    }
+    };
 }

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -125,7 +125,7 @@ export class WindowInitializer {
         await Promise.all(asyncInitializationSteps);
     }
 
-    protected dispose = (): void => {
+    protected dispose(): void {
         this.drawingController.dispose();
-    };
+    }
 }

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -111,7 +111,7 @@ export class WindowInitializer {
         EnumHelper.getNumericValues(VisualizationType).forEach(visualizationTypeDrawerRegistrar.registerType);
 
         const port = this.clientChromeAdapter.connect();
-        port.onDisconnect.addListener(this.dispose);
+        port.onDisconnect.addListener(() => this.dispose());
 
         this.elementFinderByPosition = new ElementFinderByPosition(
             this.frameCommunicator,

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind, getRTL } from '@uifabric/utilities';
+import { getRTL } from '@uifabric/utilities';
 import * as Q from 'q';
 
 import { ClientChromeAdapter } from '../common/client-browser-adapter';
@@ -125,8 +125,7 @@ export class WindowInitializer {
         await Promise.all(asyncInitializationSteps);
     }
 
-    @autobind
-    protected dispose(): void {
+    protected dispose = (): void => {
         this.drawingController.dispose();
-    }
+    };
 }

--- a/src/popup/components/diagnostic-view-toggle.tsx
+++ b/src/popup/components/diagnostic-view-toggle.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import { IToggle } from 'office-ui-fabric-react/lib/Toggle';
@@ -118,26 +117,23 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
         }
     }
 
-    @autobind
-    private onFocusHandler(): void {
+    private onFocusHandler = (): void => {
         if (this._isMounted) {
             this.setState({
                 isFocused: true,
             });
         }
-    }
+    };
 
-    @autobind
-    private onBlurHandler(): void {
+    private onBlurHandler = (): void => {
         if (this._isMounted) {
             this.setState({
                 isFocused: false,
             });
         }
-    }
+    };
 
-    @autobind
-    private addUserEventListener(): void {
+    private addUserEventListener = (): void => {
         if (!this._userEventListenerAdded) {
             this.dom.addEventListener('keydown', (event: any) => {
                 if (event.keyCode === KeyCodeConstants.TAB) {
@@ -154,7 +150,7 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
 
             this._userEventListenerAdded = true;
         }
-    }
+    };
 
     private renderLink(linkText: string): JSX.Element {
         if (this.configuration.guidance) {

--- a/src/popup/components/popup-view.tsx
+++ b/src/popup/components/popup-view.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import * as React from 'react';
 import { BrowserAdapter } from '../../background/browser-adapters/browser-adapter';
@@ -216,11 +215,10 @@ export class PopupView extends React.Component<PopupViewProps> {
         return <Header title={this.props.title} />;
     }
 
-    @autobind
-    public setlaunchPanelType(launchPanelType: LaunchPanelType): void {
+    public setlaunchPanelType = (launchPanelType: LaunchPanelType): void => {
         const { popupActionMessageCreator } = this.props.deps;
         popupActionMessageCreator.setLaunchPanelType(launchPanelType);
-    }
+    };
 }
 
 export const PopupViewWithStoreSubscription = withStoreSubscription<PopupViewProps, PopupViewControllerState>(PopupView);

--- a/src/popup/components/telemetry-permission-dialog.tsx
+++ b/src/popup/components/telemetry-permission-dialog.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
@@ -73,8 +72,7 @@ export class TelemetryPermissionDialog extends React.Component<TelemetryPermissi
         );
     }
 
-    @autobind
-    private onCheckboxChange(ev?, checked?: boolean): void {
+    private onCheckboxChange = (ev?, checked?: boolean): void => {
         this.setState({ isEnableTelemetryChecked: checked });
-    }
+    };
 }

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
 import { loadTheme } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
 
@@ -83,8 +82,7 @@ export class PopupInitializer {
         incompatibleBrowserRenderer.render();
     };
 
-    @autobind
-    private initializePopup(): void {
+    private initializePopup = (): void => {
         const telemetryFactory = new TelemetryDataFactory();
         const actionMessageDispatcher = new ActionMessageDispatcher(this.chromeAdapter.sendMessageToFrames, this.targetTabInfo.tab.id);
         const visualizationActionCreator = new VisualizationActionMessageCreator(actionMessageDispatcher);
@@ -204,5 +202,5 @@ export class PopupInitializer {
 
         const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan), new HTMLElementUtils());
         window.A11YSelfValidator = a11ySelfValidator;
-    }
+    };
 }

--- a/src/popup/target-tab-finder.ts
+++ b/src/popup/target-tab-finder.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { autobind } from '@uifabric/utilities';
-
 import { BrowserAdapter } from '../background/browser-adapters/browser-adapter';
 import { Tab } from '../common/itab';
 import { UrlParser } from '../common/url-parser';
@@ -25,8 +23,7 @@ export class TargetTabFinder {
         return await this.createTargetTabInfo(tabInfo);
     }
 
-    @autobind
-    private getTabInfo(): Promise<Tab> {
+    private getTabInfo = (): Promise<Tab> => {
         return new Promise((resolve, reject) => {
             const tabIdInUrl = this.urlParser.getIntParam(this.win.location.href, 'tabId');
 
@@ -52,15 +49,14 @@ export class TargetTabFinder {
                 );
             }
         });
-    }
+    };
 
-    @autobind
-    private async createTargetTabInfo(tab: Tab): Promise<TargetTabInfo> {
+    private createTargetTabInfo = async (tab: Tab): Promise<TargetTabInfo> => {
         const hasAccess = await this.urlValidator.isSupportedUrl(tab.url);
         const targetTab: TargetTabInfo = {
             tab: tab,
             hasAccess,
         };
         return targetTab;
-    }
+    };
 }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`DetailsViewCommandBar renders with export button and dialog 1`] = `
 "<div className=\\"details-view-command-bar\\">
   <div className=\\"details-view-target-page\\">
     Target page: 
-    <StyledLinkBase role=\\"link\\" title=\\"Switch to target page\\" className=\\"insights-link target-page-link\\" onClick={[Function: switchToTargetTabStub]}>
+    <StyledLinkBase role=\\"link\\" title=\\"Switch to target page\\" className=\\"insights-link target-page-link\\" onClick={[Function: proxy]}>
       command-bar-test-tab-title
     </StyledLinkBase>
   </div>
@@ -29,7 +29,7 @@ exports[`DetailsViewCommandBar renders without export button and dialog 1`] = `
 "<div className=\\"details-view-command-bar\\">
   <div className=\\"details-view-target-page\\">
     Target page: 
-    <StyledLinkBase role=\\"link\\" title=\\"Switch to target page\\" className=\\"insights-link target-page-link\\" onClick={[Function: switchToTargetTabStub]}>
+    <StyledLinkBase role=\\"link\\" title=\\"Switch to target page\\" className=\\"insights-link target-page-link\\" onClick={[Function: proxy]}>
       command-bar-test-tab-title
     </StyledLinkBase>
   </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/header.test.tsx.snap
@@ -30,9 +30,9 @@ exports[`HeaderTest render: tabClosed is false 1`] = `
       proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
         "dropdownActionMessageCreator": undefined,
-        "openPreviewFeaturesPanelHandler": undefined,
-        "openScopingPanelHandler": undefined,
-        "openSettingsPanelHandler": undefined,
+        "openPreviewFeaturesPanelHandler": [Function],
+        "openScopingPanelHandler": [Function],
+        "openSettingsPanelHandler": [Function],
         "source": undefined,
       }
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/preview-features-toggle-list.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/preview-features-toggle-list.test.tsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PreviewFeaturesToggleListTest render 1`] = `
+"<div className=\\"preview-feature-toggle-list\\">
+  <GenericToggle name=\\"test name 1\\" description=\\"test description 1\\" enabled={true} onClick={[Function: proxy]} id=\\"test-id-1\\" />
+  <GenericToggle name=\\"test name 2\\" description=\\"test description 2\\" enabled={false} onClick={[Function: proxy]} id=\\"test-id-2\\" />
+</div>"
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`StartOverDropdownTest render 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function: bound ]} />
+  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} />
 </div>"
 `;
 
@@ -67,16 +67,16 @@ exports[`StartOverDropdownTest render ContextualMenu with only one option 1`] = 
 
 exports[`StartOverDropdownTest render GenericDialog for start over a test 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function: bound ]} />
+  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} />
   <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} />
-  <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the test name test. Are you sure you want to start over?\\" onCancelButtonClick={[Function: bound ]} onPrimaryButtonClick={[Function: bound ]} primaryButtonText=\\"Start over\\" />
+  <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the test name test. Are you sure you want to start over?\\" onCancelButtonClick={[Function]} onPrimaryButtonClick={[Function]} primaryButtonText=\\"Start over\\" />
 </div>"
 `;
 
 exports[`StartOverDropdownTest render GenericDialog for start over the whole assessment 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function: bound ]} />
+  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} />
   <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} />
-  <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the Assessment. This will clear results and progress of all tests and requirements. Are you sure you want to start over?\\" onCancelButtonClick={[Function: bound ]} onPrimaryButtonClick={[Function: bound ]} primaryButtonText=\\"Start over\\" />
+  <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the Assessment. This will clear results and progress of all tests and requirements. Are you sure you want to start over?\\" onCancelButtonClick={[Function]} onPrimaryButtonClick={[Function]} primaryButtonText=\\"Start over\\" />
 </div>"
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <StyledLinkBase
           className="insights-link target-page-link"
+          onClick={[Function]}
           role="link"
         >
           test title 2
@@ -72,6 +73,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         className="button ms-Grid-col  action-cancel-button-col restart-button"
       >
         <CustomizedDefaultButton
+          onClick={[Function]}
           text="Start new"
         />
       </div>
@@ -80,6 +82,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <CustomizedDefaultButton
           autoFocus={true}
+          onClick={[Function]}
           text="Continue previous"
         />
       </div>
@@ -139,6 +142,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <StyledLinkBase
           className="insights-link target-page-link"
+          onClick={[Function]}
           role="link"
         >
           test title 2
@@ -164,6 +168,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         className="button ms-Grid-col  action-cancel-button-col restart-button"
       >
         <CustomizedDefaultButton
+          onClick={[Function]}
           text="Start new"
         />
       </div>
@@ -172,6 +177,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <CustomizedDefaultButton
           autoFocus={true}
+          onClick={[Function]}
           text="Continue previous"
         />
       </div>
@@ -231,6 +237,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <StyledLinkBase
           className="insights-link target-page-link"
+          onClick={[Function]}
           role="link"
         >
           test title 2
@@ -256,6 +263,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         className="button ms-Grid-col  action-cancel-button-col restart-button"
       >
         <CustomizedDefaultButton
+          onClick={[Function]}
           text="Start new"
         />
       </div>
@@ -264,6 +272,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <CustomizedDefaultButton
           autoFocus={true}
+          onClick={[Function]}
           text="Continue previous"
         />
       </div>
@@ -323,6 +332,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <StyledLinkBase
           className="insights-link target-page-link"
+          onClick={[Function]}
           role="link"
         >
           test title 2
@@ -348,6 +358,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         className="button ms-Grid-col  action-cancel-button-col restart-button"
       >
         <CustomizedDefaultButton
+          onClick={[Function]}
           text="Start new"
         />
       </div>
@@ -356,6 +367,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <CustomizedDefaultButton
           autoFocus={true}
+          onClick={[Function]}
           text="Continue previous"
         />
       </div>
@@ -415,6 +427,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <StyledLinkBase
           className="insights-link target-page-link"
+          onClick={[Function]}
           role="link"
         >
           test title 2
@@ -440,6 +453,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         className="button ms-Grid-col  action-cancel-button-col restart-button"
       >
         <CustomizedDefaultButton
+          onClick={[Function]}
           text="Start new"
         />
       </div>
@@ -448,6 +462,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       >
         <CustomizedDefaultButton
           autoFocus={true}
+          onClick={[Function]}
           text="Continue previous"
         />
       </div>

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { AssessmentsProviderImpl } from '../../../../../assessments/assessments-provider';
 import { AssessmentsProvider } from '../../../../../assessments/types/assessments-provider';
@@ -101,8 +101,6 @@ describe('DetailsViewCommandBar', () => {
     });
 
     function testOnPivot(givenRenderExportAndStartOver: boolean): void {
-        const switchToTargetTabStub = () => {};
-        actionMessageCreatorMock.setup(amc => amc.switchToTargetTab).returns(() => switchToTargetTabStub);
         renderExportAndStartOver = givenRenderExportAndStartOver;
         const props = getProps();
         const rendered = shallow(<DetailsViewCommandBar {...props} />);

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 import { AssessmentsProviderImpl } from '../../../../../assessments/assessments-provider';
 import { AssessmentsProvider } from '../../../../../assessments/types/assessments-provider';

--- a/src/tests/unit/tests/DetailsView/components/preview-features-toggle-list.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/preview-features-toggle-list.test.tsx
@@ -6,7 +6,6 @@ import { Mock } from 'typemoq';
 import { shallow } from 'enzyme';
 import { DisplayableFeatureFlag } from '../../../../../common/types/store-data/displayable-feature-flag';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
-import { GenericToggle } from '../../../../../DetailsView/components/generic-toggle';
 import {
     PreviewFeaturesToggleList,
     PreviewFeaturesToggleListProps,

--- a/src/tests/unit/tests/DetailsView/components/preview-features-toggle-list.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/preview-features-toggle-list.test.tsx
@@ -40,5 +40,7 @@ describe('PreviewFeaturesToggleListTest', () => {
 
         const testSubject = shallow(<PreviewFeaturesToggleList {...props} />);
         expect(testSubject.debug()).toMatchSnapshot();
+
+        expect(testSubject.find({ id: 'test-id-1' }).props().onClick).toBe(actionMessageCreatorMock.object.setFeatureFlag);
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/preview-features-toggle-list.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/preview-features-toggle-list.test.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import { Mock } from 'typemoq';
 
+import { shallow } from 'enzyme';
 import { DisplayableFeatureFlag } from '../../../../../common/types/store-data/displayable-feature-flag';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import { GenericToggle } from '../../../../../DetailsView/components/generic-toggle';
@@ -32,37 +33,13 @@ describe('PreviewFeaturesToggleListTest', () => {
                 enabled: false,
             },
         ];
-        const setFeatureFlagStub = () => {};
         const actionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator);
         const props: PreviewFeaturesToggleListProps = {
             displayedFeatureFlags: displayableFeatureFlagsStub,
             actionMessageCreator: actionMessageCreatorMock.object,
         };
-        const testSubject = new PreviewFeaturesToggleList(props);
 
-        actionMessageCreatorMock.setup(acm => acm.setFeatureFlag).returns(() => setFeatureFlagStub);
-
-        const expectedComponent = (
-            <div className="preview-feature-toggle-list">
-                <GenericToggle
-                    name={props.displayedFeatureFlags[0].displayableName}
-                    description={props.displayedFeatureFlags[0].displayableDescription}
-                    enabled={props.displayedFeatureFlags[0].enabled}
-                    onClick={setFeatureFlagStub}
-                    id={props.displayedFeatureFlags[0].id}
-                    key={`preview_feature_toggle${props.displayedFeatureFlags[0].id}`}
-                />
-                <GenericToggle
-                    name={props.displayedFeatureFlags[1].displayableName}
-                    description={props.displayedFeatureFlags[1].displayableDescription}
-                    enabled={props.displayedFeatureFlags[1].enabled}
-                    onClick={setFeatureFlagStub}
-                    id={props.displayedFeatureFlags[1].id}
-                    key={`preview_feature_toggle${props.displayedFeatureFlags[1].id}`}
-                />
-            </div>
-        );
-
-        expect(testSubject.render()).toEqual(expectedComponent);
+        const testSubject = shallow(<PreviewFeaturesToggleList {...props} />);
+        expect(testSubject.debug()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
+++ b/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
 import {
@@ -63,10 +63,6 @@ describe('AssessmentInstanceTableHandlerTest', () => {
             selectedTestType: 5,
         };
 
-        actionMessageCreatorMock.setup(a => a.changeManualTestStatus).verifiable(Times.atLeastOnce());
-
-        actionMessageCreatorMock.setup(a => a.undoManualTestStatusChange).verifiable(Times.atLeastOnce());
-
         const rows = testSubject.createAssessmentInstanceTableItems(instancesMap, assessmentNavState, true);
         const choiceGroup: JSX.Element = (
             <TestStatusChoiceGroup
@@ -109,7 +105,6 @@ describe('AssessmentInstanceTableHandlerTest', () => {
                 visualizationButton: selectedButton,
             },
         ];
-        actionMessageCreatorMock.verifyAll();
         configFactoryMock.verifyAll();
         expect(expectedRows).toEqual(rows);
     });
@@ -123,8 +118,6 @@ describe('AssessmentInstanceTableHandlerTest', () => {
             selectedTestStep: 'step1',
             selectedTestType: 5,
         };
-
-        actionMessageCreatorMock.setup(a => a.removeFailureInstance).verifiable(Times.atLeastOnce());
 
         const rows = testSubject.createCapturedInstanceTableItems(
             [instance],
@@ -149,7 +142,6 @@ describe('AssessmentInstanceTableHandlerTest', () => {
                 instanceActionButtons: instanceActionButtons,
             },
         ];
-        actionMessageCreatorMock.verifyAll();
         expect(expectedRows).toEqual(rows);
     });
 

--- a/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
+++ b/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { IMock, It, Mock, Times } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 
 import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
 import {

--- a/src/tests/unit/tests/common/components/__snapshots__/issue-filing-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/issue-filing-button.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`IssueFilingButtonTest onclick: invalid settings, %s 1`] = `
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={true} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={true} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
 </Fragment>"
 `;
 
@@ -20,7 +20,7 @@ exports[`IssueFilingButtonTest onclick: valid settings, file bug and set %s to f
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
 </Fragment>"
 `;
 
@@ -32,7 +32,7 @@ exports[`IssueFilingButtonTest render: isSettingsValid: false 1`] = `
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
 </Fragment>"
 `;
 
@@ -44,6 +44,6 @@ exports[`IssueFilingButtonTest render: isSettingsValid: true 1`] = `
       File issue
     </div>
   </CustomizedDefaultButton>
-  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function: bound ]} issueFilingServicePropertiesMap={{...}} />
+  <testRenderer deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
 </Fragment>"
 `;

--- a/src/tests/unit/tests/common/components/gear-options-button-component.test.tsx
+++ b/src/tests/unit/tests/common/components/gear-options-button-component.test.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { shallow, ShallowWrapper } from 'enzyme';
-import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, Mock } from 'typemoq';
+import { It, Mock, Times } from 'typemoq';
 
 import {
     GearOptionsButtonComponent,
@@ -12,113 +11,118 @@ import {
 import { DropdownClickHandler } from '../../../../../common/dropdown-click-handler';
 import { FeatureFlags } from '../../../../../common/feature-flags';
 import { DetailsViewDropDown } from '../../../../../DetailsView/components/details-view-dropdown';
-import { DictionaryStringTo } from '../../../../../types/common-types';
 
-describe('gear-options-button-component.test', () => {
-    let dropdownClickHandlerMock: IMock<DropdownClickHandler>;
-    const openScopingPanelClickHandler: (event: any) => void = 'open scoping handler' as any;
-    const openPreviewFeaturesClickHandler: (event: any) => void = 'open preview features handler' as any;
-    const openSettingsPanelClickHandler: (event: any) => void = 'open settings panel handler' as any;
-
-    beforeEach(() => {
-        dropdownClickHandlerMock = Mock.ofType(DropdownClickHandler);
-
-        dropdownClickHandlerMock.setup(acm => acm.openPreviewFeaturesPanelHandler).returns(event => openPreviewFeaturesClickHandler);
-
-        dropdownClickHandlerMock.setup(acm => acm.openScopingPanelHandler).returns(event => openScopingPanelClickHandler);
-
-        dropdownClickHandlerMock.setup(acm => acm.openSettingsPanelHandler).returns(event => openSettingsPanelClickHandler);
-    });
-
-    test('constructor', () => {
-        const testSubject = new GearOptionsButtonComponent(null);
-        expect(testSubject).toEqual(expect.anything());
-    });
-
-    type TestCase = {
-        featureFlags: DictionaryStringTo<boolean>;
-        expectedMenuItems: IContextualMenuItem[];
-    };
-    test.each([
-        {
-            featureFlags: {
-                [FeatureFlags[FeatureFlags.scoping]]: true,
-            },
-            expectedMenuItems: [getSettingsFeatureMenuItem(), getPreviewFeatureMenuItem(), getScopingFeatureMenuItem()],
-        },
-        {
-            featureFlags: {
-                [FeatureFlags[FeatureFlags.scoping]]: false,
-            },
-            expectedMenuItems: [getSettingsFeatureMenuItem(), getPreviewFeatureMenuItem()],
-        },
-        {
-            featureFlags: {
-                [FeatureFlags[FeatureFlags.scoping]]: false,
-            },
-            expectedMenuItems: [getSettingsFeatureMenuItem(), getPreviewFeatureMenuItem()],
-        },
-        {
-            featureFlags: {
-                [FeatureFlags[FeatureFlags.scoping]]: true,
-            },
-            expectedMenuItems: [getSettingsFeatureMenuItem(), getPreviewFeatureMenuItem(), getScopingFeatureMenuItem()],
-        },
-    ] as TestCase[])('verify rendering with menu items: %#', (testCase: TestCase) => {
-        verifyRendering(testCase.featureFlags, testCase.expectedMenuItems);
-    });
-
-    function verifyRendering(featureFlags: DictionaryStringTo<boolean>, menuItems: IContextualMenuItem[]): void {
+describe('GearOptionsButtonComponent', () => {
+    it('renders like snapshot', () => {
         const props: GearOptionsButtonComponentProps = {
-            dropdownClickHandler: dropdownClickHandlerMock.object,
-            featureFlags: featureFlags,
+            dropdownClickHandler: Mock.ofType(DropdownClickHandler).object,
+            featureFlags: { [FeatureFlags[FeatureFlags.scoping]]: false },
         };
 
-        const dropDownProps = {
-            menuItems: menuItems,
-        };
-        const wrapper = shallow(<GearOptionsButtonComponent {...props} />);
-        const div = wrapper.find('.gear-options-button-component');
-        expect(div.exists()).toBe(true);
-        const dropDown = div.find(dropDownProps);
-        makeDropdownAssertions(dropDown, DetailsViewDropDown);
-    }
+        const testSubject = shallow(<GearOptionsButtonComponent {...props} />);
+        expect(testSubject.debug()).toMatchInlineSnapshot(`
+            "<div className=\\"gear-options-button-component\\">
+              <DetailsViewDropDown menuItems={{...}} />
+            </div>"
+        `);
+    });
 
-    function getScopingFeatureMenuItem(): IContextualMenuItem {
-        return {
-            key: 'scoping-feature',
-            iconProps: {
-                iconName: 'scopeTemplate',
-            },
-            onClick: openScopingPanelClickHandler,
-            name: 'Scoping',
+    it('renders its contained dropdown with the appropriate menu items (including scoping) with scoping flag enabled', () => {
+        const props: GearOptionsButtonComponentProps = {
+            dropdownClickHandler: Mock.ofType(DropdownClickHandler).object,
+            featureFlags: { [FeatureFlags[FeatureFlags.scoping]]: true },
         };
-    }
 
-    function getPreviewFeatureMenuItem(): IContextualMenuItem {
-        return {
-            key: 'preview-features',
-            iconProps: {
-                iconName: 'giftboxOpen',
-            },
-            onClick: openPreviewFeaturesClickHandler,
-            name: 'Preview features',
+        const testSubject = shallow(<GearOptionsButtonComponent {...props} />);
+        const dropdownProps = testSubject.find(DetailsViewDropDown).props();
+        expect(dropdownProps).toMatchInlineSnapshot(`
+            Object {
+              "menuItems": Array [
+                Object {
+                  "iconProps": Object {
+                    "iconName": "gear",
+                  },
+                  "key": "settings",
+                  "name": "Settings",
+                  "onClick": [Function],
+                },
+                Object {
+                  "className": "preview-features-drop-down-button",
+                  "iconProps": Object {
+                    "iconName": "giftboxOpen",
+                  },
+                  "key": "preview-features",
+                  "name": "Preview features",
+                  "onClick": [Function],
+                },
+                Object {
+                  "iconProps": Object {
+                    "iconName": "scopeTemplate",
+                  },
+                  "key": "scoping-feature",
+                  "name": "Scoping",
+                  "onClick": [Function],
+                },
+              ],
+            }
+        `);
+    });
+
+    it('renders its contained dropdown with the appropriate menu items (excluding scoping) with scoping flag disabled', () => {
+        const props: GearOptionsButtonComponentProps = {
+            dropdownClickHandler: Mock.ofType(DropdownClickHandler).object,
+            featureFlags: { [FeatureFlags[FeatureFlags.scoping]]: false },
         };
-    }
 
-    function getSettingsFeatureMenuItem(): IContextualMenuItem {
-        return {
-            key: 'settings',
-            iconProps: {
-                iconName: 'gear',
-            },
-            onClick: openSettingsPanelClickHandler,
-            name: 'Settings',
+        const testSubject = shallow(<GearOptionsButtonComponent {...props} />);
+        const dropdownProps = testSubject.find(DetailsViewDropDown).props();
+        expect(dropdownProps).toMatchInlineSnapshot(`
+            Object {
+              "menuItems": Array [
+                Object {
+                  "iconProps": Object {
+                    "iconName": "gear",
+                  },
+                  "key": "settings",
+                  "name": "Settings",
+                  "onClick": [Function],
+                },
+                Object {
+                  "className": "preview-features-drop-down-button",
+                  "iconProps": Object {
+                    "iconName": "giftboxOpen",
+                  },
+                  "key": "preview-features",
+                  "name": "Preview features",
+                  "onClick": [Function],
+                },
+              ],
+            }
+        `);
+    });
+
+    it('delegates menu item onClick calls to the appropriate clickHandler methods', () => {
+        const stubClickEvent = {};
+        const mockDropdownClickHandler = Mock.ofType(DropdownClickHandler);
+
+        const props: GearOptionsButtonComponentProps = {
+            dropdownClickHandler: mockDropdownClickHandler.object,
+            featureFlags: { [FeatureFlags[FeatureFlags.scoping]]: true },
         };
-    }
 
-    function makeDropdownAssertions(dropDownWrapper: ShallowWrapper<any, any>, expectedDropdown): void {
-        expect(dropDownWrapper.exists()).toBe(true);
-        expect(dropDownWrapper.type()).toEqual(expectedDropdown);
-    }
+        const testSubject = shallow(<GearOptionsButtonComponent {...props} />);
+        const dropdownProps = testSubject.find(DetailsViewDropDown).props();
+
+        mockDropdownClickHandler.verify(h => h.openSettingsPanelHandler(It.isAny()), Times.never());
+        dropdownProps.menuItems.filter(item => item.key === 'settings')[0].onClick(stubClickEvent);
+        mockDropdownClickHandler.verify(h => h.openSettingsPanelHandler(It.isAny()), Times.once());
+
+        mockDropdownClickHandler.verify(h => h.openScopingPanelHandler(It.isAny()), Times.never());
+        dropdownProps.menuItems.filter(item => item.key === 'scoping-feature')[0].onClick(stubClickEvent);
+        mockDropdownClickHandler.verify(h => h.openScopingPanelHandler(It.isAny()), Times.once());
+
+        mockDropdownClickHandler.verify(h => h.openPreviewFeaturesPanelHandler(It.isAny()), Times.never());
+        dropdownProps.menuItems.filter(item => item.key === 'preview-features')[0].onClick(stubClickEvent);
+        mockDropdownClickHandler.verify(h => h.openPreviewFeaturesPanelHandler(It.isAny()), Times.once());
+    });
 });

--- a/src/tests/unit/tests/injected/drawing-initiator.test.ts
+++ b/src/tests/unit/tests/injected/drawing-initiator.test.ts
@@ -11,7 +11,7 @@ import { PropertyBags, VisualizationInstanceProcessorCallback } from '../../../.
 import { DictionaryStringTo } from '../../../../types/common-types';
 
 class DrawingControllerStub extends DrawingController {
-    public processRequest(message: VisualizationWindowMessage): void {}
+    public processRequest = (message: VisualizationWindowMessage): void => {};
 }
 
 describe('DrawingInitiatorTest', () => {


### PR DESCRIPTION
#### Description of changes

Replaces all usages of autobind (mostly with arrow functions). This helps move us towards upgrading to office fabric v7.x (which removes the previously deprecated autobind utility)

Most changes in this PR are unremarkable, mechanical conversions. The points that require a little more review are:

1. `src/injected/main-window-initializer.ts` and `src/injected/window-initializer.ts` use an explicit `.bind(this)` instead of an arrow function because the way the former uses `super.methodCall()` cannot be directly replicated in ES5 when `methodCall` is changed from a method to a property.
1. Some tests used `typemoq` in a way that specifically relied on mocked methods being methods, rather than properties that are functions. These tests were rewritten in terms of verifying the act of calling the things under test, rather than verifying the identity of the things under test. The impacted cases are primarily in `src/tests/unit/tests/DetailsView/components/preview-features-toggle-list.test.tsx` and `src/tests/unit/tests/common/components/gear-options-button-component.test.tsx`

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
