### PR TITLE
fix: parsing errors on automated checks report

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -46,6 +46,22 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     margin-top: 8px;
     margin-bottom: 8px;
 
+    .outcome-chip {
+        margin-top: 5px;
+
+        &.outcome-chip-fail {
+            margin-top: 10px;
+
+            .count {
+                line-height: 11px;
+            }
+
+            svg {
+                margin-bottom: 3px;
+            }
+        }
+    }
+
     .title {
         font-size: 17px;
         line-height: 24px;

--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -84,6 +84,13 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
 
 .result-section {
     padding-bottom: 58px;
+
+    .title-container[aria-level='2'] {
+        .collapsible-control::before {
+            position: relative;
+            bottom: 2px;
+        }
+    }
 }
 
 .rule-details-group {

--- a/src/DetailsView/reports/components/report-sections/minimal-rule-detail.tsx
+++ b/src/DetailsView/reports/components/report-sections/minimal-rule-detail.tsx
@@ -27,10 +27,10 @@ export const MinimalRuleDetail = NamedSFC<MinimalRuleDetailProps>('MinimalRuleDe
     const renderDescription = () => <span className="rule-details-description">{rule.description}</span>;
 
     return (
-        <div className="rule-detail">
-            <div>
+        <span className="rule-detail">
+            <span>
                 {renderCountBadge()} {renderRuleName()}: {renderDescription()}
-            </div>
-        </div>
+            </span>
+        </span>
     );
 });

--- a/src/DetailsView/reports/components/report-sections/result-section-title.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section-title.tsx
@@ -14,16 +14,16 @@ export type ResultSectionTitleProps = {
 
 export const ResultSectionTitle = NamedSFC<ResultSectionTitleProps>('ResultSectionTitle', props => {
     return (
-        <div className="result-section-title">
-            <div className="screen-reader-only">
+        <span className="result-section-title">
+            <span className="screen-reader-only">
                 {props.title} {props.badgeCount}
-            </div>
+            </span>
             <span className="title" aria-hidden="true">
                 {props.title}
             </span>
-            <div aria-hidden="true">
+            <span aria-hidden="true">
                 <OutcomeChip outcomeType={props.outcomeType} count={props.badgeCount} />
-            </div>
-        </div>
+            </span>
+        </span>
     );
 });

--- a/src/DetailsView/reports/report-html-generator-v2.tsx
+++ b/src/DetailsView/reports/report-html-generator-v2.tsx
@@ -48,6 +48,6 @@ export class ReportHtmlGeneratorV2 implements ReportHtmlGenerator {
         const bodyElement: JSX.Element = <ReportBody {...props} />;
         const bodyMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(bodyElement);
 
-        return '<html lang="en">' + headMarkup + bodyMarkup + '</html>';
+        return '<!DOCTYPE html><html lang="en">' + headMarkup + bodyMarkup + '</html>';
     }
 }

--- a/src/icons/brand/white/brand-white.tsx
+++ b/src/icons/brand/white/brand-white.tsx
@@ -6,7 +6,7 @@ import { NamedSFC } from '../../../common/react/named-sfc';
 
 export const BrandWhite = NamedSFC('BrandWhite', () => (
     <svg role="img" aria-hidden="true" className="header-icon" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="3" width="48" height="43">
+        <mask id="mask0" maskUnits="userSpaceOnUse" x="0" y="3" width="48" height="43" style={{ maskType: 'alpha' }}>
             <path
                 d="M43.8309 27.1383C49.3148 21.6544 49.3148 12.7633 43.8309 7.27934C38.347 1.79544 29.4558 1.79543 23.9719 7.27934C18.488 1.79544 9.59684 1.79544 4.11293 7.27934C-1.37098 12.7633 -1.37098 21.6544 4.11293 27.1383L21.986 45.0114C23.0828 46.1082 24.861 46.1082 25.9578 45.0114L43.8309 27.1383Z"
                 fill="white"
@@ -18,7 +18,7 @@ export const BrandWhite = NamedSFC('BrandWhite', () => (
                 fill="white"
             />
             <rect x="43.9494" y="7.24556" width="14.0948" height="42.2726" transform="rotate(45 43.9494 7.24556)" fill="#D6E9F7" />
-            <mask id="mask1" mask-type="alpha" maskUnits="userSpaceOnUse" x="-6" y="-3" width="30" height="31">
+            <mask id="mask1" maskUnits="userSpaceOnUse" x="-6" y="-3" width="30" height="31" style={{ maskType: 'alpha' }}>
                 <path
                     d="M23.9718 7.27863L4.11284 27.1376C-1.37106 21.6537 -1.37106 12.7625 4.11284 7.27863C9.59675 1.79472 18.4879 1.79472 23.9718 7.27863Z"
                     fill="#CFEBFF"

--- a/src/tests/unit/tests/DetailsView/reports/__snapshots__/report-html-generator-v2.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/__snapshots__/report-html-generator-v2.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ReportHtmlGeneratorV2 generateHtml 1`] = `"<html lang=\\"en\\"><head-markup /><body-markup /></html>"`;
+exports[`ReportHtmlGeneratorV2 generateHtml 1`] = `"<!DOCTYPE html><html lang=\\"en\\"><head-markup /><body-markup /></html>"`;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/minimal-rule-detail.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/minimal-rule-detail.test.tsx.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`MinimalRuleDetail renders, outcomeType = fail 1`] = `
-<div
+<span
   className="rule-detail"
 >
-  <div>
+  <span>
     <OutcomeChip
       count={1}
       outcomeType="fail"
@@ -21,15 +21,15 @@ exports[`MinimalRuleDetail renders, outcomeType = fail 1`] = `
     >
       rule description
     </span>
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`MinimalRuleDetail renders, outcomeType = inapplicable 1`] = `
-<div
+<span
   className="rule-detail"
 >
-  <div>
+  <span>
      
     <span
       className="rule-details-id"
@@ -42,15 +42,15 @@ exports[`MinimalRuleDetail renders, outcomeType = inapplicable 1`] = `
     >
       rule description
     </span>
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`MinimalRuleDetail renders, outcomeType = pass 1`] = `
-<div
+<span
   className="rule-detail"
 >
-  <div>
+  <span>
      
     <span
       className="rule-details-id"
@@ -63,6 +63,6 @@ exports[`MinimalRuleDetail renders, outcomeType = pass 1`] = `
     >
       rule description
     </span>
-  </div>
-</div>
+  </span>
+</span>
 `;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section-title.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/result-section-title.test.tsx.snap
@@ -1,29 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ResultSectionTitle renders 1`] = `
-<div
+<span
   className="result-section-title"
 >
-  <div
+  <span
     className="screen-reader-only"
   >
     test title
      
     10
-  </div>
+  </span>
   <span
     aria-hidden="true"
     className="title"
   >
     test title
   </span>
-  <div
+  <span
     aria-hidden="true"
   >
     <OutcomeChip
       count={10}
       outcomeType="pass"
     />
-  </div>
-</div>
+  </span>
+</span>
 `;


### PR DESCRIPTION
#### Description of changes

By running assessment -> parsing -> parsing, we got around 50~ (actual number varies base on the amount of failed rules on the target page).
Roughly, the errors were on 3 categories:
- block elements inside inline elements (think of `<span><div/></span>`, where `<div>` is a block element while `<span>` is an inline element, some more info [here](https://www.w3schools.com/htmL/html_blocks.asp))
- missing `<!DOCTYPE html>`
- `mask-type` attribute on one of our svg icon (have to use `style` to set the mask type on this one)

By swaping `<div>` with `<span>` I have to also adjust some styles and fix some minor issues (with the chevron on passed/not applicable checks h2 titles)

![01 - overview](https://user-images.githubusercontent.com/2837582/60908958-ec1e0b80-a231-11e9-9dfb-c1b2e2d0a913.png)

#### Pull request checklist

- [x] Addresses an existing issue: Part of WI # 1558756
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not impacted
