### PR TITLE
chore: remove unnecessary -- args to "yarn run" to fix build warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,14 +117,14 @@ You can start an interactive watch session that automatically runs tests affecte
 #### Using the terminal
 
 `yarn test` runs all unit tests.
-`yarn test -- -u` runs all unit tests and updates snapshot files.
+`yarn test -u` runs all unit tests and updates snapshot files.
 
 `yarn test:e2e` runs all end-to-end tests - you'll need to run `yarn build` first if you've changed non-test code.
-`yarn test:e2e -- -u` runs all end-to-end tests and updates snapshot files.
+`yarn test:e2e -u` runs all end-to-end tests and updates snapshot files.
 
-To run a single or small number of test files, run `yarn test -- {FILE_NAME_REGEX}`
+To run a single or small number of test files, run `yarn test {FILE_NAME_REGEX}`
 
-Options after the `--` are passed to Jest. For example, `yarn test -- --watch` will start an interactive watch session. See more about Jest options [here](https://jestjs.io/docs/en/cli.html).
+Extra command line arguments and flags are passed to Jest. For example, `yarn test --watch` will start an interactive watch session. See more about Jest options [here](https://jestjs.io/docs/en/cli.html).
 
 To debug using an external tool, run `node --inspect-brk ./node_modules/jest/bin/jest.js --runInBand {RELATIVE_FILE_PATH}`. In Chrome, for example, navigate to `chrome://inspect` and click `Open dedicated DevTools for Node`.
 

--- a/pipeline/e2e-test-from-agent.yaml
+++ b/pipeline/e2e-test-from-agent.yaml
@@ -5,5 +5,5 @@ steps:
     - script: yarn build:dev
       displayName: build:dev
 
-    - script: yarn test:e2e -- --ci
+    - script: yarn test:e2e --ci
       displayName: run e2e tests


### PR DESCRIPTION
#### Description of changes

Before this change, the windows E2E test logs showed the following warning:

```
warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.
```

This addresses it in the CI build and also in our README suggested commands (I searched the codebase for uses of the string ` -- `)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
