### PR TITLE
refactor: move frames+tab coordination responsibility out of BrowserAdapter

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -78,7 +78,7 @@ getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
         const telemetryStateListener = new TelemetryStateListener(globalContext.stores.userConfigurationStore, telemetryEventHandler);
         telemetryStateListener.initialize();
 
-        const broadcaster = new TabContextBroadcaster(browserAdapter.sendMessageToFramesAndTab);
+        const broadcaster = new TabContextBroadcaster(browserAdapter);
         const detailsViewController = new DetailsViewController(browserAdapter);
 
         const tabToContextMap: TabToContextMap = {};

--- a/src/background/tab-context-broadcaster.ts
+++ b/src/background/tab-context-broadcaster.ts
@@ -1,18 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { StoreUpdateMessage } from '../common/types/store-update-message';
 
 export class TabContextBroadcaster {
-    private sendMessageToFramesAndTab: (tabId: number, message: any) => void;
-
-    constructor(sendMessageToFramesAndTabDelegate: (tabId: number, message: any) => void) {
-        this.sendMessageToFramesAndTab = sendMessageToFramesAndTabDelegate;
-    }
+    constructor(private readonly browserAdapter: BrowserAdapter) {}
 
     public getBroadcastMessageDelegate = (tabId): ((message: StoreUpdateMessage<any>) => void) => {
         return message => {
             message.tabId = tabId;
-            this.sendMessageToFramesAndTab(tabId, message);
+            this.browserAdapter.sendMessageToFrames(message);
+            this.browserAdapter.sendMessageToTab(tabId, message);
         };
     };
 }

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -22,7 +22,7 @@ export interface BrowserAdapter {
     closeTab(tabId: number): void;
     switchToTab(tabId: number): void;
     getTab(tabId: number, onResolve: (tab: chrome.tabs.Tab) => void, onReject?: () => void): void;
-    sendMessageToFramesAndTab(tabId: number, message: any): void;
+    sendMessageToTab(tabId: number, message: any): void;
     sendMessageToFrames(message: any): void;
     sendMessageToAllFramesAndTabs(message: any): void;
     injectJs(tabId, file: string, callback: Function): void;
@@ -42,7 +42,6 @@ export interface BrowserAdapter {
         callback: (message: any, sender: chrome.runtime.MessageSender, sendResponse: (response: any) => void) => void,
     ): void;
     connect(connectionInfo?: chrome.runtime.ConnectInfo): chrome.runtime.Port;
-    sendMessageToFrames(message: any): void;
     getManifest(): chrome.runtime.Manifest;
     extensionVersion: string;
 

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -128,8 +128,7 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         });
     }
 
-    public sendMessageToFramesAndTab(tabId: number, message: any): void {
-        chrome.runtime.sendMessage(message);
+    public sendMessageToTab(tabId: number, message: any): void {
         chrome.tabs.sendMessage(tabId, message);
     }
 

--- a/src/tests/unit/tests/background/tab-context-broadcaster.test.ts
+++ b/src/tests/unit/tests/background/tab-context-broadcaster.test.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Mock } from 'typemoq';
+import { Mock, MockBehavior, Times } from 'typemoq';
 
 import { TabContextBroadcaster } from '../../../../background/tab-context-broadcaster';
+import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { StoreUpdateMessage } from '../../../../common/types/store-update-message';
 
 describe('TabContextBroadcasterTest', () => {
@@ -11,13 +12,14 @@ describe('TabContextBroadcasterTest', () => {
         const testMessage = { someData: 1 } as any;
         const expectedMessage = { tabId: testTabId, ...testMessage } as StoreUpdateMessage<any>;
 
-        const sendMessageToFramesAndTabMock = Mock.ofInstance((tabId, message) => {});
+        const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
+        browserAdapterMock.setup(ba => ba.sendMessageToFrames(expectedMessage)).verifiable(Times.once());
+        browserAdapterMock.setup(ba => ba.sendMessageToTab(testTabId, expectedMessage)).verifiable(Times.once());
 
-        sendMessageToFramesAndTabMock.setup(send => send(testTabId, expectedMessage)).verifiable();
+        const testSubject = new TabContextBroadcaster(browserAdapterMock.object);
 
-        const testSubject = new TabContextBroadcaster(sendMessageToFramesAndTabMock.object);
         testSubject.getBroadcastMessageDelegate(1)(testMessage);
 
-        sendMessageToFramesAndTabMock.verifyAll();
+        browserAdapterMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -108,7 +108,7 @@ exports[`PopupView renderFailureMsgPanelForFileUrl 1`] = `
         "removeUserData": [Function],
         "sendMessageToAllFramesAndTabs": [Function],
         "sendMessageToFrames": [Function],
-        "sendMessageToFramesAndTab": [Function],
+        "sendMessageToTab": [Function],
         "setUserData": [Function],
         "switchToTab": [Function],
         "tabsQuery": [Function],


### PR DESCRIPTION
#### Description of changes

Make BrowserAdapter slightly thinner by moving the multi-method coordination in BrowserAdapter.sendMessageToFramesAndTab out of the adapter and into its only consumer

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
