### PR TITLE
refactor: remove underscore prefixes from fields/variables

### DIFF
--- a/src/DetailsView/components/test-status-choice-group.tsx
+++ b/src/DetailsView/components/test-status-choice-group.tsx
@@ -26,7 +26,7 @@ interface ChoiceGroupState {
 }
 
 export class TestStatusChoiceGroup extends React.Component<TestStatusChoiceGroupProps, ChoiceGroupState> {
-    protected _choiceGroup: IChoiceGroup;
+    protected choiceGroup: IChoiceGroup;
 
     constructor(props) {
         super(props);
@@ -81,7 +81,7 @@ export class TestStatusChoiceGroup extends React.Component<TestStatusChoiceGroup
     }
 
     protected compomentRef = (component: IChoiceGroup): void => {
-        this._choiceGroup = component;
+        this.choiceGroup = component;
     };
 
     protected onChange = (ev: React.FocusEvent<HTMLElement>, option: IChoiceGroupOption): void => {
@@ -91,7 +91,7 @@ export class TestStatusChoiceGroup extends React.Component<TestStatusChoiceGroup
 
     protected onUndoClicked = (): void => {
         this.setState({ selectedKey: ManualTestStatus[ManualTestStatus.UNKNOWN] });
-        this._choiceGroup.focus();
+        this.choiceGroup.focus();
         this.props.onUndoClicked(this.props.test, this.props.step, this.props.selector);
     };
 }

--- a/src/Devtools/dev-tool-initializer.ts
+++ b/src/Devtools/dev-tool-initializer.ts
@@ -7,15 +7,15 @@ import { DevToolState } from '../common/types/store-data/idev-tool-state';
 import { InspectHandler } from './inspect-handler';
 
 export class DevToolInitializer {
-    protected _devToolsChromeAdapter: DevToolsChromeAdapter;
+    protected devToolsChromeAdapter: DevToolsChromeAdapter;
 
     constructor(devToolsChromeAdapter: DevToolsChromeAdapter) {
-        this._devToolsChromeAdapter = devToolsChromeAdapter;
+        this.devToolsChromeAdapter = devToolsChromeAdapter;
     }
 
     public initialize(): void {
-        const devtoolsStore = new StoreProxy<DevToolState>(StoreNames[StoreNames.DevToolsStore], this._devToolsChromeAdapter);
-        const inspectHandler = new InspectHandler(devtoolsStore, this._devToolsChromeAdapter);
+        const devtoolsStore = new StoreProxy<DevToolState>(StoreNames[StoreNames.DevToolsStore], this.devToolsChromeAdapter);
+        const inspectHandler = new InspectHandler(devtoolsStore, this.devToolsChromeAdapter);
 
         inspectHandler.initialize();
     }

--- a/src/Devtools/inspect-handler.ts
+++ b/src/Devtools/inspect-handler.ts
@@ -7,30 +7,30 @@ import { DevToolsOpenMessage } from '../common/types/dev-tools-open-message';
 import { DevToolState } from '../common/types/store-data/idev-tool-state';
 
 export class InspectHandler {
-    private _devToolsStore: BaseStore<DevToolState>;
-    private _devToolsChromeAdapter: DevToolsChromeAdapter;
+    private devToolsStore: BaseStore<DevToolState>;
+    private devToolsChromeAdapter: DevToolsChromeAdapter;
 
     constructor(devToolsStore: BaseStore<DevToolState>, devToolsChromeAdapter: DevToolsChromeAdapter) {
-        this._devToolsStore = devToolsStore;
-        this._devToolsChromeAdapter = devToolsChromeAdapter;
+        this.devToolsStore = devToolsStore;
+        this.devToolsChromeAdapter = devToolsChromeAdapter;
     }
 
     public initialize(): void {
-        this._devToolsStore.addChangedListener(() => {
-            const state = this._devToolsStore.getState();
+        this.devToolsStore.addChangedListener(() => {
+            const state = this.devToolsStore.getState();
 
             if (state && state.inspectElement && (state.inspectElement.length === 1 || state.frameUrl)) {
-                this._devToolsChromeAdapter.executeScriptInInspectedWindow(
+                this.devToolsChromeAdapter.executeScriptInInspectedWindow(
                     "inspect(document.querySelector('" + state.inspectElement[state.inspectElement.length - 1] + "'))",
                     state.frameUrl,
                 );
             }
         });
 
-        const backgroundPageConnection = this._devToolsChromeAdapter.connect({
+        const backgroundPageConnection = this.devToolsChromeAdapter.connect({
             name: ConnectionNames.devTools,
         });
 
-        backgroundPageConnection.postMessage({ tabId: this._devToolsChromeAdapter.getInspectedWindowTabId() } as DevToolsOpenMessage);
+        backgroundPageConnection.postMessage({ tabId: this.devToolsChromeAdapter.getInspectedWindowTabId() } as DevToolsOpenMessage);
     }
 }

--- a/src/background/chrome-feature-controller.ts
+++ b/src/background/chrome-feature-controller.ts
@@ -4,13 +4,13 @@ import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 
 export class ChromeFeatureController {
     public static configureCommandTabUrl: string = 'chrome://extensions/configureCommands';
-    private _browserAdapter: BrowserAdapter;
+    private browserAdapter: BrowserAdapter;
 
     constructor(adapter: BrowserAdapter) {
-        this._browserAdapter = adapter;
+        this.browserAdapter = adapter;
     }
 
     public openCommandConfigureTab(): void {
-        this._browserAdapter.createTab(ChromeFeatureController.configureCommandTabUrl);
+        this.browserAdapter.createTab(ChromeFeatureController.configureCommandTabUrl);
     }
 }

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -4,30 +4,30 @@ import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { DictionaryStringTo } from '../types/common-types';
 
 export class DetailsViewController {
-    private _tabIdToDetailsViewMap: DictionaryStringTo<number> = {};
-    private _browserAdapter: BrowserAdapter;
-    private _detailsViewRemovedHandler: (tabId: number) => void;
+    private tabIdToDetailsViewMap: DictionaryStringTo<number> = {};
+    private browserAdapter: BrowserAdapter;
+    private detailsViewRemovedHandler: (tabId: number) => void;
 
     constructor(adapter: BrowserAdapter) {
-        this._browserAdapter = adapter;
-        this._browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
-        this._browserAdapter.addListenerToTabsOnUpdated(this.onUpdateTab);
+        this.browserAdapter = adapter;
+        this.browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
+        this.browserAdapter.addListenerToTabsOnUpdated(this.onUpdateTab);
     }
 
     public setupDetailsViewTabRemovedHandler(handler: (tabId: number) => void): void {
-        this._detailsViewRemovedHandler = handler;
+        this.detailsViewRemovedHandler = handler;
     }
 
     public showDetailsView(targetTabId: number): void {
-        const detailsViewTabId = this._tabIdToDetailsViewMap[targetTabId];
+        const detailsViewTabId = this.tabIdToDetailsViewMap[targetTabId];
 
         if (detailsViewTabId != null) {
-            this._browserAdapter.switchToTab(detailsViewTabId);
+            this.browserAdapter.switchToTab(detailsViewTabId);
             return;
         }
 
-        this._browserAdapter.createTabInNewWindow(this.getDetailsUrl(targetTabId), (tab: chrome.tabs.Tab) => {
-            this._tabIdToDetailsViewMap[targetTabId] = tab.id;
+        this.browserAdapter.createTabInNewWindow(this.getDetailsUrl(targetTabId), (tab: chrome.tabs.Tab) => {
+            this.tabIdToDetailsViewMap[targetTabId] = tab.id;
         });
     }
 
@@ -39,9 +39,9 @@ export class DetailsViewController {
         }
 
         if (this.hasUrlChange(changeInfo, targetTabId)) {
-            delete this._tabIdToDetailsViewMap[targetTabId];
-            if (this._detailsViewRemovedHandler != null) {
-                this._detailsViewRemovedHandler(targetTabId);
+            delete this.tabIdToDetailsViewMap[targetTabId];
+            if (this.detailsViewRemovedHandler != null) {
+                this.detailsViewRemovedHandler(targetTabId);
             }
         }
     };
@@ -62,13 +62,13 @@ export class DetailsViewController {
     }
 
     private getDetailsUrlWithExtensionId(tabId: number): string {
-        return `${this._browserAdapter.getRunTimeId()}/${this.getDetailsUrl(tabId)}`;
+        return `${this.browserAdapter.getRunTimeId()}/${this.getDetailsUrl(tabId)}`;
     }
 
     private getTargetTabIdForDetailsTabId(detailsTabId: number): number {
         if (detailsTabId != null) {
-            for (const tabId in this._tabIdToDetailsViewMap) {
-                if (this._tabIdToDetailsViewMap[tabId] === detailsTabId) {
+            for (const tabId in this.tabIdToDetailsViewMap) {
+                if (this.tabIdToDetailsViewMap[tabId] === detailsTabId) {
                     return parseInt(tabId, 10);
                 }
             }
@@ -77,14 +77,14 @@ export class DetailsViewController {
     }
 
     private onRemoveTab = (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo): void => {
-        if (this._tabIdToDetailsViewMap[tabId]) {
-            delete this._tabIdToDetailsViewMap[tabId];
+        if (this.tabIdToDetailsViewMap[tabId]) {
+            delete this.tabIdToDetailsViewMap[tabId];
         } else {
             const targetTabId = this.getTargetTabIdForDetailsTabId(tabId);
             if (targetTabId) {
-                delete this._tabIdToDetailsViewMap[targetTabId];
-                if (this._detailsViewRemovedHandler != null) {
-                    this._detailsViewRemovedHandler(targetTabId);
+                delete this.tabIdToDetailsViewMap[targetTabId];
+                if (this.detailsViewRemovedHandler != null) {
+                    this.detailsViewRemovedHandler(targetTabId);
                 }
             }
         }

--- a/src/background/dev-tools-listener.ts
+++ b/src/background/dev-tools-listener.ts
@@ -12,16 +12,16 @@ export interface PortWithTabId extends chrome.runtime.Port {
 }
 
 export class DevToolsListener {
-    private _tabIdToContextMap: TabToContextMap;
-    private _browserAdapter: BrowserAdapter;
+    private tabIdToContextMap: TabToContextMap;
+    private browserAdapter: BrowserAdapter;
 
     constructor(tabIdToContextMap: TabToContextMap, browserAdapter: BrowserAdapter) {
-        this._tabIdToContextMap = tabIdToContextMap;
-        this._browserAdapter = browserAdapter;
+        this.tabIdToContextMap = tabIdToContextMap;
+        this.browserAdapter = browserAdapter;
     }
 
     public initialize(): void {
-        this._browserAdapter.addListenerOnConnect((devToolsConnection: PortWithTabId) => {
+        this.browserAdapter.addListenerOnConnect((devToolsConnection: PortWithTabId) => {
             if (devToolsConnection.name === ConnectionNames.devTools) {
                 const devToolsListener = (message: DevToolsOpenMessage, port: chrome.runtime.Port) => {
                     devToolsConnection.targetPageTabId = message.tabId;
@@ -41,7 +41,7 @@ export class DevToolsListener {
 
     private sendDevToolStatus(devToolsConnection: PortWithTabId, status: boolean): void {
         const tabId = devToolsConnection.targetPageTabId;
-        const tabContext = this._tabIdToContextMap[tabId];
+        const tabContext = this.tabIdToContextMap[tabId];
 
         if (tabContext) {
             tabContext.interpreter.interpret({

--- a/src/background/injector-controller.ts
+++ b/src/background/injector-controller.ts
@@ -10,15 +10,15 @@ import { TabStore } from './stores/tab-store';
 import { VisualizationStore } from './stores/visualization-store';
 
 export class InjectorController {
-    private _injector: ContentScriptInjector;
-    private _visualizationStore: VisualizationStore;
-    private _inspectStore: InspectStore;
-    private _interpreter: Interpreter;
-    private _tabStore: TabStore;
-    private _windowUtils: WindowUtils;
+    private injector: ContentScriptInjector;
+    private visualizationStore: VisualizationStore;
+    private inspectStore: InspectStore;
+    private interpreter: Interpreter;
+    private tabStore: TabStore;
+    private windowUtils: WindowUtils;
     private static readonly injectionStartedWaitTime = 10;
 
-    private _oldInspectType = InspectMode.off;
+    private oldInspectType = InspectMode.off;
 
     constructor(
         injector: ContentScriptInjector,
@@ -28,45 +28,45 @@ export class InjectorController {
         inspectStore: InspectStore,
         windowUtils?: WindowUtils,
     ) {
-        this._injector = injector;
-        this._visualizationStore = visualizationStore;
-        this._tabStore = tabStore;
-        this._inspectStore = inspectStore;
-        this._interpreter = interpreter;
-        this._windowUtils = windowUtils || new WindowUtils();
+        this.injector = injector;
+        this.visualizationStore = visualizationStore;
+        this.tabStore = tabStore;
+        this.inspectStore = inspectStore;
+        this.interpreter = interpreter;
+        this.windowUtils = windowUtils || new WindowUtils();
     }
 
     public initialize(): void {
-        this._visualizationStore.addChangedListener(this.inject);
-        this._inspectStore.addChangedListener(this.inject);
+        this.visualizationStore.addChangedListener(this.inject);
+        this.inspectStore.addChangedListener(this.inject);
     }
 
     private inject = (): void => {
-        const tabId: number = this._tabStore.getState().id;
-        const visualizationStoreState = this._visualizationStore.getState();
-        const inspectStoreState = this._inspectStore.getState();
+        const tabId: number = this.tabStore.getState().id;
+        const visualizationStoreState = this.visualizationStore.getState();
+        const inspectStoreState = this.inspectStore.getState();
 
         if (
-            ((this._oldInspectType !== inspectStoreState.inspectMode && inspectStoreState.inspectMode !== InspectMode.off) ||
+            ((this.oldInspectType !== inspectStoreState.inspectMode && inspectStoreState.inspectMode !== InspectMode.off) ||
                 visualizationStoreState.injectingInProgress === true) &&
             !visualizationStoreState.injectingStarted
         ) {
-            this._windowUtils.setTimeout(() => {
-                this._interpreter.interpret({
+            this.windowUtils.setTimeout(() => {
+                this.interpreter.interpret({
                     messageType: Messages.Visualizations.State.InjectionStarted,
                     tabId: tabId,
                 });
             }, InjectorController.injectionStartedWaitTime);
 
             // tslint:disable-next-line:no-floating-promises - grandfathered
-            this._injector.injectScripts(tabId).then(() => {
-                this._interpreter.interpret({
+            this.injector.injectScripts(tabId).then(() => {
+                this.interpreter.interpret({
                     messageType: Messages.Visualizations.State.InjectionCompleted,
                     tabId: tabId,
                 });
             });
         }
 
-        this._oldInspectType = inspectStoreState.inspectMode;
+        this.oldInspectType = inspectStoreState.inspectMode;
     };
 }

--- a/src/background/tab-context-broadcaster.ts
+++ b/src/background/tab-context-broadcaster.ts
@@ -3,16 +3,16 @@
 import { StoreUpdateMessage } from '../common/types/store-update-message';
 
 export class TabContextBroadcaster {
-    private _sendMessageToFramesAndTab: (tabId: number, message: any) => void;
+    private sendMessageToFramesAndTab: (tabId: number, message: any) => void;
 
     constructor(sendMessageToFramesAndTabDelegate: (tabId: number, message: any) => void) {
-        this._sendMessageToFramesAndTab = sendMessageToFramesAndTabDelegate;
+        this.sendMessageToFramesAndTab = sendMessageToFramesAndTabDelegate;
     }
 
     public getBroadcastMessageDelegate = (tabId): ((message: StoreUpdateMessage<any>) => void) => {
         return message => {
             message.tabId = tabId;
-            this._sendMessageToFramesAndTab(tabId, message);
+            this.sendMessageToFramesAndTab(tabId, message);
         };
     };
 }

--- a/src/common/flux/action.ts
+++ b/src/common/flux/action.ts
@@ -9,26 +9,26 @@ export class Action<TPayload> {
      */
     private static executingScopes: DictionaryStringTo<boolean> = {};
 
-    private _listeners: ((payload: TPayload) => void)[] = [];
-    private _scope: string = 'DEFAULT_SCOPE';
+    private listeners: ((payload: TPayload) => void)[] = [];
+    private scope: string = 'DEFAULT_SCOPE';
 
     public invoke(payload: TPayload): void {
-        if (Action.executingScopes[this._scope]) {
-            throw new Error(`Cannot invoke an action with scope ${this._scope} from inside another action with the same scope`);
+        if (Action.executingScopes[this.scope]) {
+            throw new Error(`Cannot invoke an action with scope ${this.scope} from inside another action with the same scope`);
         }
 
-        Action.executingScopes[this._scope] = true;
+        Action.executingScopes[this.scope] = true;
 
         try {
-            this._listeners.forEach((listener: (payload: TPayload) => void) => {
+            this.listeners.forEach((listener: (payload: TPayload) => void) => {
                 listener(payload);
             });
         } finally {
-            delete Action.executingScopes[this._scope];
+            delete Action.executingScopes[this.scope];
         }
     }
 
     public addListener(listener: (payload: TPayload) => void): void {
-        this._listeners.push(listener);
+        this.listeners.push(listener);
     }
 }

--- a/src/common/flux/event-handler-list.ts
+++ b/src/common/flux/event-handler-list.ts
@@ -3,22 +3,22 @@
 import { FunctionPPR } from '../../types/common-types';
 
 export class EventHandlerList<TSender, TEventArgs> {
-    private _handlers: FunctionPPR<TSender, TEventArgs, any>[] = [];
+    private handlers: FunctionPPR<TSender, TEventArgs, any>[] = [];
 
     public subscribe(handler: FunctionPPR<TSender, TEventArgs, any>): void {
         if (handler) {
-            this._handlers.push(handler);
+            this.handlers.push(handler);
         }
     }
 
     public unsubscribe(handler: FunctionPPR<TSender, TEventArgs, any>): void {
-        if (this._handlers) {
-            this._handlers = this._handlers.filter(h => h !== handler);
+        if (this.handlers) {
+            this.handlers = this.handlers.filter(h => h !== handler);
         }
     }
 
     public invokeHandlers(sender?: TSender, eventArgs?: TEventArgs): void {
-        const handlersCopy = Array.apply(null, this._handlers);
+        const handlersCopy = Array.apply(null, this.handlers);
 
         handlersCopy.forEach(handler => handler(sender, eventArgs));
     }

--- a/src/common/flux/store.ts
+++ b/src/common/flux/store.ts
@@ -3,17 +3,17 @@
 import { EventHandlerList } from './event-handler-list';
 
 export class Store {
-    private _changedHandlers = new EventHandlerList();
+    private changedHandlers = new EventHandlerList();
 
     public addChangedListener(handler: Function): void {
-        this._changedHandlers.subscribe(handler as any);
+        this.changedHandlers.subscribe(handler as any);
     }
 
     public removeChangedListener(handler: Function): void {
-        this._changedHandlers.unsubscribe(handler as any);
+        this.changedHandlers.unsubscribe(handler as any);
     }
 
     protected emitChanged(): void {
-        this._changedHandlers.invokeHandlers(this);
+        this.changedHandlers.invokeHandlers(this);
     }
 }

--- a/src/common/indexedDB/idb.ts
+++ b/src/common/indexedDB/idb.ts
@@ -7,6 +7,8 @@
 // using this code till that issue is fixed
 
 export class Store {
+    // keeping naming consistent with original external source
+    // tslint:disable-next-line: variable-name
     public readonly _dbp: Promise<IDBDatabase>;
 
     constructor(dbName = 'default-db', readonly storeName = 'default-store') {

--- a/src/common/store-proxy.ts
+++ b/src/common/store-proxy.ts
@@ -10,16 +10,16 @@ import { StoreType } from './types/store-type';
 import { StoreUpdateMessage } from './types/store-update-message';
 
 export class StoreProxy<TState> extends Store implements BaseStore<TState> {
-    private _state: TState;
-    private _storeId: string;
-    private _tabId: number;
-    private _browserAdapter: BrowserAdapter;
+    private state: TState;
+    private storeId: string;
+    private tabId: number;
+    private browserAdapter: BrowserAdapter;
 
     constructor(storeId: string, browserAdapter: BrowserAdapter) {
         super();
-        this._storeId = storeId;
-        this._browserAdapter = browserAdapter;
-        this._browserAdapter.addListenerOnMessage(this.onChange);
+        this.storeId = storeId;
+        this.browserAdapter = browserAdapter;
+        this.browserAdapter.addListenerOnMessage(this.onChange);
     }
 
     private onChange = (message: StoreUpdateMessage<TState>): void => {
@@ -27,8 +27,8 @@ export class StoreProxy<TState> extends Store implements BaseStore<TState> {
             return;
         }
 
-        if (message.type === GenericStoreMessageTypes.storeStateChanged && !_.isEqual(this._state, message.payload)) {
-            this._state = message.payload;
+        if (message.type === GenericStoreMessageTypes.storeStateChanged && !_.isEqual(this.state, message.payload)) {
+            this.state = message.payload;
             this.emitChanged();
         }
     };
@@ -43,7 +43,7 @@ export class StoreProxy<TState> extends Store implements BaseStore<TState> {
 
     private isMessageForCurrentTab(message: StoreUpdateMessage<TState>): boolean {
         return (
-            this._tabId == null || message.tabId === this._tabId // tabid will be null on inital state in content script of target page
+            this.tabId == null || message.tabId === this.tabId // tabid will be null on inital state in content script of target page
         );
     }
 
@@ -52,18 +52,18 @@ export class StoreProxy<TState> extends Store implements BaseStore<TState> {
     }
 
     public getState = (): TState => {
-        return this._state;
+        return this.state;
     };
 
     public getId(): string {
-        return this._storeId;
+        return this.storeId;
     }
 
     public setTabId(tabId: number): void {
-        this._tabId = tabId;
+        this.tabId = tabId;
     }
 
     public dispose(): void {
-        this._browserAdapter.removeListenerOnMessage(this.onChange);
+        this.browserAdapter.removeListenerOnMessage(this.onChange);
     }
 }

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -13,10 +13,10 @@ export interface ProgressResult<T> {
 export class TabStopsAnalyzer extends BaseAnalyzer {
     private tabStopsListener: TabStopsListener;
     private deferred: Q.Deferred<AxeAnalyzerResult>;
-    private _windowUtils: WindowUtils;
+    private windowUtils: WindowUtils;
 
-    private _pendingTabbedElements: TabStopEvent[] = [];
-    private _onTabbedTimeoutId: number;
+    private pendingTabbedElements: TabStopEvent[] = [];
+    private onTabbedTimeoutId: number;
     protected config: FocusAnalyzerConfiguration;
 
     constructor(
@@ -27,7 +27,7 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
     ) {
         super(config, sendMessageDelegate);
         this.tabStopsListener = tabStopsListener;
-        this._windowUtils = windowUtils;
+        this.windowUtils = windowUtils;
     }
 
     public analyze(): void {
@@ -42,19 +42,19 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
     protected getResults = (): Q.Promise<AxeAnalyzerResult> => {
         this.deferred = Q.defer<AxeAnalyzerResult>();
         this.tabStopsListener.setTabEventListenerOnMainWindow((tabEvent: TabStopEvent) => {
-            if (this._onTabbedTimeoutId != null) {
-                this._windowUtils.clearTimeout(this._onTabbedTimeoutId);
-                this._onTabbedTimeoutId = null;
+            if (this.onTabbedTimeoutId != null) {
+                this.windowUtils.clearTimeout(this.onTabbedTimeoutId);
+                this.onTabbedTimeoutId = null;
             }
 
-            this._pendingTabbedElements.push(tabEvent);
+            this.pendingTabbedElements.push(tabEvent);
 
-            this._onTabbedTimeoutId = this._windowUtils.setTimeout(() => {
+            this.onTabbedTimeoutId = this.windowUtils.setTimeout(() => {
                 this.deferred.notify({
-                    result: this._pendingTabbedElements,
+                    result: this.pendingTabbedElements,
                 });
-                this._onTabbedTimeoutId = null;
-                this._pendingTabbedElements = [];
+                this.onTabbedTimeoutId = null;
+                this.pendingTabbedElements = [];
             }, 50);
         });
 

--- a/src/injected/details-dialog-handler.ts
+++ b/src/injected/details-dialog-handler.ts
@@ -6,8 +6,8 @@ import { HTMLElementUtils } from '../common/html-element-utils';
 import { DetailsDialog } from './components/details-dialog';
 
 export class DetailsDialogHandler {
-    private _onDevToolChanged: () => void;
-    private _onUserConfigChanged: () => void;
+    private onDevToolChangedHandler: () => void;
+    private onUserConfigChangedHandler: () => void;
 
     constructor(private htmlElementUtils: HTMLElementUtils) {}
 
@@ -101,16 +101,16 @@ export class DetailsDialogHandler {
             return;
         }
 
-        this._onDevToolChanged = () => {
+        this.onDevToolChangedHandler = () => {
             this.onDevToolChanged(dialog);
         };
-        dialog.props.devToolStore.addChangedListener(this._onDevToolChanged);
+        dialog.props.devToolStore.addChangedListener(this.onDevToolChangedHandler);
         this.onDevToolChanged(dialog);
 
-        this._onUserConfigChanged = () => {
+        this.onUserConfigChangedHandler = () => {
             this.onUserConfigChanged(dialog);
         };
-        dialog.props.userConfigStore.addChangedListener(this._onUserConfigChanged);
+        dialog.props.userConfigStore.addChangedListener(this.onUserConfigChangedHandler);
         this.onUserConfigChanged(dialog);
 
         if (dialog.props.featureFlagStoreData[FeatureFlags.shadowDialog]) {
@@ -171,8 +171,8 @@ export class DetailsDialogHandler {
     }
 
     public componentWillUnmount = (dialog: DetailsDialog): void => {
-        dialog.props.devToolStore.removeChangedListener(this._onDevToolChanged);
-        dialog.props.userConfigStore.removeChangedListener(this._onUserConfigChanged);
+        dialog.props.devToolStore.removeChangedListener(this.onDevToolChangedHandler);
+        dialog.props.userConfigStore.removeChangedListener(this.onUserConfigChangedHandler);
     };
 
     private hasStore(dialog: DetailsDialog): boolean {

--- a/src/injected/frameCommunicators/scrolling-controller.ts
+++ b/src/injected/frameCommunicators/scrolling-controller.ts
@@ -11,16 +11,16 @@ export interface ScrollingWindowMessage {
 
 export class ScrollingController {
     public static readonly triggerScrollingCommand = 'insights.scroll';
-    private _htmlElementUtils: HTMLElementUtils;
-    private _frameCommunicator: FrameCommunicator;
+    private htmlElementUtils: HTMLElementUtils;
+    private frameCommunicator: FrameCommunicator;
 
     constructor(frameCommunicator: FrameCommunicator, htmlElementUtils: HTMLElementUtils) {
-        this._frameCommunicator = frameCommunicator;
-        this._htmlElementUtils = htmlElementUtils;
+        this.frameCommunicator = frameCommunicator;
+        this.htmlElementUtils = htmlElementUtils;
     }
 
     public initialize(): void {
-        this._frameCommunicator.subscribe(ScrollingController.triggerScrollingCommand, this.onTriggerScrolling);
+        this.frameCommunicator.subscribe(ScrollingController.triggerScrollingCommand, this.onTriggerScrolling);
     }
 
     private onTriggerScrolling = (
@@ -38,15 +38,15 @@ export class ScrollingController {
             this.scrollElementInCurrentFrame(selector[0]);
         } else {
             const frameSelector: string = selector.splice(0, 1)[0];
-            const frame = this._htmlElementUtils.querySelector(frameSelector) as HTMLIFrameElement;
+            const frame = this.htmlElementUtils.querySelector(frameSelector) as HTMLIFrameElement;
 
             this.scrollElementInIFrames(selector, frame);
         }
     }
 
     private scrollElementInCurrentFrame(selector: string): void {
-        const targetElement: Element = this._htmlElementUtils.querySelector(selector);
-        this._htmlElementUtils.scrollInToView(targetElement);
+        const targetElement: Element = this.htmlElementUtils.querySelector(selector);
+        this.htmlElementUtils.scrollInToView(targetElement);
     }
 
     private scrollElementInIFrames(focusedTarget: string[], frame: HTMLIFrameElement): void {
@@ -54,7 +54,7 @@ export class ScrollingController {
             focusedTarget: focusedTarget,
         };
 
-        this._frameCommunicator.sendMessage(this.createFrameRequestMessage(frame, message));
+        this.frameCommunicator.sendMessage(this.createFrameRequestMessage(frame, message));
     }
 
     private createFrameRequestMessage(frame: HTMLIFrameElement, message: ScrollingWindowMessage): MessageRequest<ScrollingWindowMessage> {

--- a/src/injected/frameCommunicators/window-message-handler.ts
+++ b/src/injected/frameCommunicators/window-message-handler.ts
@@ -14,55 +14,55 @@ export type FrameMessageResponseCallback = (
 ) => void;
 
 export class WindowMessageHandler {
-    private _windowUtils: WindowUtils;
-    private _initialized: boolean;
-    private _windowMessageParser: WindowMessageMarshaller;
-    private _callbacksForMessagesSentFromCurrentFrame: { [messageId: string]: FrameMessageResponseCallback } = {};
+    private windowUtils: WindowUtils;
+    private initialized: boolean;
+    private windowMessageParser: WindowMessageMarshaller;
+    private callbacksForMessagesSentFromCurrentFrame: { [messageId: string]: FrameMessageResponseCallback } = {};
 
-    private _messageSubscribers: DictionaryStringTo<FrameMessageResponseCallback>;
+    private messageSubscribers: DictionaryStringTo<FrameMessageResponseCallback>;
 
     constructor(windowUtils: WindowUtils, windowMessageParser: WindowMessageMarshaller) {
-        this._windowUtils = windowUtils;
-        this._windowMessageParser = windowMessageParser;
-        this._messageSubscribers = {};
+        this.windowUtils = windowUtils;
+        this.windowMessageParser = windowMessageParser;
+        this.messageSubscribers = {};
     }
 
     public addSubscriber(command: string, callback: FrameMessageResponseCallback): void {
-        if (!this._messageSubscribers[command]) {
-            this._messageSubscribers[command] = callback;
+        if (!this.messageSubscribers[command]) {
+            this.messageSubscribers[command] = callback;
         }
     }
 
     public removeSubscriber(command): void {
-        delete this._messageSubscribers[command];
+        delete this.messageSubscribers[command];
     }
 
     public initialize(): void {
-        if (!this._initialized) {
-            this._initialized = true;
-            this._windowUtils.addEventListener(window, 'message', this.windowMessageHandler, false);
+        if (!this.initialized) {
+            this.initialized = true;
+            this.windowUtils.addEventListener(window, 'message', this.windowMessageHandler, false);
         }
     }
 
     public dispose(): void {
-        this._windowUtils.removeEventListener(window, 'message', this.windowMessageHandler, false);
+        this.windowUtils.removeEventListener(window, 'message', this.windowMessageHandler, false);
     }
 
     public post(win: Window, command: string, message: any, callback?: FrameMessageResponseCallback, responseId?: string): void {
-        const data = this._windowMessageParser.createMessage(command, message, responseId);
+        const data = this.windowMessageParser.createMessage(command, message, responseId);
 
         this.updateResponseCallbackMap(data.messageId, callback);
 
-        this._windowUtils.postMessage(win, data, '*');
+        this.windowUtils.postMessage(win, data, '*');
     }
 
     private windowMessageHandler = (e: MessageEvent): void => {
-        const data: WindowMessage = this._windowMessageParser.parseMessage(e.data);
+        const data: WindowMessage = this.windowMessageParser.parseMessage(e.data);
         if (data == null) {
             return;
         }
         const messageId = data.messageId;
-        const callback = this._callbacksForMessagesSentFromCurrentFrame[messageId];
+        const callback = this.callbacksForMessagesSentFromCurrentFrame[messageId];
 
         try {
             if (callback) {
@@ -77,16 +77,16 @@ export class WindowMessageHandler {
 
     private updateResponseCallbackMap(messageId, callback): void {
         if (callback) {
-            this._callbacksForMessagesSentFromCurrentFrame[messageId] = callback;
+            this.callbacksForMessagesSentFromCurrentFrame[messageId] = callback;
         } else {
-            delete this._callbacksForMessagesSentFromCurrentFrame[messageId];
+            delete this.callbacksForMessagesSentFromCurrentFrame[messageId];
         }
     }
 
     private processResponseFromPreviousRequest(source: Window, data: WindowMessage, callback: FrameMessageResponseCallback): void {
         const responderCallback = this.createFrameResponderCallback(source, data.command, data.messageId);
         callback(data.message, data.error, source, responderCallback);
-        delete this._callbacksForMessagesSentFromCurrentFrame[data.messageId];
+        delete this.callbacksForMessagesSentFromCurrentFrame[data.messageId];
     }
 
     private processNewMessage(source: Window, data: WindowMessage): void {
@@ -100,7 +100,7 @@ export class WindowMessageHandler {
     }
 
     private notifySubscriber(target: Window, data: WindowMessage): void {
-        const subscriber = this._messageSubscribers[data.command];
+        const subscriber = this.messageSubscribers[data.command];
         if (subscriber) {
             subscriber(data.message, data.error, target, this.createFrameResponderCallback(target, data.command, data.messageId));
         }

--- a/src/injected/instance-visibility-checker.ts
+++ b/src/injected/instance-visibility-checker.ts
@@ -12,8 +12,8 @@ import { AssessmentVisualizationInstance } from './frameCommunicators/html-eleme
 
 export class InstanceVisibilityChecker {
     private sendMessage: (message) => void;
-    private _windowUtils: WindowUtils;
-    private _htmlElementUtils: HTMLElementUtils;
+    private windowUtils: WindowUtils;
+    private htmlElementUtils: HTMLElementUtils;
     public static recalculationTimeInterval = 1500;
     private identifierToIntervalMap: DictionaryNumberTo<string> = {};
     private configurationFactory: VisualizationConfigurationFactory;
@@ -25,8 +25,8 @@ export class InstanceVisibilityChecker {
         configurationFactory: VisualizationConfigurationFactory,
     ) {
         this.sendMessage = sendMessage;
-        this._windowUtils = windowUtils;
-        this._htmlElementUtils = htmlElementUtils;
+        this.windowUtils = windowUtils;
+        this.htmlElementUtils = htmlElementUtils;
         this.configurationFactory = configurationFactory;
     }
 
@@ -42,7 +42,7 @@ export class InstanceVisibilityChecker {
 
         this.clearVisibilityCheck(drawerIdentifier, visualizationType);
         const checkVisibilityFunction = this.generateCheckVisibilityFunction(drawerIdentifier, visualizationType, currentFrameResults);
-        this.identifierToIntervalMap[drawerIdentifier] = this._windowUtils.setInterval(
+        this.identifierToIntervalMap[drawerIdentifier] = this.windowUtils.setInterval(
             checkVisibilityFunction,
             InstanceVisibilityChecker.recalculationTimeInterval,
         );
@@ -51,7 +51,7 @@ export class InstanceVisibilityChecker {
     public clearVisibilityCheck(drawerIdentifier: string, test: VisualizationType): void {
         const intervalId = this.identifierToIntervalMap[drawerIdentifier];
         if (intervalId != null) {
-            this._windowUtils.clearInterval(intervalId);
+            this.windowUtils.clearInterval(intervalId);
             this.identifierToIntervalMap[drawerIdentifier] = null;
         }
     }
@@ -63,7 +63,7 @@ export class InstanceVisibilityChecker {
     ): Function {
         return () => {
             const payloadBatch: UpdateInstanceVisibilityPayload[] = currentFrameResults.map(elementResult => {
-                const element = this._htmlElementUtils.querySelector(elementResult.target[elementResult.targetIndex]) as HTMLElement;
+                const element = this.htmlElementUtils.querySelector(elementResult.target[elementResult.targetIndex]) as HTMLElement;
                 const elementFoundMatchesStoredInstance =
                     this.elementIsVisible(element) && this.identifiersMatch(visualizationType, drawerIdentifier, elementResult, element);
 

--- a/src/injected/shadow-utils.ts
+++ b/src/injected/shadow-utils.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 import { HTMLElementUtils } from '../common/html-element-utils';
 export class ShadowUtils {
-    private _htmlElementUtils: HTMLElementUtils;
+    private htmlElementUtils: HTMLElementUtils;
 
     constructor(htmlElementUtils: HTMLElementUtils) {
-        this._htmlElementUtils = htmlElementUtils;
+        this.htmlElementUtils = htmlElementUtils;
     }
     public getShadowContainer(): HTMLElement {
-        const shadowHost = this._htmlElementUtils.querySelector('#insights-shadow-host');
+        const shadowHost = this.htmlElementUtils.querySelector('#insights-shadow-host');
 
         return shadowHost.shadowRoot.querySelector('#insights-shadow-container') as HTMLElement;
     }

--- a/src/injected/visualization/base-drawer.ts
+++ b/src/injected/visualization/base-drawer.ts
@@ -20,7 +20,7 @@ export abstract class BaseDrawer implements Drawer {
     protected containerElement: HTMLElement;
     protected drawerUtils: DrawerUtils;
 
-    private _shadowUtils: ShadowUtils;
+    private shadowUtils: ShadowUtils;
 
     constructor(
         dom: NodeSelector & Node,
@@ -34,7 +34,7 @@ export abstract class BaseDrawer implements Drawer {
         this.containerClass = containerClass;
         this.formatter = formatter;
         this.windowUtils = windowUtils;
-        this._shadowUtils = shadowUtils;
+        this.shadowUtils = shadowUtils;
         this.changeHandlerBind = this.onPositionChangeHandler.bind(this);
         this.drawerUtils = drawerUtils;
     }
@@ -114,6 +114,6 @@ export abstract class BaseDrawer implements Drawer {
     }
 
     private attachContainerToDom(): void {
-        this._shadowUtils.getShadowContainer().appendChild(this.containerElement);
+        this.shadowUtils.getShadowContainer().appendChild(this.containerElement);
     }
 }

--- a/src/popup/components/diagnostic-view-toggle.tsx
+++ b/src/popup/components/diagnostic-view-toggle.tsx
@@ -78,17 +78,17 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
     }
 
     private renderToggleOrSpinner(): JSX.Element {
-        const _scanning = this.props.visualizationStoreData.scanning;
+        const scanning = this.props.visualizationStoreData.scanning;
         const id = this.configuration.getIdentifier();
-        const _scanData = this.configuration.getStoreData(this.props.visualizationStoreData.tests);
+        const scanData = this.configuration.getStoreData(this.props.visualizationStoreData.tests);
 
-        if (_scanning === id) {
+        if (scanning === id) {
             return <Spinner size={SpinnerSize.small} componentRef={this.addUserEventListener} />;
         } else {
-            const disabled = _scanning != null;
+            const disabled = scanning != null;
             return (
                 <VisualizationToggle
-                    checked={_scanData.enabled}
+                    checked={scanData.enabled}
                     disabled={disabled}
                     onClick={ev =>
                         this.props.clickHandler.toggleVisualization(this.props.visualizationStoreData, this.props.visualizationType, ev)

--- a/src/popup/components/diagnostic-view-toggle.tsx
+++ b/src/popup/components/diagnostic-view-toggle.tsx
@@ -40,14 +40,14 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
     private configuration: VisualizationConfiguration;
     private toggle: React.RefObject<IToggle> = React.createRef<IToggle>();
     private dom: NodeSelector & Node;
-    private isMounted: boolean;
+    private _isMounted: boolean;
     private userEventListenerAdded: boolean;
 
     constructor(props: DiagnosticViewToggleProps) {
         super(props);
         this.configuration = this.props.visualizationConfigurationFactory.getConfiguration(this.props.visualizationType);
         this.dom = this.props.dom;
-        this.isMounted = false;
+        this._isMounted = false;
         this.userEventListenerAdded = false;
         this.state = {
             isFocused: false,
@@ -103,7 +103,7 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
     }
 
     public componentDidMount(): void {
-        this.isMounted = true;
+        this._isMounted = true;
         this.setFocus();
     }
 
@@ -112,13 +112,13 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
     }
 
     private setFocus(): void {
-        if (this.isMounted && this.state.isFocused && this.toggle.current) {
+        if (this._isMounted && this.state.isFocused && this.toggle.current) {
             this.toggle.current.focus();
         }
     }
 
     private onFocusHandler = (): void => {
-        if (this.isMounted) {
+        if (this._isMounted) {
             this.setState({
                 isFocused: true,
             });
@@ -126,7 +126,7 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
     };
 
     private onBlurHandler = (): void => {
-        if (this.isMounted) {
+        if (this._isMounted) {
             this.setState({
                 isFocused: false,
             });

--- a/src/popup/components/diagnostic-view-toggle.tsx
+++ b/src/popup/components/diagnostic-view-toggle.tsx
@@ -40,8 +40,11 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
     private configuration: VisualizationConfiguration;
     private toggle: React.RefObject<IToggle> = React.createRef<IToggle>();
     private dom: NodeSelector & Node;
-    private _isMounted: boolean;
     private userEventListenerAdded: boolean;
+
+    // Must be consistent with internal react naming for same property to work
+    // tslint:disable-next-line: variable-name
+    private _isMounted: boolean;
 
     constructor(props: DiagnosticViewToggleProps) {
         super(props);

--- a/src/popup/components/diagnostic-view-toggle.tsx
+++ b/src/popup/components/diagnostic-view-toggle.tsx
@@ -38,17 +38,17 @@ export interface DiagnosticViewToggleState {
 
 export class DiagnosticViewToggle extends React.Component<DiagnosticViewToggleProps, DiagnosticViewToggleState> {
     private configuration: VisualizationConfiguration;
-    private _toggle: React.RefObject<IToggle> = React.createRef<IToggle>();
+    private toggle: React.RefObject<IToggle> = React.createRef<IToggle>();
     private dom: NodeSelector & Node;
-    private _isMounted: boolean;
-    private _userEventListenerAdded: boolean;
+    private isMounted: boolean;
+    private userEventListenerAdded: boolean;
 
     constructor(props: DiagnosticViewToggleProps) {
         super(props);
         this.configuration = this.props.visualizationConfigurationFactory.getConfiguration(this.props.visualizationType);
         this.dom = this.props.dom;
-        this._isMounted = false;
-        this._userEventListenerAdded = false;
+        this.isMounted = false;
+        this.userEventListenerAdded = false;
         this.state = {
             isFocused: false,
         };
@@ -94,7 +94,7 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
                         this.props.clickHandler.toggleVisualization(this.props.visualizationStoreData, this.props.visualizationType, ev)
                     }
                     visualizationName={this.configuration.displayableData.title}
-                    componentRef={this._toggle}
+                    componentRef={this.toggle}
                     onFocus={this.onFocusHandler}
                     onBlur={this.onBlurHandler}
                 />
@@ -103,7 +103,7 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
     }
 
     public componentDidMount(): void {
-        this._isMounted = true;
+        this.isMounted = true;
         this.setFocus();
     }
 
@@ -112,13 +112,13 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
     }
 
     private setFocus(): void {
-        if (this._isMounted && this.state.isFocused && this._toggle.current) {
-            this._toggle.current.focus();
+        if (this.isMounted && this.state.isFocused && this.toggle.current) {
+            this.toggle.current.focus();
         }
     }
 
     private onFocusHandler = (): void => {
-        if (this._isMounted) {
+        if (this.isMounted) {
             this.setState({
                 isFocused: true,
             });
@@ -126,7 +126,7 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
     };
 
     private onBlurHandler = (): void => {
-        if (this._isMounted) {
+        if (this.isMounted) {
             this.setState({
                 isFocused: false,
             });
@@ -134,7 +134,7 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
     };
 
     private addUserEventListener = (): void => {
-        if (!this._userEventListenerAdded) {
+        if (!this.userEventListenerAdded) {
             this.dom.addEventListener('keydown', (event: any) => {
                 if (event.keyCode === KeyCodeConstants.TAB) {
                     this.onBlurHandler();
@@ -148,7 +148,7 @@ export class DiagnosticViewToggle extends React.Component<DiagnosticViewTogglePr
                 });
             }
 
-            this._userEventListenerAdded = true;
+            this.userEventListenerAdded = true;
         }
     };
 

--- a/src/popup/support-link-handler.ts
+++ b/src/popup/support-link-handler.ts
@@ -5,21 +5,21 @@ import { config } from '../common/configuration';
 import { WindowUtils } from '../common/window-utils';
 
 export class SupportLinkHandler {
-    private _browserAdapter: BrowserAdapter;
-    private _windowUtils: WindowUtils;
+    private browserAdapter: BrowserAdapter;
+    private windowUtils: WindowUtils;
 
     constructor(browserAdapter: BrowserAdapter, windowUtils: WindowUtils) {
-        this._browserAdapter = browserAdapter;
-        this._windowUtils = windowUtils;
+        this.browserAdapter = browserAdapter;
+        this.windowUtils = windowUtils;
     }
 
     public sendEmail(title: string): void {
         const emailHelpAlias = config.getOption('emailHelpAlias');
         const mailToLink = encodeURI(`mailto:${emailHelpAlias}?subject=Question about ${title}`);
 
-        this._browserAdapter.createInactiveTab(mailToLink, tab => {
-            this._windowUtils.setTimeout(() => {
-                this._browserAdapter.closeTab(tab.id);
+        this.browserAdapter.createInactiveTab(mailToLink, tab => {
+            this.windowUtils.setTimeout(() => {
+                this.browserAdapter.closeTab(tab.id);
             }, 500);
         });
     }

--- a/src/scanner/result-decorator.ts
+++ b/src/scanner/result-decorator.ts
@@ -10,17 +10,17 @@ import { MessageDecorator } from './message-decorator';
 import { Processor } from './processor';
 
 export class ResultDecorator {
-    private _ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]>;
-    private _documentUtils: DocumentUtils;
-    private _messageDecorator: MessageDecorator;
+    private ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]>;
+    private documentUtils: DocumentUtils;
+    private messageDecorator: MessageDecorator;
 
     constructor(
         documentUtils: DocumentUtils,
         messageDecorator: MessageDecorator,
         private getHelpUrl: (ruleId: string, axeHelpUrl: string) => string,
     ) {
-        this._documentUtils = documentUtils;
-        this._messageDecorator = messageDecorator;
+        this.documentUtils = documentUtils;
+        this.messageDecorator = messageDecorator;
     }
 
     public decorateResults(results: Axe.AxeResults): ScanResults {
@@ -31,7 +31,7 @@ export class ResultDecorator {
             incomplete: this.decorateAxeRuleResults(results.incomplete),
             timestamp: results.timestamp,
             targetPageUrl: results.url,
-            targetPageTitle: this._documentUtils.title(),
+            targetPageTitle: this.documentUtils.title(),
         };
 
         return scanResults;
@@ -39,7 +39,7 @@ export class ResultDecorator {
 
     private decorateAxeRuleResults(ruleResults: AxeRule[], isInapplicable: boolean = false): RuleResult[] {
         return ruleResults.reduce((filteredArray: RuleResult[], result: AxeRule) => {
-            this._messageDecorator.decorateResultWithMessages(result);
+            this.messageDecorator.decorateResultWithMessages(result);
             const processedResult = Processor.suppressChecksByMessages(result, !isInapplicable);
 
             if (processedResult != null) {
@@ -55,14 +55,14 @@ export class ResultDecorator {
     }
 
     private getMapping(ruleId: string): HyperlinkDefinition[] {
-        if (this._ruleToLinkConfiguration == null) {
+        if (this.ruleToLinkConfiguration == null) {
             return null;
         }
 
-        return this._ruleToLinkConfiguration[ruleId];
+        return this.ruleToLinkConfiguration[ruleId];
     }
 
     public setRuleToLinksConfiguration(configuration: DictionaryStringTo<HyperlinkDefinition[]>): void {
-        this._ruleToLinkConfiguration = configuration;
+        this.ruleToLinkConfiguration = configuration;
     }
 }

--- a/src/tests/unit/common/axe-internals.ts
+++ b/src/tests/unit/common/axe-internals.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as axe from 'axe-core';
+
+export function setAxeGlobalTreeTo(element: HTMLElement): void {
+    const axeInternals: AxeInternals = axe as any;
+    axeInternals._tree = axeInternals.utils.getFlattenedTree(element);
+}
+
+type AxeInternals = {
+    _tree: any;
+    utils: {
+        getFlattenedTree: (root: HTMLElement) => any;
+    };
+};

--- a/src/tests/unit/mock-helpers/chrome-event-mock.ts
+++ b/src/tests/unit/mock-helpers/chrome-event-mock.ts
@@ -3,14 +3,14 @@
 import { IMock, It, Times } from 'typemoq';
 
 export class ChromeEventMock {
-    protected _eventMock: IMock<chrome.events.Event<any>>;
+    protected eventMock: IMock<chrome.events.Event<any>>;
 
     constructor(eventMock: IMock<chrome.events.Event<any>>) {
-        this._eventMock = eventMock;
+        this.eventMock = eventMock;
     }
 
     public setupAddListenerMock(callback?: (onAddListener: Function) => void): ChromeEventMock {
-        this._eventMock
+        this.eventMock
             .setup(x => x.addListener(It.isAny()))
             .returns(cb => {
                 if (callback) {
@@ -22,16 +22,16 @@ export class ChromeEventMock {
     }
 
     public setupRemoveListener(): ChromeEventMock {
-        this._eventMock.setup(x => x.removeListener(It.isAny())).verifiable(Times.once());
+        this.eventMock.setup(x => x.removeListener(It.isAny())).verifiable(Times.once());
 
         return this;
     }
 
     public verify(): void {
-        this._eventMock.verifyAll();
+        this.eventMock.verifyAll();
     }
 
     public getObject(): chrome.events.Event<any> {
-        return this._eventMock.object;
+        return this.eventMock.object;
     }
 }

--- a/src/tests/unit/mock-helpers/dev-tools-chrome-adapter-mock.ts
+++ b/src/tests/unit/mock-helpers/dev-tools-chrome-adapter-mock.ts
@@ -19,13 +19,13 @@ export class PortWithTabTabIdStub extends PortStub implements PortWithTabId {
 }
 
 export class DevToolsChromeAdapterMock {
-    private _underlyingMock: IMock<DevToolsChromeAdapter> = Mock.ofType(DevToolsChromeAdapterImpl, MockBehavior.Strict);
+    private underlyingMock: IMock<DevToolsChromeAdapter> = Mock.ofType(DevToolsChromeAdapterImpl, MockBehavior.Strict);
 
     public setUpAddListenerOnConnect(
         callback?: (onListenerConnect: (port: PortWithTabTabIdStub) => void) => void,
         times: number = 1,
     ): DevToolsChromeAdapterMock {
-        this._underlyingMock
+        this.underlyingMock
             .setup(x => x.addListenerOnConnect(It.isAny()))
             .callback(cb => {
                 if (callback) {
@@ -38,7 +38,7 @@ export class DevToolsChromeAdapterMock {
     }
 
     public setUpConnect(name: string, onConnectPort: chrome.runtime.Port): DevToolsChromeAdapterMock {
-        this._underlyingMock
+        this.underlyingMock
             .setup(x => x.connect(It.isObjectWith({ name: name })))
             .returns(() => onConnectPort)
             .verifiable(Times.once());
@@ -47,7 +47,7 @@ export class DevToolsChromeAdapterMock {
     }
 
     public setupGetInspectedWindowTabId(tabId: number): DevToolsChromeAdapterMock {
-        this._underlyingMock
+        this.underlyingMock
             .setup(x => x.getInspectedWindowTabId())
             .returns(() => tabId)
             .verifiable(Times.once());
@@ -56,16 +56,16 @@ export class DevToolsChromeAdapterMock {
     }
 
     public setupExecuteScriptInInspectedWindow(script: string, frameUrl: string): DevToolsChromeAdapterMock {
-        this._underlyingMock.setup(x => x.executeScriptInInspectedWindow(It.isValue(script), frameUrl)).verifiable(Times.once());
+        this.underlyingMock.setup(x => x.executeScriptInInspectedWindow(It.isValue(script), frameUrl)).verifiable(Times.once());
 
         return this;
     }
 
     public verifyAll(): void {
-        this._underlyingMock.verifyAll();
+        this.underlyingMock.verifyAll();
     }
 
     public getObject(): DevToolsChromeAdapter {
-        return this._underlyingMock.object;
+        return this.underlyingMock.object;
     }
 }

--- a/src/tests/unit/mock-helpers/port-on-disconnect-mock.ts
+++ b/src/tests/unit/mock-helpers/port-on-disconnect-mock.ts
@@ -6,11 +6,11 @@ import { ChromeEventMock } from './chrome-event-mock';
 import { PortDisconnectStub } from '../stubs/chrome-adapter-stub';
 
 export class PortOnDisconnectMock extends ChromeEventMock {
-    private _portOnDisconnectMock = Mock.ofType(PortDisconnectStub, MockBehavior.Strict);
+    private portOnDisconnectMock = Mock.ofType(PortDisconnectStub, MockBehavior.Strict);
 
     constructor() {
         super(Mock.ofType(PortDisconnectStub, MockBehavior.Strict));
-        this._portOnDisconnectMock = this._eventMock as IMock<PortDisconnectStub>;
+        this.portOnDisconnectMock = this.eventMock as IMock<PortDisconnectStub>;
     }
 
     public setupAddListenerMock(callback?: (onAddListener: (msg: any, port: chrome.runtime.Port) => void) => void): ChromeEventMock {
@@ -18,6 +18,6 @@ export class PortOnDisconnectMock extends ChromeEventMock {
     }
 
     public getObject(): PortDisconnectStub {
-        return this._portOnDisconnectMock.object;
+        return this.portOnDisconnectMock.object;
     }
 }

--- a/src/tests/unit/mock-helpers/port-on-message-mock.ts
+++ b/src/tests/unit/mock-helpers/port-on-message-mock.ts
@@ -6,11 +6,11 @@ import { ChromeEventMock } from './chrome-event-mock';
 import { PortOnMessageStub } from '../stubs/chrome-adapter-stub';
 
 export class PortOnMessageMock extends ChromeEventMock {
-    private _portOnMessageMock: IMock<PortOnMessageStub>;
+    private portOnMessageMock: IMock<PortOnMessageStub>;
 
     constructor() {
         super(Mock.ofType(PortOnMessageStub, MockBehavior.Strict));
-        this._portOnMessageMock = this._eventMock as IMock<PortOnMessageStub>;
+        this.portOnMessageMock = this.eventMock as IMock<PortOnMessageStub>;
     }
 
     public setupAddListenerMock(callback?: (onAddListener: (msg: any, port: chrome.runtime.Port) => void) => void): PortOnMessageMock {
@@ -18,6 +18,6 @@ export class PortOnMessageMock extends ChromeEventMock {
     }
 
     public getObject(): PortOnMessageStub {
-        return this._portOnMessageMock.object;
+        return this.portOnMessageMock.object;
     }
 }

--- a/src/tests/unit/mock-helpers/store-mock.ts
+++ b/src/tests/unit/mock-helpers/store-mock.ts
@@ -6,11 +6,11 @@ import { DevToolStore } from '../../../background/stores/dev-tools-store';
 import { BaseStore } from '../../../common/base-store';
 
 export class StoreMock<TStoreState> {
-    private _store: IMock<BaseStore<TStoreState>> = Mock.ofType(DevToolStore as any);
+    private store: IMock<BaseStore<TStoreState>> = Mock.ofType(DevToolStore as any);
 
-    private _listeners: Function[] = [];
+    private listeners: Function[] = [];
     public setupGetId(id: string, times: number = 1): StoreMock<TStoreState> {
-        this._store
+        this.store
             .setup(x => x.getId())
             .returns(() => id)
             .verifiable(Times.exactly(times));
@@ -19,7 +19,7 @@ export class StoreMock<TStoreState> {
     }
 
     public setupGetState(state: TStoreState, times: number = 1): StoreMock<TStoreState> {
-        this._store
+        this.store
             .setup(x => x.getState())
             .returns(() => state)
             .verifiable(Times.exactly(times));
@@ -28,19 +28,19 @@ export class StoreMock<TStoreState> {
     }
 
     public setupAddChangedListener(times: number = 1): StoreMock<TStoreState> {
-        this._store
+        this.store
             .setup(x => x.addChangedListener(It.isAny()))
-            .returns(cb => this._listeners.push(cb))
+            .returns(cb => this.listeners.push(cb))
             .verifiable(Times.exactly(times));
 
         return this;
     }
 
     public setupRemoveListener(times: number = 1): StoreMock<TStoreState> {
-        this._store
+        this.store
             .setup(x => x.removeChangedListener(It.isAny()))
             .callback(cb => {
-                this._listeners = this._listeners.filter(listener => listener !== cb);
+                this.listeners = this.listeners.filter(listener => listener !== cb);
             })
             .verifiable(Times.exactly(times));
 
@@ -48,7 +48,7 @@ export class StoreMock<TStoreState> {
     }
 
     public invokeChangeListener(): StoreMock<TStoreState> {
-        this._listeners.forEach(listener => {
+        this.listeners.forEach(listener => {
             listener();
         });
 
@@ -56,10 +56,10 @@ export class StoreMock<TStoreState> {
     }
 
     public getObject(): BaseStore<TStoreState> {
-        return this._store.object;
+        return this.store.object;
     }
 
     public verifyAll(): void {
-        this._store.verifyAll();
+        this.store.verifyAll();
     }
 }

--- a/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
@@ -167,6 +167,6 @@ class TestableTestStatusChoiceGroup extends TestStatusChoiceGroup {
     }
 
     public getComponent(): IChoiceGroup {
-        return this._choiceGroup;
+        return this.choiceGroup;
     }
 }

--- a/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
@@ -22,7 +22,7 @@ describe('DevToolsActionCreatorTest', () => {
     beforeEach(() => {
         devtoolActionsMock = Mock.ofType(DevToolActions, MockBehavior.Strict);
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
-        registerTypeToPayloadCallback = Mock.ofInstance((_type, _callback) => {});
+        registerTypeToPayloadCallback = Mock.ofInstance((payloadType, callback) => {});
 
         testObject = new DevToolsActionCreator(
             devtoolActionsMock.object,
@@ -108,9 +108,9 @@ describe('DevToolsActionCreatorTest', () => {
         return getCurrentStateAction;
     }
 
-    function setupRegisterTypeToPayloadCallbackMock(message: string, payload: any, _tabId: number): void {
+    function setupRegisterTypeToPayloadCallbackMock(message: string, payload: any, listeningTabId: number): void {
         registerTypeToPayloadCallback
             .setup(registrar => registrar(message, It.is(_.isFunction)))
-            .callback((_message, listener) => listener(payload, _tabId));
+            .callback((passedMessage, listener) => listener(payload, listeningTabId));
     }
 });

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -26,7 +26,7 @@ describe('InspectActionCreatorTest', () => {
         inspectActionsMock = Mock.ofType(InspectActions, MockBehavior.Strict);
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
         browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
-        registerTypeToPayloadCallbackMock = Mock.ofInstance((_type, _callback) => {});
+        registerTypeToPayloadCallbackMock = Mock.ofInstance((payloadType, callback) => {});
 
         testObject = new InspectActionCreator(
             inspectActionsMock.object,
@@ -79,9 +79,9 @@ describe('InspectActionCreatorTest', () => {
         inspectActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);
     }
 
-    function setupRegisterTypeToPayloadCallbackMock(message: string, payload: any, _tabId: number): void {
+    function setupRegisterTypeToPayloadCallbackMock(message: string, payload: any, listeningTabId: number): void {
         registerTypeToPayloadCallbackMock
             .setup(registrar => registrar(message, It.is(_.isFunction)))
-            .callback((_message, listener) => listener(payload, _tabId));
+            .callback((passedMessage, listener) => listener(payload, listeningTabId));
     }
 });

--- a/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
@@ -17,7 +17,7 @@ describe('PathSnippetActionCreatorTest', () => {
 
     beforeAll(() => {
         pathSnippetActionsMock = Mock.ofType(PathSnippetActions, MockBehavior.Strict);
-        registerTypeToPayloadCallbackMock = Mock.ofInstance((_type, _callback) => {});
+        registerTypeToPayloadCallbackMock = Mock.ofInstance((payloadType, callback) => {});
 
         testObject = new PathSnippetActionCreator(pathSnippetActionsMock.object, registerTypeToPayloadCallbackMock.object);
     });
@@ -64,6 +64,6 @@ describe('PathSnippetActionCreatorTest', () => {
     function setupRegisterTypeToPayloadCallbackMock(message: string, payload: any): void {
         registerTypeToPayloadCallbackMock
             .setup(registrar => registrar(message, It.is(_.isFunction)))
-            .callback((_message, listener) => listener(payload));
+            .callback((passedMessage, listener) => listener(payload));
     }
 });

--- a/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
@@ -78,9 +78,9 @@ describe('ScopingPanelActionCreatorTest', () => {
         scopingActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);
     }
 
-    function setupRegisterTypeToPayloadCallbackMock(message: string, actionPayload: any, _tabId: number): void {
+    function setupRegisterTypeToPayloadCallbackMock(message: string, actionPayload: any, listeningTabId: number): void {
         registerTypeToPayloadCallbackMock
             .setup(regitrar => regitrar(message, It.is(param => _.isFunction(param))))
-            .callback((_message, handler) => handler(actionPayload, _tabId));
+            .callback((passedMessage, handler) => handler(actionPayload, listeningTabId));
     }
 });

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -121,9 +121,9 @@ describe('TestActionCreatorTest', () => {
         tabActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);
     }
 
-    function setupRegisterTypeToPayloadCallbackMock(message: string, actionPayload: any, _tabId: number): void {
+    function setupRegisterTypeToPayloadCallbackMock(message: string, actionPayload: any, listeningTabId: number): void {
         registerTypeToPayloadCallbackMock
             .setup(regitrar => regitrar(message, It.is(param => _.isFunction(param))))
-            .callback((_message, handler) => handler(actionPayload, _tabId));
+            .callback((passedMessage, handler) => handler(actionPayload, listeningTabId));
     }
 });

--- a/src/tests/unit/tests/background/dev-tools-listener.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-listener.test.ts
@@ -12,21 +12,21 @@ import { PortOnDisconnectMock } from '../../mock-helpers/port-on-disconnect-mock
 import { PortOnMessageMock } from '../../mock-helpers/port-on-message-mock';
 
 describe('DevToolsListenerTests', () => {
-    let _testSubject: DevToolsListener;
-    let _devToolsChromeAdapterMock: DevToolsChromeAdapterMock;
-    let _tabIdToContextMap: TabToContextMap;
-    let _tabId1InterpreterMock: IMock<Interpreter>;
-    let _tabId2InterpreterMock: IMock<Interpreter>;
+    let testSubject: DevToolsListener;
+    let devToolsChromeAdapterMock: DevToolsChromeAdapterMock;
+    let tabIdToContextMap: TabToContextMap;
+    let tabId1InterpreterMock: IMock<Interpreter>;
+    let tabId2InterpreterMock: IMock<Interpreter>;
 
     beforeEach(() => {
-        _tabId1InterpreterMock = Mock.ofType(Interpreter, MockBehavior.Strict);
-        _tabId2InterpreterMock = Mock.ofType(Interpreter, MockBehavior.Strict);
-        _tabIdToContextMap = {
-            1: new TabContext(_tabId1InterpreterMock.object, null),
-            2: new TabContext(_tabId2InterpreterMock.object, null),
+        tabId1InterpreterMock = Mock.ofType(Interpreter, MockBehavior.Strict);
+        tabId2InterpreterMock = Mock.ofType(Interpreter, MockBehavior.Strict);
+        tabIdToContextMap = {
+            1: new TabContext(tabId1InterpreterMock.object, null),
+            2: new TabContext(tabId2InterpreterMock.object, null),
         };
-        _devToolsChromeAdapterMock = new DevToolsChromeAdapterMock();
-        _testSubject = new DevToolsListener(_tabIdToContextMap, _devToolsChromeAdapterMock.getObject());
+        devToolsChromeAdapterMock = new DevToolsChromeAdapterMock();
+        testSubject = new DevToolsListener(tabIdToContextMap, devToolsChromeAdapterMock.getObject());
     });
 
     test('initialize - ignore non-dev tools connections', () => {
@@ -38,16 +38,16 @@ describe('DevToolsListenerTests', () => {
             .returns(() => 'some other connection')
             .verifiable();
 
-        _devToolsChromeAdapterMock.setUpAddListenerOnConnect(cb => {
+        devToolsChromeAdapterMock.setUpAddListenerOnConnect(cb => {
             listenerCB = cb;
         });
 
-        _testSubject.initialize();
+        testSubject.initialize();
 
         listenerCB(portMock.object);
 
         portMock.verifyAll();
-        _devToolsChromeAdapterMock.verifyAll();
+        devToolsChromeAdapterMock.verifyAll();
     });
 
     test('initialize - ignore if tab context does not exist', () => {
@@ -65,15 +65,15 @@ describe('DevToolsListenerTests', () => {
         onMessagePortMock.setupAddListenerMock();
         onDisconnectPortMock.setupAddListenerMock();
 
-        _devToolsChromeAdapterMock.setUpAddListenerOnConnect(cb => {
+        devToolsChromeAdapterMock.setUpAddListenerOnConnect(cb => {
             listenerCB = cb;
         });
 
-        _testSubject.initialize();
+        testSubject.initialize();
 
         listenerCB(portStub);
 
-        _devToolsChromeAdapterMock.verifyAll();
+        devToolsChromeAdapterMock.verifyAll();
         onMessagePortMock.verify();
         onDisconnectPortMock.verify();
     });
@@ -94,11 +94,11 @@ describe('DevToolsListenerTests', () => {
         });
         onDisconnectPortMock.setupAddListenerMock();
 
-        _devToolsChromeAdapterMock.setUpAddListenerOnConnect(cb => {
+        devToolsChromeAdapterMock.setUpAddListenerOnConnect(cb => {
             connectListenerCB = cb;
         });
 
-        _tabId2InterpreterMock
+        tabId2InterpreterMock
             .setup(x =>
                 x.interpret(
                     It.isValue({
@@ -112,17 +112,17 @@ describe('DevToolsListenerTests', () => {
             )
             .verifiable(Times.once());
 
-        _testSubject.initialize();
+        testSubject.initialize();
         connectListenerCB(portStub);
 
         messageListenerCB({ tabId: 2 }, null);
 
-        _devToolsChromeAdapterMock.verifyAll();
+        devToolsChromeAdapterMock.verifyAll();
         onMessagePortMock.verify();
         onDisconnectPortMock.verify();
 
         expect(portStub.targetPageTabId).toBe(2);
-        _tabId2InterpreterMock.verifyAll();
+        tabId2InterpreterMock.verifyAll();
     });
 
     test('initialize - disconnect - call interpreter with status false', () => {
@@ -144,11 +144,11 @@ describe('DevToolsListenerTests', () => {
             disconnectMessageCB = cb;
         });
 
-        _devToolsChromeAdapterMock.setUpAddListenerOnConnect(cb => {
+        devToolsChromeAdapterMock.setUpAddListenerOnConnect(cb => {
             connectListenerCB = cb;
         });
 
-        _tabId2InterpreterMock
+        tabId2InterpreterMock
             .setup(x =>
                 x.interpret(
                     It.isValue({
@@ -162,15 +162,15 @@ describe('DevToolsListenerTests', () => {
             )
             .verifiable(Times.once());
 
-        _testSubject.initialize();
+        testSubject.initialize();
         connectListenerCB(portStub);
 
         disconnectMessageCB({ tabId: 2 }, null);
 
-        _devToolsChromeAdapterMock.verifyAll();
+        devToolsChromeAdapterMock.verifyAll();
         onMessagePortMockValidator.verify();
         onDisconnectPortMockValidator.verify();
 
-        _tabId2InterpreterMock.verifyAll();
+        tabId2InterpreterMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/background/stores/base-store.test.ts
+++ b/src/tests/unit/tests/background/stores/base-store.test.ts
@@ -46,7 +46,7 @@ describe('BaseStoreTest', () => {
     });
 
     test('onGetCurrentState', () => {
-        const changedListener = Mock.ofInstance((_testObject: TestStore, _args: any) => {}, MockBehavior.Strict);
+        const changedListener = Mock.ofInstance((testStore: TestStore, args: any) => {}, MockBehavior.Strict);
 
         const listenerAdder = function(): void {
             // hack to access onGetCurrentState from the BaseStore class

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -95,7 +95,7 @@ describe('AnalyzerProviderTests', () => {
         const analyzer = testObject.createFocusTrackingAnalyzer(config);
         const openAnalyzer = analyzer as any;
         expect(analyzer).toBeInstanceOf(BaseAnalyzer);
-        expect(openAnalyzer._windowUtils).toBeInstanceOf(WindowUtils);
+        expect(openAnalyzer.windowUtils).toBeInstanceOf(WindowUtils);
         expect(openAnalyzer.tabStopsListener).toEqual(tabStopsListener.object);
         expect(openAnalyzer.config).toEqual(config);
         expect(openAnalyzer.sendMessage).toEqual(sendMessageMock.object);

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -67,7 +67,7 @@ describe('TabStopsAnalyzerTests', () => {
         setupSendMessageMock(expectedBaseMessage);
         setupSendMessageMock(expectedOnProgressMessage, () => {
             verifyAll();
-            expect((testSubject as any)._onTabbedTimeoutId).toBeNull();
+            expect((testSubject as any).onTabbedTimeoutId).toBeNull();
             completeSignal();
         });
 
@@ -109,15 +109,15 @@ describe('TabStopsAnalyzerTests', () => {
             },
         };
 
-        (testSubject as any)._onTabbedTimeoutId = onTabbedTimoutIdStub;
-        (testSubject as any)._pendingTabbedElements = [tabEventStub1];
+        (testSubject as any).onTabbedTimeoutId = onTabbedTimoutIdStub;
+        (testSubject as any).pendingTabbedElements = [tabEventStub1];
 
         setupTabStopsListenerForStartTabStops();
         setupWindowUtils();
         setupSendMessageMock(expectedBaseMessage);
         setupSendMessageMock(expectedOnProgressMessage, () => {
             verifyAll();
-            expect((testSubject as any)._onTabbedTimeoutId).toBeNull();
+            expect((testSubject as any).onTabbedTimeoutId).toBeNull();
             completeSignal();
         });
 

--- a/src/tests/unit/tests/injected/client-view-controller.test.ts
+++ b/src/tests/unit/tests/injected/client-view-controller.test.ts
@@ -370,108 +370,108 @@ class TestableClientViewController extends ClientViewController {
 }
 
 class MocksAndTestSubjectBuilder {
-    private _fromVisualizationStoreState: VisualizationStoreData;
-    private _toVisualizationStoreState: VisualizationStoreData;
-    private _fromVisualizationScanStoreState: VisualizationScanResultData;
-    private _toVisualizationScanStoreState: VisualizationScanResultData;
-    private _fromAssessmentStoreState: AssessmentStoreData;
-    private _toAssessmentStoreState: AssessmentStoreData;
-    private _fromTabStoreState: TabStoreData;
-    private _toTabStoreState: TabStoreData;
-    private _fromUserConfigurationStoreState: UserConfigurationStoreData;
-    private _toUserConfigurationStoreState: UserConfigurationStoreData;
-    private _fromTargetTabId: number;
-    private _toTargetTabId: number;
+    private fromVisualizationStoreState: VisualizationStoreData;
+    private toVisualizationStoreState: VisualizationStoreData;
+    private fromVisualizationScanStoreState: VisualizationScanResultData;
+    private toVisualizationScanStoreState: VisualizationScanResultData;
+    private fromAssessmentStoreState: AssessmentStoreData;
+    private toAssessmentStoreState: AssessmentStoreData;
+    private fromTabStoreState: TabStoreData;
+    private toTabStoreState: TabStoreData;
+    private fromUserConfigurationStoreState: UserConfigurationStoreData;
+    private toUserConfigurationStoreState: UserConfigurationStoreData;
+    private fromTargetTabId: number;
+    private toTargetTabId: number;
 
-    private _fromFeatureFlagStoreState: FeatureFlagStoreData = getDefaultFeatureFlagValues();
-    private _toFeatureFlagStoreState: FeatureFlagStoreData = getDefaultFeatureFlagValues();
-    private _visualizationStore: IMock<BaseStore<VisualizationStoreData>>;
-    private _assessmentStoreMock: IMock<BaseStore<AssessmentStoreData>>;
-    private _tabStoreMock: IMock<BaseStore<TabStoreData>>;
-    private _userConfigStoreMock: IMock<BaseStore<UserConfigurationStoreData>>;
-    private _selectorMapHelperMock: IMock<SelectorMapHelper>;
-    private _visualizationScanResultStoreMock: IMock<BaseStore<VisualizationScanResultData>>;
-    private _featureFlagStoreMock: IMock<BaseStore<DictionaryStringTo<boolean>>>;
-    private _drawingInitiatorMock: IMock<DrawingInitiator>;
-    private _scrollingControllerMock: IMock<ScrollingController>;
-    private _dataBuilderForFromVisualizationStoreState: VisualizationStoreDataBuilder = new VisualizationStoreDataBuilder();
-    private _dataBuilderForToVisualizationStoreState: VisualizationStoreDataBuilder = new VisualizationStoreDataBuilder();
-    private _dataBuilderForFromVisualizationScanStoreState = new VisualizationScanResultStoreDataBuilder();
-    private _dataBuilderForToVisualizationScanStoreState = new VisualizationScanResultStoreDataBuilder();
-    private IsScrollingInitiatorSetup: boolean = false;
-    private _initializedVisualizationState: DictionaryStringTo<boolean> = {};
-    private _initializedVisualizationSelectorMapState: DictionaryNumberTo<DictionaryStringTo<AssessmentVisualizationInstance>> = {};
-    private _selectorMap: DictionaryStringTo<AssessmentVisualizationInstance>;
-    private _visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
-    private _actualVisualizationConfigurationFactory: VisualizationConfigurationFactory;
-    private _visualizationInstanceProcessorStub: VisualizationInstanceProcessorCallback<PropertyBags, PropertyBags>;
-    private _getVisualizationInstanceProcessorMock: IMock<
+    private fromFeatureFlagStoreState: FeatureFlagStoreData = getDefaultFeatureFlagValues();
+    private toFeatureFlagStoreState: FeatureFlagStoreData = getDefaultFeatureFlagValues();
+    private visualizationStore: IMock<BaseStore<VisualizationStoreData>>;
+    private assessmentStoreMock: IMock<BaseStore<AssessmentStoreData>>;
+    private tabStoreMock: IMock<BaseStore<TabStoreData>>;
+    private userConfigStoreMock: IMock<BaseStore<UserConfigurationStoreData>>;
+    private selectorMapHelperMock: IMock<SelectorMapHelper>;
+    private visualizationScanResultStoreMock: IMock<BaseStore<VisualizationScanResultData>>;
+    private featureFlagStoreMock: IMock<BaseStore<DictionaryStringTo<boolean>>>;
+    private drawingInitiatorMock: IMock<DrawingInitiator>;
+    private scrollingControllerMock: IMock<ScrollingController>;
+    private dataBuilderForFromVisualizationStoreState: VisualizationStoreDataBuilder = new VisualizationStoreDataBuilder();
+    private dataBuilderForToVisualizationStoreState: VisualizationStoreDataBuilder = new VisualizationStoreDataBuilder();
+    private dataBuilderForFromVisualizationScanStoreState = new VisualizationScanResultStoreDataBuilder();
+    private dataBuilderForToVisualizationScanStoreState = new VisualizationScanResultStoreDataBuilder();
+    private isScrollingInitiatorSetup: boolean = false;
+    private initializedVisualizationState: DictionaryStringTo<boolean> = {};
+    private initializedVisualizationSelectorMapState: DictionaryNumberTo<DictionaryStringTo<AssessmentVisualizationInstance>> = {};
+    private selectorMap: DictionaryStringTo<AssessmentVisualizationInstance>;
+    private visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
+    private actualVisualizationConfigurationFactory: VisualizationConfigurationFactory;
+    private visualizationInstanceProcessorStub: VisualizationInstanceProcessorCallback<PropertyBags, PropertyBags>;
+    private getVisualizationInstanceProcessorMock: IMock<
         (testStep?: string) => VisualizationInstanceProcessorCallback<PropertyBags, PropertyBags>
     >;
-    private _targetPageActionMessageCreatorMock: IMock<TargetPageActionMessageCreator>;
+    private targetPageActionMessageCreatorMock: IMock<TargetPageActionMessageCreator>;
 
     public setScanning(id: string): MocksAndTestSubjectBuilder {
-        this._dataBuilderForToVisualizationStoreState.with('scanning', id);
+        this.dataBuilderForToVisualizationStoreState.with('scanning', id);
         return this;
     }
 
     public toDisabled(visualizationType: VisualizationType): MocksAndTestSubjectBuilder {
-        this._dataBuilderForToVisualizationStoreState.withDisable(visualizationType);
+        this.dataBuilderForToVisualizationStoreState.withDisable(visualizationType);
         return this;
     }
 
     public toEnabled(visualizationType: VisualizationType): MocksAndTestSubjectBuilder {
-        this._dataBuilderForToVisualizationStoreState.withEnable(visualizationType);
+        this.dataBuilderForToVisualizationStoreState.withEnable(visualizationType);
         return this;
     }
 
     public fromDisabled(visualizationType: VisualizationType): MocksAndTestSubjectBuilder {
-        this._dataBuilderForFromVisualizationStoreState.withDisable(visualizationType);
+        this.dataBuilderForFromVisualizationStoreState.withDisable(visualizationType);
         return this;
     }
 
     public fromEnabled(visualizationType: VisualizationType): MocksAndTestSubjectBuilder {
-        this._dataBuilderForFromVisualizationStoreState.withEnable(visualizationType);
+        this.dataBuilderForFromVisualizationStoreState.withEnable(visualizationType);
         return this;
     }
 
     public fromAssessmentTarget(id: number): MocksAndTestSubjectBuilder {
-        this._fromTargetTabId = id;
+        this.fromTargetTabId = id;
         return this;
     }
 
     public toAssessmentTarget(id: number): MocksAndTestSubjectBuilder {
-        this._toTargetTabId = id;
+        this.toTargetTabId = id;
         return this;
     }
 
     public fromFocusedTarget(target: string[]): MocksAndTestSubjectBuilder {
-        this._dataBuilderForFromVisualizationStoreState.withFocusedTarget(target);
+        this.dataBuilderForFromVisualizationStoreState.withFocusedTarget(target);
         return this;
     }
 
     public ToFocusedTarget(target: string[]): MocksAndTestSubjectBuilder {
-        this._dataBuilderForToVisualizationStoreState.withFocusedTarget(target);
+        this.dataBuilderForToVisualizationStoreState.withFocusedTarget(target);
         return this;
     }
 
     public setFullIdToRuleResultMap(map): MocksAndTestSubjectBuilder {
-        this._dataBuilderForToVisualizationScanStoreState.withFullIdToRuleResultMapForIssues(map);
+        this.dataBuilderForToVisualizationScanStoreState.withFullIdToRuleResultMapForIssues(map);
         return this;
     }
 
     public fromFeatureFlagState(state: FeatureFlagStoreData): MocksAndTestSubjectBuilder {
-        this._fromFeatureFlagStoreState = state;
+        this.fromFeatureFlagStoreState = state;
         return this;
     }
 
     public setupScrolling(times: Times, message: ScrollingWindowMessage): MocksAndTestSubjectBuilder {
-        this._scrollingControllerMock = Mock.ofType(ScrollingController);
-        this._scrollingControllerMock.setup(s => s.processRequest(It.isValue(message))).verifiable(times);
-        this.IsScrollingInitiatorSetup = true;
+        this.scrollingControllerMock = Mock.ofType(ScrollingController);
+        this.scrollingControllerMock.setup(s => s.processRequest(It.isValue(message))).verifiable(times);
+        this.isScrollingInitiatorSetup = true;
 
-        this._targetPageActionMessageCreatorMock = Mock.ofType(TargetPageActionMessageCreator);
-        this._targetPageActionMessageCreatorMock.setup(m => m.scrollRequested()).verifiable(times);
+        this.targetPageActionMessageCreatorMock = Mock.ofType(TargetPageActionMessageCreator);
+        this.targetPageActionMessageCreatorMock.setup(m => m.scrollRequested()).verifiable(times);
 
         return this;
     }
@@ -486,44 +486,44 @@ class MocksAndTestSubjectBuilder {
         this.buildPreviousSelectorMapStatesStub();
 
         const controller = new TestableClientViewController(
-            this._visualizationStore.object,
-            this._visualizationScanResultStoreMock.object,
-            this._drawingInitiatorMock.object,
-            this._scrollingControllerMock.object,
-            this._visualizationConfigurationFactoryMock.object,
-            this._featureFlagStoreMock.object,
-            this._assessmentStoreMock.object,
-            this._tabStoreMock.object,
-            this._userConfigStoreMock.object,
-            this._selectorMapHelperMock.object,
-            this._targetPageActionMessageCreatorMock.object,
+            this.visualizationStore.object,
+            this.visualizationScanResultStoreMock.object,
+            this.drawingInitiatorMock.object,
+            this.scrollingControllerMock.object,
+            this.visualizationConfigurationFactoryMock.object,
+            this.featureFlagStoreMock.object,
+            this.assessmentStoreMock.object,
+            this.tabStoreMock.object,
+            this.userConfigStoreMock.object,
+            this.selectorMapHelperMock.object,
+            this.targetPageActionMessageCreatorMock.object,
         );
 
-        (controller as any).currentVisualizationState = this._visualizationStore.object.getState();
-        (controller as any).currentScanResultState = this._visualizationScanResultStoreMock.object.getState();
-        (controller as any).currentAssessmentState = this._assessmentStoreMock.object.getState();
-        (controller as any).currentTabState = this._tabStoreMock.object.getState();
-        (controller as any).currentUserConfigStoreState = this._userConfigStoreMock.object.getState();
+        (controller as any).currentVisualizationState = this.visualizationStore.object.getState();
+        (controller as any).currentScanResultState = this.visualizationScanResultStoreMock.object.getState();
+        (controller as any).currentAssessmentState = this.assessmentStoreMock.object.getState();
+        (controller as any).currentTabState = this.tabStoreMock.object.getState();
+        (controller as any).currentUserConfigStoreState = this.userConfigStoreMock.object.getState();
 
-        controller.setPreviousVisualizationStatesStub(this._initializedVisualizationState);
-        controller.setPreviousVisualizationSelectorMapStatesStub(this._initializedVisualizationSelectorMapState);
-        this._actualVisualizationConfigurationFactory = new VisualizationConfigurationFactory();
+        controller.setPreviousVisualizationStatesStub(this.initializedVisualizationState);
+        controller.setPreviousVisualizationSelectorMapStatesStub(this.initializedVisualizationSelectorMapState);
+        this.actualVisualizationConfigurationFactory = new VisualizationConfigurationFactory();
 
         return controller;
     }
 
     public verifyAll(): void {
-        this._drawingInitiatorMock.verifyAll();
-        this._visualizationStore.verifyAll();
-        if (this.IsScrollingInitiatorSetup) {
-            this._scrollingControllerMock.verifyAll();
-            this._targetPageActionMessageCreatorMock.verifyAll();
+        this.drawingInitiatorMock.verifyAll();
+        this.visualizationStore.verifyAll();
+        if (this.isScrollingInitiatorSetup) {
+            this.scrollingControllerMock.verifyAll();
+            this.targetPageActionMessageCreatorMock.verifyAll();
         }
     }
 
     private setupDrawingControllerAndSelectorMapMock(): void {
-        this._drawingInitiatorMock = Mock.ofType(DrawingInitiator);
-        this._selectorMapHelperMock = Mock.ofType(SelectorMapHelper);
+        this.drawingInitiatorMock = Mock.ofType(DrawingInitiator);
+        this.selectorMapHelperMock = Mock.ofType(SelectorMapHelper);
         this.setupVisualizationMocks();
     }
 
@@ -534,7 +534,7 @@ class MocksAndTestSubjectBuilder {
             const config = factory.getConfiguration(visualizationType);
             if (config.testMode === TestMode.Adhoc) {
                 const id = config.getIdentifier();
-                this._initializedVisualizationState[id] = this.getFromStateForType(visualizationType)
+                this.initializedVisualizationState[id] = this.getFromStateForType(visualizationType)
                     ? this.getFromStateForType(visualizationType).enabled
                     : false;
             }
@@ -543,15 +543,15 @@ class MocksAndTestSubjectBuilder {
 
     private buildPreviousSelectorMapStatesStub(): void {
         const types = EnumHelper.getNumericValues<VisualizationType>(VisualizationType);
-        types.forEach(visualizationType => (this._initializedVisualizationSelectorMapState[visualizationType] = this._selectorMap));
+        types.forEach(visualizationType => (this.initializedVisualizationSelectorMapState[visualizationType] = this.selectorMap));
     }
 
     private setupScrollingControllerMock(): void {
-        this._scrollingControllerMock = this._scrollingControllerMock || Mock.ofType(ScrollingController);
+        this.scrollingControllerMock = this.scrollingControllerMock || Mock.ofType(ScrollingController);
     }
 
     private setupTargetActionCreatorMock(): void {
-        this._targetPageActionMessageCreatorMock = this._targetPageActionMessageCreatorMock || Mock.ofType(TargetPageActionMessageCreator);
+        this.targetPageActionMessageCreatorMock = this.targetPageActionMessageCreatorMock || Mock.ofType(TargetPageActionMessageCreator);
     }
 
     private setupVisualizationMocks(): void {
@@ -565,22 +565,22 @@ class MocksAndTestSubjectBuilder {
         assessmentsProviderMock.setup(ap => ap.all()).returns(() => []);
         const assessmentDataConverterMock = Mock.ofType(AssessmentDataConverter);
         assessmentDataConverterMock.setup(acdm => acdm.getNewManualTestStepResult(It.isAny())).returns(() => null);
-        this._fromVisualizationStoreState = this._dataBuilderForFromVisualizationStoreState.build();
-        this._toVisualizationStoreState = this._dataBuilderForToVisualizationStoreState.build();
-        this._fromVisualizationScanStoreState = this._dataBuilderForFromVisualizationScanStoreState.build();
-        this._toVisualizationScanStoreState = this._dataBuilderForToVisualizationScanStoreState.build();
-        this._fromAssessmentStoreState = new AssessmentsStoreDataBuilder(assessmentsProviderMock.object, assessmentDataConverterMock.object)
-            .withTargetTab(this._fromTargetTabId, null, null, false)
+        this.fromVisualizationStoreState = this.dataBuilderForFromVisualizationStoreState.build();
+        this.toVisualizationStoreState = this.dataBuilderForToVisualizationStoreState.build();
+        this.fromVisualizationScanStoreState = this.dataBuilderForFromVisualizationScanStoreState.build();
+        this.toVisualizationScanStoreState = this.dataBuilderForToVisualizationScanStoreState.build();
+        this.fromAssessmentStoreState = new AssessmentsStoreDataBuilder(assessmentsProviderMock.object, assessmentDataConverterMock.object)
+            .withTargetTab(this.fromTargetTabId, null, null, false)
             .build();
-        this._toAssessmentStoreState = new AssessmentsStoreDataBuilder(assessmentsProviderMock.object, assessmentDataConverterMock.object)
-            .withTargetTab(this._toTargetTabId, null, null, false)
+        this.toAssessmentStoreState = new AssessmentsStoreDataBuilder(assessmentsProviderMock.object, assessmentDataConverterMock.object)
+            .withTargetTab(this.toTargetTabId, null, null, false)
             .build();
-        this._fromTabStoreState = { id: 1 } as TabStoreData;
-        this._toTabStoreState = { id: 1 } as TabStoreData;
-        this._fromUserConfigurationStoreState = {} as UserConfigurationStoreData;
-        this._toUserConfigurationStoreState = {} as UserConfigurationStoreData;
+        this.fromTabStoreState = { id: 1 } as TabStoreData;
+        this.toTabStoreState = { id: 1 } as TabStoreData;
+        this.fromUserConfigurationStoreState = {} as UserConfigurationStoreData;
+        this.toUserConfigurationStoreState = {} as UserConfigurationStoreData;
 
-        this._selectorMap = {
+        this.selectorMap = {
             key1: {
                 target: ['element1'],
                 html: 'test',
@@ -603,39 +603,39 @@ class MocksAndTestSubjectBuilder {
     }
 
     private setupGetStateMock(): void {
-        this._visualizationStore = Mock.ofType(VisualizationStore);
-        this._assessmentStoreMock = Mock.ofType<BaseStore<AssessmentStoreData>>();
-        this._tabStoreMock = Mock.ofType<BaseStore<TabStoreData>>(TabStore);
-        this._userConfigStoreMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>(UserConfigurationStore);
-        this._visualizationScanResultStoreMock = Mock.ofType(VisualizationScanResultStore);
-        this._featureFlagStoreMock = Mock.ofType(FeatureFlagStore);
+        this.visualizationStore = Mock.ofType(VisualizationStore);
+        this.assessmentStoreMock = Mock.ofType<BaseStore<AssessmentStoreData>>();
+        this.tabStoreMock = Mock.ofType<BaseStore<TabStoreData>>(TabStore);
+        this.userConfigStoreMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>(UserConfigurationStore);
+        this.visualizationScanResultStoreMock = Mock.ofType(VisualizationScanResultStore);
+        this.featureFlagStoreMock = Mock.ofType(FeatureFlagStore);
 
-        this._visualizationStore.setup(sm => sm.getState()).returns(() => this._fromVisualizationStoreState);
+        this.visualizationStore.setup(sm => sm.getState()).returns(() => this.fromVisualizationStoreState);
 
-        this._visualizationStore.setup(sm => sm.getState()).returns(() => this._toVisualizationStoreState);
+        this.visualizationStore.setup(sm => sm.getState()).returns(() => this.toVisualizationStoreState);
 
-        this._visualizationScanResultStoreMock.setup(sm => sm.getState()).returns(() => this._fromVisualizationScanStoreState);
+        this.visualizationScanResultStoreMock.setup(sm => sm.getState()).returns(() => this.fromVisualizationScanStoreState);
 
-        this._visualizationScanResultStoreMock.setup(sm => sm.getState()).returns(() => this._toVisualizationScanStoreState);
+        this.visualizationScanResultStoreMock.setup(sm => sm.getState()).returns(() => this.toVisualizationScanStoreState);
 
-        this._assessmentStoreMock.setup(sm => sm.getState()).returns(() => this._fromAssessmentStoreState);
+        this.assessmentStoreMock.setup(sm => sm.getState()).returns(() => this.fromAssessmentStoreState);
 
-        this._assessmentStoreMock.setup(sm => sm.getState()).returns(() => this._toAssessmentStoreState);
+        this.assessmentStoreMock.setup(sm => sm.getState()).returns(() => this.toAssessmentStoreState);
 
-        this._tabStoreMock
+        this.tabStoreMock
             .setup(sm => sm.getState())
-            .returns(() => this._fromTabStoreState)
+            .returns(() => this.fromTabStoreState)
             .verifiable();
 
-        this._userConfigStoreMock.setup(sm => sm.getState()).returns(() => this._fromUserConfigurationStoreState);
+        this.userConfigStoreMock.setup(sm => sm.getState()).returns(() => this.fromUserConfigurationStoreState);
 
-        this._userConfigStoreMock.setup(sm => sm.getState()).returns(() => this._toUserConfigurationStoreState);
+        this.userConfigStoreMock.setup(sm => sm.getState()).returns(() => this.toUserConfigurationStoreState);
 
-        this._tabStoreMock.setup(sm => sm.getState()).returns(() => this._toTabStoreState);
+        this.tabStoreMock.setup(sm => sm.getState()).returns(() => this.toTabStoreState);
 
-        this._featureFlagStoreMock.setup(sm => sm.getState()).returns(() => this._fromFeatureFlagStoreState);
+        this.featureFlagStoreMock.setup(sm => sm.getState()).returns(() => this.fromFeatureFlagStoreState);
 
-        this._featureFlagStoreMock.setup(sm => sm.getState()).returns(() => this._toFeatureFlagStoreState);
+        this.featureFlagStoreMock.setup(sm => sm.getState()).returns(() => this.toFeatureFlagStoreState);
     }
 
     private setupEnableDisableVisualizationMock(visualizationType: VisualizationType): void {
@@ -656,56 +656,56 @@ class MocksAndTestSubjectBuilder {
             disableTimes = Times.once();
         }
 
-        if (this._toVisualizationStoreState.scanning != null || this._fromFeatureFlagStoreState == null) {
+        if (this.toVisualizationStoreState.scanning != null || this.fromFeatureFlagStoreState == null) {
             enableTimes = Times.never();
             disableTimes = Times.never();
         }
 
-        this._visualizationInstanceProcessorStub = null;
-        this._getVisualizationInstanceProcessorMock = Mock.ofInstance(step => null);
-        this._getVisualizationInstanceProcessorMock
+        this.visualizationInstanceProcessorStub = null;
+        this.getVisualizationInstanceProcessorMock = Mock.ofInstance(step => null);
+        this.getVisualizationInstanceProcessorMock
             .setup(vimpcm => vimpcm(It.isAny()))
-            .returns(() => this._visualizationInstanceProcessorStub);
+            .returns(() => this.visualizationInstanceProcessorStub);
 
-        this._visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
-        this._visualizationConfigurationFactoryMock
+        this.visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
+        this.visualizationConfigurationFactoryMock
             .setup(vcfm => vcfm.getConfiguration(It.isAny()))
             .returns(theVisualizationType => {
-                const config = this._actualVisualizationConfigurationFactory.getConfiguration(theVisualizationType);
-                config.visualizationInstanceProcessor = this._getVisualizationInstanceProcessorMock.object;
+                const config = this.actualVisualizationConfigurationFactory.getConfiguration(theVisualizationType);
+                config.visualizationInstanceProcessor = this.getVisualizationInstanceProcessorMock.object;
                 return config;
             });
 
-        this._drawingInitiatorMock
+        this.drawingInitiatorMock
             .setup(dw =>
                 dw.enableVisualization(
                     visualizationType,
-                    this._fromFeatureFlagStoreState,
-                    this._selectorMap,
+                    this.fromFeatureFlagStoreState,
+                    this.selectorMap,
                     It.isAny(),
-                    this._visualizationInstanceProcessorStub,
+                    this.visualizationInstanceProcessorStub,
                 ),
             )
             .verifiable(enableTimes);
 
-        this._drawingInitiatorMock
-            .setup(dw => dw.disableVisualization(visualizationType, this._fromFeatureFlagStoreState, It.isAny()))
+        this.drawingInitiatorMock
+            .setup(dw => dw.disableVisualization(visualizationType, this.fromFeatureFlagStoreState, It.isAny()))
             .verifiable(disableTimes);
 
-        this._selectorMapHelperMock
+        this.selectorMapHelperMock
             .setup(sm => sm.getSelectorMap(visualizationType))
-            .returns(() => this._selectorMap)
+            .returns(() => this.selectorMap)
             .verifiable(Times.once());
     }
 
     private getToStateForType(visualizationType: VisualizationType): any {
         switch (visualizationType) {
             case VisualizationType.Headings:
-                return this._toVisualizationStoreState.tests.adhoc.headings;
+                return this.toVisualizationStoreState.tests.adhoc.headings;
             case VisualizationType.Issues:
-                return this._toVisualizationStoreState.tests.adhoc.issues;
+                return this.toVisualizationStoreState.tests.adhoc.issues;
             case VisualizationType.Landmarks:
-                return this._toVisualizationStoreState.tests.adhoc.landmarks;
+                return this.toVisualizationStoreState.tests.adhoc.landmarks;
             default:
                 return null;
         }
@@ -714,11 +714,11 @@ class MocksAndTestSubjectBuilder {
     private getFromStateForType(visualizationType: VisualizationType): ScanData {
         switch (visualizationType) {
             case VisualizationType.Headings:
-                return this._fromVisualizationStoreState.tests.adhoc.headings;
+                return this.fromVisualizationStoreState.tests.adhoc.headings;
             case VisualizationType.Issues:
-                return this._fromVisualizationStoreState.tests.adhoc.issues;
+                return this.fromVisualizationStoreState.tests.adhoc.issues;
             case VisualizationType.Landmarks:
-                return this._fromVisualizationStoreState.tests.adhoc.landmarks;
+                return this.fromVisualizationStoreState.tests.adhoc.landmarks;
             default:
                 return null;
         }

--- a/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
+++ b/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
@@ -280,7 +280,7 @@ describe('DiagnosticViewToggleTest', () => {
         const addUserEventListenerFunction = (testObject as any).addUserEventListener;
         addUserEventListenerFunction();
 
-        expect((testObject as any)._userEventListenerAdded).toBe(true);
+        expect((testObject as any).userEventListenerAdded).toBe(true);
         propsBuilder.addUserListenerVerifyAll();
     });
 

--- a/src/tests/unit/tests/scanner/accessible-text.test.ts
+++ b/src/tests/unit/tests/scanner/accessible-text.test.ts
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Axe from 'axe-core';
+import { setAxeGlobalTreeTo } from '../../common/axe-internals';
 
 describe('axe.commons.text.accessibleText examples', () => {
     let fixture;
-    let _axe;
 
     beforeEach(() => {
         fixture = createTestFixture('test-fixture', '');
-        _axe = Axe as any;
     });
 
     it('should find accessible text by following aria-labelledby', () => {
@@ -20,7 +19,7 @@ describe('axe.commons.text.accessibleText examples', () => {
 
         const element1 = fixture.querySelector('#el1');
 
-        _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+        setAxeGlobalTreeTo(document.documentElement);
         const accessibleText = Axe.commons.text.accessibleText(element1, false);
         expect(accessibleText).toBe('hello');
     });
@@ -34,7 +33,7 @@ describe('axe.commons.text.accessibleText examples', () => {
 
         const element2 = fixture.querySelector('#el2');
 
-        _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+        setAxeGlobalTreeTo(document.documentElement);
         const accessibleText = Axe.commons.text.accessibleText(element2, false);
         expect(accessibleText).toBe('hello');
     });
@@ -47,7 +46,7 @@ describe('axe.commons.text.accessibleText examples', () => {
 
         const span = fixture.querySelector('#del_row2');
 
-        _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+        setAxeGlobalTreeTo(document.documentElement);
 
         const accessibleText = Axe.commons.text.accessibleText(span, false);
         expect(accessibleText).toBe('Delete HolidayLetter.pdf');

--- a/src/tests/unit/tests/scanner/axe-utils.test.ts
+++ b/src/tests/unit/tests/scanner/axe-utils.test.ts
@@ -4,6 +4,7 @@ import * as axe from 'axe-core';
 import { GlobalMock, GlobalScope, IGlobalMock, It, MockBehavior, Times } from 'typemoq';
 
 import * as AxeUtils from '../../../../scanner/axe-utils';
+import { setAxeGlobalTreeTo } from '../../common/axe-internals';
 
 describe('AxeUtils', () => {
     describe('getMatchesFromRule', () => {
@@ -51,11 +52,9 @@ describe('AxeUtils', () => {
 
     describe('getAccessibleDescription', () => {
         let fixture: HTMLElement;
-        let _axe;
 
         beforeEach(() => {
             fixture = createTestFixture('test-fixture', '');
-            _axe = axe as any;
         });
 
         afterEach(() => {
@@ -67,7 +66,7 @@ describe('AxeUtils', () => {
                 <img id="el1" />
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getAccessibleDescription(element1 as HTMLElement);
             expect(result).toEqual('');
@@ -80,7 +79,7 @@ describe('AxeUtils', () => {
                 <div id="el3"> hello </div>
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getAccessibleDescription(element1 as HTMLElement);
             expect(result).toEqual('hello');
@@ -93,7 +92,7 @@ describe('AxeUtils', () => {
                 <div id="el3">world</div>
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getAccessibleDescription(element1 as HTMLElement);
             expect(result).toEqual('hello world');
@@ -102,11 +101,9 @@ describe('AxeUtils', () => {
 
     describe('getImageCodedAs', () => {
         let fixture: HTMLElement;
-        let _axe;
 
         beforeEach(() => {
             fixture = createTestFixture('test-fixture', '');
-            _axe = axe as any;
         });
 
         afterEach(() => {
@@ -118,7 +115,7 @@ describe('AxeUtils', () => {
                 <img id="el1" alt="" />
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getImageCodedAs(element1 as HTMLElement);
             expect(result).toEqual('Decorative');
@@ -129,7 +126,7 @@ describe('AxeUtils', () => {
                 <img id="el1" alt="" aria-label="some"/>
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getImageCodedAs(element1 as HTMLElement);
             expect(result).toEqual('Decorative');
@@ -140,7 +137,7 @@ describe('AxeUtils', () => {
                 <img id="el1" alt aria-label="some"/>
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getImageCodedAs(element1 as HTMLElement);
             expect(result).toEqual('Decorative');
@@ -151,7 +148,7 @@ describe('AxeUtils', () => {
                 <img id="el1" alt="some value"/>
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getImageCodedAs(element1 as HTMLElement);
             expect(result).toEqual('Meaningful');
@@ -162,7 +159,7 @@ describe('AxeUtils', () => {
                 <img id="el1" aria-label="some"/>
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getImageCodedAs(element1 as HTMLElement);
             expect(result).toEqual('Meaningful');
@@ -174,7 +171,7 @@ describe('AxeUtils', () => {
                 <div id="some"> hello </div>
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getImageCodedAs(element1 as HTMLElement);
             expect(result).toEqual('Meaningful');
@@ -185,7 +182,7 @@ describe('AxeUtils', () => {
                 <img id="el1" title="some"/>
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getImageCodedAs(element1 as HTMLElement);
             expect(result).toEqual('Meaningful');
@@ -196,7 +193,7 @@ describe('AxeUtils', () => {
                 <img id="el1" alt="   "/>
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getImageCodedAs(element1 as HTMLElement);
             expect(result).toEqual('Meaningful');
@@ -207,7 +204,7 @@ describe('AxeUtils', () => {
                 <img id="el1"/>
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getImageCodedAs(element1 as HTMLElement);
             expect(result).toBeNull();
@@ -219,7 +216,7 @@ describe('AxeUtils', () => {
                 <div id="some-id"> hello </div>
             `;
             const element1 = fixture.querySelector('#el1');
-            _axe._tree = _axe.utils.getFlattenedTree(document.documentElement);
+            setAxeGlobalTreeTo(document.documentElement);
 
             const result = AxeUtils.getImageCodedAs(element1 as HTMLElement);
             expect(result).toBeNull();

--- a/tslint.json
+++ b/tslint.json
@@ -1,24 +1,40 @@
 {
     "rules": {
-        "arrow-parens": [true, "ban-single-arg-parens"],
+        "arrow-parens": [
+            true,
+            "ban-single-arg-parens"
+        ],
         "await-promise": true,
         "class-name": true,
         "comment-format": [
             true,
             "check-space",
             {
-                "ignore-words": ["TODO", "HACK", "NOTE"]
+                "ignore-words": [
+                    "TODO",
+                    "HACK",
+                    "NOTE"
+                ]
             }
         ],
         "curly": true,
         "eofline": true,
         "forin": true,
         "function-constructor": true,
-        "indent": [true, "spaces"],
-        "interface-name": [true, "never-prefix"],
+        "indent": [
+            true,
+            "spaces"
+        ],
+        "interface-name": [
+            true,
+            "never-prefix"
+        ],
         "jsdoc-format": true,
         "label-position": true,
-        "max-classes-per-file": [true, 2],
+        "max-classes-per-file": [
+            true,
+            2
+        ],
         "member-access": true,
         "new-parens": true,
         "no-angle-bracket-type-assertion": true,
@@ -28,7 +44,14 @@
         "no-bitwise": true,
         "no-conditional-assignment": true,
         "no-consecutive-blank-lines": false,
-        "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
+        "no-console": [
+            true,
+            "debug",
+            "info",
+            "time",
+            "timeEnd",
+            "trace"
+        ],
         "no-construct": true,
         "no-constructor-vars": false,
         "no-debugger": true,
@@ -38,13 +61,19 @@
         "no-document-domain": true,
         "no-duplicate-parameter-names": true,
         "no-duplicate-variable": true,
-        "no-empty": [true, "allow-empty-functions"],
+        "no-empty": [
+            true,
+            "allow-empty-functions"
+        ],
         "no-eval": true,
         "no-exec-script": true,
         "no-floating-promises": true,
         "no-inferrable-types": false,
         "no-internal-module": true,
-        "no-invalid-this": [true, "check-function-in-method"],
+        "no-invalid-this": [
+            true,
+            "check-function-in-method"
+        ],
         "no-null-keyword": false,
         "no-octal-literal": true,
         "no-require-imports": true,
@@ -62,8 +91,15 @@
         "no-useless-files": true,
         "no-var-keyword": true,
         "no-var-requires": true,
-        "one-line": [true, "check-open-brace", "check-whitespace"],
-        "one-variable-per-declaration": [true, "ignore-for-loop"],
+        "one-line": [
+            true,
+            "check-open-brace",
+            "check-whitespace"
+        ],
+        "one-variable-per-declaration": [
+            true,
+            "ignore-for-loop"
+        ],
         "ordered-imports": true,
         "prefer-const": [
             true,
@@ -71,7 +107,12 @@
                 "destructuring": "all"
             }
         ],
-        "quotemark": [true, "single", "avoid-escape", "jsx-double"],
+        "quotemark": [
+            true,
+            "single",
+            "avoid-escape",
+            "jsx-double"
+        ],
         "radix": true,
         "react-a11y-aria-unsupported-elements": true,
         "react-a11y-img-has-alt": true,
@@ -81,7 +122,11 @@
         "react-a11y-role": true,
         "react-a11y-role-has-required-aria-props": true,
         "react-a11y-role-supports-aria-props": true,
-        "semicolon": [true, "always", "ignore-bound-class-methods"],
+        "semicolon": [
+            true,
+            "always",
+            "ignore-bound-class-methods"
+        ],
         "switch-default": true,
         "trailing-comma": [
             true,
@@ -90,8 +135,16 @@
                 "singleline": "never"
             }
         ],
-        "triple-equals": [true, "allow-null-check", "allow-undefined-check"],
-        "typedef": [true, "call-signature", "property-declaration"],
+        "triple-equals": [
+            true,
+            "allow-null-check",
+            "allow-undefined-check"
+        ],
+        "typedef": [
+            true,
+            "call-signature",
+            "property-declaration"
+        ],
         "typedef-whitespace": [
             true,
             {
@@ -110,16 +163,29 @@
             }
         ],
         "use-isnan": true,
-        "use-strict": [false, "check-module", "check-function"],
+        "use-strict": [
+            false,
+            "check-module",
+            "check-function"
+        ],
         "variable-name": [
             true,
             "ban-keywords",
             "check-format",
-            "allow-leading-underscore",
             "allow-trailing-underscore",
             "allow-pascal-case"
         ],
-        "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type", "check-type-operator"]
+        "whitespace": [
+            true,
+            "check-branch",
+            "check-decl",
+            "check-operator",
+            "check-separator",
+            "check-type",
+            "check-type-operator"
+        ]
     },
-    "rulesDirectory": ["tslint-microsoft-contrib"]
+    "rulesDirectory": [
+        "tslint-microsoft-contrib"
+    ]
 }

--- a/tslint.json
+++ b/tslint.json
@@ -1,40 +1,24 @@
 {
     "rules": {
-        "arrow-parens": [
-            true,
-            "ban-single-arg-parens"
-        ],
+        "arrow-parens": [true, "ban-single-arg-parens"],
         "await-promise": true,
         "class-name": true,
         "comment-format": [
             true,
             "check-space",
             {
-                "ignore-words": [
-                    "TODO",
-                    "HACK",
-                    "NOTE"
-                ]
+                "ignore-words": ["TODO", "HACK", "NOTE"]
             }
         ],
         "curly": true,
         "eofline": true,
         "forin": true,
         "function-constructor": true,
-        "indent": [
-            true,
-            "spaces"
-        ],
-        "interface-name": [
-            true,
-            "never-prefix"
-        ],
+        "indent": [true, "spaces"],
+        "interface-name": [true, "never-prefix"],
         "jsdoc-format": true,
         "label-position": true,
-        "max-classes-per-file": [
-            true,
-            2
-        ],
+        "max-classes-per-file": [true, 2],
         "member-access": true,
         "new-parens": true,
         "no-angle-bracket-type-assertion": true,
@@ -44,14 +28,7 @@
         "no-bitwise": true,
         "no-conditional-assignment": true,
         "no-consecutive-blank-lines": false,
-        "no-console": [
-            true,
-            "debug",
-            "info",
-            "time",
-            "timeEnd",
-            "trace"
-        ],
+        "no-console": [true, "debug", "info", "time", "timeEnd", "trace"],
         "no-construct": true,
         "no-constructor-vars": false,
         "no-debugger": true,
@@ -61,19 +38,13 @@
         "no-document-domain": true,
         "no-duplicate-parameter-names": true,
         "no-duplicate-variable": true,
-        "no-empty": [
-            true,
-            "allow-empty-functions"
-        ],
+        "no-empty": [true, "allow-empty-functions"],
         "no-eval": true,
         "no-exec-script": true,
         "no-floating-promises": true,
         "no-inferrable-types": false,
         "no-internal-module": true,
-        "no-invalid-this": [
-            true,
-            "check-function-in-method"
-        ],
+        "no-invalid-this": [true, "check-function-in-method"],
         "no-null-keyword": false,
         "no-octal-literal": true,
         "no-require-imports": true,
@@ -91,15 +62,8 @@
         "no-useless-files": true,
         "no-var-keyword": true,
         "no-var-requires": true,
-        "one-line": [
-            true,
-            "check-open-brace",
-            "check-whitespace"
-        ],
-        "one-variable-per-declaration": [
-            true,
-            "ignore-for-loop"
-        ],
+        "one-line": [true, "check-open-brace", "check-whitespace"],
+        "one-variable-per-declaration": [true, "ignore-for-loop"],
         "ordered-imports": true,
         "prefer-const": [
             true,
@@ -107,12 +71,7 @@
                 "destructuring": "all"
             }
         ],
-        "quotemark": [
-            true,
-            "single",
-            "avoid-escape",
-            "jsx-double"
-        ],
+        "quotemark": [true, "single", "avoid-escape", "jsx-double"],
         "radix": true,
         "react-a11y-aria-unsupported-elements": true,
         "react-a11y-img-has-alt": true,
@@ -122,11 +81,7 @@
         "react-a11y-role": true,
         "react-a11y-role-has-required-aria-props": true,
         "react-a11y-role-supports-aria-props": true,
-        "semicolon": [
-            true,
-            "always",
-            "ignore-bound-class-methods"
-        ],
+        "semicolon": [true, "always", "ignore-bound-class-methods"],
         "switch-default": true,
         "trailing-comma": [
             true,
@@ -135,16 +90,8 @@
                 "singleline": "never"
             }
         ],
-        "triple-equals": [
-            true,
-            "allow-null-check",
-            "allow-undefined-check"
-        ],
-        "typedef": [
-            true,
-            "call-signature",
-            "property-declaration"
-        ],
+        "triple-equals": [true, "allow-null-check", "allow-undefined-check"],
+        "typedef": [true, "call-signature", "property-declaration"],
         "typedef-whitespace": [
             true,
             {
@@ -163,29 +110,9 @@
             }
         ],
         "use-isnan": true,
-        "use-strict": [
-            false,
-            "check-module",
-            "check-function"
-        ],
-        "variable-name": [
-            true,
-            "ban-keywords",
-            "check-format",
-            "allow-trailing-underscore",
-            "allow-pascal-case"
-        ],
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type",
-            "check-type-operator"
-        ]
+        "use-strict": [false, "check-module", "check-function"],
+        "variable-name": [true, "ban-keywords", "check-format", "allow-trailing-underscore", "allow-pascal-case"],
+        "whitespace": [true, "check-branch", "check-decl", "check-operator", "check-separator", "check-type", "check-type-operator"]
     },
-    "rulesDirectory": [
-        "tslint-microsoft-contrib"
-    ]
+    "rulesDirectory": ["tslint-microsoft-contrib"]
 }


### PR DESCRIPTION
#### Description of changes

Implements deferred suggestion from #966 broadly:

* Removes "allow-leading-underscore" from our tslint variable-name config
* fixes all pre-existing issues of the rule (with 2 exceptions that were suppressed with explanatory comments)
* only particularly interesting change was in some `src/tests/unit/tests/scanner/`, where there was some repetitive use of leading-underscore axe internal fields that I abstracted into a test helper
* I believe I avoided needing to touch any classes involved in our serialization formats, but it would be good for a reviewer to double check this

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
