### PR TITLE
feat: Add Contrast assessment test (behind feature flag)

### DIFF
--- a/src/assessments/assessments.ts
+++ b/src/assessments/assessments.ts
@@ -4,6 +4,7 @@ import { AssessmentsProviderImpl } from './assessments-provider';
 import { AudioVideoOnlyAssessment } from './audio-video-only/assessment';
 import { AutomatedChecks } from './automated-checks/assessment';
 import { ColorSensoryAssessment } from './color/assessment';
+import { ContrastAssessment } from './contrast/assessment';
 import { CustomWidgets } from './custom-widgets/assessment';
 import { ErrorsAssessment } from './errors/assessment';
 import { HeadingsAssessment } from './headings/assessment';
@@ -50,4 +51,5 @@ export const Assessments: AssessmentsProvider = AssessmentsProviderImpl.Create([
     SequenceAssessment,
     SemanticsAssessment,
     PointerMotionAssessment,
+    ContrastAssessment,
 ]);

--- a/src/assessments/contrast/assessment.tsx
+++ b/src/assessments/contrast/assessment.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { test as content } from 'content/test';
+import * as React from 'react';
+
+import { VisualizationType } from 'common/types/visualization-type';
+import { AssessmentBuilder } from '../assessment-builder';
+import { Assessment } from '../types/iassessment';
+import { StateChanges } from './test-steps/state-changes';
+import { UIComponents } from './test-steps/ui-components';
+
+const { guidance } = content.contrast;
+const key = 'contrast';
+const title = 'Contrast';
+
+const gettingStarted: JSX.Element = (
+    <>
+        <p>
+            Contrast ratio describes the relative brightness of foreground and background colors on a computer display. In general, higher
+            contrast ratios make text and graphics easier to perceive and read. Black and white have the highest possible contrast ratio,
+            21:1. Identical colors have the lowest possible contrast ratio, 1:1. All other color combinations fall somewhere in between.
+        </p>
+    </>
+);
+
+export const ContrastAssessment: Assessment = AssessmentBuilder.Assisted({
+    key,
+    title: title,
+    gettingStarted: gettingStarted,
+    guidance,
+    visualizationType: VisualizationType.ContrastAssessment,
+    requirements: [UIComponents, StateChanges],
+    storeDataKey: 'contrastAssessment',
+    featureFlag: { required: ['showAllAssessments'] },
+});

--- a/src/assessments/contrast/test-steps/state-changes.tsx
+++ b/src/assessments/contrast/test-steps/state-changes.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NewTabLink } from 'common/components/new-tab-link';
+import { link } from 'content/link';
+import * as content from 'content/test/contrast/state-changes';
+import * as React from 'react';
+
+import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
+import { Requirement } from '../../types/requirement';
+import { ContrastTestStep } from './test-steps';
+
+const description: JSX.Element = (
+    <span>If state changes are indicated solely by changes in color, the different states must have sufficient contrast.</span>
+);
+
+const howToTest: JSX.Element = (
+    <div>
+        <p>The visual helper for this requirement highlights links, native widgets, and custom widgets in the target page.</p>
+        <ol>
+            <li>
+                In the target page, examine each highlighted user interface component in each of the following states:
+                <ol>
+                    <li>Normal</li>
+                    <li>Focused</li>
+                    <li>Mouseover</li>
+                    <li>Selected (if applicable)</li>
+                </ol>
+            </li>
+            <li>
+                If any component indicates state changes solely by a change of color, use{' '}
+                <NewTabLink href="https://accessibilityinsights.io/docs/en/windows/getstarted/colorcontrast">
+                    Accessibility Insights for Windows
+                </NewTabLink>{' '}
+                to verify that the contrast ratio between different states is at least 3:1.
+            </li>
+            <AssistedTestRecordYourResults />
+        </ol>
+    </div>
+);
+
+export const StateChanges: Requirement = {
+    key: ContrastTestStep.stateChanges,
+    name: 'State Changes',
+    description,
+    howToTest,
+    ...content,
+    guidanceLinks: [link.WCAG_1_4_11],
+    isManual: true, // TODO: false
+    // TODO: columnsConfig, reportInstanceFields, getAnalyzer, getDrawer, getVisualHelperToggle
+};

