### PR TITLE
Updating CSS of instance failure details pane

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -224,11 +224,7 @@ div.insights-file-issue-details-dialog-container {
         margin: 20px 0px 20px 0px;
     }
     .header-text {
-        margin-top: 30px;
         font-size: 21px;
-    }
-    .footer {
-        padding: 16px 16px 16px 0px;
     }
     .learn-more {
         color: $communication-primary;

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -124,7 +124,6 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                     : 'Edit failure instance',
             hasCloseButton: true,
             closeButtonAriaLabel: 'Close failure instance panel',
-            onRenderFooterContent: this.getActionCancelButtons,
         };
 
         return (
@@ -140,11 +139,12 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                     label="Comment"
                     styles={getStyles}
                     multiline={true}
-                    rows={4}
+                    rows={8}
                     value={this.state.currentInstance.failureDescription}
                     onChange={this.onFailureDescriptionChange}
                     resizable={false}
                 />
+                {this.getActionCancelButtons()}
             </GenericPanel>
         );
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
@@ -20,7 +20,6 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: cre
     hasCloseButton={true}
     isOpen={false}
     onDismiss={[Function]}
-    onRenderFooterContent={[Function]}
     title="Add a failure instance"
   >
     <FlaggedComponent
@@ -41,10 +40,21 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: cre
       multiline={true}
       onChange={[Function]}
       resizable={false}
-      rows={4}
+      rows={8}
       styles={[Function]}
       value={null}
     />
+    <div
+      className="footer"
+    >
+      <ActionAndCancelButtonsComponent
+        cancelButtonOnClick={[Function]}
+        isHidden={false}
+        primaryButtonDisabled={true}
+        primaryButtonOnClick={[Function]}
+        primaryButtonText="Add failed instance"
+      />
+    </div>
   </GenericPanel>
 </React.Fragment>
 `;
@@ -66,7 +76,6 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
     hasCloseButton={true}
     isOpen={false}
     onDismiss={[Function]}
-    onRenderFooterContent={[Function]}
     title="Edit failure instance"
   >
     <FlaggedComponent
@@ -87,10 +96,21 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
       multiline={true}
       onChange={[Function]}
       resizable={false}
-      rows={4}
+      rows={8}
       styles={[Function]}
       value={null}
     />
+    <div
+      className="footer"
+    >
+      <ActionAndCancelButtonsComponent
+        cancelButtonOnClick={[Function]}
+        isHidden={false}
+        primaryButtonDisabled={true}
+        primaryButtonOnClick={[Function]}
+        primaryButtonText="Save"
+      />
+    </div>
   </GenericPanel>
 </React.Fragment>
 `;
@@ -115,7 +135,6 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: par
     hasCloseButton={true}
     isOpen={false}
     onDismiss={[Function]}
-    onRenderFooterContent={[Function]}
     title="Add a failure instance"
   >
     <FlaggedComponent
@@ -136,10 +155,21 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: par
       multiline={true}
       onChange={[Function]}
       resizable={false}
-      rows={4}
+      rows={8}
       styles={[Function]}
       value="original text"
     />
+    <div
+      className="footer"
+    >
+      <ActionAndCancelButtonsComponent
+        cancelButtonOnClick={[Function]}
+        isHidden={false}
+        primaryButtonDisabled={false}
+        primaryButtonOnClick={[Function]}
+        primaryButtonText="Add failed instance"
+      />
+    </div>
   </GenericPanel>
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -10,10 +10,7 @@ import { Assessments } from 'assessments/assessments';
 import { FlaggedComponent } from '../../../../../common/components/flagged-component';
 import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
-import {
-    ActionAndCancelButtonsComponent,
-    ActionAndCancelButtonsComponentProps,
-} from '../../../../../DetailsView/components/action-and-cancel-buttons-component';
+import { ActionAndCancelButtonsComponent } from '../../../../../DetailsView/components/action-and-cancel-buttons-component';
 import {
     CapturedInstanceActionType,
     FailureInstancePanelControl,

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -185,16 +185,10 @@ describe('FailureInstancePanelControlTest', () => {
             .props()
             .onChange(null, description);
 
-        const buttonsWrapper = shallow<JSX.Element>(
-            wrapper
-                .find(GenericPanel)
-                .props()
-                .onRenderFooterContent(),
-        );
-        const buttons = buttonsWrapper.find(ActionAndCancelButtonsComponent);
-        const buttonProps = buttons.props() as ActionAndCancelButtonsComponentProps;
-
-        buttonProps.primaryButtonOnClick(null);
+        wrapper
+            .find(ActionAndCancelButtonsComponent)
+            .props()
+            .primaryButtonOnClick(null);
 
         expect(wrapper.state().isPanelOpen).toBe(false);
 
@@ -223,16 +217,10 @@ describe('FailureInstancePanelControlTest', () => {
             .props()
             .onChange(null, description);
 
-        const buttonsWrapper = shallow<JSX.Element>(
-            wrapper
-                .find(GenericPanel)
-                .props()
-                .onRenderFooterContent(),
-        );
-        const buttons = buttonsWrapper.find(ActionAndCancelButtonsComponent);
-        const buttonProps = buttons.props() as ActionAndCancelButtonsComponentProps;
-
-        buttonProps.primaryButtonOnClick(null);
+        wrapper
+            .find(ActionAndCancelButtonsComponent)
+            .props()
+            .primaryButtonOnClick(null);
 
         expect(wrapper.state().isPanelOpen).toBe(false);
 


### PR DESCRIPTION
#### Description of changes

The default failure instance comment view in Canary was inadvertently touched in PR #1063 - this PR reverts some of those changes. We will reintroduce the styling updates so they are fully contained inside the feature-flag in a separate PR.

The side effect of this PR is that the feature-flag-on experience no longer has an absolute footer for the add/cancel buttons. We will re-add this soon.

Before:
![screenshot of comment field before this PR](https://user-images.githubusercontent.com/7775527/63189352-a6b2e200-c018-11e9-8743-6a7fbe6144e3.png)

After:
![screenshot of comment field after this PR, better styled](https://user-images.githubusercontent.com/7775527/63189401-c34f1a00-c018-11e9-88c6-26b15aa641c2.png)


#### Pull request checklist

- [no] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
