### PR TITLE
fix: image role on svg and guidance content

### DIFF
--- a/src/common/icons/cancel-icon.tsx
+++ b/src/common/icons/cancel-icon.tsx
@@ -9,7 +9,7 @@ const d =
     '0.991211L7.99121 7Z';
 
 export const CancelIcon = NamedSFC('CancelIcon', () => (
-    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" role="image" aria-hidden="true">
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
         <path d={d} fill="black" fillOpacity="0.9" />
     </svg>
 ));

--- a/src/common/icons/copy-icon.tsx
+++ b/src/common/icons/copy-icon.tsx
@@ -9,7 +9,7 @@ const d =
     '7H10V4H5V15H13V7Z';
 
 export const CopyIcon = NamedSFC('CopyIcon', () => (
-    <svg width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="image" aria-hidden="true">
+    <svg width="14" height="16" viewBox="0 0 14 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
         <path d={d} />
     </svg>
 ));

--- a/src/common/icons/file-html-icon.tsx
+++ b/src/common/icons/file-html-icon.tsx
@@ -15,7 +15,7 @@ const d =
     '8.5 12ZM14.2031 13.5L11.8516 15.8516L11.1484 15.1484L12.7969 13.5L11.1484 11.8516L11.8516 11.1484L14.2031 13.5Z';
 
 export const FileHTMLIcon = NamedSFC('FileHTMLIcon', () => (
-    <svg width="15" height="16" viewBox="0 0 15 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="image" aria-hidden="true">
+    <svg width="15" height="16" viewBox="0 0 15 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
         <path d={d} />
     </svg>
 ));

--- a/src/common/icons/lady-bug-solid-icon.tsx
+++ b/src/common/icons/lady-bug-solid-icon.tsx
@@ -45,7 +45,7 @@ const d =
     '3.70312C3.5026 3.63542 3.5 3.56771 3.5 3.5Z';
 
 export const LadyBugSolidIcon = NamedSFC('LadyBugSolidIcon', () => (
-    <svg width="12" height="16" viewBox="0 0 12 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="image" aria-hidden="true">
+    <svg width="12" height="16" viewBox="0 0 12 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
         <path d={d} />
     </svg>
 ));

