### PR TITLE
refactor: IssueDetailsTextGenerator to use IssueDetailsBuilder

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -69,7 +69,9 @@ import { WindowUtils } from '../common/window-utils';
 import { contentPages } from '../content';
 import { FixInstructionProcessor } from '../injected/fix-instruction-processor';
 import { ScannerUtils } from '../injected/scanner-utils';
+import { createIssueDetailsBuilder } from '../issue-filing/common/create-issue-details-builder';
 import { IssueFilingUrlStringUtils } from '../issue-filing/common/issue-filing-url-string-utils';
+import { PlainTextFormatter } from '../issue-filing/common/markup/plain-text-formatter';
 import { getVersion, scan } from '../scanner/exposed-apis';
 import { DictionaryStringTo } from '../types/common-types';
 import { IssueFilingServiceProviderImpl } from './../issue-filing/issue-filing-service-provider-impl';
@@ -248,10 +250,9 @@ if (isNaN(tabId) === false) {
             documentTitleUpdater.initialize();
 
             const issueDetailsTextGenerator = new IssueDetailsTextGenerator(
-                browserAdapter.extensionVersion,
-                browserSpec,
-                AxeInfo.Default.version,
                 IssueFilingUrlStringUtils,
+                environmentInfoProvider,
+                createIssueDetailsBuilder(PlainTextFormatter),
             );
 
             const windowUtils = new WindowUtils();

--- a/src/background/issue-details-text-generator.ts
+++ b/src/background/issue-details-text-generator.ts
@@ -1,58 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { EnvironmentInfoProvider } from '../common/environment-info-provider';
 import { CreateIssueDetailsTextData } from '../common/types/create-issue-details-text-data';
+import { IssueDetailsBuilder } from '../issue-filing/common/issue-details-builder';
 import { IssueUrlCreationUtils } from '../issue-filing/common/issue-filing-url-string-utils';
 
 export class IssueDetailsTextGenerator {
     constructor(
-        private extensionVersion: string,
-        private browserSpec: string,
-        private axeCoreVersion: string,
         private issueFilingUrlStringUtils: IssueUrlCreationUtils,
+        private environmentInfoProvider: EnvironmentInfoProvider,
+        private issueDetailsBuilder: IssueDetailsBuilder,
     ) {}
 
     public buildText(data: CreateIssueDetailsTextData): string {
-        const result = data.ruleResult;
         const standardTags = this.issueFilingUrlStringUtils.standardizeTags(data);
 
         const text = [
             `Title: ${this.issueFilingUrlStringUtils.getTitle(data)}`,
             `Tags: ${this.buildTags(data, standardTags)}`,
             ``,
-            `Issue: ${result.help} (${result.ruleId}: ${result.helpUrl})`,
-            ``,
-            `Target application title: ${data.pageTitle}`,
-            `Target application url: ${data.pageUrl}`,
-            ``,
-            `Element path: ${data.ruleResult.selector}`,
-            ``,
-            `Snippet: ${this.collapseConsecutiveSpaces(result.snippet)}`,
-            ``,
-            `How to fix:`,
-            `${result.failureSummary}`,
-            ``,
-            `Environment:`,
-            `${this.browserSpec}`,
-            ``,
-            `====`,
-            ``,
-            this.footer,
+            this.issueDetailsBuilder(this.environmentInfoProvider.getEnvironmentInfo(), data),
         ].join('\n');
 
         return text;
-    }
-
-    private get footer(): string {
-        return (
-            'This accessibility issue was found using Accessibility Insights for Web ' +
-            `${this.extensionVersion} (axe-core ${this.axeCoreVersion}), ` +
-            'a tool that helps find and fix accessibility issues. Get more information & download ' +
-            'this tool at http://aka.ms/AccessibilityInsights.'
-        );
-    }
-
-    private collapseConsecutiveSpaces(input: string): string {
-        return input.replace(/\s+/g, ' ');
     }
 
     public buildTags(createIssueData: CreateIssueDetailsTextData, standardTags: string[]): string {

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -5,15 +5,15 @@ import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
-import { AxeInfo } from '../common/axe-info';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { FeatureFlags } from '../common/feature-flags';
 import { HTMLElementUtils } from '../common/html-element-utils';
-import { NavigatorUtils } from '../common/navigator-utils';
 import { getPlatform } from '../common/platform';
 import { FeatureFlagStoreData } from '../common/types/store-data/feature-flag-store-data';
 import { WindowUtils } from '../common/window-utils';
+import { createIssueDetailsBuilder } from '../issue-filing/common/create-issue-details-builder';
 import { IssueFilingUrlStringUtils } from '../issue-filing/common/issue-filing-url-string-utils';
+import { PlainTextFormatter } from '../issue-filing/common/markup/plain-text-formatter';
 import { DictionaryStringTo } from '../types/common-types';
 import { rootContainerId } from './constants';
 import { DetailsDialogHandler } from './details-dialog-handler';
@@ -64,12 +64,10 @@ export class DialogRenderer {
                 ? this.initializeDialogContainerInShadowDom()
                 : this.appendDialogContainer();
 
-            const browserSpec = new NavigatorUtils(window.navigator).getBrowserSpec();
             const issueDetailsTextGenerator = new IssueDetailsTextGenerator(
-                this.browserAdapter.extensionVersion,
-                browserSpec,
-                AxeInfo.Default.version,
                 IssueFilingUrlStringUtils,
+                mainWindowContext.getEnvironmentInfoProvider(),
+                createIssueDetailsBuilder(PlainTextFormatter),
             );
 
             const fixInstructionProcessor = new FixInstructionProcessor();

--- a/src/issue-filing/common/create-issue-details-builder.ts
+++ b/src/issue-filing/common/create-issue-details-builder.ts
@@ -11,38 +11,38 @@ export const createIssueDetailsBuilder = (markup: MarkupFormatter): IssueDetails
     const getter = (environmentInfo: EnvironmentInfo, data: CreateIssueDetailsTextData): string => {
         const result = data.ruleResult;
 
-        const { howToFixSection, link, sectionHeader, snippet, sectionHeaderSeparator, footerSeparator } = markup;
+        const { howToFixSection, link, sectionHeader, snippet, sectionHeaderSeparator, footerSeparator, newLine } = markup;
 
         const lines = [
             sectionHeader('Issue'),
             sectionHeaderSeparator(),
             `${snippet(result.help)} (${link(result.helpUrl, result.ruleId)})`,
-            '\n',
+            newLine(),
 
             sectionHeader('Target application'),
             sectionHeaderSeparator(),
             link(data.pageUrl, data.pageTitle),
-            '\n',
+            newLine(),
 
             sectionHeader('Element path'),
             sectionHeaderSeparator(),
             data.ruleResult.selector,
-            '\n',
+            newLine(),
 
             sectionHeader('Snippet'),
             sectionHeaderSeparator(),
             snippet(result.snippet),
-            '\n',
+            newLine(),
 
             sectionHeader('How to fix'),
             sectionHeaderSeparator(),
             howToFixSection(result.failureSummary),
-            '\n',
+            newLine(),
 
             sectionHeader('Environment'),
             sectionHeaderSeparator(),
             environmentInfo.browserSpec,
-            '\n',
+            newLine(),
 
             footerSeparator(),
 

--- a/src/issue-filing/common/create-issue-details-builder.ts
+++ b/src/issue-filing/common/create-issue-details-builder.ts
@@ -10,29 +10,31 @@ export const createIssueDetailsBuilder = (markup: MarkupFormatter): IssueDetails
     const getter = (environmentInfo: EnvironmentInfo, data: CreateIssueDetailsTextData): string => {
         const result = data.ruleResult;
 
+        const { howToFixSection, link, sectionHeader, snippet } = markup;
+
         const text = [
-            markup.sectionHeader('Issue'),
-            `${markup.snippet(result.help)} (${markup.link(result.helpUrl, result.ruleId)})`,
+            sectionHeader('Issue'),
+            `${snippet(result.help)} (${link(result.helpUrl, result.ruleId)})`,
 
-            markup.sectionHeader('Target application'),
-            markup.link(data.pageUrl, data.pageTitle),
+            sectionHeader('Target application'),
+            link(data.pageUrl, data.pageTitle),
 
-            markup.sectionHeader('Element path'),
+            sectionHeader('Element path'),
             data.ruleResult.selector,
 
-            markup.sectionHeader('Snippet'),
-            markup.snippet(result.snippet),
+            sectionHeader('Snippet'),
+            snippet(result.snippet),
 
-            markup.sectionHeader('How to fix'),
-            markup.howToFixSection(result.failureSummary),
+            sectionHeader('How to fix'),
+            howToFixSection(result.failureSummary),
 
-            markup.sectionHeader('Environment'),
+            sectionHeader('Environment'),
             environmentInfo.browserSpec,
 
             `This accessibility issue was found using ${title} ` +
                 `${environmentInfo.extensionVersion} (axe-core ${environmentInfo.axeCoreVersion}), ` +
                 'a tool that helps find and fix accessibility issues. Get more information & download ' +
-                `this tool at ${markup.link('http://aka.ms/AccessibilityInsights')}.`,
+                `this tool at ${link('http://aka.ms/AccessibilityInsights')}.`,
         ].join('\n');
 
         return text;

--- a/src/issue-filing/common/create-issue-details-builder.ts
+++ b/src/issue-filing/common/create-issue-details-builder.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { title } from 'content/strings/application';
+import { compact } from 'lodash';
 import { EnvironmentInfo } from '../../common/environment-info-provider';
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { IssueDetailsBuilder } from './issue-details-builder';
@@ -10,34 +11,48 @@ export const createIssueDetailsBuilder = (markup: MarkupFormatter): IssueDetails
     const getter = (environmentInfo: EnvironmentInfo, data: CreateIssueDetailsTextData): string => {
         const result = data.ruleResult;
 
-        const { howToFixSection, link, sectionHeader, snippet } = markup;
+        const { howToFixSection, link, sectionHeader, snippet, sectionHeaderSeparator, footerSeparator } = markup;
 
-        const text = [
+        const lines = [
             sectionHeader('Issue'),
+            sectionHeaderSeparator(),
             `${snippet(result.help)} (${link(result.helpUrl, result.ruleId)})`,
+            '\n',
 
             sectionHeader('Target application'),
+            sectionHeaderSeparator(),
             link(data.pageUrl, data.pageTitle),
+            '\n',
 
             sectionHeader('Element path'),
+            sectionHeaderSeparator(),
             data.ruleResult.selector,
+            '\n',
 
             sectionHeader('Snippet'),
+            sectionHeaderSeparator(),
             snippet(result.snippet),
+            '\n',
 
             sectionHeader('How to fix'),
+            sectionHeaderSeparator(),
             howToFixSection(result.failureSummary),
+            '\n',
 
             sectionHeader('Environment'),
+            sectionHeaderSeparator(),
             environmentInfo.browserSpec,
+            '\n',
+
+            footerSeparator(),
 
             `This accessibility issue was found using ${title} ` +
                 `${environmentInfo.extensionVersion} (axe-core ${environmentInfo.axeCoreVersion}), ` +
                 'a tool that helps find and fix accessibility issues. Get more information & download ' +
                 `this tool at ${link('http://aka.ms/AccessibilityInsights')}.`,
-        ].join('\n');
+        ];
 
-        return text;
+        return compact(lines).join('');
     };
 
     return getter;

--- a/src/issue-filing/common/create-issue-details-builder.ts
+++ b/src/issue-filing/common/create-issue-details-builder.ts
@@ -11,38 +11,38 @@ export const createIssueDetailsBuilder = (markup: MarkupFormatter): IssueDetails
     const getter = (environmentInfo: EnvironmentInfo, data: CreateIssueDetailsTextData): string => {
         const result = data.ruleResult;
 
-        const { howToFixSection, link, sectionHeader, snippet, sectionHeaderSeparator, footerSeparator, newLine } = markup;
+        const { howToFixSection, link, sectionHeader, snippet, sectionHeaderSeparator, footerSeparator, sectionSeparator } = markup;
 
         const lines = [
             sectionHeader('Issue'),
             sectionHeaderSeparator(),
             `${snippet(result.help)} (${link(result.helpUrl, result.ruleId)})`,
-            newLine(),
+            sectionSeparator(),
 
             sectionHeader('Target application'),
             sectionHeaderSeparator(),
             link(data.pageUrl, data.pageTitle),
-            newLine(),
+            sectionSeparator(),
 
             sectionHeader('Element path'),
             sectionHeaderSeparator(),
             data.ruleResult.selector,
-            newLine(),
+            sectionSeparator(),
 
             sectionHeader('Snippet'),
             sectionHeaderSeparator(),
             snippet(result.snippet),
-            newLine(),
+            sectionSeparator(),
 
             sectionHeader('How to fix'),
             sectionHeaderSeparator(),
             howToFixSection(result.failureSummary),
-            newLine(),
+            sectionSeparator(),
 
             sectionHeader('Environment'),
             sectionHeaderSeparator(),
             environmentInfo.browserSpec,
-            newLine(),
+            sectionSeparator(),
 
             footerSeparator(),
 

--- a/src/issue-filing/common/markup/html-formatter.ts
+++ b/src/issue-filing/common/markup/html-formatter.ts
@@ -30,6 +30,8 @@ export const createFormatter = (truncateSnippet: (text: string) => string): Mark
 
     const footerSeparator = () => null;
 
+    const newLine = () => '\n';
+
     return {
         snippet,
         link,
@@ -37,6 +39,7 @@ export const createFormatter = (truncateSnippet: (text: string) => string): Mark
         howToFixSection,
         sectionHeaderSeparator,
         footerSeparator,
+        newLine,
     };
 };
 

--- a/src/issue-filing/common/markup/html-formatter.ts
+++ b/src/issue-filing/common/markup/html-formatter.ts
@@ -30,7 +30,7 @@ export const createFormatter = (truncateSnippet: (text: string) => string): Mark
 
     const footerSeparator = () => null;
 
-    const newLine = () => '\n';
+    const sectionSeparator = () => '\n';
 
     return {
         snippet,
@@ -39,7 +39,7 @@ export const createFormatter = (truncateSnippet: (text: string) => string): Mark
         howToFixSection,
         sectionHeaderSeparator,
         footerSeparator,
-        newLine,
+        sectionSeparator,
     };
 };
 

--- a/src/issue-filing/common/markup/html-formatter.ts
+++ b/src/issue-filing/common/markup/html-formatter.ts
@@ -26,11 +26,17 @@ export const createFormatter = (truncateSnippet: (text: string) => string): Mark
             .replace(/\n/g, '<br>');
     };
 
+    const sectionHeaderSeparator = () => null;
+
+    const footerSeparator = () => null;
+
     return {
         snippet,
         link,
         sectionHeader,
         howToFixSection,
+        sectionHeaderSeparator,
+        footerSeparator,
     };
 };
 

--- a/src/issue-filing/common/markup/markdown-formatter.ts
+++ b/src/issue-filing/common/markup/markdown-formatter.ts
@@ -29,7 +29,7 @@ export const createFormatter = (truncateSnippet: (text: string) => string): Mark
 
     const footerSeparator = () => null;
 
-    const newLine = () => '\n';
+    const sectionSeparator = () => '\n';
 
     return {
         snippet,
@@ -38,7 +38,7 @@ export const createFormatter = (truncateSnippet: (text: string) => string): Mark
         howToFixSection,
         sectionHeaderSeparator,
         footerSeparator,
-        newLine,
+        sectionSeparator,
     };
 };
 

--- a/src/issue-filing/common/markup/markdown-formatter.ts
+++ b/src/issue-filing/common/markup/markdown-formatter.ts
@@ -25,11 +25,17 @@ export const createFormatter = (truncateSnippet: (text: string) => string): Mark
             .join('\n');
     };
 
+    const sectionHeaderSeparator = () => '\n';
+
+    const footerSeparator = () => null;
+
     return {
         snippet,
         link,
         sectionHeader,
         howToFixSection,
+        sectionHeaderSeparator,
+        footerSeparator,
     };
 };
 

--- a/src/issue-filing/common/markup/markdown-formatter.ts
+++ b/src/issue-filing/common/markup/markdown-formatter.ts
@@ -29,6 +29,8 @@ export const createFormatter = (truncateSnippet: (text: string) => string): Mark
 
     const footerSeparator = () => null;
 
+    const newLine = () => '\n';
+
     return {
         snippet,
         link,
@@ -36,6 +38,7 @@ export const createFormatter = (truncateSnippet: (text: string) => string): Mark
         howToFixSection,
         sectionHeaderSeparator,
         footerSeparator,
+        newLine,
     };
 };
 

--- a/src/issue-filing/common/markup/markup-formatter.ts
+++ b/src/issue-filing/common/markup/markup-formatter.ts
@@ -8,4 +8,5 @@ export type MarkupFormatter = {
     howToFixSection(failureSummary: string): string;
     sectionHeaderSeparator(): string;
     footerSeparator(): string;
+    newLine(): string;
 };

--- a/src/issue-filing/common/markup/markup-formatter.ts
+++ b/src/issue-filing/common/markup/markup-formatter.ts
@@ -8,5 +8,5 @@ export type MarkupFormatter = {
     howToFixSection(failureSummary: string): string;
     sectionHeaderSeparator(): string;
     footerSeparator(): string;
-    newLine(): string;
+    sectionSeparator(): string;
 };

--- a/src/issue-filing/common/markup/markup-formatter.ts
+++ b/src/issue-filing/common/markup/markup-formatter.ts
@@ -6,4 +6,6 @@ export type MarkupFormatter = {
     link(href: string, text?: string): string;
     sectionHeader(text: string): string;
     howToFixSection(failureSummary: string): string;
+    sectionHeaderSeparator(): string;
+    footerSeparator(): string;
 };

--- a/src/issue-filing/common/markup/plain-text-formatter.ts
+++ b/src/issue-filing/common/markup/plain-text-formatter.ts
@@ -7,7 +7,7 @@ const createFormmatter = (): MarkupFormatter => {
 
     const link = (href: string, text?: string): string => {
         if (text) {
-            return `${text}: ${href}`;
+            return `${text} - ${href}`;
         }
 
         return href;

--- a/src/issue-filing/common/markup/plain-text-formatter.ts
+++ b/src/issue-filing/common/markup/plain-text-formatter.ts
@@ -30,7 +30,7 @@ const createFormmatter = (): MarkupFormatter => {
         howToFixSection,
         sectionHeaderSeparator,
         footerSeparator,
-        newLine,
+        sectionSeparator: newLine,
     };
 };
 

--- a/src/issue-filing/common/markup/plain-text-formatter.ts
+++ b/src/issue-filing/common/markup/plain-text-formatter.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { MarkupFormatter } from './markup-formatter';
+
+const createFormmatter = (): MarkupFormatter => {
+    const snippet = (text: string): string => text.replace(/\s+/g, ' ').trim();
+
+    const link = (href: string, text?: string): string => {
+        if (text) {
+            return `${text}: ${href}`;
+        }
+
+        return href;
+    };
+
+    const sectionHeader = (text: string): string => text;
+
+    const howToFixSection = (failureSummary: string): string => `\n${failureSummary}`;
+
+    const sectionHeaderSeparator = () => ': ';
+
+    const footerSeparator = () => '====\n\n';
+
+    const newLine = () => '\n\n';
+
+    return {
+        snippet,
+        link,
+        sectionHeader,
+        howToFixSection,
+        sectionHeaderSeparator,
+        footerSeparator,
+        newLine,
+    };
+};
+
+export const PlainTextFormatter = createFormmatter();

--- a/src/tests/unit/tests/issue-filing/common/__snapshots__/issue-details-builder.test.ts.snap
+++ b/src/tests/unit/tests/issue-filing/common/__snapshots__/issue-details-builder.test.ts.snap
@@ -1,17 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Name of the group build issue details 1`] = `
-"h-Issue-h
-s-RR-help-s (l-RR-help-url-RR-rule-id-l)
-h-Target application-h
-l-pageUrl-pageTitle<x>-l
-h-Element path-h
-RR-selector<x>
-h-Snippet-h
-s-RR-snippet   space-s
-h-How to fix-h
-h-t--RR-failureSummary--h-t
-h-Environment-h
-test spec
-This accessibility issue was found using Accessibility Insights for Web 1.1.1 (axe-core 2.2.2), a tool that helps find and fix accessibility issues. Get more information & download this tool at l-http://aka.ms/AccessibilityInsights-l."
+"h-Issue-h--s-h-s--s-RR-help-s (l-RR-help-url-RR-rule-id-l)
+h-Target application-h--s-h-s--l-pageUrl-pageTitle<x>-l
+h-Element path-h--s-h-s--RR-selector<x>
+h-Snippet-h--s-h-s--s-RR-snippet   space-s
+h-How to fix-h--s-h-s--h-t--RR-failureSummary--h-t
+h-Environment-h--s-h-s--test spec
+--f-s--This accessibility issue was found using Accessibility Insights for Web 1.1.1 (axe-core 2.2.2), a tool that helps find and fix accessibility issues. Get more information & download this tool at l-http://aka.ms/AccessibilityInsights-l."
 `;

--- a/src/tests/unit/tests/issue-filing/common/issue-details-builder.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-details-builder.test.ts
@@ -38,7 +38,7 @@ describe('Name of the group', () => {
         markupMock.setup(factory => factory.howToFixSection(It.isAnyString())).returns(text => `h-t--${text}--h-t`);
         markupMock.setup(factory => factory.sectionHeaderSeparator()).returns(() => '--s-h-s--');
         markupMock.setup(factory => factory.footerSeparator()).returns(() => '--f-s--');
-        markupMock.setup(factory => factory.newLine()).returns(() => '\n');
+        markupMock.setup(factory => factory.sectionSeparator()).returns(() => '\n');
     });
 
     it('build issue details', () => {

--- a/src/tests/unit/tests/issue-filing/common/issue-details-builder.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-details-builder.test.ts
@@ -29,13 +29,15 @@ describe('Name of the group', () => {
     let markupMock: IMock<MarkupFormatter>;
 
     beforeEach(() => {
-        markupMock = Mock.ofType<MarkupFormatter>(null, MockBehavior.Strict);
+        markupMock = Mock.ofType<MarkupFormatter>(undefined, MockBehavior.Strict);
 
         markupMock.setup(factory => factory.snippet(It.isAnyString())).returns(text => `s-${text}-s`);
         markupMock.setup(factory => factory.link(It.isAnyString(), It.isAnyString())).returns((href, text) => `l-${href}-${text}-l`);
         markupMock.setup(factory => factory.link(It.isAnyString())).returns(href => `l-${href}-l`);
         markupMock.setup(factory => factory.sectionHeader(It.isAnyString())).returns(header => `h-${header}-h`);
         markupMock.setup(factory => factory.howToFixSection(It.isAnyString())).returns(text => `h-t--${text}--h-t`);
+        markupMock.setup(factory => factory.sectionHeaderSeparator()).returns(() => '--s-h-s--');
+        markupMock.setup(factory => factory.footerSeparator()).returns(() => '--f-s--');
     });
 
     it('build issue details', () => {

--- a/src/tests/unit/tests/issue-filing/common/issue-details-builder.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-details-builder.test.ts
@@ -38,6 +38,7 @@ describe('Name of the group', () => {
         markupMock.setup(factory => factory.howToFixSection(It.isAnyString())).returns(text => `h-t--${text}--h-t`);
         markupMock.setup(factory => factory.sectionHeaderSeparator()).returns(() => '--s-h-s--');
         markupMock.setup(factory => factory.footerSeparator()).returns(() => '--f-s--');
+        markupMock.setup(factory => factory.newLine()).returns(() => '\n');
     });
 
     it('build issue details', () => {

--- a/src/tests/unit/tests/issue-filing/common/markup/html-formatter.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/markup/html-formatter.test.ts
@@ -26,6 +26,14 @@ describe('HTMLFormatter', () => {
         expect(result).toEqual('fix<br>- 1<br> 2<br>3<br>4');
     });
 
+    it('returns section header separator', () => {
+        expect(testSubject.sectionHeaderSeparator()).toBe(null);
+    });
+
+    it('returns footer separator', () => {
+        expect(testSubject.footerSeparator()).toBe(null);
+    });
+
     describe('creates snippet', () => {
         beforeEach(() => {
             truncateMock.setup(truncate => truncate(It.isAnyString())).returns(text => text);

--- a/src/tests/unit/tests/issue-filing/common/markup/html-formatter.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/markup/html-formatter.test.ts
@@ -35,7 +35,7 @@ describe('HTMLFormatter', () => {
     });
 
     it('return new line', () => {
-        expect(testSubject.newLine()).toBe('\n');
+        expect(testSubject.sectionSeparator()).toBe('\n');
     });
 
     describe('creates snippet', () => {

--- a/src/tests/unit/tests/issue-filing/common/markup/html-formatter.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/markup/html-formatter.test.ts
@@ -34,6 +34,10 @@ describe('HTMLFormatter', () => {
         expect(testSubject.footerSeparator()).toBe(null);
     });
 
+    it('return new line', () => {
+        expect(testSubject.newLine()).toBe('\n');
+    });
+
     describe('creates snippet', () => {
         beforeEach(() => {
             truncateMock.setup(truncate => truncate(It.isAnyString())).returns(text => text);

--- a/src/tests/unit/tests/issue-filing/common/markup/markdown-formatter.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/markup/markdown-formatter.test.ts
@@ -42,6 +42,10 @@ describe('MarkdownFormatter', () => {
         expect(result).toEqual(`\`this is code\``);
     });
 
