### PR TITLE
refactor: setup relative path for imports

### DIFF
--- a/src/DetailsView/reports/components/report-sections/body-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/body-section.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
 import { NamedSFC } from 'common/react/named-sfc';
+import * as React from 'react';
 
 export const BodySection = NamedSFC('BodySection', ({ children }) => {
     return <body>{children}</body>;

--- a/src/DetailsView/reports/components/report-sections/body-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/body-section.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 
 export const BodySection = NamedSFC('BodySection', ({ children }) => {
     return <body>{children}</body>;

--- a/src/DetailsView/reports/components/report-sections/collapsible-container.tsx
+++ b/src/DetailsView/reports/components/report-sections/collapsible-container.tsx
@@ -3,7 +3,7 @@
 import { css } from '@uifabric/utilities';
 import * as React from 'react';
 
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 
 export type CollapsibleContainerProps = {
     id: string;

--- a/src/DetailsView/reports/components/report-sections/collapsible-result-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/collapsible-result-section.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
 import { NamedSFC } from 'common/react/named-sfc';
+import * as React from 'react';
 import { CollapsibleContainer } from './collapsible-container';
 import { ResultSectionProps } from './result-section';
 import { ResultSectionTitle } from './result-section-title';

--- a/src/DetailsView/reports/components/report-sections/collapsible-result-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/collapsible-result-section.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 import { CollapsibleContainer } from './collapsible-container';
 import { ResultSectionProps } from './result-section';
 import { ResultSectionTitle } from './result-section-title';

--- a/src/DetailsView/reports/components/report-sections/content-container.tsx
+++ b/src/DetailsView/reports/components/report-sections/content-container.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 
 export const ContentContainer = NamedSFC('ContentSection', ({ children }) => {
     return (

--- a/src/DetailsView/reports/components/report-sections/content-container.tsx
+++ b/src/DetailsView/reports/components/report-sections/content-container.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
 import { NamedSFC } from 'common/react/named-sfc';
+import * as React from 'react';
 
 export const ContentContainer = NamedSFC('ContentSection', ({ children }) => {
     return (

--- a/src/DetailsView/reports/components/report-sections/details-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/details-section.tsx
@@ -3,11 +3,11 @@
 import { css } from '@uifabric/utilities';
 import * as React from 'react';
 
-import { NewTabLink } from '../../../../common/components/new-tab-link';
-import { CommentIcon } from '../../../../common/icons/comment-icon';
-import { DateIcon } from '../../../../common/icons/date-icon';
-import { UrlIcon } from '../../../../common/icons/url-icon';
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { CommentIcon } from 'common/icons/comment-icon';
+import { DateIcon } from 'common/icons/date-icon';
+import { UrlIcon } from 'common/icons/url-icon';
+import { NamedSFC } from 'common/react/named-sfc';
 import { SectionProps } from './report-section-factory';
 
 export type DetailsSectionProps = Pick<SectionProps, 'pageTitle' | 'pageUrl' | 'description' | 'scanDate' | 'toUtcString'>;

--- a/src/DetailsView/reports/components/report-sections/failed-instances-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/failed-instances-section.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 import { SectionProps } from './report-section-factory';
 import { ResultSection } from './result-section';
 

--- a/src/DetailsView/reports/components/report-sections/footer-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/footer-section.tsx
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NewTabLink } from '../../../../common/components/new-tab-link';
-import { NamedSFC } from '../../../../common/react/named-sfc';
-import { toolName } from '../../../../content/strings/application';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { NamedSFC } from 'common/react/named-sfc';
+import { toolName } from 'content/strings/application';
 
 import { reportFooter, reportFooterContainer } from './footer-section.scss';
 

--- a/src/DetailsView/reports/components/report-sections/full-rule-header.tsx
+++ b/src/DetailsView/reports/components/report-sections/full-rule-header.tsx
@@ -3,12 +3,12 @@
 import { kebabCase } from 'lodash';
 import * as React from 'react';
 
-import { GuidanceLinks } from '../../../../common/components/guidance-links';
-import { GuidanceTags } from '../../../../common/components/guidance-tags';
-import { NewTabLink } from '../../../../common/components/new-tab-link';
-import { GetGuidanceTagsFromGuidanceLinks } from '../../../../common/get-guidance-tags-from-guidance-links';
-import { NamedSFC } from '../../../../common/react/named-sfc';
-import { RuleResult } from '../../../../scanner/iruleresults';
+import { GuidanceLinks } from 'common/components/guidance-links';
+import { GuidanceTags } from 'common/components/guidance-tags';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { NamedSFC } from 'common/react/named-sfc';
+import { RuleResult } from 'scanner/iruleresults';
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { OutcomeChip } from '../outcome-chip';
 import { outcomeTypeSemantics } from '../outcome-type';

--- a/src/DetailsView/reports/components/report-sections/header-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/header-section.tsx
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NewTabLink } from '../../../../common/components/new-tab-link';
-import { NamedSFC } from '../../../../common/react/named-sfc';
-import { productName } from '../../../../content/strings/application';
-import { BrandWhite } from '../../../../icons/brand/white/brand-white';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { NamedSFC } from 'common/react/named-sfc';
+import { productName } from 'content/strings/application';
+import { BrandWhite } from 'icons/brand/white/brand-white';
 
 export interface HeaderSectionProps {
     pageTitle: string;

--- a/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
+++ b/src/DetailsView/reports/components/report-sections/instance-details-group.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { NamedSFC } from 'common/react/named-sfc';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
-import { GetGuidanceTagsFromGuidanceLinks } from '../../../../common/get-guidance-tags-from-guidance-links';
-import { NamedSFC } from '../../../../common/react/named-sfc';
-import { FixInstructionProcessor } from '../../../../injected/fix-instruction-processor';
-import { RuleResult } from '../../../../scanner/iruleresults';
+import { RuleResult } from 'scanner/iruleresults';
+
 import { InstanceDetails } from './instance-details';
 
 export type InstanceDetailsGroupDeps = {

--- a/src/DetailsView/reports/components/report-sections/instance-details.tsx
+++ b/src/DetailsView/reports/components/report-sections/instance-details.tsx
@@ -3,10 +3,10 @@
 import * as classNames from 'classnames';
 import * as React from 'react';
 
-import { NamedSFC } from '../../../../common/react/named-sfc';
-import { CheckType } from '../../../../injected/components/details-dialog';
-import { FixInstructionPanel } from '../../../../injected/components/fix-instruction-panel';
-import { FixInstructionProcessor } from '../../../../injected/fix-instruction-processor';
+import { NamedSFC } from 'common/react/named-sfc';
+import { CheckType } from 'injected/components/details-dialog';
+import { FixInstructionPanel } from 'injected/components/fix-instruction-panel';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 
 export type InstanceDetailsProps = Pick<AxeNodeResult, 'none' | 'all' | 'any' | 'html' | 'target'> & {
     index: number;

--- a/src/DetailsView/reports/components/report-sections/minimal-rule-header.tsx
+++ b/src/DetailsView/reports/components/report-sections/minimal-rule-header.tsx
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NamedSFC } from '../../../../common/react/named-sfc';
-import { RuleResult } from '../../../../scanner/iruleresults';
+import { NamedSFC } from 'common/react/named-sfc';
+import { RuleResult } from 'scanner/iruleresults';
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { OutcomeChip } from '../outcome-chip';
 

--- a/src/DetailsView/reports/components/report-sections/no-failed-instances-congrats.tsx
+++ b/src/DetailsView/reports/components/report-sections/no-failed-instances-congrats.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 import { InlineImage, InlineImageType } from '../inline-image';
 import {
     reportCongrats,

--- a/src/DetailsView/reports/components/report-sections/not-applicable-checks-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/not-applicable-checks-section.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 import { CollapsibleResultSection } from './collapsible-result-section';
 import { SectionProps } from './report-section-factory';
 

--- a/src/DetailsView/reports/components/report-sections/passed-checks-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/passed-checks-section.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 import { CollapsibleResultSection } from './collapsible-result-section';
 import { SectionProps } from './report-section-factory';
 

--- a/src/DetailsView/reports/components/report-sections/report-body.tsx
+++ b/src/DetailsView/reports/components/report-sections/report-body.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 import { ReportSectionFactory, SectionProps } from './report-section-factory';
 
 export type ReportBodyProps = {

--- a/src/DetailsView/reports/components/report-sections/report-footer.tsx
+++ b/src/DetailsView/reports/components/report-sections/report-footer.tsx
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NewTabLink } from '../../../../common/components/new-tab-link';
-import { NamedSFC } from '../../../../common/react/named-sfc';
-import { toolName } from '../../../../content/strings/application';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { NamedSFC } from 'common/react/named-sfc';
+import { toolName } from 'content/strings/application';
 import { SectionProps } from './report-section-factory';
 
 export type ReportFooterProps = Pick<SectionProps, 'environmentInfo'>;

--- a/src/DetailsView/reports/components/report-sections/report-section-factory.tsx
+++ b/src/DetailsView/reports/components/report-sections/report-section-factory.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { EnvironmentInfo } from '../../../../common/environment-info-provider';
-import { GetGuidanceTagsFromGuidanceLinks } from '../../../../common/get-guidance-tags-from-guidance-links';
-import { ReactSFCWithDisplayName } from '../../../../common/react/named-sfc';
-import { FixInstructionProcessor } from '../../../../injected/fix-instruction-processor';
-import { ScanResults } from '../../../../scanner/iruleresults';
+import { EnvironmentInfo } from 'common/environment-info-provider';
+import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { ReactSFCWithDisplayName } from 'common/react/named-sfc';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
+import { ScanResults } from 'scanner/iruleresults';
 
 export type SectionProps = {
     fixInstructionProcessor: FixInstructionProcessor;

--- a/src/DetailsView/reports/components/report-sections/result-section-content.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section-content.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedSFC } from 'common/react/named-sfc';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
-import { NamedSFC } from '../../../../common/react/named-sfc';
-import { FixInstructionProcessor } from '../../../../injected/fix-instruction-processor';
-import { RuleResult } from '../../../../scanner/iruleresults';
+import { RuleResult } from 'scanner/iruleresults';
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { NoFailedInstancesCongrats } from './no-failed-instances-congrats';
 import { RulesWithInstances, RulesWithInstancesDeps } from './rules-with-instances';

--- a/src/DetailsView/reports/components/report-sections/result-section-title.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section-title.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { OutcomeChip } from '../outcome-chip';
 

--- a/src/DetailsView/reports/components/report-sections/result-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
 import { NamedSFC } from 'common/react/named-sfc';
+import * as React from 'react';
 import { ResultSectionContent, ResultSectionContentDeps, ResultSectionContentProps } from './result-section-content';
 import { ResultSectionTitle, ResultSectionTitleProps } from './result-section-title';
 

--- a/src/DetailsView/reports/components/report-sections/result-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/result-section.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 import { ResultSectionContent, ResultSectionContentDeps, ResultSectionContentProps } from './result-section-content';
 import { ResultSectionTitle, ResultSectionTitleProps } from './result-section-title';
 

--- a/src/DetailsView/reports/components/report-sections/results-container.tsx
+++ b/src/DetailsView/reports/components/report-sections/results-container.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
 import { NamedSFC } from 'common/react/named-sfc';
+import * as React from 'react';
 import { SectionProps } from './report-section-factory';
 
 export type ResultsContainerProps = Pick<SectionProps, 'getCollapsibleScript'>;

--- a/src/DetailsView/reports/components/report-sections/results-container.tsx
+++ b/src/DetailsView/reports/components/report-sections/results-container.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 import { SectionProps } from './report-section-factory';
 
 export type ResultsContainerProps = Pick<SectionProps, 'getCollapsibleScript'>;

--- a/src/DetailsView/reports/components/report-sections/rule-content.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-content.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 import { InstanceDetailsGroup, InstanceDetailsGroupDeps, InstanceDetailsGroupProps } from './instance-details-group';
 import { RuleResources, RuleResourcesDeps, RuleResourcesProps } from './rule-resources';
 

--- a/src/DetailsView/reports/components/report-sections/rule-resources.tsx
+++ b/src/DetailsView/reports/components/report-sections/rule-resources.tsx
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { GuidanceLinks } from '../../../../common/components/guidance-links';
-import { GuidanceTags, GuidanceTagsDeps } from '../../../../common/components/guidance-tags';
-import { NewTabLink } from '../../../../common/components/new-tab-link';
-import { NamedSFC } from '../../../../common/react/named-sfc';
-import { RuleResult } from '../../../../scanner/iruleresults';
+import { GuidanceLinks } from 'common/components/guidance-links';
+import { GuidanceTags, GuidanceTagsDeps } from 'common/components/guidance-tags';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { NamedSFC } from 'common/react/named-sfc';
+import { RuleResult } from 'scanner/iruleresults';
 
 export type RuleResourcesDeps = GuidanceTagsDeps;
 

--- a/src/DetailsView/reports/components/report-sections/rules-only.tsx
+++ b/src/DetailsView/reports/components/report-sections/rules-only.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedSFC } from 'common/react/named-sfc';
 import * as React from 'react';
-import { NamedSFC } from '../../../../common/react/named-sfc';
-import { RuleResult } from '../../../../scanner/iruleresults';
+import { RuleResult } from 'scanner/iruleresults';
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { FullRuleHeader, FullRuleHeaderDeps } from './full-rule-header';
 

--- a/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
+++ b/src/DetailsView/reports/components/report-sections/rules-with-instances.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedSFC } from 'common/react/named-sfc';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
-import { NamedSFC } from '../../../../common/react/named-sfc';
-import { FixInstructionProcessor } from '../../../../injected/fix-instruction-processor';
-import { RuleResult } from '../../../../scanner/iruleresults';
+import { RuleResult } from 'scanner/iruleresults';
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { outcomeTypeSemantics } from '../outcome-type';
 import { CollapsibleContainer } from './collapsible-container';

--- a/src/DetailsView/reports/components/report-sections/summary-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/summary-section.tsx
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 import { allInstanceOutcomeTypes, InstanceOutcomeType } from '../instance-outcome-type';
-import { OutcomeSummaryBar } from './../outcome-summary-bar';
+import { OutcomeSummaryBar } from '../outcome-summary-bar';
 import { SectionProps } from './report-section-factory';
 
 export type SummarySectionProps = Pick<SectionProps, 'scanResult'>;

--- a/src/DetailsView/reports/components/report-sections/title-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/title-section.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { NamedSFC } from '../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
 
 export const TitleSection = NamedSFC('TitleSection', () => {
     return (

--- a/src/DetailsView/reports/components/report-sections/title-section.tsx
+++ b/src/DetailsView/reports/components/report-sections/title-section.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
 import { NamedSFC } from 'common/react/named-sfc';
+import * as React from 'react';
 
 export const TitleSection = NamedSFC('TitleSection', () => {
     return (

--- a/src/tests/jest.common.config.js
+++ b/src/tests/jest.common.config.js
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 module.exports = {
     clearMocks: true,
+    moduleDirectories: ['node_modules', 'src'],
     moduleNameMapper: {
         'office-ui-fabric-react/lib/(.*)$': 'office-ui-fabric-react/lib-commonjs/$1',
         '@uifabric/utilities': '@uifabric/utilities/lib-commonjs',

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/details-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/details-section.test.tsx
@@ -3,8 +3,8 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { IMock, Mock, MockBehavior } from 'typemoq';
 import { DateProvider } from 'common/date-provider';
+import { IMock, Mock, MockBehavior } from 'typemoq';
 import { DetailsSection, DetailsSectionProps } from '../../../../../../../DetailsView/reports/components/report-sections/details-section';
 
 describe('DetailsSection', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/details-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/details-section.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { IMock, Mock, MockBehavior } from 'typemoq';
-import { DateProvider } from '../../../../../../../common/date-provider';
+import { DateProvider } from 'common/date-provider';
 import { DetailsSection, DetailsSectionProps } from '../../../../../../../DetailsView/reports/components/report-sections/details-section';
 
 describe('DetailsSection', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/failed-instances-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/failed-instances-section.test.tsx
@@ -4,13 +4,13 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock } from 'typemoq';
 
-import { GetGuidanceTagsFromGuidanceLinks } from '../../../../../../../common/get-guidance-tags-from-guidance-links';
+import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
+import { RuleResult } from 'scanner/iruleresults';
 import {
     FailedInstancesSection,
     FailedInstancesSectionProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/failed-instances-section';
-import { FixInstructionProcessor } from '../../../../../../../injected/fix-instruction-processor';
-import { RuleResult } from '../../../../../../../scanner/iruleresults';
 
 describe('FailedInstancesSection', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/full-rule-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/full-rule-header.test.tsx
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { RuleResult } from 'scanner/iruleresults';
 import { allInstanceOutcomeTypes } from '../../../../../../../DetailsView/reports/components/instance-outcome-type';
 import {
     FullRuleHeader,
     FullRuleHeaderDeps,
     FullRuleHeaderProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/full-rule-header';
-import { RuleResult } from 'scanner/iruleresults';
 
 describe('FullRuleHeader', () => {
     const depsStub = {} as FullRuleHeaderDeps;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/full-rule-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/full-rule-header.test.tsx
@@ -8,7 +8,7 @@ import {
     FullRuleHeaderDeps,
     FullRuleHeaderProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/full-rule-header';
-import { RuleResult } from '../../../../../../../scanner/iruleresults';
+import { RuleResult } from 'scanner/iruleresults';
 
 describe('FullRuleHeader', () => {
     const depsStub = {} as FullRuleHeaderDeps;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/instance-details-group.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/instance-details-group.test.tsx
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
+import { RuleResult } from 'scanner/iruleresults';
 import { Mock } from 'typemoq';
 import {
     InstanceDetailsGroup,
     InstanceDetailsGroupDeps,
     InstanceDetailsGroupProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/instance-details-group';
-import { FixInstructionProcessor } from '../../../../../../../injected/fix-instruction-processor';
-import { RuleResult } from '../../../../../../../scanner/iruleresults';
 
 describe('InstanceDetailsGroup', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/instance-details.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/instance-details.test.tsx
@@ -4,11 +4,11 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock } from 'typemoq';
 
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import {
     InstanceDetails,
     InstanceDetailsProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/instance-details';
-import { FixInstructionProcessor } from '../../../../../../../injected/fix-instruction-processor';
 
 describe('InstanceDetails', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/minimal-rule-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/minimal-rule-header.test.tsx
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { RuleResult } from 'scanner/iruleresults';
 import { allInstanceOutcomeTypes } from '../../../../../../../DetailsView/reports/components/instance-outcome-type';
 import {
     MinimalRuleHeader,
     MinimalRuleHeaderProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/minimal-rule-header';
-import { RuleResult } from 'scanner/iruleresults';
 
 describe('MinimalRuleHeader', () => {
     const rule = {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/minimal-rule-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/minimal-rule-header.test.tsx
@@ -7,7 +7,7 @@ import {
     MinimalRuleHeader,
     MinimalRuleHeaderProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/minimal-rule-header';
-import { RuleResult } from '../../../../../../../scanner/iruleresults';
+import { RuleResult } from 'scanner/iruleresults';
 
 describe('MinimalRuleHeader', () => {
     const rule = {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/not-applicable-checks-sections.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/not-applicable-checks-sections.test.tsx
@@ -3,12 +3,12 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { GetGuidanceTagsFromGuidanceLinks } from '../../../../../../../common/get-guidance-tags-from-guidance-links';
+import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import {
     NotApplicableChecksSection,
     NotApplicableChecksSectionProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/not-applicable-checks-section';
-import { RuleResult } from '../../../../../../../scanner/iruleresults';
+import { RuleResult } from 'scanner/iruleresults';
 
 describe('NotApplicableChecksSection', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/not-applicable-checks-sections.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/not-applicable-checks-sections.test.tsx
@@ -4,11 +4,11 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { RuleResult } from 'scanner/iruleresults';
 import {
     NotApplicableChecksSection,
     NotApplicableChecksSectionProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/not-applicable-checks-section';
-import { RuleResult } from 'scanner/iruleresults';
 
 describe('NotApplicableChecksSection', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/passed-checks-sections.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/passed-checks-sections.test.tsx
@@ -3,12 +3,12 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { GetGuidanceTagsFromGuidanceLinks } from '../../../../../../../common/get-guidance-tags-from-guidance-links';
+import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import {
     PassedChecksSection,
     PassedChecksSectionProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/passed-checks-section';
-import { RuleResult } from '../../../../../../../scanner/iruleresults';
+import { RuleResult } from 'scanner/iruleresults';
 
 describe('PassedChecksSection', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/passed-checks-sections.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/passed-checks-sections.test.tsx
@@ -4,11 +4,11 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { RuleResult } from 'scanner/iruleresults';
 import {
     PassedChecksSection,
     PassedChecksSectionProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/passed-checks-section';
-import { RuleResult } from 'scanner/iruleresults';
 
 describe('PassedChecksSection', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/report-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/report-body.test.tsx
@@ -4,13 +4,13 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock } from 'typemoq';
 
-import { NamedSFC } from '../../../../../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import { ReportBody, ReportBodyProps } from '../../../../../../../DetailsView/reports/components/report-sections/report-body';
 import {
     ReportSectionFactory,
     SectionProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/report-section-factory';
-import { FixInstructionProcessor } from '../../../../../../../injected/fix-instruction-processor';
 
 describe('ReportBody', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/report-footer.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/report-footer.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { EnvironmentInfo } from 'common/environment-info-provider';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { EnvironmentInfo } from 'common/environment-info-provider';
 import { ReportFooter } from '../../../../../../../DetailsView/reports/components/report-sections/report-footer';
 import { SectionProps } from '../../../../../../../DetailsView/reports/components/report-sections/report-section-factory';
 

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/report-footer.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/report-footer.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { EnvironmentInfo } from '../../../../../../../common/environment-info-provider';
+import { EnvironmentInfo } from 'common/environment-info-provider';
 import { ReportFooter } from '../../../../../../../DetailsView/reports/components/report-sections/report-footer';
 import { SectionProps } from '../../../../../../../DetailsView/reports/components/report-sections/report-section-factory';
 

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section-content.test.tsx
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { RuleResult } from 'scanner/iruleresults';
 import {
     ResultSectionContent,
     ResultSectionContentDeps,
     ResultSectionContentProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/result-section-content';
-import { RuleResult } from 'scanner/iruleresults';
 
 describe('ResultSectionContent', () => {
     const emptyRules: RuleResult[] = [];

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/result-section-content.test.tsx
@@ -7,7 +7,7 @@ import {
     ResultSectionContentDeps,
     ResultSectionContentProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/result-section-content';
-import { RuleResult } from '../../../../../../../scanner/iruleresults';
+import { RuleResult } from 'scanner/iruleresults';
 
 describe('ResultSectionContent', () => {
     const emptyRules: RuleResult[] = [];

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-resources.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-resources.test.tsx
@@ -8,7 +8,7 @@ import {
     RuleResourcesDeps,
     RuleResourcesProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/rule-resources';
-import { RuleResult } from '../../../../../../../scanner/iruleresults';
+import { RuleResult } from 'scanner/iruleresults';
 
 describe('RuleResources', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-resources.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/rule-resources.test.tsx
@@ -3,12 +3,12 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
+import { RuleResult } from 'scanner/iruleresults';
 import {
     RuleResources,
     RuleResourcesDeps,
     RuleResourcesProps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/rule-resources';
-import { RuleResult } from 'scanner/iruleresults';
 
 describe('RuleResources', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/rules-only.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/rules-only.test.tsx
@@ -3,7 +3,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { RulesOnly, RulesOnlyDeps } from '../../../../../../../DetailsView/reports/components/report-sections/rules-only';
-import { RuleResult } from '../../../../../../../scanner/iruleresults';
+import { RuleResult } from 'scanner/iruleresults';
 
 describe('RulesOnly', () => {
     const depsStub = {} as RulesOnlyDeps;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/rules-only.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/rules-only.test.tsx
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { RulesOnly, RulesOnlyDeps } from '../../../../../../../DetailsView/reports/components/report-sections/rules-only';
 import { RuleResult } from 'scanner/iruleresults';
+import { RulesOnly, RulesOnlyDeps } from '../../../../../../../DetailsView/reports/components/report-sections/rules-only';
 
 describe('RulesOnly', () => {
     const depsStub = {} as RulesOnlyDeps;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/rules-with-instances.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/rules-with-instances.test.tsx
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
+import { RuleResult } from 'scanner/iruleresults';
 import { IMock, Mock } from 'typemoq';
 import {
     RulesWithInstances,
     RulesWithInstancesDeps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/rules-with-instances';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
-import { RuleResult } from 'scanner/iruleresults';
 
 describe('RulesWithInstances', () => {
     let fixInstructionProcessorMock: IMock<FixInstructionProcessor>;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/rules-with-instances.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/rules-with-instances.test.tsx
@@ -7,8 +7,8 @@ import {
     RulesWithInstances,
     RulesWithInstancesDeps,
 } from '../../../../../../../DetailsView/reports/components/report-sections/rules-with-instances';
-import { FixInstructionProcessor } from '../../../../../../../injected/fix-instruction-processor';
-import { RuleResult } from '../../../../../../../scanner/iruleresults';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
+import { RuleResult } from 'scanner/iruleresults';
 
 describe('RulesWithInstances', () => {
     let fixInstructionProcessorMock: IMock<FixInstructionProcessor>;

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/summary-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/summary-section.test.tsx
@@ -3,7 +3,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { SummarySection, SummarySectionProps } from '../../../../../../../DetailsView/reports/components/report-sections/summary-section';
-import { ScanResults } from '../../../../../../../scanner/iruleresults';
+import { ScanResults } from 'scanner/iruleresults';
 
 describe('SummarySection', () => {
     const noViolations = [];

--- a/src/tests/unit/tests/DetailsView/reports/components/report-sections/summary-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/report-sections/summary-section.test.tsx
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { SummarySection, SummarySectionProps } from '../../../../../../../DetailsView/reports/components/report-sections/summary-section';
 import { ScanResults } from 'scanner/iruleresults';
+import { SummarySection, SummarySectionProps } from '../../../../../../../DetailsView/reports/components/report-sections/summary-section';
 
 describe('SummarySection', () => {
     const noViolations = [];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
         "allowJs": false,
         "typeRoots": ["node_modules/@types"],
         "plugins": [{ "name": "tslint-language-service" }],
-        "baseUrl": ".",
+        "baseUrl": "./src",
         "paths": {
             "*": ["*"],
             "typemoq": ["typemoq/typemoq"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,7 +79,7 @@ const commonConfig = {
         ],
     },
     resolve: {
-        modules: [path.resolve(__dirname, 'node_modules')],
+        modules: [path.resolve(__dirname, './src'), path.resolve(__dirname, 'node_modules')],
         extensions: ['.tsx', '.ts', '.js'],
     },
     plugins: commonPlugins,


### PR DESCRIPTION
#### Description of changes

Currently, moving files around force us to update the import path for our own code. To make this kind of refactor simpler, we should be using relative paths so instead of using this:
```typescript
import { NamedSFC } from '../../../../common/react/named-sfc';
```
we could use this:
```typescript
import { NamedSFC } from 'common/react/named-sfc';
```
That means that moving that file will not affect how do we import `NamedSFC` and thus, less file changes when moving files around.

In order to achieve this, we need to:
- update tsconfig's `baseUrl` value
   - this will make vscode work properly
- update how webpack resolve modules from our own source code
   - this will make "building" work properly

So only 2 changes are necessary to enable us to use relative path imports. As an example of how this will look, I update all components under `src\DetailsView\reports\components\report-sections` to use relative path imports.

**NOTES**
- One of the nice thing about how tsc and webpack handle this is we can have relative and absolute path imports, i.e. we don't need to update all of our imports right away.
- I started with `report-sections` folder because my most immediate plan is to move the whole `reports` folder out of the `DetailsView` folder.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`)
   - not affected
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - not affected
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected