### PR TITLE
building the web extension only

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -361,6 +361,15 @@ module.exports = function(grunt) {
         'drop:electron',
         'release-drops',
     ]);
+    grunt.registerTask('build-web-extension', [
+        'clean:intermediates',
+        'exec:generate-scss-typings',
+        'build-assets',
+        'exec:webpack-dev', // needed for running e2e tests
+        'exec:webpack-prod',
+        'drop:dev',
+        'release-drops',
+    ]);
 
     grunt.registerTask('default', ['build-dev']);
 };

--- a/build.yaml
+++ b/build.yaml
@@ -78,3 +78,14 @@ jobs:
                 pathtoPublish: '$(System.DefaultWorkingDirectory)/drop'
                 artifactName: 'drop'
             displayName: publish drop
+
+    - job: 'build_electron_app'
+
+      pool:
+          vmImage: 'macOS-10.13'
+
+      steps:
+          - template: pipeline/prerequisites.yaml
+
+          - script: yarn build:electron
+            displayName: build electron app

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "build:dev": "grunt build-dev",
         "build:electron": "grunt build-electron",
         "build:prod": "grunt build-prod",
+        "build:web-extension": "grunt build-web-extension",
         "copyrightheaders": "grunt copyright-check",
         "copyrightheaders:fix": "grunt copyright-add",
         "format": "prettier --config prettier.config.js --write \"**/*\"",

--- a/pipeline/e2e-test.yaml
+++ b/pipeline/e2e-test.yaml
@@ -2,8 +2,8 @@
 # Licensed under the MIT License.
 steps:
     # e2e tests depend drop folder. run build:all will create said folder
-    - script: yarn build:all
-      displayName: build:all
+    - script: yarn build:web-extension
+      displayName: build:web-extension
 
     - script: yarn test:e2e -- --ci
       displayName: run e2e tests


### PR DESCRIPTION
#### Description of changes

Our builds are currently building "all" which includes our electron "getting started" app.
Working on updating typescript to 3.5.x, I can see our build failing (logs [here](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=22980&view=logs)) due to `Fatal error: Missing required file extension/devBundle/background.bundle.js`
Not sure what the root cause of this is but it looks like calling `webpack` without the `config` or `config-name` param, which up to this moment was building all configs -dev, prod & electron- only builds `prod` config.

One way to address this is by calling `webpack` with an explicit config/config-name.

To summaries this PR includes:
- new grunt task to build only the web extension (no electron building on the new task)
- calling webpack configs explicitly
   - we need to call `dev` config in order to run e2e test
   - we need to call `prod` to build the artifact we use on our release process

**Notes**:
- manual build logs [here](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_build/results?buildId=1597)
- playground release logs [here](https://dev.azure.com/accessibility-insights-private/Accessibility%20Insights%20(private)/_releaseProgress?_a=release-pipeline-progress&releaseId=719)
- extension version: 2019.7.1.2248 

![01 - extension version on chrome](https://user-images.githubusercontent.com/2837582/60472476-e450dc80-9c1d-11e9-9efb-3af93b58cd04.png)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`)
   - no code changes => does not apply
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - no code changes => does not apply
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no code changes => does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - no code changes => does not apply
