### PR TITLE
test: reduce docker build time by 1min by using cypress/base:10 image instead node:10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,11 @@
 
 # reference: https://stackoverflow.com/a/51683309/3711475
 # reference: https://github.com/GoogleChrome/puppeteer/blob/master/docs/troubleshooting.md#running-puppeteer-in-docker
-FROM node:10
 
-RUN apt-get update && apt-get install -yq gconf-service libasound2 libatk1.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils wget x11vnc x11-xkb-utils xfonts-100dpi xfonts-75dpi xfonts-scalable xfonts-cyrillic x11-apps xvfb
+# We use Puppeteer, not Cypress; however, Cypress's docker images are up to date baselines that already contain both node and
+# the system dependencies required to run headful Chromium, so we use them to avoid the performance hit of having our own
+# build agents running apt-get for all those dependencies. 
+FROM cypress/base:10.16.0
 
 WORKDIR /app
 


### PR DESCRIPTION
#### Description of changes

[Cypress](https://www.cypress.io/) maintains [a set of Docker images](https://github.com/cypress-io/cypress-docker-images) that come with the necessary dependencies for running headful Chromium pre-installed. We can't use Cypress itself because of our need for multi-tab scenario validation, but their docker images save us having to do a long "apt-get" operation with each build and cut off about a minute from the linux e2e tests (which are the long pole for e2e-reliability runs right now).

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
