### PR TITLE
Add cross platform electron e2e tests to PR build

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -80,3 +80,24 @@ jobs:
                 pathtoPublish: '$(System.DefaultWorkingDirectory)/dist'
                 artifactName: 'dist'
             displayName: publish dist
+
+    - job: 'electron_tests_mac'
+      pool:
+          vmImage: macOS-10.14
+      steps:
+          - template: pipeline/install-node-prerequisites.yaml
+          - template: pipeline/electron-e2e-test.yaml
+
+    - job: 'electron_tests_linux'
+      pool:
+          vmImage: ubuntu-16.04
+      steps:
+          - template: pipeline/install-node-prerequisites.yaml
+          - template: pipeline/electron-e2e-test.yaml
+
+    - job: 'electron_tests_windows'
+      pool:
+          vmImage: windows-latest
+      steps:
+          - template: pipeline/install-node-prerequisites.yaml
+          - template: pipeline/electron-e2e-test.yaml

--- a/build.yaml
+++ b/build.yaml
@@ -81,9 +81,26 @@ jobs:
                 artifactName: 'dist'
             displayName: publish dist
 
+    - job: 'electron_tests_mac'
+      pool:
+          vmImage: macOS-10.14
+      steps:
+          - template: pipeline/install-node-prerequisites.yaml
+          - template: pipeline/electron/electron-e2e-test-interactive.yaml
+          - template: pipeline/electron/electron-e2e-publish-results.yaml
+
     - job: 'electron_tests_linux'
       pool:
           vmImage: ubuntu-16.04
       steps:
           - template: pipeline/install-node-prerequisites.yaml
-          - template: pipeline/electron-e2e-test.yaml
+          - template: pipeline/electron/electron-e2e-test-linux.yaml
+          - template: pipeline/electron/electron-e2e-publish-results.yaml
+
+    - job: 'electron_tests_windows'
+      pool:
+          vmImage: windows-latest
+      steps:
+          - template: pipeline/install-node-prerequisites.yaml
+          - template: pipeline/electron/electron-e2e-test-interactive.yaml
+          - template: pipeline/electron/electron-e2e-publish-results.yaml

--- a/build.yaml
+++ b/build.yaml
@@ -81,23 +81,9 @@ jobs:
                 artifactName: 'dist'
             displayName: publish dist
 
-    - job: 'electron_tests_mac'
-      pool:
-          vmImage: macOS-10.14
-      steps:
-          - template: pipeline/install-node-prerequisites.yaml
-          - template: pipeline/electron-e2e-test.yaml
-
     - job: 'electron_tests_linux'
       pool:
           vmImage: ubuntu-16.04
-      steps:
-          - template: pipeline/install-node-prerequisites.yaml
-          - template: pipeline/electron-e2e-test.yaml
-
-    - job: 'electron_tests_windows'
-      pool:
-          vmImage: windows-latest
       steps:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/electron-e2e-test.yaml

--- a/pipeline/electron-e2e-test.yaml
+++ b/pipeline/electron-e2e-test.yaml
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+steps:
+    - script: yarn build:electron
+      displayName: build:electron
+
+    - script: yarn test:electron --ci
+      displayName: run electron e2e tests
+
+    - task: PublishTestResults@2
+      inputs:
+          testResultsFiles: test-results/electron/junit-electron.xml
+          testRunTitle: $(Agent.JobName)
+      condition: succeededOrFailed()
+      displayName: publish electron e2e test results

--- a/pipeline/electron-e2e-test.yaml
+++ b/pipeline/electron-e2e-test.yaml
@@ -4,7 +4,7 @@ steps:
     - script: yarn build:electron
       displayName: build:electron
 
-    - script: yarn test:electron --ci
+    - script: xvfb-run --server-args="-screen 0 1024x768x24" yarn test:electron --ci
       displayName: run electron e2e tests
 
     - task: PublishTestResults@2

--- a/pipeline/electron/electron-e2e-publish-results.yaml
+++ b/pipeline/electron/electron-e2e-publish-results.yaml
@@ -1,12 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 steps:
-    - script: yarn build:electron
-      displayName: build:electron
-
-    - script: xvfb-run --server-args="-screen 0 1024x768x24" yarn test:electron --ci
-      displayName: run electron e2e tests
-
     - task: PublishTestResults@2
       inputs:
           testResultsFiles: test-results/electron/junit-electron.xml

--- a/pipeline/electron/electron-e2e-test-interactive.yaml
+++ b/pipeline/electron/electron-e2e-test-interactive.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+steps:
+    - script: yarn build:electron
+      displayName: build:electron
+
+    - script: yarn test:electron --ci
+      displayName: run electron e2e tests

--- a/pipeline/electron/electron-e2e-test-linux.yaml
+++ b/pipeline/electron/electron-e2e-test-linux.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+steps:
+    - script: yarn build:electron
+      displayName: build:electron
+
+    - script: xvfb-run --server-args="-screen 0 1024x768x24" yarn test:electron --ci
+      displayName: run electron e2e tests


### PR DESCRIPTION
#### Description of changes
PR #1001 added some electron e2e tests. This PR runs those tests on mac, linux, and windows as a part of the PR/CI builds. Since the linux agents appear to be non-interactive, we have to use xvfb to run tests on them.

#### Pull request checklist

- [x] Ran precheckin (`yarn precheckin`)