### PR TITLE
test: temporarily disable e2e tests from PR/CI gates until we can resolve flakiness

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -49,21 +49,6 @@ jobs:
             inputs:
                 verbosity: Normal
 
-    - job: 'e2e_tests_windows'
-      pool:
-          vmImage: 'vs2017-win2016'
-      steps:
-          - template: pipeline/install-node-prerequisites.yaml
-          - template: pipeline/e2e-test-from-agent.yaml
-          - template: pipeline/e2e-test-publish-results.yaml
-
-    - job: 'e2e_tests_linux'
-      pool:
-          vmImage: 'ubuntu-16.04'
-      steps:
-          - template: pipeline/e2e-test-from-docker.yaml
-          - template: pipeline/e2e-test-publish-results.yaml
-
     - job: 'publish_build_drops'
       pool:
           vmImage: 'ubuntu-16.04'

--- a/pipeline/e2e-reliability.yaml
+++ b/pipeline/e2e-reliability.yaml
@@ -89,7 +89,6 @@ jobs:
           - template: ./e2e-test-from-agent.yaml
           - template: ./e2e-test-publish-results.yaml
 
-
     - job: 'e2e_tests_linux_1'
       pool:
           vmImage: 'ubuntu-16.04'

--- a/pipeline/e2e-reliability.yaml
+++ b/pipeline/e2e-reliability.yaml
@@ -1,0 +1,126 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+trigger:
+    - master
+    - e2e-reliability/*
+pr:
+    paths:
+        include:
+            - src/tests/end-to-end/
+
+jobs:
+    - job: 'e2e_tests_windows_1'
+      pool:
+          vmImage: 'vs2017-win2016'
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_windows_2'
+      pool:
+          vmImage: 'vs2017-win2016'
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_windows_3'
+      pool:
+          vmImage: 'vs2017-win2016'
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_windows_4'
+      pool:
+          vmImage: 'vs2017-win2016'
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_windows_5'
+      pool:
+          vmImage: 'vs2017-win2016'
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_mac_1'
+      pool:
+          vmImage: 'macOS-10.14'
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_mac_2'
+      pool:
+          vmImage: 'macOS-10.14'
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_mac_3'
+      pool:
+          vmImage: 'macOS-10.14'
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_mac_4'
+      pool:
+          vmImage: 'macOS-10.14'
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_mac_5'
+      pool:
+          vmImage: 'macOS-10.14'
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./e2e-test-from-agent.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+
+    - job: 'e2e_tests_linux_1'
+      pool:
+          vmImage: 'ubuntu-16.04'
+      steps:
+          - template: ./e2e-test-from-docker.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_linux_2'
+      pool:
+          vmImage: 'ubuntu-16.04'
+      steps:
+          - template: ./e2e-test-from-docker.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_linux_3'
+      pool:
+          vmImage: 'ubuntu-16.04'
+      steps:
+          - template: ./e2e-test-from-docker.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_linux_4'
+      pool:
+          vmImage: 'ubuntu-16.04'
+      steps:
+          - template: ./e2e-test-from-docker.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'e2e_tests_linux_5'
+      pool:
+          vmImage: 'ubuntu-16.04'
+      steps:
+          - template: ./e2e-test-from-docker.yaml
+          - template: ./e2e-test-publish-results.yaml


### PR DESCRIPTION
#### Description of changes

Since the recent change to run them in linux/windows, the e2e test suite has proven too flaky to use as a PR/CI gate. This change temporarily moves the flaky tests out of the required suite in `build.yaml` and into a 5x-per-environment run in a separate `e2e-reliability.yaml` instead, which will be set up to run as a non-required gate only in those PRs/branches working on e2e updates/fixes.

We'll be prioritizing improving the flakiness and getting the runs re-enabled as required checks as part of #867.

#### Pull request checklist

- [x] Addresses an existing issue: Temporary workaround for #867
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
