### PR TITLE
fix: avoid popup being invisible in Firefox

### DIFF
--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -5,7 +5,7 @@
 body {
     margin: 0;
     overflow-y: auto;
-    height: 0px;
+    height: fit-content; // required for the popup's window to resize properly when the details view is zoomed in/out
     background: $neutral-0;
     font-family: $fontFamily;
 }
@@ -49,7 +49,7 @@ div.insights-dialog-main-override.telemetry-permission-dialog {
 }
 
 html {
-    height: 0px; //required for properly resize the popup when zoom in/out
+    height: fit-content; // required for the popup's window to resize properly when the details view is zoomed in/out
 }
 
 // The CSS selector here specifically targets Microsoft Edge.


### PR DESCRIPTION
#### Description of changes

For some time, the extension's popup window has used CSS that sets `body, html { height: 0px; }` as a workaround for a Chromium issue where, without that CSS, the popup window does not resize like it should when its content is zoomed in/out. It doesn't actually set the window height to 0; it forces it to dynamically fit the content.

(note that, due to a *separate* Chromium issue, you can't zoom in/out on the popup content directly; to observe this, you need to have the popup open while you're zooming in/out on a different extension page, like the details page)

In Firefox, the original workaround has the effect you would *actually* expect, and causes the popup window to be of 0 height, ie, invisible. Using `fit-content` instead of `0px` still achieves the desired dynamic zoom behavior in Chrome, but also achieves a correct popup window size in Firefox.

Note that this fix does *not* allow for correct popup window zooming in Firefox; it only enables correct window sizing in Firefox at the 100% zoom level. Popup window sizing at other zoom levels is broken in Firefox due to [Firefox bug 1570849](https://bugzilla.mozilla.org/show_bug.cgi?id=1570849), which appears to affect all extensions that use this type of popup window.

**Before:**
Firefox:
![firefox-before](https://user-images.githubusercontent.com/376284/62339965-b9fb7480-b492-11e9-97bd-d96e7367b2e9.gif)

Chrome:
![chrome-before](https://user-images.githubusercontent.com/376284/62339973-c2ec4600-b492-11e9-9db3-100b5af003a2.gif)

**After:**
Firefox:
![firefox-after](https://user-images.githubusercontent.com/376284/62339988-d39cbc00-b492-11e9-8e8b-598e86590acd.gif)

Chrome:
![chrome-after](https://user-images.githubusercontent.com/376284/62339972-c1bb1900-b492-11e9-8b18-594293749184.gif)

#### Pull request checklist

- [x] Addresses an existing issue: Part of #445 
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
