### PR TITLE
test: use latest windows hosted agent version in e2e-reliability runs

### DIFF
--- a/pipeline/e2e-reliability.yaml
+++ b/pipeline/e2e-reliability.yaml
@@ -11,7 +11,7 @@ pr:
 jobs:
     - job: 'e2e_tests_windows_1'
       pool:
-          vmImage: 'vs2017-win2016'
+          vmImage: 'windows-2019'
       steps:
           - template: ./install-node-prerequisites.yaml
           - template: ./e2e-test-from-agent.yaml
@@ -19,7 +19,7 @@ jobs:
 
     - job: 'e2e_tests_windows_2'
       pool:
-          vmImage: 'vs2017-win2016'
+          vmImage: 'windows-2019'
       steps:
           - template: ./install-node-prerequisites.yaml
           - template: ./e2e-test-from-agent.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - job: 'e2e_tests_windows_3'
       pool:
-          vmImage: 'vs2017-win2016'
+          vmImage: 'windows-2019'
       steps:
           - template: ./install-node-prerequisites.yaml
           - template: ./e2e-test-from-agent.yaml
@@ -35,7 +35,7 @@ jobs:
 
     - job: 'e2e_tests_windows_4'
       pool:
-          vmImage: 'vs2017-win2016'
+          vmImage: 'windows-2019'
       steps:
           - template: ./install-node-prerequisites.yaml
           - template: ./e2e-test-from-agent.yaml
@@ -43,7 +43,7 @@ jobs:
 
     - job: 'e2e_tests_windows_5'
       pool:
-          vmImage: 'vs2017-win2016'
+          vmImage: 'windows-2019'
       steps:
           - template: ./install-node-prerequisites.yaml
           - template: ./e2e-test-from-agent.yaml


### PR DESCRIPTION
#### Description of changes

We tried updating to the latest agent version to see if it had any impact on reducing page crash rates compared to the older agents. It didn't impact page crash rate, but it improved performance 5-10%, so we'll take it anyway as we continue to test other options for fixing the page crashes.

#### Pull request checklist

- [x] Addresses an existing issue: Attempt to address 1 bucket of #867
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
