### PR TITLE
test: update target-page-changed-view test cases to match actual use cases

### DIFF
--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
@@ -1,28 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TargetPageChangedView renders case { subtitle:
-   { '$$typeof': Symbol(react.element),
-     type: 'span',
-     key: null,
-     ref: null,
-     props: { children: 'subtitle' },
-     _owner: null,
-     _store: { [validated]: false },
-     [_self]: null,
-     [_source]: null } } 1`] = `
+exports[`TargetPageChangedView renders with optional subtitle 1`] = `
 <div
   className="target-page-changed"
 >
   <h1>
-    
+    test title
   </h1>
   <div
     className="target-page-changed-subtitle"
-  />
+  >
+    <span>
+      test subtitle content
+    </span>
+  </div>
   <StyledToggleBase
     checked={false}
     className="details-view-toggle"
-    label=""
+    label="test toggle label"
     offText="Off"
     onClick={[Function]}
     onText="On"
@@ -33,12 +28,12 @@ exports[`TargetPageChangedView renders case { subtitle:
 </div>
 `;
 
-exports[`TargetPageChangedView renders case { title: 'title' } 1`] = `
+exports[`TargetPageChangedView renders without optional subtitle 1`] = `
 <div
   className="target-page-changed"
 >
   <h1>
-    title
+    test title
   </h1>
   <div
     className="target-page-changed-subtitle"
@@ -46,90 +41,7 @@ exports[`TargetPageChangedView renders case { title: 'title' } 1`] = `
   <StyledToggleBase
     checked={false}
     className="details-view-toggle"
-    label=""
-    offText="Off"
-    onClick={[Function]}
-    onText="On"
-  />
-  <p>
-    The target page was changed. Use the toggle to enable the visualization in the current target page.
-  </p>
-</div>
-`;
-
-exports[`TargetPageChangedView renders case { title: 'title',
-  toggleLabel: 'toggle-label',
-  subtitle:
-   { '$$typeof': Symbol(react.element),
-     type: 'span',
-     key: null,
-     ref: null,
-     props: { children: 'subtitle' },
-     _owner: null,
-     _store: { [validated]: false },
-     [_self]: null,
-     [_source]: null } } 1`] = `
-<div
-  className="target-page-changed"
->
-  <h1>
-    title
-  </h1>
-  <div
-    className="target-page-changed-subtitle"
-  />
-  <StyledToggleBase
-    checked={false}
-    className="details-view-toggle"
-    label="toggle-label"
-    offText="Off"
-    onClick={[Function]}
-    onText="On"
-  />
-  <p>
-    The target page was changed. Use the toggle to enable the visualization in the current target page.
-  </p>
-</div>
-`;
-
-exports[`TargetPageChangedView renders case { toggleLabel: 'toggle-label' } 1`] = `
-<div
-  className="target-page-changed"
->
-  <h1>
-    
-  </h1>
-  <div
-    className="target-page-changed-subtitle"
-  />
-  <StyledToggleBase
-    checked={false}
-    className="details-view-toggle"
-    label="toggle-label"
-    offText="Off"
-    onClick={[Function]}
-    onText="On"
-  />
-  <p>
-    The target page was changed. Use the toggle to enable the visualization in the current target page.
-  </p>
-</div>
-`;
-
-exports[`TargetPageChangedView renders case {} 1`] = `
-<div
-  className="target-page-changed"
->
-  <h1>
-    
-  </h1>
-  <div
-    className="target-page-changed-subtitle"
-  />
-  <StyledToggleBase
-    checked={false}
-    className="details-view-toggle"
-    label=""
+    label="test toggle label"
     offText="Off"
     onClick={[Function]}
     onText="On"

--- a/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
@@ -6,38 +6,32 @@ import { DisplayableVisualizationTypeData } from '../../../../../common/configs/
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { TargetPageChangedView, TargetPageChangedViewProps } from '../../../../../DetailsView/components/target-page-changed-view';
 
-type RenderTestCases = {
-    title?: string;
-    toggleLabel?: string;
-    subtitle?: JSX.Element;
-};
-
 describe('TargetPageChangedView', () => {
-    describe('renders', () => {
-        const clickHandlerStub: () => void = () => {};
-        const testCases: RenderTestCases[] = [
-            {},
-            { title: 'title' },
-            { toggleLabel: 'toggle-label' },
-            { subtitle: <span>subtitle</span> },
-            { title: 'title', toggleLabel: 'toggle-label', subtitle: <span>subtitle</span> },
-        ];
-
-        it.each(testCases)('case %o', testCase => {
-            const { title = '', toggleLabel = '' } = testCase;
-
-            const visualizationType = VisualizationType.Landmarks;
-            const displayableData = { title, toggleLabel } as DisplayableVisualizationTypeData;
-
-            const props: TargetPageChangedViewProps = {
-                visualizationType,
-                displayableData,
-                toggleClickHandler: clickHandlerStub,
-            };
-
-            const wrapped = shallow(<TargetPageChangedView {...props} />);
-
-            expect(wrapped.getElement()).toMatchSnapshot();
-        });
+    it('renders without optional subtitle', () => {
+        testRenderWithOptionalSubtitle(undefined);
     });
+
+    it('renders with optional subtitle', () => {
+        testRenderWithOptionalSubtitle(<span>test subtitle content</span>);
+    });
+
+    function testRenderWithOptionalSubtitle(subtitle?: JSX.Element): void {
+        const visualizationType = VisualizationType.Landmarks;
+        const clickHandlerStub: () => void = () => {};
+        const displayableData = {
+            title: 'test title',
+            toggleLabel: 'test toggle label',
+            subtitle,
+        } as DisplayableVisualizationTypeData;
+
+        const props: TargetPageChangedViewProps = {
+            visualizationType,
+            displayableData,
+            toggleClickHandler: clickHandlerStub,
+        };
+
+        const wrapped = shallow(<TargetPageChangedView {...props} />);
+
+        expect(wrapped.getElement()).toMatchSnapshot();
+    }
 });


### PR DESCRIPTION
#### Description of changes

Noticed a few different issues with `target-page-changed-view.test.tsx`:

* It was testing several cases that aren't allowed to occur in practice (title and toggleLabel are non-optional properties of DisplayableVisualizationTypeData)
* Its tests of subtitle differences were incomplete (the test cases included different subtitles, but didn't actually pass subtitle to the thing under test)
* The test's snapshot behavior wasn't consistent between node 10 and node 12 (the way the testCase objects serialized into test names differed on the 2 platforms)

This PR fixes all of these issues by partially rewriting the tests. This fixes the only case where our unit tests didn't work consistently in node 12.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
