### PR TITLE
test: waitForSelector before evaling against it in getOuterHTMLOfSelector

### DIFF
--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -164,7 +164,10 @@ export class Page {
 
     public async getOuterHTMLOfSelector(selector: string): Promise<string> {
         return await this.screenshotOnError(async () => {
-            return await this.underlyingPage.$eval(selector, el => el.outerHTML);
+            const element = await this.underlyingPage.waitForSelector(selector, {
+                timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS,
+            });
+            return await this.underlyingPage.evaluate(el => el.outerHTML, element);
         });
     }
 


### PR DESCRIPTION
#### Description of changes

e2e-reliability CI build for https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=27762 hit a failure where it tried to getOuterHTMLOfSelector against an element that wasn't yet present on the page. This PR makes that helper more reliable by having it wait for the element to exist on the page (with the normal timeout) prior to grabbing its snapshot.

#### Pull request checklist

- [x] Addresses an existing issue: Partially addresses #867
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
