### PR TITLE
fix: resolve alignment issues in assessment overview

### DIFF
--- a/src/reports/components/assessment-summary-details.scss
+++ b/src/reports/components/assessment-summary-details.scss
@@ -8,29 +8,39 @@
 
     .assessment-summary-details-body {
         column-count: 2;
-        column-gap: 2%;
+        column-gap: 4%;
         display: block;
         width: 100%;
+        align-items: start;
 
-        .test-summary {
-            display: flex;
-            width: 98%;
-            padding: 2% 1% 2% 1%;
-            justify-content: space-between;
-        }
+        .assessment-summary-details-row {
+            // This intermediate inline-block element between the wrapping multi-column block layout and
+            // the per-row flex layout is required for Chromium to respect the parent's align-items style.
+            display: inline-block;
+            width: 100%;
 
-        .test-summary {
-            border-bottom: $neutral-alpha-8 solid 1px;
-        }
-        .test-summary-status {
-            display: flex;
-            align-items: center;
-        }
+            .test-summary {
+                // This prevents rows from overflowing/wrapping at small screen widths; it will need to be
+                // adjusted if we add new tests with longer names in the future.
+                min-width: 230px;
 
-        .test-summary-display-name {
-            font-family: $semiBoldFontFamily;
-            font-size: 14px;
-            line-height: 20px;
+                display: flex;
+                width: 98%;
+                padding: 2% 1% 2% 1%;
+                justify-content: space-between;
+                border-bottom: $neutral-alpha-8 solid 1px;
+            }
+
+            .test-summary-status {
+                display: flex;
+                align-items: center;
+            }
+
+            .test-summary-display-name {
+                font-family: $semiBoldFontFamily;
+                font-size: 14px;
+                line-height: 20px;
+            }
         }
     }
 }

--- a/src/reports/components/assessment-summary-details.tsx
+++ b/src/reports/components/assessment-summary-details.tsx
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { css } from '@uifabric/utilities';
 import { AssessmentSummaryReportModel } from '../assessment-report-model';
 import { OutcomeChipSet } from './outcome-chip-set';
 import { OutcomeIconSet } from './outcome-icon-set';

--- a/src/reports/components/assessment-summary-details.tsx
+++ b/src/reports/components/assessment-summary-details.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
+import { css } from '@uifabric/utilities';
 import { AssessmentSummaryReportModel } from '../assessment-report-model';
 import { OutcomeChipSet } from './outcome-chip-set';
 import { OutcomeIconSet } from './outcome-icon-set';
@@ -15,24 +16,20 @@ export class AssessmentSummaryDetails extends React.Component<AssessmentSummaryD
         return (
             <div role="table" className="assessment-summary-details">
                 <div role="rowgroup" className="assessment-summary-details-body">
-                    {this.getTestDetailsColumns()}
+                    {this.getTestDetailsList(this.props.testSummaries)}
                 </div>
             </div>
         );
     }
 
-    private getTestDetailsColumns(): JSX.Element[] {
-        return this.getTestDetailsList(this.props.testSummaries, 1);
-    }
-
-    private getTestDetailsList(summaries: AssessmentSummaryReportModel[], colIndex: number): JSX.Element[] {
-        return summaries.map((testSummary, index) => {
-            return (
-                <div role="row" key={`${colIndex}-${index}`} className="test-summary">
+    private getTestDetailsList(summaries: AssessmentSummaryReportModel[]): JSX.Element[] {
+        return summaries.map(testSummary => (
+            <div role="row" key={testSummary.displayName} className="assessment-summary-details-row">
+                <div className="test-summary">
                     <div role="cell" className="test-summary-display-name">
                         {testSummary.displayName}
                     </div>
-                    <div role="cell" key={`${colIndex}-${index}-status`} className="test-summary-status">
+                    <div role="cell" className="test-summary-status">
                         {testSummary.pass + testSummary.incomplete + testSummary.fail > 7 ? (
                             <OutcomeChipSet {...testSummary} />
                         ) : (
@@ -40,7 +37,7 @@ export class AssessmentSummaryDetails extends React.Component<AssessmentSummaryD
                         )}
                     </div>
                 </div>
-            );
-        });
+            </div>
+        ));
     }
 }

