### PR TITLE
fix: update links styles, match style on the report

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -314,8 +314,9 @@ div.insights-file-issue-details-dialog-container {
         align-items: center;
         background-color: $neutral-0;
         font-size: 14px;
-        font-weight: 600;
+        font-weight: normal;
         border-bottom: 1px solid $neutral-alpha-8;
+
         .details-view-target-page {
             margin-left: 12px;
             padding: 13px 8px;
@@ -323,6 +324,7 @@ div.insights-file-issue-details-dialog-container {
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
+            color: $primary-text;
             width: 50%;
             .ms-Link {
                 color: $communication-primary;

--- a/src/DetailsView/reports/automated-checks-report.scss
+++ b/src/DetailsView/reports/automated-checks-report.scss
@@ -103,14 +103,6 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
 
         .rule-details-id {
             padding: 12px 0;
-
-            a {
-                text-decoration: none !important;
-            }
-        }
-
-        .guidance-links a {
-            text-decoration: none !important;
         }
     }
 }

--- a/src/DetailsView/reports/components/report-sections/header-section.scss
+++ b/src/DetailsView/reports/components/report-sections/header-section.scss
@@ -29,10 +29,11 @@
         margin: 0px 0px 0px 16px;
         display: inherit;
 
-        color: $neutral-60;
+        color: $primary-text;
         font-family: $fontFamily;
         font-size: 14px;
         line-height: 20px;
+        font-weight: 600;
 
         a {
             @include ellipsedText();

--- a/src/DetailsView/reports/components/report-sections/header-section.scss
+++ b/src/DetailsView/reports/components/report-sections/header-section.scss
@@ -33,7 +33,7 @@
         font-family: $fontFamily;
         font-size: 14px;
         line-height: 20px;
-        font-weight: 600;
+        font-weight: normal;
 
         a {
             @include ellipsedText();

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -71,8 +71,11 @@ button::after {
 .insights-link {
     // marking important to override office fabric style
     color: $link !important;
+    text-decoration: none;
+
     &:hover {
         color: $link-hover !important;
+        text-decoration: underline;
     }
 }
 


### PR DESCRIPTION
#### Description of changes

- Updating default links style to:
   - have no underline normally
   - have underline when hover
- Remove link style override on the automated checks report (so we pick up the default links style
- Update font color and weight for the header target page text on the automated checks report

**_Details view_**
**Target page url**
![01 - target page normal and hover](https://user-images.githubusercontent.com/2837582/61162004-5eede780-a4bb-11e9-976e-d0f9884b88dc.gif)

**Rule and WCAG links**
![02 - rule and wcag links normal and hover](https://user-images.githubusercontent.com/2837582/61162008-657c5f00-a4bb-11e9-8667-a041c8a693f0.gif)

**_Automated checks report_**
**Header target page url**
![03 - report target page normal and hover](https://user-images.githubusercontent.com/2837582/61162031-81800080-a4bb-11e9-8635-4297a045a99a.gif)

**Scan details page url**
![04 - scan details page url normal and hover](https://user-images.githubusercontent.com/2837582/61162034-83e25a80-a4bb-11e9-9c52-f10dfcbd09e2.gif)

**Rule and WCAG links**
![05 - rule resources normal and hover](https://user-images.githubusercontent.com/2837582/61162036-8644b480-a4bb-11e9-83ee-9711603ffd01.gif)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - found during insider validation
- [x] Added relevant unit test for your changes. (`yarn test`)
   - no code changes
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - no code changes
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
