### PR TITLE
test: prevent errors in takeScreenshot from suppressing the error that motivated taking the screenshot

### DIFF
--- a/src/tests/end-to-end/common/generate-screenshot.ts
+++ b/src/tests/end-to-end/common/generate-screenshot.ts
@@ -14,9 +14,13 @@ export async function takeScreenshot(pageInstance: Puppeteer.Page): Promise<Buff
     await makeDir(screenshotsPath);
     const screenshotName = generateUID();
     const filePath = path.join(screenshotsPath, toFilename(`${screenshotName}.png`));
-    console.log(`Screenshot file is located at: ${filePath}`);
-    return await pageInstance.screenshot({
+    const screenshotBuffer = await pageInstance.screenshot({
         path: filePath,
         fullPage: true,
     });
+
+    if (screenshotBuffer.length !== 0) {
+        console.log(`Screenshot file is located at: ${filePath}`);
+    }
+    return screenshotBuffer;
 }

--- a/src/tests/end-to-end/common/generate-screenshot.ts
+++ b/src/tests/end-to-end/common/generate-screenshot.ts
@@ -19,8 +19,8 @@ export async function takeScreenshot(pageInstance: Puppeteer.Page): Promise<Buff
         fullPage: true,
     });
 
-    if (screenshotBuffer.length !== 0) {
-        console.log(`Screenshot file is located at: ${filePath}`);
-    }
+    // We don't log this until after screenshot() succeeds to avoid misleading logs if it throws
+    console.log(`Screenshot file is located at: ${filePath}`);
+
     return screenshotBuffer;
 }

--- a/src/tests/end-to-end/common/page.ts
+++ b/src/tests/end-to-end/common/page.ts
@@ -140,6 +140,7 @@ export class Page {
         try {
             return await fn();
         } catch (error) {
+            console.log(`error thrown by page ${this.underlyingPage} in screenshot method`, error);
             await takeScreenshot(this.underlyingPage);
             throw error;
         }

--- a/src/tests/end-to-end/common/page.ts
+++ b/src/tests/end-to-end/common/page.ts
@@ -147,10 +147,17 @@ export class Page {
     private async screenshotOnError<T>(fn: () => Promise<T>): Promise<T> {
         try {
             return await fn();
-        } catch (error) {
-            console.log(`error thrown by page ${this.underlyingPage} in screenshot method`, error);
-            await takeScreenshot(this.underlyingPage);
-            throw error;
+        } catch (originalError) {
+            try {
+                await takeScreenshot(this.underlyingPage);
+            } catch (secondaryTakeScreenshotError) {
+                console.error(
+                    `screenshotOnError: Detected an error, and then *additionally* hit a second error while trying to take a screenshot of the page state after the first error.\n` +
+                        `screenshotOnError: The secondary error from taking the screenshot is: ${secondaryTakeScreenshotError.stack}\n` +
+                        `screenshotOnError: rethrowing the original error...`,
+                );
+            }
+            throw originalError;
         }
     }
 }


### PR DESCRIPTION
#### Description of changes

Previously, in our e2e action wrappers that used `screenshotOnError`, an error case that prevents both the original error and the screenshot-taking from working (eg, underlying browser/page closed prematurely) would only show an error text/stack for the takeScreenshot error, even though the original error is usually more valuable. This causes it to print both errors and use the original as the primary.

Replaces/builds on @Shobhit1 's #956 , since he's out today 

#### Pull request checklist

- [x] Addresses an existing issue: Contributes to #867 
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
