### PR TITLE
fix: fix tslint warning for string based timeout in setInterval

### DIFF
--- a/src/injected/instance-visibility-checker.ts
+++ b/src/injected/instance-visibility-checker.ts
@@ -14,7 +14,7 @@ export class InstanceVisibilityChecker {
     private sendMessage: (message) => void;
     private windowUtils: WindowUtils;
     private htmlElementUtils: HTMLElementUtils;
-    public static recalculationTimeInterval = 1500;
+    public static recalculationTimeInterval: number = 1500;
     private identifierToIntervalMap: DictionaryNumberTo<string> = {};
     private configurationFactory: VisualizationConfigurationFactory;
 

--- a/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
+++ b/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
@@ -104,7 +104,7 @@ describe('InstanceVisibilityCheckerTest', () => {
 
         windowUtilsMock
             .setup(wU => wU.setInterval(itIsFunction, InstanceVisibilityChecker.recalculationTimeInterval))
-            .callback((cb, timeout) => {
+            .callback((cb: Function) => {
                 cb();
             })
             .verifiable(Times.once());

--- a/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
+++ b/src/tests/unit/tests/injected/instance-visibility-checker.test.ts
@@ -173,7 +173,7 @@ describe('InstanceVisibilityCheckerTest', () => {
 
         windowUtilsMock
             .setup(wU => wU.setInterval(itIsFunction, InstanceVisibilityChecker.recalculationTimeInterval))
-            .callback((cb, timeout) => {
+            .callback((cb: Function) => {
                 cb();
             })
             .verifiable(Times.once());
@@ -220,7 +220,7 @@ describe('InstanceVisibilityCheckerTest', () => {
 
         windowUtilsMock
             .setup(wU => wU.setInterval(It.isAny(), InstanceVisibilityChecker.recalculationTimeInterval))
-            .callback((cb, timeout) => {
+            .callback((cb: Function) => {
                 cb();
             })
             .verifiable(Times.once());


### PR DESCRIPTION
#### Description of changes

Fix `no-string-based-set-interval` tslint error from TSA.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes WI #1580137
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
