### PR TITLE
refactor: replace NodeSelector with Document in preparation for Typescript upgrade

### DIFF
--- a/src/DetailsView/details-view-renderer.tsx
+++ b/src/DetailsView/details-view-renderer.tsx
@@ -19,7 +19,7 @@ import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-han
 
 export class DetailsViewRenderer {
     private renderer: typeof ReactDOM.render;
-    private dom: NodeSelector & Node;
+    private dom: Document;
     private scopingActionMessageCreator: ScopingActionMessageCreator;
     private inspectActionMessageCreator: InspectActionMessageCreator;
     private issuesSelection: ISelection;
@@ -34,7 +34,7 @@ export class DetailsViewRenderer {
 
     constructor(
         private readonly deps: DetailsViewContainerDeps,
-        dom: NodeSelector & Node,
+        dom: Document,
         renderer: typeof ReactDOM.render,
         scopingActionMessageCreator: ScopingActionMessageCreator,
         inspectActionMessageCreator: InspectActionMessageCreator,

--- a/src/common/document-manipulator.ts
+++ b/src/common/document-manipulator.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 export class DocumentManipulator {
-    constructor(private document: Node & NodeSelector) {}
+    constructor(private document: Document) {}
 
     public setShortcutIcon(href: string): void {
         const icon = this.document.querySelector('head link[rel="shortcut icon"]');

--- a/src/injected/visualization/base-drawer.ts
+++ b/src/injected/visualization/base-drawer.ts
@@ -8,7 +8,7 @@ import { DrawerUtils } from './drawer-utils';
 import { Formatter } from './formatter';
 
 export abstract class BaseDrawer implements Drawer {
-    protected dom: NodeSelector & Node;
+    protected dom: Document;
     protected formatter: Formatter;
     protected isEnabled = false;
     protected containerClass: string;
@@ -23,7 +23,7 @@ export abstract class BaseDrawer implements Drawer {
     private shadowUtils: ShadowUtils;
 
     constructor(
-        dom: NodeSelector & Node,
+        dom: Document,
         containerClass: string,
         windowUtils: WindowUtils,
         shadowUtils: ShadowUtils,

--- a/src/injected/visualization/drawer-utils.ts
+++ b/src/injected/visualization/drawer-utils.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { ClientRectOffset } from '../client-utils';
 export class DrawerUtils {
-    private dom: NodeSelector & Node;
+    private dom: Document;
     public clientWindowOffsetThreshold: number = 5;
 
     constructor(dom) {
@@ -18,7 +18,7 @@ export class DrawerUtils {
     }
 
     public getDocumentElement(): Document {
-        return this.dom.ownerDocument || (this.dom as Document);
+        return this.dom.ownerDocument || this.dom;
     }
 
     public getContainerWidth(

--- a/src/injected/visualization/highlight-box-drawer.ts
+++ b/src/injected/visualization/highlight-box-drawer.ts
@@ -31,7 +31,7 @@ export class HighlightBoxDrawer extends BaseDrawer {
     };
 
     constructor(
-        dom: NodeSelector & Node,
+        dom: Document,
         containerClass: string,
         windowUtils: WindowUtils,
         shadowUtils: ShadowUtils,

--- a/src/injected/visualization/svg-drawer.ts
+++ b/src/injected/visualization/svg-drawer.ts
@@ -26,7 +26,7 @@ export class SVGDrawer extends BaseDrawer {
     private centerPositionCalculator: CenterPositionCalculator;
 
     constructor(
-        dom: NodeSelector & Node,
+        dom: Document,
         containerClass: string,
         windowUtils: WindowUtils,
         shadowUtils: ShadowUtils,

--- a/src/popup/components/diagnostic-view-toggle-factory.tsx
+++ b/src/popup/components/diagnostic-view-toggle-factory.tsx
@@ -22,11 +22,11 @@ export class DiagnosticViewToggleFactory {
     private commandStore: BaseStore<CommandStoreData>;
     private actionMessageCreator: PopupActionMessageCreator;
     private clickHandler: DiagnosticViewClickHandler;
-    private dom: NodeSelector & Node;
+    private dom: Document;
 
     constructor(
         private readonly deps: DiagnosticViewToggleDeps,
-        dom: NodeSelector & Node,
+        dom: Document,
         visualizationTypes: VisualizationType[],
         visualizationConfigurationFactory: VisualizationConfigurationFactory,
         visualizationStore: BaseStore<VisualizationStoreData>,

--- a/src/popup/components/diagnostic-view-toggle.tsx
+++ b/src/popup/components/diagnostic-view-toggle.tsx
@@ -27,7 +27,7 @@ export interface DiagnosticViewToggleProps {
     clickHandler: DiagnosticViewClickHandler;
     shortcutCommands: chrome.commands.Command[];
     telemetrySource: TelemetryEventSource;
-    dom: NodeSelector & Node;
+    dom: Document;
 }
 
 export type DiagnosticViewToggleDeps = ContentLinkDeps;
@@ -39,7 +39,7 @@ export interface DiagnosticViewToggleState {
 export class DiagnosticViewToggle extends React.Component<DiagnosticViewToggleProps, DiagnosticViewToggleState> {
     private configuration: VisualizationConfiguration;
     private toggle: React.RefObject<IToggle> = React.createRef<IToggle>();
-    private dom: NodeSelector & Node;
+    private dom: Document;
     private userEventListenerAdded: boolean;
 
     // Must be consistent with internal react naming for same property to work

--- a/src/popup/incompatible-browser-renderer.tsx
+++ b/src/popup/incompatible-browser-renderer.tsx
@@ -8,7 +8,7 @@ import { NewTabLink } from '../common/components/new-tab-link';
 import { Header } from './components/header';
 
 export class IncompatibleBrowserRenderer {
-    constructor(private readonly renderer: typeof ReactDOM.render, private readonly dom: NodeSelector & Node) {}
+    constructor(private readonly renderer: typeof ReactDOM.render, private readonly dom: Document) {}
 
     public render(): void {
         const container = this.dom.querySelector('#popup-container');

--- a/src/popup/main-renderer.tsx
+++ b/src/popup/main-renderer.tsx
@@ -19,7 +19,7 @@ export class MainRenderer {
         private readonly deps: MainRendererDeps,
         private readonly popupHandlers: IPopupHandlers,
         private readonly renderer: typeof ReactDOM.render,
-        private readonly dom: NodeSelector & Node,
+        private readonly dom: Document,
         private readonly popupWindow: Window,
         private readonly targetTabUrl: string,
         private readonly hasAccess: boolean,

--- a/src/scanner/axe-options.ts
+++ b/src/scanner/axe-options.ts
@@ -6,7 +6,7 @@ export interface AxeOptions {
     runOnly?: Axe.RunOnly;
     restoreScroll?: Boolean; // missing from axe options.
 }
-export type AxeScanContext = string | NodeSelector & Node | IncludeExcludeOptions | NodeList;
+export type AxeScanContext = string | Document | IncludeExcludeOptions | NodeList;
 export interface IncludeExcludeOptions {
     include: string[][];
     exclude: string[][];

--- a/src/scanner/launcher.ts
+++ b/src/scanner/launcher.ts
@@ -10,7 +10,7 @@ export class Launcher {
     constructor(
         private axe: typeof Axe,
         private scanParameterGenerator: ScanParameterGenerator,
-        private dom: NodeSelector & Node,
+        private dom: Document,
         private options: ScanOptions,
     ) {}
 

--- a/src/scanner/scan-options.ts
+++ b/src/scanner/scan-options.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 export interface ScanOptions {
     testsToRun?: string[];
-    dom?: NodeSelector & Node | NodeList;
+    dom?: Document | NodeList;
     selector?: string;
     include?: string[][];
     exclude?: string[][];

--- a/src/scanner/scan-parameter-generator.ts
+++ b/src/scanner/scan-parameter-generator.ts
@@ -24,7 +24,7 @@ export class ScanParameterGenerator {
         return result;
     }
 
-    public getContext(dom: NodeSelector & Node, options: ScanOptions): AxeScanContext {
+    public getContext(dom: Document, options: ScanOptions): AxeScanContext {
         if (options == null) {
             return dom;
         }

--- a/src/tests/unit/common/test-document-creator.ts
+++ b/src/tests/unit/common/test-document-creator.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { JSDOM } from 'jsdom';
+
 export class TestDocumentCreator {
-    public static createTestDocument(html: string): Node & NodeSelector {
-        const element = document.createElement('html');
-        element.innerHTML = html;
-        return element;
+    public static createTestDocument(html: string = ''): Document {
+        const jsdom = new JSDOM(`<html>${html}</html>`);
+        return jsdom.window.document;
     }
 }

--- a/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
@@ -28,8 +28,7 @@ describe('DetailsViewRendererTest', () => {
         const scopingActionMessageCreatorStrictMock = Mock.ofType<ScopingActionMessageCreator>(null, MockBehavior.Strict);
         const inspectActionMessageCreatorStrictMock = Mock.ofType<InspectActionMessageCreator>(null, MockBehavior.Strict);
 
-        const fakeDocument = TestDocumentCreator.createTestDocument();
-        const detailsViewContainer = fakeDocument.createElement('div');
+        const fakeDocument = TestDocumentCreator.createTestDocument('<div id="details-container"></div>');
 
         const renderMock: IMock<typeof ReactDOM.render> = Mock.ofInstance(() => null);
         const selectionMock = Mock.ofType<ISelection>(Selection);
@@ -46,9 +45,6 @@ describe('DetailsViewRendererTest', () => {
         configMutator.setOption('icon128', expectedIcon16);
         const documentManipulatorMock = Mock.ofType(DocumentManipulator);
         documentManipulatorMock.setup(des => des.setShortcutIcon('../' + expectedIcon16)).verifiable();
-
-        detailsViewContainer.setAttribute('id', 'details-container');
-        fakeDocument.appendChild(detailsViewContainer);
 
         renderMock
             .setup(r =>
@@ -72,7 +68,7 @@ describe('DetailsViewRendererTest', () => {
                             />
                         </>,
                     ),
-                    detailsViewContainer,
+                    fakeDocument.getElementById('details-container'),
                 ),
             )
             .verifiable();

--- a/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
@@ -19,6 +19,7 @@ import { AssessmentInstanceTableHandler } from '../../../../DetailsView/handlers
 import { DetailsViewToggleClickHandlerFactory } from '../../../../DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { PreviewFeatureFlagsHandler } from '../../../../DetailsView/handlers/preview-feature-flags-handler';
 import { CreateTestAssessmentProvider } from '../../common/test-assessment-provider';
+import { TestDocumentCreator } from '../../common/test-document-creator';
 
 describe('DetailsViewRendererTest', () => {
     test('render', () => {
@@ -27,8 +28,8 @@ describe('DetailsViewRendererTest', () => {
         const scopingActionMessageCreatorStrictMock = Mock.ofType<ScopingActionMessageCreator>(null, MockBehavior.Strict);
         const inspectActionMessageCreatorStrictMock = Mock.ofType<InspectActionMessageCreator>(null, MockBehavior.Strict);
 
-        const dom = document.createElement('div');
-        const detailsViewContainer = document.createElement('div');
+        const fakeDocument = TestDocumentCreator.createTestDocument();
+        const detailsViewContainer = fakeDocument.createElement('div');
 
         const renderMock: IMock<typeof ReactDOM.render> = Mock.ofInstance(() => null);
         const selectionMock = Mock.ofType<ISelection>(Selection);
@@ -47,7 +48,7 @@ describe('DetailsViewRendererTest', () => {
         documentManipulatorMock.setup(des => des.setShortcutIcon('../' + expectedIcon16)).verifiable();
 
         detailsViewContainer.setAttribute('id', 'details-container');
-        dom.appendChild(detailsViewContainer);
+        fakeDocument.appendChild(detailsViewContainer);
 
         renderMock
             .setup(r =>
@@ -78,7 +79,7 @@ describe('DetailsViewRendererTest', () => {
 
         const renderer = new DetailsViewRenderer(
             deps,
-            dom,
+            fakeDocument,
             renderMock.object,
             scopingActionMessageCreatorStrictMock.object,
             inspectActionMessageCreatorStrictMock.object,

--- a/src/tests/unit/tests/injected/visualization/drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/drawer.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { JSDOM } from 'jsdom';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { IActionN } from 'typemoq/_all';
 import { getDefaultFeatureFlagValues } from '../../../../../common/feature-flags';
@@ -21,16 +22,18 @@ describe('Drawer', () => {
         overflowY: null,
     } as CSSStyleDeclaration;
     const containerClass = 'drawer-test';
+    let fakeDocument: Document;
     let clientUtilsMock: IMock<ClientUtils>;
     let shadowUtilsMock: IMock<ShadowUtils>;
     let shadowContainer: HTMLElement;
     let windowStub: Window;
     let windowUtilsMock: IMock<WindowUtils>;
     beforeEach(() => {
+        fakeDocument = TestDocumentCreator.createTestDocument();
         clientUtilsMock = Mock.ofType(ClientUtils);
         windowStub = { stubWindow: true } as any;
         windowUtilsMock = Mock.ofType(WindowUtils);
-        shadowContainer = document.createElement('div');
+        shadowContainer = fakeDocument.createElement('div');
 
         shadowUtilsMock = Mock.ofType(ShadowUtils);
         shadowUtilsMock.setup(x => x.getShadowContainer()).returns(() => shadowContainer);
@@ -49,10 +52,10 @@ describe('Drawer', () => {
     });
 
     test('verifyDefaultStyling', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                <div id='id1'></div>
-                <div id='id2'></div>
-            `);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+        `;
 
         windowUtilsMock
             .setup(it => it.getComputedStyle(It.isAny()))
@@ -64,9 +67,9 @@ describe('Drawer', () => {
         const elementResults = createElementResults(['#id1', '#id2']);
 
         const testSubject = createDrawerBuilder()
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setWindowUtils(windowUtilsMock.object)
-            .setDrawerUtils(getDrawerUtilsMock(dom).object)
+            .setDrawerUtils(getDrawerUtilsMock(fakeDocument).object)
             .build();
 
         testSubject.initialize(createDrawerInfo(elementResults));
@@ -748,16 +751,14 @@ describe('Drawer', () => {
     });
 
     test('verifyListenersSetupOnDraw', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                <div id='id1'></div>
-            `);
+        fakeDocument.body.innerHTML = "<div id='id1'></div>";
 
         setupGetComputedStyleCalled();
 
         const elementResults = createElementResults(['#id1']);
 
         const testSubject = createDrawerBuilder()
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setWindowUtils(windowUtilsMock.object)
             .build();
 
@@ -790,9 +791,7 @@ describe('Drawer', () => {
     });
 
     test('verifyListenersSetupOnErase', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                <div id='id1'></div>
-            `);
+        fakeDocument.body.innerHTML = "<div id='id1'></div>";
 
         setupWindow();
         setupGetComputedStyleNotCalled();
@@ -800,7 +799,7 @@ describe('Drawer', () => {
         const elementResults = createElementResults(['#id1']);
 
         const testSubject = createDrawerBuilder()
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setWindowUtils(windowUtilsMock.object)
             .build();
 
@@ -819,16 +818,14 @@ describe('Drawer', () => {
     });
 
     test('verifyResetTimerOnScrolling', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                <div id='id1'></div>
-            `);
+        fakeDocument.body.innerHTML = "<div id='id1'></div>";
 
         setupGetComputedStyleCalled();
 
         const elementResults = createElementResults(['#id1']);
 
         const testSubject = createDrawerBuilder()
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setWindowUtils(windowUtilsMock.object)
             .build();
 
@@ -869,15 +866,13 @@ describe('Drawer', () => {
     });
 
     test('verifyScrollHandlerExecution', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                <div id='id1'></div>
-            `);
+        fakeDocument.body.innerHTML = "<div id='id1'></div>";
 
         setupGetComputedStyleCalled();
 
         const elementResults = createElementResults(['#id1']);
         const testSubject = createDrawerBuilder()
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setWindowUtils(windowUtilsMock.object)
             .build();
 
@@ -920,9 +915,7 @@ describe('Drawer', () => {
     });
 
     test('verifyWhenElementResultsIsEmpty', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                <div id='id1'></div>
-            `);
+        fakeDocument.body.innerHTML = "<div id='id1'></div>";
         const elementResults = [];
 
         windowUtilsMock
@@ -936,7 +929,7 @@ describe('Drawer', () => {
             .verifiable(Times.never());
 
         const testSubject = createDrawerBuilder()
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setWindowUtils(windowUtilsMock.object)
             .build();
 
@@ -954,9 +947,7 @@ describe('Drawer', () => {
     });
 
     test('verifyWhenNoElementsFoundForSelectors', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                <div id='id1'></div>
-            `);
+        fakeDocument.body.innerHTML = "<div id='id1'></div>";
 
         windowUtilsMock
             .setup(it => it.getComputedStyle(It.isAny()))
@@ -971,7 +962,7 @@ describe('Drawer', () => {
         const elementResults = createElementResults(['#id2']);
 
         const testSubject = createDrawerBuilder()
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setWindowUtils(windowUtilsMock.object)
             .build();
 
@@ -988,10 +979,10 @@ describe('Drawer', () => {
     });
 
     test('verifyRemoveLayout', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                <div id='id1'></div>
-                <div id='id2'></div>
-            `);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+        `;
 
         setupWindow();
         setupGetComputedStyleCalled();
@@ -999,7 +990,7 @@ describe('Drawer', () => {
         const elementResults = createElementResults(['#id1', '#id2']);
 
         const testSubject = createDrawerBuilder()
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setWindowUtils(windowUtilsMock.object)
             .build();
 
@@ -1007,7 +998,7 @@ describe('Drawer', () => {
 
         const anotherDrawer = createDrawerBuilder()
             .setContainerClass('anotherDrawer')
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setWindowUtils(windowUtilsMock.object)
             .build();
 
@@ -1030,10 +1021,11 @@ describe('Drawer', () => {
     });
 
     test('verifyRedraw', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                <div id='id1'></div>
-                <div id='id2'></div>
-            `);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+        `;
+
         const elementResults = createElementResults(['#id1', '#id2']);
 
         windowUtilsMock
@@ -1044,16 +1036,16 @@ describe('Drawer', () => {
             .verifiable(Times.atLeastOnce());
 
         const testSubject = createDrawerBuilder()
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setWindowUtils(windowUtilsMock.object)
-            .setDrawerUtils(getDrawerUtilsMock(dom).object)
+            .setDrawerUtils(getDrawerUtilsMock(fakeDocument).object)
             .build();
 
         testSubject.initialize(createDrawerInfo(elementResults));
 
         const anotherDrawer = createDrawerBuilder()
             .setContainerClass('anotherDrawer')
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setWindowUtils(windowUtilsMock.object)
             .build();
         anotherDrawer.initialize(createDrawerInfo(elementResults));
@@ -1083,12 +1075,12 @@ describe('Drawer', () => {
     });
 
     test('verifyFormatter', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                <div id='id1'></div>
-                <div id='id2'></div>
-                <div id='id3'></div>
-                <div id='id4'></div>
-            `);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+            <div id='id3'></div>
+            <div id='id4'></div>
+        `;
 
         const element1Config: DrawerConfiguration = {
             borderColor: 'rgb(12, 13, 14)',
@@ -1156,7 +1148,7 @@ describe('Drawer', () => {
         function addMockForElement(selector: string, config: DrawerConfiguration): void {
             const elementResult = elementResults.filter(el => el.target[0] === selector)[0];
             formatterMock
-                .setup(it => it.getDrawerConfiguration(dom.querySelector(selector), elementResult))
+                .setup(it => it.getDrawerConfiguration(fakeDocument.querySelector(selector), elementResult))
                 .returns(() => config)
                 .verifiable();
         }
@@ -1166,10 +1158,10 @@ describe('Drawer', () => {
         addMockForElement('#id4', element4Config);
 
         const testSubject = createDrawerBuilder()
-            .setDomAndDrawerUtils(dom)
+            .setDomAndDrawerUtils(fakeDocument)
             .setFormatter(formatterMock.object)
             .setWindowUtils(windowUtilsMock.object)
-            .setDrawerUtils(getDrawerUtilsMock(dom).object)
+            .setDrawerUtils(getDrawerUtilsMock(fakeDocument).object)
             .build();
         testSubject.initialize(createDrawerInfo(elementResults));
 
@@ -1209,12 +1201,12 @@ describe('Drawer', () => {
     function getDrawerUtilsMock(dom): IMock<DrawerUtils> {
         const drawerUtilsMock = Mock.ofType(DrawerUtils);
         drawerUtilsMock
-            .setup(dm => dm.isOutsideOfDocument(It.isAny(), dom.ownerDocument, defaultStyleStub, defaultStyleStub))
+            .setup(dm => dm.isOutsideOfDocument(It.isAny(), dom, defaultStyleStub, defaultStyleStub))
             .returns(() => false)
             .verifiable(Times.atLeastOnce());
         drawerUtilsMock
             .setup(dm => dm.getDocumentElement())
-            .returns(() => dom.ownerDocument)
+            .returns(() => dom)
             .verifiable(Times.atLeastOnce());
         drawerUtilsMock
             .setup(dm => dm.getContainerTopOffset(It.isAny()))
@@ -1225,11 +1217,11 @@ describe('Drawer', () => {
             .returns(() => 5)
             .verifiable(Times.atLeastOnce());
         drawerUtilsMock
-            .setup(dm => dm.getContainerWidth(It.isAny(), dom.ownerDocument, It.isAnyNumber(), defaultStyleStub, defaultStyleStub))
+            .setup(dm => dm.getContainerWidth(It.isAny(), dom, It.isAnyNumber(), defaultStyleStub, defaultStyleStub))
             .returns(() => 0)
             .verifiable(Times.atLeastOnce());
         drawerUtilsMock
-            .setup(dm => dm.getContainerHeight(It.isAny(), dom.ownerDocument, It.isAnyNumber(), defaultStyleStub, defaultStyleStub))
+            .setup(dm => dm.getContainerHeight(It.isAny(), dom, It.isAnyNumber(), defaultStyleStub, defaultStyleStub))
             .returns(() => 0)
             .verifiable(Times.atLeastOnce());
         return drawerUtilsMock;
@@ -1284,7 +1276,7 @@ describe('Drawer', () => {
     }
 
     class DrawerBuilder {
-        private dom: NodeSelector & Node;
+        private dom: Document;
         private containerClass: string = containerClass;
         private windowUtils: WindowUtils;
         private drawerUtils: DrawerUtils;
@@ -1310,7 +1302,7 @@ describe('Drawer', () => {
             return this;
         }
 
-        public setDomAndDrawerUtils(dom: NodeSelector & Node): DrawerBuilder {
+        public setDomAndDrawerUtils(dom: Document): DrawerBuilder {
             this.dom = dom;
             this.drawerUtils = new DrawerUtils(dom);
             return this;

--- a/src/tests/unit/tests/injected/visualization/drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/drawer.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { JSDOM } from 'jsdom';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { IActionN } from 'typemoq/_all';
 import { getDefaultFeatureFlagValues } from '../../../../../common/feature-flags';

--- a/src/tests/unit/tests/injected/visualization/single-target-drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/single-target-drawer.test.ts
@@ -137,12 +137,10 @@ describe('SingleTargetDrawer Tests', () => {
         formatterMock.verifyAll();
     });
 
-    function setupDrawerUtilsMockDefault(dom): void {
+    function setupDrawerUtilsMockDefault(dom: Document): void {
         drawerUtilsMock
             .setup(d => d.getDocumentElement())
-            .returns(() => {
-                return dom.ownerDocument || (dom as Document);
-            })
+            .returns(() => dom)
             .verifiable(Times.atLeastOnce());
     }
 

--- a/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { JSDOM } from 'jsdom';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { getDefaultFeatureFlagValues } from '../../../../../common/feature-flags';
@@ -20,6 +21,7 @@ import { TestDocumentCreator } from '../../../common/test-document-creator';
 import { DrawerUtilsMockBuilder } from './drawer-utils-mock-builder';
 
 describe('SVGDrawer', () => {
+    let fakeDocument: Document;
     let svgShapeFactoryMock: IMock<SVGShapeFactory>;
     let formatterMock: IMock<TabStopsFormatter>;
     let shadowUtilsMock: IMock<ShadowUtils>;
@@ -34,13 +36,14 @@ describe('SVGDrawer', () => {
     const containerClass = 'svg-drawer-test';
 
     beforeEach(() => {
+        fakeDocument = TestDocumentCreator.createTestDocument();
         windowUtilsMock = Mock.ofType(WindowUtils);
         filterFactoryMock = Mock.ofType(SVGSolidShadowFilterFactory);
         centerPositionCalculatorMock = Mock.ofType(CenterPositionCalculator);
         formatterMock = Mock.ofType(TabStopsFormatter);
         svgShapeFactoryMock = Mock.ofType(SVGShapeFactory);
         shadowUtilsMock = Mock.ofType(ShadowUtils);
-        shadowContainer = document.createElement('div');
+        shadowContainer = fakeDocument.createElement('div');
         shadowUtilsMock.setup(x => x.getShadowContainer()).returns(() => shadowContainer);
     });
 
@@ -52,11 +55,9 @@ describe('SVGDrawer', () => {
     }
 
     test('initialize', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <div id='id1'></div>
-                `);
+        fakeDocument.body.innerHTML = "<div id='id1'></div>";
 
-        const element = dom.querySelector('#id1');
+        const element = fakeDocument.querySelector('#id1');
         const expectedTabbedElements: TabbedItem[] = [
             {
                 element: element,
@@ -75,10 +76,10 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(dom, styleStub).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).build();
 
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -95,11 +96,9 @@ describe('SVGDrawer', () => {
     });
 
     test('initialize with element having property bag instead of taborder', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <div id='id1'></div>
-                `);
+        fakeDocument.body.innerHTML = "<div id='id1'></div>";
 
-        const element = dom.querySelector('#id1');
+        const element = fakeDocument.querySelector('#id1');
         const expectedTabbedElements: TabbedItem[] = [
             {
                 element: element,
@@ -122,10 +121,10 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(dom, styleStub).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).build();
 
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -142,14 +141,14 @@ describe('SVGDrawer', () => {
     });
 
     test('initialize: validate existing elements should not redraw', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <div id='id1'></div>
-                    <div id='id2'></div>
-                    <div id='id3'></div>
-                `);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+            <div id='id3'></div>
+        `;
 
-        const element1 = dom.querySelector('#id1');
-        const element2 = dom.querySelector('#id2');
+        const element1 = fakeDocument.querySelector('#id1');
+        const element2 = fakeDocument.querySelector('#id2');
 
         const existingTabbedElements: TabbedItem[] = [
             {
@@ -193,10 +192,10 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(dom, styleStub).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).build();
 
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -215,14 +214,14 @@ describe('SVGDrawer', () => {
     });
 
     test('initialize: validate existing elements should not redraw with taborder from propertybag', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <div id='id1'></div>
-                    <div id='id2'></div>
-                    <div id='id3'></div>
-                `);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+            <div id='id3'></div>
+        `;
 
-        const element1 = dom.querySelector('#id1');
-        const element2 = dom.querySelector('#id2');
+        const element1 = fakeDocument.querySelector('#id1');
+        const element2 = fakeDocument.querySelector('#id2');
 
         const existingTabbedElements: TabbedItem[] = [
             {
@@ -274,10 +273,10 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(dom, styleStub).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).build();
 
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -296,17 +295,17 @@ describe('SVGDrawer', () => {
     });
 
     test('initialize: verify tab order change', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <div id='id1'></div>
-                    <div id='id2'></div>
-                    <div id='id3'></div>
-                    <div id='id4'></div>
-                `);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+            <div id='id3'></div>
+            <div id='id4'></div>
+        `;
 
-        const element1 = dom.querySelector('#id1');
-        const element2 = dom.querySelector('#id2');
-        const element3 = dom.querySelector('#id3');
-        const element4 = dom.querySelector('#id4');
+        const element1 = fakeDocument.querySelector('#id1');
+        const element2 = fakeDocument.querySelector('#id2');
+        const element3 = fakeDocument.querySelector('#id3');
+        const element4 = fakeDocument.querySelector('#id4');
 
         const existingTabbedElements: TabbedItem[] = [
             {
@@ -390,10 +389,10 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(dom, styleStub).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).build();
 
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -444,14 +443,8 @@ describe('SVGDrawer', () => {
     });
 
     test('svg has proper size and a filter child (inside a defs child)', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <body>
-                        <div id="id1">
-                        </div>
-                    </body>
-                `);
-        const docMock = dom.ownerDocument || dom;
-        const element = dom.querySelector<HTMLElement>('#id1');
+        fakeDocument.body.innerHTML = "<div id='id1'></div>";
+        const element = fakeDocument.querySelector<HTMLElement>('#id1');
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
         const tabbedElements: TabbedElementData[] = [
             {
@@ -461,9 +454,9 @@ describe('SVGDrawer', () => {
                 target: ['#id1'],
             },
         ];
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(docMock, styleStub).setupGetDocSize(100).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).setupGetDocSize(100).build();
 
-        setupFilterFactoryDefault(dom);
+        setupFilterFactoryDefault(fakeDocument);
         setupWindowUtilsMockDefault(styleStub);
 
         formatterMock
@@ -472,7 +465,7 @@ describe('SVGDrawer', () => {
             .verifiable();
 
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -509,15 +502,10 @@ describe('SVGDrawer', () => {
     });
 
     test('verify focus indicator drawn on the first tabbable element', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <div id='id1'></div>
-                `);
-        const docMock = dom.ownerDocument || dom;
-
-        document.body.appendChild(dom);
+        fakeDocument.body.innerHTML = "<div id='id1'></div>";
 
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
-        const element = dom.querySelector<HTMLElement>('#id1');
+        const element = fakeDocument.querySelector<HTMLElement>('#id1');
         const tabbedElements: TabbedElementData[] = [
             {
                 tabOrder: 1,
@@ -527,18 +515,18 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(docMock, styleStub).setupGetDocSize(100).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).setupGetDocSize(100).build();
         setupWindowUtilsMockDefault(styleStub);
-        setupFilterFactoryDefault(dom);
+        setupFilterFactoryDefault(fakeDocument);
         setupCenterPositionCalculatorDefault();
-        setupSVGshapeFactoryDefault(dom);
+        setupSVGshapeFactoryDefault(fakeDocument);
         formatterMock
             .setup(f => f.getDrawerConfiguration(element, null))
             .returns(() => drawerConfig)
             .verifiable();
 
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -564,18 +552,13 @@ describe('SVGDrawer', () => {
         expect(circles.length).toBe(1);
         expect(lines.length).toBe(0);
         expect(labels.length).toBe(0);
-
-        document.body.removeChild(dom);
     });
 
     test('draw circles with line in between without details', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <div id='id1'></div>
-                    <div id='id2'></div>
-                `);
-        const docMock = dom.ownerDocument || dom;
-
-        document.body.appendChild(dom);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+        `;
 
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig(false, false);
         const tabbedElements: TabbedElementData[] = [
@@ -593,18 +576,18 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(docMock, styleStub).setupGetDocSize(100).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).setupGetDocSize(100).build();
         setupWindowUtilsMockDefault(styleStub);
-        setupFilterFactoryDefault(dom);
+        setupFilterFactoryDefault(fakeDocument);
         setupCenterPositionCalculatorDefault();
-        setupSVGshapeFactoryDefault(dom);
+        setupSVGshapeFactoryDefault(fakeDocument);
         formatterMock
             .setup(f => f.getDrawerConfiguration(It.isAny(), null))
             .returns(() => drawerConfig)
             .verifiable();
 
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -631,17 +614,14 @@ describe('SVGDrawer', () => {
         expect(circles.length).toBe(2);
         expect(lines.length).toBe(1);
         expect(labels.length).toBe(0);
-
-        document.body.removeChild(dom);
     });
 
     test('draw circles with line in between with details', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <div id='id1'></div>
-                    <div id='id2'></div>
-                `);
-        const docMock = dom.ownerDocument || dom;
-        document.body.appendChild(dom);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+        `;
+
         // pass true or false in createTestDrawingConfig falseto set showDetailedTabOrder parameter in config
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
         const tabbedElements: TabbedElementData[] = [
@@ -659,18 +639,18 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(docMock, styleStub).setupGetDocSize(100).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).setupGetDocSize(100).build();
         setupWindowUtilsMockDefault(styleStub);
-        setupFilterFactoryDefault(dom);
+        setupFilterFactoryDefault(fakeDocument);
         setupCenterPositionCalculatorDefault();
-        setupSVGshapeFactoryDefault(dom);
+        setupSVGshapeFactoryDefault(fakeDocument);
         formatterMock
             .setup(f => f.getDrawerConfiguration(It.isAny(), null))
             .returns(() => drawerConfig)
             .verifiable();
 
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -697,17 +677,14 @@ describe('SVGDrawer', () => {
         expect(circles.length).toBe(2);
         expect(lines.length).toBe(1);
         expect(labels.length).toBe(1);
-
-        document.body.removeChild(dom);
     });
 
     test('draw circles with line in between with details', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <div id='id1'></div>
-                    <div id='id2'></div>
-                `);
-        const docMock = dom.ownerDocument || dom;
-        document.body.appendChild(dom);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+        `;
+
         // pass true or false in createTestDrawingConfig falseto set showDetailedTabOrder parameter in config
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
         const tabbedElements: TabbedElementData[] = [
@@ -725,21 +702,21 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(docMock, styleStub).setupGetDocSize(100).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).setupGetDocSize(100).build();
         setupWindowUtilsMockDefault(styleStub);
-        setupFilterFactoryDefault(dom);
+        setupFilterFactoryDefault(fakeDocument);
         setupCenterPositionCalculatorDefault();
-        setupSVGshapeFactoryDefault(dom);
+        setupSVGshapeFactoryDefault(fakeDocument);
         formatterMock
             .setup(f => f.getDrawerConfiguration(It.isAny(), null))
             .returns(() => drawerConfig)
             .verifiable();
         centerPositionCalculatorMock
-            .setup(c => c.getElementCenterPosition(document.getElementById('id1')))
+            .setup(c => c.getElementCenterPosition(fakeDocument.getElementById('id1')))
             .returns(element => null)
             .verifiable();
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -766,17 +743,14 @@ describe('SVGDrawer', () => {
         expect(circles.length).toBe(2);
         expect(lines.length).toBe(0);
         expect(labels.length).toBe(1);
-
-        document.body.removeChild(dom);
     });
 
     test('break graph', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <div id='id1'></div>
-                    <div id='id2'></div>
-                `);
-        const docMock = dom.ownerDocument || dom;
-        document.body.appendChild(dom);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+        `;
+
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
         const tabbedElements: TabbedElementData[] = [
             {
@@ -793,18 +767,18 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(docMock, styleStub).setupGetDocSize(100).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).setupGetDocSize(100).build();
         setupWindowUtilsMockDefault(styleStub);
-        setupFilterFactoryDefault(dom);
+        setupFilterFactoryDefault(fakeDocument);
         setupCenterPositionCalculatorDefault();
-        setupSVGshapeFactoryDefault(dom);
+        setupSVGshapeFactoryDefault(fakeDocument);
         formatterMock
             .setup(f => f.getDrawerConfiguration(It.isAny(), null))
             .returns(() => drawerConfig)
             .verifiable();
 
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -831,17 +805,14 @@ describe('SVGDrawer', () => {
         expect(circles.length).toBe(2);
         expect(lines.length).toBe(0);
         expect(labels.length).toBe(1);
-
-        document.body.removeChild(dom);
     });
 
     test('eraseLayout', () => {
-        const dom = TestDocumentCreator.createTestDocument(`
-                    <div id='id1'></div>
-                    <div id='id2'></div>
-                `);
-        const docMock = dom.ownerDocument || dom;
-        document.body.appendChild(dom);
+        fakeDocument.body.innerHTML = `
+            <div id='id1'></div>
+            <div id='id2'></div>
+        `;
+
         const drawerConfig: SVGDrawerConfiguration = createTestDrawingConfig();
         const tabbedElements: TabbedElementData[] = [
             {
@@ -858,18 +829,18 @@ describe('SVGDrawer', () => {
             },
         ];
 
-        const drawerUtilsMock = new DrawerUtilsMockBuilder(docMock, styleStub).setupGetDocSize(100).build();
+        const drawerUtilsMock = new DrawerUtilsMockBuilder(fakeDocument, styleStub).setupGetDocSize(100).build();
         setupWindowUtilsMockDefault(styleStub);
-        setupFilterFactoryDefault(dom);
+        setupFilterFactoryDefault(fakeDocument);
         setupCenterPositionCalculatorDefault();
-        setupSVGshapeFactoryDefault(dom);
+        setupSVGshapeFactoryDefault(fakeDocument);
         formatterMock
             .setup(f => f.getDrawerConfiguration(It.isAny(), null))
             .returns(() => drawerConfig)
             .verifiable();
 
         const testSubject = new SVGDrawer(
-            dom,
+            fakeDocument,
             containerClass,
             windowUtilsMock.object,
             shadowUtilsMock.object,
@@ -898,8 +869,6 @@ describe('SVGDrawer', () => {
         expect(circles.length).toBe(0);
         expect(lines.length).toBe(0);
         expect(labels.length).toBe(0);
-
-        document.body.removeChild(dom);
     });
 
     function createTestDrawingConfig(showSolidFocusLine = true, showTabIndexedLabel = true): SVGDrawerConfiguration {
@@ -1016,7 +985,7 @@ describe('SVGDrawer', () => {
             .returns((center, config, tabOrder) => {
                 const text = doc.createElementNS(SVGNamespaceUrl, 'text');
                 text.setAttributeNS(null, 'class', 'insights-svg-focus-indicator-text');
-                text.innerHTML = tabOrder;
+                text.innerHTML = `<span>${tabOrder}</span>`;
                 return text;
             });
     }

--- a/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/svg-drawer.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { JSDOM } from 'jsdom';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { getDefaultFeatureFlagValues } from '../../../../../common/feature-flags';

--- a/src/tests/unit/tests/popup/incompatible-browser-renderer.test.tsx
+++ b/src/tests/unit/tests/popup/incompatible-browser-renderer.test.tsx
@@ -9,7 +9,7 @@ describe('IncompatibleBrowserRenderer', () => {
     it('renders', () => {
         const renderMock = Mock.ofType<typeof ReactDOM.render>();
         const containerMock = Mock.ofType<HTMLElement>();
-        const documentMock = Mock.ofType<NodeSelector & Node>();
+        const documentMock = Mock.ofType<Document>();
 
         documentMock.setup(mock => mock.querySelector('#popup-container')).returns(() => containerMock.object);
 

--- a/src/tests/unit/tests/popup/main-renderer.test.tsx
+++ b/src/tests/unit/tests/popup/main-renderer.test.tsx
@@ -16,15 +16,16 @@ import { PopupViewControllerHandler } from '../../../../popup/handlers/popup-vie
 import { LaunchPadRowConfigurationFactory } from '../../../../popup/launch-pad-row-configuration-factory';
 import { MainRenderer, MainRendererDeps } from '../../../../popup/main-renderer';
 import { SupportLinkHandler } from '../../../../popup/support-link-handler';
+import { TestDocumentCreator } from '../../common/test-document-creator';
 
 describe('MainRenderer', () => {
     const expectedTitle = title;
 
     test('render', () => {
-        const dom = document.createElement('div');
-        const container = document.createElement('div');
+        const fakeDocument = TestDocumentCreator.createTestDocument();
+        const container = fakeDocument.createElement('div');
         container.setAttribute('id', 'popup-container');
-        dom.appendChild(container);
+        fakeDocument.appendChild(container);
 
         const diagnosticViewClickHandlerMock = Mock.ofType(DiagnosticViewClickHandler);
         const gettingStartedDialogHandlerMock = Mock.ofType(PopupViewControllerHandler);
@@ -83,7 +84,7 @@ describe('MainRenderer', () => {
                 browserAdapter: browserAdapterMock.object,
             },
             renderMock.object,
-            dom,
+            fakeDocument,
             popupWindowMock.object,
             targetTabUrl,
             hasAccess,

--- a/src/tests/unit/tests/popup/main-renderer.test.tsx
+++ b/src/tests/unit/tests/popup/main-renderer.test.tsx
@@ -22,10 +22,7 @@ describe('MainRenderer', () => {
     const expectedTitle = title;
 
     test('render', () => {
-        const fakeDocument = TestDocumentCreator.createTestDocument();
-        const container = fakeDocument.createElement('div');
-        container.setAttribute('id', 'popup-container');
-        fakeDocument.appendChild(container);
+        const fakeDocument = TestDocumentCreator.createTestDocument('<div id="popup-container"></div>');
 
         const diagnosticViewClickHandlerMock = Mock.ofType(DiagnosticViewClickHandler);
         const gettingStartedDialogHandlerMock = Mock.ofType(PopupViewControllerHandler);
@@ -69,7 +66,7 @@ describe('MainRenderer', () => {
                             />
                         </>,
                     ),
-                    container,
+                    fakeDocument.getElementById('popup-container'),
                 ),
             )
             .verifiable();

--- a/src/views/insights/renderer.tsx
+++ b/src/views/insights/renderer.tsx
@@ -9,7 +9,7 @@ import { DocumentManipulator } from '../../common/document-manipulator';
 import { Router, RouterDeps } from './router';
 
 export type RendererDeps = {
-    dom: Node & NodeSelector;
+    dom: Document;
     render: ReactDOM.Renderer;
     initializeFabricIcons: () => void;
 } & RouterDeps &


### PR DESCRIPTION
#### Description of changes

Updating from Typescript 2.9 to 3.5 results in a variety of errors that look like this:

```
ERROR in Q:/repos/accessibility-insights-web/src/common/document-manipulator.ts(4,42):
TS2304: Cannot find name 'NodeSelector'.
```

It looks like https://github.com/microsoft/TSJS-lib-generator/pull/647 was the point where it was removed, merged into a separate `ParentNode` interface. We considered using `ParentNode` instead here, but `Document` seemed closer to the intended usage in most cases and led to the tests working more similarly to the product code than anything else, so that's what I went with.

Replacing the usages with Document is a no-op in Typescript 2.9 (so nice to do as a separate PR, to make the eventual Typescript upgrade PR smaller). It also forces the affected tests to be a little bit better (they create test documents for the cases where the product passes real documents, rather than creating test nodes within a global document and hoping that they act similarly and that no other test touches global document state).

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
