### PR TITLE
docs: add class diagram for issue details builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /test-results/
 /drop/
 *.scss.d.ts
+/docs/diagrams/out/
 # Dependency directories
 node_modules/

--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,5 @@ docs/LICENSE.txt
 **/*.gitignore
 **/*.gitattributes
 **/Dockerfile
+docs/diagrams/out/
+docs/diagrams/**/*.puml

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
         "esbenp.prettier-vscode",
         "ms-vscode.vscode-typescript-tslint-plugin",
         "msjsdiag.debugger-for-chrome",
-        "psioniq.psi-header"
+        "psioniq.psi-header",
+        "jebbs.plantuml"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,7 @@
     "prettier.requireConfig": true,
     "editor.formatOnSave": true,
     "editor.rulers": [140],
-    "typescript.tsdk": "node_modules\\typescript\\lib"
+    "typescript.tsdk": "node_modules\\typescript\\lib",
+    "plantuml.diagramsRoot": "docs/diagrams/src",
+    "plantuml.exportOutDir": "docs/diagrams/out"
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,9 +25,10 @@ module.exports = function(grunt) {
             './test-results',
             './docs/NOTICE.html',
             './docs/LICENSE.txt',
+            './docs/diagrams/out',
         ],
         file_type_method: 'INCLUDE',
