### PR TITLE
fix: revert #1098 to fix #1112

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -343,7 +343,6 @@ div.insights-file-issue-details-dialog-container {
         width: 100%;
     }
     .details-view-command-bar {
-        height: $detailsViewCommandBarHeight;
         width: 100%;
         display: flex;
         justify-content: space-between;
@@ -352,11 +351,11 @@ div.insights-file-issue-details-dialog-container {
         background-color: $neutral-0;
         font-size: 14px;
         font-weight: normal;
-        border-bottom: $detailsViewCommandBarBorderHeight solid $neutral-alpha-8;
+        border-bottom: 1px solid $neutral-alpha-8;
 
         .details-view-target-page {
             margin-left: 12px;
-            padding: 8px 8px;
+            padding: 13px 8px;
             display: inherit;
             white-space: nowrap;
             overflow: hidden;
@@ -435,12 +434,8 @@ div.insights-file-issue-details-dialog-container {
     .details-view-main-content {
         padding-left: 0px;
         padding-right: 0px;
-        display: grid;
-        grid-template-columns: 230px 1fr;
-        grid-template-rows: 1fr;
-        width: 100%;
+        flex-grow: 1;
         min-height: 0;
-
         .details-view-nav-pivots {
             > :first-child {
                 height: $detailsViewNavPivotsHeight;
@@ -450,8 +445,7 @@ div.insights-file-issue-details-dialog-container {
             }
         }
         .details-view-test-nav-area {
-            box-sizing: border-box;
-            max-height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
+            max-height: calc(100vh - #{$detailsViewHeaderBarHeight} - #{$detailsViewCommandBarHeight} - 12px);
             .ms-Nav-groupContent,
             .ms-Nav-navItems {
                 margin-bottom: 0px;
@@ -828,8 +822,6 @@ div.insights-file-issue-details-dialog-container {
             width: 100%;
             padding-bottom: 1px;
             overflow: auto;
-            box-sizing: border-box;
-            max-height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
             > div {
                 min-width: 600px;
                 height: auto;

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -96,10 +96,8 @@ $pivotItemBorderStyle: solid !default;
 $detailsViewHeaderBarHeight: 40px !default;
 $detailsViewNavPivotsHeight: 41px !default;
 $detailsViewCommandBarHeight: 40px !default;
-$detailsViewCommandBarBorderHeight: 1px !default;
-$detailsViewManNavWidth: 185px !default;
 
-$detailsViewTotalHeaderHeight: (#{$detailsViewCommandBarBorderHeight} + #{$detailsViewCommandBarHeight} + #{$detailsViewHeaderBarHeight});
+$detailsViewManNavWidth: 185px !default;
 
 .header-bar,
 .report-header-bar {


### PR DESCRIPTION
This reverts commit 1ff86174ffc81f50483ad3805182e7e9befd77c3 to avoid #1112.

#### Description of changes

#1098 accidentally caused #1112 while fixing #1118. #1112 is a more impactful bug, so we're reverting the fix until Chromium 77 reaches stable, when we can un-revert it (since Chromium 77 incidentally fixes #1112).

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1112
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a, see #1098] (UI changes only) Added screenshots/GIFs to description above
- [n/a, revert] (UI changes only) Verified usability with NVDA/JAWS
