### PR TITLE
changing to a try catch

### DIFF
--- a/src/injected/element-finder-by-path.ts
+++ b/src/injected/element-finder-by-path.ts
@@ -35,11 +35,13 @@ export class ElementFinderByPath {
     };
 
     public processRequest = (message: ElementFinderByPathMessage): PromiseLike<string> => {
-        if (!this.checkSyntax(message.path[0])) {
+        let element = null;
+
+        try {
+            element = this.htmlElementUtils.querySelector(message.path[0]) as HTMLElement;
+        } catch (e) {
             return Promise.reject();
         }
-
-        const element = this.htmlElementUtils.querySelector(message.path[0]) as HTMLElement;
 
         if (element == null) {
             return Promise.reject();
@@ -67,12 +69,5 @@ export class ElementFinderByPath {
                 path: message.path,
             } as ElementFinderByPathMessage,
         });
-    };
-
-    private checkSyntax = (pathSegment: string): boolean => {
-        if (pathSegment.startsWith(',') || pathSegment.startsWith(';')) {
-            return false;
-        }
-        return true;
     };
 }

--- a/src/injected/element-finder-by-path.ts
+++ b/src/injected/element-finder-by-path.ts
@@ -34,29 +34,22 @@ export class ElementFinderByPath {
         );
     };
 