--- a/src/tests/unit/tests/reports/components/__snapshots__/assessment-summary-details.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/assessment-summary-details.test.tsx.snap
@@ -10,47 +10,55 @@ exports[`AssessmentSummaryDetails render Correct composition 1`] = `
     role="rowgroup"
   >
     <div
-      className="test-summary"
+      className="assessment-summary-details-row"
       role="row"
     >
       <div
-        className="test-summary-display-name"
-        role="cell"
+        className="test-summary"
       >
-        Assessment1
-      </div>
-      <div
-        className="test-summary-status"
-        role="cell"
-      >
-        <OutcomeIconSet
-          displayName="Assessment1"
-          fail={2}
-          incomplete={1}
-          pass={1}
-        />
+        <div
+          className="test-summary-display-name"
+          role="cell"
+        >
+          Assessment1
+        </div>
+        <div
+          className="test-summary-status"
+          role="cell"
+        >
+          <OutcomeIconSet
+            displayName="Assessment1"
+            fail={2}
+            incomplete={1}
+            pass={1}
+          />
+        </div>
       </div>
     </div>
     <div
-      className="test-summary"
+      className="assessment-summary-details-row"
       role="row"
     >
       <div
-        className="test-summary-display-name"
-        role="cell"
+        className="test-summary"
       >
-        Assessment2
-      </div>
-      <div
-        className="test-summary-status"
-        role="cell"
-      >
-        <OutcomeIconSet
-          displayName="Assessment2"
-          fail={1}
-          incomplete={1}
-          pass={0}
-        />
+        <div
+          className="test-summary-display-name"
+          role="cell"
+        >
+          Assessment2
+        </div>
+        <div
+          className="test-summary-status"
+          role="cell"
+        >
+          <OutcomeIconSet
+            displayName="Assessment2"
+            fail={1}
+            incomplete={1}
+            pass={0}
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -67,25 +75,29 @@ exports[`AssessmentSummaryDetails render Renders an OutcomeChipSet for 8 items 1
     role="rowgroup"
   >
     <div
-      className="test-summary"
+      className="assessment-summary-details-row"
       role="row"
     >
       <div
-        className="test-summary-display-name"
-        role="cell"
+        className="test-summary"
       >
-        test
-      </div>
-      <div
-        className="test-summary-status"
-        role="cell"
-      >
-        <OutcomeChipSet
-          displayName="test"
-          fail={0}
-          incomplete={8}
-          pass={0}
-        />
+        <div
+          className="test-summary-display-name"
+          role="cell"
+        >
+          test
+        </div>
+        <div
+          className="test-summary-status"
+          role="cell"
+        >
+          <OutcomeChipSet
+            displayName="test"
+            fail={0}
+            incomplete={8}
+            pass={0}
+          />
+        </div>
       </div>
     </div>
   </div>
@@ -102,25 +114,29 @@ exports[`AssessmentSummaryDetails render Renders an OutcomeIconSet for 7 items 1
     role="rowgroup"
   >
     <div
-      className="test-summary"
+      className="assessment-summary-details-row"
       role="row"
     >
       <div
-        className="test-summary-display-name"
-        role="cell"
+        className="test-summary"
       >
-        test
-      </div>
-      <div
-        className="test-summary-status"
-        role="cell"
-      >
-        <OutcomeIconSet
-          displayName="test"
-          fail={0}
-          incomplete={7}
-          pass={0}
-        />
+        <div
+          className="test-summary-display-name"
+          role="cell"
+        >
+          test
+        </div>
+        <div
+          className="test-summary-status"
+          role="cell"
+        >
+          <OutcomeIconSet
+            displayName="test"
+            fail={0}
+            incomplete={7}
+            pass={0}
+          />
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
#### Description of changes

Fixes overview test summary alignment issue noted in #1088 caused by now having an odd number of tests in the table.

Also included:
* Increasing the column gap per @cheade 's recommendation (the columns were too close together at low widths and ended up overlapping a bit, see first "before" screenshot below)
* Adding a min-width for the individual rows (prevents the bad overflow at certain breakpoint widths, see second "before" screenshot below)

This does *not* fix the the excessive scrollbars/bad left test nav sizing also noted in #1088 (fixing that is proving much trickier; leaving it for a separate PR)

Before:
![image](https://user-images.githubusercontent.com/376284/63304996-08ce4a00-c29a-11e9-9e2c-48fc440ecdfa.png)
![image](https://user-images.githubusercontent.com/376284/63305087-5b0f6b00-c29a-11e9-8668-8aaf8cfd45ac.png)


After:
![image](https://user-images.githubusercontent.com/376284/63304940-ce64ad00-c299-11e9-80cf-f9b612bd7d72.png)
![image](https://user-images.githubusercontent.com/376284/63305139-94e07180-c29a-11e9-9b2a-b88ab6097bd5.png)

#### Pull request checklist

- [x] Addresses an existing issue: Partially addresses #1088
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
