### PR TITLE
feat: moved Cards view to a more appropriate place

### DIFF
--- a/src/DetailsView/components/adhoc-issues-test-view.tsx
+++ b/src/DetailsView/components/adhoc-issues-test-view.tsx
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { FlaggedComponent } from '../../common/components/flagged-component';
-import { FeatureFlags } from '../../common/feature-flags';
 import { NamedSFC } from '../../common/react/named-sfc';
-import { CardsView } from './cards-view';
 import { DetailsListIssuesView, DetailsListIssuesViewDeps, DetailsListIssuesViewProps } from './details-list-issues-view';
 import { TargetPageChangedView } from './target-page-changed-view';
 
@@ -18,14 +15,7 @@ export const AdhocIssuesTestView = NamedSFC<AdhocIssuesTestViewProps>('AdhocIssu
         return createTargetPageChangedView(props);
     }
 
-    return (
-        <FlaggedComponent
-            disableJSXElement={<DetailsListIssuesView {...props} />}
-            enableJSXElement={<CardsView />}
-            featureFlag={FeatureFlags.universalCardsUI}
-            featureFlagStoreData={props.featureFlagStoreData}
-        />
-    );
+    return <DetailsListIssuesView {...props} />;
 });
 
 function createTargetPageChangedView(props: AdhocIssuesTestViewProps): JSX.Element {

--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -5,15 +5,19 @@ import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
+
+import { FlaggedComponent } from '../../common/components/flagged-component';
 import { VisualizationToggle } from '../../common/components/visualization-toggle';
 import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
+import { FeatureFlags } from '../../common/feature-flags';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { DecoratedAxeNodeResult } from '../../injected/scanner-utils';
 import { RuleResult, ScanResults } from '../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../types/common-types';
+import { CardsView } from './cards-view';
 import { ExportDialogDeps } from './export-dialog';
 import { IssuesDetailsList } from './issues-details-list';
 import { IssuesDetailsPane, IssuesDetailsPaneDeps } from './Issues-details-pane';
@@ -141,7 +145,14 @@ export class IssuesTable extends React.Component<IssuesTableProps> {
             return this.renderSpinner('Loading data...');
         }
 
-        return this.renderDetails();
+        return (
+            <FlaggedComponent
+                disableJSXElement={this.renderDetails()}
+                enableJSXElement={<CardsView />}
+                featureFlag={FeatureFlags.universalCardsUI}
+                featureFlagStoreData={this.props.featureFlags}
+            />
+        );
     }
 
     private renderToggle(): JSX.Element {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-issues-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-issues-test-view.test.tsx.snap
@@ -1,5 +1,45 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AdhocIssuesTestView should return flagged component for cards and issues views 1`] = `"<FlaggedComponent disableJSXElement={{...}} enableJSXElement={{...}} featureFlag=\\"universalCardsUI\\" featureFlagStoreData={[undefined]} />"`;
+exports[`AdhocIssuesTestView should return DetailsListIssuesView 1`] = `
+<DetailsListIssuesView
+  clickHandlerFactory={
+    proxy {
+      "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+      "actionCreator": undefined,
+      "telemetryFactory": undefined,
+    }
+  }
+  configuration={
+    Object {
+      "displayableData": Object {
+        "title": "test title",
+      },
+      "getStoreData": [Function],
+    }
+  }
+  selectedTest={-1}
+  tabStoreData={
+    Object {
+      "isChanged": false,
+    }
+  }
+  visualizationStoreData={
+    Object {
+      "scanning": "test-scanning",
+      "tests": Object {},
+    }
+  }
+/>
+`;
 
-exports[`AdhocIssuesTestView should return target page changed view as tab is changed 1`] = `"<TargetPageChangedView displayableData={{...}} visualizationType={-1} toggleClickHandler={[Function: clickHandlerStub]} />"`;
+exports[`AdhocIssuesTestView should return target page changed view as tab is changed 1`] = `
+<TargetPageChangedView
+  displayableData={
+    Object {
+      "title": "test title",
+    }
+  }
+  toggleClickHandler={[Function]}
+  visualizationType={-1}
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
@@ -79,17 +79,7 @@ exports[`IssuesTableTest spinner, issuesEnabled is an empty object 1`] = `
   <div className=\\"issues-table-content\\">
     <div className=\\"details-view-command-bar\\">
       <VisualizationToggle label=\\"Show failures\\" checked={{...}} disabled={false} onClick={[undefined]} className=\\"automated-checks-details-view-toggle\\" visualizationName=\\"Automated checks\\" />
-      <ReportExportComponent deps={{...}} scanDate={{...}} reportGenerator={[Function: function () {
-                          var args = [];
-                          for (var _i = 0; _i < arguments.length; _i++) {
-                              args[_i] = arguments[_i];
-                          }
-                          _this._interceptor.removeInvocation(invocation_1);
-                          var method = new MethodInfo(target, p);
-                          var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
-                          _this._interceptor.intercept(methodInvocation);
-                          return methodInvocation.returnValue;
-                      }]} pageTitle=\\"pageTitle\\" exportResultsType=\\"AutomatedChecks\\" htmlGenerator={[Function: bound ]} updatePersistedDescription={[Function: nullUpdatePersistedDescription]} getExportDescription={[Function]} />
+      <ReportExportComponent deps={{...}} scanDate={{...}} reportGenerator={{...}} pageTitle=\\"pageTitle\\" exportResultsType=\\"AutomatedChecks\\" htmlGenerator={[Function: bound proxy]} updatePersistedDescription={[Function: nullUpdatePersistedDescription]} getExportDescription={[Function]} />
     </div>
     <StyledSpinnerBase className=\\"details-view-spinner\\" size={3} label=\\"Loading data...\\" />
   </div>
@@ -97,91 +87,480 @@ exports[`IssuesTableTest spinner, issuesEnabled is an empty object 1`] = `
 `;
 
 exports[`IssuesTableTest table with 0 issues 1`] = `
-"<div className=\\"issues-table\\">
+<div
+  className="issues-table"
+>
   <h1>
     test title
   </h1>
-  <div className=\\"issues-table-content\\">
-    <div className=\\"details-view-command-bar\\">
-      <VisualizationToggle label=\\"Show failures\\" checked={true} disabled={false} onClick={[Function: proxy]} className=\\"automated-checks-details-view-toggle\\" visualizationName=\\"Automated checks\\" />
-      <ReportExportComponent deps={{...}} scanDate={{...}} reportGenerator={[Function: function () {
-                          var args = [];
-                          for (var _i = 0; _i < arguments.length; _i++) {
-                              args[_i] = arguments[_i];
-                          }
-                          _this._interceptor.removeInvocation(invocation_1);
-                          var method = new MethodInfo(target, p);
-                          var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
-                          _this._interceptor.intercept(methodInvocation);
-                          return methodInvocation.returnValue;
-                      }]} pageTitle=\\"pageTitle\\" exportResultsType=\\"AutomatedChecks\\" htmlGenerator={[Function: bound ]} updatePersistedDescription={[Function: nullUpdatePersistedDescription]} getExportDescription={[Function]} />
+  <div
+    className="issues-table-content"
+  >
+    <div
+      className="details-view-command-bar"
+    >
+      <VisualizationToggle
+        checked={true}
+        className="automated-checks-details-view-toggle"
+        disabled={false}
+        label="Show failures"
+        onClick={[Function]}
+        visualizationName="Automated checks"
+      />
+      <ReportExportComponent
+        deps={
+          Object {
+            "getDateFromTimestamp": [Function],
+            "reportGenerator": proxy {
+              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "assessmentReportHtmlGenerator": undefined,
+              "reportHtmlGenerator": undefined,
+              "reportNameGenerator": undefined,
+            },
+          }
+        }
+        exportResultsType="AutomatedChecks"
+        getExportDescription={[Function]}
+        htmlGenerator={[Function]}
+        pageTitle="pageTitle"
+        reportGenerator={
+          proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "assessmentReportHtmlGenerator": undefined,
+            "reportHtmlGenerator": undefined,
+            "reportNameGenerator": undefined,
+          }
+        }
+        scanDate={Date { NaN }}
+        updatePersistedDescription={[Function]}
+      />
     </div>
