### PR TITLE
test: improve click() reliability by disabling animations in pages under test

### DIFF
--- a/src/tests/end-to-end/common/browser.ts
+++ b/src/tests/end-to-end/common/browser.ts
@@ -90,12 +90,6 @@ export class Browser {
         }
     }
 
-    public async getLastOpenPage(): Promise<Page> {
-        const targets = await this.underlyingBrowser.targets();
-        const puppeteerPage = await targets[targets.length - 1].page();
-        return new Page(puppeteerPage, { onPageCrash: this.onPageCrash });
-    }
-
     public async getActivePageTabId(): Promise<number> {
         const backgroundPage = await this.waitForExtensionBackgroundPage();
         return await backgroundPage.evaluate(() => {
@@ -108,7 +102,9 @@ export class Browser {
     public async waitForPageMatchingUrl(url: string): Promise<Page> {
         const underlyingTarget = await this.underlyingBrowser.waitForTarget(t => t.url().toLowerCase() === url.toLowerCase());
         const underlyingPage = await underlyingTarget.page();
-        return new Page(underlyingPage, { onPageCrash: this.onPageCrash });
+        const page = new Page(underlyingPage, { onPageCrash: this.onPageCrash });
+        await page.disableAnimations();
+        return page;
     }
 
     private async getExtensionUrl(relativePath: string): Promise<string> {

--- a/src/tests/end-to-end/common/page.ts
+++ b/src/tests/end-to-end/common/page.ts
@@ -50,7 +50,7 @@ export class Page {
 
     public async disableAnimations(): Promise<void> {
         await this.underlyingPage.evaluate(() => {
-            function addDisableStyleToBody() {
+            function addDisableStyleToBody(): void {
                 const disableAnimationsStyleElement = document.createElement('style');
                 disableAnimationsStyleElement.type = 'text/css';
                 disableAnimationsStyleElement.innerHTML = `* {

--- a/src/tests/end-to-end/common/page.ts
+++ b/src/tests/end-to-end/common/page.ts
@@ -45,6 +45,26 @@ export class Page {
 
     public async goto(url: string): Promise<void> {
         await this.screenshotOnError(async () => await this.underlyingPage.goto(url, { timeout: DEFAULT_NEW_PAGE_WAIT_TIMEOUT_MS }));
+        await this.disableAnimations();
+    }
+
+    public async disableAnimations(): Promise<void> {
+        await this.underlyingPage.evaluate(() => {
+            function addDisableStyleToBody() {
+                const disableAnimationsStyleElement = document.createElement('style');
+                disableAnimationsStyleElement.type = 'text/css';
+                disableAnimationsStyleElement.innerHTML = `* {
+                    transition: none !important;
+                    animation: none !important;
+                }`;
+                document.body.appendChild(disableAnimationsStyleElement);
+            }
+            if (document.readyState !== 'loading') {
+                addDisableStyleToBody();
+            } else {
+                window.addEventListener('load', addDisableStyleToBody, false);
+            }
+        });
     }
 
     public async close(ignoreIfAlreadyClosed: boolean = false): Promise<void> {

--- a/src/tests/end-to-end/common/page.ts
+++ b/src/tests/end-to-end/common/page.ts
@@ -62,7 +62,7 @@ export class Page {
             if (document.readyState !== 'loading') {
                 addDisableStyleToBody();
             } else {
-                window.addEventListener('load', addDisableStyleToBody, false);
+                window.addEventListener('load', addDisableStyleToBody);
             }
         });
     }


### PR DESCRIPTION
#### Description of changes

This PR addresses a recurring source of e2e test flakiness in scenarios like "open a panel then click a button in it", where if the panel opening has an animation, the button can move out from under the click coordinates during the attempt to click on it, resulting in the click not registering and the next step of the test timing out.

We considered/tried out several options for reducing this flakiness:
* Using cypress's strategy of waiting for elements being clicked to have a stable position. This is maybe the "best" solution in theory but we weren't able to come up with a stable implementation that wasn't itself flaky.
* Waiting for the element being clicked to be free of running animation/transition style properties. This doesn't work because other elements' animations (not necessarily just ancestors) can change the positioning of a non-directly-animating element.
* Waiting for *all* elements on the page to be free of running animation/transition style properties. This wasn't feasible performance-wise and still had edge cases like "loading spinners" that would have made it complex to write non-flaky logic.
* Adding a waitFor(MAX_FABRIC_ANIMATION_DURATION) before each click. This wasn't feasible performance-wise; it brought the total test duration from ~6min to >1hr
* Adding a waitFor(MAX_FABRIC_ANIMATION_DURATION) before specific clicks on elements we know to be animating in. This worked, but was too fragile; it would be too easy for individual test cases added later to not do this reliably.
* Disabling animations on the page. We don't love this because it means we're testing the page in a way that users won't actually see this, but it is otherwise effective and performant.

None of these options were great, but we felt the last option was the least-bad, so we went with it.

This specific implementation puts `disableAnimations()` calls in the specific Page creation paths that require it. I think it would be better to have individual page controllers that require it be responsible for this in their setup (`TargetPageController`, `DetailsPageController`, `PopupPageController`), but wanted to keep the scope of this change relatively minimal, so leaving that change out of scope until a separate PR.

#### Pull request checklist

- [x] Addresses an existing issue: Addresses most buckets of #867
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
