### PR TITLE
feat: add rule resources card

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -64,6 +64,40 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
             }
         }
     }
+
+    .rule-more-resources {
+        display: flex;
+        flex-direction: column;
+
+        margin-left: 24px;
+        margin-bottom: 16px;
+        padding: 14px 20px;
+
+        background-color: $always-white;
+
+        box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108), 0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
+
+        border-radius: 4px;
+
+        line-height: 20px;
+
+        .more-resources-title {
+            font-family: $semiBoldFontFamily;
+        }
+
+        .rule-details-id {
+            padding: 12px 0;
+            font-size: 15px;
+
+            a {
+                text-decoration: none !important;
+            }
+        }
+
+        .guidance-links a {
+            text-decoration: none !important;
+        }
+    }
 }
 
 .result-section {

--- a/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
@@ -1,24 +1,54 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-
+import { GuidanceLinks } from '../../../../common/components/guidance-links';
+import { NewTabLink } from '../../../../common/components/new-tab-link';
+import { GetGuidanceTagsFromGuidanceLinks } from '../../../../common/get-guidance-tags-from-guidance-links';
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { FixInstructionProcessor } from '../../../../injected/fix-instruction-processor';
+import { RuleResult } from '../../../../scanner/iruleresults';
 import { InstanceDetails } from './instance-details';
 
+export type InstanceDetailsGroupDeps = {
+    getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks;
+};
+
 export type InstanceDetailsGroupProps = {
+    deps: InstanceDetailsGroupDeps;
+    rule: RuleResult;
     fixInstructionProcessor: FixInstructionProcessor;
-    nodeResults: AxeNodeResult[];
 };
 
 export const InstanceDetailsGroup = NamedSFC<InstanceDetailsGroupProps>('InstanceDetailsGroup', props => {
+    const { fixInstructionProcessor, rule } = props;
+    const { nodes } = rule;
+
+    const renderRuleLink = () => {
+        const ruleId = rule.id;
+        const ruleUrl = rule.helpUrl;
+        return (
+            <span className="rule-details-id">
+                <NewTabLink href={ruleUrl}>More information about {ruleId}</NewTabLink>
+            </span>
+        );
+    };
+
+    const renderGuidanceLinks = () => <GuidanceLinks links={rule.guidanceLinks} />;
+
     return (
-        <ul className="instance-details-list" aria-label="failed instances with path, snippet and how to fix information">
-            {props.nodeResults.map((node, index) => (
-                <li key={`instance-details-${index}`}>
-                    <InstanceDetails {...{ index, ...node, fixInstructionProcessor: props.fixInstructionProcessor }} />
-                </li>
-            ))}
-        </ul>
+        <>
+            <div className="rule-more-resources">
+                <div>Resources for this rule</div>
+                {renderRuleLink()}
+                {renderGuidanceLinks()}
+            </div>
+            <ul className="instance-details-list" aria-label="failed instances with path, snippet and how to fix information">
+                {nodes.map((node, index) => (
+                    <li key={`instance-details-${index}`}>
+                        <InstanceDetails {...{ index, ...node, fixInstructionProcessor: fixInstructionProcessor }} />
+                    </li>
+                ))}
+            </ul>
+        </>
     );
 });

--- a/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
@@ -38,7 +38,7 @@ export const InstanceDetailsGroup = NamedSFC<InstanceDetailsGroupProps>('Instanc
     return (
         <>
             <div className="rule-more-resources">
-                <div>Resources for this rule</div>
+                <div className="more-resources-title">Resources for this rule</div>
                 {renderRuleLink()}
                 {renderGuidanceLinks()}
             </div>

--- a/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { GuidanceLinks } from '../../../../common/components/guidance-links';
-import { NewTabLink } from '../../../../common/components/new-tab-link';
 import { GetGuidanceTagsFromGuidanceLinks } from '../../../../common/get-guidance-tags-from-guidance-links';
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { FixInstructionProcessor } from '../../../../injected/fix-instruction-processor';
@@ -23,32 +21,13 @@ export const InstanceDetailsGroup = NamedSFC<InstanceDetailsGroupProps>('Instanc
     const { fixInstructionProcessor, rule } = props;
     const { nodes } = rule;
 
-    const renderRuleLink = () => {
-        const ruleId = rule.id;
-        const ruleUrl = rule.helpUrl;
-        return (
-            <span className="rule-details-id">
-                <NewTabLink href={ruleUrl}>More information about {ruleId}</NewTabLink>
-            </span>
-        );
-    };
-
-    const renderGuidanceLinks = () => <GuidanceLinks links={rule.guidanceLinks} />;
-
     return (
-        <>
-            <div className="rule-more-resources">
-                <div className="more-resources-title">Resources for this rule</div>
-                {renderRuleLink()}
-                {renderGuidanceLinks()}
-            </div>
-            <ul className="instance-details-list" aria-label="failed instances with path, snippet and how to fix information">
-                {nodes.map((node, index) => (
-                    <li key={`instance-details-${index}`}>
-                        <InstanceDetails {...{ index, ...node, fixInstructionProcessor: fixInstructionProcessor }} />
-                    </li>
-                ))}
-            </ul>
-        </>
+        <ul className="instance-details-list" aria-label="failed instances with path, snippet and how to fix information">
+            {nodes.map((node, index) => (
+                <li key={`instance-details-${index}`}>
+                    <InstanceDetails {...{ index, ...node, fixInstructionProcessor: fixInstructionProcessor }} />
+                </li>
+            ))}
+        </ul>
     );
 });

--- a/src/DetailsView/reports/components/report-sections/rule-content.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-content.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+import { NamedSFC } from '../../../../common/react/named-sfc';
+import { InstanceDetailsGroup, InstanceDetailsGroupDeps, InstanceDetailsGroupProps } from './instance-details-group';
+import { RuleResources, RuleResourcesProps } from './rule-resources';
+
+export type RuleContentDeps = InstanceDetailsGroupDeps;
+
+type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
+
+export type RuleContentProps = Omit<InstanceDetailsGroupProps, 'deps'> &
+    RuleResourcesProps & {
+        deps: RuleContentDeps;
+    };
+
+export const RuleContent = NamedSFC<RuleContentProps>('RuleContent', props => {
+    return (
+        <>
+            <RuleResources {...props} />
+            <InstanceDetailsGroup {...props} />
+        </>
+    );
+});

--- a/src/DetailsView/reports/components/report-sections/rule-resources.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-resources.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+import { GuidanceLinks } from '../../../../common/components/guidance-links';
+import { NewTabLink } from '../../../../common/components/new-tab-link';
+import { NamedSFC } from '../../../../common/react/named-sfc';
+import { RuleResult } from '../../../../scanner/iruleresults';
+
+export type RuleResourcesProps = {
+    rule: RuleResult;
+};
+
+export const RuleResources = NamedSFC<RuleResourcesProps>('RuleResources', ({ rule }) => {
+    const renderRuleLink = () => {
+        const ruleId = rule.id;
+        const ruleUrl = rule.helpUrl;
+
+        return (
+            <span className="rule-details-id">
+                <NewTabLink href={ruleUrl}>More information about {ruleId}</NewTabLink>
+            </span>
+        );
+    };
+
+    const renderGuidanceLinks = () => <GuidanceLinks links={rule.guidanceLinks} />;
+    return (
+        <div className="rule-more-resources">
+            <div className="more-resources-title">Resources for this rule</div>
+            {renderRuleLink()}
+            {renderGuidanceLinks()}
+        </div>
+    );
+});

--- a/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
+++ b/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { FixInstructionProcessor } from '../../../../injected/fix-instruction-processor';
 import { RuleResult } from '../../../../scanner/iruleresults';
@@ -9,10 +8,10 @@ import { InstanceOutcomeType } from '../instance-outcome-type';
 import { outcomeTypeSemantics } from '../outcome-type';
 import { CollapsibleContainer } from './collapsible-container';
 import { FullRuleDetailDeps } from './full-rule-detail';
-import { InstanceDetailsGroup } from './instance-details-group';
+import { InstanceDetailsGroup, InstanceDetailsGroupDeps } from './instance-details-group';
 import { MinimalRuleDetail } from './minimal-rule-detail';
 
-export type RulesWithInstancesDeps = FullRuleDetailDeps;
+export type RulesWithInstancesDeps = FullRuleDetailDeps & InstanceDetailsGroupDeps;
 
 export type RulesWithInstancesProps = {
     deps: RulesWithInstancesDeps;
@@ -36,9 +35,10 @@ export const RulesWithInstances = NamedSFC<RulesWithInstancesProps>(
                             visibleHeadingContent={<MinimalRuleDetail key={rule.id} rule={rule} outcomeType={outcomeType} />}
                             collapsibleContent={
                                 <InstanceDetailsGroup
-                                    fixInstructionProcessor={fixInstructionProcessor}
                                     key={`${rule.id}-rule-group`}
-                                    nodeResults={rule.nodes}
+                                    deps={deps}
+                                    rule={rule}
+                                    fixInstructionProcessor={fixInstructionProcessor}
                                 />
                             }
                             containerClassName="collapsible-rule-details-group"

--- a/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
+++ b/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
@@ -8,11 +8,10 @@ import { InstanceOutcomeType } from '../instance-outcome-type';
 import { outcomeTypeSemantics } from '../outcome-type';
 import { CollapsibleContainer } from './collapsible-container';
 import { FullRuleDetailDeps } from './full-rule-detail';
-import { InstanceDetailsGroup, InstanceDetailsGroupDeps } from './instance-details-group';
 import { MinimalRuleDetail } from './minimal-rule-detail';
-import { RuleContent } from './rule-content';
+import { RuleContent, RuleContentDeps } from './rule-content';
 
-export type RulesWithInstancesDeps = FullRuleDetailDeps & InstanceDetailsGroupDeps;
+export type RulesWithInstancesDeps = FullRuleDetailDeps & RuleContentDeps;
 
 export type RulesWithInstancesProps = {
     deps: RulesWithInstancesDeps;

--- a/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
+++ b/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
@@ -10,6 +10,7 @@ import { CollapsibleContainer } from './collapsible-container';
 import { FullRuleDetailDeps } from './full-rule-detail';
 import { InstanceDetailsGroup, InstanceDetailsGroupDeps } from './instance-details-group';
 import { MinimalRuleDetail } from './minimal-rule-detail';
+import { RuleContent } from './rule-content';
 
 export type RulesWithInstancesDeps = FullRuleDetailDeps & InstanceDetailsGroupDeps;
 
@@ -34,7 +35,7 @@ export const RulesWithInstances = NamedSFC<RulesWithInstancesProps>(
                             id={rule.id}
                             visibleHeadingContent={<MinimalRuleDetail key={rule.id} rule={rule} outcomeType={outcomeType} />}
                             collapsibleContent={
-                                <InstanceDetailsGroup
+                                <RuleContent
                                     key={`${rule.id}-rule-group`}
                                     deps={deps}
                                     rule={rule}

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/instance-details-group.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/instance-details-group.test.tsx.snap
@@ -1,63 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InstanceDetailsGroup renders 1`] = `
-<ul
-  aria-label="failed instances with path, snippet and how to fix information"
-  className="instance-details-list"
->
-  <li>
-    <InstanceDetail
-      failureSummary="fix the error on html"
-      fixInstructionProcessor={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "backgroundColorText": "background color: ",
-          "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "colorGroupName": "color",
-          "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
-          "createColorBox": [Function],
-          "foregroundColorText": "foreground color: ",
-          "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "getColorMatch": [Function],
-          "process": [Function],
-          "splitFixInstruction": [Function],
+<React.Fragment>
+  <div
+    className="rule-more-resources"
+  >
+    <div>
+      Resources for this rule
+    </div>
+    <span
+      className="rule-details-id"
+    >
+      <NewTabLink>
+        More information about 
+      </NewTabLink>
+    </span>
+    <GuidanceLinks />
+  </div>
+  <ul
+    aria-label="failed instances with path, snippet and how to fix information"
+    className="instance-details-list"
+  >
+    <li>
+      <InstanceDetail
+        failureSummary="fix the error on html"
+        fixInstructionProcessor={
+          proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "backgroundColorText": "background color: ",
+            "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "colorGroupName": "color",
+            "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+            "createColorBox": [Function],
+            "foregroundColorText": "foreground color: ",
+            "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "getColorMatch": [Function],
+            "process": [Function],
+            "splitFixInstruction": [Function],
+          }
         }
-      }
-      html="<html>"
-      index={0}
-      target={
-        Array [
-          "<html>",
-        ]
-      }
-    />
-  </li>
-  <li>
-    <InstanceDetail
-      failureSummary="fix the error on body"
-      fixInstructionProcessor={
-        proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "backgroundColorText": "background color: ",
-          "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "colorGroupName": "color",
-          "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
-          "createColorBox": [Function],
-          "foregroundColorText": "foreground color: ",
-          "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "getColorMatch": [Function],
-          "process": [Function],
-          "splitFixInstruction": [Function],
+        html="<html>"
+        index={0}
+        target={
+          Array [
+            "<html>",
+          ]
         }
-      }
-      html="<body >"
-      index={1}
-      target={
-        Array [
-          "<body>",
-        ]
-      }
-    />
-  </li>
-</ul>
+      />
+    </li>
+    <li>
+      <InstanceDetail
+        failureSummary="fix the error on body"
+        fixInstructionProcessor={
+          proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "backgroundColorText": "background color: ",
+            "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "colorGroupName": "color",
+            "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+            "createColorBox": [Function],
+            "foregroundColorText": "foreground color: ",
+            "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "getColorMatch": [Function],
+            "process": [Function],
+            "splitFixInstruction": [Function],
+          }
+        }
+        html="<body >"
+        index={1}
+        target={
+          Array [
+            "<body>",
+          ]
+        }
+      />
+    </li>
+  </ul>
+</React.Fragment>
 `;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/instance-details-group.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/instance-details-group.test.tsx.snap
@@ -1,80 +1,63 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InstanceDetailsGroup renders 1`] = `
-<React.Fragment>
-  <div
-    className="rule-more-resources"
-  >
-    <div>
-      Resources for this rule
-    </div>
-    <span
-      className="rule-details-id"
-    >
-      <NewTabLink>
-        More information about 
-      </NewTabLink>
-    </span>
-    <GuidanceLinks />
-  </div>
-  <ul
-    aria-label="failed instances with path, snippet and how to fix information"
-    className="instance-details-list"
-  >
-    <li>
-      <InstanceDetail
-        failureSummary="fix the error on html"
-        fixInstructionProcessor={
-          proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "backgroundColorText": "background color: ",
-            "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "colorGroupName": "color",
-            "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
-            "createColorBox": [Function],
-            "foregroundColorText": "foreground color: ",
-            "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "getColorMatch": [Function],
-            "process": [Function],
-            "splitFixInstruction": [Function],
-          }
+<ul
+  aria-label="failed instances with path, snippet and how to fix information"
+  className="instance-details-list"
+>
+  <li>
+    <InstanceDetail
+      failureSummary="fix the error on html"
+      fixInstructionProcessor={
+        proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "backgroundColorText": "background color: ",
+          "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "colorGroupName": "color",
+          "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+          "createColorBox": [Function],
+          "foregroundColorText": "foreground color: ",
+          "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "getColorMatch": [Function],
+          "process": [Function],
+          "splitFixInstruction": [Function],
         }
-        html="<html>"
-        index={0}
-        target={
-          Array [
-            "<html>",
-          ]
+      }
+      html="<html>"
+      index={0}
+      target={
+        Array [
+          "<html>",
+        ]
+      }
+    />
+  </li>
+  <li>
+    <InstanceDetail
+      failureSummary="fix the error on body"
+      fixInstructionProcessor={
+        proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "backgroundColorText": "background color: ",
+          "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "colorGroupName": "color",
+          "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+          "createColorBox": [Function],
+          "foregroundColorText": "foreground color: ",
+          "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "getColorMatch": [Function],
+          "process": [Function],
+          "splitFixInstruction": [Function],
         }
-      />
-    </li>
-    <li>
-      <InstanceDetail
-        failureSummary="fix the error on body"
-        fixInstructionProcessor={
-          proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "backgroundColorText": "background color: ",
-            "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "colorGroupName": "color",
-            "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
-            "createColorBox": [Function],
-            "foregroundColorText": "foreground color: ",
-            "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "getColorMatch": [Function],
-            "process": [Function],
-            "splitFixInstruction": [Function],
-          }
-        }
-        html="<body >"
-        index={1}
-        target={
-          Array [
-            "<body>",
-          ]
-        }
-      />
-    </li>
-  </ul>
-</React.Fragment>
+      }
+      html="<body >"
+      index={1}
+      target={
+        Array [
+          "<body>",
+        ]
+      }
+    />
+  </li>
+</ul>
 `;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-content.test.tsx.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RuleContent renders 1`] = `
+<React.Fragment>
+  <RuleResources
+    rule={
+      Object {
+        "id": "test-id",
+      }
+    }
+  />
+  <InstanceDetailsGroup
+    rule={
+      Object {
+        "id": "test-id",
+      }
+    }
+  />
+</React.Fragment>
+`;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-resources.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-resources.test.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RuleResources renders 1`] = `
+<div
+  className="rule-more-resources"
+>
+  <div
+    className="more-resources-title"
+  >
+    Resources for this rule
+  </div>
+  <span
+    className="rule-details-id"
+  >
+    <NewTabLink
+      href="test-help-url"
+    >
+      More information about 
+      test-rule-id
+    </NewTabLink>
+  </span>
+  <GuidanceLinks
+    links={Array []}
+  />
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rules-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rules-with-instances.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`RulesWithInstances renders 1`] = `
   <CollapsibleContainer
     buttonAriaLabel="test-rule 1 Passed undefined"
     collapsibleContent={
-      <InstanceDetailsGroup
+      <RuleContent
         deps={Object {}}
         fixInstructionProcessor={
           proxy {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rules-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rules-with-instances.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`RulesWithInstances renders 1`] = `
     buttonAriaLabel="test-rule 1 Passed undefined"
     collapsibleContent={
       <InstanceDetailsGroup
+        deps={Object {}}
         fixInstructionProcessor={
           proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -23,14 +24,17 @@ exports[`RulesWithInstances renders 1`] = `
             "splitFixInstruction": [Function],
           }
         }
-        nodeResults={
-          Array [
-            Object {
-              "failureSummary": "fix the error on html tag",
-              "html": "<html>",
-              "snippet": "<html>",
-            },
-          ]
+        rule={
+          Object {
+            "id": "test-rule",
+            "nodes": Array [
+              Object {
+                "failureSummary": "fix the error on html tag",
+                "html": "<html>",
+                "snippet": "<html>",
+              },
+            ],
+          }
         }
       />
     }

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/instance-details-group.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/instance-details-group.test.tsx
@@ -3,12 +3,13 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock } from 'typemoq';
-
 import {
     InstanceDetailsGroup,
+    InstanceDetailsGroupDeps,
     InstanceDetailsGroupProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/instance-details-group';
 import { FixInstructionProcessor } from '../../../../../../../injected/fix-instruction-processor';
+import { RuleResult } from '../../../../../../../scanner/iruleresults';
 
 describe('InstanceDetailsGroup', () => {
     it('renders', () => {
@@ -26,9 +27,16 @@ describe('InstanceDetailsGroup', () => {
             } as AxeNodeResult,
         ];
 
+        const rule: RuleResult = {
+            nodes: nodes,
+        } as RuleResult;
+
+        const depsStub: InstanceDetailsGroupDeps = {} as InstanceDetailsGroupDeps;
+
         const props: InstanceDetailsGroupProps = {
+            deps: depsStub,
             fixInstructionProcessor: fixInstructionProcessorMock.object,
-            nodeResults: nodes,
+            rule,
         };
 
         const wrapper = shallow(<InstanceDetailsGroup {...props} />);

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-content.test.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { RuleContent, RuleContentProps } from '../../../../../../../DetailsView/reports/components/report-sections/rule-content';
+
+describe('RuleContent', () => {
+    it('renders', () => {
+        const props = {
+            rule: {
+                id: 'test-id',
+            },
+        } as RuleContentProps;
+
+        const wrapper = shallow(<RuleContent {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-resources.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-resources.test.tsx
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { RuleResources } from '../../../../../../../DetailsView/reports/components/report-sections/rule-resources';
+import { RuleResult } from '../../../../../../../scanner/iruleresults';
+
+describe('RuleResources', () => {
+    it('renders', () => {
+        const rule: RuleResult = {
+            id: 'test-rule-id',
+            helpUrl: 'test-help-url',
+            guidanceLinks: [],
+        } as RuleResult;
+
+        const wrapper = shallow(<RuleResources rule={rule} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Add new card for **rule resources** under failed instances section.

**Out of scope for this PR**: currently, the figma mocks do not show the "New for WCAG 2.1" badge. I'm talking with design on where to add this but for now, I'll leave it out of scope for this PR.

**"Normal"**
![01 - rule resources, no focus, no hover](https://user-images.githubusercontent.com/2837582/60764308-04c4d080-a03c-11e9-9844-ee2d5038ecb7.png)

**Focus**
![02 - rule resources, focus](https://user-images.githubusercontent.com/2837582/60764310-0bebde80-a03c-11e9-9d9a-73354fed8eeb.png)

**Hover**
![03 - rule resources, hover](https://user-images.githubusercontent.com/2837582/60764311-0ee6cf00-a03c-11e9-8158-d8b34b86c088.png)

#### Pull request checklist

- [x] Addresses an existing issue: Part of WI # 1558756
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - after expanding the hidden content, user can normally navigate to the new card by pressing down arrow key. It will read the title, and then the links one by one