-    <div className=\\"issues-table-details\\">
-      <IssuesDetailsList violations={{...}} issuesTableHandler={{...}} issuesSelection={{...}} />
-      <div className=\\"issue-detail-outer-container ms-Fabric\\">
-        <IssuesDetailsPane deps={{...}} selectedIdToRuleResultMap={{...}} pageTitle=\\"pageTitle\\" pageUrl=\\"http://pageUrl\\" featureFlagData={{...}} userConfigurationStoreData={{...}} />
-      </div>
-    </div>
+    <FlaggedComponent
+      disableJSXElement={
+        <div
+          className="issues-table-details"
+        >
+          <IssuesDetailsList
+            issuesSelection={
+              proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "_anchoredIndex": 0,
+                "_canSelectItem": [Function],
+                "_change": [Function],
+                "_changeEventSuppressionCount": 0,
+                "_exemptedCount": 0,
+                "_exemptedIndices": Object {},
+                "_getKey": [Function],
+                "_isModal": false,
+                "_items": Array [],
+                "_keyToIndexMap": Object {},
+                "_onSelectionChanged": undefined,
+                "_selectedItems": null,
+                "_setAllSelected": [Function],
+                "_unselectableCount": 0,
+                "_unselectableIndices": Object {},
+                "_updateCount": [Function],
+                "canSelectItem": [Function],
+                "count": 0,
+                "getItems": [Function],
+                "getKey": [Function],
+                "getSelectedCount": [Function],
+                "getSelectedIndices": [Function],
+                "getSelection": [Function],
+                "isAllSelected": [Function],
+                "isIndexSelected": [Function],
+                "isKeySelected": [Function],
+                "isModal": [Function],
+                "isRangeSelected": [Function],
+                "mode": 2,
+                "selectToIndex": [Function],
+                "selectToKey": [Function],
+                "setAllSelected": [Function],
+                "setChangeEvents": [Function],
+                "setIndexSelected": [Function],
+                "setItems": [Function],
+                "setKeySelected": [Function],
+                "setModal": [Function],
+                "toggleAllSelected": [Function],
+                "toggleIndexSelected": [Function],
+                "toggleKeySelected": [Function],
+                "toggleRangeSelected": [Function],
+              }
+            }
+            issuesTableHandler={
+              proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              }
+            }
+            violations={Array []}
+          />
+          <div
+            className="issue-detail-outer-container ms-Fabric"
+          >
+            <IssuesDetailsPane
+              deps={
+                Object {
+                  "getDateFromTimestamp": [Function],
+                  "reportGenerator": proxy {
+                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                    "assessmentReportHtmlGenerator": undefined,
+                    "reportHtmlGenerator": undefined,
+                    "reportNameGenerator": undefined,
+                  },
+                }
+              }
+              featureFlagData={Object {}}
+              pageTitle="pageTitle"
+              pageUrl="http://pageUrl"
+              selectedIdToRuleResultMap={Object {}}
+              userConfigurationStoreData={
+                Object {
+                  "bugService": "gitHub",
+                }
+              }
+            />
+          </div>
+        </div>
+      }
+      enableJSXElement={<CardsView />}
+      featureFlag="universalCardsUI"
+      featureFlagStoreData={Object {}}
+    />
   </div>
