### PR TITLE
fix: a11y issue on target page link

### DIFF
--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -10,10 +10,10 @@ import { UrlIcon } from '../../../../common/icons/url-icon';
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { SectionProps } from './report-section-factory';
 
-export type DetailsSectionProps = Pick<SectionProps, 'pageUrl' | 'description' | 'scanDate' | 'toUtcString'>;
+export type DetailsSectionProps = Pick<SectionProps, 'pageTitle' | 'pageUrl' | 'description' | 'scanDate' | 'toUtcString'>;
 
 export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', props => {
-    const { pageUrl, description, scanDate, toUtcString } = props;
+    const { pageTitle, pageUrl, description, scanDate, toUtcString } = props;
 
     const createListItem = (icon: JSX.Element, label: string, content: string | JSX.Element, contentClassName?: string) => (
         <li>
@@ -32,7 +32,13 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
         <div className="scan-details-section">
             <h2>Scan details</h2>
             <ul className="details-section-list">
-                {createListItem(<UrlIcon />, 'target page:', <NewTabLink href={pageUrl}>{pageUrl}</NewTabLink>)}
+                {createListItem(
+                    <UrlIcon />,
+                    'target page:',
+                    <NewTabLink href={pageUrl} aria-label={pageTitle}>
+                        {pageUrl}
+                    </NewTabLink>,
+                )}
                 {createListItem(<DateIcon />, 'scan date:', scanDateUTC)}
                 {showCommentRow && createListItem(<CommentIcon />, 'comment:', description, 'description-text')}
             </ul>

--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -34,8 +34,8 @@ export const DetailsSection = NamedSFC<DetailsSectionProps>('DetailsSection', pr
             <ul className="details-section-list">
                 {createListItem(
                     <UrlIcon />,
-                    'target page:',
-                    <NewTabLink href={pageUrl} aria-label={pageTitle}>
+                    'target page url:',
+                    <NewTabLink href={pageUrl} title={pageTitle}>
                         {pageUrl}
                     </NewTabLink>,
                 )}

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
@@ -20,14 +20,14 @@ exports[`DetailsSection renders with description:  1`] = `
       <span
         className="screen-reader-only"
       >
-        target page:
+        target page url:
       </span>
       <span
         className="text"
       >
         <NewTabLink
-          aria-label="page-title"
           href="https://page-url/"
+          title="page-title"
         >
           https://page-url/
         </NewTabLink>
@@ -75,14 +75,14 @@ exports[`DetailsSection renders with description: description-text 1`] = `
       <span
         className="screen-reader-only"
       >
-        target page:
+        target page url:
       </span>
       <span
         className="text"
       >
         <NewTabLink
-          aria-label="page-title"
           href="https://page-url/"
+          title="page-title"
         >
           https://page-url/
         </NewTabLink>
@@ -148,14 +148,14 @@ exports[`DetailsSection renders with description: null 1`] = `
       <span
         className="screen-reader-only"
       >
-        target page:
+        target page url:
       </span>
       <span
         className="text"
       >
         <NewTabLink
-          aria-label="page-title"
           href="https://page-url/"
+          title="page-title"
         >
           https://page-url/
         </NewTabLink>
@@ -203,14 +203,14 @@ exports[`DetailsSection renders with description: undefined 1`] = `
       <span
         className="screen-reader-only"
       >
-        target page:
+        target page url:
       </span>
       <span
         className="text"
       >
         <NewTabLink
-          aria-label="page-title"
           href="https://page-url/"
+          title="page-title"
         >
           https://page-url/
         </NewTabLink>

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/details-section.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DetailsSection rendering of comment row is dependent on description value renders and matches saved snapshot for description value:  1`] = `
+exports[`DetailsSection renders with description:  1`] = `
 <div
   className="scan-details-section"
 >
@@ -26,6 +26,7 @@ exports[`DetailsSection rendering of comment row is dependent on description val
         className="text"
       >
         <NewTabLink
+          aria-label="page-title"
           href="https://page-url/"
         >
           https://page-url/
@@ -54,7 +55,7 @@ exports[`DetailsSection rendering of comment row is dependent on description val
 </div>
 `;
 
-exports[`DetailsSection rendering of comment row is dependent on description value renders and matches saved snapshot for description value: description-text 1`] = `
+exports[`DetailsSection renders with description: description-text 1`] = `
 <div
   className="scan-details-section"
 >
@@ -80,6 +81,7 @@ exports[`DetailsSection rendering of comment row is dependent on description val
         className="text"
       >
         <NewTabLink
+          aria-label="page-title"
           href="https://page-url/"
         >
           https://page-url/
@@ -126,7 +128,7 @@ exports[`DetailsSection rendering of comment row is dependent on description val
 </div>
 `;
 
-exports[`DetailsSection rendering of comment row is dependent on description value renders and matches saved snapshot for description value: null 1`] = `
+exports[`DetailsSection renders with description: null 1`] = `
 <div
   className="scan-details-section"
 >
@@ -152,6 +154,7 @@ exports[`DetailsSection rendering of comment row is dependent on description val
         className="text"
       >
         <NewTabLink
+          aria-label="page-title"
           href="https://page-url/"
         >
           https://page-url/
@@ -180,7 +183,7 @@ exports[`DetailsSection rendering of comment row is dependent on description val
 </div>
 `;
 
-exports[`DetailsSection rendering of comment row is dependent on description value renders and matches saved snapshot for description value: undefined 1`] = `
+exports[`DetailsSection renders with description: undefined 1`] = `
 <div
   className="scan-details-section"
 >
@@ -206,6 +209,7 @@ exports[`DetailsSection rendering of comment row is dependent on description val
         className="text"
       >
         <NewTabLink
+          aria-label="page-title"
           href="https://page-url/"
         >
           https://page-url/

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/details-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/details-section.test.tsx
@@ -2,39 +2,36 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
+
 import { IMock, Mock, MockBehavior } from 'typemoq';
 import { DateProvider } from '../../../../../../../common/date-provider';
 import { DetailsSection, DetailsSectionProps } from '../../../../../../../DetailsView/reports/components/report-sections/details-section';
 
 describe('DetailsSection', () => {
-    describe('rendering of comment row is dependent on description value', () => {
-        const descriptionValues = ['description-text', '', undefined, null];
-        test.each(descriptionValues)('renders and matches saved snapshot for description value: %s', description => {
-            const scanDate = new Date(Date.UTC(2018, 2, 9, 9, 48));
+    const descriptionValues = ['description-text', '', undefined, null];
 
-            const toUtcStringMock: IMock<(date: Date) => string> = Mock.ofInstance(DateProvider.getUTCStringFromDate, MockBehavior.Strict);
+    test.each(descriptionValues)('renders with description: %s', description => {
+        const scanDate = new Date(Date.UTC(2018, 2, 9, 9, 48));
 
-            toUtcStringMock
-                .setup(getter => getter(scanDate))
-                .returns(() => '2018-03-12 11:24 PM UTC')
-                .verifiable();
+        const toUtcStringMock: IMock<(date: Date) => string> = Mock.ofInstance(DateProvider.getUTCStringFromDate, MockBehavior.Strict);
 
-            const props: DetailsSectionProps = {
-                scanDate,
-                pageTitle: 'page-title',
-                pageUrl: 'https://page-url/',
-                description,
-                environmentInfo: {
-                    browserSpec: 'environment-version',
-                    extensionVersion: 'extension-version',
-                    axeCoreVersion: 'axe-version',
-                },
-                toUtcString: toUtcStringMock.object,
-            };
+        toUtcStringMock.setup(getter => getter(scanDate)).returns(() => '2018-03-12 11:24 PM UTC');
 
-            const wrapper = shallow(<DetailsSection {...props} />);
-            expect(wrapper.getElement()).toMatchSnapshot();
-            toUtcStringMock.verifyAll();
-        });
+        const props: DetailsSectionProps = {
+            scanDate,
+            pageTitle: 'page-title',
+            pageUrl: 'https://page-url/',
+            description,
+            environmentInfo: {
+                browserSpec: 'environment-version',
+                extensionVersion: 'extension-version',
+                axeCoreVersion: 'axe-version',
+            },
+            toUtcString: toUtcStringMock.object,
+        };
+
+        const wrapper = shallow(<DetailsSection {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Description of changes

On the new automated checks report we have the target page link twice, one on the top level header of the report, where we use the target page name as the link text; and the second on the scan details section (right after the globe icon) where we use the url as the link text. 

This links are failing `assessment -> links -> link purpose` as they do not have the same **accessible name**.

**Edit:**
To fix this: 
- use `title` attribute on the anchor tag to match the one on the page header (basically the page title)
- update the hidden label to `"target page url"` to clarify what the value is (i.e. the url itself)

This two fixes are needed because we have to modes of operations here:
- **tab key navigation**: using the tab key, the user will navigate through interactive elements. The second tab from the top of the page will make the focus to land directly on the link which the AT will read as: <link text> <visited|not visited> link <link title>. Here **link text** is the url itself while **link title** comes from the title attribute
- **arrow key navigation**: using down (or up) arrow key, the user will navigate through screen reader visible content. On the **Scan details** section, this will move from the title to a list of 2 items (the target page url and the scan date being those items). Another down arrow key and the user will land on the first element which is compose of 2 things: a visually hidden label which the screen reader will announce: "page title url" and then (after another down arrow key) the link itself (without the title in this case). 

**End of the Edit**

#### Pull request checklist

- [x] Addresses an existing issue: Part of WI #1558756
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no changes
- [x] (UI changes only) Verified usability with NVDA/JAWS
