### PR TITLE
test: run result publishing steps to even when previous steps failed

### DIFF
--- a/pipeline/e2e-test-from-docker.yaml
+++ b/pipeline/e2e-test-from-docker.yaml
@@ -11,6 +11,8 @@ steps:
           export CONTAINERID=$(docker ps -alq)
           echo "##vso[task.setvariable variable=CONTAINER_ID]$CONTAINERID"
       displayName: get container id for docker
+      condition: succeededOrFailed()
 
     - script: docker cp $(CONTAINER_ID):/app/test-results/ .
       displayName: copy test results from docker to base agent
+      condition: succeededOrFailed()

--- a/pipeline/e2e-test-publish-results.yaml
+++ b/pipeline/e2e-test-publish-results.yaml
@@ -5,7 +5,7 @@ steps:
       inputs:
           testResultsFiles: test-results/e2e/junit-e2e.xml
           testRunTitle: $(Agent.JobName)
-      condition: always()
+      condition: succeededOrFailed()
       displayName: publish e2e test results
 
     - publish: '$(System.DefaultWorkingDirectory)/test-results/e2e'


### PR DESCRIPTION
#### Description of changes

Sets up the docker-specific parts of gathering failure screenshots to still execute when the tests fail.

Also updates the more general results publishing task to work consistently with them and not run if the pipeline is cancelled (that's the difference between `always()` and `succeededOrFailed()`.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
