### PR TITLE
Add more E2E tests for device connect

### DIFF
--- a/src/tests/electron/common/element-identifiers/common-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/common-selectors.ts
@@ -2,4 +2,7 @@
 // Licensed under the MIT License.
 export const CommonSelectors = {
     cancelButton: '.footer-button-cancel',
+    portNumber: '.port-number-field',
+    startButton: '.footer-button-start',
+    validateButton: '.button-validate-port',
 };

--- a/src/tests/electron/common/element-identifiers/common-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/common-selectors.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 export const CommonSelectors = {
     cancelButton: '.footer-button-cancel',
+    deviceViewContainer: '#device-connect-view-container',
     portNumber: '.port-number-field',
     startButton: '.footer-button-start',
     validateButton: '.button-validate-port',

--- a/src/tests/electron/main.test.ts
+++ b/src/tests/electron/main.test.ts
@@ -4,6 +4,7 @@ import * as Electron from 'electron';
 import { Application } from 'spectron';
 import * as WebdriverIO from 'webdriverio';
 import { CommonSelectors } from './common/element-identifiers/common-selectors';
+import { DEFAULT_ELECTRON_TEST_TIMEOUT_MS } from './setup/timeouts';
 
 describe('Electron E2E', () => {
     let app: Application;
@@ -25,7 +26,7 @@ describe('Electron E2E', () => {
     // tslint:disable-next-line:typedef
     async function ensureAppIsInDeviceConnectionDialog() {
         const webDriverClient: WebdriverIO.Client<void> = app.client;
-        await webDriverClient.waitForVisible(CommonSelectors.deviceViewContainer, 5000);
+        await webDriverClient.waitForVisible(CommonSelectors.deviceViewContainer, DEFAULT_ELECTRON_TEST_TIMEOUT_MS);
         expect(await app.webContents.getTitle()).toBe('Accessibility Insights for Mobile');
     }
 

--- a/src/tests/electron/main.test.ts
+++ b/src/tests/electron/main.test.ts
@@ -18,21 +18,18 @@ describe('Electron E2E', () => {
         return app.start();
     });
 
+    // spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,
+    // so tslint thinks some of the methods do not return promises.
+    // tslint:disable: await-promise
+
     // tslint:disable-next-line:typedef
     async function ensureAppIsInDeviceConnectionDialog() {
-        // spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,
-        // so tslint thinks some of the methods do not return promises.
-        // tslint:disable: await-promise
-        expect(await app.browserWindow.isVisible()).toBe(true);
-        expect(await app.client.getWindowCount()).toBe(1);
+        const webDriverClient: WebdriverIO.Client<void> = app.client;
+        await webDriverClient.waitForVisible(CommonSelectors.deviceViewContainer, 5000);
         expect(await app.webContents.getTitle()).toBe('Accessibility Insights for Mobile');
-        // tslint:enable: await-promise
     }
 
     test('test that app opened & set initial state', async () => {
-        // spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,
-        // so tslint thinks some of the methods do not return promises.
-        // tslint:disable: await-promise
         await ensureAppIsInDeviceConnectionDialog();
 
         const webDriverClient: WebdriverIO.Client<void> = app.client;
@@ -40,13 +37,9 @@ describe('Electron E2E', () => {
         expect(await webDriverClient.isEnabled(CommonSelectors.portNumber)).toBe(true);
         expect(await webDriverClient.isEnabled(CommonSelectors.startButton)).toBe(false);
         expect(await webDriverClient.isEnabled(CommonSelectors.validateButton)).toBe(false);
-        // tslint:enable: await-promise
     });
 
     test('test that validate port remains disabled when we provide an invalid port number', async () => {
-        // spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,
-        // so tslint thinks some of the methods do not return promises.
-        // tslint:disable: await-promise
         await ensureAppIsInDeviceConnectionDialog();
 
         const webDriverClient: WebdriverIO.Client<void> = app.client;
@@ -54,13 +47,9 @@ describe('Electron E2E', () => {
         await webDriverClient.element(CommonSelectors.portNumber).keys('abc');
         expect(await webDriverClient.isEnabled(CommonSelectors.validateButton)).toBe(false);
         expect(await webDriverClient.isEnabled(CommonSelectors.startButton)).toBe(false);
-        // tslint:enable: await-promise
     });
 
     test('test that validate port enables when we provide a valid port number', async () => {
-        // spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,
-        // so tslint thinks some of the methods do not return promises.
-        // tslint:disable: await-promise
         await ensureAppIsInDeviceConnectionDialog();
 
         const webDriverClient: WebdriverIO.Client<void> = app.client;
@@ -68,8 +57,9 @@ describe('Electron E2E', () => {
         await webDriverClient.element(CommonSelectors.portNumber).keys('999');
         expect(await webDriverClient.isEnabled(CommonSelectors.validateButton)).toBe(true);
         expect(await webDriverClient.isEnabled(CommonSelectors.startButton)).toBe(false);
-        // tslint:enable: await-promise
     });
+
+    // tslint:enable: await-promise
 
     afterEach(() => {
         if (app && app.isRunning()) {

--- a/src/tests/electron/main.test.ts
+++ b/src/tests/electron/main.test.ts
@@ -8,7 +8,7 @@ import { CommonSelectors } from './common/element-identifiers/common-selectors';
 describe('Electron E2E', () => {
     let app: Application;
 
-    beforeAll(() => {
+    beforeEach(() => {
         const electronPath = `${(global as any).rootDir}/drop/electron/extension/bundle/main.bundle.js`;
         app = new Application({
             path: Electron as any,
@@ -18,20 +18,60 @@ describe('Electron E2E', () => {
         return app.start();
     });
 
-    test('test that app opened & set initial state', async () => {
+    // tslint:disable-next-line:typedef
+    async function ensureAppIsInDeviceConnectionDialog() {
         // spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,
         // so tslint thinks some of the methods do not return promises.
         // tslint:disable: await-promise
         expect(await app.browserWindow.isVisible()).toBe(true);
         expect(await app.client.getWindowCount()).toBe(1);
         expect(await app.webContents.getTitle()).toBe('Accessibility Insights for Mobile');
+        // tslint:enable: await-promise
+    }
+
+    test('test that app opened & set initial state', async () => {
+        // spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,
+        // so tslint thinks some of the methods do not return promises.
+        // tslint:disable: await-promise
+        await ensureAppIsInDeviceConnectionDialog();
 
         const webDriverClient: WebdriverIO.Client<void> = app.client;
         expect(await webDriverClient.isEnabled(CommonSelectors.cancelButton)).toBe(true);
+        expect(await webDriverClient.isEnabled(CommonSelectors.portNumber)).toBe(true);
+        expect(await webDriverClient.isEnabled(CommonSelectors.startButton)).toBe(false);
+        expect(await webDriverClient.isEnabled(CommonSelectors.validateButton)).toBe(false);
         // tslint:enable: await-promise
     });
 
-    afterAll(() => {
+    test('test that validate port remains disabled when we provide an invalid port number', async () => {
+        // spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,
+        // so tslint thinks some of the methods do not return promises.
+        // tslint:disable: await-promise
+        await ensureAppIsInDeviceConnectionDialog();
+
+        const webDriverClient: WebdriverIO.Client<void> = app.client;
+        await webDriverClient.click(CommonSelectors.portNumber);
+        await webDriverClient.element(CommonSelectors.portNumber).keys('abc');
+        expect(await webDriverClient.isEnabled(CommonSelectors.validateButton)).toBe(false);
+        expect(await webDriverClient.isEnabled(CommonSelectors.startButton)).toBe(false);
+        // tslint:enable: await-promise
+    });
+
+    test('test that validate port enables when we provide a valid port number', async () => {
+        // spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,
+        // so tslint thinks some of the methods do not return promises.
+        // tslint:disable: await-promise
+        await ensureAppIsInDeviceConnectionDialog();
+
+        const webDriverClient: WebdriverIO.Client<void> = app.client;
+        await webDriverClient.click(CommonSelectors.portNumber);
+        await webDriverClient.element(CommonSelectors.portNumber).keys('999');
+        expect(await webDriverClient.isEnabled(CommonSelectors.validateButton)).toBe(true);
+        expect(await webDriverClient.isEnabled(CommonSelectors.startButton)).toBe(false);
+        // tslint:enable: await-promise
+    });
+
+    afterEach(() => {
         if (app && app.isRunning()) {
             return app.stop();
         }


### PR DESCRIPTION
#### Description of changes

Add more useful E2E tests of the electron device connect dialog. Validates interaction of the controls while entering a port number

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
