### PR TITLE
Use issue instead of bug when description is chosen

### DIFF
--- a/src/issue-filing/services/azure-boards/azure-boards-issue-filing-settings.tsx
+++ b/src/issue-filing/services/azure-boards/azure-boards-issue-filing-settings.tsx
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 export type AzureBoardsIssueDetailField = 'reproSteps' | 'description';
 
+export type AzureBoardsWorkItemType = 'Bug' | 'Issue';
+
 export type AzureBoardsIssueFilingSettings = {
     projectURL: string;
     issueDetailsField: AzureBoardsIssueDetailField;

--- a/src/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.ts
+++ b/src/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.ts
@@ -8,7 +8,7 @@ import { HTTPQueryBuilder } from '../../common/http-query-builder';
 import { IssueDetailsBuilder } from '../../common/issue-details-builder';
 import { IssueFilingUrlStringUtils, IssueUrlCreationUtils } from '../../common/issue-filing-url-string-utils';
 import { HTMLFormatter } from '../../common/markup/html-formatter';
-import { AzureBoardsIssueFilingSettings } from './azure-boards-issue-filing-settings';
+import { AzureBoardsIssueFilingSettings, AzureBoardsWorkItemType } from './azure-boards-issue-filing-settings';
 
 const buildTags = (createIssueData: CreateIssueDetailsTextData, standardTags: string[]): string => {
     const tags = ['Accessibility', title, `rule: ${createIssueData.ruleResult.ruleId}`, ...standardTags];
@@ -27,13 +27,15 @@ export const createAzureBoardsIssueFilingUrlProvider = (
         const body = issueDetailsBuilder(environmentInfo, issueData);
 
         let bodyField: string = '[Microsoft.VSTS.TCM.ReproSteps]';
+        let workItemType: AzureBoardsWorkItemType = 'Bug';
 
         if (settingsData.issueDetailsField === 'description') {
             bodyField = '[System.Description]';
+            workItemType = 'Issue';
         }
 
         return queryBuilderProvider()
-            .withBaseUrl(`${settingsData.projectURL}/_workitems/create/Bug`)
+            .withBaseUrl(`${settingsData.projectURL}/_workitems/create/${workItemType}`)
             .withParam('fullScreen', 'true')
             .withParam('[System.Title]', titleField)
             .withParam('[System.Tags]', tags)

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.test.ts
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.test.ts
@@ -60,10 +60,6 @@ describe('createAzureBoardsIssueFilingUrl', () => {
 
         queryBuilderMock = Mock.ofType<HTTPQueryBuilder>();
 
-        queryBuilderMock
-            .setup(builder => builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Bug`))
-            .returns(() => queryBuilderMock.object);
-
         queryBuilderMock.setup(builder => builder.withParam('fullScreen', 'true')).returns(() => queryBuilderMock.object);
         queryBuilderMock.setup(builder => builder.withParam('[System.Title]', testTitle)).returns(() => queryBuilderMock.object);
 
@@ -80,6 +76,9 @@ describe('createAzureBoardsIssueFilingUrl', () => {
         it('uses description field, without tags', () => {
             stringUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => []);
 
+            queryBuilderMock
+                .setup(builder => builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Issue`))
+                .returns(() => queryBuilderMock.object);
             queryBuilderMock.setup(builder => builder.withParam('[System.Tags]', baseTags)).returns(() => queryBuilderMock.object);
 
             queryBuilderMock
@@ -93,6 +92,10 @@ describe('createAzureBoardsIssueFilingUrl', () => {
 
         it('uses description field, with tags', () => {
             stringUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => ['TAG1', 'TAG2']);
+
+            queryBuilderMock
+                .setup(builder => builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Issue`))
+                .returns(() => queryBuilderMock.object);
 
             const expectedTags = `${baseTags}; TAG1; TAG2`;
             queryBuilderMock.setup(builder => builder.withParam('[System.Tags]', expectedTags)).returns(() => queryBuilderMock.object);
@@ -109,6 +112,10 @@ describe('createAzureBoardsIssueFilingUrl', () => {
             settingsData.issueDetailsField = 'reproSteps';
             stringUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => []);
 
+            queryBuilderMock
+                .setup(builder => builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Bug`))
+                .returns(() => queryBuilderMock.object);
+
             queryBuilderMock.setup(builder => builder.withParam('[System.Tags]', baseTags)).returns(() => queryBuilderMock.object);
             queryBuilderMock
                 .setup(builder => builder.withParam('[Microsoft.VSTS.TCM.ReproSteps]', testIssueDetails))
@@ -122,6 +129,10 @@ describe('createAzureBoardsIssueFilingUrl', () => {
         it('uses repro steps field, with tags', () => {
             settingsData.issueDetailsField = 'reproSteps';
             stringUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => ['TAG1', 'TAG2']);
+
+            queryBuilderMock
+                .setup(builder => builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Bug`))
+                .returns(() => queryBuilderMock.object);
 
             const expectedTags = `${baseTags}; TAG1; TAG2`;
             queryBuilderMock.setup(builder => builder.withParam('[System.Tags]', expectedTags)).returns(() => queryBuilderMock.object);


### PR DESCRIPTION
#### Description of changes

When a user chooses the "Description" work item field in ADO bug filing, we should create an "issue" work item instead of a "bug" work item. This results from discussion in #1009. 

#### Pull request checklist

- [x] Addresses an existing issue: #1009 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
