### PR TITLE
Adding CSS to Failure Instance Panel

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -221,15 +221,56 @@ div.insights-file-issue-details-dialog-container {
     }
     .add-failure-instruction {
         font-weight: 500;
-        margin-bottom: 20px;
-        margin-top: 20px;
+        margin: 20px 0px 20px 0px;
     }
     .header-text {
         margin-top: 30px;
         font-size: 21px;
     }
-}
+    .footer {
+        margin: 8px 0px 16px 0px;
+        padding: 16px 0px 16px 0px;
+        border-top: #edebe9 1px solid;
+    }
+    .learn-more {
+        color: $communication-primary;
+        text-decoration: none;
+        display: inline-block;
+        margin-bottom: 24px;
+    }
+    .failure-instance-snippet-title {
+        margin: 24px 0px 8px 0px;
+        color: $primary-text;
+    }
 
+    .failure-instance-snippet-empty-body {
+        margin: 8px 0px 24px 0px;
+        color: $secondary-text;
+    }
+    .failure-instance-snippet-filled-body {
+        margin: 8px 0px 24px 0px;
+        padding: 12px 16px 12px 16px;
+        max-height: 200px;
+        color: $primary-text;
+        background-color: $neutral-4;
+        overflow-y: scroll;
+        word-wrap: break-word;
+    }
+    .failure-instance-snippet-error {
+        margin: 9px 0px 50px 9px;
+        color: $secondary-text;
+        display: flex;
+        flex-direction: row;
+    }
+    .failure-instance-snippet-error-icon {
+        color: $negative-outcome;
+        padding: 3px 8px;
+    }
+}
+.failure-instance-selector-note {
+    color: $secondary-text;
+    margin: 8px 0px 8px 0px;
+}
 .preview-features-panel {
     .preview-feature-toggle-list {
         margin-top: 2vh;
@@ -623,9 +664,18 @@ div.insights-file-issue-details-dialog-container {
             .assessment-instance-label.not-applicable {
                 font-size: 10px;
             }
-            .assessment-instance-textContent {
+            .all-content {
+                display: flex;
+                flex-direction: row;
+                vertical-align: center;
                 font-size: 14px;
                 line-height: 24px;
+            }
+            .instance-header {
+                color: $primary-text;
+                white-space: pre;
+            }
+            .assessment-instance-textContent {
                 overflow: hidden;
                 white-space: nowrap;
                 text-overflow: ellipsis;

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -228,9 +228,7 @@ div.insights-file-issue-details-dialog-container {
         font-size: 21px;
     }
     .footer {
-        margin: 8px 0px 16px 0px;
-        padding: 16px 0px 16px 0px;
-        border-top: #edebe9 1px solid;
+        padding: 16px 16px 16px 0px;
     }
     .learn-more {
         color: $communication-primary;

--- a/src/DetailsView/components/assessment-instance-details-column.tsx
+++ b/src/DetailsView/components/assessment-instance-details-column.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 
 export interface AssessmentInstanceDetailsColumnProps {
     labelText?: string;
+    headerText?: string;
     textContent: string;
     background: string;
     tooltipId: string;
@@ -15,6 +16,7 @@ export interface AssessmentInstanceDetailsColumnProps {
 export class AssessmentInstanceDetailsColumn extends React.Component<AssessmentInstanceDetailsColumnProps> {
     public render(): JSX.Element {
         const showLabel = !!this.props.labelText;
+        const showHeader = !!this.props.headerText;
         const textContent = this.props.textContent;
 
         const classNames = css('assessment-instance-label', this.props.customClassName);
@@ -28,7 +30,10 @@ export class AssessmentInstanceDetailsColumn extends React.Component<AssessmentI
                 ) : null}
                 <div>
                     <TooltipHost content={textContent} calloutProps={{ gapSpace: 0 }}>
-                        <div className="assessment-instance-textContent">{textContent}</div>
+                        <div className="all-content">
+                            {showHeader ? <strong className="instance-header">{this.props.headerText} </strong> : null}
+                            <div className="assessment-instance-textContent">{textContent}</div>
+                        </div>
                     </TooltipHost>
                 </div>
             </div>

--- a/src/DetailsView/components/assessment-table-column-config-handler.tsx
+++ b/src/DetailsView/components/assessment-table-column-config-handler.tsx
@@ -108,11 +108,13 @@ export class AssessmentTableColumnConfigHandler {
     }
 
     private onRenderCapturedInstanceDetailsColumn(item: CapturedInstanceRowData): JSX.Element {
+        const headerText = item.instance.description ? 'Comment:' : 'Path:';
+        const textContent = item.instance.description ? item.instance.description : item.instance.selector;
         return (
             <AssessmentInstanceDetailsColumn
                 background={'#767676'}
-                labelText={'N/A'}
-                textContent={item.instance.description}
+                textContent={textContent}
+                headerText={headerText}
                 tooltipId={item.instance.id}
                 customClassName="not-applicable"
             />

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -150,6 +150,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
     }
 
     private getActionCancelButtons = (): JSX.Element => {
+        const createMode = this.props.actionType === CapturedInstanceActionType.CREATE ? true : false;
         return (
             <div className="footer">
                 <ActionAndCancelButtonsComponent
@@ -157,12 +158,8 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                     primaryButtonDisabled={
                         this.state.currentInstance.failureDescription === null && this.state.currentInstance.path === null
                     }
-                    primaryButtonText={this.props.actionType === CapturedInstanceActionType.CREATE ? 'Add failed instance' : 'Save'}
-                    primaryButtonOnClick={
-                        this.props.actionType === CapturedInstanceActionType.CREATE
-                            ? this.onAddFailureInstance
-                            : this.onSaveEditedFailureInstance
-                    }
+                    primaryButtonText={createMode ? 'Add failed instance' : 'Save'}
+                    primaryButtonOnClick={createMode ? this.onAddFailureInstance : this.onSaveEditedFailureInstance}
                     cancelButtonOnClick={this.closeFailureInstancePanel}
                 />
             </div>

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -121,8 +121,9 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                 this.props.actionType === CapturedInstanceActionType.CREATE
                     ? FailureInstancePanelControl.addFailureInstanceLabel
                     : 'Edit failure instance',
-            hasCloseButton: false,
-            closeButtonAriaLabel: null,
+            hasCloseButton: true,
+            closeButtonAriaLabel: 'Close failure instance panel',
+            onRenderFooterContent: this.getActionCancelButtons,
         };
 
         return (
@@ -135,19 +136,26 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                 />
                 <TextField
                     className="observed-failure-textfield"
-                    label="Comments"
+                    label="Comment"
                     multiline={true}
-                    rows={8}
+                    rows={4}
                     value={this.state.currentInstance.failureDescription}
                     onChange={this.onFailureDescriptionChange}
                     resizable={false}
                 />
+            </GenericPanel>
+        );
+    }
+
+    private getActionCancelButtons = (): JSX.Element => {
+        return (
+            <div className="footer">
                 <ActionAndCancelButtonsComponent
                     isHidden={false}
                     primaryButtonDisabled={
                         this.state.currentInstance.failureDescription === null && this.state.currentInstance.path === null
                     }
-                    primaryButtonText={this.props.actionType === CapturedInstanceActionType.CREATE ? 'Add' : 'Save'}
+                    primaryButtonText={this.props.actionType === CapturedInstanceActionType.CREATE ? 'Add failed instance' : 'Save'}
                     primaryButtonOnClick={
                         this.props.actionType === CapturedInstanceActionType.CREATE
                             ? this.onAddFailureInstance
@@ -155,9 +163,9 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                     }
                     cancelButtonOnClick={this.closeFailureInstancePanel}
                 />
-            </GenericPanel>
+            </div>
         );
-    }
+    };
 
     private getFailureInstancePanelDetails = (): JSX.Element => {
         return (

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -150,7 +150,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
     }
 
     private getActionCancelButtons = (): JSX.Element => {
-        const createMode = this.props.actionType === CapturedInstanceActionType.CREATE ? true : false;
+        const createMode = this.props.actionType === CapturedInstanceActionType.CREATE;
         return (
             <div className="footer">
                 <ActionAndCancelButtonsComponent

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -150,7 +150,14 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
     }
 
     private getActionCancelButtons = (): JSX.Element => {
-        const createMode = this.props.actionType === CapturedInstanceActionType.CREATE;
+        let primaryButtonText = 'Save';
+        let primaryButtonOnClick = this.onSaveEditedFailureInstance;
+
+        if (this.props.actionType === CapturedInstanceActionType.CREATE) {
+            primaryButtonText = 'Add failed instance';
+            primaryButtonOnClick = this.onAddFailureInstance;
+        }
+
         return (
             <div className="footer">
                 <ActionAndCancelButtonsComponent
@@ -158,8 +165,8 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                     primaryButtonDisabled={
                         this.state.currentInstance.failureDescription === null && this.state.currentInstance.path === null
                     }
-                    primaryButtonText={createMode ? 'Add failed instance' : 'Save'}
-                    primaryButtonOnClick={createMode ? this.onAddFailureInstance : this.onSaveEditedFailureInstance}
+                    primaryButtonText={primaryButtonText}
+                    primaryButtonOnClick={primaryButtonOnClick}
                     cancelButtonOnClick={this.closeFailureInstancePanel}
                 />
             </div>

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -3,8 +3,9 @@
 import { clone, isEqual } from 'lodash';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { ILabelStyles } from 'office-ui-fabric-react/lib/Label';
 import { Link } from 'office-ui-fabric-react/lib/Link';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { ITextFieldStyles, TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
@@ -137,6 +138,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                 <TextField
                     className="observed-failure-textfield"
                     label="Comment"
+                    styles={getStyles}
                     multiline={true}
                     rows={4}
                     value={this.state.currentInstance.failureDescription}
@@ -230,5 +232,23 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
     protected closeFailureInstancePanel = (): void => {
         this.props.clearPathSnippetData();
         this.setState({ isPanelOpen: false });
+    };
+}
+
+function getStyles(): Partial<ITextFieldStyles> {
+    return {
+        subComponentStyles: {
+            label: getLabelStyles,
+        },
+    };
+}
+
+function getLabelStyles(): ILabelStyles {
+    return {
+        root: [
+            {
+                paddingBottom: 8,
+            },
+        ],
     };
 }

--- a/src/DetailsView/components/failure-instance-panel-details.tsx
+++ b/src/DetailsView/components/failure-instance-panel-details.tsx
@@ -20,7 +20,7 @@ export const FailureInstancePanelDetails = NamedSFC<FailureInstancePanelDetailsP
             return (
                 <div className="failure-instance-snippet-empty-body"> Code snippet will auto-populate based on the CSS selector input.</div>
             );
-        } else if (props.snippet.startsWith('No code snippet map')) {
+        } else if (props.snippet.startsWith('No code snippet is map')) {
             return (
                 <div className="failure-instance-snippet-error">
                     <Icon iconName="statusErrorFull" className="failure-instance-snippet-error-icon" />

--- a/src/DetailsView/components/failure-instance-panel-details.tsx
+++ b/src/DetailsView/components/failure-instance-panel-details.tsx
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { ILabelStyles } from 'office-ui-fabric-react/lib/Label';
+import { ITextFieldStyles, TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 import { NamedSFC } from '../../common/react/named-sfc';
 
@@ -37,6 +38,7 @@ export const FailureInstancePanelDetails = NamedSFC<FailureInstancePanelDetailsP
             </a>
             <TextField
                 label="CSS Selector"
+                styles={getStyles}
                 multiline={true}
                 rows={4}
                 value={props.path}
@@ -57,3 +59,21 @@ export const FailureInstancePanelDetails = NamedSFC<FailureInstancePanelDetailsP
         </div>
     );
 });
+
+function getStyles(): Partial<ITextFieldStyles> {
+    return {
+        subComponentStyles: {
+            label: getLabelStyles,
+        },
+    };
+}
+
+function getLabelStyles(): ILabelStyles {
+    return {
+        root: [
+            {
+                paddingBottom: 8,
+            },
+        ],
+    };
+}

--- a/src/DetailsView/components/failure-instance-panel-details.tsx
+++ b/src/DetailsView/components/failure-instance-panel-details.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 import { NamedSFC } from '../../common/react/named-sfc';
@@ -13,26 +14,45 @@ export type FailureInstancePanelDetailsProps = {
 };
 
 export const FailureInstancePanelDetails = NamedSFC<FailureInstancePanelDetailsProps>('FailureInstancePanelDetails', props => {
+    const getSnippetInfo = (): JSX.Element => {
+        if (!props.snippet) {
+            return (
+                <div className="failure-instance-snippet-empty-body"> Code snippet will auto-populate based on the CSS selector input.</div>
+            );
+        } else if (props.snippet.startsWith('No code snippet map')) {
+            return (
+                <div className="failure-instance-snippet-error">
+                    <Icon iconName="statusErrorFull" className="failure-instance-snippet-error-icon" />
+                    <div>{props.snippet}</div>
+                </div>
+            );
+        } else {
+            return <div className="failure-instance-snippet-filled-body">{props.snippet}</div>;
+        }
+    };
     return (
         <div>
-            <a className="learn-more"> Learn more about adding failure instances </a>
+            <a href="#" className="learn-more">
+                Learn more about adding failure instances
+            </a>
             <TextField
-                className="selector-failure-textfield"
                 label="CSS Selector"
                 multiline={true}
-                rows={8}
+                rows={4}
                 value={props.path}
                 onChange={props.onSelectorChange}
                 resizable={false}
-                defaultValue="CSS selector"
+                placeholder="CSS Selector"
             />
-            <div>Note: If the CSS selector maps to multiple snippets, the first will be selected.</div>
-            <div>
-                <DefaultButton text="Validate CSS selector" onClick={props.onValidateSelector} disabled={props.path === ''} />
+            <div className="failure-instance-selector-note">
+                Note: If the CSS selector maps to multiple snippets, the first will be selected
             </div>
             <div>
-                <label>Code Snippet</label>
-                <div>{props.snippet}</div>
+                <DefaultButton text="Validate CSS selector" onClick={props.onValidateSelector} disabled={props.path === null} />
+            </div>
+            <div aria-live="polite" aria-atomic="true">
+                <div className="failure-instance-snippet-title"> Code Snippet</div>
+                {getSnippetInfo()}
             </div>
         </div>
     );

--- a/src/DetailsView/components/failure-instance-panel-details.tsx
+++ b/src/DetailsView/components/failure-instance-panel-details.tsx
@@ -18,7 +18,7 @@ export const FailureInstancePanelDetails = NamedSFC<FailureInstancePanelDetailsP
     const getSnippetInfo = (): JSX.Element => {
         if (!props.snippet) {
             return (
-                <div className="failure-instance-snippet-empty-body"> Code snippet will auto-populate based on the CSS selector input.</div>
+                <div className="failure-instance-snippet-empty-body">Code snippet will auto-populate based on the CSS selector input.</div>
             );
         } else if (props.snippet.startsWith('No code snippet is map')) {
             return (
@@ -53,7 +53,7 @@ export const FailureInstancePanelDetails = NamedSFC<FailureInstancePanelDetailsP
                 <DefaultButton text="Validate CSS selector" onClick={props.onValidateSelector} disabled={props.path === null} />
             </div>
             <div aria-live="polite" aria-atomic="true">
-                <div className="failure-instance-snippet-title"> Code Snippet</div>
+                <div className="failure-instance-snippet-title">Code Snippet</div>
                 {getSnippetInfo()}
             </div>
         </div>

--- a/src/DetailsView/components/generic-panel.tsx
+++ b/src/DetailsView/components/generic-panel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { css } from '@uifabric/utilities';
-import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
+import { css, IRenderFunction } from '@uifabric/utilities';
+import { Panel, PanelType, IPanelProps } from 'office-ui-fabric-react/lib/Panel';
 import * as React from 'react';
 
 export interface GenericPanelProps {
@@ -11,6 +11,7 @@ export interface GenericPanelProps {
     className?: string;
     closeButtonAriaLabel: string;
     hasCloseButton: boolean;
+    onRenderFooterContent?: IRenderFunction<IPanelProps>;
 }
 
 export class GenericPanel extends React.Component<GenericPanelProps> {
@@ -27,6 +28,7 @@ export class GenericPanel extends React.Component<GenericPanelProps> {
                 hasCloseButton={this.props.hasCloseButton}
                 headerText={this.props.title}
                 headerClassName="header-text"
+                onRenderFooter={this.props.onRenderFooterContent}
             >
                 {this.props.children}
             </Panel>

--- a/src/DetailsView/components/generic-panel.tsx
+++ b/src/DetailsView/components/generic-panel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css, IRenderFunction } from '@uifabric/utilities';
-import { Panel, PanelType, IPanelProps } from 'office-ui-fabric-react/lib/Panel';
+import { IPanelProps, Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
 import * as React from 'react';
 
 export interface GenericPanelProps {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
@@ -16,10 +16,11 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: cre
   </CustomizedActionButton>
   <GenericPanel
     className="failure-instance-panel"
-    closeButtonAriaLabel={null}
-    hasCloseButton={false}
+    closeButtonAriaLabel="Close failure instance panel"
+    hasCloseButton={true}
     isOpen={false}
     onDismiss={[Function]}
+    onRenderFooterContent={[Function]}
     title="Add a failure instance"
   >
     <FlaggedComponent
@@ -36,19 +37,13 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: cre
     />
     <StyledTextFieldBase
       className="observed-failure-textfield"
-      label="Comments"
+      label="Comment"
       multiline={true}
       onChange={[Function]}
       resizable={false}
-      rows={8}
+      rows={4}
+      styles={[Function]}
       value={null}
-    />
-    <ActionAndCancelButtonsComponent
-      cancelButtonOnClick={[Function]}
-      isHidden={false}
-      primaryButtonDisabled={true}
-      primaryButtonOnClick={[Function]}
-      primaryButtonText="Add"
     />
   </GenericPanel>
 </React.Fragment>
@@ -67,10 +62,11 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
   </StyledLinkBase>
   <GenericPanel
     className="failure-instance-panel"
-    closeButtonAriaLabel={null}
-    hasCloseButton={false}
+    closeButtonAriaLabel="Close failure instance panel"
+    hasCloseButton={true}
     isOpen={false}
     onDismiss={[Function]}
+    onRenderFooterContent={[Function]}
     title="Edit failure instance"
   >
     <FlaggedComponent
@@ -87,19 +83,13 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
     />
     <StyledTextFieldBase
       className="observed-failure-textfield"
-      label="Comments"
+      label="Comment"
       multiline={true}
       onChange={[Function]}
       resizable={false}
-      rows={8}
+      rows={4}
+      styles={[Function]}
       value={null}
-    />
-    <ActionAndCancelButtonsComponent
-      cancelButtonOnClick={[Function]}
-      isHidden={false}
-      primaryButtonDisabled={true}
-      primaryButtonOnClick={[Function]}
-      primaryButtonText="Save"
     />
   </GenericPanel>
 </React.Fragment>
@@ -121,10 +111,11 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: par
   </CustomizedActionButton>
   <GenericPanel
     className="failure-instance-panel"
-    closeButtonAriaLabel={null}
-    hasCloseButton={false}
+    closeButtonAriaLabel="Close failure instance panel"
+    hasCloseButton={true}
     isOpen={false}
     onDismiss={[Function]}
+    onRenderFooterContent={[Function]}
     title="Add a failure instance"
   >
     <FlaggedComponent
@@ -141,19 +132,13 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: par
     />
     <StyledTextFieldBase
       className="observed-failure-textfield"
-      label="Comments"
+      label="Comment"
       multiline={true}
       onChange={[Function]}
       resizable={false}
-      rows={8}
+      rows={4}
+      styles={[Function]}
       value="original text"
-    />
-    <ActionAndCancelButtonsComponent
-      cancelButtonOnClick={[Function]}
-      isHidden={false}
-      primaryButtonDisabled={false}
-      primaryButtonOnClick={[Function]}
-      primaryButtonText="Add"
     />
   </GenericPanel>
 </React.Fragment>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-details.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-details.test.tsx.snap
@@ -4,21 +4,24 @@ exports[`FailureInstancePanelDetailsTest renders 1`] = `
 <div>
   <a
     className="learn-more"
+    href="#"
   >
-     Learn more about adding failure instances 
+    Learn more about adding failure instances
   </a>
   <StyledTextFieldBase
-    className="selector-failure-textfield"
-    defaultValue="CSS selector"
     label="CSS Selector"
     multiline={true}
     onChange={[Function]}
+    placeholder="CSS Selector"
     resizable={false}
-    rows={8}
+    rows={4}
+    styles={[Function]}
     value="Given Path"
   />
-  <div>
-    Note: If the CSS selector maps to multiple snippets, the first will be selected.
+  <div
+    className="failure-instance-selector-note"
+  >
+    Note: If the CSS selector maps to multiple snippets, the first will be selected
   </div>
   <div>
     <CustomizedDefaultButton
@@ -27,11 +30,18 @@ exports[`FailureInstancePanelDetailsTest renders 1`] = `
       text="Validate CSS selector"
     />
   </div>
-  <div>
-    <label>
-      Code Snippet
-    </label>
-    <div>
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+  >
+    <div
+      className="failure-instance-snippet-title"
+    >
+       Code Snippet
+    </div>
+    <div
+      className="failure-instance-snippet-filled-body"
+    >
       Snippet for Given Path
     </div>
   </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-details.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-details.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`FailureInstancePanelDetailsTest renders 1`] = `
     <div
       className="failure-instance-snippet-title"
     >
-       Code Snippet
+      Code Snippet
     </div>
     <div
       className="failure-instance-snippet-filled-body"

--- a/src/tests/unit/tests/DetailsView/components/assessment-table-column-config-handler.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-table-column-config-handler.test.tsx
@@ -125,7 +125,7 @@ describe('AssessmentTableColumnConfigHandlerTest', () => {
         const expected = (
             <AssessmentInstanceDetailsColumn
                 background={'#767676'}
-                labelText={'N/A'}
+                headerText={'Comment:'}
                 textContent={item.instance.description}
                 tooltipId={item.instance.id}
                 customClassName="not-applicable"

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -10,7 +10,10 @@ import { Assessments } from 'assessments/assessments';
 import { FlaggedComponent } from '../../../../../common/components/flagged-component';
 import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { ActionAndCancelButtonsComponent } from '../../../../../DetailsView/components/action-and-cancel-buttons-component';
+import {
+    ActionAndCancelButtonsComponent,
+    ActionAndCancelButtonsComponentProps,
+} from '../../../../../DetailsView/components/action-and-cancel-buttons-component';
 import {
     CapturedInstanceActionType,
     FailureInstanceData,
@@ -182,10 +185,17 @@ describe('FailureInstancePanelControlTest', () => {
             .find(TextField)
             .props()
             .onChange(null, description);
-        wrapper
-            .find(ActionAndCancelButtonsComponent)
-            .props()
-            .primaryButtonOnClick(null);
+
+        const buttonsWrapper = shallow<JSX.Element>(
+            wrapper
+                .find(GenericPanel)
+                .props()
+                .onRenderFooterContent(),
+        );
+        const buttons = buttonsWrapper.find(ActionAndCancelButtonsComponent);
+        const buttonProps = buttons.props() as ActionAndCancelButtonsComponentProps;
+
+        buttonProps.primaryButtonOnClick(null);
 
         expect(wrapper.state().isPanelOpen).toBe(false);
 
@@ -213,10 +223,17 @@ describe('FailureInstancePanelControlTest', () => {
             .find(TextField)
             .props()
             .onChange(null, description);
-        wrapper
-            .find(ActionAndCancelButtonsComponent)
-            .props()
-            .primaryButtonOnClick(null);
+
+        const buttonsWrapper = shallow<JSX.Element>(
+            wrapper
+                .find(GenericPanel)
+                .props()
+                .onRenderFooterContent(),
+        );
+        const buttons = buttonsWrapper.find(ActionAndCancelButtonsComponent);
+        const buttonProps = buttons.props() as ActionAndCancelButtonsComponentProps;
+
+        buttonProps.primaryButtonOnClick(null);
 
         expect(wrapper.state().isPanelOpen).toBe(false);
 


### PR DESCRIPTION
#### Description of changes

CSS fixes to match Figma. Changes occur on the Failure Instance Panel as well as the list of Failure Instances that grows on the main page as you add new Failure Instances.

To Note:
-- Duplicated JS functions to set the style of two TextFields (Comment in FIPC and CSS Selector in FIPD)
-- Still working with Fer and Chelsea to decide if we want to change the wording on the Validate Selector button
-- Path Snippet Store changes are coming in separate PR
-- Changes on the screen where you click to open the panel (with the list of added failure instances) is NOT behind feature flag (approved by Fer as long as I implemented her thoughts correctly)
-- Footer should have a bar above it, but that's for a Panel and we use a GenericPanel (may be another Fabric version issue as well)
-- Can't add placeholder text to TextFields until we update Fabric Version

#### Pull request checklist

- [X] Addresses an existing issue: PR for Feature #1555720
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [X] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS

<img width="405" alt="1" src="https://user-images.githubusercontent.com/24820607/62984805-67eb1500-bde9-11e9-96ff-a3065073bbce.PNG">
<img width="408" alt="2" src="https://user-images.githubusercontent.com/24820607/62984806-6883ab80-bde9-11e9-99c4-da007ee6621a.PNG">
<img width="408" alt="3" src="https://user-images.githubusercontent.com/24820607/62984807-6883ab80-bde9-11e9-837b-ad3c510d815d.PNG">
<img width="409" alt="4" src="https://user-images.githubusercontent.com/24820607/62984809-6883ab80-bde9-11e9-8849-e85c6b130e24.PNG">
<img width="614" alt="5" src="https://user-images.githubusercontent.com/24820607/62984810-691c4200-bde9-11e9-9c40-f8f627c220ba.PNG">
