### PR TITLE
Introduce adapter for scan results to unified rules

### DIFF
--- a/src/injected/adapters/scan-results-to-unified-rules.ts
+++ b/src/injected/adapters/scan-results-to-unified-rules.ts
@@ -13,7 +13,7 @@ export function convertScanResultsToUnifiedRules(scanResults: ScanResults): Unif
 function createUnifiedRulesFromScanResults(scanResults: ScanResults): UnifiedRule[] {
     const unifiedRules: UnifiedRule[] = [];
     const ruleIds: Set<string> = new Set();
-    const allRuleResults = [...scanResults.passes, ...scanResults.violations, ...scanResults.incomplete, ...scanResults.inapplicable];
+    const allRuleResults = getAllRuleResults(scanResults);
 
     for (const ruleResult of allRuleResults) {
         if (!ruleIds.has(ruleResult.id)) {
@@ -23,6 +23,10 @@ function createUnifiedRulesFromScanResults(scanResults: ScanResults): UnifiedRul
     }
 
     return unifiedRules;
+}
+
+function getAllRuleResults(scanResults: ScanResults): RuleResult[] {
+    return [...scanResults.passes, ...scanResults.violations, ...scanResults.incomplete, ...scanResults.inapplicable];
 }
 
 function createUnifiedRuleFromRuleResult(ruleResult: RuleResult): UnifiedRule {

--- a/src/injected/adapters/scan-results-to-unified-rules.ts
+++ b/src/injected/adapters/scan-results-to-unified-rules.ts
@@ -12,13 +12,11 @@ export function convertScanResultsToUnifiedRules(scanResults: ScanResults): Unif
 
 function createUnifiedRulesFromScanResults(scanResults: ScanResults): UnifiedRule[] {
     const unifiedRules: UnifiedRule[] = [];
-    const ruleIds: Set<string> = new Set();
     const allRuleResults = getAllRuleResults(scanResults);
 
     for (const ruleResult of allRuleResults) {
-        if (!ruleIds.has(ruleResult.id)) {
+        if (!unifiedRules.find(rule => rule.id === ruleResult.id)) {
             unifiedRules.push(createUnifiedRuleFromRuleResult(ruleResult));
-            ruleIds.add(ruleResult.id);
         }
     }
 

--- a/src/injected/adapters/scan-results-to-unified-rules.ts
+++ b/src/injected/adapters/scan-results-to-unified-rules.ts
@@ -12,11 +12,13 @@ export function convertScanResultsToUnifiedRules(scanResults: ScanResults): Unif
 
 function createUnifiedRulesFromScanResults(scanResults: ScanResults): UnifiedRule[] {
     const unifiedRules: UnifiedRule[] = [];
+    const ruleIds: Set<string> = new Set();
     const allRuleResults = getAllRuleResults(scanResults);
 
     for (const ruleResult of allRuleResults) {
-        if (!unifiedRules.find(rule => rule.id === ruleResult.id)) {
+        if (!ruleIds.has(ruleResult.id)) {
             unifiedRules.push(createUnifiedRuleFromRuleResult(ruleResult));
+            ruleIds.add(ruleResult.id);
         }
     }
 

--- a/src/injected/adapters/scan-results-to-unified-rules.ts
+++ b/src/injected/adapters/scan-results-to-unified-rules.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UnifiedRule } from '../../common/types/store-data/unified-data-interface';
+import { RuleResult, ScanResults } from '../../scanner/iruleresults';
+
+export function convertScanResultsToUnifiedRules(scanResults: ScanResults): UnifiedRule[] {
+    if (!scanResults) {
+        return [] as UnifiedRule[];
+    }
+    return createUnifiedRulesFromScanResults(scanResults);
+}
+
+function createUnifiedRulesFromScanResults(scanResults: ScanResults): UnifiedRule[] {
+    const unifiedRules: UnifiedRule[] = [];
+    const ruleIds: Set<string> = new Set();
+    const allRuleResults = [...scanResults.passes, ...scanResults.violations, ...scanResults.incomplete, ...scanResults.inapplicable];
+
+    for (const ruleResult of allRuleResults) {
+        if (!ruleIds.has(ruleResult.id)) {
+            unifiedRules.push(createUnifiedRuleFromRuleResult(ruleResult));
+            ruleIds.add(ruleResult.id);
+        }
+    }
+
+    return unifiedRules;
+}
+
+function createUnifiedRuleFromRuleResult(ruleResult: RuleResult): UnifiedRule {
+    return {
+        id: ruleResult.id,
+        description: ruleResult.description,
+        url: ruleResult.helpUrl,
+        guidance: ruleResult.guidanceLinks,
+    };
+}

--- a/src/tests/unit/tests/injected/adapters/scan-results-to-unified-rules.test.ts
+++ b/src/tests/unit/tests/injected/adapters/scan-results-to-unified-rules.test.ts
@@ -6,7 +6,7 @@ import { RuleResult, ScanResults } from '../../../../../scanner/iruleresults';
 
 describe('ScanResults to UnifiedRule[] test', () => {
     describe('convertScanResultsToUnifiedRules', () => {
-        it('returns empty UnifiedRule array when scanResults is undefined/null', () => {
+        it('returns empty UnifiedRule[] when scanResults is undefined/null', () => {
             const undefinedScanResults = undefined;
             const nullScanResults = null;
 

--- a/src/tests/unit/tests/injected/adapters/scan-results-to-unified-rules.test.ts
+++ b/src/tests/unit/tests/injected/adapters/scan-results-to-unified-rules.test.ts
@@ -1,9 +1,61 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ScanResults } from '../../../../../scanner/iruleresults';
+import { UnifiedRule } from '../../../../../common/types/store-data/unified-data-interface';
+import { convertScanResultsToUnifiedRules } from '../../../../../injected/adapters/scan-results-to-unified-rules';
+import { RuleResult, ScanResults } from '../../../../../scanner/iruleresults';
 
 describe('ScanResults to UnifiedRule[] test', () => {
     test('convertScanResultsToUnifiedRules', () => {
-        const scanResultsStub: ScanResults = {};
+        const scanResultsStub = {
+            passes: [createRuleResultStub('rule1')],
+            violations: [createRuleResultStub('rule1')],
+            inapplicable: [createRuleResultStub('rule2'), createRuleResultStub('rule3')],
+            incomplete: [],
+        } as ScanResults;
+
+        const expectedResults: UnifiedRule[] = getSampleUnifiedRuleStubs(3);
+
+        const actualResults: UnifiedRule[] = convertScanResultsToUnifiedRules(scanResultsStub);
+
+        expect(actualResults).toEqual(expectedResults);
     });
+
+    function createRuleResultStub(id: string): RuleResult {
+        return {
+            id: `stub_${id}`,
+            nodes: [],
+            description: `stub_description_${id}`,
+            helpUrl: `stub_url_${id}`,
+            guidanceLinks: [
+                {
+                    href: `stub_guidance_href_${id}`,
+                    text: `stub_guidance_text_${id}`,
+                },
+            ],
+        };
+    }
+
+    function createUnifiedRuleStub(id: string): UnifiedRule {
+        return {
+            id: `stub_${id}`,
+            description: `stub_description_${id}`,
+            url: `stub_url_${id}`,
+            guidance: [
+                {
+                    href: `stub_guidance_href_${id}`,
+                    text: `stub_guidance_text_${id}`,
+                },
+            ],
+        };
+    }
+
+    function getSampleUnifiedRuleStubs(numRules: number): UnifiedRule[] {
+        const unifiedRules = [] as UnifiedRule[];
+
+        for (let i = 1; i <= numRules; i++) {
+            unifiedRules.push(createUnifiedRuleStub(`rule${i}`));
+        }
+
+        return unifiedRules;
+    }
 });

--- a/src/tests/unit/tests/injected/adapters/scan-results-to-unified-rules.test.ts
+++ b/src/tests/unit/tests/injected/adapters/scan-results-to-unified-rules.test.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ScanResults } from '../../../../../scanner/iruleresults';
+
+describe('ScanResults to UnifiedRule[] test', () => {
+    test('convertScanResultsToUnifiedRules', () => {
+        const scanResultsStub: ScanResults = {};
+    });
+});

--- a/src/tests/unit/tests/injected/adapters/scan-results-to-unified-rules.test.ts
+++ b/src/tests/unit/tests/injected/adapters/scan-results-to-unified-rules.test.ts
@@ -5,57 +5,69 @@ import { convertScanResultsToUnifiedRules } from '../../../../../injected/adapte
 import { RuleResult, ScanResults } from '../../../../../scanner/iruleresults';
 
 describe('ScanResults to UnifiedRule[] test', () => {
-    test('convertScanResultsToUnifiedRules', () => {
-        const scanResultsStub = {
-            passes: [createRuleResultStub('rule1')],
-            violations: [createRuleResultStub('rule1')],
-            inapplicable: [createRuleResultStub('rule2'), createRuleResultStub('rule3')],
-            incomplete: [],
-        } as ScanResults;
+    describe('convertScanResultsToUnifiedRules', () => {
+        it('returns empty UnifiedRule array when scanResults is undefined/null', () => {
+            const undefinedScanResults = undefined;
+            const nullScanResults = null;
 
-        const expectedResults = getSampleUnifiedRuleStubs(3);
+            const expectedResults = [] as UnifiedRule[];
 
-        const actualResults = convertScanResultsToUnifiedRules(scanResultsStub);
+            expect(convertScanResultsToUnifiedRules(undefinedScanResults)).toEqual(expectedResults);
+            expect(convertScanResultsToUnifiedRules(nullScanResults)).toEqual(expectedResults);
+        });
 
-        expect(actualResults).toEqual(expectedResults);
-    });
+        it('returns the expected UnifiedRule[] from sample ScanResults', () => {
+            const scanResultsStub = {
+                passes: [createRuleResultStub('rule1')],
+                violations: [createRuleResultStub('rule1')],
+                inapplicable: [createRuleResultStub('rule2'), createRuleResultStub('rule3')],
+                incomplete: [],
+            } as ScanResults;
 
-    function createRuleResultStub(id: string): RuleResult {
-        return {
-            id: `stub_${id}`,
-            nodes: [],
-            description: `stub_description_${id}`,
-            helpUrl: `stub_url_${id}`,
-            guidanceLinks: [
-                {
-                    href: `stub_guidance_href_${id}`,
-                    text: `stub_guidance_text_${id}`,
-                },
-            ],
-        };
-    }
+            const expectedResults = getSampleUnifiedRuleStubs(3);
 
-    function createUnifiedRuleStub(id: string): UnifiedRule {
-        return {
-            id: `stub_${id}`,
-            description: `stub_description_${id}`,
-            url: `stub_url_${id}`,
-            guidance: [
-                {
-                    href: `stub_guidance_href_${id}`,
-                    text: `stub_guidance_text_${id}`,
-                },
-            ],
-        };
-    }
+            const actualResults = convertScanResultsToUnifiedRules(scanResultsStub);
 
-    function getSampleUnifiedRuleStubs(numRules: number): UnifiedRule[] {
-        const unifiedRules = [] as UnifiedRule[];
+            expect(actualResults).toEqual(expectedResults);
+        });
 
-        for (let i = 1; i <= numRules; i++) {
-            unifiedRules.push(createUnifiedRuleStub(`rule${i}`));
+        function createRuleResultStub(id: string): RuleResult {
+            return {
+                id: `stub_${id}`,
+                nodes: [],
+                description: `stub_description_${id}`,
+                helpUrl: `stub_url_${id}`,
+                guidanceLinks: [
+                    {
+                        href: `stub_guidance_href_${id}`,
+                        text: `stub_guidance_text_${id}`,
+                    },
+                ],
+            };
         }
 
-        return unifiedRules;
-    }
+        function createUnifiedRuleStub(id: string): UnifiedRule {
+            return {
+                id: `stub_${id}`,
+                description: `stub_description_${id}`,
+                url: `stub_url_${id}`,
+                guidance: [
+                    {
+                        href: `stub_guidance_href_${id}`,
+                        text: `stub_guidance_text_${id}`,
+                    },
+                ],
+            };
+        }
+
+        function getSampleUnifiedRuleStubs(numRules: number): UnifiedRule[] {
+            const unifiedRules = [] as UnifiedRule[];
+
+            for (let i = 1; i <= numRules; i++) {
+                unifiedRules.push(createUnifiedRuleStub(`rule${i}`));
+            }
+
+            return unifiedRules;
+        }
+    });
 });

--- a/src/tests/unit/tests/injected/adapters/scan-results-to-unified-rules.test.ts
+++ b/src/tests/unit/tests/injected/adapters/scan-results-to-unified-rules.test.ts
@@ -13,9 +13,9 @@ describe('ScanResults to UnifiedRule[] test', () => {
             incomplete: [],
         } as ScanResults;
 
-        const expectedResults: UnifiedRule[] = getSampleUnifiedRuleStubs(3);
+        const expectedResults = getSampleUnifiedRuleStubs(3);
 
-        const actualResults: UnifiedRule[] = convertScanResultsToUnifiedRules(scanResultsStub);
+        const actualResults = convertScanResultsToUnifiedRules(scanResultsStub);
 
         expect(actualResults).toEqual(expectedResults);
     });


### PR DESCRIPTION
#### Description of changes

`scan-results-to-unified-rules` parses `scanResults` input and returns an array of `UnifiedRule`. We decided to get the rules from scan results, so the unified results, which are also generated from scan results, and unified rules will correspond to the same data.

*Note: We considered 2 approaches to check for duplicate rules in the results: using a Set of ruleIds or checking the UnifiedRule array directly, as rules are added to it. When run on inputs of 2,000 and 20,000 scan results, the implementation **with the Set** took 55ms and 501ms, respectively, while the implementation **without the Set** took 117ms and 3276ms, respectively. Since using the Set could save a significant amount of time, we decided to add the set back in exchange for the extra space complexity.*

#### Pull request checklist

- [x] Addresses an existing issue: Contributes to WI # 1567501
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
