### PR TITLE
Build mac executables in ADO

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -64,40 +64,6 @@ jobs:
                 artifactName: 'drop'
             displayName: publish drop
 
-    # CI build only
-    - job: 'publish_electron_windows_linux'
-      #condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
-      pool:
-          vmImage: 'windows-latest'
-      steps:
-          - template: pipeline/install-node-prerequisites.yaml
-
-          - script: yarn dist:electron -wl
-            displayName: create electron distributables
-
-          - task: PublishBuildArtifacts@1
-            inputs:
-                pathtoPublish: '$(System.DefaultWorkingDirectory)/dist'
-                artifactName: $(Agent.JobName)
-            displayName: publish dist
-
-    # CI build only
-    - job: 'publish_electron_mac'
-      #condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
-      pool:
-          vmImage: 'macOS-10.14'
-      steps:
-          - template: pipeline/install-node-prerequisites.yaml
-
-          - script: yarn dist:electron -m
-            displayName: create electron distributables
-
-          - task: PublishBuildArtifacts@1
-            inputs:
-                pathtoPublish: '$(System.DefaultWorkingDirectory)/dist'
-                artifactName: $(Agent.JobName)
-            displayName: publish dist
-
     - job: 'electron_tests_mac'
       pool:
           vmImage: macOS-10.14
@@ -121,3 +87,23 @@ jobs:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/electron/electron-e2e-test-interactive.yaml
           - template: pipeline/electron/electron-e2e-publish-results.yaml
+
+    # CI build only
+    - job: 'publish_electron_windows_linux'
+      #condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+      pool:
+          vmImage: 'windows-latest'
+      steps:
+          - template: pipeline/distribute-electron.yaml
+            parameters:
+                platforms: -wl
+
+    # CI build only
+    - job: 'publish_electron_mac'
+      #condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+      pool:
+          vmImage: 'macOS-10.14'
+      steps:
+          - template: pipeline/distribute-electron.yaml
+            parameters:
+                platforms: -m

--- a/build.yaml
+++ b/build.yaml
@@ -65,18 +65,35 @@ jobs:
             displayName: publish drop
 
     # CI build only
-    - job: 'publish_electron_dist'
-      condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    - job: 'publish_electron_windows_linux'
+      #condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
       pool:
           vmImage: 'windows-latest'
       steps:
           - template: pipeline/install-node-prerequisites.yaml
 
           - script: yarn dist:electron -wl
-            displayName: create electron distributables (windows, linux)
+            displayName: create electron distributables
 
           - task: PublishBuildArtifacts@1
             inputs:
                 pathtoPublish: '$(System.DefaultWorkingDirectory)/dist'
-                artifactName: 'dist'
+                artifactName: $(Agent.JobName)
+            displayName: publish dist
+
+    # CI build only
+    - job: 'publish_electron_mac'
+      #condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+      pool:
+          vmImage: 'macOS-10.14'
+      steps:
+          - template: pipeline/install-node-prerequisites.yaml
+
+          - script: yarn dist:electron -m
+            displayName: create electron distributables
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+                pathtoPublish: '$(System.DefaultWorkingDirectory)/dist'
+                artifactName: $(Agent.JobName)
             displayName: publish dist

--- a/build.yaml
+++ b/build.yaml
@@ -94,7 +94,7 @@ jobs:
       pool:
           vmImage: 'windows-latest'
       steps:
-          - template: pipeline/distribute-electron.yaml
+          - template: pipeline/electron/distribute-electron.yaml
             parameters:
                 platforms: -wl
 
@@ -104,6 +104,6 @@ jobs:
       pool:
           vmImage: 'macOS-10.14'
       steps:
-          - template: pipeline/distribute-electron.yaml
+          - template: pipeline/electron/distribute-electron.yaml
             parameters:
                 platforms: -m

--- a/build.yaml
+++ b/build.yaml
@@ -90,7 +90,7 @@ jobs:
 
     # CI build only
     - job: 'publish_electron_windows_linux'
-      #condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+      condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
       pool:
           vmImage: 'windows-latest'
       steps:
@@ -100,7 +100,7 @@ jobs:
 
     # CI build only
     - job: 'publish_electron_mac'
-      #condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+      condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
       pool:
           vmImage: 'macOS-10.14'
       steps:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,0 +1,10 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+appId: com.aimobile.app
+directories:
+    app: drop/electron
+extraMetadata:
+    main: extension/bundle/main.bundle.js
+    name: ai-mobile
+mac:
+    target: dmg # can be changed to a zip, app or something else. ref: https://www.electron.build/configuration/mac

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "build:prod": "grunt build-prod",
         "copyrightheaders": "grunt copyright-check",
         "copyrightheaders:fix": "grunt copyright-add",
-        "dist:electron": "yarn build:electron && electron-builder -c.extraMetadata.main=drop/electron/extension/bundle/main.bundle.js -c.extraMetadata.name=ai-mobile -p never",
+        "dist:electron": "yarn build:electron && electron-builder -p never",
         "format": "prettier --config prettier.config.js --write \"**/*\"",
         "format-check": "prettier --config prettier.config.js --check \"**/*\"",
         "generate-scss-typings": "tsm \"src/**/*.scss\"",

--- a/pipeline/electron/distribute-electron.yaml
+++ b/pipeline/electron/distribute-electron.yaml
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+parameters:
+    platforms: '' # electron-builder platforms, e.g. -wl for win/linux, -m for mac, etc
+
+steps:
+    - template: pipeline/install-node-prerequisites.yaml
+
+    - script: yarn dist:electron ${{ parameters.platforms }}
+      displayName: create electron distributables
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+          pathtoPublish: '$(System.DefaultWorkingDirectory)/dist'
+          artifactName: $(Agent.JobName)
+      displayName: publish dist

--- a/pipeline/electron/distribute-electron.yaml
+++ b/pipeline/electron/distribute-electron.yaml
@@ -5,7 +5,7 @@ parameters:
     platforms: '' # electron-builder platforms, e.g. -wl for win/linux, -m for mac, etc
 
 steps:
-    - template: pipeline/install-node-prerequisites.yaml
+    - template: ../install-node-prerequisites.yaml
 
     - script: yarn dist:electron ${{ parameters.platforms }}
       displayName: create electron distributables


### PR DESCRIPTION
#### Description of changes

We build a mac executable in ADO and introduce an electron-builder YML file that allows us to specify the app directory and mac target. This also removes unnecessary files from the resulting application, so we're in the 100-200 MB range.

There are opportunities to share agents between different jobs - it seems it might be easier to do this after our web e2e tests are back in.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
