### PR TITLE
chore: replace uglifyjs with terser for minifying prod builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
         "serve-static": "^1.13.2",
         "source-map-loader": "^0.2.4",
         "spectron": "^8.0.0",
+        "terser-webpack-plugin": "^1.4.1",
         "ts-jest": "^24.0.2",
         "ts-loader": "^6.0.4",
         "tslint": "^5.18.0",
@@ -104,7 +105,6 @@
         "typed-scss-modules": "^0.0.11",
         "typemoq": "^2.1.0",
         "typescript": "^2.9.2",
-        "uglifyjs-webpack-plugin": "^2.2.0",
         "webpack": "^4.39.1",
         "webpack-cli": "^3.3.6"
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserWebpackPlugin = require('terser-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
@@ -153,9 +153,9 @@ const prodConfig = {
     optimization: {
         splitChunks: false,
         minimizer: [
-            new UglifyJsPlugin({
+            new TerserWebpackPlugin({
                 sourceMap: false,
-                uglifyOptions: {
+                terserOptions: {
                     compress: false,
                     mangle: false,
                     output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8464,28 +8464,13 @@ ua-parser-js@^0.7.20:
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.20.tgz#7527178b82f6a62a0f243d1f94fd30e3e3c21098"
   integrity sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw==
 
-uglify-js@^3.1.4, uglify-js@^3.6.0:
+uglify-js@^3.1.4:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
   integrity sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==
   dependencies:
     commander "~2.20.0"
     source-map "~0.6.1"
-
-uglifyjs-webpack-plugin@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.2.0.tgz#e75bc80e7f1937f725954c9b4c5a1e967ea9d0d7"
-  integrity sha512-mHSkufBmBuJ+KHQhv5H0MXijtsoA1lynJt1lXOaotja8/I0pR4L9oGaPIZw+bQBOFittXZg9OC1sXSGO9D9ZYg==
-  dependencies:
-    cacache "^12.0.2"
-    find-cache-dir "^2.1.0"
-    is-wsl "^1.1.0"
-    schema-utils "^1.0.0"
-    serialize-javascript "^1.7.0"
-    source-map "^0.6.1"
-    uglify-js "^3.6.0"
-    webpack-sources "^1.4.0"
-    worker-farm "^1.7.0"
 
 unc-path-regex@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
#### Description of changes

Replaces the minifier we're using on prod builds from `uglify-js` to `terser`.

Terser is a more updated replacement for UglifyJS. Webpack 4 switched to using it as the default minifier in Nov 2018 (https://github.com/webpack/webpack/pull/8392). The reasons we'd want to switch:

* Unblocks future updates to typescript output target; uglify only supports up to ES5 javascript, Terser supports more recent javascript as input
* Closer to the "normal" webpack happy path
* As of recently, [more widely used (with webpack)](https://www.npmtrends.com/uglifyjs-webpack-plugin-vs-terser-webpack-plugin)

It is essentially a drop in replacement; we expect no customer-visible changes as a result of this update.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