-    public processRequest = (message: ElementFinderByPathMessage): PromiseLike<string> => {
-        let element = null;
-
-        try {
-            element = this.htmlElementUtils.querySelector(message.path[0]) as HTMLElement;
-        } catch (e) {
-            return Promise.reject();
-        }
+    public processRequest = async (message: ElementFinderByPathMessage): Promise<string> => {
+        const element = this.htmlElementUtils.querySelector(message.path[0]) as HTMLElement;
 
         if (element == null) {
-            return Promise.reject();
+            throw new Error(`Element with selector ${message} not found`);
         }
 
         if (element.tagName.toLocaleLowerCase() !== 'iframe' && message.path.length > 1) {
-            return Promise.reject();
+            throw new Error(`Selector not following proper iframe syntax`);
         }
 
         if (element.tagName.toLocaleLowerCase() !== 'iframe' && message.path.length === 1) {
-            const response = element.outerHTML;
-            return Promise.resolve(response);
+            return element.outerHTML;
         }
 
-        return this.iterateDeeperOnIframe(element, message);
+        return await this.iterateDeeperOnIframe(element, message);
     };
 
     private iterateDeeperOnIframe = (element: HTMLElement, message: ElementFinderByPathMessage): PromiseLike<string> => {

--- a/src/injected/path-snippet-controller.ts
+++ b/src/injected/path-snippet-controller.ts
@@ -28,20 +28,18 @@ export class PathSnippetController {
         }
     };
 
-    private getElementFromPath = (path: string): void => {
+    private getElementFromPath = async (path: string): Promise<void> => {
         const splitPath = path.split(';');
         const message = {
             path: splitPath,
         } as ElementFinderByPathMessage;
 
-        this.elementFinderByPath.processRequest(message).then(
-            result => {
-                this.sendBackSnippetFromPath(result);
-            },
-            err => {
-                this.sendBackErrorFromPath(path);
-            },
-        );
+        try {
+            const responseSnippet = await this.elementFinderByPath.processRequest(message);
+            this.sendBackSnippetFromPath(responseSnippet);
+        } catch (error) {
+            this.sendBackErrorFromPath(path);
+        }
     };
 
     private sendBackSnippetFromPath = (snippet: string): void => {

--- a/src/injected/path-snippet-controller.ts
+++ b/src/injected/path-snippet-controller.ts
@@ -35,8 +35,7 @@ export class PathSnippetController {
         } as ElementFinderByPathMessage;
 
         try {
-            const responseSnippet = await this.elementFinderByPath.processRequest(message);
-            this.sendBackSnippetFromPath(responseSnippet);
+            this.elementFinderByPath.processRequest(message).then(responseSnippet => this.sendBackSnippetFromPath(responseSnippet));
         } catch (error) {
             this.sendBackErrorFromPath(path);
         }

--- a/src/tests/end-to-end/test-resources/iframes/second-level.html
+++ b/src/tests/end-to-end/test-resources/iframes/second-level.html
@@ -1,0 +1,15 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Input radio - Native Widgets</title>
+    </head>
+
+    <body role="main">
+        <iframe src="./third-level.html" sandbox="allow-scripts"> </iframe>
+    </body>
+</html>

--- a/src/tests/end-to-end/test-resources/iframes/third-level.html
+++ b/src/tests/end-to-end/test-resources/iframes/third-level.html
@@ -1,0 +1,15 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Input radio - Native Widgets</title>
+    </head>
+
+    <body role="main">
+        <p>Hello</p>
+    </body>
+</html>

--- a/src/tests/end-to-end/test-resources/iframes/top-level.html
+++ b/src/tests/end-to-end/test-resources/iframes/top-level.html
@@ -1,0 +1,15 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+        <title>Input radio - Native Widgets</title>
+    </head>
+
+    <body role="main">
+        <iframe src="./second-level.html"> </iframe>
+    </body>
+</html>

--- a/src/tests/unit/tests/injected/element-finder-by-path.test.ts
+++ b/src/tests/unit/tests/injected/element-finder-by-path.test.ts
@@ -89,7 +89,7 @@ describe('ElementFinderByPositionTest', () => {
             path: [',bad path'],
         } as ElementFinderByPathMessage;
 
-        return expect(testSubject.processRequest(messageStub)).rejects.toBeUndefined();
+        return expect(testSubject.processRequest(messageStub)).rejects.toThrowError();
     });
 
     test('process request when element is null', async () => {
@@ -98,7 +98,8 @@ describe('ElementFinderByPositionTest', () => {
         } as ElementFinderByPathMessage;
 
         setupQuerySelectorMock(messageStub, null);
-        return expect(testSubject.processRequest(messageStub)).rejects.toBeUndefined();
+
+        return expect(testSubject.processRequest(messageStub)).rejects.toThrowError();
     });
 
     test('process request when path is invalid', async () => {
@@ -109,7 +110,8 @@ describe('ElementFinderByPositionTest', () => {
         const elementStub = { tagName: 'test' } as HTMLElement;
 
         setupQuerySelectorMock(messageStub, elementStub);
-        return expect(testSubject.processRequest(messageStub)).rejects.toBeUndefined();
+
+        return expect(testSubject.processRequest(messageStub)).rejects.toThrowError();
     });
 
     test('process request when element is not iframe', async () => {

--- a/src/tests/unit/tests/injected/element-finder-by-position.test.ts
+++ b/src/tests/unit/tests/injected/element-finder-by-position.test.ts
@@ -142,6 +142,7 @@ describe('ElementFinderByPositionTest', () => {
         const selector = 'selectorTest';
 
         setupElementsFromPointMock(messageStub, [elementStub]);
+
         setupGetUniqueSelector(elementStub, selector);
 
         mockQ.setup(q => q.defer()).returns(() => deferredObjectStub);


### PR DESCRIPTION
#### Description of changes

QuerySelector() is an HTML Element Utils method that takes a path and finds the corresponding element. We use it to retrieve a snippet based on a path. The method returns null if the path doesn't map to a snippet, but we recently realized it will just hang if given a path which follows incorrect syntax. I at first thought it was only in the case that the path started with a comma, but soon realized there were more cases (like when the path started with a number). For this reason, I modified the code to not try and test the path for all potentially failing edge cases (as is in the code base currently to fix commas specifically), but instead wrap the call in a try/catch statement.

#### Pull request checklist

- [X] Addresses an existing issue: PR for Feature #1555720
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [N/A] (UI changes only) Verified usability with NVDA/JAWS
