### PR TITLE
refactor: extract file url unsupported message panel

### DIFF
--- a/src/popup/components/file-url-unsupported-message-panel.tsx
+++ b/src/popup/components/file-url-unsupported-message-panel.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { BrowserAdapter } from '../../background/browser-adapters/browser-adapter';
+
+import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
 import { NewTabLink } from '../../common/components/new-tab-link';
 import { DisplayableStrings } from '../../common/constants/displayable-strings';
 import { NamedSFC } from '../../common/react/named-sfc';

--- a/src/popup/components/file-url-unsupported-message-panel.tsx
+++ b/src/popup/components/file-url-unsupported-message-panel.tsx
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+import { BrowserAdapter } from '../../background/browser-adapters/browser-adapter';
+import { NewTabLink } from '../../common/components/new-tab-link';
+import { DisplayableStrings } from '../../common/constants/displayable-strings';
+import { NamedSFC } from '../../common/react/named-sfc';
+
+export type FileUrlUnsupportedMessagePanelDeps = {
+    browserAdapter: BrowserAdapter;
+};
+export type FileUrlUnsupportedMessagePanelProps = {
+    deps: FileUrlUnsupportedMessagePanelDeps;
+    header: JSX.Element;
+    title: string;
+};
+
+export const FileUrlUnsupportedMessagePanel = NamedSFC<FileUrlUnsupportedMessagePanelProps>(
+    'FileUrlUnsupportedMessagePanel',
+    ({ deps, header, title }) => {
+        const { browserAdapter } = deps;
+
+        return (
+            <div className="ms-Fabric unsupported-url-info-panel">
+                {header}
+                <div className="ms-Grid main-section">
+                    <div className="launch-panel-general-container">{DisplayableStrings.fileUrlDoesNotHaveAccess}</div>
+                    <div>
+                        <div>To allow this extension to run on file URLs:</div>
+                        <div>
+                            {'1. Open '}
+                            <NewTabLink onClick={browserAdapter.openManageExtensionPage} aria-label={`open ${title} extension page`}>
+                                {`${title} extension page`}
+                            </NewTabLink>
+                            {'.'}
+                        </div>
+                        <div>
+                            {'2. Enable '}
+                            <span className="ms-fontWeight-semibold">Allow Access to file URLs</span>.
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    },
+);

--- a/src/popup/components/popup-view.tsx
+++ b/src/popup/components/popup-view.tsx
@@ -16,6 +16,7 @@ import { PopupViewControllerHandler } from '../handlers/popup-view-controller-ha
 import { LaunchPadRowConfigurationFactory } from '../launch-pad-row-configuration-factory';
 import { AdHocToolsPanel } from './ad-hoc-tools-panel';
 import { DiagnosticViewToggleFactory } from './diagnostic-view-toggle-factory';
+import { FileUrlUnsupportedMessagePanelDeps } from './file-url-unsupported-message-panel';
 import { Header } from './header';
 import { LaunchPad, LaunchPadDeps, LaunchPadRowConfiguration } from './launch-pad';
 import { LaunchPanelHeader, LaunchPanelHeaderDeps } from './launch-panel-header';
@@ -26,7 +27,6 @@ export interface PopupViewProps {
     title: string;
     popupHandlers: IPopupHandlers;
     popupWindow: Window;
-    browserAdapter: BrowserAdapter;
     targetTabUrl: string;
     hasAccess: boolean;
     launchPadRowConfigurationFactory: LaunchPadRowConfigurationFactory;
@@ -38,7 +38,10 @@ export interface PopupViewProps {
 export type PopupViewControllerDeps = LaunchPadDeps &
     LaunchPanelHeaderDeps &
     TelemetryPermissionDialogDeps &
-    WithStoreSubscriptionDeps<PopupViewControllerState>;
+    FileUrlUnsupportedMessagePanelDeps &
+    WithStoreSubscriptionDeps<PopupViewControllerState> & {
+        browserAdapter: BrowserAdapter;
+    };
 
 export enum LaunchPanelType {
     AdhocToolsPanel,
@@ -61,7 +64,7 @@ export class PopupView extends React.Component<PopupViewProps> {
     constructor(props: PopupViewProps) {
         super(props);
         this.handler = props.popupHandlers.popupViewControllerHandler;
-        this.versionNumber = props.browserAdapter.getManifest().version;
+        this.versionNumber = props.deps.browserAdapter.getManifest().version;
         this.openTogglesView = () => {
             this.handler.openLaunchPad(this);
         };
@@ -194,7 +197,7 @@ export class PopupView extends React.Component<PopupViewProps> {
                         <div>
                             {'1. Open '}
                             <NewTabLink
-                                onClick={this.props.browserAdapter.openManageExtensionPage}
+                                onClick={this.props.deps.browserAdapter.openManageExtensionPage}
                                 aria-label={`open ${this.props.title} extension page`}
                             >
                                 {`${this.props.title} extension page`}

--- a/src/popup/components/popup-view.tsx
+++ b/src/popup/components/popup-view.tsx
@@ -16,7 +16,11 @@ import { PopupViewControllerHandler } from '../handlers/popup-view-controller-ha
 import { LaunchPadRowConfigurationFactory } from '../launch-pad-row-configuration-factory';
 import { AdHocToolsPanel } from './ad-hoc-tools-panel';
 import { DiagnosticViewToggleFactory } from './diagnostic-view-toggle-factory';
-import { FileUrlUnsupportedMessagePanelDeps } from './file-url-unsupported-message-panel';
+import {
+    FileUrlUnsupportedMessagePanel,
+    FileUrlUnsupportedMessagePanelDeps,
+    FileUrlUnsupportedMessagePanelProps,
+} from './file-url-unsupported-message-panel';
 import { Header } from './header';
 import { LaunchPad, LaunchPadDeps, LaunchPadRowConfiguration } from './launch-pad';
 import { LaunchPanelHeader, LaunchPanelHeaderDeps } from './launch-panel-header';
@@ -187,31 +191,13 @@ export class PopupView extends React.Component<PopupViewProps> {
     }
 
     private renderUnsupportedMsgPanelForFileUrl(): JSX.Element {
-        return (
-            <div className="ms-Fabric unsupported-url-info-panel">
-                {this.renderDefaultHeader()}
-                <div className="ms-Grid main-section">
-                    <div className="launch-panel-general-container">{DisplayableStrings.fileUrlDoesNotHaveAccess}</div>
-                    <div>
-                        <div>To allow this extension to run on file URLs:</div>
-                        <div>
-                            {'1. Open '}
-                            <NewTabLink
-                                onClick={this.props.deps.browserAdapter.openManageExtensionPage}
-                                aria-label={`open ${this.props.title} extension page`}
-                            >
-                                {`${this.props.title} extension page`}
-                            </NewTabLink>
-                            {'.'}
-                        </div>
-                        <div>
-                            {'2. Enable '}
-                            <span className="ms-fontWeight-semibold">Allow Access to file URLs</span>.
-                        </div>
-                    </div>
-                </div>
-            </div>
-        );
+        const props: FileUrlUnsupportedMessagePanelProps = {
+            title: this.props.title,
+            header: this.renderDefaultHeader(),
+            deps: this.props.deps,
+        };
+
+        return <FileUrlUnsupportedMessagePanel {...props} />;
     }
 
     private renderDefaultHeader(): JSX.Element {

--- a/src/popup/main-renderer.tsx
+++ b/src/popup/main-renderer.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
+
 import { Theme, ThemeDeps, ThemeInnerState } from '../common/components/theme';
 import { WithStoreSubscriptionDeps } from '../common/components/with-store-subscription';
 import { DropdownClickHandler } from '../common/dropdown-click-handler';
@@ -13,6 +13,7 @@ import { IPopupHandlers } from './handlers/ipopup-handlers';
 import { LaunchPadRowConfigurationFactory } from './launch-pad-row-configuration-factory';
 
 export type MainRendererDeps = PopupViewControllerDeps & WithStoreSubscriptionDeps<ThemeInnerState> & ThemeDeps;
+
 export class MainRenderer {
     constructor(
         private readonly deps: MainRendererDeps,
@@ -20,7 +21,6 @@ export class MainRenderer {
         private readonly renderer: typeof ReactDOM.render,
         private readonly dom: NodeSelector & Node,
         private readonly popupWindow: Window,
-        private readonly browserAdapter: BrowserAdapter,
         private readonly targetTabUrl: string,
         private readonly hasAccess: boolean,
         private readonly launchPadRowConfigurationFactory: LaunchPadRowConfigurationFactory,
@@ -39,7 +39,6 @@ export class MainRenderer {
                     title={title}
                     popupHandlers={this.popupHandlers}
                     popupWindow={this.popupWindow}
-                    browserAdapter={this.browserAdapter}
                     targetTabUrl={this.targetTabUrl}
                     hasAccess={this.hasAccess}
                     launchPadRowConfigurationFactory={this.launchPadRowConfigurationFactory}

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -170,6 +170,7 @@ export class PopupInitializer {
             loadTheme,
             axeInfo,
             launchPanelHeaderClickHandler,
+            browserAdapter: this.chromeAdapter,
         };
 
         const diagnosticViewToggleFactory = new DiagnosticViewToggleFactory(
@@ -190,7 +191,6 @@ export class PopupInitializer {
             ReactDOM.render,
             document,
             window,
-            this.browserAdapter,
             this.targetTabInfo.tab.url,
             this.targetTabInfo.hasAccess,
             launchPadRowConfigurationFactory,

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -170,7 +170,7 @@ export class PopupInitializer {
             loadTheme,
             axeInfo,
             launchPanelHeaderClickHandler,
-            browserAdapter: this.chromeAdapter,
+            browserAdapter: this.browserAdapter,
         };
 
         const diagnosticViewToggleFactory = new DiagnosticViewToggleFactory(

--- a/src/tests/unit/tests/popup/components/__snapshots__/file-url-unsupported-message-panel.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/file-url-unsupported-message-panel.test.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FileUrlUnsupportedMessagePanel renders 1`] = `
+<div
+  className="ms-Fabric unsupported-url-info-panel"
+>
+  <span>
+    TEST HEADER
+  </span>
+  <div
+    className="ms-Grid main-section"
+  >
+    <div
+      className="launch-panel-general-container"
+    >
+      Your browser settings don't allow Accessibility Insights for Web to run on file URLs.
+    </div>
+    <div>
+      <div>
+        To allow this extension to run on file URLs:
+      </div>
+      <div>
+        1. Open 
+        <NewTabLink
+          aria-label="open test-title extension page"
+          onClick={[Function]}
+        >
+          test-title extension page
+        </NewTabLink>
+        .
+      </div>
+      <div>
+        2. Enable 
+        <span
+          className="ms-fontWeight-semibold"
+        >
+          Allow Access to file URLs
+        </span>
+        .
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -20,6 +20,15 @@ exports[`PopupView render actual content render toggles view: launch pad 1`] = `
 </Fragment>"
 `;
 
+exports[`PopupView render actual content render toggles view: launch pad: subtitle 1`] = `
+"<Fragment>
+  <NewTabLink href=\\"https://go.microsoft.com/fwlink/?linkid=2082374\\" aria-label=\\"demo video\\" title=\\"watch the 3 minute video introduction\\" onClick={[Function: onClickTutorialLink]}>
+    Watch 3-minute video introduction
+  </NewTabLink>
+   
+</Fragment>"
+`;
+
 exports[`PopupView render actual content renderAdHocToolsPanel 1`] = `
 "<Fragment>
   <div className=\\"ms-Fabric ad-hoc-tools-panel\\">

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -20,15 +20,6 @@ exports[`PopupView render actual content render toggles view: launch pad 1`] = `
 </Fragment>"
 `;
 
-exports[`PopupView render actual content render toggles view: launch pad: subtitle 1`] = `
-"<Fragment>
-  <NewTabLink href=\\"https://go.microsoft.com/fwlink/?linkid=2082374\\" aria-label=\\"demo video\\" title=\\"watch the 3 minute video introduction\\" onClick={[Function: onClickTutorialLink]}>
-    Watch 3-minute video introduction
-  </NewTabLink>
-   
-</Fragment>"
-`;
-
 exports[`PopupView render actual content renderAdHocToolsPanel 1`] = `
 "<Fragment>
   <div className=\\"ms-Fabric ad-hoc-tools-panel\\">
@@ -70,44 +61,65 @@ exports[`PopupView renderFailureMsgPanelForChromeUrl 1`] = `
 `;
 
 exports[`PopupView renderFailureMsgPanelForFileUrl 1`] = `
-<div
-  className="ms-Fabric unsupported-url-info-panel"
->
-  <Header
-    title="test title"
-  />
-  <div
-    className="ms-Grid main-section"
-  >
-    <div
-      className="launch-panel-general-container"
-    >
-      Your browser settings don't allow Accessibility Insights for Web to run on file URLs.
-    </div>
-    <div>
-      <div>
-        To allow this extension to run on file URLs:
-      </div>
-      <div>
-        1. Open 
-        <NewTabLink
-          aria-label="open test title extension page"
-          onClick={[Function]}
-        >
-          test title extension page
-        </NewTabLink>
-        .
-      </div>
-      <div>
-        2. Enable 
-        <span
-          className="ms-fontWeight-semibold"
-        >
-          Allow Access to file URLs
-        </span>
-        .
-      </div>
-    </div>
-  </div>
-</div>
+<FileUrlUnsupportedMessagePanel
+  deps={
+    Object {
+      "browserAdapter": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "addCommandListener": [Function],
+        "addListenerOnConnect": [Function],
+        "addListenerOnMessage": [Function],
+        "addListenerOnWindowsFocusChanged": [Function],
+        "addListenerToLocalStorage": [Function],
+        "addListenerToTabsOnActivated": [Function],
+        "addListenerToTabsOnRemoved": [Function],
+        "addListenerToTabsOnUpdated": [Function],
+        "addListenerToWebNavigationUpdated": [Function],
+        "closeTab": [Function],
+        "connect": [Function],
+        "createInactiveTab": [Function],
+        "createNotification": [Function],
+        "createTab": [Function],
+        "createTabInNewWindow": [Function],
+        "extensionVersion": undefined,
+        "getAllWindows": [Function],
+        "getCommands": [Function],
+        "getManifest": [Function],
+        "getRunTimeId": [Function],
+        "getRuntimeLastError": [Function],
+        "getSelectedTabInWindow": [Function],
+        "getTab": [Function],
+        "getUrl": [Function],
+        "getUserData": [Function],
+        "injectCss": [Function],
+        "injectJs": [Function],
+        "isAllowedFileSchemeAccess": [Function],
+        "openManageExtensionPage": [Function],
+        "removeListenerOnMessage": [Function],
+        "removeUserData": [Function],
+        "sendMessageToAllFramesAndTabs": [Function],
+        "sendMessageToFrames": [Function],
+        "sendMessageToFramesAndTab": [Function],
+        "setUserData": [Function],
+        "switchToTab": [Function],
+        "tabsQuery": [Function],
+      },
+      "storesHub": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "addChangedListenerToAllStores": [Function],
+        "getAllStoreData": [Function],
+        "hasStoreData": [Function],
+        "hasStores": [Function],
+        "removeChangedListenerFromAllStores": [Function],
+        "stores": undefined,
+      },
+    }
+  }
+  header={
+    <Header
+      title="test title"
+    />
+  }
+  title="test title"
+/>
 `;

--- a/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
+++ b/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock } from 'typemoq';
 
-import { BrowserAdapter } from '../../../../../background/browser-adapters/browser-adapter';
+import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
 import {
     FileUrlUnsupportedMessagePanel,
     FileUrlUnsupportedMessagePanelProps,

--- a/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
+++ b/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { IMock, Mock } from 'typemoq';
+
+import { BrowserAdapter } from '../../../../../background/browser-adapters/browser-adapter';
+import {
+    FileUrlUnsupportedMessagePanel,
+    FileUrlUnsupportedMessagePanelProps,
+} from '../../../../../popup/components/file-url-unsupported-message-panel';
+
+describe('FileUrlUnsupportedMessagePanel', () => {
+    let browserAdapterMock: IMock<BrowserAdapter>;
+    const openManageExtensionPageStub = () => {};
+
+    beforeEach(() => {
+        browserAdapterMock = Mock.ofType<BrowserAdapter>();
+        browserAdapterMock.setup(adapter => adapter.openManageExtensionPage).returns(() => openManageExtensionPageStub);
+    });
+
+    it('renders', () => {
+        const header = <span>TEST HEADER</span>;
+        const title = 'test-title';
+
+        const props: FileUrlUnsupportedMessagePanelProps = {
+            deps: {
+                browserAdapter: browserAdapterMock.object,
+            },
+            title,
+            header,
+        };
+
+        const wrapper = shallow(<FileUrlUnsupportedMessagePanel {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/popup/components/popup-view.test.tsx
+++ b/src/tests/unit/tests/popup/components/popup-view.test.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
+import { ChromeAdapter } from '../../../../../common/browser-adapters/chrome-adapter';
 import { NewTabLink } from '../../../../../common/components/new-tab-link';
 import { DropdownClickHandler } from '../../../../../common/dropdown-click-handler';
 import { StoreActionMessageCreatorImpl } from '../../../../../common/message-creators/store-action-message-creator-impl';
@@ -28,7 +29,7 @@ import { BaseDataBuilder } from '../../../common/base-data-builder';
 import { IsSameObject } from '../../../common/typemoq-helper';
 
 describe('PopupView', () => {
-    const browserAdapterMock = Mock.ofType<BrowserAdapter>();
+    const browserAdapterMock = Mock.ofType<BrowserAdapter>(ChromeAdapter);
     const launchPanelStateStoreState: LaunchPanelStoreData = {
         launchPanelType: LaunchPanelType.LaunchPad,
     };

--- a/src/tests/unit/tests/popup/components/popup-view.test.tsx
+++ b/src/tests/unit/tests/popup/components/popup-view.test.tsx
@@ -123,6 +123,7 @@ describe('PopupView', () => {
             deps = {
                 popupActionMessageCreator: actionMessageCreatorStrictMock.object,
                 dropdownClickHandler: dropdownClickHandlerMock.object,
+                browserAdapter: browserAdapterMock.object,
             } as PopupViewControllerDeps;
         });
 
@@ -268,7 +269,7 @@ describe('PopupView', () => {
     });
 
     function createDefaultPropsBuilder(storeHub: BaseClientStoresHub<any>): PopupViewPropsBuilder {
-        return new PopupViewPropsBuilder().withStoresHub(storeHub).with('browserAdapter', browserAdapterMock.object);
+        return new PopupViewPropsBuilder().withStoresHub(storeHub).withBrowserAdapter(browserAdapterMock.object);
     }
 
     function createDefaultStoresHubMock(hasStores = true, hasStoreData = true): IMock<BaseClientStoresHub<any>> {
@@ -293,11 +294,20 @@ class PopupViewPropsBuilder extends BaseDataBuilder<PopupViewProps> {
         return this;
     }
     public withStoresHub(storesHub: BaseClientStoresHub<any>): PopupViewPropsBuilder {
-        this.data = {
-            deps: {
-                storesHub,
-            },
-        } as PopupViewProps;
+        this.data.deps = {
+            ...this.data.deps,
+            storesHub,
+        };
+
+        return this;
+    }
+
+    public withBrowserAdapter(browserAdapter: BrowserAdapter): PopupViewPropsBuilder {
+        this.data.deps = {
+            ...this.data.deps,
+            browserAdapter,
+        };
+
         return this;
     }
 }

--- a/src/tests/unit/tests/popup/main-renderer.test.tsx
+++ b/src/tests/unit/tests/popup/main-renderer.test.tsx
@@ -57,9 +57,9 @@ describe('MainRenderer', () => {
                                     popupViewControllerHandler: gettingStartedDialogHandlerMock.object,
                                     launchPanelHeaderClickHandler: feedbackMenuClickhandlerMock.object,
                                     supportLinkHandler: supportLinkHandlerMock.object,
+                                    browserAdapter: browserAdapterMock.object,
                                 }}
                                 popupWindow={popupWindowMock.object}
-                                browserAdapter={browserAdapterMock.object}
                                 targetTabUrl={targetTabUrl}
                                 hasAccess={hasAccess}
                                 launchPadRowConfigurationFactory={launchPadRowConfigurationFactoryMock.object}
@@ -80,11 +80,11 @@ describe('MainRenderer', () => {
                 popupViewControllerHandler: gettingStartedDialogHandlerMock.object,
                 launchPanelHeaderClickHandler: feedbackMenuClickhandlerMock.object,
                 supportLinkHandler: supportLinkHandlerMock.object,
+                browserAdapter: browserAdapterMock.object,
             },
             renderMock.object,
             dom,
             popupWindowMock.object,
-            browserAdapterMock.object,
             targetTabUrl,
             hasAccess,
             launchPadRowConfigurationFactoryMock.object,


### PR DESCRIPTION
#### Description of changes

`PopupView` knows a lot of lower level details. In this PR I'm extracting one of those concerns out to a new component. 

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
