### PR TITLE
test: add a workaround for various flaky e2e click operations

### DIFF
--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -56,7 +56,10 @@ export class Page {
     }
 
     public async goto(url: string): Promise<void> {
-        await this.screenshotOnError(async () => await this.underlyingPage.goto(url, { timeout: DEFAULT_NEW_PAGE_WAIT_TIMEOUT_MS }));
+        await this.screenshotOnError(async () => {
+            await this.underlyingPage.goto(url, { timeout: DEFAULT_NEW_PAGE_WAIT_TIMEOUT_MS });
+            await this.underlyingPage.waitFor(200);
+        });
         await this.disableAnimations();
     }
 
@@ -140,14 +143,14 @@ export class Page {
     public async clickSelector(selector: string): Promise<void> {
         const element = await this.waitForSelector(selector);
         await this.screenshotOnError(async () => {
-            await element.click({ delay: 50 });
+            await element.click();
         });
     }
 
     public async clickSelectorXPath(xpath: string): Promise<void> {
         const element = await this.waitForSelectorXPath(xpath);
         await this.screenshotOnError(async () => {
-            await element.click({ delay: 50 });
+            await element.click();
         });
     }
 

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -3,6 +3,7 @@
 import * as Puppeteer from 'puppeteer';
 
 import { includes } from 'lodash';
+import { element } from 'prop-types';
 import { forceTestFailure } from '../force-test-failure';
 import { takeScreenshot } from '../generate-screenshot';
 import { DEFAULT_NEW_PAGE_WAIT_TIMEOUT_MS, DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS } from '../timeouts';
@@ -139,14 +140,14 @@ export class Page {
     public async clickSelector(selector: string): Promise<void> {
         const element = await this.waitForSelector(selector);
         await this.screenshotOnError(async () => {
-            await element.click();
+            await element.click({ delay: 50 });
         });
     }
 
     public async clickSelectorXPath(xpath: string): Promise<void> {
         const element = await this.waitForSelectorXPath(xpath);
         await this.screenshotOnError(async () => {
-            await element.click();
+            await element.click({ delay: 50 });
         });
     }
 

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -3,7 +3,6 @@
 import * as Puppeteer from 'puppeteer';
 
 import { includes } from 'lodash';
-import { element } from 'prop-types';
 import { forceTestFailure } from '../force-test-failure';
 import { takeScreenshot } from '../generate-screenshot';
 import { DEFAULT_NEW_PAGE_WAIT_TIMEOUT_MS, DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS } from '../timeouts';
@@ -58,6 +57,12 @@ export class Page {
     public async goto(url: string): Promise<void> {
         await this.screenshotOnError(async () => {
             await this.underlyingPage.goto(url, { timeout: DEFAULT_NEW_PAGE_WAIT_TIMEOUT_MS });
+
+            // This waitFor is a hack to work around a class of various different flakiness issues that generally take the form of
+            // "some button had been loaded into the DOM, but when we clicked on it, nothing happened". We would prefer to use a more
+            // reliable mechanism to wait for those elements being interactable; #1011 tracks adding and using such a mechanism.
+            //
+            // 200ms was chosen based on experimentation; it was the lowest value that reliably worked around the class of issue.
             await this.underlyingPage.waitFor(200);
         });
         await this.disableAnimations();


### PR DESCRIPTION
#### Description of changes

This PR addresses a class of e2e flakiness (#867) with the signature of "some button had been loaded into the DOM, but when we clicked on it, nothing happened". We were seeing this in about 5% of runs before this change. With this change, 135 runs never showed this class of issue (15x9: [1](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=28624) [2](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=28625) [3](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=28626) [4](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=28809) [5](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=28810) [6](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=28811) [7](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=28822) [8](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=28823) [9](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=28824)) - in those runs, we saw 3 issues total (1 where a page timed out after 5s of trying to navigate to it, and 2 where all tests passed but Puppeteer hanged while trying to close the browser afterwards).

Using `waitFor(200)` is a hack/workaround; issue #1011 was filed to separately track improving this to identify what the actual missing initialization is and waiting for that instead of the 200ms.

#### Pull request checklist

- [x] Addresses an existing issue: Addresses #867
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
