### PR TITLE
refactor: update all imports under report folder

### DIFF
--- a/src/DetailsView/reports/assessment-report-html-generator.tsx
+++ b/src/DetailsView/reports/assessment-report-html-generator.tsx
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
+import { assessmentsProviderWithFeaturesEnabled } from 'assessments/assessments-feature-flag-filter';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import * as React from 'react';
-import { AssessmentDefaultMessageGenerator } from '../../assessments/assessment-default-message-generator';
-import { assessmentsProviderWithFeaturesEnabled } from '../../assessments/assessments-feature-flag-filter';
-import { AssessmentsProvider } from '../../assessments/types/assessments-provider';
-import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { TabStoreData } from '../../common/types/store-data/tab-store-data';
+
 import { AssessmentReportModelBuilderFactory } from './assessment-report-model-builder-factory';
 import * as reportStyles from './assessment-report.styles';
 import { AssessmentReport, AssessmentReportDeps } from './components/assessment-report';

--- a/src/DetailsView/reports/assessment-report-model-builder-factory.ts
+++ b/src/DetailsView/reports/assessment-report-model-builder-factory.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentDefaultMessageGenerator } from '../../assessments/assessment-default-message-generator';
-import { AssessmentsProvider } from '../../assessments/types/assessments-provider';
-import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
-import { TabStoreData } from '../../common/types/store-data/tab-store-data';
+import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+
 import { AssessmentReportModelBuilder } from './assessment-report-model-builder';
 
 export class AssessmentReportModelBuilderFactory {

--- a/src/DetailsView/reports/assessment-report-model-builder.ts
+++ b/src/DetailsView/reports/assessment-report-model-builder.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentDefaultMessageGenerator, DefaultMessageInterface } from 'assessments/assessment-default-message-generator';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { Assessment } from 'assessments/types/iassessment';
+import { ManualTestStatus } from 'common/types/manual-test-status';
+import { AssessmentData, AssessmentStoreData, TestStepInstance } from 'common/types/store-data/assessment-result-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import * as _ from 'lodash';
 
