### PR TITLE
fix: color of message bar icon in high contrast mode

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -792,7 +792,7 @@ div.insights-file-issue-details-dialog-container {
             .ms-MessageBar {
                 padding-left: 24px;
             }
-            .ms-MessageBar-icon {
+            .ms-MessageBar-icon i {
                 color: $secondary-text;
             }
             .target-tab-info {


### PR DESCRIPTION
#### Description of changes

Increased CSS specificity of message bar icon rule so the "Target page is in a hidden state" icon changes color as expected when high contrast mode is applied.

#### Pull request checklist

- [X] Addresses an existing issue: #756 
- [ ] Added relevant unit test for your changes. (N/A - CSS change only)
- [ ] Verified code coverage for the changes made. (N/A - CSS change only)
- [X] Ran precheckin (`yarn precheckin`)
- [X] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS

#### Screenshots
##### Before:
![image](https://user-images.githubusercontent.com/1752950/60851293-740b0380-a1a7-11e9-99ad-5a7c1f36f78f.png)
(if you magnify, you might be able to see that the icon is there next to the text "The target page...", it's grey on the brown background)

##### After:
![image](https://user-images.githubusercontent.com/1752950/60851244-37d7a300-a1a7-11e9-9fee-e1ae20df6fb5.png)
