### PR TITLE
test: fix/remove console warning/errors from unit tests

### DIFF
--- a/src/assessments/custom-widgets/custom-widgets-column-renderer.tsx
+++ b/src/assessments/custom-widgets/custom-widgets-column-renderer.tsx
@@ -16,7 +16,7 @@ export function customWidgetsColumnRenderer<TPropertyBag extends ColumnValueBag>
 ): JSX.Element {
     const mapDesignPatterns = (pattern: DesignPattern) => {
         return (
-            <div className="expanded-property-div">
+            <div key={`pattern-${pattern.designPattern}`} className="expanded-property-div">
                 {includeLink ? renderDesignPatternWithLink(pattern) : renderDesignPatternWithoutLink(pattern)}
             </div>
         );

--- a/src/tests/unit/jest-setup.ts
+++ b/src/tests/unit/jest-setup.ts
@@ -2,5 +2,9 @@
 // Licensed under the MIT License.
 import { configure } from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
+import { setIconOptions } from 'office-ui-fabric-react/lib/Styling';
 
 configure({ adapter: new Adapter() });
+setIconOptions({
+    disableWarnings: true,
+});

--- a/src/tests/unit/tests/DetailsView/extensions/wait-for-all-requirements-to-complete.test.tsx
+++ b/src/tests/unit/tests/DetailsView/extensions/wait-for-all-requirements-to-complete.test.tsx
@@ -45,7 +45,7 @@ describe('WaitForAllRequirementsToComplete', () => {
     it('renders children when oneHundredPercent', () => {
         const rendered = shallow(<Extension {...oneHundredPercent}>INSIDE</Extension>);
         const spinner = rendered.find(Spinner);
-        expect(spinner.isEmpty()).toEqual(true);
+        expect(spinner.exists()).toEqual(false);
         expect(rendered.text()).toEqual('INSIDE');
         expect(rendered.debug()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/body-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/body-section.test.tsx
@@ -6,7 +6,12 @@ import { BodySection } from '../../../../../../../DetailsView/reports/components
 
 describe('BodySection', () => {
     it('renders', () => {
-        const children: JSX.Element[] = [<div>1</div>, <div id="2">2</div>];
+        const children: JSX.Element[] = [
+            <div key="1">1</div>,
+            <div key="2" id="2">
+                2
+            </div>,
+        ];
 
         const wrapped = shallow(<BodySection>{children}</BodySection>);
 

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/content-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/content-container.test.tsx
@@ -7,7 +7,12 @@ import { ContentContainer } from '../../../../../../../DetailsView/reports/compo
 
 describe('ContentContainer', () => {
     it('renders', () => {
-        const children: JSX.Element[] = [<div>1</div>, <div id="2">2</div>];
+        const children: JSX.Element[] = [
+            <div key="1">1</div>,
+            <div key="2" id="2">
+                2
+            </div>,
+        ];
 
         const wrapped = shallow(<ContentContainer>{children}</ContentContainer>);
 

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/results-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/results-container.test.tsx
@@ -18,7 +18,12 @@ describe('ResultsContainer', () => {
             getCollapsibleScript: getScriptMock.object,
         };
 
-        const children: JSX.Element[] = [<div>1</div>, <div id="2">2</div>];
+        const children: JSX.Element[] = [
+            <div key="1">1</div>,
+            <div key="2" id="2">
+                2
+            </div>,
+        ];
 
         const wrapped = shallow(<ResultsContainer {...props}>{children}</ResultsContainer>);
 

--- a/src/tests/unit/tests/common/components/toast.test.tsx
+++ b/src/tests/unit/tests/common/components/toast.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as Enzyme from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
 
@@ -26,7 +26,7 @@ describe('ToastTest', () => {
     });
 
     test('render', () => {
-        const result = Enzyme.shallow(<Toast {...props}>Hello</Toast>);
+        const result = shallow(<Toast {...props}>Hello</Toast>);
         expect(result.getElement()).toMatchSnapshot();
     });
 
@@ -46,23 +46,20 @@ describe('ToastTest', () => {
 
     test('when timeout ends, callback is called & render is null', () => {
         const timeoutId = 1;
-        let callback;
         windowUtilsMock
             .setup(m => m.setTimeout(itIsFunction, 2000))
-            .callback((func, _) => (callback = func))
+            .callback((func, _) => func())
             .returns(() => timeoutId)
             .verifiable(Times.once());
 
         onTimeoutMock.setup(m => m()).verifiable(Times.once());
 
-        const subject = new Toast(props);
-        subject.componentDidMount();
-        callback();
+        const wrapper = mount(<Toast {...props} />);
 
         windowUtilsMock.verifyAll();
         onTimeoutMock.verifyAll();
 
-        expect(subject.render()).toBe(null);
+        expect(wrapper.instance().render()).toBe(null);
     });
 
     test('clearTimeout upon componentWillUnmount', () => {

--- a/src/tests/unit/tests/views/content/markup/code-example.test.tsx
+++ b/src/tests/unit/tests/views/content/markup/code-example.test.tsx
@@ -18,7 +18,7 @@ describe('<CodeExample>', () => {
 
     it('renders with no title', () => {
         const wrapper = shallow(<CodeExample>code</CodeExample>);
-        expect(wrapper.find('.code-example-title').isEmpty()).toEqual(true);
+        expect(wrapper.find('.code-example-title').exists()).toEqual(false);
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 


### PR DESCRIPTION
#### Description of changes

Clean up/update/fix some unit tests to get rid of all of the console warning/errors messages we were getting from running our unit tests.

Catergories:
- office fabric icons not being registered 
   - use `setIconOptions` from `'office-ui-fabric-react/lib/Styling'`
- Adding missing key property on elements that are part of an array (like when we map with a render function)
- Update usage of enzyme`isEmpty()` for `exists()`
- Use `Enzyme.mount` for testing a `componentDidUpdate` method that internally calls `forceUpdate()` (the component needs to be mounted in order to properly call `forceUpdate`, otherwise, you get a console error)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not impacted
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not impacted
