### PR TITLE
refactor: assessment provider filtering clean up

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -16,6 +16,7 @@ import { StartOverDropdown } from './start-over-dropdown';
 export type DetailsViewCommandBarDeps = ReportExportComponentDeps & {
     getCurrentDate: () => Date;
     reportGenerator: ReportGenerator;
+    assessmentsProvider: AssessmentsProvider;
 };
 
 export interface DetailsViewCommandBarProps {
@@ -24,7 +25,6 @@ export interface DetailsViewCommandBarProps {
     tabStoreData: TabStoreData;
     actionMessageCreator: DetailsViewActionMessageCreator;
     assessmentStoreData: AssessmentStoreData;
-    assessmentsProvider: AssessmentsProvider;
     renderExportAndStartOver: boolean;
     rightPanelConfiguration: DetailsRightPanelConfiguration;
 }
@@ -72,10 +72,11 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
         if (!this.props.renderExportAndStartOver) {
             return null;
         }
-        const { deps, assessmentStoreData, assessmentsProvider, featureFlagStoreData, tabStoreData } = this.props;
+        const { deps, assessmentStoreData, featureFlagStoreData, tabStoreData } = this.props;
+        const { assessmentsProvider } = deps;
         const reportGenerator = deps.reportGenerator;
         const selectedTest = this.props.assessmentStoreData.assessmentNavState.selectedTestType;
-        const test = this.props.assessmentsProvider.forType(selectedTest);
+        const test = assessmentsProvider.forType(selectedTest);
         const htmlGenerator = reportGenerator.generateAssessmentReport.bind(
             reportGenerator,
             assessmentStoreData,

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -5,8 +5,8 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
+
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { DetailsRightPanelConfiguration } from './details-view-right-panel';
@@ -21,7 +21,6 @@ export type DetailsViewCommandBarDeps = ReportExportComponentDeps & {
 
 export interface DetailsViewCommandBarProps {
     deps: DetailsViewCommandBarDeps;
-    featureFlagStoreData: FeatureFlagStoreData;
     tabStoreData: TabStoreData;
     actionMessageCreator: DetailsViewActionMessageCreator;
     assessmentStoreData: AssessmentStoreData;
@@ -72,7 +71,7 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
         if (!this.props.renderExportAndStartOver) {
             return null;
         }
-        const { deps, assessmentStoreData, featureFlagStoreData, tabStoreData } = this.props;
+        const { deps, assessmentStoreData, tabStoreData } = this.props;
         const { assessmentsProvider } = deps;
         const reportGenerator = deps.reportGenerator;
         const selectedTest = this.props.assessmentStoreData.assessmentNavState.selectedTestType;
@@ -81,7 +80,6 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
             reportGenerator,
             assessmentStoreData,
             assessmentsProvider,
-            featureFlagStoreData,
             tabStoreData,
         );
 

--- a/src/DetailsView/components/left-nav/details-view-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.tsx
@@ -6,7 +6,6 @@ import * as React from 'react';
 
 import { NamedSFC } from '../../../common/react/named-sfc';
 import { AssessmentStoreData } from '../../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { DetailsRightPanelConfiguration } from '../details-view-right-panel';
 import { DetailsViewSwitcherNavConfiguration, LeftNavDeps } from '../details-view-switcher-nav';
@@ -20,12 +19,11 @@ export type DetailsViewLeftNavProps = {
     selectedTest: VisualizationType;
     switcherNavConfiguration: DetailsViewSwitcherNavConfiguration;
     rightPanelConfiguration: DetailsRightPanelConfiguration;
-    featureFlagStoreData: FeatureFlagStoreData;
     assessmentStoreData: AssessmentStoreData;
 };
 
 export const DetailsViewLeftNav = NamedSFC<DetailsViewLeftNavProps>('DetailsViewLeftNav', props => {
-    const { deps, selectedTest, switcherNavConfiguration, rightPanelConfiguration, featureFlagStoreData, assessmentStoreData } = props;
+    const { deps, selectedTest, switcherNavConfiguration, rightPanelConfiguration, assessmentStoreData } = props;
 
     const { assessmentsProvider } = deps;
 

--- a/src/DetailsView/components/left-nav/details-view-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { mapValues } from 'lodash';
 import * as React from 'react';
 
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { NamedSFC } from '../../../common/react/named-sfc';
 import { AssessmentStoreData } from '../../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-flag-store-data';
@@ -13,7 +13,6 @@ import { DetailsViewSwitcherNavConfiguration, LeftNavDeps } from '../details-vie
 
 export type DetailsViewLeftNavDeps = {
     assessmentsProvider: AssessmentsProvider;
-    assessmentsProviderWithFeaturesEnabled: (assessmentProvider: AssessmentsProvider, flags: FeatureFlagStoreData) => AssessmentsProvider;
 } & LeftNavDeps;
 
 export type DetailsViewLeftNavProps = {
@@ -28,16 +27,15 @@ export type DetailsViewLeftNavProps = {
 export const DetailsViewLeftNav = NamedSFC<DetailsViewLeftNavProps>('DetailsViewLeftNav', props => {
     const { deps, selectedTest, switcherNavConfiguration, rightPanelConfiguration, featureFlagStoreData, assessmentStoreData } = props;
 
-    const { assessmentsProvider, assessmentsProviderWithFeaturesEnabled } = deps;
+    const { assessmentsProvider } = deps;
 
     const selectedKey: string = rightPanelConfiguration.GetLeftNavSelectedKey({ visualizationType: selectedTest });
-    const filteredProvider = assessmentsProviderWithFeaturesEnabled(assessmentsProvider, featureFlagStoreData);
 
     const leftNav: JSX.Element = (
         <div className="left-nav main-nav">
             <switcherNavConfiguration.LeftNav
                 {...props}
-                assessmentsProvider={filteredProvider}
+                assessmentsProvider={assessmentsProvider}
                 selectedKey={selectedKey}
                 assessmentsData={mapValues(assessmentStoreData.assessments, data => data.testStepStatus)}
             />

--- a/src/DetailsView/components/overview-content/overview-content-container.tsx
+++ b/src/DetailsView/components/overview-content/overview-content-container.tsx
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
-
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import * as React from 'react';
 import { OverviewSummaryReportModel } from 'reports/assessment-report-model';
 import { AssessmentReportSummary } from 'reports/components/assessment-report-summary';
 import { GetAssessmentSummaryModelFromProviderAndStoreData } from 'reports/get-assessment-summary-model';
 import { HyperlinkDefinition } from 'views/content/content-page';
+
 import { NamedSFC } from '../../../common/react/named-sfc';
 import { AssessmentStoreData } from '../../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../../common/types/store-data/tab-store-data';
 import { DetailsViewActionMessageCreator } from '../../actions/details-view-action-message-creator';
 import { TargetChangeDialog, TargetChangeDialogDeps } from '../target-change-dialog';
@@ -39,7 +38,6 @@ export type OverviewContainerDeps = {
     assessmentsProvider: AssessmentsProvider;
     getAssessmentSummaryModelFromProviderAndStoreData: GetAssessmentSummaryModelFromProviderAndStoreData;
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-    assessmentsProviderWithFeaturesEnabled: (assessmentProvider: AssessmentsProvider, flags: FeatureFlagStoreData) => AssessmentsProvider;
 } & OverviewHelpSectionDeps &
     TargetChangeDialogDeps;
 
@@ -47,22 +45,20 @@ export interface OverviewContainerProps {
     deps: OverviewContainerDeps;
     assessmentStoreData: AssessmentStoreData;
     tabStoreData: TabStoreData;
-    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export const OverviewContainer = NamedSFC<OverviewContainerProps>('OverviewContainer', props => {
-    const { deps, assessmentStoreData, tabStoreData, featureFlagStoreData } = props;
-    const { assessmentsProvider, getAssessmentSummaryModelFromProviderAndStoreData, assessmentsProviderWithFeaturesEnabled } = deps;
+    const { deps, assessmentStoreData, tabStoreData } = props;
+    const { assessmentsProvider, getAssessmentSummaryModelFromProviderAndStoreData } = deps;
     const prevTarget = assessmentStoreData.persistedTabInfo;
     const currentTarget = {
         id: tabStoreData.id,
         url: tabStoreData.url,
         title: tabStoreData.title,
     };
-    const filteredProvider = assessmentsProviderWithFeaturesEnabled(assessmentsProvider, featureFlagStoreData);
 
     const summaryData: OverviewSummaryReportModel = getAssessmentSummaryModelFromProviderAndStoreData(
-        filteredProvider,
+        assessmentsProvider,
         assessmentStoreData,
     );
 

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -5,6 +5,7 @@ import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import * as React from 'react';
 
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { AssessmentsProviderWithFeaturesEnabled } from '../assessments/assessments-feature-flag-filter';
 import { ThemeDeps } from '../common/components/theme';
 import { withStoreSubscription, WithStoreSubscriptionDeps } from '../common/components/with-store-subscription';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -37,6 +38,8 @@ import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-han
 export type DetailsViewContainerDeps = {
     getDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration;
     getDetailsSwitcherNavConfiguration: GetDetailsSwitcherNavConfiguration;
+    assessmentsProvider: AssessmentsProvider;
+    assessmentsProviderWithFeaturesEnabled: AssessmentsProviderWithFeaturesEnabled;
 } & DetailsViewMainContentDeps &
     DetailsViewOverlayDeps &
     DetailsViewCommandBarDeps &
@@ -119,6 +122,8 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
     }
 
     private renderContent(): JSX.Element {
+        this.updateAssessmentsProvider();
+
         return (
             <div className="table column-layout main-wrapper">
                 {this.renderHeader()}
@@ -126,6 +131,11 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
                 {this.renderOverlay()}
             </div>
         );
+    }
+
+    private updateAssessmentsProvider(): void {
+        const { assessmentsProvider, deps, storeState } = this.props;
+        deps.assessmentsProvider = deps.assessmentsProviderWithFeaturesEnabled(assessmentsProvider, storeState.featureFlagStoreData);
     }
 
     private renderHeader(): JSX.Element {

--- a/src/assessments/assessments-feature-flag-filter.ts
+++ b/src/assessments/assessments-feature-flag-filter.ts
@@ -12,9 +12,12 @@ function assessmentIsFeatureEnabled(flags: FeatureFlagStoreData): (assessment: A
         !assessment.featureFlag || !assessment.featureFlag.required || _.every(assessment.featureFlag.required, f => flags[f]);
 }
 
-export function assessmentsProviderWithFeaturesEnabled(
+export type AssessmentsProviderWithFeaturesEnabled = (
     assessmentProvider: AssessmentsProvider,
     flags: FeatureFlagStoreData,
-): AssessmentsProvider {
-    return AssessmentsProviderImpl.Create(assessmentProvider.all().filter(assessmentIsFeatureEnabled(flags)));
-}
+) => AssessmentsProvider;
+
+export const assessmentsProviderWithFeaturesEnabled: AssessmentsProviderWithFeaturesEnabled = (
+    assessmentProvider: AssessmentsProvider,
+    flags: FeatureFlagStoreData,
+) => AssessmentsProviderImpl.Create(assessmentProvider.all().filter(assessmentIsFeatureEnabled(flags)));

--- a/src/reports/assessment-report-html-generator.tsx
+++ b/src/reports/assessment-report-html-generator.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
-import { assessmentsProviderWithFeaturesEnabled } from 'assessments/assessments-feature-flag-filter';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -34,10 +33,8 @@ export class AssessmentReportHtmlGenerator {
         tabStoreData: TabStoreData,
         description: string,
     ): string {
-        const filteredProvider = assessmentsProviderWithFeaturesEnabled(assessmentsProvider, featureFlagStoreData);
-
         const modelBuilder = this.assessmentReportModelBuilderFactory.create(
-            filteredProvider,
+            assessmentsProvider,
             assessmentStoreData,
             tabStoreData,
             this.dateGetter(),

--- a/src/reports/assessment-report-html-generator.tsx
+++ b/src/reports/assessment-report-html-generator.tsx
@@ -3,7 +3,6 @@
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import * as React from 'react';
 
@@ -29,7 +28,6 @@ export class AssessmentReportHtmlGenerator {
     public generateHtml(
         assessmentStoreData: AssessmentStoreData,
         assessmentsProvider: AssessmentsProvider,
-        featureFlagStoreData: FeatureFlagStoreData,
         tabStoreData: TabStoreData,
         description: string,
     ): string {

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { ScanResults } from 'scanner/iruleresults';
 
@@ -34,16 +33,9 @@ export class ReportGenerator {
     public generateAssessmentReport(
         assessmentStoreData: AssessmentStoreData,
         assessmentsProvider: AssessmentsProvider,
-        featureFlagStoreData: FeatureFlagStoreData,
         tabStoreData: TabStoreData,
         description: string,
     ): string {
-        return this.assessmentReportHtmlGenerator.generateHtml(
-            assessmentStoreData,
-            assessmentsProvider,
-            featureFlagStoreData,
-            tabStoreData,
-            description,
-        );
+        return this.assessmentReportHtmlGenerator.generateHtml(assessmentStoreData, assessmentsProvider, tabStoreData, description);
     }
 }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bars.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bars.test.tsx.snap
@@ -2,14 +2,22 @@
 
 exports[`getBasicCommandBar should return command bar with renderExportAndStartOver as false 1`] = `
 <DetailsViewCommandBar
-  assessmentsProvider={null}
+  deps={
+    Object {
+      "assessmentsProvider": null,
+    }
+  }
   renderExportAndStartOver={false}
 />
 `;
 
 exports[`getCommandBarWithExportAndStartOver should return command bar with renderExportAndStartOver as true 1`] = `
 <DetailsViewCommandBar
-  assessmentsProvider={null}
+  deps={
+    Object {
+      "assessmentsProvider": null,
+    }
+  }
   renderExportAndStartOver={true}
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/command-bars.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bars.test.tsx
@@ -8,7 +8,9 @@ import { BasicCommandBar, CommandBarProps, CommandBarWithExportAndStartOver } fr
 describe('getCommandBarWithExportAndStartOver', () => {
     it('should return command bar with renderExportAndStartOver as true', () => {
         const props = {
-            assessmentsProvider: null,
+            deps: {
+                assessmentsProvider: null,
+            },
         } as CommandBarProps;
         const actual = shallow(<CommandBarWithExportAndStartOver {...props} />);
 
@@ -19,7 +21,9 @@ describe('getCommandBarWithExportAndStartOver', () => {
 describe('getBasicCommandBar', () => {
     it('should return command bar with renderExportAndStartOver as false', () => {
         const props = {
-            assessmentsProvider: null,
+            deps: {
+                assessmentsProvider: null,
+            },
         } as CommandBarProps;
         const actual = shallow(<BasicCommandBar {...props} />);
 

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -10,7 +10,6 @@ import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 import { FileURLProvider } from '../../../../../common/file-url-provider';
 import { AssessmentStoreData } from '../../../../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../../../../common/types/store-data/tab-store-data';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import {
@@ -25,7 +24,6 @@ describe('DetailsViewCommandBar', () => {
     const theDate = new Date(2019, 2, 12, 9, 0);
     const thePageTitle = 'command-bar-test-tab-title';
 
-    let featureFlagStoreData: FeatureFlagStoreData;
     let actionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
     let tabStoreData: TabStoreData;
     let assessmentsProviderMock: IMock<AssessmentsProvider>;
@@ -36,7 +34,6 @@ describe('DetailsViewCommandBar', () => {
     let renderExportAndStartOver: boolean;
 
     beforeEach(() => {
-        featureFlagStoreData = {};
         actionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator, MockBehavior.Loose);
         tabStoreData = {
             title: thePageTitle,
@@ -75,7 +72,6 @@ describe('DetailsViewCommandBar', () => {
 
         return {
             deps,
-            featureFlagStoreData,
             actionMessageCreator: actionMessageCreatorMock.object,
             tabStoreData,
             renderExportAndStartOver,
@@ -111,7 +107,6 @@ describe('DetailsViewCommandBar', () => {
                     rgm.generateAssessmentReport(
                         props.assessmentStoreData,
                         props.deps.assessmentsProvider,
-                        props.featureFlagStoreData,
                         props.tabStoreData,
                         descriptionPlaceholder,
                     ),

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -7,6 +7,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+
 import { FileURLProvider } from '../../../../../common/file-url-provider';
 import { AssessmentStoreData } from '../../../../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
@@ -69,6 +70,7 @@ describe('DetailsViewCommandBar', () => {
             outcomeTypeSemanticsFromTestStatus: { stub: 'outcomeTypeSemanticsFromTestStatus' } as any,
             getCurrentDate: () => theDate,
             reportGenerator: reportGeneratorMock.object,
+            assessmentsProvider: assessmentsProviderMock.object,
         };
 
         return {
@@ -77,7 +79,6 @@ describe('DetailsViewCommandBar', () => {
             actionMessageCreator: actionMessageCreatorMock.object,
             tabStoreData,
             renderExportAndStartOver,
-            assessmentsProvider: assessmentsProviderMock.object,
             assessmentStoreData,
             rightPanelConfiguration: rightPanelConfig,
         };
@@ -109,7 +110,7 @@ describe('DetailsViewCommandBar', () => {
                 .setup(rgm =>
                     rgm.generateAssessmentReport(
                         props.assessmentStoreData,
-                        props.assessmentsProvider,
+                        props.deps.assessmentsProvider,
                         props.featureFlagStoreData,
                         props.tabStoreData,
                         descriptionPlaceholder,

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/details-view-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/details-view-left-nav.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`DetailsViewLeftNav should render from switcher nav 1`] = `
     deps={
       Object {
         "assessmentsProvider": Object {},
-        "assessmentsProviderWithFeaturesEnabled": [Function],
       }
     }
     featureFlagStoreData={Object {}}

--- a/src/tests/unit/tests/DetailsView/components/left-nav/details-view-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/details-view-left-nav.test.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { It, Mock, MockBehavior } from 'typemoq';
 
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { NamedSFC, ReactSFCWithDisplayName } from '../../../../../../common/react/named-sfc';
 import { AssessmentData, AssessmentStoreData } from '../../../../../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../../../../../common/types/store-data/feature-flag-store-data';
@@ -23,9 +23,7 @@ describe('DetailsViewLeftNav', () => {
         const selectedTestStub: VisualizationType = -1;
         const selectedKeyStub: string = 'some key';
         const featureFlagDataStub: FeatureFlagStoreData = {};
-        const assessmentsProviderWithFeaturesEnabledMock = Mock.ofInstance((provider, featureFlagData) => null, MockBehavior.Strict);
         const assessmentProviderStub = {} as AssessmentsProvider;
-        const filteredProviderStub = {} as AssessmentsProvider;
         const GetLeftNavSelectedKeyMock = Mock.ofInstance((theProps: GetLeftNavSelectedKeyProps) => null, MockBehavior.Strict);
         const LeftNavStub: Readonly<ReactSFCWithDisplayName<DetailsViewLeftNavProps>> = NamedSFC<DetailsViewLeftNavProps>(
             'test',
@@ -46,7 +44,6 @@ describe('DetailsViewLeftNav', () => {
 
         const deps = {
             assessmentsProvider: assessmentProviderStub,
-            assessmentsProviderWithFeaturesEnabled: assessmentsProviderWithFeaturesEnabledMock.object,
         } as DetailsViewLeftNavDeps;
 
         const props = {
@@ -59,10 +56,6 @@ describe('DetailsViewLeftNav', () => {
         } as DetailsViewLeftNavProps;
 
         GetLeftNavSelectedKeyMock.setup(glnsm => glnsm(It.isValue({ visualizationType: selectedTestStub }))).returns(() => selectedKeyStub);
-
-        assessmentsProviderWithFeaturesEnabledMock
-            .setup(ap => ap(assessmentProviderStub, featureFlagDataStub))
-            .returns(() => filteredProviderStub);
 
         const actual = shallow(<DetailsViewLeftNav {...props} />);
         expect(actual.getElement()).toMatchSnapshot();

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
         "assessmentsProvider": Object {
           "all": [Function],
         },
-        "assessmentsProviderWithFeaturesEnabled": [Function],
         "detailsViewActionMessageCreator": Object {},
         "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
         "urlParser": Object {},
@@ -47,7 +46,6 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
           "assessmentsProvider": Object {
             "all": [Function],
           },
-          "assessmentsProviderWithFeaturesEnabled": [Function],
           "detailsViewActionMessageCreator": Object {},
           "getAssessmentSummaryModelFromProviderAndStoreData": [MockFunction],
           "urlParser": Object {},

--- a/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/overview-content-container.test.tsx
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Mock, MockBehavior } from 'typemoq';
 
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData, PersistedTabInfo } from '../../../../../../common/types/store-data/assessment-result-data';
 import { TabStoreData } from '../../../../../../common/types/store-data/tab-store-data';
 import { UrlParser } from '../../../../../../common/url-parser';
@@ -36,9 +35,7 @@ describe('OverviewContainer', () => {
         all: () => [],
     } as any;
 
-    const filteredProvider = {} as AssessmentsProvider;
     const detailsViewActionMessageCreatorStub = {} as DetailsViewActionMessageCreator;
-    const assessmentsProviderWithFeaturesEnabledMock = Mock.ofInstance((provider, featureFlagData) => null, MockBehavior.Strict);
     const getAssessmentSummaryModelFromProviderAndStoreData = jest.fn();
 
     const deps: OverviewContainerDeps = {
@@ -47,27 +44,13 @@ describe('OverviewContainer', () => {
         getAssessmentSummaryModelFromProviderAndStoreData: getAssessmentSummaryModelFromProviderAndStoreData,
         detailsViewActionMessageCreator: detailsViewActionMessageCreatorStub,
         urlParser: urlParserMock,
-        assessmentsProviderWithFeaturesEnabled: assessmentsProviderWithFeaturesEnabledMock.object,
     };
-
-    const featureFlagDataStub = {};
 
     const assessmentStoreData: AssessmentStoreData = {
         persistedTabInfo: {} as PersistedTabInfo,
     } as AssessmentStoreData;
 
-    assessmentsProviderWithFeaturesEnabledMock
-        .setup(mock => mock(assessmentsProvider, featureFlagDataStub))
-        .returns(() => filteredProvider);
-
-    const component = (
-        <OverviewContainer
-            deps={deps}
-            assessmentStoreData={assessmentStoreData}
-            featureFlagStoreData={featureFlagDataStub}
-            tabStoreData={tabStoreDataStub}
-        />
-    );
+    const component = <OverviewContainer deps={deps} assessmentStoreData={assessmentStoreData} tabStoreData={tabStoreDataStub} />;
     const wrapper = shallow(component);
 
     test('component is defined and matches snapshot', () => {

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -5,6 +5,7 @@ import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
+import { AssessmentsProviderWithFeaturesEnabled } from '../../../../assessments/assessments-feature-flag-filter';
 import { DropdownClickHandler } from '../../../../common/dropdown-click-handler';
 import { StoreActionMessageCreator } from '../../../../common/message-creators/store-action-message-creator';
 import { StoreActionMessageCreatorImpl } from '../../../../common/message-creators/store-action-message-creator-impl';
@@ -49,19 +50,25 @@ describe('DetailsViewContainer', () => {
     let deps: DetailsViewContainerDeps;
     let getDetailsRightPanelConfiguration: IMock<GetDetailsRightPanelConfiguration>;
     let getDetailsSwitcherNavConfiguration: IMock<GetDetailsSwitcherNavConfiguration>;
+    let assessmentsProviderWithFeaturesEnabledMock: IMock<AssessmentsProviderWithFeaturesEnabled>;
+
+    const assessmentProviderMock = Mock.ofInstance(CreateTestAssessmentProviderWithFeatureFlag());
 
     beforeEach(() => {
         detailsViewActionMessageCreator = Mock.ofType<DetailsViewActionMessageCreator>();
         getDetailsRightPanelConfiguration = Mock.ofInstance((props: GetDetailsRightPanelConfigurationProps) => null, MockBehavior.Strict);
         getDetailsSwitcherNavConfiguration = Mock.ofInstance((props: GetDetailsSwitcherNavConfigurationProps) => null, MockBehavior.Strict);
+        assessmentsProviderWithFeaturesEnabledMock = Mock.ofType<AssessmentsProviderWithFeaturesEnabled>();
+        assessmentsProviderWithFeaturesEnabledMock
+            .setup(filter => filter(assessmentProviderMock.object, It.isAny()))
+            .returns(() => assessmentProviderMock.object);
         deps = {
             detailsViewActionMessageCreator: detailsViewActionMessageCreator.object,
             getDetailsRightPanelConfiguration: getDetailsRightPanelConfiguration.object,
             getDetailsSwitcherNavConfiguration: getDetailsSwitcherNavConfiguration.object,
+            assessmentsProviderWithFeaturesEnabled: assessmentsProviderWithFeaturesEnabledMock.object,
         } as DetailsViewContainerDeps;
     });
-
-    const assessmentProviderMock = Mock.ofInstance(CreateTestAssessmentProviderWithFeatureFlag());
 
     describe('render', () => {
         it('renders spinner when stores not ready', () => {

--- a/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
@@ -2,11 +2,8 @@
 // Licensed under the MIT License.
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import * as React from 'react';
-import { It, Mock, MockBehavior } from 'typemoq';
-
 import { AssessmentReportHtmlGenerator, AssessmentReportHtmlGeneratorDeps } from 'reports/assessment-report-html-generator';
 import { ReportModel } from 'reports/assessment-report-model';
 import { AssessmentReportModelBuilder } from 'reports/assessment-report-model-builder';
@@ -14,6 +11,8 @@ import { AssessmentReportModelBuilderFactory } from 'reports/assessment-report-m
 import * as reportStyles from 'reports/assessment-report.styles';
 import { AssessmentReport } from 'reports/components/assessment-report';
 import { ReactStaticRenderer } from 'reports/react-static-renderer';
+import { It, Mock, MockBehavior } from 'typemoq';
+
 import { CreateTestAssessmentProviderWithFeatureFlag } from '../../common/test-assessment-provider';
 
 describe('AssessmentReportHtmlGenerator', () => {
@@ -26,7 +25,6 @@ describe('AssessmentReportHtmlGenerator', () => {
 
         const assessmentsProvider = CreateTestAssessmentProviderWithFeatureFlag();
         const assessmentStoreData: AssessmentStoreData = { stub: 'assessmentStoreData' } as any;
-        const featureFlagStoreData: FeatureFlagStoreData = { stub: 'featureFlagStoreData' } as any;
         const tabStoreData: TabStoreData = { stub: 'tabStoreData' } as any;
         const description = 'generateHtml-description';
 
@@ -82,13 +80,7 @@ describe('AssessmentReportHtmlGenerator', () => {
             assessmentDefaultMessageGenerator,
         );
 
-        const actualHtml = testSubject.generateHtml(
-            assessmentStoreData,
-            assessmentsProvider,
-            featureFlagStoreData,
-            tabStoreData,
-            description,
-        );
+        const actualHtml = testSubject.generateHtml(assessmentStoreData, assessmentsProvider, tabStoreData, description);
 
         expect(actualHtml).toEqual(expectedHtml);
 

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { AssessmentReportHtmlGenerator } from 'reports/assessment-report-html-generator';
 import { ReportGenerator } from 'reports/report-generator';
@@ -50,25 +49,16 @@ describe('ReportGenerator', () => {
     test('generateAssessmentHtml', () => {
         const assessmentStoreData: AssessmentStoreData = { stub: 'assessmentStoreData' } as any;
         const assessmentsProvider: AssessmentsProvider = { stub: 'assessmentsProvider' } as any;
-        const featureFlagStoreData: FeatureFlagStoreData = { stub: 'featureFlagStoreData' } as any;
         const tabStoreData: TabStoreData = { stub: 'tabStoreData' } as any;
         const assessmentDescription = 'generateAssessmentHtml-description';
 
         assessmentReportHtmlGeneratorMock
-            .setup(builder =>
-                builder.generateHtml(assessmentStoreData, assessmentsProvider, featureFlagStoreData, tabStoreData, assessmentDescription),
-            )
+            .setup(builder => builder.generateHtml(assessmentStoreData, assessmentsProvider, tabStoreData, assessmentDescription))
             .returns(() => 'generated-assessment-html')
             .verifiable(Times.once());
 
         const testObject = new ReportGenerator(nameBuilderMock.object, dataBuilderMock.object, assessmentReportHtmlGeneratorMock.object);
-        const actual = testObject.generateAssessmentReport(
-            assessmentStoreData,
-            assessmentsProvider,
-            featureFlagStoreData,
-            tabStoreData,
-            assessmentDescription,
-        );
+        const actual = testObject.generateAssessmentReport(assessmentStoreData, assessmentsProvider, tabStoreData, assessmentDescription);
 
         const expected = 'generated-assessment-html';
         expect(actual).toEqual(expected);


### PR DESCRIPTION
#### Description of changes

We're currently filtering test base on feature flags on several places. The condition to change which test are used are the same in all places (when the feature flags change) so we should be able to do the filtering at a higher level in the hierarchy (closer to the composition root).

This PR is just that, moving the filtering to the `DetailsViewContainer` component where we do get "notified" every time the feature flag store data is updated. 

By doing this, we remove the responsibility of filtering assessment provider from any class that uses the provider, simplifying logic and tests and creating a single place where we do the filtering.

**Note for reviewers** It may be worth (even easier) to review this commit by commit instead of all the changes at the same time.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
