### PR TITLE
fix: Automated checks report: x icons are coded as no value

### DIFF
--- a/src/DetailsView/reports/components/outcome-summary-bar.tsx
+++ b/src/DetailsView/reports/components/outcome-summary-bar.tsx
@@ -26,7 +26,8 @@ export const OutcomeSummaryBar = NamedSFC<OutcomeSummaryBarProps>('OutcomeSummar
                 return (
                     <div key={outcomeType} style={{ flexGrow: count }}>
                         <span className={kebabCase(outcomeType)}>
-                            {outcomeIcon} {count}
+                            <span aria-hidden="true">{outcomeIcon}</span>
+                            {count}
                             {countSuffix} <span className="outcome-past-tense">{text}</span>
                         </span>
                     </div>

--- a/src/DetailsView/reports/components/report-sections/minimal-rule-header.tsx
+++ b/src/DetailsView/reports/components/report-sections/minimal-rule-header.tsx
@@ -20,7 +20,11 @@ export const MinimalRuleHeader = NamedSFC<MinimalRuleHeaderProps>('MinimalRuleHe
             return null;
         }
 
-        return <OutcomeChip count={rule.nodes.length} outcomeType={outcomeType} />;
+        return (
+            <span aria-hidden="true">
+                <OutcomeChip count={rule.nodes.length} outcomeType={outcomeType} />
+            </span>
+        );
     };
 
     const renderRuleName = () => <span className="rule-details-id">{rule.id}</span>;

--- a/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/__snapshots__/outcome-summary-bar.test.tsx.snap
@@ -14,8 +14,11 @@ exports[`OutcomeSummaryBar render inverted badges 1`] = `
     <span
       className="pass"
     >
-      <CheckIconInverted />
-       
+      <span
+        aria-hidden="true"
+      >
+        <CheckIconInverted />
+      </span>
       42
        
       <span
@@ -35,8 +38,11 @@ exports[`OutcomeSummaryBar render inverted badges 1`] = `
     <span
       className="fail"
     >
-      <CrossIconInverted />
-       
+      <span
+        aria-hidden="true"
+      >
+        <CrossIconInverted />
+      </span>
       13
        
       <span
@@ -56,8 +62,90 @@ exports[`OutcomeSummaryBar render inverted badges 1`] = `
     <span
       className="incomplete"
     >
-      <CircleIcon />
+      <span
+        aria-hidden="true"
+      >
+        <CircleIcon />
+      </span>
+      7
        
+      <span
+        className="outcome-past-tense"
+      >
+        Incomplete
+      </span>
+    </span>
+  </div>
+</div>
+`;
+
+exports[`OutcomeSummaryBar show by count 1`] = `
+<div
+  className="outcome-summary-bar"
+>
+  <div
+    style={
+      Object {
+        "flexGrow": 42,
+      }
+    }
+  >
+    <span
+      className="pass"
+    >
+      <span
+        aria-hidden="true"
+      >
+        <CheckIcon />
+      </span>
+      42
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Passed
+      </span>
+    </span>
+  </div>
+  <div
+    style={
+      Object {
+        "flexGrow": 13,
+      }
+    }
+  >
+    <span
+      className="fail"
+    >
+      <span
+        aria-hidden="true"
+      >
+        <CrossIcon />
+      </span>
+      13
+       
+      <span
+        className="outcome-past-tense"
+      >
+        Failed
+      </span>
+    </span>
+  </div>
+  <div
+    style={
+      Object {
+        "flexGrow": 7,
+      }
+    }
+  >
+    <span
+      className="incomplete"
+    >
+      <span
+        aria-hidden="true"
+      >
+        <CircleIcon />
+      </span>
       7
        
       <span
@@ -84,8 +172,11 @@ exports[`OutcomeSummaryBar show by percentage 1`] = `
     <span
       className="pass"
     >
-      <CheckIcon />
-       
+      <span
+        aria-hidden="true"
+      >
+        <CheckIcon />
+      </span>
       42
       %
        
@@ -106,8 +197,11 @@ exports[`OutcomeSummaryBar show by percentage 1`] = `
     <span
       className="fail"
     >
-      <CrossIcon />
-       
+      <span
+        aria-hidden="true"
+      >
+        <CrossIcon />
+      </span>
       13
       %
        
@@ -128,80 +222,13 @@ exports[`OutcomeSummaryBar show by percentage 1`] = `
     <span
       className="incomplete"
     >
-      <CircleIcon />
-       
+      <span
+        aria-hidden="true"
+      >
+        <CircleIcon />
+      </span>
       7
       %
-       
-      <span
-        className="outcome-past-tense"
-      >
-        Incomplete
-      </span>
-    </span>
-  </div>
-</div>
-`;
-
-exports[`OutcomeSummaryBar show by percentage 2`] = `
-<div
-  className="outcome-summary-bar"
->
-  <div
-    style={
-      Object {
-        "flexGrow": 42,
-      }
-    }
-  >
-    <span
-      className="pass"
-    >
-      <CheckIcon />
-       
-      42
-       
-      <span
-        className="outcome-past-tense"
-      >
-        Passed
-      </span>
-    </span>
-  </div>
-  <div
-    style={
-      Object {
-        "flexGrow": 13,
-      }
-    }
-  >
-    <span
-      className="fail"
-    >
-      <CrossIcon />
-       
-      13
-       
-      <span
-        className="outcome-past-tense"
-      >
-        Failed
-      </span>
-    </span>
-  </div>
-  <div
-    style={
-      Object {
-        "flexGrow": 7,
-      }
-    }
-  >
-    <span
-      className="incomplete"
-    >
-      <CircleIcon />
-       
-      7
        
       <span
         className="outcome-past-tense"

--- a/src/tests/unit/tests/DetailsView/reports/components/outcome-summary-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/outcome-summary-bar.test.tsx
@@ -20,7 +20,7 @@ describe('OutcomeSummaryBar', () => {
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 
-    it('show by percentage', () => {
+    it('show by count', () => {
         const props: OutcomeSummaryBarProps = { outcomeStats, allOutcomeTypes };
         const wrapper = shallow(<OutcomeSummaryBar {...props} />);
 

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/minimal-rule-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/__snapshots__/minimal-rule-header.test.tsx.snap
@@ -5,10 +5,14 @@ exports[`MinimalRuleHeader renders, outcomeType = fail 1`] = `
   className="rule-detail"
 >
   <span>
-    <OutcomeChip
-      count={1}
-      outcomeType="fail"
-    />
+    <span
+      aria-hidden="true"
+    >
+      <OutcomeChip
+        count={1}
+        outcomeType="fail"
+      />
+    </span>
      
     <span
       className="rule-details-id"


### PR DESCRIPTION
#### Description of changes

The icons where not under an `aria-hidden="true"` container and thus, were being flag on Assessment > Images > Image function.

We do have proper text/aria-labels for both icons (on the summary bar and on the collapse/expand rule header) so hiding the icons is enough to fix this issue.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #937
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - no changes
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - AT still reads the information correctly
