### PR TITLE
fix: prevent redundant assessment overview page scroll bars 

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -343,6 +343,7 @@ div.insights-file-issue-details-dialog-container {
         width: 100%;
     }
     .details-view-command-bar {
+        height: $detailsViewCommandBarHeight;
         width: 100%;
         display: flex;
         justify-content: space-between;
@@ -351,11 +352,11 @@ div.insights-file-issue-details-dialog-container {
         background-color: $neutral-0;
         font-size: 14px;
         font-weight: normal;
-        border-bottom: 1px solid $neutral-alpha-8;
+        border-bottom: $detailsViewCommandBarBorderHeight solid $neutral-alpha-8;
 
         .details-view-target-page {
             margin-left: 12px;
-            padding: 13px 8px;
+            padding: 8px 8px;
             display: inherit;
             white-space: nowrap;
             overflow: hidden;
@@ -434,8 +435,12 @@ div.insights-file-issue-details-dialog-container {
     .details-view-main-content {
         padding-left: 0px;
         padding-right: 0px;
-        flex-grow: 1;
+        display: grid;
+        grid-template-columns: 230px 1fr;
+        grid-template-rows: 1fr;
+        width: 100%;
         min-height: 0;
+
         .details-view-nav-pivots {
             > :first-child {
                 height: $detailsViewNavPivotsHeight;
@@ -445,7 +450,8 @@ div.insights-file-issue-details-dialog-container {
             }
         }
         .details-view-test-nav-area {
-            max-height: calc(100vh - #{$detailsViewHeaderBarHeight} - #{$detailsViewCommandBarHeight} - 12px);
+            box-sizing: border-box;
+            max-height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
             .ms-Nav-groupContent,
             .ms-Nav-navItems {
                 margin-bottom: 0px;
@@ -822,6 +828,8 @@ div.insights-file-issue-details-dialog-container {
             width: 100%;
             padding-bottom: 1px;
             overflow: auto;
+            box-sizing: border-box;
+            max-height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
             > div {
                 min-width: 600px;
                 height: auto;

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -96,8 +96,10 @@ $pivotItemBorderStyle: solid !default;
 $detailsViewHeaderBarHeight: 40px !default;
 $detailsViewNavPivotsHeight: 41px !default;
 $detailsViewCommandBarHeight: 40px !default;
-
+$detailsViewCommandBarBorderHeight: 1px !default;
 $detailsViewManNavWidth: 185px !default;
+
+$detailsViewTotalHeaderHeight: (#{$detailsViewCommandBarBorderHeight} + #{$detailsViewCommandBarHeight} + #{$detailsViewHeaderBarHeight});
 
 .header-bar,
 .report-header-bar {


### PR DESCRIPTION
#### Description of changes

Second half of fixing #1088. A regression between chrome 75 and 76 broke the scrolling behavior of the assessment overview page, resulting in multiple redundant scrollbars and a malformed size on the left nav area. This addresses both issues.

This does *not* address the test details rows being misaligned; see separate PR #1096 for that.

Before:
![image](https://user-images.githubusercontent.com/376284/63310043-feb64680-c2ad-11e9-835d-a22d8c71206c.png)

After:
![image](https://user-images.githubusercontent.com/376284/63310081-29080400-c2ae-11e9-9a63-e02a0905bbdf.png)

#### Pull request checklist

- [x] Addresses an existing issue: Partially addresses #1088
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