-</div>"
+</div>
 `;
 
 exports[`IssuesTableTest table with 1 issues 1`] = `
-"<div className=\\"issues-table\\">
+<div
+  className="issues-table"
+>
   <h1>
     test title
   </h1>
-  <div className=\\"issues-table-content\\">
-    <div className=\\"details-view-command-bar\\">
-      <VisualizationToggle label=\\"Show failures\\" checked={true} disabled={false} onClick={[Function: proxy]} className=\\"automated-checks-details-view-toggle\\" visualizationName=\\"Automated checks\\" />
-      <ReportExportComponent deps={{...}} scanDate={{...}} reportGenerator={[Function: function () {
-                          var args = [];
-                          for (var _i = 0; _i < arguments.length; _i++) {
-                              args[_i] = arguments[_i];
-                          }
-                          _this._interceptor.removeInvocation(invocation_1);
-                          var method = new MethodInfo(target, p);
-                          var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
-                          _this._interceptor.intercept(methodInvocation);
-                          return methodInvocation.returnValue;
-                      }]} pageTitle=\\"pageTitle\\" exportResultsType=\\"AutomatedChecks\\" htmlGenerator={[Function: bound ]} updatePersistedDescription={[Function: nullUpdatePersistedDescription]} getExportDescription={[Function]} />
+  <div
+    className="issues-table-content"
+  >
+    <div
+      className="details-view-command-bar"
+    >
+      <VisualizationToggle
+        checked={true}
+        className="automated-checks-details-view-toggle"
+        disabled={false}
+        label="Show failures"
+        onClick={[Function]}
+        visualizationName="Automated checks"
+      />
+      <ReportExportComponent
+        deps={
+          Object {
+            "getDateFromTimestamp": [Function],
+            "reportGenerator": proxy {
+              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "assessmentReportHtmlGenerator": undefined,
+              "reportHtmlGenerator": undefined,
+              "reportNameGenerator": undefined,
+            },
+          }
+        }
+        exportResultsType="AutomatedChecks"
+        getExportDescription={[Function]}
+        htmlGenerator={[Function]}
+        pageTitle="pageTitle"
+        reportGenerator={
+          proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "assessmentReportHtmlGenerator": undefined,
+            "reportHtmlGenerator": undefined,
+            "reportNameGenerator": undefined,
+          }
+        }
+        scanDate={Date { NaN }}
+        updatePersistedDescription={[Function]}
+      />
     </div>
