### PR TITLE
Basic UI for Path/Snippet Addition to Failures

### DIFF
--- a/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
+++ b/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
@@ -30,6 +30,7 @@ export class AssessmentInstanceEditAndRemoveControl extends React.Component<Asse
                     editFailureInstance={this.props.onEdit}
                     originalText={this.props.description}
                     assessmentsProvider={this.props.assessmentsProvider}
+                    featureFlagStoreData={null}
                 />
                 <Link className="remove-button" onClick={this.onRemoveButtonClicked}>
                     <Icon iconName="delete" ariaLabel={'delete instance'} />

--- a/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
+++ b/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
@@ -5,6 +5,7 @@ import { Link } from 'office-ui-fabric-react/lib/Link';
 import * as React from 'react';
 
 import { AssessmentsProvider } from '../../assessments/types/assessments-provider';
+import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { CapturedInstanceActionType, FailureInstancePanelControl } from './failure-instance-panel-control';
 
@@ -16,6 +17,7 @@ export interface AssessmentInstanceEditAndRemoveControlProps {
     onRemove: (test, step, id) => void;
     onEdit: (description, test, step, id) => void;
     assessmentsProvider: AssessmentsProvider;
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export class AssessmentInstanceEditAndRemoveControl extends React.Component<AssessmentInstanceEditAndRemoveControlProps> {
@@ -30,7 +32,7 @@ export class AssessmentInstanceEditAndRemoveControl extends React.Component<Asse
                     editFailureInstance={this.props.onEdit}
                     originalText={this.props.description}
                     assessmentsProvider={this.props.assessmentsProvider}
-                    featureFlagStoreData={null}
+                    featureFlagStoreData={this.props.featureFlagStoreData}
                 />
                 <Link className="remove-button" onClick={this.onRemoveButtonClicked}>
                     <Icon iconName="delete" ariaLabel={'delete instance'} />

--- a/src/DetailsView/components/assessment-test-view.tsx
+++ b/src/DetailsView/components/assessment-test-view.tsx
@@ -8,6 +8,7 @@ import { AssessmentTestResult } from '../../common/assessment/assessment-test-re
 import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
 import { NamedSFC } from '../../common/react/named-sfc';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
 import { VisualizationStoreData } from '../../common/types/store-data/visualization-store-data';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
@@ -25,6 +26,7 @@ export interface AssessmentTestViewProps {
     visualizationStoreData: VisualizationStoreData;
     assessmentInstanceTableHandler: AssessmentInstanceTableHandler;
     configuration: VisualizationConfiguration;
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export const AssessmentTestView = NamedSFC<AssessmentTestViewProps>('AssessmentTestView', ({ deps, ...props }) => {
@@ -55,6 +57,7 @@ export const AssessmentTestView = NamedSFC<AssessmentTestViewProps>('AssessmentT
             prevTarget={prevTarget}
             assessmentDefaultMessageGenerator={deps.assessmentDefaultMessageGenerator}
             assessmentTestResult={assessmentTestResult}
+            featureFlagStoreData={props.featureFlagStoreData}
         />
     );
 });

--- a/src/DetailsView/components/assessment-view.tsx
+++ b/src/DetailsView/components/assessment-view.tsx
@@ -9,6 +9,7 @@ import { CollapsibleComponent } from '../../common/components/collapsible-compon
 import { reactExtensionPoint } from '../../common/extensibility/react-extension-point';
 import { Tab } from '../../common/itab';
 import { AssessmentData, AssessmentNavState, PersistedTabInfo } from '../../common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { ContentLink, ContentLinkDeps } from '../../views/content/content-link';
 import { ContentPageComponent } from '../../views/content/content-page';
@@ -43,6 +44,7 @@ export interface AssessmentViewProps {
     prevTarget: PersistedTabInfo;
     assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator;
     assessmentTestResult: AssessmentTestResult;
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export class AssessmentView extends React.Component<AssessmentViewProps> {
@@ -196,6 +198,7 @@ export class AssessmentView extends React.Component<AssessmentViewProps> {
                         isStepEnabled={this.props.isEnabled}
                         isStepScanned={isStepScanned}
                         assessmentDefaultMessageGenerator={this.props.assessmentDefaultMessageGenerator}
+                        featureFlagStoreData={this.props.featureFlagStoreData}
                     />
                 </div>
             </div>

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -48,7 +48,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
             isPanelOpen: false,
             failureDescription: this.props.originalText || '',
             selector: '',
-            snippet: 'Code snippet will auto-populate based on the CSS selector input.',
+            snippet: '',
         };
     }
 
@@ -125,7 +125,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                 </div>
                 <div>
                     <label>Code Snippet</label>
-                    <div> {this.state.snippet} </div>
+                    <div>{this.state.snippet}</div>
                 </div>
                 <TextField
                     className="observed-failure-textfield"

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -130,7 +130,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
         );
     }
 
-    protected getSelectorAndSnippet = (): JSX.Element => {
+    private getSelectorAndSnippet = (): JSX.Element => {
         return (
             <div>
                 <a className="learn-more"> Learn more about adding failure instances </a>
@@ -156,43 +156,15 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
         );
     };
 
-    protected panelWithoutSelectorAndSnippet = (testStepConfig: Readonly<Requirement>, panelProps: GenericPanelProps): JSX.Element => {
-        return (
-            <GenericPanel {...panelProps}>
-                {testStepConfig.addFailureInstruction}
-                <TextField
-                    className="observed-failure-textfield"
-                    label="Observed failure"
-                    multiline={true}
-                    rows={8}
-                    value={this.state.failureDescription}
-                    onChange={this.onFailureDescriptionChange}
-                    resizable={false}
-                />
-                <ActionAndCancelButtonsComponent
-                    isHidden={false}
-                    primaryButtonDisabled={this.state.failureDescription === ''}
-                    primaryButtonText={this.props.actionType === CapturedInstanceActionType.CREATE ? 'Add' : 'Save'}
-                    primaryButtonOnClick={
-                        this.props.actionType === CapturedInstanceActionType.CREATE
-                            ? this.onAddFailureInstance
-                            : this.onSaveEditedFailureInstance
-                    }
-                    cancelButtonOnClick={this.closeFailureInstancePanel}
-                />
-            </GenericPanel>
-        );
-    };
-
     protected onFailureDescriptionChange = (event, value: string): void => {
         this.setState({ failureDescription: value });
     };
 
-    protected onSelectorChange = (event, value: string): void => {
+    private onSelectorChange = (event, value: string): void => {
         this.setState({ selector: value });
     };
 
-    protected onValidateSelector = (event): void => {
+    private onValidateSelector = (event): void => {
         const currSelector = this.state.selector;
         this.setState({ snippet: 'snippet for ' + currSelector });
     };

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -9,6 +9,7 @@ import * as React from 'react';
 import { AssessmentsProvider } from '../../assessments/types/assessments-provider';
 import { Requirement } from '../../assessments/types/requirement';
 import { BaseStore } from '../../common/base-store';
+import { FlaggedComponent } from '../../common/components/flagged-component';
 import { FeatureFlags } from '../../common/feature-flags';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../common/types/visualization-type';
@@ -97,17 +98,41 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
             closeButtonAriaLabel: null,
         };
 
-        if (this.props.featureFlagStoreData && this.props.featureFlagStoreData[FeatureFlags.manualInstanceDetails]) {
-            return this.panelWithSelectorAndSnippet(testStepConfig, panelProps);
-        } else {
-            return this.panelWithoutSelectorAndSnippet(testStepConfig, panelProps);
-        }
-    }
-
-    protected panelWithSelectorAndSnippet = (testStepConfig: Readonly<Requirement>, panelProps: GenericPanelProps): JSX.Element => {
         return (
             <GenericPanel {...panelProps}>
                 {testStepConfig.addFailureInstruction}
+                <FlaggedComponent
+                    enableJSXElement={this.getSelectorAndSnippet()}
+                    featureFlag={FeatureFlags[FeatureFlags.manualInstanceDetails]}
+                    featureFlagStoreData={this.props.featureFlagStoreData}
+                />
+                <TextField
+                    className="observed-failure-textfield"
+                    label="Observed failure"
+                    multiline={true}
+                    rows={8}
+                    value={this.state.failureDescription}
+                    onChange={this.onFailureDescriptionChange}
+                    resizable={false}
+                />
+                <ActionAndCancelButtonsComponent
+                    isHidden={false}
+                    primaryButtonDisabled={this.state.failureDescription === ''}
+                    primaryButtonText={this.props.actionType === CapturedInstanceActionType.CREATE ? 'Add' : 'Save'}
+                    primaryButtonOnClick={
+                        this.props.actionType === CapturedInstanceActionType.CREATE
+                            ? this.onAddFailureInstance
+                            : this.onSaveEditedFailureInstance
+                    }
+                    cancelButtonOnClick={this.closeFailureInstancePanel}
+                />
+            </GenericPanel>
+        );
+    }
+
+    protected getSelectorAndSnippet = (): JSX.Element => {
+        return (
+            <div>
                 <a className="learn-more"> Learn more about adding failure instances </a>
                 <TextField
                     className="selector-failure-textfield"
@@ -127,28 +152,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                     <label>Code Snippet</label>
                     <div>{this.state.snippet}</div>
                 </div>
-                <TextField
-                    className="observed-failure-textfield"
-                    label="Observed failure"
-                    multiline={true}
-                    rows={8}
-                    value={this.state.failureDescription}
-                    onChange={this.onFailureDescriptionChange}
-                    resizable={false}
-                    defaultValue="Comments"
-                />
-                <ActionAndCancelButtonsComponent
-                    isHidden={false}
-                    primaryButtonDisabled={this.state.failureDescription === '' && this.state.selector === ''}
-                    primaryButtonText={this.props.actionType === CapturedInstanceActionType.CREATE ? 'Add failed instance' : 'Save'}
-                    primaryButtonOnClick={
-                        this.props.actionType === CapturedInstanceActionType.CREATE
-                            ? this.onAddFailureInstance
-                            : this.onSaveEditedFailureInstance
-                    }
-                    cancelButtonOnClick={this.closeFailureInstancePanel}
-                />
-            </GenericPanel>
+            </div>
         );
     };
 

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ActionButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 
 import { AssessmentsProvider } from '../../assessments/types/assessments-provider';
-import { Requirement } from '../../assessments/types/requirement';
 import { BaseStore } from '../../common/base-store';
 import { FlaggedComponent } from '../../common/components/flagged-component';
 import { FeatureFlags } from '../../common/feature-flags';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { ActionAndCancelButtonsComponent } from './action-and-cancel-buttons-component';
+import { FailureInstancePanelDetails } from './failure-instance-panel-details';
 import { GenericPanel, GenericPanelProps } from './generic-panel';
 
 export interface FailureInstancePanelControlProps {
@@ -31,7 +31,7 @@ export interface FailureInstancePanelControlProps {
 export interface FailureInstancePanelControlState {
     isPanelOpen: boolean;
     failureDescription: string;
-    selector: string;
+    path: string;
     snippet: string;
 }
 
@@ -48,7 +48,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
         this.state = {
             isPanelOpen: false,
             failureDescription: this.props.originalText || '',
-            selector: '',
+            path: '',
             snippet: '',
         };
     }
@@ -102,13 +102,13 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
             <GenericPanel {...panelProps}>
                 {testStepConfig.addFailureInstruction}
                 <FlaggedComponent
-                    enableJSXElement={this.getSelectorAndSnippet()}
+                    enableJSXElement={this.getFailureInstancePanelDetails()}
                     featureFlag={FeatureFlags[FeatureFlags.manualInstanceDetails]}
                     featureFlagStoreData={this.props.featureFlagStoreData}
                 />
                 <TextField
                     className="observed-failure-textfield"
-                    label="Observed failure"
+                    label="Comments"
                     multiline={true}
                     rows={8}
                     value={this.state.failureDescription}
@@ -130,29 +130,14 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
         );
     }
 
-    private getSelectorAndSnippet = (): JSX.Element => {
+    private getFailureInstancePanelDetails = (): JSX.Element => {
         return (
-            <div>
-                <a className="learn-more"> Learn more about adding failure instances </a>
-                <TextField
-                    className="selector-failure-textfield"
-                    label="CSS Selector"
-                    multiline={true}
-                    rows={8}
-                    value={this.state.selector}
-                    onChange={this.onSelectorChange}
-                    resizable={false}
-                    defaultValue="CSS selector"
-                />
-                <div>Note: If the CSS selector maps to multiple snippets, the first will be selected.</div>
-                <div>
-                    <DefaultButton text="Validate CSS selector" onClick={this.onValidateSelector} disabled={this.state.selector === ''} />
-                </div>
-                <div>
-                    <label>Code Snippet</label>
-                    <div>{this.state.snippet}</div>
-                </div>
-            </div>
+            <FailureInstancePanelDetails
+                path={this.state.path}
+                snippet={this.state.snippet}
+                onSelectorChange={this.onSelectorChange}
+                onValidateSelector={this.onValidateSelector}
+            />
         );
     };
 
@@ -160,12 +145,12 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
         this.setState({ failureDescription: value });
     };
 
-    private onSelectorChange = (event, value: string): void => {
-        this.setState({ selector: value });
+    protected onSelectorChange = (event, value: string): void => {
+        this.setState({ path: value });
     };
 
-    private onValidateSelector = (event): void => {
-        const currSelector = this.state.selector;
+    protected onValidateSelector = (event): void => {
+        const currSelector = this.state.path;
         this.setState({ snippet: 'snippet for ' + currSelector });
     };
 

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -145,11 +145,11 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
         this.setState({ failureDescription: value });
     };
 
-    protected onSelectorChange = (event, value: string): void => {
+    private onSelectorChange = (event, value: string): void => {
         this.setState({ path: value });
     };
 
-    protected onValidateSelector = (event): void => {
+    private onValidateSelector = (event): void => {
         const currSelector = this.state.path;
         this.setState({ snippet: 'snippet for ' + currSelector });
     };

--- a/src/DetailsView/components/failure-instance-panel-details.tsx
+++ b/src/DetailsView/components/failure-instance-panel-details.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import * as React from 'react';
+import { NamedSFC } from '../../common/react/named-sfc';
+
+export type FailureInstancePanelDetailsProps = {
+    path: string;
+    snippet: string;
+    onSelectorChange: (event, value) => void;
+    onValidateSelector: (event) => void;
+};
+
+export const FailureInstancePanelDetails = NamedSFC<FailureInstancePanelDetailsProps>('FailureInstancePanelDetails', props => {
+    return (
+        <div>
+            <a className="learn-more"> Learn more about adding failure instances </a>
+            <TextField
+                className="selector-failure-textfield"
+                label="CSS Selector"
+                multiline={true}
+                rows={8}
+                value={props.path}
+                onChange={props.onSelectorChange}
+                resizable={false}
+                defaultValue="CSS selector"
+            />
+            <div>Note: If the CSS selector maps to multiple snippets, the first will be selected.</div>
+            <div>
+                <DefaultButton text="Validate CSS selector" onClick={props.onValidateSelector} disabled={props.path === ''} />
+            </div>
+            <div>
+                <label>Code Snippet</label>
+                <div>{props.snippet}</div>
+            </div>
+        </div>
+    );
+});

--- a/src/DetailsView/components/manual-test-step-view.tsx
+++ b/src/DetailsView/components/manual-test-step-view.tsx
@@ -52,6 +52,7 @@ export class ManualTestStepView extends React.Component<ManualTestStepViewProps>
             this.props.manualTestStepResultMap[this.props.step].instances,
             this.props.test,
             this.props.step,
+            this.props.featureFlagStoreData,
         );
         return (
             <React.Fragment>

--- a/src/DetailsView/components/manual-test-step-view.tsx
+++ b/src/DetailsView/components/manual-test-step-view.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { AssessmentsProvider } from '../../assessments/types/assessments-provider';
 import { ManualTestStatus } from '../../common/types/manual-test-status';
 import { ManualTestStepResult } from '../../common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { DictionaryStringTo } from '../../types/common-types';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
@@ -18,6 +19,7 @@ export interface ManualTestStepViewProps {
     assessmentInstanceTableHandler: AssessmentInstanceTableHandler;
     manualTestStepResultMap: DictionaryStringTo<ManualTestStepResult>;
     assessmentsProvider: AssessmentsProvider;
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export class ManualTestStepView extends React.Component<ManualTestStepViewProps> {
@@ -60,6 +62,7 @@ export class ManualTestStepView extends React.Component<ManualTestStepViewProps>
                     addFailureInstance={this.props.assessmentInstanceTableHandler.addFailureInstance}
                     actionType={CapturedInstanceActionType.CREATE}
                     assessmentsProvider={this.props.assessmentsProvider}
+                    featureFlagStoreData={this.props.featureFlagStoreData}
                 />
                 <DetailsList
                     items={items}

--- a/src/DetailsView/components/test-step-view.tsx
+++ b/src/DetailsView/components/test-step-view.tsx
@@ -13,6 +13,7 @@ import {
     GeneratedAssessmentInstance,
     ManualTestStepResult,
 } from '../../common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { DictionaryStringTo } from '../../types/common-types';
 import { ContentPanelButton, ContentPanelButtonDeps } from '../../views/content/content-panel-button';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
@@ -36,6 +37,7 @@ export interface TestStepViewProps {
     actionMessageCreator: DetailsViewActionMessageCreator;
     assessmentsProvider: AssessmentsProvider;
     assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator;
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export class TestStepView extends React.Component<TestStepViewProps> {
@@ -71,6 +73,7 @@ export class TestStepView extends React.Component<TestStepViewProps> {
                     manualTestStepResultMap={this.props.manualTestStepResultMap}
                     assessmentInstanceTableHandler={this.props.assessmentInstanceTableHandler}
                     assessmentsProvider={this.props.assessmentsProvider}
+                    featureFlagStoreData={this.props.featureFlagStoreData}
                 />
             );
         }

--- a/src/DetailsView/handlers/assessment-instance-table-handler.tsx
+++ b/src/DetailsView/handlers/assessment-instance-table-handler.tsx
@@ -10,6 +10,7 @@ import {
     GeneratedAssessmentInstance,
     UserCapturedInstance,
 } from '../../common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { DictionaryStringTo } from '../../types/common-types';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
@@ -94,11 +95,12 @@ export class AssessmentInstanceTableHandler {
         instances: UserCapturedInstance[],
         test: VisualizationType,
         step: string,
+        featureFlagStoreData: FeatureFlagStoreData,
     ): CapturedInstanceRowData[] {
         return instances.map((instance: UserCapturedInstance) => {
             return {
                 instance: instance,
-                instanceActionButtons: this.renderInstanceActionButtons(instance, test, step),
+                instanceActionButtons: this.renderInstanceActionButtons(instance, test, step, featureFlagStoreData),
             };
         });
     }
@@ -147,7 +149,12 @@ export class AssessmentInstanceTableHandler {
         );
     };
 
-    private renderInstanceActionButtons = (instance: UserCapturedInstance, test: VisualizationType, step: string): JSX.Element => {
+    private renderInstanceActionButtons = (
+        instance: UserCapturedInstance,
+        test: VisualizationType,
+        step: string,
+        featureFlagStoreData: FeatureFlagStoreData,
+    ): JSX.Element => {
         return (
             <AssessmentInstanceEditAndRemoveControl
                 test={test}
@@ -157,6 +164,7 @@ export class AssessmentInstanceTableHandler {
                 onRemove={this.actionMessageCreator.removeFailureInstance}
                 onEdit={this.actionMessageCreator.editFailureInstance}
                 assessmentsProvider={this.assessmentsProvider}
+                featureFlagStoreData={featureFlagStoreData}
             />
         );
     };

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-test-view.test.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AssessmentTestView assessment view, isScanning is false 1`] = `"<AssessmentView deps={{...}} isScanning={false} isEnabled={false} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} assessmentData={{...}} currentTarget={{...}} prevTarget={[undefined]} assessmentDefaultMessageGenerator={[undefined]} assessmentTestResult={{...}} />"`;
+exports[`AssessmentTestView assessment view, isScanning is false 1`] = `"<AssessmentView deps={{...}} isScanning={false} isEnabled={false} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} assessmentData={{...}} currentTarget={{...}} prevTarget={[undefined]} assessmentDefaultMessageGenerator={[undefined]} assessmentTestResult={{...}} featureFlagStoreData={{...}} />"`;
 
-exports[`AssessmentTestView assessment view, isScanning is true 1`] = `"<AssessmentView deps={{...}} isScanning={true} isEnabled={false} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} assessmentData={{...}} currentTarget={{...}} prevTarget={[undefined]} assessmentDefaultMessageGenerator={[undefined]} assessmentTestResult={{...}} />"`;
+exports[`AssessmentTestView assessment view, isScanning is true 1`] = `"<AssessmentView deps={{...}} isScanning={true} isEnabled={false} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} assessmentData={{...}} currentTarget={{...}} prevTarget={[undefined]} assessmentDefaultMessageGenerator={[undefined]} assessmentTestResult={{...}} featureFlagStoreData={{...}} />"`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-view.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`AssessmentViewTest render 1`] = `
         <TestStepsNav deps={{...}} ariaLabel=\\"Requirements\\" selectedTest={-1} selectedTestStep=\\"assessment-1-step-1\\" stepStatus={{...}} />
       </div>
       <div className=\\"test-step-view-container\\">
-        <TestStepView deps={{...}} isScanning={false} testStep={{...}} renderStaticContent={[undefined]} instancesMap={{...}} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} manualTestStepResultMap={{...}} actionMessageCreator={{...}} assessmentsProvider={{...}} isStepEnabled={false} isStepScanned={false} assessmentDefaultMessageGenerator={{...}} />
+        <TestStepView deps={{...}} isScanning={false} testStep={{...}} renderStaticContent={[undefined]} instancesMap={{...}} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} manualTestStepResultMap={{...}} actionMessageCreator={{...}} assessmentsProvider={{...}} isStepEnabled={false} isStepScanned={false} assessmentDefaultMessageGenerator={{...}} featureFlagStoreData={{...}} />
       </div>
     </div>
   </AssessmentViewMainContentExtensionPoint>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
@@ -24,48 +24,19 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: add
   >
     <FlaggedComponent
       enableJSXElement={
-        <div>
-          <a
-            className="learn-more"
-          >
-             Learn more about adding failure instances 
-          </a>
-          <StyledTextFieldBase
-            className="selector-failure-textfield"
-            defaultValue="CSS selector"
-            label="CSS Selector"
-            multiline={true}
-            onChange={[Function]}
-            resizable={false}
-            rows={8}
-            value=""
-          />
-          <div>
-            Note: If the CSS selector maps to multiple snippets, the first will be selected.
-          </div>
-          <div>
-            <CustomizedDefaultButton
-              disabled={true}
-              onClick={[Function]}
-              text="Validate CSS selector"
-            />
-          </div>
-          <div>
-            <label>
-              Code Snippet
-            </label>
-            <div>
-              
-            </div>
-          </div>
-        </div>
+        <FailureInstancePanelDetails
+          onSelectorChange={[Function]}
+          onValidateSelector={[Function]}
+          path=""
+          snippet=""
+        />
       }
       featureFlag="manualInstanceDetails"
       featureFlagStoreData={Object {}}
     />
     <StyledTextFieldBase
       className="observed-failure-textfield"
-      label="Observed failure"
+      label="Comments"
       multiline={true}
       onChange={[Function]}
       resizable={false}
@@ -104,48 +75,19 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
   >
     <FlaggedComponent
       enableJSXElement={
-        <div>
-          <a
-            className="learn-more"
-          >
-             Learn more about adding failure instances 
-          </a>
-          <StyledTextFieldBase
-            className="selector-failure-textfield"
-            defaultValue="CSS selector"
-            label="CSS Selector"
-            multiline={true}
-            onChange={[Function]}
-            resizable={false}
-            rows={8}
-            value=""
-          />
-          <div>
-            Note: If the CSS selector maps to multiple snippets, the first will be selected.
-          </div>
-          <div>
-            <CustomizedDefaultButton
-              disabled={true}
-              onClick={[Function]}
-              text="Validate CSS selector"
-            />
-          </div>
-          <div>
-            <label>
-              Code Snippet
-            </label>
-            <div>
-              
-            </div>
-          </div>
-        </div>
+        <FailureInstancePanelDetails
+          onSelectorChange={[Function]}
+          onValidateSelector={[Function]}
+          path=""
+          snippet=""
+        />
       }
       featureFlag="manualInstanceDetails"
       featureFlagStoreData={Object {}}
     />
     <StyledTextFieldBase
       className="observed-failure-textfield"
-      label="Observed failure"
+      label="Comments"
       multiline={true}
       onChange={[Function]}
       resizable={false}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
@@ -52,9 +52,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl with
         Code Snippet
       </label>
       <div>
-         
-        Code snippet will auto-populate based on the CSS selector input.
-         
+        
       </div>
     </div>
     <StyledTextFieldBase

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
@@ -1,5 +1,83 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FailureInstancePanelControlTest render FailureInstancePanelControl with details: add instance 1`] = `
+<React.Fragment>
+  <CustomizedActionButton
+    ariaDescription="Open add a failure instance panel"
+    ariaLabel="Add a failure instance"
+    iconProps={
+      Object {
+        "iconName": "Add",
+      }
+    }
+    onClick={[Function]}
+  >
+    Add a failure instance
+  </CustomizedActionButton>
+  <GenericPanel
+    className="failure-instance-panel"
+    closeButtonAriaLabel={null}
+    hasCloseButton={false}
+    isOpen={false}
+    onDismiss={[Function]}
+    title="Add a failure instance"
+  >
+    <a
+      className="learn-more"
+    >
+       Learn more about adding failure instances 
+    </a>
+    <StyledTextFieldBase
+      className="selector-failure-textfield"
+      defaultValue="CSS selector"
+      label="CSS Selector"
+      multiline={true}
+      onChange={[Function]}
+      resizable={false}
+      rows={8}
+      value=""
+    />
+    <div>
+      Note: If the CSS selector maps to multiple snippets, the first will be selected.
+    </div>
+    <div>
+      <CustomizedDefaultButton
+        disabled={true}
+        onClick={[Function]}
+        text="Validate CSS selector"
+      />
+    </div>
+    <div>
+      <label>
+        Code Snippet
+      </label>
+      <div>
+         
+        Code snippet will auto-populate based on the CSS selector input.
+         
+      </div>
+    </div>
+    <StyledTextFieldBase
+      className="observed-failure-textfield"
+      defaultValue="Comments"
+      label="Observed failure"
+      multiline={true}
+      onChange={[Function]}
+      resizable={false}
+      rows={8}
+      value=""
+    />
+    <ActionAndCancelButtonsComponent
+      cancelButtonOnClick={[Function]}
+      isHidden={false}
+      primaryButtonDisabled={true}
+      primaryButtonOnClick={[Function]}
+      primaryButtonText="Add failed instance"
+    />
+  </GenericPanel>
+</React.Fragment>
+`;
+
 exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: add instance 1`] = `
 <React.Fragment>
   <CustomizedActionButton

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
@@ -1,81 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FailureInstancePanelControlTest render FailureInstancePanelControl with details: add instance 1`] = `
-<React.Fragment>
-  <CustomizedActionButton
-    ariaDescription="Open add a failure instance panel"
-    ariaLabel="Add a failure instance"
-    iconProps={
-      Object {
-        "iconName": "Add",
-      }
-    }
-    onClick={[Function]}
-  >
-    Add a failure instance
-  </CustomizedActionButton>
-  <GenericPanel
-    className="failure-instance-panel"
-    closeButtonAriaLabel={null}
-    hasCloseButton={false}
-    isOpen={false}
-    onDismiss={[Function]}
-    title="Add a failure instance"
-  >
-    <a
-      className="learn-more"
-    >
-       Learn more about adding failure instances 
-    </a>
-    <StyledTextFieldBase
-      className="selector-failure-textfield"
-      defaultValue="CSS selector"
-      label="CSS Selector"
-      multiline={true}
-      onChange={[Function]}
-      resizable={false}
-      rows={8}
-      value=""
-    />
-    <div>
-      Note: If the CSS selector maps to multiple snippets, the first will be selected.
-    </div>
-    <div>
-      <CustomizedDefaultButton
-        disabled={true}
-        onClick={[Function]}
-        text="Validate CSS selector"
-      />
-    </div>
-    <div>
-      <label>
-        Code Snippet
-      </label>
-      <div>
-        
-      </div>
-    </div>
-    <StyledTextFieldBase
-      className="observed-failure-textfield"
-      defaultValue="Comments"
-      label="Observed failure"
-      multiline={true}
-      onChange={[Function]}
-      resizable={false}
-      rows={8}
-      value=""
-    />
-    <ActionAndCancelButtonsComponent
-      cancelButtonOnClick={[Function]}
-      isHidden={false}
-      primaryButtonDisabled={true}
-      primaryButtonOnClick={[Function]}
-      primaryButtonText="Add failed instance"
-    />
-  </GenericPanel>
-</React.Fragment>
-`;
-
 exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: add instance 1`] = `
 <React.Fragment>
   <CustomizedActionButton
@@ -98,6 +22,47 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: add
     onDismiss={[Function]}
     title="Add a failure instance"
   >
+    <FlaggedComponent
+      enableJSXElement={
+        <div>
+          <a
+            className="learn-more"
+          >
+             Learn more about adding failure instances 
+          </a>
+          <StyledTextFieldBase
+            className="selector-failure-textfield"
+            defaultValue="CSS selector"
+            label="CSS Selector"
+            multiline={true}
+            onChange={[Function]}
+            resizable={false}
+            rows={8}
+            value=""
+          />
+          <div>
+            Note: If the CSS selector maps to multiple snippets, the first will be selected.
+          </div>
+          <div>
+            <CustomizedDefaultButton
+              disabled={true}
+              onClick={[Function]}
+              text="Validate CSS selector"
+            />
+          </div>
+          <div>
+            <label>
+              Code Snippet
+            </label>
+            <div>
+              
+            </div>
+          </div>
+        </div>
+      }
+      featureFlag="manualInstanceDetails"
+      featureFlagStoreData={Object {}}
+    />
     <StyledTextFieldBase
       className="observed-failure-textfield"
       label="Observed failure"
@@ -137,6 +102,47 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
     onDismiss={[Function]}
     title="Edit failure instance"
   >
+    <FlaggedComponent
+      enableJSXElement={
+        <div>
+          <a
+            className="learn-more"
+          >
+             Learn more about adding failure instances 
+          </a>
+          <StyledTextFieldBase
+            className="selector-failure-textfield"
+            defaultValue="CSS selector"
+            label="CSS Selector"
+            multiline={true}
+            onChange={[Function]}
+            resizable={false}
+            rows={8}
+            value=""
+          />
+          <div>
+            Note: If the CSS selector maps to multiple snippets, the first will be selected.
+          </div>
+          <div>
+            <CustomizedDefaultButton
+              disabled={true}
+              onClick={[Function]}
+              text="Validate CSS selector"
+            />
+          </div>
+          <div>
+            <label>
+              Code Snippet
+            </label>
+            <div>
+              
+            </div>
+          </div>
+        </div>
+      }
+      featureFlag="manualInstanceDetails"
+      featureFlagStoreData={Object {}}
+    />
     <StyledTextFieldBase
       className="observed-failure-textfield"
       label="Observed failure"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-details.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-details.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FailureInstancePanelDetailsTest renders 1`] = `
+<div>
+  <a
+    className="learn-more"
+  >
+     Learn more about adding failure instances 
+  </a>
+  <StyledTextFieldBase
+    className="selector-failure-textfield"
+    defaultValue="CSS selector"
+    label="CSS Selector"
+    multiline={true}
+    onChange={[Function]}
+    resizable={false}
+    rows={8}
+    value="Given Path"
+  />
+  <div>
+    Note: If the CSS selector maps to multiple snippets, the first will be selected.
+  </div>
+  <div>
+    <CustomizedDefaultButton
+      disabled={false}
+      onClick={[Function]}
+      text="Validate CSS selector"
+    />
+  </div>
+  <div>
+    <label>
+      Code Snippet
+    </label>
+    <div>
+      Snippet for Given Path
+    </div>
+  </div>
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
@@ -5,6 +5,7 @@ import { Link } from 'office-ui-fabric-react/lib/Link';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
 
+import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import {
     AssessmentInstanceEditAndRemoveControl,
@@ -17,6 +18,8 @@ import {
 import { CreateTestAssessmentProvider } from '../../../common/test-assessment-provider';
 
 describe('AssessmentInstanceRemoveButton', () => {
+    const featureFlagStoreData = {} as FeatureFlagStoreData;
+
     test('constructor', () => {
         const testObject = new AssessmentInstanceEditAndRemoveControl({} as AssessmentInstanceEditAndRemoveControlProps);
         expect(testObject).toBeInstanceOf(React.Component);
@@ -32,6 +35,7 @@ describe('AssessmentInstanceRemoveButton', () => {
             onRemove: onRemoveMock.object,
             onEdit: null,
             assessmentsProvider: CreateTestAssessmentProvider(),
+            featureFlagStoreData: featureFlagStoreData,
         };
         onRemoveMock.setup(r => r(props.test, props.step, props.id)).verifiable(Times.once());
 
@@ -46,7 +50,7 @@ describe('AssessmentInstanceRemoveButton', () => {
                     editFailureInstance={props.onEdit}
                     originalText={props.description}
                     assessmentsProvider={props.assessmentsProvider}
-                    featureFlagStoreData={null}
+                    featureFlagStoreData={featureFlagStoreData}
                 />
                 <Link className="remove-button" onClick={testSubject.getOnRemoveButtonClicked()}>
                     <Icon iconName="delete" ariaLabel={'delete instance'} />

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
@@ -46,6 +46,7 @@ describe('AssessmentInstanceRemoveButton', () => {
                     editFailureInstance={props.onEdit}
                     originalText={props.description}
                     assessmentsProvider={props.assessmentsProvider}
+                    featureFlagStoreData={null}
                 />
                 <Link className="remove-button" onClick={testSubject.getOnRemoveButtonClicked()}>
                     <Icon iconName="delete" ariaLabel={'delete instance'} />

--- a/src/tests/unit/tests/DetailsView/components/assessment-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-test-view.test.tsx
@@ -6,6 +6,7 @@ import { IMock, Mock, MockBehavior } from 'typemoq';
 
 import { VisualizationConfiguration } from '../../../../../common/configs/visualization-configuration';
 import { AssessmentData, AssessmentStoreData } from '../../../../../common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { ScanData, TestsEnabledState, VisualizationStoreData } from '../../../../../common/types/store-data/visualization-store-data';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import {
@@ -25,6 +26,7 @@ describe('AssessmentTestView', () => {
     let actionMessageCreatorStub: DetailsViewActionMessageCreator;
     let assessmentInstanceHandlerStub: AssessmentInstanceTableHandler;
     let configuration: VisualizationConfiguration;
+    let featureFlagStoreDataStub: FeatureFlagStoreData;
     let assessmentStoreDataStub: AssessmentStoreData;
     let assessmentDataStub: AssessmentData;
     const selectedTestStep = 'step';
@@ -53,6 +55,7 @@ describe('AssessmentTestView', () => {
                 selectedTestStep: selectedTestStep,
             },
         } as AssessmentStoreData;
+        featureFlagStoreDataStub = {} as FeatureFlagStoreData;
         actionMessageCreatorStub = {} as DetailsViewActionMessageCreator;
         assessmentInstanceHandlerStub = {} as AssessmentInstanceTableHandler;
         assessmentDataStub = {} as AssessmentData;
@@ -70,6 +73,7 @@ describe('AssessmentTestView', () => {
             },
             assessmentStoreData: assessmentStoreDataStub,
             assessmentInstanceTableHandler: assessmentInstanceHandlerStub,
+            featureFlagStoreData: featureFlagStoreDataStub,
         } as AssessmentTestViewProps;
 
         getStoreDataMock

--- a/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
@@ -12,6 +12,7 @@ import { getInnerTextFromJsxElement } from '../../../../../common/get-inner-text
 import { ContentActionMessageCreator } from '../../../../../common/message-creators/content-action-message-creator';
 import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
 import { AssessmentData } from '../../../../../common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { UrlParser } from '../../../../../common/url-parser';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
@@ -252,6 +253,8 @@ class AssessmentViewPropsBuilder {
             manualTestStepResultMap: {},
         } as AssessmentData;
 
+        const featureFlagStoreData = {} as FeatureFlagStoreData;
+
         const props: AssessmentViewProps = {
             deps,
             prevTarget,
@@ -266,6 +269,7 @@ class AssessmentViewPropsBuilder {
             assessmentData,
             assessmentDefaultMessageGenerator: this.assessmentGeneratorInstance,
             assessmentTestResult: new AssessmentTestResult(this.provider, assessment.visualizationType, assessmentData),
+            featureFlagStoreData,
         };
 
         return props;

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
 import { Assessments } from '../../../../../assessments/assessments';
+import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { ActionAndCancelButtonsComponent } from '../../../../../DetailsView/components/action-and-cancel-buttons-component';
 import {
@@ -26,14 +27,30 @@ describe('FailureInstancePanelControlTest', () => {
     });
 
     test('render FailureInstancePanelControl: add instance', () => {
-        const props = createPropsWithType(CapturedInstanceActionType.CREATE);
+        const featureFlagStoreData = {
+            manualInstanceDetails: false,
+        };
+
+        const props = createPropsWithTypeAndData(CapturedInstanceActionType.CREATE, featureFlagStoreData);
+
+        const rendered = shallow(<FailureInstancePanelControl {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    test('render FailureInstancePanelControl with details: add instance', () => {
+        const featureFlagStoreData = {
+            manualInstanceDetails: true,
+        };
+
+        const props = createPropsWithTypeAndData(CapturedInstanceActionType.CREATE, featureFlagStoreData);
 
         const rendered = shallow(<FailureInstancePanelControl {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
     test('render FailureInstancePanelControl: edit instance', () => {
-        const props = createPropsWithType(CapturedInstanceActionType.EDIT);
+        const featureFlagStoreData = null;
+        const props = createPropsWithTypeAndData(CapturedInstanceActionType.EDIT, featureFlagStoreData);
 
         const rendered = shallow(<FailureInstancePanelControl {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
@@ -140,12 +157,28 @@ describe('FailureInstancePanelControlTest', () => {
     });
 
     function createPropsWithType(actionType: CapturedInstanceActionType): FailureInstancePanelControlProps {
+        const featureFlagStoreData = {} as FeatureFlagStoreData;
         return {
             step: 'missingHeadings',
             test: VisualizationType.HeadingsAssessment,
             addFailureInstance: addInstanceMock.object,
             actionType: actionType,
             assessmentsProvider: Assessments,
+            featureFlagStoreData: featureFlagStoreData,
+        };
+    }
+
+    function createPropsWithTypeAndData(
+        actionType: CapturedInstanceActionType,
+        featureData: FeatureFlagStoreData,
+    ): FailureInstancePanelControlProps {
+        return {
+            step: 'missingHeadings',
+            test: VisualizationType.HeadingsAssessment,
+            addFailureInstance: addInstanceMock.object,
+            actionType: actionType,
+            assessmentsProvider: Assessments,
+            featureFlagStoreData: featureData,
         };
     }
 });

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -27,31 +27,13 @@ describe('FailureInstancePanelControlTest', () => {
     });
 
     test('render FailureInstancePanelControl: add instance', () => {
-        const featureFlagStoreData = {
-            manualInstanceDetails: false,
-        };
-
-        const props = createPropsWithTypeAndData(CapturedInstanceActionType.CREATE, featureFlagStoreData);
-
-        const rendered = shallow(<FailureInstancePanelControl {...props} />);
-        expect(rendered.getElement()).toMatchSnapshot();
-    });
-
-    test('render FailureInstancePanelControl with details: add instance', () => {
-        const featureFlagStoreData = {
-            manualInstanceDetails: true,
-        };
-
-        const props = createPropsWithTypeAndData(CapturedInstanceActionType.CREATE, featureFlagStoreData);
-
+        const props = createPropsWithType(CapturedInstanceActionType.CREATE);
         const rendered = shallow(<FailureInstancePanelControl {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
     test('render FailureInstancePanelControl: edit instance', () => {
-        const featureFlagStoreData = null;
-        const props = createPropsWithTypeAndData(CapturedInstanceActionType.EDIT, featureFlagStoreData);
-
+        const props = createPropsWithType(CapturedInstanceActionType.EDIT);
         const rendered = shallow(<FailureInstancePanelControl {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
@@ -59,6 +41,7 @@ describe('FailureInstancePanelControlTest', () => {
     test('onFailureDescriptionChange', () => {
         const description = 'abc';
         const props = createPropsWithType(CapturedInstanceActionType.CREATE);
+
         const wrapper = shallow<FailureInstancePanelControl>(<FailureInstancePanelControl {...props} />);
         wrapper
             .find(TextField)
@@ -157,21 +140,7 @@ describe('FailureInstancePanelControlTest', () => {
     });
 
     function createPropsWithType(actionType: CapturedInstanceActionType): FailureInstancePanelControlProps {
-        const featureFlagStoreData = {} as FeatureFlagStoreData;
-        return {
-            step: 'missingHeadings',
-            test: VisualizationType.HeadingsAssessment,
-            addFailureInstance: addInstanceMock.object,
-            actionType: actionType,
-            assessmentsProvider: Assessments,
-            featureFlagStoreData: featureFlagStoreData,
-        };
-    }
-
-    function createPropsWithTypeAndData(
-        actionType: CapturedInstanceActionType,
-        featureData: FeatureFlagStoreData,
-    ): FailureInstancePanelControlProps {
+        const featureData = {} as FeatureFlagStoreData;
         return {
             step: 'missingHeadings',
             test: VisualizationType.HeadingsAssessment,

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-details.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-details.test.tsx
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { It, Mock, Times } from 'typemoq';
+import { DefaultButton, TextField } from '../../../../../../node_modules/office-ui-fabric-react';
+import { FailureInstancePanelDetails } from '../../../../../DetailsView/components/failure-instance-panel-details';
+
+describe('FailureInstancePanelDetailsTest', () => {
+    const path = 'Given Path';
+    const snippet = 'Snippet for Given Path';
+    const onSelectorChangeMock = Mock.ofInstance((value: string) => {});
+    const onValidateSelectorMock = Mock.ofInstance(() => {});
+
+    beforeEach(() => {
+        onSelectorChangeMock.reset();
+        onValidateSelectorMock.reset();
+    });
+
+    const rendered = shallow(
+        <FailureInstancePanelDetails
+            path={path}
+            snippet={snippet}
+            onSelectorChange={onSelectorChangeMock.object}
+            onValidateSelector={onValidateSelectorMock.object}
+        ></FailureInstancePanelDetails>,
+    );
+
+    it('renders', () => {
+        expect(rendered.exists());
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('triggers selector change on typing', () => {
+        const newPath = 'updated path';
+        onSelectorChangeMock.setup(dc => dc(It.isValue(newPath))).verifiable(Times.once());
+
+        const textField = rendered.find(TextField);
+        textField.simulate('change', newPath);
+        onSelectorChangeMock.verifyAll();
+    });
+
+    it('triggers validation on click', () => {
+        onValidateSelectorMock.setup(getter => getter()).verifiable(Times.once());
+
+        rendered.find(DefaultButton).simulate('click');
+        onValidateSelectorMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
@@ -6,6 +6,7 @@ import { Mock } from 'typemoq';
 
 import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
 import { ManualTestStepResult } from '../../../../../common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import {
     CapturedInstanceActionType,
@@ -17,6 +18,8 @@ import { AssessmentInstanceTableHandler } from '../../../../../DetailsView/handl
 import { CreateTestAssessmentProvider } from '../../../common/test-assessment-provider';
 
 describe('ManualTestStepView', () => {
+    const featureFlagStoreData = {} as FeatureFlagStoreData;
+
     test('constructor: default', () => {
         const assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
         const props: ManualTestStepViewProps = {
@@ -29,6 +32,7 @@ describe('ManualTestStepView', () => {
                 } as ManualTestStepResult,
             },
             assessmentsProvider: CreateTestAssessmentProvider(),
+            featureFlagStoreData: featureFlagStoreData,
         };
         const testObject = new ManualTestStepView(props);
 
@@ -71,6 +75,7 @@ describe('ManualTestStepView', () => {
                 },
             },
             assessmentsProvider: CreateTestAssessmentProvider(),
+            featureFlagStoreData: featureFlagStoreData,
         };
         assessmentInstanceTableHandlerMock.setup(a => a.getColumnConfigsForCapturedInstance()).returns(() => cols);
         assessmentInstanceTableHandlerMock
@@ -100,6 +105,7 @@ describe('ManualTestStepView', () => {
                             actionType={CapturedInstanceActionType.CREATE}
                             addFailureInstance={props.assessmentInstanceTableHandler.addFailureInstance}
                             assessmentsProvider={props.assessmentsProvider}
+                            featureFlagStoreData={featureFlagStoreData}
                         />
                         <DetailsList
                             items={items}

--- a/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
@@ -79,7 +79,7 @@ describe('ManualTestStepView', () => {
         };
         assessmentInstanceTableHandlerMock.setup(a => a.getColumnConfigsForCapturedInstance()).returns(() => cols);
         assessmentInstanceTableHandlerMock
-            .setup(a => a.createCapturedInstanceTableItems(instances, props.test, props.step))
+            .setup(a => a.createCapturedInstanceTableItems(instances, props.test, props.step, featureFlagStoreData))
             .returns(() => items);
         const testObject = new ManualTestStepView(props);
 

--- a/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
+++ b/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
@@ -9,6 +9,7 @@ import {
     GeneratedAssessmentInstance,
     UserCapturedInstance,
 } from '../../../../../common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import { AssessmentInstanceEditAndRemoveControl } from '../../../../../DetailsView/components/assessment-instance-edit-and-remove-control';
@@ -25,6 +26,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
     let actionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
     let configFactoryMock: IMock<AssessmentTableColumnConfigHandler>;
     const assessmentsProvider = CreateTestAssessmentProvider();
+    const featureFlagStoreData = {} as FeatureFlagStoreData;
 
     beforeEach(() => {
         actionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator);
@@ -123,6 +125,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
             [instance],
             assessmentNavState.selectedTestType,
             assessmentNavState.selectedTestStep,
+            featureFlagStoreData,
         );
 
         const instanceActionButtons: JSX.Element = (
@@ -134,6 +137,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
                 onEdit={actionMessageCreatorMock.object.editFailureInstance}
                 description={instance.description}
                 assessmentsProvider={assessmentsProvider}
+                featureFlagStoreData={featureFlagStoreData}
             />
         );
         const expectedRows: CapturedInstanceRowData[] = [


### PR DESCRIPTION
#### Description of changes

Adding fields for the path/snippet in the Failure Instance Panel *only* when Manual Instance Detail Feature Flag is flipped to "on." Lots of edits to get the Feature Flag Store Data all the way to the Failure Instance Panel. 
Most test changes are to reflect this new prop added to the flow. One unit test added to Failure Instance Panel Test to check that UI reflects classic version when flag is off and new version when flag is on.
Finally added snippet and path to the state of Failure Instance Panel (where comment was/is as well).

#### Pull request checklist

- [X] Addresses an existing issue: First PR for Feature #1555720
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [X] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS

<img width="396" alt="FailureInstanceDetails" src="https://user-images.githubusercontent.com/24820607/60375301-7d34ed00-99bd-11e9-83aa-557312ad431f.png">

