### PR TITLE
fix: link size is too big on resources for this rule card

### DIFF
--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -103,7 +103,6 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
 
         .rule-details-id {
             padding: 12px 0;
-            font-size: 15px;
 
             a {
                 text-decoration: none !important;


### PR DESCRIPTION
#### Description of changes

Fix link size on the **Resources for this rule** card in the automated checks report.

**After (fixed)**
![02 - after (fixed)](https://user-images.githubusercontent.com/2837582/61157298-9d2edb00-a4aa-11e9-986b-b59b5815add1.png)

**Before**
![01 - before](https://user-images.githubusercontent.com/2837582/61157305-a0c26200-a4aa-11e9-90f6-5e38487aed27.png)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
   - does not apply
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - not affected
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
