### PR TITLE
refactor: add missing react imports

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as React from 'react';
 import {
     AddFailureInstancePayload,
     AddResultDescriptionPayload,

--- a/src/DetailsView/components/left-nav/nav-link-handler.ts
+++ b/src/DetailsView/components/left-nav/nav-link-handler.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as React from 'react';
 import { DetailsViewPivotType } from '../../../common/types/details-view-pivot-type';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../../actions/details-view-action-message-creator';

--- a/src/common/dropdown-click-handler.ts
+++ b/src/common/dropdown-click-handler.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as React from 'react';
+
 import { DropdownActionMessageCreator } from './message-creators/dropdown-action-message-creator';
 import { TelemetryEventSource } from './telemetry-events';
 

--- a/src/common/message-creators/content-action-message-creator.ts
+++ b/src/common/message-creators/content-action-message-creator.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as React from 'react';
 import { BaseActionPayload } from '../../background/actions/action-payloads';
 import { ContentPayload } from '../../background/actions/content-actions';
 import { ActionInitiators } from '../action/action-initiator';

--- a/src/common/message-creators/inspect-action-message-creator.ts
+++ b/src/common/message-creators/inspect-action-message-creator.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as React from 'react';
 import { InspectMode } from '../../background/inspect-modes';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';

--- a/src/common/message-creators/scoping-action-message-creator.ts
+++ b/src/common/message-creators/scoping-action-message-creator.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as React from 'react';
 import { Messages } from '../messages';
 import { TelemetryDataFactory } from '../telemetry-data-factory';
 import { ScopingPayload } from './../../background/actions/scoping-actions';

--- a/src/injected/details-dialog-handler.ts
+++ b/src/injected/details-dialog-handler.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as React from 'react';
 import { FeatureFlags } from '../common/feature-flags';
 import { HTMLElementUtils } from '../common/html-element-utils';
 import { DetailsDialog } from './components/details-dialog';

--- a/src/injected/target-page-action-message-creator.ts
+++ b/src/injected/target-page-action-message-creator.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as React from 'react';
 import { BaseActionPayload } from '../background/actions/action-payloads';
 import { Message } from '../common/message';
 import { ActionMessageDispatcher } from '../common/message-creators/action-message-dispatcher';


### PR DESCRIPTION
#### Description of changes

Looking at the Typescript 3.5 update and webpack config changes it may need, I came across an compilation error where we are using React.<Mouse events> types without actually importing react on the file. I don't know why this is not happening right now with our current setup but using the experimental watch flag on one of the webpack plugins make this error appears.
Also, for sake of correctness, we should import anything we are using on each file.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`)
   - not impacted
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - not impacted
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not impacted
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not impacted
