### PR TITLE
Revert device connect state if port number changes

### DIFF
--- a/src/electron/device-connect-view/components/device-connect-body.tsx
+++ b/src/electron/device-connect-view/components/device-connect-body.tsx
@@ -8,7 +8,7 @@ import { DeviceConnectFooter } from './device-connect-footer';
 import { DeviceConnectHeader } from './device-connect-header';
 import { DeviceConnectPortEntry } from './device-connect-port-entry';
 
-export type OnConnectedCallback = (isConnected: boolean, deviceName?: string) => void;
+export type OnConnectedCallback = (isConnected: boolean, hasFailedConnecting: boolean, deviceName?: string) => void;
 export type OnConnectingCallback = () => void;
 
 export interface DeviceConnectBodyProps {
@@ -67,11 +67,11 @@ export class DeviceConnectBody extends React.Component<DeviceConnectBodyProps, D
         });
     };
 
-    private OnConnectedCallback: OnConnectedCallback = (isConnected: boolean, deviceName?: string) => {
+    private OnConnectedCallback: OnConnectedCallback = (isConnected: boolean, hasFailedConnecting: boolean, deviceName?: string) => {
         this.setState({
             canStartTesting: isConnected,
             connectedDevice: deviceName,
-            hasFailedConnecting: !isConnected,
+            hasFailedConnecting: hasFailedConnecting,
             isConnecting: false,
             needsValidation: !isConnected,
         });

--- a/src/electron/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/device-connect-view/components/device-connect-port-entry.tsx
@@ -4,12 +4,11 @@ import { Button } from 'office-ui-fabric-react/lib/Button';
 import { MaskedTextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 import { FetchScanResultsType } from '../../platform/android/fetch-scan-results';
-import { OnConnectedCallback, OnConnectingCallback } from './device-connect-body';
+import { DeviceConnectState, UpdateStateCallback } from './device-connect-body';
 
 export interface DeviceConnectPortEntryProps {
     needsValidation: boolean;
-    onConnectedCallback: OnConnectedCallback;
-    onConnectingCallback: OnConnectingCallback;
+    updateStateCallback: UpdateStateCallback;
     fetchScanResults: FetchScanResultsType;
 }
 
@@ -27,7 +26,7 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
     public render(): JSX.Element {
         const onPortTextChanged = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
             this.setState({ isValidateButtonDisabled: !newValue || newValue === '', port: newValue });
-            this.props.onConnectedCallback(false, false);
+            this.props.updateStateCallback(DeviceConnectState.Default);
         };
 
         return (
@@ -55,14 +54,14 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
 
     private onValidateClick = async (event: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
         this.setState({ isValidateButtonDisabled: true });
-        this.props.onConnectingCallback();
+        this.props.updateStateCallback(DeviceConnectState.Connecting);
 
         await this.props
             .fetchScanResults(parseInt(this.state.port, 10))
             .then(data => {
-                this.props.onConnectedCallback(true, false, `${data.deviceName} - ${data.appIdentifier}`);
+                this.props.updateStateCallback(DeviceConnectState.Connected, `${data.deviceName} - ${data.appIdentifier}`);
             })
-            .catch(err => this.props.onConnectedCallback(false, true));
+            .catch(err => this.props.updateStateCallback(DeviceConnectState.Error));
 
         this.setState({ isValidateButtonDisabled: false });
     };

--- a/src/electron/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/device-connect-view/components/device-connect-port-entry.tsx
@@ -27,6 +27,7 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
     public render(): JSX.Element {
         const onPortTextChanged = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
             this.setState({ isValidateButtonDisabled: !newValue || newValue === '', port: newValue });
+            this.props.onConnectedCallback(false, false);
         };
 
         return (
@@ -59,9 +60,9 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
         await this.props
             .fetchScanResults(parseInt(this.state.port, 10))
             .then(data => {
-                this.props.onConnectedCallback(true, `${data.deviceName} - ${data.appIdentifier}`);
+                this.props.onConnectedCallback(true, false, `${data.deviceName} - ${data.appIdentifier}`);
             })
-            .catch(err => this.props.onConnectedCallback(false));
+            .catch(err => this.props.onConnectedCallback(false, true));
 
         this.setState({ isValidateButtonDisabled: false });
     };

--- a/src/tests/unit/electron/device-connect-view/components/__snapshots__/device-connect-body.test.tsx.snap
+++ b/src/tests/unit/electron/device-connect-view/components/__snapshots__/device-connect-body.test.tsx.snap
@@ -8,8 +8,7 @@ exports[`DeviceConnectBodyTest render 1`] = `
   <DeviceConnectPortEntry
     fetchScanResults={[Function]}
     needsValidation={true}
-    onConnectedCallback={[Function]}
-    onConnectingCallback={[Function]}
+    updateStateCallback={[Function]}
   />
   <DeviceConnectConnectedDevice
     hasFailed={false}

--- a/src/tests/unit/electron/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/electron/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DeviceConnectPortEntryTest onChange updates state 1`] = `
+Object {
+  "isValidateButtonDisabled": true,
+  "port": "",
+}
+`;
+
+exports[`DeviceConnectPortEntryTest onChange updates state 2`] = `
+Object {
+  "isValidateButtonDisabled": false,
+  "port": "111",
+}
+`;
+
 exports[`DeviceConnectPortEntryTest render 1`] = `
 <div
   className="device-connect-port-entry"

--- a/src/tests/unit/electron/device-connect-view/components/device-connect-body.test.tsx
+++ b/src/tests/unit/electron/device-connect-view/components/device-connect-body.test.tsx
@@ -70,7 +70,7 @@ describe('DeviceConnectBodyTest', () => {
         const propsWithCallback = rendered.find('DeviceConnectPortEntry').props() as DeviceConnectPortEntryProps;
 
         expect(rendered.state()).toEqual(expectedBeforeState);
-        propsWithCallback.onConnectedCallback(true, expectedStateConnectedSuccess.connectedDevice);
+        propsWithCallback.onConnectedCallback(true, false, expectedStateConnectedSuccess.connectedDevice);
         expect(rendered.state()).toEqual(expectedStateConnectedSuccess);
     });
 
@@ -79,7 +79,7 @@ describe('DeviceConnectBodyTest', () => {
         const propsWithCallback = rendered.find('DeviceConnectPortEntry').props() as DeviceConnectPortEntryProps;
 
         expect(rendered.state()).toEqual(expectedBeforeState);
-        propsWithCallback.onConnectedCallback(false, expectedStateConnectedFail.connectedDevice);
+        propsWithCallback.onConnectedCallback(false, true, expectedStateConnectedFail.connectedDevice);
         expect(rendered.state()).toEqual(expectedStateConnectedFail);
     });
 });

--- a/src/tests/unit/electron/device-connect-view/components/device-connect-body.test.tsx
+++ b/src/tests/unit/electron/device-connect-view/components/device-connect-body.test.tsx
@@ -7,6 +7,7 @@ import {
     DeviceConnectBody,
     DeviceConnectBodyProps,
     DeviceConnectBodyState,
+    DeviceConnectState,
 } from '../../../../../electron/device-connect-view/components/device-connect-body';
 import { DeviceConnectPortEntryProps } from '../../../../../electron/device-connect-view/components/device-connect-port-entry';
 
@@ -20,33 +21,21 @@ describe('DeviceConnectBodyTest', () => {
     };
 
     const expectedBeforeState: DeviceConnectBodyState = {
-        canStartTesting: false,
-        hasFailedConnecting: false,
-        needsValidation: true,
-        isConnecting: false,
+        deviceConnectState: DeviceConnectState.Default,
     };
 
     const expectedStateWhileConnecting: DeviceConnectBodyState = {
-        canStartTesting: false,
-        connectedDevice: '',
-        hasFailedConnecting: false,
-        isConnecting: true,
-        needsValidation: true,
+        deviceConnectState: DeviceConnectState.Connecting,
+        connectedDevice: undefined,
     };
 
     const expectedStateConnectedSuccess: DeviceConnectBodyState = {
-        isConnecting: false,
-        canStartTesting: true,
-        hasFailedConnecting: false,
-        needsValidation: false,
+        deviceConnectState: DeviceConnectState.Connected,
         connectedDevice: 'Test Device Name!',
     };
 
     const expectedStateConnectedFail: DeviceConnectBodyState = {
-        isConnecting: false,
-        canStartTesting: false,
-        hasFailedConnecting: true,
-        needsValidation: true,
+        deviceConnectState: DeviceConnectState.Error,
         connectedDevice: '',
     };
 
@@ -61,7 +50,7 @@ describe('DeviceConnectBodyTest', () => {
         const propsWithCallback = rendered.find('DeviceConnectPortEntry').props() as DeviceConnectPortEntryProps;
 
         expect(rendered.state()).toEqual(expectedBeforeState);
-        propsWithCallback.onConnectingCallback();
+        propsWithCallback.updateStateCallback(DeviceConnectState.Connecting);
         expect(rendered.state()).toEqual(expectedStateWhileConnecting);
     });
 
@@ -70,7 +59,7 @@ describe('DeviceConnectBodyTest', () => {
         const propsWithCallback = rendered.find('DeviceConnectPortEntry').props() as DeviceConnectPortEntryProps;
 
         expect(rendered.state()).toEqual(expectedBeforeState);
-        propsWithCallback.onConnectedCallback(true, false, expectedStateConnectedSuccess.connectedDevice);
+        propsWithCallback.updateStateCallback(DeviceConnectState.Connected, expectedStateConnectedSuccess.connectedDevice);
         expect(rendered.state()).toEqual(expectedStateConnectedSuccess);
     });
 
@@ -79,7 +68,7 @@ describe('DeviceConnectBodyTest', () => {
         const propsWithCallback = rendered.find('DeviceConnectPortEntry').props() as DeviceConnectPortEntryProps;
 
         expect(rendered.state()).toEqual(expectedBeforeState);
-        propsWithCallback.onConnectedCallback(false, true, expectedStateConnectedFail.connectedDevice);
+        propsWithCallback.updateStateCallback(DeviceConnectState.Error, expectedStateConnectedFail.connectedDevice);
         expect(rendered.state()).toEqual(expectedStateConnectedFail);
     });
 });

--- a/src/tests/unit/electron/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/electron/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -36,21 +36,40 @@ describe('DeviceConnectPortEntryTest', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
+    test('onChange updates state', () => {
+        const fetch: FetchScanResultsType = _ => Promise.reject({} as ScanResults);
+        const props = SetupPropsMocks(fetch, false, false, undefined);
+        const rendered = shallow(<DeviceConnectPortEntry {...props} />);
+
+        expect(rendered.state()).toMatchSnapshot();
+
+        const onChangeHandler = rendered.find('.port-number-field').prop('onChange') as (
+            event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
+            newValue?: string,
+        ) => void;
+
+        onChangeHandler(null, testPortNumber.toString());
+
+        onConnectedMock.verifyAll();
+        expect(rendered.state()).toMatchSnapshot();
+    });
+
     test('validate click fetch succeeds', () => {
         const fetch: FetchScanResultsType = _ => Promise.resolve({ deviceName: 'dev', appIdentifier: 'app' } as ScanResults);
-        const props = SetupPropsMocks(fetch, true, 'dev - app');
+        const props = SetupPropsMocks(fetch, true, false, 'dev - app');
         ValidatePortValidateClick(props);
     });
 
     test('validate click fetch fails', () => {
         const fetch: FetchScanResultsType = _ => Promise.reject({} as ScanResults);
-        const props = SetupPropsMocks(fetch, false, undefined);
+        const props = SetupPropsMocks(fetch, false, true, undefined);
         ValidatePortValidateClick(props);
     });
 
     const SetupPropsMocks = (
         fetch: FetchScanResultsType,
         expectedSuccess: boolean,
+        expectedFailed: boolean,
         expectedDevice: string,
     ): DeviceConnectPortEntryProps => {
         onConnectingMock.reset();
@@ -63,7 +82,7 @@ describe('DeviceConnectPortEntryTest', () => {
             .verifiable();
 
         onConnectedMock.reset();
-        onConnectedMock.setup(r => r(expectedSuccess, expectedDevice)).verifiable();
+        onConnectedMock.setup(r => r(expectedSuccess, expectedFailed, expectedDevice)).verifiable();
 
         return {
             fetchScanResults: fetchScanResultsMock.object,

--- a/src/tests/unit/electron/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/electron/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import { Button } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import { IMock, Mock } from 'typemoq';
-import { OnConnectedCallback, OnConnectingCallback } from '../../../../../electron/device-connect-view/components/device-connect-body';
+import { DeviceConnectState, UpdateStateCallback } from '../../../../../electron/device-connect-view/components/device-connect-body';
 import {
     DeviceConnectPortEntry,
     DeviceConnectPortEntryProps,
@@ -17,15 +17,13 @@ describe('DeviceConnectPortEntryTest', () => {
     let testPortNumber: number;
     let eventStub: React.MouseEvent<Button>;
     let fetchScanResultsMock: IMock<FetchScanResultsType>;
-    let onConnected: OnConnectedCallback;
-    let onConnectingMock: IMock<OnConnectingCallback>;
-    let onConnectedMock: IMock<OnConnectedCallback>;
+    let onConnected: UpdateStateCallback;
+    let onConnectedMock: IMock<UpdateStateCallback>;
 
     beforeAll(() => {
         testPortNumber = 111;
         eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
         onConnected = (isConnected, deviceName) => {};
-        onConnectingMock = Mock.ofInstance(() => {});
         onConnectedMock = Mock.ofInstance(onConnected);
     });
 
@@ -38,7 +36,7 @@ describe('DeviceConnectPortEntryTest', () => {
 
     test('onChange updates state', () => {
         const fetch: FetchScanResultsType = _ => Promise.reject({} as ScanResults);
-        const props = SetupPropsMocks(fetch, false, false, undefined);
+        const props = SetupPropsMocks(fetch, DeviceConnectState.Default, undefined);
         const rendered = shallow(<DeviceConnectPortEntry {...props} />);
 
         expect(rendered.state()).toMatchSnapshot();
@@ -56,25 +54,21 @@ describe('DeviceConnectPortEntryTest', () => {
 
     test('validate click fetch succeeds', () => {
         const fetch: FetchScanResultsType = _ => Promise.resolve({ deviceName: 'dev', appIdentifier: 'app' } as ScanResults);
-        const props = SetupPropsMocks(fetch, true, false, 'dev - app');
+        const props = SetupPropsMocks(fetch, DeviceConnectState.Connected, 'dev - app');
         ValidatePortValidateClick(props);
     });
 
     test('validate click fetch fails', () => {
         const fetch: FetchScanResultsType = _ => Promise.reject({} as ScanResults);
-        const props = SetupPropsMocks(fetch, false, true, undefined);
+        const props = SetupPropsMocks(fetch, DeviceConnectState.Error, undefined);
         ValidatePortValidateClick(props);
     });
 
     const SetupPropsMocks = (
         fetch: FetchScanResultsType,
-        expectedSuccess: boolean,
-        expectedFailed: boolean,
+        expectedState: DeviceConnectState,
         expectedDevice: string,
     ): DeviceConnectPortEntryProps => {
-        onConnectingMock.reset();
-        onConnectingMock.setup(r => r()).verifiable();
-
         fetchScanResultsMock = Mock.ofInstance(fetch);
         fetchScanResultsMock
             .setup(r => r(testPortNumber))
@@ -82,12 +76,11 @@ describe('DeviceConnectPortEntryTest', () => {
             .verifiable();
 
         onConnectedMock.reset();
-        onConnectedMock.setup(r => r(expectedSuccess, expectedFailed, expectedDevice)).verifiable();
+        onConnectedMock.setup(r => r(expectedState, expectedDevice)).verifiable();
 
         return {
             fetchScanResults: fetchScanResultsMock.object,
-            onConnectingCallback: onConnectingMock.object,
-            onConnectedCallback: onConnectedMock.object,
+            updateStateCallback: onConnectedMock.object,
         } as DeviceConnectPortEntryProps;
     };
 
@@ -98,7 +91,6 @@ describe('DeviceConnectPortEntryTest', () => {
         button.simulate('click', eventStub);
 
         fetchScanResultsMock.verifyAll();
-        onConnectingMock.verifyAll();
 
         const validateAfterPromise = (): void => {
             expect(rendered.state()).toEqual({ isValidateButtonDisabled: false, port: testPortNumber });


### PR DESCRIPTION
#### Description of changes
Currently in the device connect screen, if a user enters a port, validates it, and then changes the port, the state remains unchanged. That behavior makes it seem like the user has validated their newly entered port, which is not the case. This PR updates the behavior such that whenever the user changes the port value, the state is restored to the original, pre-validation state. There are no actual UI/visual changes.

GIF of state change (same effect for connection success and failure):
![electron](https://user-images.githubusercontent.com/4615491/63471334-ba4cb700-c423-11e9-86e9-e99bf62de764.gif)

#### Pull request checklist

- [-] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [-] (UI changes only) Added screenshots/GIFs to description above
- [-] (UI changes only) Verified usability with NVDA/JAWS
