### PR TITLE
clear path on refresh of detailsview

### DIFF
--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -64,6 +64,10 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
         };
     }
 
+    public componentDidMount(): void {
+        this.props.clearPathSnippetData();
+    }
+
     public componentDidUpdate(prevProps: Readonly<FailureInstancePanelControlProps>): void {
         if (isEqual(prevProps, this.props) === false) {
             this.setState(() => ({

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -236,10 +236,10 @@ describe('FailureInstancePanelControlTest', () => {
         };
         props.failureInstance = failureInstance;
 
-        const wrapper = shallow<FailureInstancePanelControl>(<FailureInstancePanelControl {...props} />);
-        (wrapper.instance() as FailureInstancePanelControl).componentDidMount();
+        const component = new FailureInstancePanelControl(props);
+        component.componentDidMount();
 
-        clearPathSnippetDataMock.verify(handler => handler(), Times.exactly(2));
+        clearPathSnippetDataMock.verify(handler => handler(), Times.exactly(1));
     });
 
     test('componentDidUpdate reassigns state', () => {

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -159,7 +159,7 @@ describe('FailureInstancePanelControlTest', () => {
         // This shouldn't be cleared because it stays briefly visible as the panel close animation happens
         expect(wrapper.state().currentInstance.failureDescription).toEqual(description);
 
-        clearPathSnippetDataMock.verify(handler => handler(), Times.once());
+        clearPathSnippetDataMock.verify(handler => handler(), Times.exactly(2));
     });
 
     test('onSaveEditedFailureInstance', () => {
@@ -193,7 +193,7 @@ describe('FailureInstancePanelControlTest', () => {
         expect(wrapper.state().currentInstance.failureDescription).toEqual(description);
 
         editInstanceMock.verifyAll();
-        clearPathSnippetDataMock.verify(handler => handler(), Times.once());
+        clearPathSnippetDataMock.verify(handler => handler(), Times.exactly(2));
     });
 
     test('onAddFailureInstance', () => {
@@ -224,7 +224,22 @@ describe('FailureInstancePanelControlTest', () => {
         expect(wrapper.state().currentInstance.failureDescription).toEqual(description);
 
         addInstanceMock.verifyAll();
-        clearPathSnippetDataMock.verify(handler => handler(), Times.once());
+        clearPathSnippetDataMock.verify(handler => handler(), Times.exactly(2));
+    });
+
+    test('componentDidMount clears store', () => {
+        const props = createPropsWithType(CapturedInstanceActionType.CREATE);
+        const failureInstance = {
+            failureDescription: null,
+            path: 'inputed path',
+            snippet: 'snippet for path',
+        };
+        props.failureInstance = failureInstance;
+
+        const wrapper = shallow<FailureInstancePanelControl>(<FailureInstancePanelControl {...props} />);
+        (wrapper.instance() as FailureInstancePanelControl).componentDidMount();
+
+        clearPathSnippetDataMock.verify(handler => handler(), Times.exactly(2));
     });
 
     test('componentDidUpdate reassigns state', () => {


### PR DESCRIPTION
#### Description of changes

Clears the PathSnippet store *only* on the refresh of the Details View Page (not the Target Page) to follow the behavior of the comment in the Failure Instance Panel. We do this by clearing the store within the panel's ComponentDidMount in order to clear on the first render of the panel as it is inserted into the DOM. This means the PathSnippet store is cleared twice per panel usage (once on open and once on close) we decided to keep it this way in case we changed refresh behavior in the future/just to be safer.

#### Pull request checklist

- [X] Addresses an existing issue: PR for Feature #1555720
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [X] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS


![refresh](https://user-images.githubusercontent.com/24820607/62559738-5a092300-b830-11e9-9efe-c4a29d5841b8.gif)
