### PR TITLE
Clear PathSnippet Store on Refresh

### DIFF
--- a/src/background/stores/path-snippet-store.ts
+++ b/src/background/stores/path-snippet-store.ts
@@ -3,10 +3,11 @@
 import { StoreNames } from '../../common/stores/store-names';
 import { PathSnippetStoreData } from '../../common/types/store-data/path-snippet-store-data';
 import { PathSnippetActions } from '../actions/path-snippet-actions';
+import { TabActions } from '../actions/tab-actions';
 import { BaseStoreImpl } from './base-store-impl';
 
 export class PathSnippetStore extends BaseStoreImpl<PathSnippetStoreData> {
-    constructor(private readonly pathSnippetActions: PathSnippetActions) {
+    constructor(private readonly pathSnippetActions: PathSnippetActions, private readonly tabActions: TabActions) {
         super(StoreNames.PathSnippetStore);
     }
 
@@ -23,6 +24,7 @@ export class PathSnippetStore extends BaseStoreImpl<PathSnippetStoreData> {
         this.pathSnippetActions.getCurrentState.addListener(this.onGetCurrentState);
         this.pathSnippetActions.onAddPath.addListener(payload => this.onChangeProperty('path', payload));
         this.pathSnippetActions.onAddSnippet.addListener(payload => this.onChangeProperty('snippet', payload));
+        this.tabActions.tabChange.addListener(this.onClearState);
         this.pathSnippetActions.onClearData.addListener(this.onClearState);
     }
 

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -53,7 +53,7 @@ export class TabContextStoreHub implements StoreHub {
         this.inspectStore = new InspectStore(actionHub.inspectActions, actionHub.tabActions);
         this.inspectStore.initialize();
 
-        this.pathSnippetStore = new PathSnippetStore(actionHub.pathSnippetActions);
+        this.pathSnippetStore = new PathSnippetStore(actionHub.pathSnippetActions, actionHub.tabActions);
         this.pathSnippetStore.initialize();
     }
 

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -62,7 +62,7 @@ export class StoreMocks {
     public userConfigurationStoreData = new UserConfigurationStore(null, null, null).getDefaultState();
     public scopingStoreData = new ScopingStore(null).getDefaultState();
     public inspectStoreData = new InspectStore(null, null).getDefaultState();
-    public pathSnippetStoreData = new PathSnippetStore(null).getDefaultState();
+    public pathSnippetStoreData = new PathSnippetStore(null, null).getDefaultState();
     public launchPanelStateStoreData = new LaunchPanelStore(null, null, null).getDefaultState();
     public featureFlagStoreData: FeatureFlagStoreData = {
         [FeatureFlags[FeatureFlags.logTelemetryToConsole]]: false,

--- a/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
+++ b/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { PathSnippetActions } from '../../../../../background/actions/path-snippet-actions';
+import { TabActions } from '../../../../../background/actions/tab-actions';
 import { PathSnippetStore } from '../../../../../background/stores/path-snippet-store';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import { PathSnippetStoreData } from '../../../../../common/types/store-data/path-snippet-store-data';
@@ -65,12 +66,31 @@ describe('PathSnippetStoreTest', () => {
             .testListenerToBeCalledOnce(initialState, finalState);
     });
 
+    test('on clearState from tab change', () => {
+        const initialState = {
+            path: 'test path',
+            snippet: 'test snippet',
+        };
+        const finalState = getDefaultState();
+
+        createStoreForTabActions('tabChange')
+            .withActionParam(null)
+            .testListenerToBeCalledOnce(initialState, finalState);
+    });
+
     function getDefaultState(): PathSnippetStoreData {
         return createStoreWithNullParams(PathSnippetStore).getDefaultState();
     }
 
     function createStoreForPathSnippetActions(actionName: keyof PathSnippetActions): StoreTester<PathSnippetStoreData, PathSnippetActions> {
-        const factory = (actions: PathSnippetActions) => new PathSnippetStore(actions);
+        const tabActions = new TabActions();
+        const factory = (actions: PathSnippetActions) => new PathSnippetStore(actions, tabActions);
+
         return new StoreTester(PathSnippetActions, actionName, factory);
+    }
+
+    function createStoreForTabActions(actionName: keyof TabActions): StoreTester<PathSnippetStoreData, TabActions> {
+        const factory = (actions: TabActions) => new PathSnippetStore(new PathSnippetActions(), actions);
+        return new StoreTester(TabActions, actionName, factory);
     }
 });


### PR DESCRIPTION
#### Description of changes

Now, when the page is refreshed the path and snippet fields in the Failure Instance Panel will reset to blank (following the same behavior as the comment field). Just added a listener to Tab Actions within the Path Snippet Store, testing in the Path Snippet Store Test file.

#### Pull request checklist

- [X] Addresses an existing issue: PR for Feature #1555720
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [X] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS


![refresh](https://user-images.githubusercontent.com/24820607/62478505-1ba43300-b760-11e9-92bb-77f6fb2e109b.gif)
