### PR TITLE
feat: add  new for wcag 2.1 badge on new report

### DIFF
--- a/src/DetailsView/reports/components/report-sections/rule-content.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-content.tsx
@@ -4,9 +4,9 @@ import * as React from 'react';
 
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { InstanceDetailsGroup, InstanceDetailsGroupDeps, InstanceDetailsGroupProps } from './instance-details-group';
-import { RuleResources, RuleResourcesProps } from './rule-resources';
+import { RuleResources, RuleResourcesDeps, RuleResourcesProps } from './rule-resources';
 
-export type RuleContentDeps = InstanceDetailsGroupDeps;
+export type RuleContentDeps = InstanceDetailsGroupDeps & RuleResourcesDeps;
 
 type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 

--- a/src/DetailsView/reports/components/report-sections/rule-resources.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-resources.tsx
@@ -3,15 +3,21 @@
 import * as React from 'react';
 
 import { GuidanceLinks } from '../../../../common/components/guidance-links';
+import { GuidanceTags, GuidanceTagsDeps } from '../../../../common/components/guidance-tags';
 import { NewTabLink } from '../../../../common/components/new-tab-link';
 import { NamedSFC } from '../../../../common/react/named-sfc';
 import { RuleResult } from '../../../../scanner/iruleresults';
 
+export type RuleResourcesDeps = GuidanceTagsDeps;
+
 export type RuleResourcesProps = {
+    deps: RuleResourcesDeps;
     rule: RuleResult;
 };
 
-export const RuleResources = NamedSFC<RuleResourcesProps>('RuleResources', ({ rule }) => {
+export const RuleResources = NamedSFC<RuleResourcesProps>('RuleResources', ({ deps, rule }) => {
+    const renderTitle = () => <div className="more-resources-title">Resources for this rule</div>;
+
     const renderRuleLink = () => {
         const ruleId = rule.id;
         const ruleUrl = rule.helpUrl;
@@ -24,11 +30,16 @@ export const RuleResources = NamedSFC<RuleResourcesProps>('RuleResources', ({ ru
     };
 
     const renderGuidanceLinks = () => <GuidanceLinks links={rule.guidanceLinks} />;
+    const renderGuidanceTags = () => <GuidanceTags deps={deps} links={rule.guidanceLinks} />;
+
     return (
         <div className="rule-more-resources">
-            <div className="more-resources-title">Resources for this rule</div>
+            {renderTitle()}
             {renderRuleLink()}
-            {renderGuidanceLinks()}
+            <span>
+                {renderGuidanceLinks()}
+                {renderGuidanceTags()}
+            </span>
         </div>
     );
 });

--- a/src/common/components/guidance-tags.scss
+++ b/src/common/components/guidance-tags.scss
@@ -3,10 +3,7 @@
 @import '../styles/colors.scss';
 
 .guidance-tags {
-    display: inline-block;
-
-    div {
-        display: inline;
+    span {
         font-size: 12px;
         font-weight: normal;
         margin-left: 8px;

--- a/src/common/components/guidance-tags.tsx
+++ b/src/common/components/guidance-tags.tsx
@@ -29,8 +29,8 @@ export const GuidanceTags = NamedSFC<GuidanceTagsProps>('GuidanceTags', props =>
     }
 
     const tagElements = tags.map((tag, index) => {
-        return <div key={index}>{tag.displayText}</div>;
+        return <span key={index}>{tag.displayText}</span>;
     });
 
-    return <div className="guidance-tags">{tagElements}</div>;
+    return <span className="guidance-tags">{tagElements}</span>;
 });

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-resources.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/rule-resources.test.tsx.snap
@@ -19,8 +19,14 @@ exports[`RuleResources renders 1`] = `
       test-rule-id
     </NewTabLink>
   </span>
-  <GuidanceLinks
-    links={Array []}
-  />
+  <span>
+    <GuidanceLinks
+      links={Array []}
+    />
+    <GuidanceTags
+      deps={Object {}}
+      links={Array []}
+    />
+  </span>
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-resources.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-resources.test.tsx
@@ -3,7 +3,11 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { RuleResources } from '../../../../../../../DetailsView/reports/components/report-sections/rule-resources';
+import {
+    RuleResources,
+    RuleResourcesDeps,
+    RuleResourcesProps,
+} from '../../../../../../../DetailsView/reports/components/report-sections/rule-resources';
 import { RuleResult } from '../../../../../../../scanner/iruleresults';
 
 describe('RuleResources', () => {
@@ -14,7 +18,12 @@ describe('RuleResources', () => {
             guidanceLinks: [],
         } as RuleResult;
 
-        const wrapper = shallow(<RuleResources rule={rule} />);
+        const props: RuleResourcesProps = {
+            rule,
+            deps: {} as RuleResourcesDeps,
+        };
+
+        const wrapper = shallow(<RuleResources {...props} />);
 
         expect(wrapper.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/common/components/__snapshots__/guidance-tags.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/guidance-tags.test.tsx.snap
@@ -1,16 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`GuidanceTags renders tags 1`] = `
-<div
+<span
   className="guidance-tags"
 >
-  <div>
+  <span>
     some display text
-  </div>
-  <div>
+  </span>
+  <span>
     some other text
-  </div>
-</div>
+  </span>
+</span>
 `;
 
 exports[`GuidanceTags tags is: [ [length]: 0 ] 1`] = `null`;


### PR DESCRIPTION
#### Description of changes

Adding "New for WCAG 2.1" badge on the new report

- Add the badge reusing existing component 
- Update existing component to use `<span>` instead of `<div>`
   - Main reason for this is related to the Parsing test of our assessment. Basically, we should not use block elements (e.g `<div>`) inside inline elements (e.g. `<h1>`, `<span>`, `<button>`)
- Update styles for existing component to account for the `<div>` to `<span>` change

**New automated checks report**
![04 - on automated checks report - rule resources](https://user-images.githubusercontent.com/2837582/61000260-e7c91f80-a311-11e9-85b5-b954940f89bb.png)

**On assessment report** (fix the badge to be in the same line)
![01 - on assessment report](https://user-images.githubusercontent.com/2837582/61000284-f6afd200-a311-11e9-9997-19dcd81e863f.png)

**On failure details** (not changed)
![03 - on failure details](https://user-images.githubusercontent.com/2837582/61000302-fdd6e000-a311-11e9-8e7d-245499398366.png)

**On assessment details view** (not changed)
![02 - on assessment details view](https://user-images.githubusercontent.com/2837582/61000321-06c7b180-a312-11e9-97ab-b4f6d7821819.png)


#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1558756
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