-    <div className=\\"issues-table-details\\">
-      <IssuesDetailsList violations={{...}} issuesTableHandler={{...}} issuesSelection={{...}} />
-      <div className=\\"issue-detail-outer-container ms-Fabric\\">
-        <IssuesDetailsPane deps={{...}} selectedIdToRuleResultMap={{...}} pageTitle=\\"pageTitle\\" pageUrl=\\"http://pageUrl\\" featureFlagData={{...}} userConfigurationStoreData={{...}} />
-      </div>
-    </div>
+    <FlaggedComponent
+      disableJSXElement={
+        <div
+          className="issues-table-details"
+        >
+          <IssuesDetailsList
+            issuesSelection={
+              proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "_anchoredIndex": 0,
+                "_canSelectItem": [Function],
+                "_change": [Function],
+                "_changeEventSuppressionCount": 0,
+                "_exemptedCount": 0,
+                "_exemptedIndices": Object {},
+                "_getKey": [Function],
+                "_isModal": false,
+                "_items": Array [],
+                "_keyToIndexMap": Object {},
+                "_onSelectionChanged": undefined,
+                "_selectedItems": null,
+                "_setAllSelected": [Function],
+                "_unselectableCount": 0,
+                "_unselectableIndices": Object {},
+                "_updateCount": [Function],
+                "canSelectItem": [Function],
+                "count": 0,
+                "getItems": [Function],
+                "getKey": [Function],
+                "getSelectedCount": [Function],
+                "getSelectedIndices": [Function],
+                "getSelection": [Function],
+                "isAllSelected": [Function],
+                "isIndexSelected": [Function],
+                "isKeySelected": [Function],
+                "isModal": [Function],
+                "isRangeSelected": [Function],
+                "mode": 2,
+                "selectToIndex": [Function],
+                "selectToKey": [Function],
+                "setAllSelected": [Function],
+                "setChangeEvents": [Function],
+                "setIndexSelected": [Function],
+                "setItems": [Function],
+                "setKeySelected": [Function],
+                "setModal": [Function],
+                "toggleAllSelected": [Function],
+                "toggleIndexSelected": [Function],
+                "toggleKeySelected": [Function],
+                "toggleRangeSelected": [Function],
+              }
+            }
+            issuesTableHandler={
+              proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              }
+            }
+            violations={
+              Array [
+                Object {
+                  "description": "rule description",
+                  "help": "rule help",
+                  "id": "rule name",
+                  "nodes": Array [
+                    Object {
+                      "all": Array [],
+                      "any": Array [],
+                      "html": "",
+                      "none": Array [],
+                      "target": Array [
+                        "#target-1",
+                      ],
+                    },
+                  ],
+                },
+              ]
+            }
+          />
+          <div
+            className="issue-detail-outer-container ms-Fabric"
+          >
+            <IssuesDetailsPane
+              deps={
+                Object {
+                  "getDateFromTimestamp": [Function],
+                  "reportGenerator": proxy {
+                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                    "assessmentReportHtmlGenerator": undefined,
+                    "reportHtmlGenerator": undefined,
+                    "reportNameGenerator": undefined,
+                  },
+                }
+              }
+              featureFlagData={Object {}}
+              pageTitle="pageTitle"
+              pageUrl="http://pageUrl"
+              selectedIdToRuleResultMap={Object {}}
+              userConfigurationStoreData={
+                Object {
+                  "bugService": "gitHub",
+                }
+              }
+            />
+          </div>
+        </div>
+      }
+      enableJSXElement={<CardsView />}
+      featureFlag="universalCardsUI"
+      featureFlagStoreData={Object {}}
+    />
   </div>
