### PR TITLE
Adding Data Detail to PathSnippet Store

### DIFF
--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -13,6 +13,7 @@ import { BaseStore } from '../../common/base-store';
 import { FlaggedComponent } from '../../common/components/flagged-component';
 import { FeatureFlags } from '../../common/feature-flags';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
+import { SnippetCondition } from '../../common/types/store-data/path-snippet-store-data';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { ActionAndCancelButtonsComponent } from './action-and-cancel-buttons-component';
 import { FailureInstancePanelDetails } from './failure-instance-panel-details';
@@ -35,7 +36,7 @@ export interface FailureInstancePanelControlProps {
 export type FailureInstanceData = {
     failureDescription?: string;
     path?: string;
-    snippet?: string;
+    snippetCondition?: SnippetCondition;
 };
 
 export interface FailureInstancePanelControlState {
@@ -75,7 +76,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                 currentInstance: {
                     failureDescription: this.state.currentInstance.failureDescription,
                     path: this.props.failureInstance.path,
-                    snippet: this.props.failureInstance.snippet,
+                    snippetCondition: this.props.failureInstance.snippetCondition,
                 },
             }));
         }
@@ -177,7 +178,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
         return (
             <FailureInstancePanelDetails
                 path={this.state.currentInstance.path}
-                snippet={this.state.currentInstance.snippet}
+                snippetCondition={this.state.currentInstance.snippetCondition}
                 onSelectorChange={this.onSelectorChange}
                 onValidateSelector={this.onValidateSelector}
             />
@@ -188,7 +189,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
         const defaultInstance = {
             failureDescription: null,
             path: null,
-            snippet: null,
+            snippetCondition: { associatedPath: null, showError: false, snippet: null },
         };
 
         return defaultInstance;

--- a/src/DetailsView/components/failure-instance-panel-details.tsx
+++ b/src/DetailsView/components/failure-instance-panel-details.tsx
@@ -6,30 +6,30 @@ import { ILabelStyles } from 'office-ui-fabric-react/lib/Label';
 import { ITextFieldStyles, TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 import { NamedSFC } from '../../common/react/named-sfc';
+import { SnippetCondition } from '../../common/types/store-data/path-snippet-store-data';
 
 export type FailureInstancePanelDetailsProps = {
     path: string;
-    snippet: string;
+    snippetCondition: SnippetCondition;
     onSelectorChange: (event, value) => void;
     onValidateSelector: (event) => void;
 };
 
 export const FailureInstancePanelDetails = NamedSFC<FailureInstancePanelDetailsProps>('FailureInstancePanelDetails', props => {
     const getSnippetInfo = (): JSX.Element => {
-        if (!props.snippet) {
-            return (
-                <div className="failure-instance-snippet-empty-body">Code snippet will auto-populate based on the CSS selector input.</div>
-            );
-        } else if (props.snippet.startsWith('No code snippet is map')) {
-            return (
-                <div className="failure-instance-snippet-error">
-                    <Icon iconName="statusErrorFull" className="failure-instance-snippet-error-icon" />
-                    <div>{props.snippet}</div>
-                </div>
-            );
-        } else {
-            return <div className="failure-instance-snippet-filled-body">{props.snippet}</div>;
+        if (props.snippetCondition) {
+            if (props.snippetCondition.showError) {
+                return (
+                    <div className="failure-instance-snippet-error">
+                        <Icon iconName="statusErrorFull" className="failure-instance-snippet-error-icon" />
+                        <div>No code snippet is mapped to: {props.snippetCondition.associatedPath}</div>
+                    </div>
+                );
+            } else if (props.snippetCondition.snippet) {
+                return <div className="failure-instance-snippet-filled-body">{props.snippetCondition.snippet}</div>;
+            }
         }
+        return <div className="failure-instance-snippet-empty-body">Code snippet will auto-populate based on the CSS selector input.</div>;
     };
     return (
         <div>

--- a/src/DetailsView/components/manual-test-step-view.tsx
+++ b/src/DetailsView/components/manual-test-step-view.tsx
@@ -59,7 +59,7 @@ export class ManualTestStepView extends React.Component<ManualTestStepViewProps>
         );
         const instance: FailureInstanceData = {
             path: this.props.pathSnippetStoreData.path,
-            snippet: this.props.pathSnippetStoreData.snippet,
+            snippetCondition: this.props.pathSnippetStoreData.snippetCondition,
         };
         return (
             <React.Fragment>

--- a/src/DetailsView/handlers/assessment-instance-table-handler.tsx
+++ b/src/DetailsView/handlers/assessment-instance-table-handler.tsx
@@ -170,7 +170,11 @@ export class AssessmentInstanceTableHandler {
         const currentInstance = {
             failureDescription: instance.description,
             path: pathSnippetStoreData.path || instance.selector,
-            snippet: pathSnippetStoreData.snippet || instance.html,
+            snippetCondition: pathSnippetStoreData.snippetCondition || {
+                associatedPath: instance.selector,
+                showError: instance.htmlError,
+                snippet: instance.html,
+            },
         };
         return (
             <AssessmentInstanceEditAndRemoveControl

--- a/src/background/actions/path-snippet-action-creator.ts
+++ b/src/background/actions/path-snippet-action-creator.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { RegisterTypeToPayloadCallback } from '../../common/message';
 import { Messages } from '../../common/messages';
-import { PathSnippetActions } from './path-snippet-actions';
+import { PathSnippetActions, SnippetPayload } from './path-snippet-actions';
 
 export class PathSnippetActionCreator {
     constructor(
@@ -21,7 +21,7 @@ export class PathSnippetActionCreator {
         this.pathSnippetActions.onAddPath.invoke(payload);
     };
 
-    private onAddCorrespondingSnippet = (payload: string): void => {
+    private onAddCorrespondingSnippet = (payload: SnippetPayload): void => {
         this.pathSnippetActions.onAddSnippet.invoke(payload);
     };
 

--- a/src/background/actions/path-snippet-actions.ts
+++ b/src/background/actions/path-snippet-actions.ts
@@ -1,10 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Action } from '../../common/flux/action';
+import { BaseActionPayload } from './action-payloads';
+
+export interface SnippetPayload extends BaseActionPayload {
+    associatedPath: string;
+    showError: boolean;
+    snippet: string;
+}
 
 export class PathSnippetActions {
     public readonly getCurrentState = new Action<void>();
     public readonly onAddPath = new Action<string>();
-    public readonly onAddSnippet = new Action<string>();
+    public readonly onAddSnippet = new Action<SnippetPayload>();
     public readonly onClearData = new Action<void>();
 }

--- a/src/background/assessment-data-converter.ts
+++ b/src/background/assessment-data-converter.ts
@@ -10,6 +10,7 @@ import {
     TestStepResult,
     UserCapturedInstance,
 } from '../common/types/store-data/assessment-result-data';
+import { SnippetCondition } from '../common/types/store-data/path-snippet-store-data';
 import { DecoratedAxeNodeResult, HtmlElementAxeResults } from '../injected/scanner-utils';
 import { PartialTabOrderPropertyBag } from '../injected/tab-order-property-bag';
 import { TabStopEvent } from '../injected/tab-stops-listener';
@@ -183,12 +184,13 @@ export class AssessmentDataConverter {
         return null;
     }
 
-    public generateFailureInstance(description: string, path: string, snippet: string): UserCapturedInstance {
+    public generateFailureInstance(description: string, path: string, snippetCondition: SnippetCondition): UserCapturedInstance {
         const instance: UserCapturedInstance = {
             id: this.generateUID(),
             description,
             selector: path,
-            html: snippet,
+            html: snippetCondition.snippet,
+            htmlError: snippetCondition.showError,
         };
         return instance;
     }

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -187,7 +187,8 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
             const instance = instances[instanceIndex];
             if (instance.id === payload.id) {
                 instance.description = payload.instanceData.failureDescription;
-                instance.html = payload.instanceData.snippet;
+                instance.html = payload.instanceData.snippetCondition.snippet;
+                instance.htmlError = payload.instanceData.snippetCondition.showError;
                 instance.selector = payload.instanceData.path;
                 break;
             }
@@ -215,7 +216,7 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         const newInstance: UserCapturedInstance = this.assessmentDataConverter.generateFailureInstance(
             payload.instanceData.failureDescription,
             payload.instanceData.path,
-            payload.instanceData.snippet,
+            payload.instanceData.snippetCondition,
         );
         assessmentData.manualTestStepResultMap[payload.requirement].instances.push(newInstance);
         this.updateManualTestStepStatus(assessmentData, payload.requirement, payload.test);

--- a/src/background/stores/path-snippet-store.ts
+++ b/src/background/stores/path-snippet-store.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { StoreNames } from '../../common/stores/store-names';
 import { PathSnippetStoreData } from '../../common/types/store-data/path-snippet-store-data';
-import { PathSnippetActions } from '../actions/path-snippet-actions';
+import { PathSnippetActions, SnippetPayload } from '../actions/path-snippet-actions';
 import { BaseStoreImpl } from './base-store-impl';
 
 export class PathSnippetStore extends BaseStoreImpl<PathSnippetStoreData> {
@@ -13,7 +13,7 @@ export class PathSnippetStore extends BaseStoreImpl<PathSnippetStoreData> {
     public getDefaultState(): PathSnippetStoreData {
         const defaultValue: PathSnippetStoreData = {
             path: null,
-            snippet: null,
+            snippetCondition: null,
         };
 
         return defaultValue;
@@ -21,13 +21,18 @@ export class PathSnippetStore extends BaseStoreImpl<PathSnippetStoreData> {
 
     protected addActionListeners(): void {
         this.pathSnippetActions.getCurrentState.addListener(this.onGetCurrentState);
-        this.pathSnippetActions.onAddPath.addListener(payload => this.onChangeProperty('path', payload));
-        this.pathSnippetActions.onAddSnippet.addListener(payload => this.onChangeProperty('snippet', payload));
+        this.pathSnippetActions.onAddPath.addListener(payload => this.onChangePath(payload));
+        this.pathSnippetActions.onAddSnippet.addListener(payload => this.onChangeSnippet(payload));
         this.pathSnippetActions.onClearData.addListener(this.onClearState);
     }
 
-    private onChangeProperty = (property: keyof PathSnippetStoreData, payload: string): void => {
-        this.state[property] = payload;
+    private onChangePath = (payload: string): void => {
+        this.state.path = payload;
+        this.emitChanged();
+    };
+
+    private onChangeSnippet = (payload: SnippetPayload): void => {
+        this.state.snippetCondition = { associatedPath: payload.associatedPath, showError: payload.showError, snippet: payload.snippet };
         this.emitChanged();
     };
 

--- a/src/common/message-creators/path-snippet-action-message-creator.ts
+++ b/src/common/message-creators/path-snippet-action-message-creator.ts
@@ -6,9 +6,9 @@ import { ActionMessageDispatcher } from './action-message-dispatcher';
 export class PathSnippetActionMessageCreator {
     constructor(private readonly dispatcher: ActionMessageDispatcher) {}
 
-    public addCorrespondingSnippet = (snippet: string): void => {
+    public addCorrespondingSnippet = (associatedPath: string, showError: boolean, snippet: string): void => {
         const messageType = Messages.PathSnippet.AddCorrespondingSnippet;
-        const payload = snippet;
+        const payload = { associatedPath, showError, snippet };
         this.dispatcher.dispatchMessage({
             messageType,
             payload,

--- a/src/common/types/store-data/assessment-result-data.ts
+++ b/src/common/types/store-data/assessment-result-data.ts
@@ -41,6 +41,7 @@ export interface UserCapturedInstance {
     description: string;
     html?: string;
     selector?: string;
+    htmlError?: boolean;
 }
 
 export interface GeneratedAssessmentInstance<T = {}, K = {}> {

--- a/src/common/types/store-data/path-snippet-store-data.ts
+++ b/src/common/types/store-data/path-snippet-store-data.ts
@@ -3,5 +3,11 @@
 
 export interface PathSnippetStoreData {
     path: string;
-    snippet: string;
+    snippetCondition: SnippetCondition;
 }
+
+export type SnippetCondition = {
+    associatedPath: string;
+    showError: boolean;
+    snippet: string;
+};

--- a/src/injected/path-snippet-controller.ts
+++ b/src/injected/path-snippet-controller.ts
@@ -8,7 +8,7 @@ export class PathSnippetController {
     constructor(
         private readonly pathSnippetStore: BaseStore<PathSnippetStoreData>,
         private readonly elementFinderByPath: ElementFinderByPath,
-        private readonly addCorrespondingSnippet: (snippet: string) => void,
+        private readonly addCorrespondingSnippet: (associatedPath: string, showError: boolean, snippet: string) => void,
     ) {}
 
     public listenToStore = (): void => {
@@ -36,18 +36,11 @@ export class PathSnippetController {
 
         this.elementFinderByPath.processRequest(message).then(
             result => {
-                this.sendBackSnippetFromPath(result);
+                this.addCorrespondingSnippet(path, false, result);
             },
             err => {
-                this.sendBackErrorFromPath(path);
+                this.addCorrespondingSnippet(path, true, null);
             },
         );
-    };
-
-    private sendBackSnippetFromPath = (snippet: string): void => {
-        this.addCorrespondingSnippet(snippet);
-    };
-    private sendBackErrorFromPath = (path: string): void => {
-        this.addCorrespondingSnippet('No code snippet is mapped to: ' + path);
     };
 }

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -632,7 +632,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         const instanceData = {
             failureDescription: 'description',
             path: 'path',
-            snippet: 'snippet',
+            snippetCondition: { associatedPath: 'path', showError: false, snippet: 'snippet' },
         };
 
         const expectedMessage = {
@@ -685,7 +685,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         const instanceData = {
             failureDescription: 'des',
             path: 'path',
-            snippet: 'snippet',
+            snippetCondition: { associatedPath: 'path', showError: false, snippet: 'snippet' },
         };
         const expectedMessage = {
             messageType: Messages.Assessment.EditFailureInstance,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: cre
           onSelectorChange={[Function]}
           onValidateSelector={[Function]}
           path={null}
-          snippet={null}
+          snippetCondition={null}
         />
       }
       featureFlag="manualInstanceDetails"
@@ -75,7 +75,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
           onSelectorChange={[Function]}
           onValidateSelector={[Function]}
           path={null}
-          snippet={null}
+          snippetCondition={null}
         />
       }
       featureFlag="manualInstanceDetails"
@@ -124,7 +124,13 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: par
           onSelectorChange={[Function]}
           onValidateSelector={[Function]}
           path={null}
-          snippet={null}
+          snippetCondition={
+            Object {
+              "associatedPath": null,
+              "showError": false,
+              "snippet": null,
+            }
+          }
         />
       }
       featureFlag="manualInstanceDetails"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-details.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-details.test.tsx.snap
@@ -1,6 +1,109 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FailureInstancePanelDetailsTest renders 1`] = `
+exports[`FailureInstancePanelDetailsTest renders with invalid snippet 1`] = `
+<div>
+  <a
+    className="learn-more"
+    href="#"
+  >
+    Learn more about adding failure instances
+  </a>
+  <StyledTextFieldBase
+    label="CSS Selector"
+    multiline={true}
+    onChange={[Function]}
+    placeholder="CSS Selector"
+    resizable={false}
+    rows={4}
+    styles={[Function]}
+    value="Given Path"
+  />
+  <div
+    className="failure-instance-selector-note"
+  >
+    Note: If the CSS selector maps to multiple snippets, the first will be selected
+  </div>
+  <div>
+    <CustomizedDefaultButton
+      disabled={false}
+      onClick={[Function]}
+      text="Validate CSS selector"
+    />
+  </div>
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+  >
+    <div
+      className="failure-instance-snippet-title"
+    >
+      Code Snippet
+    </div>
+    <div
+      className="failure-instance-snippet-error"
+    >
+      <StyledIconBase
+        className="failure-instance-snippet-error-icon"
+        iconName="statusErrorFull"
+      />
+      <div>
+        No code snippet is mapped to: 
+        Given Path
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FailureInstancePanelDetailsTest renders with no snippet 1`] = `
+<div>
+  <a
+    className="learn-more"
+    href="#"
+  >
+    Learn more about adding failure instances
+  </a>
+  <StyledTextFieldBase
+    label="CSS Selector"
+    multiline={true}
+    onChange={[Function]}
+    placeholder="CSS Selector"
+    resizable={false}
+    rows={4}
+    styles={[Function]}
+    value="Given Path"
+  />
+  <div
+    className="failure-instance-selector-note"
+  >
+    Note: If the CSS selector maps to multiple snippets, the first will be selected
+  </div>
+  <div>
+    <CustomizedDefaultButton
+      disabled={false}
+      onClick={[Function]}
+      text="Validate CSS selector"
+    />
+  </div>
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+  >
+    <div
+      className="failure-instance-snippet-title"
+    >
+      Code Snippet
+    </div>
+    <div
+      className="failure-instance-snippet-empty-body"
+    >
+      Code snippet will auto-populate based on the CSS selector input.
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FailureInstancePanelDetailsTest renders with valid snippet 1`] = `
 <div>
   <a
     className="learn-more"
@@ -42,7 +145,7 @@ exports[`FailureInstancePanelDetailsTest renders 1`] = `
     <div
       className="failure-instance-snippet-filled-body"
     >
-      Snippet for Given Path
+      Found snippet
     </div>
   </div>
 </div>

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
@@ -34,7 +34,7 @@ describe('AssessmentInstanceRemoveButton', () => {
             currentInstance: {
                 failureDescription: 'original text',
                 path: 'original path',
-                snippet: 'original snippet',
+                snippetCondition: { associatedPath: 'original path', showError: false, snippet: 'original snippet' },
             },
             onRemove: onRemoveMock.object,
             onEdit: null,

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -16,7 +16,6 @@ import {
 } from '../../../../../DetailsView/components/action-and-cancel-buttons-component';
 import {
     CapturedInstanceActionType,
-    FailureInstanceData,
     FailureInstancePanelControl,
     FailureInstancePanelControlProps,
 } from '../../../../../DetailsView/components/failure-instance-panel-control';
@@ -100,7 +99,7 @@ describe('FailureInstancePanelControlTest', () => {
         const failureInstance = {
             failureDescription: 'new text',
             path: 'some selector',
-            snippet: null,
+            snippetCondition: { associatedPath: null, showError: false, snippet: null },
         };
 
         props.failureInstance = failureInstance;
@@ -120,10 +119,11 @@ describe('FailureInstancePanelControlTest', () => {
     test('openFailureInstancePanel', () => {
         const props = createPropsWithType(CapturedInstanceActionType.CREATE);
         const eventStub = null;
+        const newPath = 'new path';
         const failureInstance = {
             failureDescription: 'new text',
-            path: 'new path',
-            snippet: 'new snippet',
+            path: newPath,
+            snippetCondition: { associatedPath: newPath, showError: false, snippet: 'new snippet' },
         };
         props.failureInstance = failureInstance;
         const wrapper = shallow<FailureInstancePanelControl>(<FailureInstancePanelControl {...props} />);
@@ -139,7 +139,7 @@ describe('FailureInstancePanelControlTest', () => {
         expect(wrapper.state().isPanelOpen).toBe(true);
         expect(wrapper.state().currentInstance.failureDescription).toEqual(props.failureInstance.failureDescription);
         expect(wrapper.state().currentInstance.path).toEqual(props.failureInstance.path);
-        expect(wrapper.state().currentInstance.snippet).toEqual(props.failureInstance.snippet);
+        expect(wrapper.state().currentInstance.snippetCondition).toEqual(props.failureInstance.snippetCondition);
     });
 
     test('closeFailureInstancePanel', () => {
@@ -167,15 +167,16 @@ describe('FailureInstancePanelControlTest', () => {
 
     test('onSaveEditedFailureInstance', () => {
         const description = 'text';
-        const props = createPropsWithType(CapturedInstanceActionType.EDIT);
-        props.instanceId = '1';
-        props.editFailureInstance = editInstanceMock.object;
-
         const instanceData = {
             failureDescription: description,
             path: null,
-            snippet: null,
+            snippetCondition: { associatedPath: null, showError: false, snippet: null },
         };
+
+        const props = createPropsWithType(CapturedInstanceActionType.EDIT);
+        props.instanceId = '1';
+        props.editFailureInstance = editInstanceMock.object;
+        props.failureInstance = instanceData;
 
         editInstanceMock.setup(handler => handler(instanceData, props.test, props.step, props.instanceId)).verifiable(Times.once());
 
@@ -208,13 +209,14 @@ describe('FailureInstancePanelControlTest', () => {
 
     test('onAddFailureInstance', () => {
         const description = 'text';
-        const props = createPropsWithType(CapturedInstanceActionType.CREATE);
-
         const instanceData = {
             failureDescription: description,
-            path: null,
-            snippet: null,
+            path: 'path',
+            snippetCondition: { associatedPath: 'path', showError: false, snippet: 'snippet' },
         };
+
+        const props = createPropsWithType(CapturedInstanceActionType.CREATE);
+        props.failureInstance = instanceData;
 
         addInstanceMock.setup(handler => handler(instanceData, props.test, props.step)).verifiable(Times.once());
 
@@ -246,10 +248,11 @@ describe('FailureInstancePanelControlTest', () => {
 
     test('componentDidMount clears store', () => {
         const props = createPropsWithType(CapturedInstanceActionType.CREATE);
+        const inputPath = 'inputed path';
         const failureInstance = {
             failureDescription: null,
-            path: 'inputed path',
-            snippet: 'snippet for path',
+            path: inputPath,
+            snippetCondition: { associatedPath: inputPath, showError: false, snippet: 'snippet for path' },
         };
         props.failureInstance = failureInstance;
 
@@ -262,10 +265,11 @@ describe('FailureInstancePanelControlTest', () => {
     test('componentDidUpdate reassigns state', () => {
         const prevProps = createPropsWithType(CapturedInstanceActionType.CREATE);
         const newProps = createPropsWithType(CapturedInstanceActionType.CREATE);
+        const inputPath = 'inputed path';
         const newFailureInstance = {
             failureDescription: null,
-            path: 'inputed path',
-            snippet: 'snippet for path',
+            path: inputPath,
+            snippetCondition: { associatedPath: inputPath, showError: false, snippet: 'snippet for path' },
         };
         newProps.failureInstance = newFailureInstance;
 
@@ -287,7 +291,7 @@ describe('FailureInstancePanelControlTest', () => {
         const emptyFailureInstance = {
             failureDescription: null,
             path: null,
-            snippet: null,
+            snippetCondition: null,
         };
 
         return {

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-details.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-details.test.tsx
@@ -8,7 +8,6 @@ import { FailureInstancePanelDetails } from '../../../../../DetailsView/componen
 
 describe('FailureInstancePanelDetailsTest', () => {
     const path = 'Given Path';
-    const snippet = 'Snippet for Given Path';
     const onSelectorChangeMock = Mock.ofInstance((value: string) => {});
     const onValidateSelectorMock = Mock.ofInstance(() => {});
 
@@ -17,33 +16,48 @@ describe('FailureInstancePanelDetailsTest', () => {
         onValidateSelectorMock.reset();
     });
 
-    const rendered = shallow(
-        <FailureInstancePanelDetails
-            path={path}
-            snippet={snippet}
-            onSelectorChange={onSelectorChangeMock.object}
-            onValidateSelector={onValidateSelectorMock.object}
-        ></FailureInstancePanelDetails>,
-    );
+    const rendered = shallow(createFailureInstancePanelDetails(null, false));
 
-    it('renders', () => {
-        expect(rendered.exists());
-        expect(rendered.getElement()).toMatchSnapshot();
+    test('renders with no snippet', () => {
+        const noSnippetRender = shallow(createFailureInstancePanelDetails(null, false));
+        expect(noSnippetRender.exists());
+        expect(noSnippetRender.getElement()).toMatchSnapshot();
     });
 
-    it('triggers selector change on typing', () => {
+    test('renders with invalid snippet', () => {
+        const invalidSnippetRender = shallow(createFailureInstancePanelDetails(null, true));
+        expect(invalidSnippetRender.exists());
+        expect(invalidSnippetRender.getElement()).toMatchSnapshot();
+    });
+
+    test('renders with valid snippet', () => {
+        const validSnippetRender = shallow(createFailureInstancePanelDetails('Found snippet', false));
+        expect(validSnippetRender.exists());
+        expect(validSnippetRender.getElement()).toMatchSnapshot();
+    });
+
+    test('triggers selector change on typing', () => {
         const newPath = 'updated path';
         onSelectorChangeMock.setup(dc => dc(It.isValue(newPath))).verifiable(Times.once());
-
         const textField = rendered.find(TextField);
         textField.simulate('change', newPath);
         onSelectorChangeMock.verifyAll();
     });
 
-    it('triggers validation on click', () => {
+    test('triggers validation on click', () => {
         onValidateSelectorMock.setup(getter => getter()).verifiable(Times.once());
-
         rendered.find(DefaultButton).simulate('click');
         onValidateSelectorMock.verifyAll();
     });
+
+    function createFailureInstancePanelDetails(snippet: string, error: boolean): JSX.Element {
+        return (
+            <FailureInstancePanelDetails
+                path={path}
+                snippetCondition={{ associatedPath: path, showError: error, snippet: snippet }}
+                onSelectorChange={onSelectorChangeMock.object}
+                onValidateSelector={onValidateSelectorMock.object}
+            ></FailureInstancePanelDetails>
+        );
+    }
 });

--- a/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
@@ -62,15 +62,16 @@ describe('ManualTestStepView', () => {
         const items = [];
         const assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
         const cols = [];
+        const path = 'Validated Path';
 
         const pathSnippetStoreData = {
-            path: 'Validated Path',
-            snippet: 'Corresponding Snippet',
+            path: path,
+            snippetCondition: { associatedPath: path, showError: false, snippet: 'Corresponding Snippet' },
         };
 
         const failureInstance = {
             path: pathSnippetStoreData.path,
-            snippet: pathSnippetStoreData.snippet,
+            snippetCondition: pathSnippetStoreData.snippetCondition,
         };
 
         const props: ManualTestStepViewProps = {

--- a/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
+++ b/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
@@ -121,9 +121,11 @@ describe('AssessmentInstanceTableHandlerTest', () => {
             selectedTestType: 5,
         };
 
+        const path = 'test path';
+
         const pathSnippetStoreData = {
-            path: 'test path',
-            snippet: 'test snippet for path',
+            path: path,
+            snippetCondition: { associatedPath: path, showError: false, snippet: 'test snippet for path' },
         };
 
         const rows = testSubject.createCapturedInstanceTableItems(
@@ -137,7 +139,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
         const currentInstance = {
             failureDescription: instance.description,
             path: pathSnippetStoreData.path,
-            snippet: pathSnippetStoreData.snippet,
+            snippetCondition: pathSnippetStoreData.snippetCondition,
         };
 
         const instanceActionButtons: JSX.Element = (
@@ -169,6 +171,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
             description: 'des',
             selector: 'saved path',
             html: 'saved instance',
+            htmlError: false,
         };
         const assessmentNavState: AssessmentNavState = {
             selectedTestStep: 'step1',
@@ -177,7 +180,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
 
         const pathSnippetStoreData = {
             path: null,
-            snippet: null,
+            snippetCondition: null,
         };
 
         const rows = testSubject.createCapturedInstanceTableItems(
@@ -191,7 +194,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
         const currentInstance = {
             failureDescription: instance.description,
             path: instance.selector,
-            snippet: instance.html,
+            snippetCondition: { associatedPath: instance.selector, showError: instance.htmlError, snippet: instance.html },
         };
 
         const instanceActionButtons: JSX.Element = (

--- a/src/tests/unit/tests/background/assessment-data-converter.test.ts
+++ b/src/tests/unit/tests/background/assessment-data-converter.test.ts
@@ -451,28 +451,36 @@ describe('AssessmentDataConverterTest', () => {
         const description = 'description';
         const path = null;
         const snippet = null;
+        const snippetError = false;
+        const snippetCondition = { associatedPath: path, showError: snippetError, snippet: snippet };
+
         const expectedResult = {
             id: uid,
             html: snippet,
             description: description,
             selector: path,
+            htmlError: snippetError,
         };
 
-        expect(testSubject.generateFailureInstance(description, path, snippet)).toEqual(expectedResult);
+        expect(testSubject.generateFailureInstance(description, path, snippetCondition)).toEqual(expectedResult);
     });
 
     test('generateFailureInstance with description and path', () => {
         const description = 'description';
         const path = 'path';
         const snippet = 'snippet';
+        const snippetError = false;
+        const snippetCondition = { associatedPath: path, showError: snippetError, snippet: snippet };
+
         const expectedResult = {
             id: uid,
             description: description,
             selector: path,
             html: snippet,
+            htmlError: snippetError,
         };
 
-        expect(testSubject.generateFailureInstance(description, path, snippet)).toEqual(expectedResult);
+        expect(testSubject.generateFailureInstance(description, path, snippetCondition)).toEqual(expectedResult);
     });
 
     function setupGenerateInstanceIdentifierMock(instance: UniquelyIdentifiableInstances, identifier: string): void {

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -1114,21 +1114,26 @@ describe('AssessmentStoreTest', () => {
 
         const initialState = getStateWithAssessment(assessmentData);
 
+        const path = 'path';
+        const snippet = 'snippet';
+        const error = false;
+
         const payload: AddFailureInstancePayload = {
             test: assessmentType,
             requirement: requirementKey,
             instanceData: {
                 failureDescription: 'description',
-                path: 'path',
-                snippet: 'snippet',
+                path: path,
+                snippetCondition: { associatedPath: path, showError: error, snippet: snippet },
             },
         };
 
         const failureInstance = {
             id: '1',
             description: 'description',
-            selector: 'path',
-            html: 'snippet',
+            selector: path,
+            html: snippet,
+            htmlError: error,
         };
 
         assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
@@ -1137,9 +1142,13 @@ describe('AssessmentStoreTest', () => {
 
         assessmentDataConverterMock
             .setup(a =>
-                a.generateFailureInstance(payload.instanceData.failureDescription, payload.instanceData.path, payload.instanceData.snippet),
+                a.generateFailureInstance(
+                    payload.instanceData.failureDescription,
+                    payload.instanceData.path,
+                    payload.instanceData.snippetCondition,
+                ),
             )
-            .returns(description => failureInstance);
+            .returns(() => failureInstance);
 
         const expectedAssessment = new AssessmentDataBuilder()
             .with('manualTestStepResultMap', {
@@ -1218,6 +1227,7 @@ describe('AssessmentStoreTest', () => {
             description: oldDescription,
             selector: oldPath,
             html: oldSnippet,
+            htmlError: false,
         };
 
         const assessmentData = new AssessmentDataBuilder()
@@ -1239,7 +1249,7 @@ describe('AssessmentStoreTest', () => {
             instanceData: {
                 failureDescription: newDescription,
                 path: newPath,
-                snippet: newSnippet,
+                snippetCondition: { associatedPath: newPath, showError: false, snippet: newSnippet },
             },
         };
 
@@ -1258,6 +1268,7 @@ describe('AssessmentStoreTest', () => {
                             description: newDescription,
                             selector: newPath,
                             html: newSnippet,
+                            htmlError: false,
                         },
                     ],
                 },

--- a/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
+++ b/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
@@ -21,7 +21,7 @@ describe('PathSnippetStoreTest', () => {
         const defaultState = getDefaultState();
 
         expect(defaultState.path).toEqual(null);
-        expect(defaultState.snippet).toEqual(null);
+        expect(defaultState.snippetCondition).toEqual(null);
     });
 
     test('on getCurrentState', () => {
@@ -44,9 +44,9 @@ describe('PathSnippetStoreTest', () => {
 
     test('on addSnippet', () => {
         const initialState = getDefaultState();
-        const payload = 'new snippet';
+        const payload = { associatedPath: 'path', showError: false, snippet: 'new snippet' };
         const finalState = getDefaultState();
-        finalState.snippet = payload;
+        finalState.snippetCondition = payload;
 
         createStoreForPathSnippetActions('onAddSnippet')
             .withActionParam(payload)
@@ -56,7 +56,7 @@ describe('PathSnippetStoreTest', () => {
     test('on clearState', () => {
         const initialState = {
             path: 'test path',
-            snippet: 'test snippet',
+            snippetCondition: { associatedPath: 'test path', showError: false, snippet: 'test snippet' },
         };
         const finalState = getDefaultState();
 

--- a/src/tests/unit/tests/common/message-creators/path-snippet-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/path-snippet-action-message-creator.test.ts
@@ -17,13 +17,15 @@ describe('PathSnippetActionMessageCreatorTest', () => {
 
     it('dispatches message for addCorrespondingSnippet', () => {
         const snippet = 'test snippet';
+        const showError = false;
+        const associatedPath = 'test path';
 
         const expectedMessage: Message = {
             messageType: Messages.PathSnippet.AddCorrespondingSnippet,
-            payload: snippet,
+            payload: { associatedPath, showError, snippet },
         };
 
-        testSubject.addCorrespondingSnippet(snippet);
+        testSubject.addCorrespondingSnippet(associatedPath, showError, snippet);
         dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });
 });


### PR DESCRIPTION
#### Description of changes

Previously, we had been storing a hardcoded string ("No code snippet found for path: _______") in the snippet field of the PathSnippet store data. We then checked if we had this string to see if we should display an error message. This PR aims to refactor the PathSnippet store and its data to hold enough relevant information to discern which of three messages we should show:
a) "Code snippet will auto-populate based on the CSS selector input"
b) The code snippet for an HTML element
c) "No code snippet is mapped to: ____"

In order to make this possible, I replaced the simple 'snippet' field with a more robust 'snippetCondition' field in the PathSnippet store data. A SnippetCondition type holds a snippet (string), error (Boolean), and associated path (string). We can then show the correct message based upon the combination of values described by the SnippetCondition.

Things to note:
Originally, a SnippetCondition just held a snippet and error. We already have a path field in the larger FailureInstanceData model which we pass to the UI (which holds our SnippetCondition as well), so it may seem unnecessary to type in another path. This decision, however, is in response to a rare, but annoying bug. The component re-renders so quickly, that there is a split second between when our path is updated in the store (and our first re-render occurs) and the snippet is retrieved and added to the store (when our second re-render occurs). This means, that for a split second if you are in the very specific condition of showing a message like "No code snippet is mapped to FIRST_PATH", the screen will flash "No code snippet is mapped to SECOND_PATH", before finally showing the code snippet for SECOND_PATH. Obviously, this is for a very specific scenario (when you edit an instance with a bad path to change to a valid path), but I wanted to get ahead of this behavior and conceptually it made sense that every snippet should be linked to it's associated path. For this reason, we have two path variables in the UI, the path that the user has most recently entered, and the path that the current snippet is associated with. 99% of the time these two values will be the same, but it keeps the message from flickering that 1% of the time.

#### Pull request checklist

- [X] Addresses an existing issue: PR for Feature #1555720
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [X] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS
