### PR TITLE
fix: e2e-reliability build on CI runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@
 # We use Puppeteer, not Cypress; however, Cypress's docker images are up to date baselines that already contain both node and
 # the system dependencies required to run headful Chromium, so we use them to avoid the performance hit of having our own
 # build agents running apt-get for all those dependencies.
-FROM cypress/base:12.4.0
+FROM cypress/base:10.16.0
+
+RUN npm install -g yarn@1.17.3
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/Microsoft/accessibility-insights-web"
     },
     "engines": {
-        "node": ">=10.16.3",
+        "node": ">=10.16.0",
         "yarn": "^1.17.3"
     },
     "scripts": {


### PR DESCRIPTION
#### Description of changes

Our CI build was continuously failing because of a change we made in #1141 . That PR pins the node js version to be `10.16.3` & yarn to be at `1.17.3`. Both of the those dependencies are not available in current `cypress/base:10.16.0` docker image.
So, updating our docker file to use `cypress/base:12.4.0` which has appropriate versions. Docker file is only used to run e2e; so higher nodejs version doesn't break the build.


#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
