### PR TITLE
feat: use main instead of div for the main content section

### DIFF
--- a/src/DetailsView/reports/components/report-sections/content-container.tsx
+++ b/src/DetailsView/reports/components/report-sections/content-container.tsx
@@ -5,8 +5,8 @@ import { NamedSFC } from '../../../../common/react/named-sfc';
 
 export const ContentContainer = NamedSFC('ContentSection', ({ children }) => {
     return (
-        <div className="outer-container">
+        <main className="outer-container">
             <div className="content-container">{children}</div>
-        </div>
+        </main>
     );
 });

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/content-container.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ContentContainer renders 1`] = `
-<div
+<main
   className="outer-container"
 >
   <div
@@ -16,5 +16,5 @@ exports[`ContentContainer renders 1`] = `
       2
     </div>
   </div>
-</div>
+</main>
 `;


### PR DESCRIPTION
#### Description of changes

Using a main landmark to wrap the main content of the report.

**Top view**
![01 - top view](https://user-images.githubusercontent.com/2837582/60829616-23c18080-a16a-11e9-9639-3d778c0072f3.png)

**Bottom view**
![02 - bottom view](https://user-images.githubusercontent.com/2837582/60829629-27ed9e00-a16a-11e9-8d61-927c3e7ad287.png)


#### Pull request checklist

- [x] Addresses an existing issue: Part of WI # 1558756
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