-import { AssessmentDefaultMessageGenerator, DefaultMessageInterface } from '../../assessments/assessment-default-message-generator';
-import { AssessmentsProvider } from '../../assessments/types/assessments-provider';
-import { Assessment } from '../../assessments/types/iassessment';
-import { ManualTestStatus } from '../../common/types/manual-test-status';
-import { AssessmentData, AssessmentStoreData, TestStepInstance } from '../../common/types/store-data/assessment-result-data';
-import { TabStoreData } from '../../common/types/store-data/tab-store-data';
 import { assessmentReportExtensionPoint } from '../extensions/assessment-report-extension-point';
 import {
     AssessmentDetailsReportModel,

--- a/src/DetailsView/reports/assessment-report-model.ts
+++ b/src/DetailsView/reports/assessment-report-model.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DefaultMessageInterface } from '../../assessments/assessment-default-message-generator';
-import { ColumnValue } from '../../common/types/property-bag/column-value-bag';
-import { HyperlinkDefinition } from '../../views/content/content-page';
+import { DefaultMessageInterface } from 'assessments/assessment-default-message-generator';
+import { ColumnValue } from 'common/types/property-bag/column-value-bag';
+import { HyperlinkDefinition } from 'views/content/content-page';
+
 import { RequirementOutcomeStats } from './components/requirement-outcome-type';
 
 export interface ReportModel {

--- a/src/DetailsView/reports/components/assessment-report-assessment-list.tsx
+++ b/src/DetailsView/reports/components/assessment-report-assessment-list.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { ManualTestStatus } from '../../../common/types/manual-test-status';
+import { ManualTestStatus } from 'common/types/manual-test-status';
 import { AssessmentDetailsReportModel } from '../assessment-report-model';
 import { AssessmentReportStepList, AssessmentReportStepListDeps } from './assessment-report-step-list';
 import { OutcomeChip } from './outcome-chip';

--- a/src/DetailsView/reports/components/assessment-report-body.tsx
+++ b/src/DetailsView/reports/components/assessment-report-body.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { ManualTestStatus } from '../../../common/types/manual-test-status';
+import { ManualTestStatus } from 'common/types/manual-test-status';
 import { AssessmentDetailsReportModel, ReportModel } from '../assessment-report-model';
 import { AssessmentReportAssessmentList, AssessmentReportAssessmentListDeps } from './assessment-report-assessment-list';
 import { AssessmentReportBodyHeader } from './assessment-report-body-header';

--- a/src/DetailsView/reports/components/assessment-report-footer.tsx
+++ b/src/DetailsView/reports/components/assessment-report-footer.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { title } from 'content/strings/application';
 import * as React from 'react';
-
-import { title } from '../../../content/strings/application';
 
 export interface AssessmentReportFooterProps {
     extensionVersion: string;

--- a/src/DetailsView/reports/components/assessment-report-instance-list.tsx
+++ b/src/DetailsView/reports/components/assessment-report-instance-list.tsx
@@ -3,8 +3,8 @@
 import { flatten, toPairs } from 'lodash';
 import * as React from 'react';
 
-import { NamedSFC } from '../../../common/react/named-sfc';
-import { BagOf, isScalarColumnValue, ScalarColumnValue } from '../../../common/types/property-bag/column-value-bag';
+import { NamedSFC } from 'common/react/named-sfc';
+import { BagOf, isScalarColumnValue, ScalarColumnValue } from 'common/types/property-bag/column-value-bag';
 import { InstanceReportModel } from '../assessment-report-model';
 
 export interface AssessmentReportInstanceListProps {

--- a/src/DetailsView/reports/components/assessment-report-step-header.tsx
+++ b/src/DetailsView/reports/components/assessment-report-step-header.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DefaultMessageInterface } from 'assessments/assessment-default-message-generator';
+import { GuidanceLinks } from 'common/components/guidance-links';
+import { GuidanceTags, GuidanceTagsDeps } from 'common/components/guidance-tags';
+import { NamedSFC } from 'common/react/named-sfc';
+import { ManualTestStatus } from 'common/types/manual-test-status';
 import * as React from 'react';
 
-import { DefaultMessageInterface } from '../../../assessments/assessment-default-message-generator';
-import { GuidanceLinks } from '../../../common/components/guidance-links';
-import { GuidanceTags, GuidanceTagsDeps } from '../../../common/components/guidance-tags';
-import { NamedSFC } from '../../../common/react/named-sfc';
-import { ManualTestStatus } from '../../../common/types/manual-test-status';
 import { RequirementHeaderReportModel } from '../assessment-report-model';
 import { OutcomeChip } from './outcome-chip';
 import { OutcomeTypeSemantic } from './outcome-type';

--- a/src/DetailsView/reports/components/assessment-report-step-list.tsx
+++ b/src/DetailsView/reports/components/assessment-report-step-list.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedSFC } from 'common/react/named-sfc';
+import { ManualTestStatus } from 'common/types/manual-test-status';
 import * as React from 'react';
 
-import { NamedSFC } from '../../../common/react/named-sfc';
-import { ManualTestStatus } from '../../../common/types/manual-test-status';
 import { InstanceReportModel, RequirementReportModel } from '../assessment-report-model';
 import { AssessmentReportInstanceList } from './assessment-report-instance-list';
 import { AssessmentReportStepHeader, AssessmentReportStepHeaderDeps } from './assessment-report-step-header';

--- a/src/DetailsView/reports/components/assessment-report.tsx
+++ b/src/DetailsView/reports/components/assessment-report.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
+
 import { ReportModel } from '../assessment-report-model';
 import { AssessmentReportBody, AssessmentReportBodyDeps } from './assessment-report-body';
 import { AssessmentReportFooter } from './assessment-report-footer';

--- a/src/DetailsView/reports/components/assessment-scan-details.tsx
+++ b/src/DetailsView/reports/components/assessment-scan-details.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NewTabLink } from 'common/components/new-tab-link';
+import { CommentIcon } from 'common/icons/comment-icon';
+import { DateIcon } from 'common/icons/date-icon';
+import { UrlIcon } from 'common/icons/url-icon';
 import * as React from 'react';
 