-</div>"
+</div>
 `;
 
 exports[`IssuesTableTest table with 2 issues 1`] = `
-"<div className=\\"issues-table\\">
+<div
+  className="issues-table"
+>
   <h1>
     test title
   </h1>
-  <div className=\\"issues-table-content\\">
-    <div className=\\"details-view-command-bar\\">
-      <VisualizationToggle label=\\"Show failures\\" checked={true} disabled={false} onClick={[Function: proxy]} className=\\"automated-checks-details-view-toggle\\" visualizationName=\\"Automated checks\\" />
-      <ReportExportComponent deps={{...}} scanDate={{...}} reportGenerator={[Function: function () {
-                          var args = [];
-                          for (var _i = 0; _i < arguments.length; _i++) {
-                              args[_i] = arguments[_i];
-                          }
-                          _this._interceptor.removeInvocation(invocation_1);
-                          var method = new MethodInfo(target, p);
-                          var methodInvocation = new MethodInvocation(target, method, args, ProxyType.DYNAMIC);
-                          _this._interceptor.intercept(methodInvocation);
-                          return methodInvocation.returnValue;
-                      }]} pageTitle=\\"pageTitle\\" exportResultsType=\\"AutomatedChecks\\" htmlGenerator={[Function: bound ]} updatePersistedDescription={[Function: nullUpdatePersistedDescription]} getExportDescription={[Function]} />
+  <div
+    className="issues-table-content"
+  >
+    <div
+      className="details-view-command-bar"
+    >
+      <VisualizationToggle
+        checked={true}
+        className="automated-checks-details-view-toggle"
+        disabled={false}
+        label="Show failures"
+        onClick={[Function]}
+        visualizationName="Automated checks"
+      />
+      <ReportExportComponent
+        deps={
+          Object {
+            "getDateFromTimestamp": [Function],
+            "reportGenerator": proxy {
+              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "assessmentReportHtmlGenerator": undefined,
+              "reportHtmlGenerator": undefined,
+              "reportNameGenerator": undefined,
+            },
+          }
+        }
+        exportResultsType="AutomatedChecks"
+        getExportDescription={[Function]}
+        htmlGenerator={[Function]}
+        pageTitle="pageTitle"
+        reportGenerator={
+          proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "assessmentReportHtmlGenerator": undefined,
+            "reportHtmlGenerator": undefined,
+            "reportNameGenerator": undefined,
+          }
+        }
+        scanDate={Date { NaN }}
+        updatePersistedDescription={[Function]}
+      />
     </div>