+    it('return new line', () => {
+        expect(testSubject.newLine()).toBe('\n');
+    });
+
     describe('creates link', () => {
         it('handles href only', () => {
             const result = testSubject.link('test-href');

--- a/src/tests/unit/tests/issue-filing/common/markup/markdown-formatter.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/markup/markdown-formatter.test.ts
@@ -26,6 +26,14 @@ describe('MarkdownFormatter', () => {
         expect(result).toEqual('    fix\n    1\n    2\n    3\n    4');
     });
 
+    it('returns section header separator', () => {
+        expect(testSubject.sectionHeaderSeparator()).toBe('\n');
+    });
+
+    it('return footer separator', () => {
+        expect(testSubject.footerSeparator()).toBe(null);
+    });
+
     it('creates snippet', () => {
         truncateMock.setup(truncate => truncate(It.isAnyString())).returns(text => text);
 

--- a/src/tests/unit/tests/issue-filing/common/markup/markdown-formatter.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/markup/markdown-formatter.test.ts
@@ -43,7 +43,7 @@ describe('MarkdownFormatter', () => {
     });
 
     it('return new line', () => {
-        expect(testSubject.newLine()).toBe('\n');
+        expect(testSubject.sectionSeparator()).toBe('\n');
     });
 
     describe('creates link', () => {

--- a/src/tests/unit/tests/issue-filing/common/markup/plain-text-formatter.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/markup/plain-text-formatter.test.ts
@@ -40,7 +40,7 @@ describe('PlainTextFormatter', () => {
         });
 
         it('handles href and text', () => {
-            expect(testSubject.link('test-href', 'test-text')).toEqual('test-text: test-href');
+            expect(testSubject.link('test-href', 'test-text')).toEqual('test-text - test-href');
         });
     });
 });

--- a/src/tests/unit/tests/issue-filing/common/markup/plain-text-formatter.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/markup/plain-text-formatter.test.ts
@@ -31,7 +31,7 @@ describe('PlainTextFormatter', () => {
     });
 
     it('return new line', () => {
-        expect(testSubject.newLine()).toBe('\n\n');
+        expect(testSubject.sectionSeparator()).toBe('\n\n');
     });
 
     describe('creates link', () => {

--- a/src/tests/unit/tests/issue-filing/common/markup/plain-text-formatter.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/markup/plain-text-formatter.test.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { MarkupFormatter } from '../../../../../../issue-filing/common/markup/markup-formatter';
+import { PlainTextFormatter } from '../../../../../../issue-filing/common/markup/plain-text-formatter';
+
+describe('PlainTextFormatter', () => {
+    let testSubject: MarkupFormatter;
+
+    beforeEach(() => {
+        testSubject = PlainTextFormatter;
+    });
+
+    it('returns section header', () => {
+        expect(testSubject.sectionHeader('test-section-header')).toEqual('test-section-header');
+    });
+
+    it('returns how to fix section', () => {
+        expect(testSubject.howToFixSection('test-failure-summary')).toEqual('\ntest-failure-summary');
+    });
+
+    it('returns section header separator', () => {
+        expect(testSubject.sectionHeaderSeparator()).toEqual(': ');
+    });
+
+    it('returns footer separator', () => {
+        expect(testSubject.footerSeparator()).toEqual('====\n\n');
+    });
+
+    it('returns snippet', () => {
+        expect(testSubject.snippet('   snippet with      spaces  ')).toEqual('snippet with spaces');
+    });
+
+    it('return new line', () => {
+        expect(testSubject.newLine()).toBe('\n\n');
+    });
+
+    describe('creates link', () => {
+        it('handles href only', () => {
+            expect(testSubject.link('test-href')).toEqual('test-href');
+        });
+
+        it('handles href and text', () => {
+            expect(testSubject.link('test-href', 'test-text')).toEqual('test-text: test-href');
+        });
+    });
+});


### PR DESCRIPTION
#### Description of changes

`IssueDetailsTextGenerator` is used on the "copy failure details" button but it has duplicated logic (that we have in a generic implementation under issue filing for git hub and azure boards).
This PR refactors `IssueDetailsTextGenerator` to use `IssueDetailsBuilder` instead of having it's own logic about the issue details content. In order to do that, I had to update `IssueDetailsBuilder` to account for some style differences between file a bug and copy failure details. I've also add a new markup formatter: plain text formatter.
After this refactor, the main section of the issue details will be hold on one place only: `IssueDetailsBuilder`

**Notes for the reviewer**
- It may be helpful to review commit per commit as the first 5 commits revolve around supporting the refactor on the `IssueDetailsTextGenerator` class.
- There are two main differences between the old copy failure details content and the new one:
   - each link we render having a text and a href are render like this: <text> - <href> (note the 'dash' in between). This was discussed with @ferBonnin before making the decision. 
   - The Environment section doesn't have a new line anymore

**before**
```plaintext
Title: WCAG 1.3.1,WCAG 3.3.2: Form elements must have labels (#input-radio-1)
Tags: Accessibility, WCAG 1.3.1, WCAG 3.3.2, label

Issue: Form elements must have labels (label: https://dequeuniversity.com/rules/axe/3.2/label?application=msftAI)

Target application title: All Pages
Target application url: file:///C:/Users/semora/Repos/smoralesd/accessibility-insights-web/src/tests/end-to-end/test-resources/all.html

Element path: iframe[name="native-widgets"];#input-radio-1

Snippet: <input id="input-radio-1" type="radio" name="color" value="red" checked="">

How to fix:
Fix any of the following:
  aria-label attribute does not exist or is empty
  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
  Form element does not have an implicit (wrapped) <label>
  Form element does not have an explicit <label>
  Element has no title attribute or the title attribute is empty

Environment:
Chrome version 76.0.3809.100

====

This accessibility issue was found using Accessibility Insights for Web 2.8.1 (axe-core 3.2.2), a tool that helps find and fix accessibility issues. Get more information & download this tool at http://aka.ms/AccessibilityInsights.
```

**after**
```plaintext
Title: WCAG 1.3.1,WCAG 3.3.2: Form elements must have labels (#input-radio-1)
Tags: Accessibility, WCAG 1.3.1, WCAG 3.3.2, label

Issue: Form elements must have labels (label - https://dequeuniversity.com/rules/axe/3.2/label?application=msftAI)

Target application: All Pages - file:///C:/Users/semora/Repos/smoralesd/accessibility-insights-web/src/tests/end-to-end/test-resources/all.html

Element path: iframe[name="native-widgets"];#input-radio-1

Snippet: <input id="input-radio-1" type="radio" name="color" value="red" checked="">

How to fix: 
Fix any of the following:
  aria-label attribute does not exist or is empty
  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
  Form element does not have an implicit (wrapped) <label>
  Form element does not have an explicit <label>
  Element has no title attribute or the title attribute is empty

Environment: Chrome version 76.0.3809.100

====

This accessibility issue was found using Accessibility Insights for Web 1.0.4 (axe-core 3.2.2), a tool that helps find and fix accessibility issues. Get more information & download this tool at http://aka.ms/AccessibilityInsights.
```

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
