### PR TITLE
test: prevent stale docker test results from being pushed into container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ dist/
 drop/
 extension/
 node_modules/
+test-results/


### PR DESCRIPTION
#### Description of changes

Adds `test-results/` to `.dockerignore` to prevent pushing stale test results from old runs into the built container

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