-    <div className=\\"issues-table-details\\">
-      <IssuesDetailsList violations={{...}} issuesTableHandler={{...}} issuesSelection={{...}} />
-      <div className=\\"issue-detail-outer-container ms-Fabric\\">
-        <IssuesDetailsPane deps={{...}} selectedIdToRuleResultMap={{...}} pageTitle=\\"pageTitle\\" pageUrl=\\"http://pageUrl\\" featureFlagData={{...}} userConfigurationStoreData={{...}} />
-      </div>
-    </div>
+    <FlaggedComponent
+      disableJSXElement={
+        <div
+          className="issues-table-details"
+        >
+          <IssuesDetailsList
+            issuesSelection={
+              proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "_anchoredIndex": 0,
+                "_canSelectItem": [Function],
+                "_change": [Function],
+                "_changeEventSuppressionCount": 0,
+                "_exemptedCount": 0,
+                "_exemptedIndices": Object {},
+                "_getKey": [Function],
+                "_isModal": false,
+                "_items": Array [],
+                "_keyToIndexMap": Object {},
+                "_onSelectionChanged": undefined,
+                "_selectedItems": null,
+                "_setAllSelected": [Function],
+                "_unselectableCount": 0,
+                "_unselectableIndices": Object {},
+                "_updateCount": [Function],
+                "canSelectItem": [Function],
+                "count": 0,
+                "getItems": [Function],
+                "getKey": [Function],
+                "getSelectedCount": [Function],
+                "getSelectedIndices": [Function],
+                "getSelection": [Function],
+                "isAllSelected": [Function],
+                "isIndexSelected": [Function],
+                "isKeySelected": [Function],
+                "isModal": [Function],
+                "isRangeSelected": [Function],
+                "mode": 2,
+                "selectToIndex": [Function],
+                "selectToKey": [Function],
+                "setAllSelected": [Function],
+                "setChangeEvents": [Function],
+                "setIndexSelected": [Function],
+                "setItems": [Function],
+                "setKeySelected": [Function],
+                "setModal": [Function],
+                "toggleAllSelected": [Function],
+                "toggleIndexSelected": [Function],
+                "toggleKeySelected": [Function],
+                "toggleRangeSelected": [Function],
+              }
+            }
+            issuesTableHandler={
+              proxy {
+                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              }
+            }
+            violations={
+              Array [
+                Object {
+                  "description": "rule description",
+                  "help": "rule help",
+                  "id": "rule name",
+                  "nodes": Array [
+                    Object {
+                      "all": Array [],
+                      "any": Array [],
+                      "html": "",
+                      "none": Array [],
+                      "target": Array [
+                        "#target-1",
+                      ],
+                    },
+                    Object {
+                      "all": Array [],
+                      "any": Array [],
+                      "html": "",
+                      "none": Array [],
+                      "target": Array [
+                        "#target-2",
+                      ],
+                    },
+                  ],
+                },
+              ]
+            }
+          />
+          <div
+            className="issue-detail-outer-container ms-Fabric"
+          >
+            <IssuesDetailsPane
+              deps={
+                Object {
+                  "getDateFromTimestamp": [Function],
+                  "reportGenerator": proxy {
+                    "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                    "assessmentReportHtmlGenerator": undefined,
+                    "reportHtmlGenerator": undefined,
+                    "reportNameGenerator": undefined,
+                  },
+                }
+              }
+              featureFlagData={Object {}}
+              pageTitle="pageTitle"
+              pageUrl="http://pageUrl"
+              selectedIdToRuleResultMap={Object {}}
+              userConfigurationStoreData={
+                Object {
+                  "bugService": "gitHub",
+                }
+              }
+            />
+          </div>
+        </div>
+      }
+      enableJSXElement={<CardsView />}
+      featureFlag="universalCardsUI"
+      featureFlagStoreData={Object {}}
+    />
   </div>
