### PR TITLE
chore: replace use of deprecated chrome.tabs.getSelected API

### DIFF
--- a/src/background/tab-controller.ts
+++ b/src/background/tab-controller.ts
@@ -80,13 +80,19 @@ export class TabController {
             { populate: false, windowTypes: ['normal', 'popup'] },
             (chromeWindows: chrome.windows.Window[]) => {
                 chromeWindows.forEach((chromeWindow: chrome.windows.Window) => {
-                    this.browserAdapter.getSelectedTabInWindow(chromeWindow.id, (activeTab: chrome.tabs.Tab) => {
-                        if (!this.browserAdapter.getRuntimeLastError()) {
-                            if (activeTab) {
-                                this.sendTabVisibilityChangeAction(activeTab.id, chromeWindow.state === 'minimized');
+                    this.browserAdapter.tabsQuery(
+                        {
+                            active: true,
+                            windowId: chromeWindow.id,
+                        },
+                        (activeTabs: chrome.tabs.Tab[]) => {
+                            if (!this.browserAdapter.getRuntimeLastError()) {
+                                for (const activeTab of activeTabs) {
+                                    this.sendTabVisibilityChangeAction(activeTab.id, chromeWindow.state === 'minimized');
+                                }
                             }
-                        }
-                    });
+                        },
+                    );
                 });
             },
         );

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -3,7 +3,6 @@
 
 export interface BrowserAdapter {
     getAllWindows(getInfo: chrome.windows.GetInfo, callback: (chromeWindows: chrome.windows.Window[]) => void): void;
-    getSelectedTabInWindow(windowId: number, callback: (activeTab: chrome.tabs.Tab) => void): void;
     addListenerToTabsOnActivated(callback: (activeInfo: chrome.tabs.TabActiveInfo) => void): void;
     addListenerToTabsOnUpdated(callback: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => void): void;
     addListenerToTabsOnRemoved(callback: (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo) => void): void;

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -13,10 +13,6 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         chrome.windows.getAll(getInfo, callback);
     }
 
-    public getSelectedTabInWindow(windowId: number, callback: (activeTab: chrome.tabs.Tab) => void): void {
-        chrome.tabs.getSelected(windowId, callback);
-    }
-
     public addListenerToTabsOnActivated(callback: (activeInfo: chrome.tabs.TabActiveInfo) => void): void {
         chrome.tabs.onActivated.addListener(callback);
     }

--- a/src/tests/unit/tests/background/tab-controller.test.ts
+++ b/src/tests/unit/tests/background/tab-controller.test.ts
@@ -451,16 +451,16 @@ describe('TabControllerTest', () => {
             .verifiable(Times.once());
 
         mockChromeAdapter
-            .setup(ca => ca.getSelectedTabInWindow(windowStub1.id, It.isAny()))
+            .setup(ca => ca.tabsQuery({ windowId: windowStub1.id, active: true }, It.isAny()))
             .callback((id, getSelectedTabInWindowCallback) => {
-                getSelectedTabInWindowCallback(tabStub1 as chrome.tabs.Tab);
+                getSelectedTabInWindowCallback([tabStub1 as chrome.tabs.Tab]);
             })
             .verifiable(Times.once());
 
         mockChromeAdapter
-            .setup(ca => ca.getSelectedTabInWindow(windowStub2.id, It.isAny()))
+            .setup(ca => ca.tabsQuery({ windowId: windowStub2.id, active: true }, It.isAny()))
             .callback((id, getSelectedTabInWindowCallback) => {
-                getSelectedTabInWindowCallback(tabStub2 as chrome.tabs.Tab);
+                getSelectedTabInWindowCallback([tabStub2 as chrome.tabs.Tab]);
             })
             .verifiable(Times.once());
 
@@ -542,16 +542,16 @@ describe('TabControllerTest', () => {
             .verifiable(Times.once());
 
         mockChromeAdapter
-            .setup(ca => ca.getSelectedTabInWindow(windowStub1.id, It.isAny()))
+            .setup(ca => ca.tabsQuery({ windowId: windowStub1.id, active: true }, It.isAny()))
             .callback((id, getSelectedTabInWindowCallback) => {
-                getSelectedTabInWindowCallback(tabStub1 as chrome.tabs.Tab);
+                getSelectedTabInWindowCallback([tabStub1 as chrome.tabs.Tab]);
             })
             .verifiable(Times.once());
 
         mockChromeAdapter
-            .setup(ca => ca.getSelectedTabInWindow(windowStub2.id, It.isAny()))
+            .setup(ca => ca.tabsQuery({ windowId: windowStub2.id, active: true }, It.isAny()))
             .callback((id, getSelectedTabInWindowCallback) => {
-                getSelectedTabInWindowCallback(tabStub2 as chrome.tabs.Tab);
+                getSelectedTabInWindowCallback([tabStub2 as chrome.tabs.Tab]);
             })
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -98,7 +98,6 @@ exports[`PopupView renderFailureMsgPanelForFileUrl 1`] = `
         "getManifest": [Function],
         "getRunTimeId": [Function],
         "getRuntimeLastError": [Function],
-        "getSelectedTabInWindow": [Function],
         "getTab": [Function],
         "getUrl": [Function],
         "getUserData": [Function],


### PR DESCRIPTION
#### Description of changes

Per both the [chrome.tabs docs](https://developer.chrome.com/extensions/tabs#method-getSelected) and [MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/getSelected),

> `chrome.tabs.getSelected(integer windowId, function callback)`
> Deprecated since Chrome 33. Please use tabs.query {active: true}.

I hit this last week when experimenting with Firefox support; in Chrome, the deprecated API still works, but in Firefox, the API is not implemented. But regardless of when we get to Firefox support more broadly, it's good to stop using the deprecated thing.

#### Pull request checklist

- [x] Addresses an existing issue: Part of #445
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
