### PR TITLE
refactor: convert types file to ts extension

### DIFF
--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { clone, isEqual } from 'lodash';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
@@ -8,8 +9,6 @@ import { Link } from 'office-ui-fabric-react/lib/Link';
 import { ITextFieldStyles, TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { BaseStore } from '../../common/base-store';
 import { FlaggedComponent } from '../../common/components/flagged-component';
 import { FeatureFlags } from '../../common/feature-flags';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
@@ -29,7 +28,7 @@ export interface FailureInstancePanelControlProps {
     failureInstance: FailureInstanceData;
     instanceId?: string;
     assessmentsProvider: AssessmentsProvider;
-    featureFlagStoreData: BaseStore<FeatureFlagStoreData>;
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export type FailureInstanceData = {

--- a/src/common/types/store-data/feature-flag-store-data.ts
+++ b/src/common/types/store-data/feature-flag-store-data.ts
@@ -1,3 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DictionaryStringTo } from 'types/common-types';
+
 export type FeatureFlagStoreData = DictionaryStringTo<boolean>;


### PR DESCRIPTION
#### Description of changes

**As a reminder**: using `d.ts` file extension may hide errors on the defined types (basically, tsc doesn't compile `d.ts` files)

In this PR, updating `src\common\types\store-data\feature-flag-store-data.d.ts` -> `src\common\types\store-data\feature-flag-store-data.ts` plus some minor fixes (again, hidden from tsc because of `d.ts` file extension).

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
   - not really affected
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - not really affected
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not really affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not really affected
