### PR TITLE
refactor: remove new report feature flag

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { loadTheme } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
-
 import { AssessmentDefaultMessageGenerator } from '../assessments/assessment-default-message-generator';
 import { Assessments } from '../assessments/assessments';
 import { assessmentsProviderWithFeaturesEnabled } from '../assessments/assessments-feature-flag-filter';
@@ -87,7 +86,6 @@ import {
 } from './reports/get-assessment-summary-model';
 import { ReactStaticRenderer } from './reports/react-static-renderer';
 import { createReportGeneratorProvider } from './reports/report-generator-provider';
-import { ReportHtmlGeneratorV1 } from './reports/report-html-generator-v1';
 import { ReportHtmlGeneratorV2 } from './reports/report-html-generator-v2';
 import { ReportNameGenerator } from './reports/report-name-generator';
 
@@ -194,12 +192,6 @@ if (isNaN(tabId) === false) {
             const reactStaticRenderer = new ReactStaticRenderer();
             const reportNameGenerator = new ReportNameGenerator();
 
-            const reportHtmlGeneratorV1 = new ReportHtmlGeneratorV1(
-                reactStaticRenderer,
-                new NavigatorUtils(window.navigator).getBrowserSpec(),
-                extensionVersion,
-                axeVersion,
-            );
             const fixInstructionProcessor = new FixInstructionProcessor();
 
             const reportHtmlGeneratorV2 = new ReportHtmlGeneratorV2(
@@ -229,10 +221,8 @@ if (isNaN(tabId) === false) {
 
             const reportGeneratorProvider = createReportGeneratorProvider(
                 reportNameGenerator,
-                reportHtmlGeneratorV1,
                 reportHtmlGeneratorV2,
                 assessmentReportHtmlGenerator,
-                featureFlagStore,
             );
 
             visualizationStore.setTabId(tab.id);

--- a/src/DetailsView/reports/report-generator-provider.ts
+++ b/src/DetailsView/reports/report-generator-provider.ts
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BaseStore } from '../../common/base-store';
-import { FeatureFlags } from '../../common/feature-flags';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { AssessmentReportHtmlGenerator } from './assessment-report-html-generator';
 import { ReportGenerator } from './report-generator';
-import { ReportGeneratorV1 } from './report-generator-v1';
 import { ReportGeneratorV2 } from './report-generator-v2';
 import { ReportHtmlGenerator } from './report-html-generator';
 import { ReportNameGenerator } from './report-name-generator';
@@ -22,13 +20,7 @@ export const createReportGeneratorProvider = (
     featureFlagStore: BaseStore<FeatureFlagStoreData>,
 ): ReportGeneratorProvider => {
     const getGenerator = () => {
-        const featureFlag = featureFlagStore.getState();
-
-        if (featureFlag[FeatureFlags.newAutomatedChecksReport]) {
-            return new ReportGeneratorV2(reportNameGenerator, newReportHtmlGenerator, assessmentReportHtmlGenerator);
-        }
-
-        return new ReportGeneratorV1(reportNameGenerator, oldReportHtmlGenerator, assessmentReportHtmlGenerator);
+        return new ReportGeneratorV2(reportNameGenerator, newReportHtmlGenerator, assessmentReportHtmlGenerator);
     };
 
     return {

--- a/src/DetailsView/reports/report-generator-provider.ts
+++ b/src/DetailsView/reports/report-generator-provider.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseStore } from '../../common/base-store';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { AssessmentReportHtmlGenerator } from './assessment-report-html-generator';
 import { ReportGenerator } from './report-generator';
 import { ReportGeneratorV2 } from './report-generator-v2';
@@ -14,10 +12,8 @@ export type ReportGeneratorProvider = {
 
 export const createReportGeneratorProvider = (
     reportNameGenerator: ReportNameGenerator,
-    oldReportHtmlGenerator: ReportHtmlGenerator,
     newReportHtmlGenerator: ReportHtmlGenerator,
     assessmentReportHtmlGenerator: AssessmentReportHtmlGenerator,
-    featureFlagStore: BaseStore<FeatureFlagStoreData>,
 ): ReportGeneratorProvider => {
     const getGenerator = () => {
         return new ReportGeneratorV2(reportNameGenerator, newReportHtmlGenerator, assessmentReportHtmlGenerator);

--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -11,7 +11,6 @@ export class FeatureFlags {
     public static readonly showAllFeatureFlags = 'showAllFeatureFlags';
     public static readonly scoping = 'scoping';
     public static readonly showInstanceVisibility = 'showInstanceVisibility';
-    public static readonly newAutomatedChecksReport = 'newAutomatedChecksReport';
     public static readonly manualInstanceDetails = 'manualInstanceDetails';
 }
 
@@ -77,14 +76,6 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
                 "(You'll need to go to a different requirement and come back for it to take effect.)",
             isPreviewFeature: false,
             forceDefault: false,
-        },
-        {
-            id: FeatureFlags.newAutomatedChecksReport,
-            defaultValue: true,
-            displayableName: 'Enable new automated checks report',
-            displayableDescription: 'Enable the new FastPass Automated checks report, with new UX and accessibility improvements',
-            isPreviewFeature: false,
-            forceDefault: true,
         },
         {
             id: FeatureFlags.manualInstanceDetails,

--- a/src/tests/unit/tests/DetailsView/reports/report-generator-provider.test.ts
+++ b/src/tests/unit/tests/DetailsView/reports/report-generator-provider.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, Mock, MockBehavior } from 'typemoq';
-import { BaseStore } from '../../../../../common/base-store';
-import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
+import { IMock, Mock } from 'typemoq';
 import { AssessmentReportHtmlGenerator } from '../../../../../DetailsView/reports/assessment-report-html-generator';
 import { createReportGeneratorProvider, ReportGeneratorProvider } from '../../../../../DetailsView/reports/report-generator-provider';
 import { ReportGeneratorV2 } from '../../../../../DetailsView/reports/report-generator-v2';
@@ -13,21 +11,13 @@ describe('ReportGeneratorProvider', () => {
     let nameGeneratorMock: IMock<ReportNameGenerator>;
     let htmlGeneratorMock: IMock<ReportHtmlGenerator>;
     let assessmentHtmlGeneratorMock: IMock<AssessmentReportHtmlGenerator>;
-    let featureFlagStoreMock: IMock<BaseStore<FeatureFlagStoreData>>;
     let provider: ReportGeneratorProvider;
 
     beforeEach(() => {
         nameGeneratorMock = Mock.ofType<ReportNameGenerator>();
         htmlGeneratorMock = Mock.ofType<ReportHtmlGenerator>();
         assessmentHtmlGeneratorMock = Mock.ofType<AssessmentReportHtmlGenerator>();
-        featureFlagStoreMock = Mock.ofType<BaseStore<FeatureFlagStoreData>>(undefined, MockBehavior.Strict);
-        provider = createReportGeneratorProvider(
-            nameGeneratorMock.object,
-            htmlGeneratorMock.object,
-            htmlGeneratorMock.object,
-            assessmentHtmlGeneratorMock.object,
-            featureFlagStoreMock.object,
-        );
+        provider = createReportGeneratorProvider(nameGeneratorMock.object, htmlGeneratorMock.object, assessmentHtmlGeneratorMock.object);
     });
 
     it('creates report generator', () => {

--- a/src/tests/unit/tests/DetailsView/reports/report-generator-provider.test.ts
+++ b/src/tests/unit/tests/DetailsView/reports/report-generator-provider.test.ts
@@ -1,13 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IMock, Mock, MockBehavior } from 'typemoq';
-
 import { BaseStore } from '../../../../../common/base-store';
-import { FeatureFlags } from '../../../../../common/feature-flags';
 import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { AssessmentReportHtmlGenerator } from '../../../../../DetailsView/reports/assessment-report-html-generator';
 import { createReportGeneratorProvider, ReportGeneratorProvider } from '../../../../../DetailsView/reports/report-generator-provider';
-import { ReportGeneratorV1 } from '../../../../../DetailsView/reports/report-generator-v1';
 import { ReportGeneratorV2 } from '../../../../../DetailsView/reports/report-generator-v2';
 import { ReportHtmlGenerator } from '../../../../../DetailsView/reports/report-html-generator';
 import { ReportNameGenerator } from '../../../../../DetailsView/reports/report-name-generator';
@@ -33,24 +30,7 @@ describe('ReportGeneratorProvider', () => {
         );
     });
 
-    it('creates report generator, feature flag on', () => {
-        const featureFlag = {
-            [FeatureFlags.newAutomatedChecksReport]: false,
-        };
-
-        featureFlagStoreMock.setup(store => store.getState()).returns(() => featureFlag);
-        const generator = provider.getGenerator();
-
-        expect(generator).toBeInstanceOf(ReportGeneratorV1);
-    });
-
-    it('creates report generator, feature flag off', () => {
-        const featureFlag = {
-            [FeatureFlags.newAutomatedChecksReport]: true,
-        };
-
-        featureFlagStoreMock.setup(store => store.getState()).returns(() => featureFlag);
-
+    it('creates report generator', () => {
         const generator = provider.getGenerator();
 
         expect(generator).toBeInstanceOf(ReportGeneratorV2);

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -20,7 +20,6 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.showAllFeatureFlags]: false,
             [FeatureFlags.scoping]: false,
             [FeatureFlags.showInstanceVisibility]: false,
-            [FeatureFlags.newAutomatedChecksReport]: true,
             [FeatureFlags.manualInstanceDetails]: false,
         };
 


### PR DESCRIPTION
#### Description of changes

Removing the "new automated checks report" feature flag as we're done with the feature now.

**Out of scope**: I'm not removing the old report dead code on this PR to keep it small and single scoped. I'll have a second PR to remove that dead code.

#### Pull request checklist

- [x] Addresses an existing issue: Part of WI # 1558756
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
