### PR TITLE
fix: chevron cut off

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -193,6 +193,7 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
         display: inline-block;
         border-right: 1px solid $secondary-text;
         border-bottom: 1px solid $secondary-text;
+        min-width: 7px;
         width: 7px;
         height: 7px;
         content: '';


### PR DESCRIPTION
#### Description of changes

Chevron is being cut off if there is not enough space on the window, e.g at 400% level zoom

Using minimum width attribute to fix it.

**100%**
![01 - 100 perc zoom](https://user-images.githubusercontent.com/2837582/61008332-15b75f80-a324-11e9-9da8-2ec2d3da13e2.gif)

**400%**
![02 - 400 perc zoom](https://user-images.githubusercontent.com/2837582/61008337-194ae680-a324-11e9-9c8c-e7311f27c868.gif)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - not filed
- [x] Added relevant unit test for your changes. (`yarn test`)
  - not affected
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - not affected
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