-        file_types: ['.ts', '.tsx', '.d.ts', '.js', '.html', '.css', '.scss', '.yaml', '.md', '.txt', '.xml'],
+        file_types: ['.ts', '.tsx', '.d.ts', '.js', '.html', '.css', '.scss', '.yaml', '.md', '.txt', '.xml', '.puml'],
         insert_license: false,
         license_formats: {
             'yaml|npmrc': {
@@ -42,6 +43,11 @@ module.exports = function(grunt) {
             'snap|ts|tsx|d.ts|js|scss|css': {
                 eachLine: {
                     prepend: '// ',
+                },
+            },
+            puml: {
+                eachLine: {
+                    prepend: "' ",
                 },
             },
         },

--- a/docs/diagrams/src/issue-filing/abstract-factory-pattern.puml
+++ b/docs/diagrams/src/issue-filing/abstract-factory-pattern.puml
@@ -1,0 +1,50 @@
+' Copyright (c) Microsoft Corporation. All rights reserved.
+' Licensed under the MIT License.
+@startuml
+
+title Abstract Factory Pattern
+
+class AbstractFactory <<interface>> {
+ +CreateProductA()
+ +CreateProductB()
+}
+
+class ConcreteFactory1 {
+ +CreateProductA()
+ +CreateProductB()
+}
+
+class ConcreteFactory2 {
+ +CreateProductA()
+ +CreateProductB()
+}
+
+class AbstractProductA <<interface>>
+class ProductA2
+class ProductA1
+
+class AbstractProductB <<interface>>
+class ProductB1
+class ProductB2
+
+class Client
+
+AbstractFactory <-- Client
+
+Client --> AbstractProductA
+Client --> AbstractProductB
+
+AbstractFactory <|.. ConcreteFactory1
+AbstractFactory <|.. ConcreteFactory2
+
+AbstractProductA <|.. ProductA1
+AbstractProductA <|.. ProductA2
+AbstractProductB <|.. ProductB1
+AbstractProductB <|.. ProductB2
+
+ProductA1 <-- ConcreteFactory1
+ProductB1 <-- ConcreteFactory1
+ProductA2 <-- ConcreteFactory2
+ProductB2 <-- ConcreteFactory2
+
+@enduml

--- a/docs/diagrams/src/issue-filing/abstract-factory-pattern.puml
+++ b/docs/diagrams/src/issue-filing/abstract-factory-pattern.puml
@@ -5,18 +5,18 @@
 title Abstract Factory Pattern
 
 class AbstractFactory <<interface>> {
- +CreateProductA()
- +CreateProductB()
+    +CreateProductA()
+    +CreateProductB()
 }
 
 class ConcreteFactory1 {
- +CreateProductA()
- +CreateProductB()
+    +CreateProductA()
+    +CreateProductB()
 }
 
 class ConcreteFactory2 {
- +CreateProductA()
- +CreateProductB()
+    +CreateProductA()
+    +CreateProductB()
 }
 
 class AbstractProductA <<interface>>

--- a/docs/diagrams/src/issue-filing/issue-details-buider.puml
+++ b/docs/diagrams/src/issue-filing/issue-details-buider.puml
@@ -3,6 +3,7 @@
 @startuml
 
 title Issue Details Builder
+header partial diagram
 
 class MarkupFormatter {
  +sectionHeader()

--- a/docs/diagrams/src/issue-filing/issue-details-buider.puml
+++ b/docs/diagrams/src/issue-filing/issue-details-buider.puml
@@ -1,0 +1,54 @@
+' Copyright (c) Microsoft Corporation. All rights reserved.
+' Licensed under the MIT License.
+@startuml
+
+title Issue Details Builder
+
+class MarkupFormatter {
+ +sectionHeader()
+ +snippet()
+ +link()
+ +howToFixSection()
+}
+
+class HTMLFormatter {
+ +sectionHeader()
+ +snippet()
+ +link()
+ +howToFixSection()
+}
+
+class MarkdownFormatter {
+ +sectionHeader()
+ +snippet()
+ +link()
+ +howToFixSection()
+}
+
+class Text <<string>>
+class HTMLHeader
+class MarkdownHeader
+
+class HTMLSnippet
+class MarkdownSnippet
+
+class createIssueDetailsBuilder
+
+MarkupFormatter <-- createIssueDetailsBuilder
+
+createIssueDetailsBuilder --> Text
+
+MarkupFormatter <|.. HTMLFormatter
+MarkupFormatter <|.. MarkdownFormatter
+
+Text <|.. MarkdownHeader
+Text <|.. HTMLHeader
+Text <|.. HTMLSnippet
+Text <|.. MarkdownSnippet
+
+HTMLHeader <-- HTMLFormatter
+HTMLSnippet <-- HTMLFormatter
+MarkdownHeader <-- MarkdownFormatter
+MarkdownSnippet <-- MarkdownFormatter
+
+@enduml

--- a/docs/diagrams/src/issue-filing/issue-details-buider.puml
+++ b/docs/diagrams/src/issue-filing/issue-details-buider.puml
@@ -6,24 +6,24 @@ title Issue Details Builder
 header partial diagram
 
 class MarkupFormatter {
- +sectionHeader()
- +snippet()
- +link()
- +howToFixSection()
+    +sectionHeader()
+    +snippet()
+    +link()
+    +howToFixSection()
 }
 
 class HTMLFormatter {
- +sectionHeader()
- +snippet()
- +link()
- +howToFixSection()
+    +sectionHeader()
+    +snippet()
+    +link()
+    +howToFixSection()
 }
 
 class MarkdownFormatter {
- +sectionHeader()
- +snippet()
- +link()
- +howToFixSection()
+    +sectionHeader()
+    +snippet()
+    +link()
+    +howToFixSection()
 }
 
 class Text <<string>>


### PR DESCRIPTION
#### Description of changes

I have several purposes on this PR (they are closely related)
1. Enable use of PlantUML vscode extension (more info [here](https://marketplace.visualstudio.com/items?itemName=jebbs.plantuml))
2. Document our issue details builder (this is use on issue filing feature)
3. Add an extra diagram to be used during engineering discussion
4. Test accessibility of source base diagrams

I also update some settings for prettier and copyright header checks to play nicely with PlantUML source files and output files.

**Abstract Factory Pattern**
![Abstract Factory Pattern](https://user-images.githubusercontent.com/2837582/61007167-f965f380-a320-11e9-9385-d5172a476e44.png)

**Issue Details Builder**
![Issue Details Builder](https://user-images.githubusercontent.com/2837582/61007174-ff5bd480-a320-11e9-9662-5835d06cadcc.png)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`)
   - does not apply
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - does not apply
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
