### PR TITLE
test: improve e2e reliability around animation disablement events

### DIFF
--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -60,21 +60,14 @@ export class Page {
     }
 
     public async disableAnimations(): Promise<void> {
-        await this.underlyingPage.evaluate(() => {
-            function addDisableStyleToBody(): void {
-                const disableAnimationsStyleElement = document.createElement('style');
-                disableAnimationsStyleElement.type = 'text/css';
-                disableAnimationsStyleElement.innerHTML = `* {
-                    transition: none !important;
-                    animation: none !important;
-                }`;
-                document.body.appendChild(disableAnimationsStyleElement);
-            }
-            if (document.readyState !== 'loading') {
-                addDisableStyleToBody();
-            } else {
-                window.addEventListener('load', addDisableStyleToBody);
-            }
+        await this.underlyingPage.mainFrame().addStyleTag({
+            content: `*, ::before, ::after {
+                transition-property: none !important;
+                transition-duration: 0s !important;
+                transition: none !important;
+                animation: none !important;
+                animation-duration: 0s !important;
+            }`,
         });
     }
 

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -49,26 +49,6 @@ export class Page {
 
     public async goto(url: string): Promise<void> {
         await this.screenshotOnError(async () => await this.underlyingPage.goto(url, { timeout: DEFAULT_NEW_PAGE_WAIT_TIMEOUT_MS }));
-        await this.disableAnimations();
-    }
-
-    public async disableAnimations(): Promise<void> {
-        await this.underlyingPage.evaluate(() => {
-            function addDisableStyleToBody(): void {
-                const disableAnimationsStyleElement = document.createElement('style');
-                disableAnimationsStyleElement.type = 'text/css';
-                disableAnimationsStyleElement.innerHTML = `* {
-                    transition: none !important;
-                    animation: none !important;
-                }`;
-                document.body.appendChild(disableAnimationsStyleElement);
-            }
-            if (document.readyState !== 'loading') {
-                addDisableStyleToBody();
-            } else {
-                window.addEventListener('load', addDisableStyleToBody);
-            }
-        });
     }
 
     public async close(ignoreIfAlreadyClosed: boolean = false): Promise<void> {

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -30,8 +30,8 @@ export class Page {
         });
         underlyingPage.on('pageerror', error => {
             if (
-                error.message.startsWith(`TypeError: Cannot read property 'focusElement' of null
-            at eval (webpack-internal:/node_modules/office-ui-fabric-react/lib/components/Dropdown/Dropdown.base.js)`)
+                error.message.startsWith("TypeError: Cannot read property 'focusElement' of null") &&
+                error.message.includes('office-ui-fabric-react/lib/components/Dropdown/Dropdown.base.js')
             ) {
                 return; // benign; caused by https://github.com/OfficeDev/office-ui-fabric-react/issues/9715
             }


### PR DESCRIPTION
#### Description of changes

This addresses some flakiness related to animation timings:

* Increases scope of disableAnimations CSS
* Uses a less verbose means of applying the disable animations styles
* Adds a specific workaround to suppress pageerror events caused by https://github.com/OfficeDev/office-ui-fabric-react/issues/9715 (I thought this was being caused by the animation disabling at first, but it turns out to be unrelated; you can repro this even without applying disableAnimations)

#### Pull request checklist

- [x] Addresses an existing issue: Partially addresses #867
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