-</div>"
+</div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/adhoc-issues-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/adhoc-issues-test-view.test.tsx
@@ -30,8 +30,7 @@ describe('AdhocIssuesTestView', () => {
         displayableData: displayableDataStub,
     } as VisualizationConfiguration;
 
-    const clickHandlerFactoryMock = Mock.ofType(DetailsViewToggleClickHandlerFactory, MockBehavior.Strict);
-
+    const clickHandlerFactoryMock = Mock.ofType(DetailsViewToggleClickHandlerFactory);
     const selectedTest: VisualizationType = -1;
 
     const props = {
@@ -49,16 +48,7 @@ describe('AdhocIssuesTestView', () => {
 
     beforeEach(() => {
         getStoreDataMock.reset();
-        getStoreDataMock
-            .setup(gsdm => gsdm(visualizationStoreDataStub.tests))
-            .returns(() => scanDataStub)
-            .verifiable();
-
         clickHandlerFactoryMock.reset();
-        clickHandlerFactoryMock
-            .setup(chfm => chfm.createClickHandler(selectedTest, !scanDataStub.enabled))
-            .returns(() => clickHandlerStub)
-            .verifiable();
     });
 
     it('should return target page changed view as tab is changed', () => {
@@ -66,19 +56,29 @@ describe('AdhocIssuesTestView', () => {
             isChanged: true,
         } as TabStoreData;
 
+        getStoreDataMock
+            .setup(gsdm => gsdm(visualizationStoreDataStub.tests))
+            .returns(() => scanDataStub)
+            .verifiable();
+
+        clickHandlerFactoryMock
+            .setup(chfm => chfm.createClickHandler(selectedTest, !scanDataStub.enabled))
+            .returns(() => clickHandlerStub)
+            .verifiable();
+
         const actual = shallow(<AdhocIssuesTestView {...props} />);
-        expect(actual.debug()).toMatchSnapshot();
+
+        expect(actual.getElement()).toMatchSnapshot();
         verifyAll();
     });
 
-    it('should return flagged component for cards and issues views', () => {
+    it('should return DetailsListIssuesView', () => {
         props.tabStoreData = {
             isChanged: false,
         } as TabStoreData;
 
         const actual = shallow(<AdhocIssuesTestView {...props} />);
-        expect(actual.debug()).toMatchSnapshot();
-        // verifyAll();
+        expect(actual.getElement()).toMatchSnapshot();
     });
 
     function verifyAll(): void {

--- a/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
@@ -5,6 +5,7 @@ import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { IMock, Mock } from 'typemoq';
+
 import { VisualizationConfigurationFactory } from '../../../../../common/configs/visualization-configuration-factory';
 import { DateProvider } from '../../../../../common/date-provider';
 import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
@@ -19,7 +20,7 @@ describe('IssuesTableTest', () => {
     let reportGeneratorMock: IMock<ReportGenerator>;
 
     beforeEach(() => {
-        reportGeneratorMock = Mock.ofType<ReportGenerator>();
+        reportGeneratorMock = Mock.ofType(ReportGenerator);
         deps = {
             getDateFromTimestamp: DateProvider.getDateFromTimestamp,
             reportGenerator: reportGeneratorMock.object,
@@ -89,8 +90,8 @@ describe('IssuesTableTest', () => {
             }
 
             const issuesEnabled = true;
-            const issuesTableHandlerMock = Mock.ofType<IssuesTableHandler>(IssuesTableHandler);
-            const selectionMock = Mock.ofType<ISelection>(Selection);
+            const issuesTableHandlerMock = Mock.ofType(IssuesTableHandler);
+            const selectionMock = Mock.ofType(Selection);
             const toggleClickHandlerMock = Mock.ofInstance(event => {});
 
             const props = new TestPropsBuilder()
@@ -104,7 +105,7 @@ describe('IssuesTableTest', () => {
 
             const wrapped = shallow(<IssuesTable {...props} />);
 
-            expect(wrapped.debug()).toMatchSnapshot();
+            expect(wrapped.getElement()).toMatchSnapshot();
         });
     });
 


### PR DESCRIPTION
#### Description of changes

This moves the cards view component to under the issues table (not a great name to be honest) allowing the UI to keep the appropriate text and command bar.

![image](https://user-images.githubusercontent.com/32555133/63818614-9d6a2500-c8f6-11e9-93a7-0eeb2f93d5e4.png)

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
