### PR TITLE
fix: body font-size set to 75%

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -14,6 +14,7 @@ body {
     background: $neutral-0;
     color: $neutral-100;
     font-family: $fontFamily;
+    font-size: 14px;
 }
 
 .target-change-dialog-modal {


### PR DESCRIPTION
#### Description of changes

Chrome injects default values for ```font-family``` and ```font-size``` at the ```body``` level (see #1080 for more info). In the Details View -> Assessment-> [any requirement], we are not overriding ```font-size``` so we're getting chrome's default value (```75%```). Instead, we should explicitly override ```font-size``` for the ```body```.

**before**
![01 - details view - current prod](https://user-images.githubusercontent.com/2837582/63297634-b5063580-c286-11e9-824c-422bef0d29f0.png)

**after**
![02 - details view - with overriden font-size](https://user-images.githubusercontent.com/2837582/63297640-b8012600-c286-11e9-93ac-a09ab2fb4605.png)


#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1080
- [x] Added relevant unit test for your changes. (`yarn test`)
   - does not affect code
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
