### PR TITLE
Color changes to $communication-primary, shade-10, shade-20, shade-30

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -325,7 +325,7 @@ div.insights-file-issue-details-dialog-container {
             text-overflow: ellipsis;
             width: 50%;
             .ms-Link {
-                color: $communication-shade-10;
+                color: $communication-primary;
             }
         }
         .details-view-command-buttons {
@@ -782,7 +782,7 @@ div.insights-file-issue-details-dialog-container {
             .info-message-bar {
                 background-color: $communication-tint-40;
                 .ms-MessageBar-icon {
-                    color: $communication-shade-10;
+                    color: $communication-primary;
                 }
                 .ms-link {
                     font-weight: 700;
@@ -804,7 +804,7 @@ div.insights-file-issue-details-dialog-container {
                 word-break: break-all;
                 font-weight: 600;
                 .ms-Link {
-                    color: $communication-shade-10;
+                    color: $communication-primary;
                 }
                 .target-page-link {
                     font-family: $fontFamily;
@@ -959,7 +959,7 @@ div.insights-file-issue-details-dialog-container {
                 .more-info {
                     font-size: 14px;
                     .ms-Link {
-                        color: $communication-shade-10;
+                        color: $communication-primary;
                     }
                 }
                 .landmark-roles-table {

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -22,14 +22,14 @@
     --disabled-text-invert: rgba(255, 255, 255, 0.32);
 
     // UI colors
-    --communication-primary: #0078d4;
+    --communication-primary: #106ebe;
     --communication-tint-40: #eff6fc;
     --communication-tint-30: #deecf9;
     --communication-tint-20: #c7e0f4;
     --communication-tint-10: #2b88d8;
-    --communication-shade-10: #106ebe;
-    --communication-shade-20: #005a9e;
-    --communication-shade-30: #004578;
+    --communication-shade-10: #005a9e;
+    --communication-shade-20: #004578;
+    --communication-shade-30: #003358;
     // Base
     --neutral-0: var(--white);
     --neutral-100: var(--black);
@@ -65,15 +65,15 @@
     --accent2-dark: rgb(16, 124, 16);
     --communication-alpha-5: rgba(0, 120, 212, 0.05);
     --overview-percent-selected: var(--neutral-55);
-    --index-circle-background: var(--communication-shade-10);
+    --index-circle-background: var(--communication-primary);
     --check-box-border: var(--neutral-30);
     --check-box-tick: var(--neutral-100);
     --check-box-background: var(--neutral-8);
     --row-selected-background: var(--communication-tint-40);
     --group-selected-background: var(--communication-tint-40);
     --row-hover-background: var(--neutral-4);
-    --link: var(--communication-shade-10);
-    --link-hover: var(--communication-shade-30);
+    --link: var(--communication-primary);
+    --link-hover: var(--communication-shade-20);
     --switcher-border: var(--ada-brand-variant);
     --switcher-focus-border: var(--neutral-0);
     --help-links-section-background: var(--neutral-4);

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -23,10 +23,10 @@ button::after {
 }
 
 .ms-Button.ms-Button--primary:not(.is-disabled) {
-    background: $communication-shade-10;
+    background: $communication-primary;
 
     &:hover {
-        background: $communication-shade-20;
+        background: $communication-shade-10;
     }
 }
 

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -107,7 +107,7 @@
     }
 
     .insights-dialog-main-override .insights-dialog-button-inspect svg path {
-        fill: $communication-shade-10 !important;
+        fill: $primary-text !important;
     }
 
     .insights-dialog-main-override .insights-dialog-button-inspect.is-disabled svg path {
@@ -115,7 +115,7 @@
     }
 
     .insights-dialog-main-override-shadow .insights-dialog-button-inspect svg path {
-        fill: $communication-shade-10 !important;
+        fill: $communication-primary !important;
     }
 
     .insights-dialog-main-override-shadow .insights-dialog-button-inspect.is-disabled svg path {
@@ -176,7 +176,7 @@
         padding: 0 !important;
 
         .ms-Link {
-            color: $communication-shade-10;
+            color: $communication-primary;
         }
     }
 
@@ -218,7 +218,7 @@
                     cursor: pointer;
 
                     &:hover {
-                        color: $communication-shade-30;
+                        color: $communication-shade-20;
                     }
                 }
 

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -180,7 +180,7 @@ html {
 }
 
 .popup-menu .ms-ContextualMenu-icon {
-    color: $communication-shade-10;
+    color: $communication-primary;
     max-height: 30px;
 }
 
@@ -350,7 +350,7 @@ button[disabled]:focus:not(.ms-ContextualMenu-link) {
 
 #popup-container {
     .ms-Link {
-        color: $communication-shade-10;
+        color: $communication-primary;
         font-weight: 600;
     }
 


### PR DESCRIPTION
#### Description of changes

The original color for $communication-primary was #0078D4, which failed color contrast when sitting on backgrounds darker than #FFFFFF. Updated our primary communication shade to #106EBE, and adjusted the darker shades to stay in line with the shading gradient. Adjusted a couple of places where elements were listed with #communiation-shade-10 as a temporary fix to the contrast issue, but should be $communication-primary. 

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #601 
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
