### PR TITLE
refactor: move js/css injection logic out of BrowserAdapter and under test

### DIFF
--- a/src/background/injector/content-script-injector.ts
+++ b/src/background/injector/content-script-injector.ts
@@ -14,28 +14,48 @@ export class ContentScriptInjector {
 
     public injectScripts(tabId: number): Promise<void> {
         const inject = new Promise<null>(resolve => {
-            ContentScriptInjector.cssFiles.forEach(file => {
-                // we need js to be injected in all frames before we start sending message, but,
-                // we do not need to wait for css, since css loading doesn't affect our messaging,
-                // hence the null callback here.
-                this.browserAdapter.injectCss(tabId, file, null);
-            });
-
-            this.injectJsFiles(tabId, ContentScriptInjector.jsFiles, () => {
-                resolve();
-            });
+            // We need the JS to be injected before we can continue (ie, before we resolve the promise),
+            // because the tab can't receive other messages until that's done, but it's okay for the CSS
+            // to keep loading in the background after-the-fact, so it's fire-and-forget.
+            this.injectCssFilesConcurrently(tabId, ContentScriptInjector.cssFiles);
+            this.injectJsFilesInOrder(tabId, ContentScriptInjector.jsFiles, resolve);
         });
 
         return this.promiseFactory.timeout(inject, ContentScriptInjector.timeoutInMilliSec);
     }
 
-    private injectJsFiles(tabId: number, files: string[], callback: Function): void {
+    private injectCssFilesConcurrently(tabId: number, files: string[]): void {
+        ContentScriptInjector.cssFiles.forEach(file => {
+            this.injectCssFile(tabId, file);
+        });
+    }
+
+    private injectJsFilesInOrder(tabId: number, files: string[], callback: Function): void {
         if (files.length > 0) {
-            this.browserAdapter.injectJs(tabId, files[0], () => {
-                this.injectJsFiles(tabId, files.slice(1, files.length), callback);
+            this.injectJsFile(tabId, files[0], () => {
+                this.injectJsFilesInOrder(tabId, files.slice(1, files.length), callback);
             });
         } else {
             callback();
         }
+    }
+
+    private injectJsFile(tabId: number, file: string, callback?: (result: any[]) => void): void {
+        this.browserAdapter.executeScriptInTab(
+            tabId,
+            {
+                allFrames: true,
+                file: file,
+                runAt: 'document_start',
+            },
+            callback,
+        );
+    }
+
+    private injectCssFile(tabId: number, file: string): void {
+        this.browserAdapter.insertCSSInTab(tabId, {
+            allFrames: true,
+            file: file,
+        });
     }
 }

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -19,8 +19,8 @@ export interface BrowserAdapter {
     sendMessageToTab(tabId: number, message: any): void;
     sendMessageToFrames(message: any): void;
     sendMessageToAllFramesAndTabs(message: any): void;
-    injectJs(tabId, file: string, callback: Function): void;
-    injectCss(tabId, file: string, callback: Function): void;
+    executeScriptInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: (result: any[]) => void): void;
+    insertCSSInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: Function): void;
     getRunTimeId(): string;
     createNotification(options: chrome.notifications.NotificationOptions): void;
     getRuntimeLastError(): chrome.runtime.LastError;

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -58,26 +58,12 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         });
     }
 
-    public injectJs(tabId, file: string, callback?: (result: any[]) => void): void {
-        chrome.tabs.executeScript(
-            tabId,
-            {
-                allFrames: true,
-                file: file,
-                runAt: 'document_start',
-            },
-            callback,
-        );
+    public executeScriptInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: (result: any[]) => void): void {
+        chrome.tabs.executeScript(tabId, details, callback);
     }
