### PR TITLE
refactor: move BrowserAdapter.openManageExtensionPage coordination into its only consumer

### DIFF
--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -26,7 +26,7 @@ export interface BrowserAdapter {
     getRuntimeLastError(): chrome.runtime.LastError;
     isAllowedFileSchemeAccess(callback: Function): void;
     addListenerToLocalStorage(callback: (changes: object) => void): void;
-    openManageExtensionPage(): void;
+    getManageExtensionUrl(): string;
     addListenerOnConnect(callback: (port: chrome.runtime.Port) => void): void;
     addListenerOnMessage(
         callback: (message: any, sender: chrome.runtime.MessageSender, sendResponse: (response: any) => void) => void,

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -5,10 +5,8 @@ import { CommandsAdapter } from './commands-adapter';
 import { StorageAdapter } from './storage-adapter';
 
 export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAdapter {
-    public openManageExtensionPage(): void {
-        chrome.tabs.create({
-            url: `chrome://extensions/?id=${chrome.runtime.id}`,
-        });
+    public getManageExtensionUrl(): string {
+        return `chrome://extensions/?id=${chrome.runtime.id}`;
     }
 
     public getAllWindows(getInfo: chrome.windows.GetInfo, callback: (chromeWindows: chrome.windows.Window[]) => void): void {

--- a/src/popup/components/file-url-unsupported-message-panel.tsx
+++ b/src/popup/components/file-url-unsupported-message-panel.tsx
@@ -34,7 +34,12 @@ export const FileUrlUnsupportedMessagePanel = NamedSFC<FileUrlUnsupportedMessage
                         <div>To allow this extension to run on file URLs:</div>
                         <div>
                             {'1. Open '}
-                            <NewTabLink onClick={openExtensionPage} aria-label={`open ${title} extension page`}>
+                            <NewTabLink
+                                // It's important that we use an onClick handler that invokes createTab, rather than just setting href.
+                                // The browser will allow the former but not the latter.
+                                onClick={openExtensionPage}
+                                aria-label={`open ${title} extension page`}
+                            >
                                 {`${title} extension page`}
                             </NewTabLink>
                             {'.'}

--- a/src/popup/components/file-url-unsupported-message-panel.tsx
+++ b/src/popup/components/file-url-unsupported-message-panel.tsx
@@ -21,6 +21,10 @@ export const FileUrlUnsupportedMessagePanel = NamedSFC<FileUrlUnsupportedMessage
     ({ deps, header, title }) => {
         const { browserAdapter } = deps;
 
+        const openExtensionPage = () => {
+            browserAdapter.createTab(browserAdapter.getManageExtensionUrl());
+        };
+
         return (
             <div className="ms-Fabric unsupported-url-info-panel">
                 {header}
@@ -30,7 +34,7 @@ export const FileUrlUnsupportedMessagePanel = NamedSFC<FileUrlUnsupportedMessage
                         <div>To allow this extension to run on file URLs:</div>
                         <div>
                             {'1. Open '}
-                            <NewTabLink onClick={browserAdapter.openManageExtensionPage} aria-label={`open ${title} extension page`}>
+                            <NewTabLink onClick={openExtensionPage} aria-label={`open ${title} extension page`}>
                                 {`${title} extension page`}
                             </NewTabLink>
                             {'.'}

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -20,6 +20,15 @@ exports[`PopupView render actual content render toggles view: launch pad 1`] = `
 </Fragment>"
 `;
 
+exports[`PopupView render actual content render toggles view: launch pad: subtitle 1`] = `
+"<Fragment>
+  <NewTabLink href=\\"https://go.microsoft.com/fwlink/?linkid=2082374\\" aria-label=\\"demo video\\" title=\\"watch the 3 minute video introduction\\" onClick={[Function: onClickTutorialLink]}>
+    Watch 3-minute video introduction
+  </NewTabLink>
+   
+</Fragment>"
+`;
+
 exports[`PopupView render actual content renderAdHocToolsPanel 1`] = `
 "<Fragment>
   <div className=\\"ms-Fabric ad-hoc-tools-panel\\">

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -20,15 +20,6 @@ exports[`PopupView render actual content render toggles view: launch pad 1`] = `
 </Fragment>"
 `;
 
-exports[`PopupView render actual content render toggles view: launch pad: subtitle 1`] = `
-"<Fragment>
-  <NewTabLink href=\\"https://go.microsoft.com/fwlink/?linkid=2082374\\" aria-label=\\"demo video\\" title=\\"watch the 3 minute video introduction\\" onClick={[Function: onClickTutorialLink]}>
-    Watch 3-minute video introduction
-  </NewTabLink>
-   
-</Fragment>"
-`;
-
 exports[`PopupView render actual content renderAdHocToolsPanel 1`] = `
 "<Fragment>
   <div className=\\"ms-Fabric ad-hoc-tools-panel\\">
@@ -93,6 +84,7 @@ exports[`PopupView renderFailureMsgPanelForFileUrl 1`] = `
         "extensionVersion": undefined,
         "getAllWindows": [Function],
         "getCommands": [Function],
+        "getManageExtensionUrl": [Function],
         "getManifest": [Function],
         "getRunTimeId": [Function],
         "getRuntimeLastError": [Function],
@@ -103,7 +95,6 @@ exports[`PopupView renderFailureMsgPanelForFileUrl 1`] = `
         "injectCss": [Function],
         "injectJs": [Function],
         "isAllowedFileSchemeAccess": [Function],
-        "openManageExtensionPage": [Function],
         "removeListenerOnMessage": [Function],
         "removeUserData": [Function],
         "sendMessageToAllFramesAndTabs": [Function],

--- a/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
+++ b/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
@@ -28,8 +28,6 @@ describe('FileUrlUnsupportedMessagePanel', () => {
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 
-    // It's important that we verify it uses createTab onClick for this link rather than using href,
-    // since the browser will only allow navigation to the extension page via the chrome.tabs API
     it('has a NewTabLink that uses createTab to open the manage extension page', () => {
         const stubExtensionPageUrl = 'protocol://extension-page';
         const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);

--- a/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
+++ b/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
@@ -2,31 +2,23 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, Mock } from 'typemoq';
+import { Mock, MockBehavior, Times } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
+import { NewTabLink } from '../../../../../common/components/new-tab-link';
 import {
     FileUrlUnsupportedMessagePanel,
+    FileUrlUnsupportedMessagePanelDeps,
     FileUrlUnsupportedMessagePanelProps,
 } from '../../../../../popup/components/file-url-unsupported-message-panel';
 
 describe('FileUrlUnsupportedMessagePanel', () => {
-    let browserAdapterMock: IMock<BrowserAdapter>;
-    const openManageExtensionPageStub = () => {};
-
-    beforeEach(() => {
-        browserAdapterMock = Mock.ofType<BrowserAdapter>();
-        browserAdapterMock.setup(adapter => adapter.openManageExtensionPage).returns(() => openManageExtensionPageStub);
-    });
-
     it('renders', () => {
         const header = <span>TEST HEADER</span>;
         const title = 'test-title';
 
         const props: FileUrlUnsupportedMessagePanelProps = {
-            deps: {
-                browserAdapter: browserAdapterMock.object,
-            },
+            deps: {} as FileUrlUnsupportedMessagePanelDeps,
             title,
             header,
         };
@@ -34,5 +26,29 @@ describe('FileUrlUnsupportedMessagePanel', () => {
         const wrapper = shallow(<FileUrlUnsupportedMessagePanel {...props} />);
 
         expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    it('has a NewTabLink that uses createTab to open the manage extension page', () => {
+        const stubExtensionPageUrl = 'protocol://extension-page';
+        const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
+        browserAdapterMock.setup(adapter => adapter.createTab(stubExtensionPageUrl)).verifiable(Times.once());
+
+        // It's important that we use createTab onClick for this link rather than using href,
+        // since the browser will only allow navigation to the extension page via the chrome.tabs API
+        browserAdapterMock.setup(adapter => adapter.getManageExtensionUrl()).returns(() => stubExtensionPageUrl);
+
+        const props: FileUrlUnsupportedMessagePanelProps = {
+            deps: {
+                browserAdapter: browserAdapterMock.object,
+            },
+            title: 'irrelevant',
+            header: <>irrelevant</>,
+        };
+
+        const wrapper = shallow(<FileUrlUnsupportedMessagePanel {...props} />);
+
+        wrapper.find(NewTabLink).simulate('click');
+
+        browserAdapterMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
+++ b/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
@@ -28,13 +28,12 @@ describe('FileUrlUnsupportedMessagePanel', () => {
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 
+    // It's important that we verify it uses createTab onClick for this link rather than using href,
+    // since the browser will only allow navigation to the extension page via the chrome.tabs API
     it('has a NewTabLink that uses createTab to open the manage extension page', () => {
         const stubExtensionPageUrl = 'protocol://extension-page';
         const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
         browserAdapterMock.setup(adapter => adapter.getManageExtensionUrl()).returns(() => stubExtensionPageUrl);
-
-        // It's important that we use createTab onClick for this link rather than using href,
-        // since the browser will only allow navigation to the extension page via the chrome.tabs API
         browserAdapterMock.setup(adapter => adapter.createTab(stubExtensionPageUrl)).verifiable(Times.once());
 
         const props: FileUrlUnsupportedMessagePanelProps = {

--- a/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
+++ b/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
@@ -31,11 +31,11 @@ describe('FileUrlUnsupportedMessagePanel', () => {
     it('has a NewTabLink that uses createTab to open the manage extension page', () => {
         const stubExtensionPageUrl = 'protocol://extension-page';
         const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
-        browserAdapterMock.setup(adapter => adapter.createTab(stubExtensionPageUrl)).verifiable(Times.once());
+        browserAdapterMock.setup(adapter => adapter.getManageExtensionUrl()).returns(() => stubExtensionPageUrl);
 
         // It's important that we use createTab onClick for this link rather than using href,
         // since the browser will only allow navigation to the extension page via the chrome.tabs API
-        browserAdapterMock.setup(adapter => adapter.getManageExtensionUrl()).returns(() => stubExtensionPageUrl);
+        browserAdapterMock.setup(adapter => adapter.createTab(stubExtensionPageUrl)).verifiable(Times.once());
 
         const props: FileUrlUnsupportedMessagePanelProps = {
             deps: {


### PR DESCRIPTION
#### Description of changes

Moves the coordination responsibility out of BrowserAdapter.openManageExtensionPage into its only consumer and brings it under test.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
