### PR TITLE
fix: issue title generated contains the whole path for elements in iframe

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -69,6 +69,7 @@ import { WindowUtils } from '../common/window-utils';
 import { contentPages } from '../content';
 import { FixInstructionProcessor } from '../injected/fix-instruction-processor';
 import { ScannerUtils } from '../injected/scanner-utils';
+import { IssueFilingUrlStringUtils } from '../issue-filing/common/issue-filing-url-string-utils';
 import { getVersion, scan } from '../scanner/exposed-apis';
 import { DictionaryStringTo } from '../types/common-types';
 import { IssueFilingServiceProviderImpl } from './../issue-filing/issue-filing-service-provider-impl';
@@ -250,6 +251,7 @@ if (isNaN(tabId) === false) {
                 browserAdapter.extensionVersion,
                 browserSpec,
                 AxeInfo.Default.version,
+                IssueFilingUrlStringUtils,
             );
 
             const windowUtils = new WindowUtils();

--- a/src/background/issue-details-text-generator.ts
+++ b/src/background/issue-details-text-generator.ts
@@ -1,9 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CreateIssueDetailsTextData } from '../common/types/create-issue-details-text-data';
+import { IssueUrlCreationUtils } from '../issue-filing/common/issue-filing-url-string-utils';
 
 export class IssueDetailsTextGenerator {
-    constructor(private extensionVersion: string, private browserSpec: string, private axeCoreVersion: string) {}
+    constructor(
+        private extensionVersion: string,
+        private browserSpec: string,
+        private axeCoreVersion: string,
+        private issueFilingUrlStringUtils: IssueUrlCreationUtils,
+    ) {}
 
     public buildText(data: CreateIssueDetailsTextData): string {
         const result = data.ruleResult;
@@ -59,7 +65,7 @@ export class IssueDetailsTextGenerator {
             prefix = prefix + ': ';
         }
 
-        const selectorLastPart = this.getSelectorLastPart(data.ruleResult.selector);
+        const selectorLastPart = this.issueFilingUrlStringUtils.getSelectorLastPart(data.ruleResult.selector);
 
         return `${prefix}${data.ruleResult.help} (${selectorLastPart})`;
     }

--- a/src/background/issue-details-text-generator.ts
+++ b/src/background/issue-details-text-generator.ts
@@ -75,14 +75,6 @@ export class IssueDetailsTextGenerator {
         return tags.join(', ');
     }
 
-    public getSelectorLastPart(selector: string): string {
-        let selectorLastPart = selector;
-        if (selector.lastIndexOf(' > ') > 0) {
-            selectorLastPart = selector.substr(selector.lastIndexOf(' > ') + 3);
-        }
-        return selectorLastPart;
-    }
-
     private standardizeTags(data: CreateIssueDetailsTextData): string[] {
         return data.ruleResult.guidanceLinks.map(tag => tag.text.toUpperCase());
     }

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -13,6 +13,7 @@ import { NavigatorUtils } from '../common/navigator-utils';
 import { getPlatform } from '../common/platform';
 import { FeatureFlagStoreData } from '../common/types/store-data/feature-flag-store-data';
 import { WindowUtils } from '../common/window-utils';
+import { IssueFilingUrlStringUtils } from '../issue-filing/common/issue-filing-url-string-utils';
 import { DictionaryStringTo } from '../types/common-types';
 import { rootContainerId } from './constants';
 import { DetailsDialogHandler } from './details-dialog-handler';
@@ -68,6 +69,7 @@ export class DialogRenderer {
                 this.browserAdapter.extensionVersion,
                 browserSpec,
                 AxeInfo.Default.version,
+                IssueFilingUrlStringUtils,
             );
 
             const fixInstructionProcessor = new FixInstructionProcessor();

--- a/src/issue-filing/common/issue-filing-url-string-utils.ts
+++ b/src/issue-filing/common/issue-filing-url-string-utils.ts
@@ -21,10 +21,15 @@ const getTitle = (data: CreateIssueDetailsTextData): string => {
 };
 
 const getSelectorLastPart = (selector: string): string => {
-    let selectorLastPart = selector;
-    if (selector.lastIndexOf(' > ') > 0) {
-        selectorLastPart = selector.substr(selector.lastIndexOf(' > ') + 3);
+    const splitedSelector = selector.split(';');
+    let selectorLastPart = splitedSelector[splitedSelector.length - 1];
+
+    const childCombinator = ' > ';
+
+    if (selector.lastIndexOf(childCombinator) > 0) {
+        selectorLastPart = selector.substr(selector.lastIndexOf(childCombinator) + childCombinator.length);
     }
+
     return selectorLastPart;
 };
 

--- a/src/issue-filing/common/issue-filing-url-string-utils.ts
+++ b/src/issue-filing/common/issue-filing-url-string-utils.ts
@@ -22,12 +22,12 @@ const getTitle = (data: CreateIssueDetailsTextData): string => {
 
 const getSelectorLastPart = (selector: string): string => {
     const splitedSelector = selector.split(';');
-    let selectorLastPart = splitedSelector[splitedSelector.length - 1];
+    const selectorLastPart = splitedSelector[splitedSelector.length - 1];
 
     const childCombinator = ' > ';
 
-    if (selector.lastIndexOf(childCombinator) > 0) {
-        selectorLastPart = selector.substr(selector.lastIndexOf(childCombinator) + childCombinator.length);
+    if (selectorLastPart.lastIndexOf(childCombinator) > 0) {
+        return selectorLastPart.substr(selectorLastPart.lastIndexOf(childCombinator) + childCombinator.length);
     }
 
     return selectorLastPart;

--- a/src/tests/unit/tests/background/issue-details-text-generator.test.ts
+++ b/src/tests/unit/tests/background/issue-details-text-generator.test.ts
@@ -1,14 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
+import { IMock, Mock, MockBehavior } from 'typemoq';
 import { CreateIssueDetailsTextData } from '../../../../common/types/create-issue-details-text-data';
+import { IssueUrlCreationUtils } from '../../../../issue-filing/common/issue-filing-url-string-utils';
 
 describe('Issue details text builder', () => {
     let testSubject: IssueDetailsTextGenerator;
     let sampleIssueDetailsData: CreateIssueDetailsTextData;
+    let issueUrlCreationUtilsMock: IMock<IssueUrlCreationUtils>;
 
     beforeEach(() => {
-        testSubject = new IssueDetailsTextGenerator('MY.EXT.VER', 'browser spec', 'AXE.CORE.VER');
+        const selector = 'RR-selector<x>';
+
+        issueUrlCreationUtilsMock = Mock.ofType<IssueUrlCreationUtils>(undefined, MockBehavior.Strict);
+        issueUrlCreationUtilsMock.setup(utils => utils.getSelectorLastPart(selector)).returns(() => selector);
+
+        testSubject = new IssueDetailsTextGenerator('MY.EXT.VER', 'browser spec', 'AXE.CORE.VER', issueUrlCreationUtilsMock.object);
 
         sampleIssueDetailsData = {
             pageTitle: 'pageTitle<x>',
@@ -20,7 +28,7 @@ describe('Issue details text builder', () => {
                 html: 'RR-html',
                 ruleId: 'RR-rule-id',
                 helpUrl: 'RR-help-url',
-                selector: 'RR-selector<x>',
+                selector: selector,
                 snippet: 'RR-snippet   space',
             } as any,
         };

--- a/src/tests/unit/tests/background/issue-details-text-generator.test.ts
+++ b/src/tests/unit/tests/background/issue-details-text-generator.test.ts
@@ -120,10 +120,4 @@ describe('Issue details text builder', () => {
             expect(actual).toEqual(expected);
         });
     });
-
-    test('getSelectorLastPart', () => {
-        expect(testSubject.getSelectorLastPart('instance')).toEqual('instance');
-        expect(testSubject.getSelectorLastPart('first > last')).toEqual('last');
-        expect(testSubject.getSelectorLastPart('one > two > three')).toEqual('three');
-    });
 });

--- a/src/tests/unit/tests/issue-filing/common/issue-filing-url-string-utils.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-filing-url-string-utils.test.ts
@@ -45,9 +45,12 @@ describe('IssueFilingUrlStringUtilsTest', () => {
         });
     });
 
-    test('getSelectorLastPart', () => {
-        expect(IssueFilingUrlStringUtils.getSelectorLastPart('hello world')).toEqual('hello world');
-        expect(IssueFilingUrlStringUtils.getSelectorLastPart('hello > world')).toEqual('world');
+    describe('getSelectorLastPart', () => {
+        const testCases = [['hello world', 'hello world'], ['hello > world', 'world'], ['iframe[name="image-text"];html', 'html']];
+
+        it.each(testCases)('find the selector last part for "%s"', (input, expected) => {
+            expect(IssueFilingUrlStringUtils.getSelectorLastPart(input)).toEqual(expected);
+        });
     });
 
     test('standardizeTags', () => {

--- a/src/tests/unit/tests/issue-filing/common/issue-filing-url-string-utils.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-filing-url-string-utils.test.ts
@@ -46,7 +46,12 @@ describe('IssueFilingUrlStringUtilsTest', () => {
     });
 
     describe('getSelectorLastPart', () => {
-        const testCases = [['hello world', 'hello world'], ['hello > world', 'world'], ['iframe[name="image-text"];html', 'html']];
+        const testCases = [
+            ['hello world', 'hello world'],
+            ['hello > world', 'world'],
+            ['iframe[name="image-text"];html', 'html'],
+            ['iframe[name="image-text"];a > img:nth-child(2)', 'img:nth-child(2)'],
+        ];
 
         it.each(testCases)('find the selector last part for "%s"', (input, expected) => {
             expect(IssueFilingUrlStringUtils.getSelectorLastPart(input)).toEqual(expected);


### PR DESCRIPTION
#### Description of changes

- fix logic to get last part of the selector to consider iframes
   - basically split the selector using ```';'```
   - apply the original logic to the last element of the splited selector
- update the class that generate the text for the "copy issue details" button to use the ```IssueUrlCreationUtils.getSelectorLastPart```
   - as a result of this, I was able to remove duplicated code

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #548
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
