### PR TITLE
chore: .prettierignore for .dockerignore and Dockerfile (no prettier support)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -15,5 +15,7 @@ docs/LICENSE.txt
 **/*.snap
 **/*.png
 **/*.ico
+**/*.dockerignore
 **/*.gitignore
 **/*.gitattributes
+**/Dockerfile


### PR DESCRIPTION
#### Description of changes

`yarn format` gives errors about not understanding .dockerignore/Dockerfile. `yarn format-check` shows error lines but still "succeeds" at the end. This suppresses the unrecognized file types from prettier.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