-    public injectCss(tabId, file: string, callback?: Function): void {
-        chrome.tabs.insertCSS(
-            tabId,
-            {
-                allFrames: true,
-                file: file,
-            },
-            callback,
-        );
+
+    public insertCSSInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: Function): void {
+        chrome.tabs.insertCSS(tabId, details, callback);
     }
 
     public createTab(url: string, callback?: (tab: chrome.tabs.Tab) => void): void {

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -23,7 +23,7 @@ describe('ContentScriptInjector', () => {
     it('uses a timeout promise with the expected timeout constant', async () => {
         promiseFactoryMock
             .setup(factory => factory.timeout(It.isAny(), ContentScriptInjector.timeoutInMilliSec))
-            .returns(() => Promise.resolve())
+            .returns(() => Promise.resolve({}))
             .verifiable(Times.once());
 
         await testSubject.injectScripts(testTabId);

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -1,13 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
+import { isFunction, range } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { ContentScriptInjector } from '../../../../background/injector/content-script-injector';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { PromiseFactory } from '../../../../common/promises/promise-factory';
 
-describe('ContentScriptInjectorTest', () => {
+describe('ContentScriptInjector', () => {
+    const testTabId = 1;
+    const resolveCallbackImmediately = (tabId, details, callback) => {
+        if (callback) {
+            callback();
+        }
+    };
     let browserAdapterMock: IMock<BrowserAdapter>;
     let promiseFactoryMock: IMock<PromiseFactory>;
 
@@ -21,28 +27,96 @@ describe('ContentScriptInjectorTest', () => {
         testSubject = new ContentScriptInjector(browserAdapterMock.object, promiseFactoryMock.object);
     });
 
-    it('injects content scripts', () => {
-        expect.assertions(1);
-
-        const tabId = -1;
-
+    it('uses a timeout promise the expected timeout constant', async () => {
         promiseFactoryMock
-            .setup(factory => factory.timeout(It.is(promise => promise instanceof Promise), ContentScriptInjector.timeoutInMilliSec))
-            .returns((promise, delay) => promise);
+            .setup(factory => factory.timeout(It.isAny(), ContentScriptInjector.timeoutInMilliSec))
+            .returns(() => Promise.resolve())
+            .verifiable(Times.once());
 
-        ContentScriptInjector.cssFiles.forEach(cssFile =>
-            browserAdapterMock.setup(adapter => adapter.injectCss(tabId, cssFile, null)).verifiable(Times.once()),
-        );
+        await testSubject.injectScripts(testTabId);
 
-        ContentScriptInjector.jsFiles.forEach(jsFile => {
-            browserAdapterMock
-                .setup(adapter => adapter.injectJs(tabId, jsFile, It.is(isFunction)))
-                .callback((theTabId, theJsFile, callback) => callback())
-                .verifiable(Times.once());
+        promiseFactoryMock.verifyAll();
+    });
+
+    it('rejects if a timeout occurs', async () => {
+        promiseFactoryMock.setup(factory => factory.timeout(It.isAny(), It.isAny())).returns(() => Promise.reject('artificial timeout'));
+
+        await expect(testSubject.injectScripts(testTabId)).rejects.toBe('artificial timeout');
+    });
+
+    describe('when no timeout occurs', () => {
+        beforeEach(() => {
+            promiseFactoryMock.setup(factory => factory.timeout(It.isAny(), It.isAny())).returns(originalPromise => originalPromise);
         });
 
-        const injected = testSubject.injectScripts(tabId);
+        it('injects each CSS file once with the expected parameters', async () => {
+            ContentScriptInjector.cssFiles.forEach(cssFile =>
+                browserAdapterMock
+                    .setup(adapter => adapter.insertCSSInTab(testTabId, { allFrames: true, file: cssFile }, It.isAny()))
+                    .verifiable(Times.once()),
+            );
 
-        return expect(injected).resolves.toBeUndefined();
+            browserAdapterMock
+                .setup(adapter => adapter.executeScriptInTab(It.isAny(), It.isAny(), It.isAny()))
+                .callback(resolveCallbackImmediately);
+
+            await testSubject.injectScripts(testTabId);
+
+            browserAdapterMock.verifyAll();
+        });
+
+        it('injects each JS file once with the expected parameters', async () => {
+            ContentScriptInjector.jsFiles.forEach(jsFile =>
+                browserAdapterMock
+                    .setup(adapter =>
+                        adapter.executeScriptInTab(testTabId, { allFrames: true, file: jsFile, runAt: 'document_start' }, It.isAny()),
+                    )
+                    .callback(resolveCallbackImmediately)
+                    .verifiable(Times.once()),
+            );
+
+            await testSubject.injectScripts(testTabId);
+
+            browserAdapterMock.verifyAll();
+        });
+
+        it('resolves only after JS files have finished injecting', async () => {
+            let callbackPassedToExecuteScript: Function;
+
+            // simulate JS injection taking a while, only completing asynchronously when we explicitly invoke the callback
+            browserAdapterMock
+                .setup(adapter =>
+                    adapter.executeScriptInTab(It.isAny(), It.isObjectWith({ file: ContentScriptInjector.jsFiles[0] }), It.isAny()),
+                )
+                .callback((tabId, details, passedCallback) => {
+                    callbackPassedToExecuteScript = passedCallback;
+                });
+
+            let returnedPromiseCompleted = false;
+            const returnedPromise = testSubject.injectScripts(testTabId).then(() => {
+                returnedPromiseCompleted = true;
+            });
+
+            expect(callbackPassedToExecuteScript).toBeDefined();
+            expect(returnedPromiseCompleted).toBe(false);
+
+            callbackPassedToExecuteScript(); // simulate JS injection finishing
+            await returnedPromise;
+
+            expect(returnedPromiseCompleted).toBe(true);
+        });
+
+        it('does not wait for CSS files to be injected before resolving', async () => {
+            // simulate JS injection immediately succeeding
+            browserAdapterMock
+                .setup(adapter => adapter.executeScriptInTab(It.isAny(), It.isAny(), It.isAny()))
+                .callback(resolveCallbackImmediately);
+
+            // simulate CSS injection never completing (by not setting it up with any callback)
+
+            await testSubject.injectScripts(testTabId);
+
+            // expect to not timeout
+        });
     });
 });

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction, range } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { ContentScriptInjector } from '../../../../background/injector/content-script-injector';
@@ -21,7 +20,6 @@ describe('ContentScriptInjector', () => {
 
     beforeEach(() => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
-
         promiseFactoryMock = Mock.ofType<PromiseFactory>();
 
         testSubject = new ContentScriptInjector(browserAdapterMock.object, promiseFactoryMock.object);

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -20,6 +20,15 @@ exports[`PopupView render actual content render toggles view: launch pad 1`] = `
 </Fragment>"
 `;
 
+exports[`PopupView render actual content render toggles view: launch pad: subtitle 1`] = `
+"<Fragment>
+  <NewTabLink href=\\"https://go.microsoft.com/fwlink/?linkid=2082374\\" aria-label=\\"demo video\\" title=\\"watch the 3 minute video introduction\\" onClick={[Function: onClickTutorialLink]}>
+    Watch 3-minute video introduction
+  </NewTabLink>
+   
+</Fragment>"
+`;
+
 exports[`PopupView render actual content renderAdHocToolsPanel 1`] = `
 "<Fragment>
   <div className=\\"ms-Fabric ad-hoc-tools-panel\\">

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -20,15 +20,6 @@ exports[`PopupView render actual content render toggles view: launch pad 1`] = `
 </Fragment>"
 `;
 
-exports[`PopupView render actual content render toggles view: launch pad: subtitle 1`] = `
-"<Fragment>
-  <NewTabLink href=\\"https://go.microsoft.com/fwlink/?linkid=2082374\\" aria-label=\\"demo video\\" title=\\"watch the 3 minute video introduction\\" onClick={[Function: onClickTutorialLink]}>
-    Watch 3-minute video introduction
-  </NewTabLink>
-   
-</Fragment>"
-`;
-
 exports[`PopupView render actual content renderAdHocToolsPanel 1`] = `
 "<Fragment>
   <div className=\\"ms-Fabric ad-hoc-tools-panel\\">
@@ -90,6 +81,7 @@ exports[`PopupView renderFailureMsgPanelForFileUrl 1`] = `
         "createNotification": [Function],
         "createTab": [Function],
         "createTabInNewWindow": [Function],
+        "executeScriptInTab": [Function],
         "extensionVersion": undefined,
         "getAllWindows": [Function],
         "getCommands": [Function],
@@ -100,8 +92,7 @@ exports[`PopupView renderFailureMsgPanelForFileUrl 1`] = `
         "getTab": [Function],
         "getUrl": [Function],
         "getUserData": [Function],
-        "injectCss": [Function],
-        "injectJs": [Function],
+        "insertCSSInTab": [Function],
         "isAllowedFileSchemeAccess": [Function],
         "openManageExtensionPage": [Function],
         "removeListenerOnMessage": [Function],


### PR DESCRIPTION
#### Description of changes

The BrowserAdapter css/js injection methods had some business logic in them that wasn't tested. This moves those methods to their only consumer (`ContentScriptInjector`), leaves thinner wrappers in BrowserAdapter/ChromeAdapter, and revamps the `ContentScriptInjector` tests to include tests of the moved logic (plus some other paths in the injector that weren't previously well tested)

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
