### PR TITLE
Modify file path of HTML file used in electron-builder's generated exe

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -66,7 +66,7 @@ jobs:
 
     # CI build only
     - job: 'publish_electron_windows_linux'
-      condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+      #condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
       pool:
           vmImage: 'windows-latest'
       steps:

--- a/build.yaml
+++ b/build.yaml
@@ -66,7 +66,7 @@ jobs:
 
     # CI build only
     - job: 'publish_electron_windows_linux'
-      #condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+      condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
       pool:
           vmImage: 'windows-latest'
       steps:

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { app, BrowserWindow } from 'electron';
+import * as path from 'path';
 
 let mainWindow: BrowserWindow;
 
@@ -8,7 +9,7 @@ const createWindow = () => {
     mainWindow = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
 
     mainWindow
-        .loadFile('../electron/device-connect-view/deviceConnectView.html')
+        .loadFile(path.resolve(__dirname, '../electron/device-connect-view/deviceConnectView.html'))
         .then(() => console.log('url loaded'))
         .catch(console.log);
 


### PR DESCRIPTION
#### Description of changes
Before this change, the generated installer from electron-builder is unable to access `deviceConnectView.html`. The page loads when running `yarn start:electron` but not in the generated executable. Including `path.resolve` allows us to get the path relative to the module we're in. We may improve this / change webpack instead when we solidify release strategy but in the meantime this PR fixes the CI/CD executable.

#### Pull request checklist

Download and try resulting executable here: https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=30829&view=logs

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
