### PR TITLE
Update electron device-connect-view title bar (and more)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,7 +109,7 @@ module.exports = function(grunt) {
                         expand: true,
                     },
                     {
-                        cwd: './dist/src/electron/device-connect-view/Styles',
+                        cwd: './dist/src/electron/device-connect-view',
                         src: '*.css',
                         dest: path.join(extensionPath, 'electron/device-connect-view/styles/default'),
                         expand: true,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,6 +109,12 @@ module.exports = function(grunt) {
                         expand: true,
                     },
                     {
+                        cwd: './dist/src/electron/device-connect-view/Styles',
+                        src: '*.css',
+                        dest: path.join(extensionPath, 'electron/device-connect-view/styles/default'),
+                        expand: true,
+                    },
+                    {
                         cwd: './dist/src/injected/styles',
                         src: '*.css',
                         dest: path.join(extensionPath, 'injected/styles/default'),

--- a/src/electron/device-connect-view/Styles/deviceconnectview.scss
+++ b/src/electron/device-connect-view/Styles/deviceconnectview.scss
@@ -7,6 +7,16 @@ body {
     margin: 0px;
 }
 
+button {
+    -webkit-app-region: no-drag;
+}
+
+footer {
+    position: fixed;
+    bottom: 0;
+    padding: 32px;
+}
+
 .window-title {
     padding: 6px 9px;
 

--- a/src/electron/device-connect-view/Styles/deviceconnectview.scss
+++ b/src/electron/device-connect-view/Styles/deviceconnectview.scss
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../common/styles/common.scss';
+
+body {
+    -webkit-app-region: drag;
+    margin: 0px;
+}
+
+.window-title {
+    padding: 6px 9px;
+
+    .header-text {
+        color: $ada-brand-color;
+        font-family: $fontFamily;
+        font-size: 14.51px;
+        font-weight: $fontWeightSemiBold;
+        line-height: 19.3px;
+    }
+
+    .header-icon {
+        float: left;
+        padding: 0px 3px;
+        height: 17px;
+    }
+}

--- a/src/electron/device-connect-view/components/window-footer.scss
+++ b/src/electron/device-connect-view/components/window-footer.scss
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+.window-footer {
+    position: fixed;
+    bottom: 0;
+    padding: 32px;
+}

--- a/src/electron/device-connect-view/components/window-footer.tsx
+++ b/src/electron/device-connect-view/components/window-footer.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { css } from '@uifabric/utilities';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import { NamedSFC } from '../../../common/react/named-sfc';
@@ -12,10 +11,8 @@ export interface WindowFooterProps {
 export const WindowFooter = NamedSFC<WindowFooterProps>('WindowFooter', (props: WindowFooterProps) => {
     const onCancelClick = () => props.cancelClick();
     return (
-        <footer className="ms-Grid window-footer">
-            <div className={css('ms-Grid-row')}>
-                <DefaultButton className={css('window-footer-button-cancel')} onClick={onCancelClick} text="Cancel"></DefaultButton>
-            </div>
+        <footer className="window-footer">
+            <DefaultButton className="window-footer-button-cancel" onClick={onCancelClick} text="Cancel"></DefaultButton>
         </footer>
     );
 });

--- a/src/electron/device-connect-view/components/window-footer.tsx
+++ b/src/electron/device-connect-view/components/window-footer.tsx
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { css } from '@uifabric/utilities';
+import { remote } from 'electron';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import * as React from 'react';
+
+export class WindowFooter extends React.Component {
+    public render(): JSX.Element {
+        return (
+            <footer className="ms-Grid window-footer">
+                <div className={css('ms-Grid-row')}>
+                    <DefaultButton onClick={this.cancelClick} text="Cancel"></DefaultButton>
+                </div>
+            </footer>
+        );
+    }
+
+    private cancelClick(): void {
+        remote.getCurrentWindow().close();
+    }
+}

--- a/src/electron/device-connect-view/components/window-footer.tsx
+++ b/src/electron/device-connect-view/components/window-footer.tsx
@@ -3,29 +3,19 @@
 import { css } from '@uifabric/utilities';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
+import { NamedSFC } from '../../../common/react/named-sfc';
 
 export interface WindowFooterProps {
     cancelClick: () => void;
 }
 
-export class WindowFooter extends React.Component<WindowFooterProps> {
-    constructor(props: WindowFooterProps) {
-        super(props);
-    }
-
-    public render(): JSX.Element {
-        return (
-            <footer className="ms-Grid window-footer">
-                <div className={css('ms-Grid-row')}>
-                    <DefaultButton
-                        className={css('window-footer-button-cancel')}
-                        onClick={this.onCancelClick}
-                        text="Cancel"
-                    ></DefaultButton>
-                </div>
-            </footer>
-        );
-    }
-
-    private onCancelClick = (): void => this.props.cancelClick();
-}
+export const WindowFooter = NamedSFC<WindowFooterProps>('WindowFooter', (props: WindowFooterProps) => {
+    const onCancelClick = () => props.cancelClick();
+    return (
+        <footer className="ms-Grid window-footer">
+            <div className={css('ms-Grid-row')}>
+                <DefaultButton className={css('window-footer-button-cancel')} onClick={onCancelClick} text="Cancel"></DefaultButton>
+            </div>
+        </footer>
+    );
+});

--- a/src/electron/device-connect-view/components/window-footer.tsx
+++ b/src/electron/device-connect-view/components/window-footer.tsx
@@ -1,22 +1,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
-import { remote } from 'electron';
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { BaseButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
-export class WindowFooter extends React.Component {
+export interface WindowFooterProps {
+    cancelClick: React.MouseEventHandler<BaseButton>;
+}
+
+export class WindowFooter extends React.Component<WindowFooterProps> {
+    constructor(props: WindowFooterProps) {
+        super(props);
+    }
+
     public render(): JSX.Element {
         return (
             <footer className="ms-Grid window-footer">
                 <div className={css('ms-Grid-row')}>
-                    <DefaultButton onClick={this.cancelClick} text="Cancel"></DefaultButton>
+                    <DefaultButton
+                        className={css('window-footer-button-cancel')}
+                        onClick={this.props.cancelClick}
+                        text="Cancel"
+                    ></DefaultButton>
                 </div>
             </footer>
         );
-    }
-
-    private cancelClick(): void {
-        remote.getCurrentWindow().close();
     }
 }

--- a/src/electron/device-connect-view/components/window-footer.tsx
+++ b/src/electron/device-connect-view/components/window-footer.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
-import { BaseButton, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
 export interface WindowFooterProps {
-    cancelClick: React.MouseEventHandler<BaseButton>;
+    cancelClick: () => void;
 }
 
 export class WindowFooter extends React.Component<WindowFooterProps> {
@@ -19,11 +19,13 @@ export class WindowFooter extends React.Component<WindowFooterProps> {
                 <div className={css('ms-Grid-row')}>
                     <DefaultButton
                         className={css('window-footer-button-cancel')}
-                        onClick={this.props.cancelClick}
+                        onClick={this.onCancelClick}
                         text="Cancel"
                     ></DefaultButton>
                 </div>
             </footer>
         );
     }
+
+    private onCancelClick = (): void => this.props.cancelClick();
 }

--- a/src/electron/device-connect-view/components/window-title.scss
+++ b/src/electron/device-connect-view/components/window-title.scss
@@ -1,21 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-@import '../../../common/styles/common.scss';
-
-body {
-    -webkit-app-region: drag;
-    margin: 0px;
-}
-
-button {
-    -webkit-app-region: no-drag;
-}
-
-footer {
-    position: fixed;
-    bottom: 0;
-    padding: 32px;
-}
+@import '../../../common/styles/colors.scss';
+@import '../../../common/styles/fonts.scss';
 
 .window-title {
     padding: 6px 9px;

--- a/src/electron/device-connect-view/components/window-title.tsx
+++ b/src/electron/device-connect-view/components/window-title.tsx
@@ -2,31 +2,22 @@
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
 import * as React from 'react';
+import { NamedSFC } from '../../../common/react/named-sfc';
 
 export interface WindowTitleProps {
     title: string;
     children?: JSX.Element;
 }
 
-export class WindowTitle extends React.Component<WindowTitleProps> {
-    constructor(props: WindowTitleProps) {
-        super(props);
-
-        this.state = {
-            isContextMenuVisible: false,
-        };
-    }
-
-    public render(): JSX.Element {
-        return (
-            <header className="ms-Grid window-title">
-                <div className={css('ms-Grid-row')}>
-                    {this.props.children}
-                    <div role="heading" aria-level={1} className="ms-Grid-col header-text">
-                        {this.props.title}
-                    </div>
+export const WindowTitle = NamedSFC<WindowTitleProps>('WindowTitle', (props: WindowTitleProps) => {
+    return (
+        <header className="ms-Grid window-title">
+            <div className={css('ms-Grid-row')}>
+                {props.children}
+                <div role="heading" aria-level={1} className="ms-Grid-col header-text">
+                    {props.title}
                 </div>
-            </header>
-        );
-    }
-}
+            </div>
+        </header>
+    );
+});

--- a/src/electron/device-connect-view/components/window-title.tsx
+++ b/src/electron/device-connect-view/components/window-title.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { css } from '@uifabric/utilities';
 import * as React from 'react';
 import { NamedSFC } from '../../../common/react/named-sfc';
 
@@ -11,12 +10,10 @@ export interface WindowTitleProps {
 
 export const WindowTitle = NamedSFC<WindowTitleProps>('WindowTitle', (props: WindowTitleProps) => {
     return (
-        <header className="ms-Grid window-title">
-            <div className={css('ms-Grid-row')}>
+        <header className="window-title">
+            <div>
                 {props.children}
-                <div role="heading" aria-level={1} className="ms-Grid-col header-text">
-                    {props.title}
-                </div>
+                <h1 className="header-text">{props.title}</h1>
             </div>
         </header>
     );

--- a/src/electron/device-connect-view/components/window-title.tsx
+++ b/src/electron/device-connect-view/components/window-title.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 
 export interface WindowTitleProps {
     title: string;
-    rowExtraClassName?: string;
     children?: JSX.Element;
 }
 
@@ -21,7 +20,7 @@ export class WindowTitle extends React.Component<WindowTitleProps> {
     public render(): JSX.Element {
         return (
             <header className="ms-Grid window-title">
-                <div className={css('ms-Grid-row', this.props.rowExtraClassName)}>
+                <div className={css('ms-Grid-row')}>
                     {this.props.children}
                     <div role="heading" aria-level={1} className="ms-Grid-col header-text">
                         {this.props.title}

--- a/src/electron/device-connect-view/components/window-title.tsx
+++ b/src/electron/device-connect-view/components/window-title.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { css } from '@uifabric/utilities';
+import * as React from 'react';
+
+export interface WindowTitleProps {
+    title: string;
+    rowExtraClassName?: string;
+    children?: JSX.Element;
+}
+
+export class WindowTitle extends React.Component<WindowTitleProps> {
+    constructor(props: WindowTitleProps) {
+        super(props);
+
+        this.state = {
+            isContextMenuVisible: false,
+        };
+    }
+
+    public render(): JSX.Element {
+        return (
+            <header className="ms-Grid window-title">
+                <div className={css('ms-Grid-row', this.props.rowExtraClassName)}>
+                    {this.props.children}
+                    <div role="heading" aria-level={1} className="ms-Grid-col header-text">
+                        {this.props.title}
+                    </div>
+                </div>
+            </header>
+        );
+    }
+}

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { remote } from 'electron';
 import * as ReactDOM from 'react-dom';
 import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
 
 const dom = document;
-const renderer = new DeviceConnectViewRenderer(ReactDOM.render, dom);
+const renderer = new DeviceConnectViewRenderer(ReactDOM.render, dom, remote.getCurrentWindow());
 renderer.render();

--- a/src/electron/device-connect-view/device-connect-view-renderer.tsx
+++ b/src/electron/device-connect-view/device-connect-view-renderer.tsx
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import { BrandBlue } from '../../icons/brand/blue/brand-blue';
+import { WindowTitle } from './components/window-title';
 
 export class DeviceConnectViewRenderer {
     constructor(private readonly renderer: typeof ReactDOM.render, private readonly dom: ParentNode) {}
@@ -9,9 +11,9 @@ export class DeviceConnectViewRenderer {
     public render(): void {
         const deviceConnectViewContainer = this.dom.querySelector('#device-connect-view-container');
         this.renderer(
-            <>
-                <h1>Welcome to Accessibility Insights for Mobile</h1>
-            </>,
+            <WindowTitle title="Accessibility Insights">
+                <BrandBlue />
+            </WindowTitle>,
             deviceConnectViewContainer,
         );
     }

--- a/src/electron/device-connect-view/device-connect-view-renderer.tsx
+++ b/src/electron/device-connect-view/device-connect-view-renderer.tsx
@@ -1,22 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BrowserWindow } from 'electron';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import { brand } from '../../content/strings/application';
 import { BrandBlue } from '../../icons/brand/blue/brand-blue';
 import { WindowFooter } from './components/window-footer';
 import { WindowTitle } from './components/window-title';
 
 export class DeviceConnectViewRenderer {
-    constructor(private readonly renderer: typeof ReactDOM.render, private readonly dom: ParentNode) {}
+    constructor(
+        private readonly renderer: typeof ReactDOM.render,
+        private readonly dom: ParentNode,
+        private readonly CurrentWindow: BrowserWindow,
+    ) {}
 
     public render(): void {
         const deviceConnectViewContainer = this.dom.querySelector('#device-connect-view-container');
         this.renderer(
             <>
-                <WindowTitle title="Accessibility Insights">
+                <WindowTitle title={brand}>
                     <BrandBlue />
                 </WindowTitle>
-                <WindowFooter></WindowFooter>
+                <WindowFooter cancelClick={this.CurrentWindow.close}></WindowFooter>
             </>,
             deviceConnectViewContainer,
         );

--- a/src/electron/device-connect-view/device-connect-view-renderer.tsx
+++ b/src/electron/device-connect-view/device-connect-view-renderer.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { BrandBlue } from '../../icons/brand/blue/brand-blue';
+import { WindowFooter } from './components/window-footer';
 import { WindowTitle } from './components/window-title';
 
 export class DeviceConnectViewRenderer {
@@ -11,9 +12,12 @@ export class DeviceConnectViewRenderer {
     public render(): void {
         const deviceConnectViewContainer = this.dom.querySelector('#device-connect-view-container');
         this.renderer(
-            <WindowTitle title="Accessibility Insights">
-                <BrandBlue />
-            </WindowTitle>,
+            <>
+                <WindowTitle title="Accessibility Insights">
+                    <BrandBlue />
+                </WindowTitle>
+                <WindowFooter></WindowFooter>
+            </>,
             deviceConnectViewContainer,
         );
     }

--- a/src/electron/device-connect-view/device-connect-view.scss
+++ b/src/electron/device-connect-view/device-connect-view.scss
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import './components/window-footer.scss';
+@import './components/window-title.scss';
+
+body {
+    -webkit-app-region: drag;
+    margin: 0px;
+}
+
+button {
+    -webkit-app-region: no-drag;
+}

--- a/src/electron/device-connect-view/deviceConnectView.html
+++ b/src/electron/device-connect-view/deviceConnectView.html
@@ -7,7 +7,7 @@ Licensed under the MIT License.
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" type="text/css" href="../common/styles/fabric.min.css" />
-        <link rel="stylesheet" type="text/css" href="./styles/default/deviceconnectview.css" />
+        <link rel="stylesheet" type="text/css" href="./styles/default/device-connect-view.css" />
         <title>Accessibility Insights for Mobile</title>
     </head>
 

--- a/src/electron/device-connect-view/deviceConnectView.html
+++ b/src/electron/device-connect-view/deviceConnectView.html
@@ -7,6 +7,7 @@ Licensed under the MIT License.
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" type="text/css" href="../common/styles/fabric.min.css" />
+        <link rel="stylesheet" type="text/css" href="./styles/default/deviceconnectview.css" />
         <title>Accessibility Insights for Mobile</title>
     </head>
 

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -22,7 +22,6 @@ const createWindow = () => {
     mainWindow.on('ready-to-show', () => {
         mainWindow.setMenu(null);
         mainWindow.show();
-        mainWindow.webContents.openDevTools({ mode: 'detach' });
     });
 };
 

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -6,7 +6,13 @@ import * as path from 'path';
 let mainWindow: BrowserWindow;
 
 const createWindow = () => {
-    mainWindow = new BrowserWindow({ show: false, webPreferences: { nodeIntegration: true } });
+    mainWindow = new BrowserWindow({
+        show: false,
+        webPreferences: { nodeIntegration: true },
+        frame: false,
+        width: 600,
+        height: 391,
+    });
 
     mainWindow
         .loadFile(path.resolve(__dirname, '../electron/device-connect-view/deviceConnectView.html'))
@@ -14,10 +20,9 @@ const createWindow = () => {
         .catch(console.log);
 
     mainWindow.on('ready-to-show', () => {
-        mainWindow.maximize();
+        mainWindow.setMenu(null);
         mainWindow.show();
-
-        mainWindow.webContents.openDevTools({ mode: 'bottom' });
+        mainWindow.webContents.openDevTools({ mode: 'detach' });
     });
 };
 

--- a/src/tests/electron/main.test.ts
+++ b/src/tests/electron/main.test.ts
@@ -21,7 +21,7 @@ describe('Electron E2E', () => {
         // so tslint thinks some of the methods do not return promises.
         // tslint:disable: await-promise
         expect(await app.browserWindow.isVisible()).toBe(true);
-        expect(await app.client.getWindowCount()).toBe(2);
+        expect(await app.client.getWindowCount()).toBe(1);
         expect(await app.webContents.getTitle()).toBe('Accessibility Insights for Mobile');
         // tslint:enable: await-promise
     });

--- a/src/tests/unit/electron/device-connect-view/components/__snapshots__/window-footer.test.tsx.snap
+++ b/src/tests/unit/electron/device-connect-view/components/__snapshots__/window-footer.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WindowTitleTest render 1`] = `
+<footer
+  className="ms-Grid window-footer"
+>
+  <div
+    className="ms-Grid-row"
+  >
+    <CustomizedDefaultButton
+      className="window-footer-button-cancel"
+      onClick={[Function]}
+      text="Cancel"
+    />
+  </div>
+</footer>
+`;

--- a/src/tests/unit/electron/device-connect-view/components/__snapshots__/window-footer.test.tsx.snap
+++ b/src/tests/unit/electron/device-connect-view/components/__snapshots__/window-footer.test.tsx.snap
@@ -2,16 +2,12 @@
 
 exports[`WindowTitleTest render 1`] = `
 <footer
-  className="ms-Grid window-footer"
+  className="window-footer"
 >
-  <div
-    className="ms-Grid-row"
-  >
-    <CustomizedDefaultButton
-      className="window-footer-button-cancel"
-      onClick={[Function]}
-      text="Cancel"
-    />
-  </div>
+  <CustomizedDefaultButton
+    className="window-footer-button-cancel"
+    onClick={[Function]}
+    text="Cancel"
+  />
 </footer>
 `;

--- a/src/tests/unit/electron/device-connect-view/components/__snapshots__/window-title.test.tsx.snap
+++ b/src/tests/unit/electron/device-connect-view/components/__snapshots__/window-title.test.tsx.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WindowTitleTest render 1`] = `
+<header
+  className="ms-Grid window-title"
+>
+  <div
+    className="ms-Grid-row"
+  >
+    <span>
+      test
+    </span>
+    <div
+      aria-level={1}
+      className="ms-Grid-col header-text"
+      role="heading"
+    >
+      Test
+    </div>
+  </div>
+</header>
+`;

--- a/src/tests/unit/electron/device-connect-view/components/__snapshots__/window-title.test.tsx.snap
+++ b/src/tests/unit/electron/device-connect-view/components/__snapshots__/window-title.test.tsx.snap
@@ -2,21 +2,17 @@
 
 exports[`WindowTitleTest render 1`] = `
 <header
-  className="ms-Grid window-title"
+  className="window-title"
 >
-  <div
-    className="ms-Grid-row"
-  >
+  <div>
     <span>
       test
     </span>
-    <div
-      aria-level={1}
-      className="ms-Grid-col header-text"
-      role="heading"
+    <h1
+      className="header-text"
     >
       Test
-    </div>
+    </h1>
   </div>
 </header>
 `;

--- a/src/tests/unit/electron/device-connect-view/components/window-footer.test.tsx
+++ b/src/tests/unit/electron/device-connect-view/components/window-footer.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { BaseButton, Button } from 'office-ui-fabric-react/lib/Button';
+import { Button } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
 import { WindowFooter, WindowFooterProps } from '../../../../../electron/device-connect-view/components/window-footer';

--- a/src/tests/unit/electron/device-connect-view/components/window-footer.test.tsx
+++ b/src/tests/unit/electron/device-connect-view/components/window-footer.test.tsx
@@ -8,10 +8,6 @@ import { WindowFooter, WindowFooterProps } from '../../../../../electron/device-
 import { EventStubFactory } from '../../../common/event-stub-factory';
 
 describe('WindowTitleTest', () => {
-    test('constructor', () => {
-        expect(new WindowFooter({} as WindowFooterProps)).toBeDefined();
-    });
-
     test('render', () => {
         const props: WindowFooterProps = {
             cancelClick: () => {

--- a/src/tests/unit/electron/device-connect-view/components/window-footer.test.tsx
+++ b/src/tests/unit/electron/device-connect-view/components/window-footer.test.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import { BaseButton, Button } from 'office-ui-fabric-react/lib/Button';
+import * as React from 'react';
+import { Mock, Times } from 'typemoq';
+import { WindowFooter, WindowFooterProps } from '../../../../../electron/device-connect-view/components/window-footer';
+import { EventStubFactory } from '../../../common/event-stub-factory';
+
+describe('WindowTitleTest', () => {
+    test('constructor', () => {
+        expect(new WindowFooter({} as WindowFooterProps)).toBeDefined();
+    });
+
+    test('render', () => {
+        const props: WindowFooterProps = {
+            cancelClick: () => {
+                return;
+            },
+        };
+        const rendered = shallow(<WindowFooter {...props} />);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    test('cancel click', () => {
+        const onClickMock = Mock.ofInstance(
+            (event: React.MouseEvent<Button | BaseButton | HTMLDivElement | HTMLAnchorElement | HTMLButtonElement, MouseEvent>) => {},
+        );
+
+        const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
+
+        const props: WindowFooterProps = {
+            cancelClick: onClickMock.object,
+        };
+
+        const rendered = shallow(<WindowFooter {...props} />);
+        const button = rendered.find('.window-footer-button-cancel');
+        button.simulate('click', eventStub);
+
+        onClickMock.verify(onClick => onClick(eventStub), Times.once());
+    });
+});

--- a/src/tests/unit/electron/device-connect-view/components/window-footer.test.tsx
+++ b/src/tests/unit/electron/device-connect-view/components/window-footer.test.tsx
@@ -24,9 +24,7 @@ describe('WindowTitleTest', () => {
     });
 
     test('cancel click', () => {
-        const onClickMock = Mock.ofInstance(
-            (event: React.MouseEvent<Button | BaseButton | HTMLDivElement | HTMLAnchorElement | HTMLButtonElement, MouseEvent>) => {},
-        );
+        const onClickMock = Mock.ofInstance(() => {});
 
         const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
 
@@ -38,6 +36,6 @@ describe('WindowTitleTest', () => {
         const button = rendered.find('.window-footer-button-cancel');
         button.simulate('click', eventStub);
 
-        onClickMock.verify(onClick => onClick(eventStub), Times.once());
+        onClickMock.verify(onClick => onClick(), Times.once());
     });
 });

--- a/src/tests/unit/electron/device-connect-view/components/window-title.test.tsx
+++ b/src/tests/unit/electron/device-connect-view/components/window-title.test.tsx
@@ -5,10 +5,6 @@ import * as React from 'react';
 import { WindowTitle, WindowTitleProps } from '../../../../../electron/device-connect-view/components/window-title';
 
 describe('WindowTitleTest', () => {
-    test('constructor', () => {
-        expect(new WindowTitle({} as WindowTitleProps)).toBeDefined();
-    });
-
     test('render', () => {
         const props: WindowTitleProps = {
             title: 'Test',

--- a/src/tests/unit/electron/device-connect-view/components/window-title.test.tsx
+++ b/src/tests/unit/electron/device-connect-view/components/window-title.test.tsx
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { WindowTitle, WindowTitleProps } from '../../../../../electron/device-connect-view/components/window-title';
+
+describe('WindowTitleTest', () => {
+    test('constructor', () => {
+        expect(new WindowTitle({} as WindowTitleProps)).toBeDefined();
+    });
+
+    test('render', () => {
+        const props: WindowTitleProps = {
+            title: 'Test',
+            children: <span>test</span>,
+        };
+
+        const rendered = shallow(<WindowTitle {...props} />);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/electron/device-connect-view/device-connect-view-renderer.test.tsx
+++ b/src/tests/unit/electron/device-connect-view/device-connect-view-renderer.test.tsx
@@ -1,34 +1,43 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BrowserWindow } from 'electron';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { IMock, It, Mock } from 'typemoq';
-
+import { brand } from '../../../../content/strings/application';
+import { WindowFooter } from '../../../../electron/device-connect-view/components/window-footer';
+import { WindowTitle } from '../../../../electron/device-connect-view/components/window-title';
 import { DeviceConnectViewRenderer } from '../../../../electron/device-connect-view/device-connect-view-renderer';
+import { BrandBlue } from '../../../../icons/brand/blue/brand-blue';
 
 describe('DetailsViewRendererTest', () => {
     test('render', () => {
         const dom = document.createElement('div');
         const deviceConnectViewContainer = document.createElement('div');
         const renderMock: IMock<typeof ReactDOM.render> = Mock.ofInstance(() => null);
+        const expectedTitle = brand;
+
+        const browserWindow: BrowserWindow = {
+            close: () => {
+                return;
+            },
+        } as BrowserWindow;
 
         deviceConnectViewContainer.setAttribute('id', 'device-connect-view-container');
         dom.appendChild(deviceConnectViewContainer);
 
-        renderMock
-            .setup(r =>
-                r(
-                    It.isValue(
-                        <>
-                            <h1>Welcome to Accessibility Insights for Mobile</h1>
-                        </>,
-                    ),
-                    deviceConnectViewContainer,
-                ),
-            )
-            .verifiable();
+        const expectedComponent = (
+            <>
+                <WindowTitle title={expectedTitle}>
+                    <BrandBlue />
+                </WindowTitle>
+                <WindowFooter cancelClick={browserWindow.close}></WindowFooter>
+            </>
+        );
 
-        const renderer = new DeviceConnectViewRenderer(renderMock.object, dom);
+        renderMock.setup(r => r(It.isValue(expectedComponent), deviceConnectViewContainer)).verifiable();
+
+        const renderer = new DeviceConnectViewRenderer(renderMock.object, dom, browserWindow);
 
         renderer.render();
 


### PR DESCRIPTION
#### Description of changes
Currently, the electron app displays some placeholder text. This PR is the first step on the way towards the app actually resembling our design. It removes the default title bar and frame and adds a new logo, title, and cancel button.
![image](https://user-images.githubusercontent.com/4615491/63062492-08a30880-beae-11e9-83dd-a66e4e9bcabf.png)


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