--- a/src/content/test/images/guidance.tsx
+++ b/src/content/test/images/guidance.tsx
@@ -50,8 +50,8 @@ export const guidance = create(({ Markup, Link }) => (
                                 For {'<img>'} elements, add a non-empty <Markup.Code>alt</Markup.Code> attribute.
                             </li>
                             <li>
-                                For icon fonts, {'<svg>'} images, and CSS background images, add <Markup.Code>role="image"</Markup.Code> and
-                                a non-empty <Markup.Code>aria-label</Markup.Code> or <Markup.Code>aria-labelledby</Markup.Code> attribute.
+                                For icon fonts, {'<svg>'} images, and CSS background images, add <Markup.Code>role="img"</Markup.Code> and a
+                                non-empty <Markup.Code>aria-label</Markup.Code> or <Markup.Code>aria-labelledby</Markup.Code> attribute.
                             </li>
                         </ul>
                     </li>
@@ -64,7 +64,7 @@ export const guidance = create(({ Markup, Link }) => (
                                 <Markup.Code>alt</Markup.Code> or <Markup.Code>alt=""</Markup.Code>).
                             </li>
                             <li>
-                                For icon fonts and <Markup.Code>{`<svg>`}</Markup.Code> images, add <Markup.Code>role="image"</Markup.Code>{' '}
+                                For icon fonts and <Markup.Code>{`<svg>`}</Markup.Code> images, add <Markup.Code>role="img"</Markup.Code>{' '}
                                 and <Markup.Code>aria-hidden="true"</Markup.Code>.
                             </li>
                             <li>For CSS background images, no additional markup is needed.</li>

--- a/src/content/test/images/image-function.tsx
+++ b/src/content/test/images/image-function.tsx
@@ -41,7 +41,7 @@ export const infoAndExamples = create(({ Markup }) => (
                     </li>
                     <li>
                         If it's an icon font, <Markup.Code>{'<svg>'}</Markup.Code> image, or CSS background image, add{' '}
-                        <Markup.Code>role="image"</Markup.Code>.
+                        <Markup.Code>role="img"</Markup.Code>.
                     </li>
                 </ul>
             </li>
@@ -54,7 +54,7 @@ export const infoAndExamples = create(({ Markup }) => (
                         <Markup.Code>alt</Markup.Code> attribute (<Markup.Code>alt</Markup.Code> or <Markup.Code>alt=""</Markup.Code>).
                     </li>
                     <li>
-                        And it's an icon font or <Markup.Code>{'<svg>'}</Markup.Code> image, add <Markup.Code>role="image"</Markup.Code> and{' '}
+                        And it's an icon font or <Markup.Code>{'<svg>'}</Markup.Code> image, add <Markup.Code>role="img"</Markup.Code> and{' '}
                         <Markup.Code>aria-hidden="true"</Markup.Code>.
                     </li>
                     <li>And it's a CSS background image, no additional markup is needed.</li>

--- a/src/icons/brand/blue/brand-blue.tsx
+++ b/src/icons/brand/blue/brand-blue.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { NamedSFC } from '../../../common/react/named-sfc';
 
 export const BrandBlue = NamedSFC('BrandBlue', () => (
-    <svg role="image" aria-hidden="true" className="header-icon" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg role="img" aria-hidden="true" className="header-icon" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
         <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="3" width="48" height="43">
             <path
                 d="M43.8309 27.1383C49.3148 21.6544 49.3148 12.7632 43.8309 7.27931C38.347 1.7954 29.4558 1.7954 23.9719 7.27931C18.488 1.79541 9.59684 1.7954 4.11293 7.27931C-1.37098 12.7632 -1.37098 21.6544 4.11293 27.1383L21.986 45.0114C23.0828 46.1082 24.861 46.1082 25.9578 45.0114L43.8309 27.1383Z"

--- a/src/icons/brand/white/brand-white.tsx
+++ b/src/icons/brand/white/brand-white.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { NamedSFC } from '../../../common/react/named-sfc';
 
 export const BrandWhite = NamedSFC('BrandWhite', () => (
-    <svg role="image" aria-hidden="true" className="header-icon" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg role="img" aria-hidden="true" className="header-icon" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
         <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="3" width="48" height="43">
             <path
                 d="M43.8309 27.1383C49.3148 21.6544 49.3148 12.7633 43.8309 7.27934C38.347 1.79544 29.4558 1.79543 23.9719 7.27934C18.488 1.79544 9.59684 1.79544 4.11293 7.27934C-1.37098 12.7633 -1.37098 21.6544 4.11293 27.1383L21.986 45.0114C23.0828 46.1082 24.861 46.1082 25.9578 45.0114L43.8309 27.1383Z"

--- a/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
@@ -8662,7 +8662,7 @@ exports[`A11Y for content pages High Contrast mode test/images/guidance 1`] = `
                     <span
                       class="insights-code"
                     >
-                      role="image"
+                      role="img"
                     </span>
                      and a non-empty 
                     <span
@@ -8721,7 +8721,7 @@ exports[`A11Y for content pages High Contrast mode test/images/guidance 1`] = `
                     <span
                       class="insights-code"
                     >
-                      role="image"
+                      role="img"
                     </span>
                      and 
                     <span
@@ -9430,7 +9430,7 @@ exports[`A11Y for content pages High Contrast mode test/images/imageFunction/inf
               <span
                 class="insights-code"
               >
-                role="image"
+                role="img"
               </span>
               .
             </li>
@@ -9493,7 +9493,7 @@ exports[`A11Y for content pages High Contrast mode test/images/imageFunction/inf
               <span
                 class="insights-code"
               >
-                role="image"
+                role="img"
               </span>
                and 
               <span
@@ -38109,7 +38109,7 @@ exports[`A11Y for content pages Normal mode test/images/guidance 1`] = `
                     <span
                       class="insights-code"
                     >
-                      role="image"
+                      role="img"
                     </span>
                      and a non-empty 
                     <span
@@ -38168,7 +38168,7 @@ exports[`A11Y for content pages Normal mode test/images/guidance 1`] = `
                     <span
                       class="insights-code"
                     >
-                      role="image"
+                      role="img"
                     </span>
                      and 
                     <span
@@ -38877,7 +38877,7 @@ exports[`A11Y for content pages Normal mode test/images/imageFunction/infoAndExa
               <span
                 class="insights-code"
               >
-                role="image"
+                role="img"
               </span>
               .
             </li>
@@ -38940,7 +38940,7 @@ exports[`A11Y for content pages Normal mode test/images/imageFunction/infoAndExa
               <span
                 class="insights-code"
               >
-                role="image"
+                role="img"
               </span>
                and 
               <span


### PR DESCRIPTION
#### Description of changes

We are using (on svg icons) and mentioning (on image related guidance content) `role='image'` but this is not correct, we need to use `role='img'`

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1558756
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no changes
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - will fix some "parsing" test issues (from the assessment)
