### PR TITLE
chore: disable Puppeteer default viewport to increase its size

### DIFF
--- a/src/tests/end-to-end/common/browser-factory.ts
+++ b/src/tests/end-to-end/common/browser-factory.ts
@@ -61,6 +61,7 @@ async function launchNewBrowser(): Promise<Puppeteer.Browser> {
     const browser = await Puppeteer.launch({
         // Headless doesn't support extensions, see https://github.com/GoogleChrome/puppeteer/issues/659
         headless: false,
+        defaultViewport: null,
         args: [
             // Required to work around https://github.com/GoogleChrome/puppeteer/pull/774
             `--disable-extensions-except=${extensionPath}`,


### PR DESCRIPTION
#### Description of changes

According to [Puppeteer documentation for launch options](https://github.com/GoogleChrome/puppeteer/blob/v1.14.0/docs/api.md#puppeteerlaunchoptions), setting `defaultViewport` to `null` disables the default viewport size of 800x600. When the default viewport is disabled, the viewport size matches the browser size. This makes failture screenshots more meaningful when debugging flaky E2E tests because they will show more than the top left portion of the page that is being tested.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000 **N/A**
- [x] Added relevant unit test for your changes. (`yarn test`) **N/A**
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` **N/A**
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above **N/A**
- [x] (UI changes only) Verified usability with NVDA/JAWS **N/A**