-import { NewTabLink } from '../../../common/components/new-tab-link';
-import { CommentIcon } from '../../../common/icons/comment-icon';
-import { DateIcon } from '../../../common/icons/date-icon';
-import { UrlIcon } from '../../../common/icons/url-icon';
 import { ScanDetailsReportModel } from '../assessment-report-model';
 import { FormattedDate } from './formatted-date';
 

--- a/src/DetailsView/reports/components/inline-image.tsx
+++ b/src/DetailsView/reports/components/inline-image.tsx
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { adaLaptop } from '../../../icons/ada/ada-laptop-base64';
-import { adaMulticolorBubbles } from '../../../icons/ada/ada-multicolor-bubbles-base64';
-import { blue48 } from '../../../icons/brand/blue/brand-blue-48px-base64';
-import { DictionaryNumberTo } from '../../../types/common-types';
+import { adaLaptop } from 'icons/ada/ada-laptop-base64';
+import { adaMulticolorBubbles } from 'icons/ada/ada-multicolor-bubbles-base64';
+import { blue48 } from 'icons/brand/blue/brand-blue-48px-base64';
+import { DictionaryNumberTo } from 'types/common-types';
 
 export enum InlineImageType {
     InsightsLogo48,

--- a/src/DetailsView/reports/components/outcome-chip-set.tsx
+++ b/src/DetailsView/reports/components/outcome-chip-set.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedSFC } from 'common/react/named-sfc';
 import * as React from 'react';
 
-import { NamedSFC } from '../../../common/react/named-sfc';
 import { OutcomeChip } from './outcome-chip';
 import { allRequirementOutcomeTypes, RequirementOutcomeStats } from './requirement-outcome-type';
 

--- a/src/DetailsView/reports/components/outcome-chip.tsx
+++ b/src/DetailsView/reports/components/outcome-chip.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedSFC } from 'common/react/named-sfc';
 import * as React from 'react';
 
-import { NamedSFC } from '../../../common/react/named-sfc';
 import { OutcomeIcon } from './outcome-icon';
 import { OutcomeType, outcomeTypeSemantics } from './outcome-type';
 

--- a/src/DetailsView/reports/components/outcome-icon-set.tsx
+++ b/src/DetailsView/reports/components/outcome-icon-set.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedSFC } from 'common/react/named-sfc';
 import { join, times } from 'lodash';
 import * as React from 'react';
 
-import { NamedSFC } from '../../../common/react/named-sfc';
 import { OutcomeIcon } from './outcome-icon';
 import { outcomeTypeSemantics } from './outcome-type';
 import { allRequirementOutcomeTypes, RequirementOutcomeStats } from './requirement-outcome-type';

--- a/src/DetailsView/reports/components/outcome-icon.tsx
+++ b/src/DetailsView/reports/components/outcome-icon.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { NamedSFC } from '../../../common/react/named-sfc';
+import { NamedSFC } from 'common/react/named-sfc';
+
 import { outcomeIconMap, OutcomeType } from './outcome-type';
 
 interface OutcomeIconProps {

--- a/src/DetailsView/reports/components/outcome-summary-bar.tsx
+++ b/src/DetailsView/reports/components/outcome-summary-bar.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedSFC } from 'common/react/named-sfc';
 import { kebabCase } from 'lodash';
 import * as React from 'react';
 
-import { NamedSFC } from '../../../common/react/named-sfc';
 import { outcomeIconMap, outcomeIconMapInverted, OutcomeStats, OutcomeType, outcomeTypeSemantics } from './outcome-type';
 
 export type OutcomeSummaryBarProps = {

--- a/src/DetailsView/reports/components/outcome-type.tsx
+++ b/src/DetailsView/reports/components/outcome-type.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CheckIcon, CheckIconInverted } from 'common/icons/check-icon';
+import { CircleIcon } from 'common/icons/circle-icon';
+import { CrossIcon, CrossIconInverted } from 'common/icons/cross-icon';
+import { InapplicableIcon, InapplicableIconInverted } from 'common/icons/inapplicable-icon';
 import * as React from 'react';
 
