### PR TITLE
Small fix: tab info should not return an empty div when nothing to show, it should return null

### DIFF
--- a/src/DetailsView/components/tab-info.tsx
+++ b/src/DetailsView/components/tab-info.tsx
@@ -17,20 +17,17 @@ export interface TabInfoProps {
 
 export class TabInfo extends React.Component<TabInfoProps> {
     public render(): JSX.Element {
-        return <div>{this.renderMessageBarForTargetPageHidden()}</div>;
-    }
-
-    private renderMessageBarForTargetPageHidden(): JSX.Element {
-        if (this.props.isTargetPageHidden) {
-            const messageContent = (
-                <div>
-                    The Target page is in a hidden state. For better performance, use the Target page link above to make the page visible.
-                </div>
-            );
-            return this.renderMessageBar(messageContent, MessageBarType.warning, 'waring-message-bar');
-        } else {
+        if (!this.props.isTargetPageHidden) {
             return null;
         }
+
+        const messageContent = (
+            <div>
+                The Target page is in a hidden state. For better performance, use the Target page link above to make the page visible.
+            </div>
+        );
+
+        return <div>{this.renderMessageBar(messageContent, MessageBarType.warning, 'waring-message-bar')}</div>;
     }
 
     private renderMessageBar(messageContent: JSX.Element, messageBarType: MessageBarType, className: string): JSX.Element {

--- a/src/tests/unit/tests/DetailsView/components/tab-info.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/tab-info.test.tsx
@@ -77,10 +77,7 @@ describe('TabInfo', () => {
                 const component = React.createElement(TabInfo, testProps);
                 const testObject = TestUtils.renderIntoDocument(component);
 
-                const warningMessageBar = null;
-                const expectedComponent = getExpectedComponentRendered(warningMessageBar);
-
-                expect(testObject.render()).toEqual(expectedComponent);
+                expect(testObject.render()).toEqual(null);
             });
         });
     });


### PR DESCRIPTION
## Description of changes

Small fix: tab info should not return an empty div when nothing to show, it should return null. Noticed this while working on styling; very minor and gets the same behavior.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
