### PR TITLE
chore: suppress character encoding console.errors

### DIFF
--- a/src/DetailsView/detailsView.html
+++ b/src/DetailsView/detailsView.html
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 
 <html dir="ltr" lang="en">
     <head>
+        <meta charset="utf-8" />
         <link rel="shortcut icon" type="image/x-icon" href="../icons/brand/blue/brand-blue-16px.png" />
         <link rel="stylesheet" type="text/css" href="../common/styles/fabric.min.css" />
         <link rel="stylesheet" type="text/css" href="./styles/default/detailsview.css" />

--- a/src/Devtools/devtools.html
+++ b/src/Devtools/devtools.html
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 -->
 <html>
     <head>
+        <meta charset="utf-8" />
         <script src="../insights.config.js"></script>
     </head>
 

--- a/src/assessments/color/test-steps/flashing-text-example.html
+++ b/src/assessments/color/test-steps/flashing-text-example.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="utf-8" />
         <style>
             /* @group Blink */
             .blink {

--- a/src/background/background.html
+++ b/src/background/background.html
@@ -4,6 +4,7 @@ Licensed under the MIT License.
 -->
 <html>
     <head>
+        <meta charset="utf-8" />
         <script src="../insights.config.js"></script>
     </head>
     <body>

--- a/src/insights.html
+++ b/src/insights.html
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 
 <html dir="ltr" lang="en">
     <head>
+        <meta charset="utf-8" />
         <link rel="shortcut icon" type="image/x-icon" href="./icons/brand/blue/brand-blue-16px.png" />
         <link rel="stylesheet" type="text/css" href="./common/styles/fabric.min.css" />
         <link rel="stylesheet" type="text/css" href="./views/insights/insights.css" />

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 
 <html dir="ltr" lang="en">
     <head>
+        <meta charset="utf-8" />
         <link rel="stylesheet" type="text/css" href="../common/styles/fabric.min.css" />
         <link rel="stylesheet" type="text/css" href="./styles/default/popup.css" />
         <link rel="stylesheet" type="text/css" href="../bundle/popup.css" />

--- a/src/tests/end-to-end/test-resources/all.html
+++ b/src/tests/end-to-end/test-resources/all.html
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8" />
         <title>All Pages</title>
     </head>
 

--- a/src/tests/end-to-end/test-resources/headings/all-level-headings.html
+++ b/src/tests/end-to-end/test-resources/headings/all-level-headings.html
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <meta charset="utf-8" />
         <title>Headings - All Levels</title>
     </head>
 

--- a/src/tests/end-to-end/test-resources/image/image-text.html
+++ b/src/tests/end-to-end/test-resources/image/image-text.html
@@ -4,6 +4,9 @@ Licensed under the MIT License.
 -->
 <!DOCTYPE html>
 <html>
+    <head>
+        <meta charset="utf-8" />
+    </head>
     <body>
         <h1>Decorative text</h1>
         <ul>

--- a/src/tests/end-to-end/test-resources/native-widgets/input-type-radio.html
+++ b/src/tests/end-to-end/test-resources/native-widgets/input-type-radio.html
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 <!DOCTYPE html>
 <html>
     <head>
+        <meta charset="utf-8" />
         <title>Input radio - Native Widgets</title>
     </head>
 


### PR DESCRIPTION
#### Description of changes

In Firefox, HTML pages that don't have charsets specified explicitly cause console.errors. This fixes those errors by explicitly specifying the encoding we were previously using implicitly (utf-8).

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
