### PR TITLE
refactor: use IssueUrlCreationUtils on IssueDetailsTextGenerator

### DIFF
--- a/src/background/issue-details-text-generator.ts
+++ b/src/background/issue-details-text-generator.ts
@@ -16,7 +16,7 @@ export class IssueDetailsTextGenerator {
         const standardTags = this.standardizeTags(data);
 
         const text = [
-            `Title: ${this.buildTitle(data, standardTags)}`,
+            `Title: ${this.issueFilingUrlStringUtils.getTitle(data)}`,
             `Tags: ${this.buildTags(data, standardTags)}`,
             ``,
             `Issue: ${result.help} (${result.ruleId}: ${result.helpUrl})`,
@@ -53,21 +53,6 @@ export class IssueDetailsTextGenerator {
 
     private collapseConsecutiveSpaces(input: string): string {
         return input.replace(/\s+/g, ' ');
-    }
-
-    public buildTitle(data: CreateIssueDetailsTextData, standardTags?: string[]): string {
-        if (!standardTags) {
-            standardTags = this.standardizeTags(data);
-        }
-
-        let prefix = standardTags.join(',');
-        if (prefix.length > 0) {
-            prefix = prefix + ': ';
-        }
-
-        const selectorLastPart = this.issueFilingUrlStringUtils.getSelectorLastPart(data.ruleResult.selector);
-
-        return `${prefix}${data.ruleResult.help} (${selectorLastPart})`;
     }
 
     public buildTags(createIssueData: CreateIssueDetailsTextData, standardTags: string[]): string {

--- a/src/background/issue-details-text-generator.ts
+++ b/src/background/issue-details-text-generator.ts
@@ -13,7 +13,7 @@ export class IssueDetailsTextGenerator {
 
     public buildText(data: CreateIssueDetailsTextData): string {
         const result = data.ruleResult;
-        const standardTags = this.standardizeTags(data);
+        const standardTags = this.issueFilingUrlStringUtils.standardizeTags(data);
 
         const text = [
             `Title: ${this.issueFilingUrlStringUtils.getTitle(data)}`,
@@ -58,9 +58,5 @@ export class IssueDetailsTextGenerator {
     public buildTags(createIssueData: CreateIssueDetailsTextData, standardTags: string[]): string {
         const tags = ['Accessibility', ...standardTags, createIssueData.ruleResult.ruleId];
         return tags.join(', ');
-    }
-
-    private standardizeTags(data: CreateIssueDetailsTextData): string[] {
-        return data.ruleResult.guidanceLinks.map(tag => tag.text.toUpperCase());
     }
 }

--- a/src/tests/unit/tests/background/issue-details-text-generator.test.ts
+++ b/src/tests/unit/tests/background/issue-details-text-generator.test.ts
@@ -10,7 +10,8 @@ describe('Issue details text builder', () => {
     let sampleIssueDetailsData: CreateIssueDetailsTextData;
     let issueUrlCreationUtilsMock: IMock<IssueUrlCreationUtils>;
 
-    const title = 'WCAG-1.4.1,WCAG-2.8.2: RR-help (RR-selector<x>)';
+    const wcagTags = ['WCAG-1.4.1', 'WCAG-2.8.2'];
+    const title = `${wcagTags.join(',')}: RR-help (RR-selector<x>)`;
     const selector = 'RR-selector<x>';
 
     beforeEach(() => {
@@ -19,12 +20,12 @@ describe('Issue details text builder', () => {
             pageUrl: 'pageUrl',
             ruleResult: {
                 failureSummary: 'RR-failureSummary',
-                guidanceLinks: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
+                guidanceLinks: [{ text: wcagTags[0] }, { text: wcagTags[1] }],
                 help: 'RR-help',
                 html: 'RR-html',
                 ruleId: 'RR-rule-id',
                 helpUrl: 'RR-help-url',
-                selector: selector,
+                selector,
                 snippet: 'RR-snippet   space',
             } as any,
         };
@@ -32,6 +33,7 @@ describe('Issue details text builder', () => {
         issueUrlCreationUtilsMock = Mock.ofType<IssueUrlCreationUtils>(undefined, MockBehavior.Strict);
         issueUrlCreationUtilsMock.setup(utils => utils.getSelectorLastPart(selector)).returns(() => selector);
         issueUrlCreationUtilsMock.setup(utils => utils.getTitle(sampleIssueDetailsData)).returns(() => title);
+        issueUrlCreationUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => wcagTags);
 
         testSubject = new IssueDetailsTextGenerator('MY.EXT.VER', 'browser spec', 'AXE.CORE.VER', issueUrlCreationUtilsMock.object);
     });
@@ -40,7 +42,7 @@ describe('Issue details text builder', () => {
         const actual = testSubject.buildText(sampleIssueDetailsData);
         const expected = [
             `Title: ${title}`,
-            `Tags: Accessibility, WCAG-1.4.1, WCAG-2.8.2, RR-rule-id`,
+            `Tags: Accessibility, ${wcagTags.join(', ')}, RR-rule-id`,
             ``,
             `Issue: RR-help (RR-rule-id: RR-help-url)`,
             ``,

--- a/src/tests/unit/tests/background/issue-details-text-generator.test.ts
+++ b/src/tests/unit/tests/background/issue-details-text-generator.test.ts
@@ -10,14 +10,10 @@ describe('Issue details text builder', () => {
     let sampleIssueDetailsData: CreateIssueDetailsTextData;
     let issueUrlCreationUtilsMock: IMock<IssueUrlCreationUtils>;
 
+    const title = 'WCAG-1.4.1,WCAG-2.8.2: RR-help (RR-selector<x>)';
+    const selector = 'RR-selector<x>';
+
     beforeEach(() => {
-        const selector = 'RR-selector<x>';
-
-        issueUrlCreationUtilsMock = Mock.ofType<IssueUrlCreationUtils>(undefined, MockBehavior.Strict);
-        issueUrlCreationUtilsMock.setup(utils => utils.getSelectorLastPart(selector)).returns(() => selector);
-
-        testSubject = new IssueDetailsTextGenerator('MY.EXT.VER', 'browser spec', 'AXE.CORE.VER', issueUrlCreationUtilsMock.object);
-
         sampleIssueDetailsData = {
             pageTitle: 'pageTitle<x>',
             pageUrl: 'pageUrl',
@@ -32,12 +28,18 @@ describe('Issue details text builder', () => {
                 snippet: 'RR-snippet   space',
             } as any,
         };
+
+        issueUrlCreationUtilsMock = Mock.ofType<IssueUrlCreationUtils>(undefined, MockBehavior.Strict);
+        issueUrlCreationUtilsMock.setup(utils => utils.getSelectorLastPart(selector)).returns(() => selector);
+        issueUrlCreationUtilsMock.setup(utils => utils.getTitle(sampleIssueDetailsData)).returns(() => title);
+
+        testSubject = new IssueDetailsTextGenerator('MY.EXT.VER', 'browser spec', 'AXE.CORE.VER', issueUrlCreationUtilsMock.object);
     });
 
     test('buildText', () => {
         const actual = testSubject.buildText(sampleIssueDetailsData);
         const expected = [
-            `Title: WCAG-1.4.1,WCAG-2.8.2: RR-help (RR-selector<x>)`,
+            `Title: ${title}`,
             `Tags: Accessibility, WCAG-1.4.1, WCAG-2.8.2, RR-rule-id`,
             ``,
             `Issue: RR-help (RR-rule-id: RR-help-url)`,
@@ -45,7 +47,7 @@ describe('Issue details text builder', () => {
             `Target application title: pageTitle<x>`,
             `Target application url: pageUrl`,
             ``,
-            `Element path: RR-selector<x>`,
+            `Element path: ${selector}`,
             ``,
             `Snippet: RR-snippet space`,
             ``,
@@ -67,36 +69,6 @@ describe('Issue details text builder', () => {
     const noStandardTags = [];
     const oneStandardTag = ['WCAG-1.4.1'];
     const manyStandardTags = ['WCAG-1.4.1', 'WCAG-2.8.2', 'WCAG-4.1.4'];
-
-    describe('buildTitle', () => {
-        test('no standard tags', () => {
-            const expected = 'RR-help (RR-selector<x>)';
-            const actual = testSubject.buildTitle(sampleIssueDetailsData, noStandardTags);
-
-            expect(actual).toEqual(expected);
-        });
-
-        test('one standard tag', () => {
-            const expected = 'WCAG-1.4.1: RR-help (RR-selector<x>)';
-            const actual = testSubject.buildTitle(sampleIssueDetailsData, oneStandardTag);
-
-            expect(actual).toEqual(expected);
-        });
-
-        test('many standard tags', () => {
-            const expected = 'WCAG-1.4.1,WCAG-2.8.2,WCAG-4.1.4: RR-help (RR-selector<x>)';
-            const actual = testSubject.buildTitle(sampleIssueDetailsData, manyStandardTags);
-
-            expect(actual).toEqual(expected);
-        });
-
-        test('single argument', () => {
-            const expected = 'WCAG-1.4.1,WCAG-2.8.2: RR-help (RR-selector<x>)';
-            const actual = testSubject.buildTitle(sampleIssueDetailsData);
-
-            expect(actual).toEqual(expected);
-        });
-    });
 
     describe('buildTags', () => {
         test('no standard tags', () => {


### PR DESCRIPTION
#### Description of changes

We should normalize `IssueDetailsTextGenerator` to use `IssueDetailsBuilder`, which is the generic issue details implementation we have for issue filing and it's being used for azure board and github, that way, we remove duplicated code and thus have only one place to change if we need to update issue details content.

Before actually doing that, this PR remove some other duplicated code:
- `getTitle`
- `standardizeTags`
It does so by using `IssueUrlCreationUtils` version of this functions.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #850
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - does not apply
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - does not apply