--- a/src/assessments/contrast/test-steps/state-changes.tsx
+++ b/src/assessments/contrast/test-steps/state-changes.tsx
@@ -40,7 +40,7 @@ const howToTest: JSX.Element = (
 
 export const StateChanges: Requirement = {
     key: ContrastTestStep.stateChanges,
-    name: 'State Changes',
+    name: 'State changes',
     description,
     howToTest,
     ...content,

--- a/src/assessments/contrast/test-steps/test-steps.ts
+++ b/src/assessments/contrast/test-steps/test-steps.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export const enum ContrastTestStep {
+    uiComponents = 'ui-components',
+    stateChanges = 'state-changes',
+}

--- a/src/assessments/contrast/test-steps/ui-components.tsx
+++ b/src/assessments/contrast/test-steps/ui-components.tsx
@@ -50,7 +50,7 @@ const howToTest: JSX.Element = (
 
 export const UIComponents: Requirement = {
     key: ContrastTestStep.uiComponents,
-    name: 'UI Components',
+    name: 'UI components',
     description,
     howToTest,
     ...content,

--- a/src/assessments/contrast/test-steps/ui-components.tsx
+++ b/src/assessments/contrast/test-steps/ui-components.tsx
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NewTabLink } from 'common/components/new-tab-link';
+import { link } from 'content/link';
+import * as content from 'content/test/contrast/ui-components';
+import * as React from 'react';
+
+import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
+import { Requirement } from '../../types/requirement';
+import { ContrastTestStep } from './test-steps';
+
+const description: JSX.Element = (
+    <span>Visual information used to indicate states and boundaries of active interface components must have sufficient contrast.</span>
+);
+
+const howToTest: JSX.Element = (
+    <div>
+        <p>The visual helper for this requirement highlights links, native widgets, and custom widgets in the target page.</p>
+        <ol>
+            <li>
+                In the target page, examine each highlighted element in each of the following states:
+                <ol>
+                    <li>Normal</li>
+                    <li>Focused</li>
+                    <li>Mouseover</li>
+                    <li>Selected (if applicable)</li>
+                </ol>
+            </li>
+            <li>
+                In each state, use{' '}
+                <NewTabLink href="https://accessibilityinsights.io/docs/en/windows/getstarted/colorcontrast">
+                    Accessibility Insights for Windows
+                </NewTabLink>{' '}
+                to verify that the following visual presentations (if implemented) have a contrast ratio of at least 3:1 against the
+                adjacent background:
+                <ol>
+                    <li>Any visual effect that indicates state</li>
+                    <li>Any visual boundary that indicates the component's clickable area</li>
+                </ol>
+                Exception: A lower contrast ratio is allowed if either of the following is true:
+                <ol>
+                    <li>The component is inactive/disabled.</li>
+                    <li>The component's appearance is determined solely by the browser.</li>
+                </ol>
+            </li>
+            <AssistedTestRecordYourResults />
+        </ol>
+    </div>
+);
+
+export const UIComponents: Requirement = {
+    key: ContrastTestStep.uiComponents,
+    name: 'UI Components',
+    description,
+    howToTest,
+    ...content,
+    guidanceLinks: [link.WCAG_1_4_11],
+    isManual: true, // TODO: false
+    // TODO: columnsConfig, reportInstanceFields, getAnalyzer, getDrawer, getVisualHelperToggle
+};

--- a/src/common/types/visualization-type.ts
+++ b/src/common/types/visualization-type.ts
@@ -29,4 +29,5 @@ export enum VisualizationType {
     SequenceAssessment,
     SemanticsAssessment,
     PointerMotionAssessment,
+    ContrastAssessment,
 }

--- a/src/content/link.tsx
+++ b/src/content/link.tsx
@@ -22,6 +22,9 @@ export const link = {
     WCAG_1_4_4: guidanceLinkTo('WCAG 1.4.4', 'https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html'),
     WCAG_1_4_5: guidanceLinkTo('WCAG 1.4.5', 'https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html'),
     WCAG_1_4_10: guidanceLinkTo('WCAG 1.4.10', 'https://www.w3.org/WAI/WCAG21/Understanding/reflow.html', [guidanceTags.WCAG_2_1]),
+    WCAG_1_4_11: guidanceLinkTo('WCAG 1.4.11', 'https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html', [
+        guidanceTags.WCAG_2_1,
+    ]),
     WCAG_1_4_12: guidanceLinkTo('WCAG 1.4.12', 'https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html', [guidanceTags.WCAG_2_1]),
     WCAG_1_4_13: guidanceLinkTo('WCAG 1.4.13', 'https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html', [
         guidanceTags.WCAG_2_1,

--- a/src/content/test/contrast/guidance.tsx
+++ b/src/content/test/contrast/guidance.tsx
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { create, GuidanceTitle, React } from '../../common';
+
+export const guidance = create(({ Markup, Link }) => (
+    <>
+        <GuidanceTitle name={'Contrast'} />
+
+        <p>TODO</p>
+    </>
+));

--- a/src/content/test/contrast/index.ts
+++ b/src/content/test/contrast/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { guidance } from './guidance';
+import * as stateChanges from './state-changes';
+import * as uiComponents from './ui-components';
+
+export const contrast = {
+    guidance,
+    stateChanges,
+    uiComponents,
+};

--- a/src/content/test/contrast/state-changes.tsx
+++ b/src/content/test/contrast/state-changes.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { create, React } from '../../common';
+
+export const infoAndExamples = create(({ Markup }) => (
+    <>
+        <h1>State changes</h1>
+        <p>
+            If the only visual indication of a control's change of state is a change of color, the different colors must have sufficient
+            contrast.
+        </p>
+
+        <h2>Why it matters</h2>
+        <p>
+            A control's state changes can be indicated through changes in visual characteristics, such as shape, size, and color. If a color
+            change <Markup.Emphasis>alone</Markup.Emphasis> is used to indicate a change of state, users must be able to perceive the color
+            change. Sufficient contrast between states makes it easier for people with mild visual disabilities, low vision, limited color
+            perception, or presbyopia to perceive color changes.
+        </p>
+
+        <h2>How to fix</h2>
+        <p>Make the control's state changes visually perceptible:</p>
+        <ul>
+            <li>Good: Ensure colors used to indicate different states have a contrast ratio ≥ 3:1</li>
+
+            <li>
+                Better: Indicate state changes by changing both color and another visual characteristic, such as shape, size, or styling
+            </li>
+        </ul>
+        <h2>Example</h2>
+        <Markup.PassFail
+            failText={
+                <p>
+                    A button uses changes in its border color alone to indicate whether it is enabled or disabled. When the button is
+                    enabled, its border is medium gray (#777777). When it is disabled, the border is a lighter gray (#949494). The contrast
+                    ratio between the two border colors is insufficient (1.476:1).
+                </p>
+            }
+            passText={<p>When the button is disabled, its border becomes both lighter and dashed.</p>}
+        />
+
+        <h2>More examples</h2>
+        <h3>WCAG success criteria</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html">
+                Understanding Success Criterion 1.4.11 Non-text Contrast
+            </Markup.HyperLink>
+        </Markup.Links>
+
+        <h3>Sufficient techniques</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G195">
+                Using an author-supplied, highly visible focus indicator
+            </Markup.HyperLink>
+        </Markup.Links>
+
+        <h3>Common failures</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F78">
+                Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible
+                the visual focus indicator
+            </Markup.HyperLink>
+        </Markup.Links>
+
+        <h3>Additional guidance</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G183">
+                Using a contrast ratio of 3:1 with surrounding text and providing additional visual cues on focus for links or controls
+                where color alone is used to identify them
+            </Markup.HyperLink>
+        </Markup.Links>
+    </>
+));

--- a/src/content/test/contrast/ui-components.tsx
+++ b/src/content/test/contrast/ui-components.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { create, React } from '../../common';
+
+export const infoAndExamples = create(({ Markup }) => (
+    <>
+        <h1>UI Components</h1>
+        <p>Visual information used to indicate states and boundaries of active UI Components must have sufficient contrast.</p>
+
+        <h2>Why it matters</h2>
+        <p>
+            Most people find it easier to see and use UI Components when they have sufficient contrast against the background. People with
+            low vision, limited color perception, or{' '}
+            <Markup.HyperLink href="https://en.wikipedia.org/wiki/Presbyopia">presbyopia</Markup.HyperLink> are especially likely to
+            struggle with controls when contrast is too low.
+        </p>
+
+        <h2>How to fix</h2>
+        <p>
+            Make sure any visual information that helps users detect and operate a control has a contrast ratio ≥ 3:1. Such visual
+            information includes:
+        </p>
+        <ul>
+            <li>Any visual boundary that indicates the component's clickable area</li>
+            <li>Any visual effect that indicates the component's state</li>
+        </ul>
+        <h2>Example</h2>
+        <Markup.PassFail
+            failText={
+                <p>
+                    A button with a light gray boundary (#cccccc) is displayed on a white background (#ffffff). The boundary and background
+                    have an insufficient contrast of 1.605:1.
+                </p>
+            }
+            passText={
+                <p>
+                    The button has a medium gray boundary (#888888). The button and white background have a sufficient contrast of 3.544:1.
+                </p>
+            }
+        />
+
+        <h2>More examples</h2>
+        <h3>WCAG success criteria</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html">
+                Understanding Success Criterion 1.4.11: Non-text Contrast
+            </Markup.HyperLink>
+        </Markup.Links>
+
+        <h3>Sufficient techniques</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G195">
+                Using an author-supplied, highly visible focus indicator
+            </Markup.HyperLink>
+        </Markup.Links>
+
+        <h3>Common failures</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F78">
+                Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible
+                the visual focus indicator
+            </Markup.HyperLink>
+        </Markup.Links>
+
+        <h3>Additional guidance</h3>
+        <Markup.Links>
+            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/general/G183">
+                Using a contrast ratio of 3:1 with surrounding text and providing additional visual cues on focus for links or controls
+                where color alone is used to identify them
+            </Markup.HyperLink>
+        </Markup.Links>
+    </>
+));

--- a/src/content/test/index.ts
+++ b/src/content/test/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { audioVideoOnly } from './audio-video-only';
 import { automatedChecks } from './automated-checks';
+import { contrast } from './contrast';
 import { customWidgets } from './custom-widgets';
 import { errors } from './errors';
 import { focus } from './focus';
@@ -48,4 +49,5 @@ export const test = {
     focus,
     automatedChecks,
     pointerMotion,
+    contrast,
 };

--- a/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
@@ -1875,6 +1875,417 @@ exports[`A11Y for content pages High Contrast mode test/automatedChecks/guidance
 </DocumentFragment>
 `;
 
+exports[`A11Y for content pages High Contrast mode test/contrast/guidance 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        Contrast
+      </h1>
+      <p>
+        TODO
+      </p>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`A11Y for content pages High Contrast mode test/contrast/stateChanges/infoAndExamples 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        State changes
+      </h1>
+      <p>
+        If the only visual indication of a control's change of state is a change of color, the different colors must have sufficient contrast.
+      </p>
+      <h2>
+        Why it matters
+      </h2>
+      <p>
+        A control's state changes can be indicated through changes in visual characteristics, such as shape, size, and color. If a color change 
+        <em>
+          alone
+        </em>
+         is used to indicate a change of state, users must be able to perceive the color change. Sufficient contrast between states makes it easier for people with mild visual disabilities, low vision, limited color perception, or presbyopia to perceive color changes.
+      </p>
+      <h2>
+        How to fix
+      </h2>
+      <p>
+        Make the control's state changes visually perceptible:
+      </p>
+      <ul>
+        <li>
+          Good: Ensure colors used to indicate different states have a contrast ratio ≥ 3:1
+        </li>
+        <li>
+          Better: Indicate state changes by changing both color and another visual characteristic, such as shape, size, or styling
+        </li>
+      </ul>
+      <h2>
+        Example
+      </h2>
+      <div
+        class="pass-fail-grid"
+      >
+        <div
+          class="fail-section"
+        >
+          <div
+            class="fail-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="white"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Fail
+            </h3>
+          </div>
+          <p>
+            A button uses changes in its border color alone to indicate whether it is enabled or disabled. When the button is enabled, its border is medium gray (#777777). When it is disabled, the border is a lighter gray (#949494). The contrast ratio between the two border colors is insufficient (1.476:1).
+          </p>
+        </div>
+        <div
+          class="pass-section"
+        >
+          <div
+            class="pass-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Pass
+            </h3>
+          </div>
+          <p>
+            When the button is disabled, its border becomes both lighter and dashed.
+          </p>
+        </div>
+      </div>
+      <h2>
+        More examples
+      </h2>
+      <h3>
+        WCAG success criteria
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 1.4.11 Non-text Contrast
+        </a>
+      </div>
+      <h3>
+        Sufficient techniques
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G195"
+          target="_blank"
+        >
+          Using an author-supplied, highly visible focus indicator
+        </a>
+      </div>
+      <h3>
+        Common failures
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F78"
+          target="_blank"
+        >
+          Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator
+        </a>
+      </div>
+      <h3>
+        Additional guidance
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G183"
+          target="_blank"
+        >
+          Using a contrast ratio of 3:1 with surrounding text and providing additional visual cues on focus for links or controls where color alone is used to identify them
+        </a>
+      </div>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`A11Y for content pages High Contrast mode test/contrast/uiComponents/infoAndExamples 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        UI Components
+      </h1>
+      <p>
+        Visual information used to indicate states and boundaries of active UI Components must have sufficient contrast.
+      </p>
+      <h2>
+        Why it matters
+      </h2>
+      <p>
+        Most people find it easier to see and use UI Components when they have sufficient contrast against the background. People with low vision, limited color perception, or 
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://en.wikipedia.org/wiki/Presbyopia"
+          target="_blank"
+        >
+          presbyopia
+        </a>
+         are especially likely to struggle with controls when contrast is too low.
+      </p>
+      <h2>
+        How to fix
+      </h2>
+      <p>
+        Make sure any visual information that helps users detect and operate a control has a contrast ratio ≥ 3:1. Such visual information includes:
+      </p>
+      <ul>
+        <li>
+          Any visual boundary that indicates the component's clickable area
+        </li>
+        <li>
+          Any visual effect that indicates the component's state
+        </li>
+      </ul>
+      <h2>
+        Example
+      </h2>
+      <div
+        class="pass-fail-grid"
+      >
+        <div
+          class="fail-section"
+        >
+          <div
+            class="fail-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="white"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Fail
+            </h3>
+          </div>
+          <p>
+            A button with a light gray boundary (#cccccc) is displayed on a white background (#ffffff). The boundary and background have an insufficient contrast of 1.605:1.
+          </p>
+        </div>
+        <div
+          class="pass-section"
+        >
+          <div
+            class="pass-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Pass
+            </h3>
+          </div>
+          <p>
+            The button has a medium gray boundary (#888888). The button and white background have a sufficient contrast of 3.544:1.
+          </p>
+        </div>
+      </div>
+      <h2>
+        More examples
+      </h2>
+      <h3>
+        WCAG success criteria
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 1.4.11: Non-text Contrast
+        </a>
+      </div>
+      <h3>
+        Sufficient techniques
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G195"
+          target="_blank"
+        >
+          Using an author-supplied, highly visible focus indicator
+        </a>
+      </div>
+      <h3>
+        Common failures
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F78"
+          target="_blank"
+        >
+          Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator
+        </a>
+      </div>
+      <h3>
+        Additional guidance
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G183"
+          target="_blank"
+        >
+          Using a contrast ratio of 3:1 with surrounding text and providing additional visual cues on focus for links or controls where color alone is used to identify them
+        </a>
+      </div>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`A11Y for content pages High Contrast mode test/customWidgets/cues/infoAndExamples 1`] = `
 <DocumentFragment>
   <div
@@ -33873,6 +34284,417 @@ exports[`A11Y for content pages Normal mode test/automatedChecks/guidance 1`] = 
       <p>
         We recommend fixing any issues detected through automated checks before proceeding to the remaining tests, which require human judgement. The human-powered tests are easier, faster, and more reliable when the auto-detected issues have already been eliminated.
       </p>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`A11Y for content pages Normal mode test/contrast/guidance 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        Contrast
+      </h1>
+      <p>
+        TODO
+      </p>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`A11Y for content pages Normal mode test/contrast/stateChanges/infoAndExamples 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        State changes
+      </h1>
+      <p>
+        If the only visual indication of a control's change of state is a change of color, the different colors must have sufficient contrast.
+      </p>
+      <h2>
+        Why it matters
+      </h2>
+      <p>
+        A control's state changes can be indicated through changes in visual characteristics, such as shape, size, and color. If a color change 
+        <em>
+          alone
+        </em>
+         is used to indicate a change of state, users must be able to perceive the color change. Sufficient contrast between states makes it easier for people with mild visual disabilities, low vision, limited color perception, or presbyopia to perceive color changes.
+      </p>
+      <h2>
+        How to fix
+      </h2>
+      <p>
+        Make the control's state changes visually perceptible:
+      </p>
+      <ul>
+        <li>
+          Good: Ensure colors used to indicate different states have a contrast ratio ≥ 3:1
+        </li>
+        <li>
+          Better: Indicate state changes by changing both color and another visual characteristic, such as shape, size, or styling
+        </li>
+      </ul>
+      <h2>
+        Example
+      </h2>
+      <div
+        class="pass-fail-grid"
+      >
+        <div
+          class="fail-section"
+        >
+          <div
+            class="fail-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="white"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Fail
+            </h3>
+          </div>
+          <p>
+            A button uses changes in its border color alone to indicate whether it is enabled or disabled. When the button is enabled, its border is medium gray (#777777). When it is disabled, the border is a lighter gray (#949494). The contrast ratio between the two border colors is insufficient (1.476:1).
+          </p>
+        </div>
+        <div
+          class="pass-section"
+        >
+          <div
+            class="pass-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Pass
+            </h3>
+          </div>
+          <p>
+            When the button is disabled, its border becomes both lighter and dashed.
+          </p>
+        </div>
+      </div>
+      <h2>
+        More examples
+      </h2>
+      <h3>
+        WCAG success criteria
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 1.4.11 Non-text Contrast
+        </a>
+      </div>
+      <h3>
+        Sufficient techniques
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G195"
+          target="_blank"
+        >
+          Using an author-supplied, highly visible focus indicator
+        </a>
+      </div>
+      <h3>
+        Common failures
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F78"
+          target="_blank"
+        >
+          Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator
+        </a>
+      </div>
+      <h3>
+        Additional guidance
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G183"
+          target="_blank"
+        >
+          Using a contrast ratio of 3:1 with surrounding text and providing additional visual cues on focus for links or controls where color alone is used to identify them
+        </a>
+      </div>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`A11Y for content pages Normal mode test/contrast/uiComponents/infoAndExamples 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        UI Components
+      </h1>
+      <p>
+        Visual information used to indicate states and boundaries of active UI Components must have sufficient contrast.
+      </p>
+      <h2>
+        Why it matters
+      </h2>
+      <p>
+        Most people find it easier to see and use UI Components when they have sufficient contrast against the background. People with low vision, limited color perception, or 
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://en.wikipedia.org/wiki/Presbyopia"
+          target="_blank"
+        >
+          presbyopia
+        </a>
+         are especially likely to struggle with controls when contrast is too low.
+      </p>
+      <h2>
+        How to fix
+      </h2>
+      <p>
+        Make sure any visual information that helps users detect and operate a control has a contrast ratio ≥ 3:1. Such visual information includes:
+      </p>
+      <ul>
+        <li>
+          Any visual boundary that indicates the component's clickable area
+        </li>
+        <li>
+          Any visual effect that indicates the component's state
+        </li>
+      </ul>
+      <h2>
+        Example
+      </h2>
+      <div
+        class="pass-fail-grid"
+      >
+        <div
+          class="fail-section"
+        >
+          <div
+            class="fail-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="white"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Fail
+            </h3>
+          </div>
+          <p>
+            A button with a light gray boundary (#cccccc) is displayed on a white background (#ffffff). The boundary and background have an insufficient contrast of 1.605:1.
+          </p>
+        </div>
+        <div
+          class="pass-section"
+        >
+          <div
+            class="pass-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Pass
+            </h3>
+          </div>
+          <p>
+            The button has a medium gray boundary (#888888). The button and white background have a sufficient contrast of 3.544:1.
+          </p>
+        </div>
+      </div>
+      <h2>
+        More examples
+      </h2>
+      <h3>
+        WCAG success criteria
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-contrast.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 1.4.11: Non-text Contrast
+        </a>
+      </div>
+      <h3>
+        Sufficient techniques
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G195"
+          target="_blank"
+        >
+          Using an author-supplied, highly visible focus indicator
+        </a>
+      </div>
+      <h3>
+        Common failures
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F78"
+          target="_blank"
+        >
+          Failure of Success Criterion 2.4.7 due to styling element outlines and borders in a way that removes or renders non-visible the visual focus indicator
+        </a>
+      </div>
+      <h3>
+        Additional guidance
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G183"
+          target="_blank"
+        >
+          Using a contrast ratio of 3:1 with surrounding text and providing additional visual cues on focus for links or controls where color alone is used to identify them
+        </a>
+      </div>
     </div>
     <div
       class="content-right"


### PR DESCRIPTION
#### Description of changes

Adds the new Contrast assessment test behind the existing `showAllAssessments` feature flag.

Out of scope (for future PRs to handle before removing the flag):
* The Graphics requirement is being omitted until we can confirm that we really want to add it
* The 2 new requirements are both implemented as manual tests for now (leaving the hooking-up of their assisted rules for a separate PR)
* We don't have Guidance content written yet at the test level, so that's placeholder text for the moment

In scope but not yet completed:
* proofreading infoAndExamples content
* screenshots for PR
* verify SR readings of new content

#### Pull request checklist

- [x] Addresses an existing issue: Work towards 1587569
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
