### PR TITLE
refactor: make BrowserAdapter.createNotification a thinner wrapper

### DIFF
--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -1,11 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-export interface NotificationOptions {
-    message: string;
-    title: string;
-    iconUrl: string;
-    notificationType?: string;
-}
 
 export interface BrowserAdapter {
     getAllWindows(getInfo: chrome.windows.GetInfo, callback: (chromeWindows: chrome.windows.Window[]) => void): void;
@@ -28,7 +22,7 @@ export interface BrowserAdapter {
     injectJs(tabId, file: string, callback: Function): void;
     injectCss(tabId, file: string, callback: Function): void;
     getRunTimeId(): string;
-    createNotification(options: NotificationOptions): void;
+    createNotification(options: chrome.notifications.NotificationOptions): void;
     getRuntimeLastError(): chrome.runtime.LastError;
     isAllowedFileSchemeAccess(callback: Function): void;
     addListenerToLocalStorage(callback: (changes: object) => void): void;

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserAdapter, NotificationOptions } from './browser-adapter';
+import { BrowserAdapter } from './browser-adapter';
 import { CommandsAdapter } from './commands-adapter';
 import { StorageAdapter } from './storage-adapter';
 

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -163,13 +163,8 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return chrome.runtime.lastError;
     }
 
-    public createNotification(options: NotificationOptions): void {
-        chrome.notifications.create({
-            type: options.notificationType || 'basic',
-            iconUrl: options.iconUrl,
-            title: options.title,
-            message: options.message,
-        });
+    public createNotification(options: chrome.notifications.NotificationOptions): void {
+        chrome.notifications.create(options);
     }
 
     public isAllowedFileSchemeAccess(callback: (isAllowed: boolean) => void): void {

--- a/src/common/notification-creator.ts
+++ b/src/common/notification-creator.ts
@@ -20,6 +20,7 @@ export class NotificationCreator {
         if (message) {
             const manifest = this.browserAdapter.getManifest();
             this.browserAdapter.createNotification({
+                type: 'basic',
                 message: message,
                 title: manifest.name,
                 iconUrl: '../' + manifest.icons[128],

--- a/src/tests/unit/tests/common/notification-creator.test.ts
+++ b/src/tests/unit/tests/common/notification-creator.test.ts
@@ -42,6 +42,7 @@ describe('NotificationCreator', () => {
             .setup(x => x.createNotification(It.isAny()))
             .returns(message => {
                 const expectedMessage = {
+                    type: 'basic',
                     message: notificationMessage,
                     title: 'testname',
                     iconUrl: '../iconUrl',
@@ -68,6 +69,7 @@ describe('NotificationCreator', () => {
             .setup(x => x.createNotification(It.isAny()))
             .returns(message => {
                 const expectedMessage = {
+                    type: 'basic',
                     message: notificationMessage,
                     title: 'testname',
                     iconUrl: '../iconUrl',


### PR DESCRIPTION
#### Description of changes

Makes the `BrowserAdapter.createNotification` wrapper a little thinner by moving the "our notifications are of the 'basic' type" logic out of the BrowserAdapter and into the NotificationCreator.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