-import { InapplicableIcon, InapplicableIconInverted } from '../../../common/icons/inapplicable-icon';
-import { CheckIcon, CheckIconInverted } from './../../../common/icons/check-icon';
-import { CircleIcon } from './../../../common/icons/circle-icon';
-import { CrossIcon, CrossIconInverted } from './../../../common/icons/cross-icon';
 import { InstanceOutcomeType } from './instance-outcome-type';
 import { RequirementOutcomeType } from './requirement-outcome-type';
 

--- a/src/DetailsView/reports/components/report-head.tsx
+++ b/src/DetailsView/reports/components/report-head.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedSFC } from 'common/react/named-sfc';
+import { title } from 'content/strings/application';
 import * as React from 'react';
-import { NamedSFC } from '../../../common/react/named-sfc';
-import { title } from '../../../content/strings/application';
+
 import * as reportStyles from '../automated-checks-report.styles';
 
 export const ReportHead = NamedSFC('ReportHead', () => {

--- a/src/DetailsView/reports/components/requirement-outcome-type.ts
+++ b/src/DetailsView/reports/components/requirement-outcome-type.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ManualTestStatus, ManualTestStatusData } from 'common/types/manual-test-status';
 import { countBy, values } from 'lodash';
 
-import { ManualTestStatus, ManualTestStatusData } from '../../../common/types/manual-test-status';
 import { OutcomeTypeSemantic, outcomeTypeSemantics } from './outcome-type';
 
 export type RequirementOutcomeType = 'pass' | 'incomplete' | 'fail';

--- a/src/DetailsView/reports/get-assessment-summary-model.ts
+++ b/src/DetailsView/reports/get-assessment-summary-model.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { Assessment } from 'assessments/types/iassessment';
+import { ManualTestStatusData } from 'common/types/manual-test-status';
+import { AssessmentData, AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { chain, zipObject } from 'lodash';
 
-import { AssessmentsProvider } from '../../assessments/types/assessments-provider';
-import { Assessment } from '../../assessments/types/iassessment';
-import { ManualTestStatusData } from '../../common/types/manual-test-status';
-import { AssessmentData, AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import * as Model from './assessment-report-model';
 import { OutcomeMath } from './components/outcome-math';
 import {

--- a/src/DetailsView/reports/report-generator.ts
+++ b/src/DetailsView/reports/report-generator.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from '../../assessments/types/assessments-provider';
-import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { TabStoreData } from '../../common/types/store-data/tab-store-data';
-import { ScanResults } from '../../scanner/iruleresults';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { ScanResults } from 'scanner/iruleresults';
+
 import { AssessmentReportHtmlGenerator } from './assessment-report-html-generator';
 import { ReportHtmlGenerator } from './report-html-generator';
 import { ReportNameGenerator } from './report-name-generator';

--- a/src/DetailsView/reports/report-html-generator.tsx
+++ b/src/DetailsView/reports/report-html-generator.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { EnvironmentInfo } from 'common/environment-info-provider';
+import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
-import { EnvironmentInfo } from '../../common/environment-info-provider';
-import { GetGuidanceTagsFromGuidanceLinks } from '../../common/get-guidance-tags-from-guidance-links';
-import { FixInstructionProcessor } from '../../injected/fix-instruction-processor';
-import { ScanResults } from '../../scanner/iruleresults';
+import { ScanResults } from 'scanner/iruleresults';
+
 import { ReportHead } from './components/report-head';
 import { ReportBody, ReportBodyProps } from './components/report-sections/report-body';
 import { ReportSectionFactory, SectionProps } from './components/report-sections/report-section-factory';

--- a/src/tests/unit/tests/DetailsView/reports/assessment-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/assessment-report-html-generator.test.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import * as React from 'react';
 import { It, Mock, MockBehavior } from 'typemoq';
 
-import { AssessmentDefaultMessageGenerator } from '../../../../../assessments/assessment-default-message-generator';
-import { AssessmentStoreData } from '../../../../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
-import { TabStoreData } from '../../../../../common/types/store-data/tab-store-data';
 import {
     AssessmentReportHtmlGenerator,
     AssessmentReportHtmlGeneratorDeps,

--- a/src/tests/unit/tests/DetailsView/reports/assessment-report-model-builder-factory.test.ts
+++ b/src/tests/unit/tests/DetailsView/reports/assessment-report-model-builder-factory.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentDefaultMessageGenerator } from '../../../../../assessments/assessment-default-message-generator';
-import { AssessmentsProvider } from '../../../../../assessments/types/assessments-provider';
-import { AssessmentStoreData } from '../../../../../common/types/store-data/assessment-result-data';
-import { TabStoreData } from '../../../../../common/types/store-data/tab-store-data';
+import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { AssessmentReportModelBuilderFactory } from '../../../../../DetailsView/reports/assessment-report-model-builder-factory';
 
 describe('AssessmentReportModelBuilderFactory', () => {

--- a/src/tests/unit/tests/DetailsView/reports/components/assessment-report-assessment-list.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/assessment-report-assessment-list.test.tsx
@@ -3,7 +3,7 @@
 import * as Enzyme from 'enzyme';
 import * as React from 'react';
 
-import { ManualTestStatus } from '../../../../../../common/types/manual-test-status';
+import { ManualTestStatus } from 'common/types/manual-test-status';
 import { AssessmentDetailsReportModel } from '../../../../../../DetailsView/reports/assessment-report-model';
 import {
     AssessmentReportAssessmentList,

--- a/src/tests/unit/tests/DetailsView/reports/components/assessment-report-step-header.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/assessment-report-step-header.test.tsx
@@ -4,8 +4,8 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock } from 'typemoq';
 
-import { GetGuidanceTagsFromGuidanceLinks } from '../../../../../../common/get-guidance-tags-from-guidance-links';
-import { ManualTestStatus } from '../../../../../../common/types/manual-test-status';
+import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { ManualTestStatus } from 'common/types/manual-test-status';
 import { RequirementHeaderReportModel, RequirementType } from '../../../../../../DetailsView/reports/assessment-report-model';
 import {
     AssessmentReportStepHeader,

--- a/src/tests/unit/tests/DetailsView/reports/components/assessment-report-step-list.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/assessment-report-step-list.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ManualTestStatus } from 'common/types/manual-test-status';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { ManualTestStatus } from '../../../../../../common/types/manual-test-status';
 import {
     AssessmentReportStepList,
     AssessmentReportStepListDeps,

--- a/src/tests/unit/tests/DetailsView/reports/components/outcome-icon.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/components/outcome-icon.test.tsx
@@ -3,10 +3,10 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { CheckIcon, CheckIconInverted } from '../../../../../../common/icons/check-icon';
-import { CircleIcon } from '../../../../../../common/icons/circle-icon';
-import { CrossIconInverted } from '../../../../../../common/icons/cross-icon';
-import { InapplicableIcon, InapplicableIconInverted } from '../../../../../../common/icons/inapplicable-icon';
+import { CheckIcon, CheckIconInverted } from 'common/icons/check-icon';
+import { CircleIcon } from 'common/icons/circle-icon';
+import { CrossIconInverted } from 'common/icons/cross-icon';
+import { InapplicableIcon, InapplicableIconInverted } from 'common/icons/inapplicable-icon';
 import { OutcomeIcon } from '../../../../../../DetailsView/reports/components/outcome-icon';
 import { allRequirementOutcomeTypes } from '../../../../../../DetailsView/reports/components/requirement-outcome-type';
 

--- a/src/tests/unit/tests/DetailsView/reports/components/requirement-outcome-type.test.ts
+++ b/src/tests/unit/tests/DetailsView/reports/components/requirement-outcome-type.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { times } from 'lodash';
 
-import { ManualTestStatus, ManualTestStatusData } from '../../../../../../common/types/manual-test-status';
+import { ManualTestStatus, ManualTestStatusData } from 'common/types/manual-test-status';
 import { OutcomeTypeSemantic } from '../../../../../../DetailsView/reports/components/outcome-type';
 import {
     outcomeStatsFromManualTestStatus,

--- a/src/tests/unit/tests/DetailsView/reports/get-assessment-summary-model.test.ts
+++ b/src/tests/unit/tests/DetailsView/reports/get-assessment-summary-model.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from '../../../../../assessments/types/assessments-provider';
-import { Assessment } from '../../../../../assessments/types/iassessment';
-import { ManualTestStatus, TestStepData } from '../../../../../common/types/manual-test-status';
-import { AssessmentStoreData } from '../../../../../common/types/store-data/assessment-result-data';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { Assessment } from 'assessments/types/iassessment';
+import { ManualTestStatus, TestStepData } from 'common/types/manual-test-status';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { OverviewSummaryReportModel } from '../../../../../DetailsView/reports/assessment-report-model';
 import {
     AssessmentStatusData,

--- a/src/tests/unit/tests/DetailsView/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/DetailsView/reports/report-generator.test.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { ScanResults } from 'scanner/iruleresults';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { AssessmentsProvider } from '../../../../../assessments/types/assessments-provider';
-import { AssessmentStoreData } from '../../../../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
-import { TabStoreData } from '../../../../../common/types/store-data/tab-store-data';
 import { AssessmentReportHtmlGenerator } from '../../../../../DetailsView/reports/assessment-report-html-generator';
 import { ReportGenerator } from '../../../../../DetailsView/reports/report-generator';
 import { ReportHtmlGenerator } from '../../../../../DetailsView/reports/report-html-generator';
 import { ReportNameGenerator } from '../../../../../DetailsView/reports/report-name-generator';
-import { ScanResults } from '../../../../../scanner/iruleresults';
 
 describe('ReportGenerator', () => {
     const scanResult: ScanResults = {} as any;

--- a/src/tests/unit/tests/DetailsView/reports/report-html-generator.test.tsx
+++ b/src/tests/unit/tests/DetailsView/reports/report-html-generator.test.tsx
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DateProvider } from 'common/date-provider';
+import { EnvironmentInfo } from 'common/environment-info-provider';
+import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
+import { ScanResults } from 'scanner/iruleresults';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
-import { DateProvider } from '../../../../../common/date-provider';
-import { EnvironmentInfo } from '../../../../../common/environment-info-provider';
-import { GetGuidanceTagsFromGuidanceLinks } from '../../../../../common/get-guidance-tags-from-guidance-links';
 import { ReportHead } from '../../../../../DetailsView/reports/components/report-head';
 import { ReportBody, ReportBodyProps } from '../../../../../DetailsView/reports/components/report-sections/report-body';
 import { ReportSectionFactory } from '../../../../../DetailsView/reports/components/report-sections/report-section-factory';
 import { ReactStaticRenderer } from '../../../../../DetailsView/reports/react-static-renderer';
 import { ReportHtmlGenerator } from '../../../../../DetailsView/reports/report-html-generator';
-import { FixInstructionProcessor } from '../../../../../injected/fix-instruction-processor';
-import { ScanResults } from '../../../../../scanner/iruleresults';
 
 describe('ReportHtmlGenerator', () => {
     test('generateHtml', () => {

--- a/src/tests/unit/tests/assessments/report-instance-field.test.ts
+++ b/src/tests/unit/tests/assessments/report-instance-field.test.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ReportInstanceField } from 'assessments/types/report-instance-field';
+import { BagOf } from 'common/types/property-bag/column-value-bag';
+
 import { PropertyBagColumnRendererConfig } from '../../../../assessments/common/property-bag-column-renderer';
-import { ReportInstanceField } from '../../../../assessments/types/report-instance-field';
-import { BagOf } from '../../../../common/types/property-bag/column-value-bag';
 
 describe('ReportInstanceField', () => {
     type Bag = { one?: string; two?: string; attr?: BagOf<string> };


### PR DESCRIPTION
#### Description of changes

Following up on #982 

Basically updating all the imports under `DetailsView/report` folder (but not in `DetailsView/report/components/report-sections` which was the target of the above mentioned PR).

This get use one step closer to being able to move the `report` folder to be directly under `src`.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`)
   - not affected code-wise
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - not affected
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
