### PR TITLE
feat: add Graphics requirement to new Contrast assessment test

### DIFF
--- a/src/assessments/contrast/assessment.tsx
+++ b/src/assessments/contrast/assessment.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { VisualizationType } from 'common/types/visualization-type';
 import { AssessmentBuilder } from '../assessment-builder';
 import { Assessment } from '../types/iassessment';
+import { Graphics } from './test-steps/graphics';
 import { StateChanges } from './test-steps/state-changes';
 import { UIComponents } from './test-steps/ui-components';
 
@@ -29,7 +30,7 @@ export const ContrastAssessment: Assessment = AssessmentBuilder.Assisted({
     gettingStarted: gettingStarted,
     guidance,
     visualizationType: VisualizationType.ContrastAssessment,
-    requirements: [UIComponents, StateChanges],
+    requirements: [UIComponents, StateChanges, Graphics],
     storeDataKey: 'contrastAssessment',
     featureFlag: { required: ['showAllAssessments'] },
 });

--- a/src/assessments/contrast/test-steps/graphics.tsx
+++ b/src/assessments/contrast/test-steps/graphics.tsx
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { MacContrastCheckerAppLink, WindowsContrastCheckerAppLink } from 'common/components/contrast-checker-app-links';
-import { ImagesOfTextPropertyBag } from 'common/types/property-bag/image-of-text';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { MeaningfulImagePropertyBag } from 'common/types/property-bag/meaningful-image';
+import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
-import * as content from 'content/test/contrast/ui-components';
+import * as content from 'content/test/contrast/graphics';
+import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
 import * as React from 'react';
 
-import { VisualizationType } from '../../../common/types/visualization-type';
-import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
 import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
 import { NoValue, PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
@@ -20,9 +21,6 @@ const description: JSX.Element = <span>Graphics must have sufficient contrast.</
 
 const howToTest: JSX.Element = (
     <div>
-        Use Accessibility Insights for Windows to verify that each necessary part has a contrast ratio of at least 3:1 against the adjacent
-        background. Exception: A lower contrast ratio is allowed for logos, photos, and other cases where a specific visual presentation is
-        essential.
         <p>The visual helper for this requirement highlights images coded as meaningful.</p>
         <ol>
             <li>
@@ -42,8 +40,8 @@ const howToTest: JSX.Element = (
                     .)
                 </p>
                 <p>
-                    Exception: A lower contrast ratio is allowed for logos, photos, and other cases where a specific visual presentation is
-                    essential.
+                    Exception: A lower contrast ratio is allowed for logos, photos, and other cases where a specific visual presentation is{' '}
+                    <NewTabLink href="https://www.w3.org/TR/WCAG21/#dfn-essential">essential</NewTabLink>.
                 </p>
             </li>
             <AssistedTestRecordYourResults />
@@ -51,7 +49,7 @@ const howToTest: JSX.Element = (
     </div>
 );
 
-const propertyBagConfig: PropertyBagColumnRendererConfig<ImagesOfTextPropertyBag>[] = [
+const propertyBagConfig: PropertyBagColumnRendererConfig<MeaningfulImagePropertyBag>[] = [
     {
         propertyName: 'imageType',
         displayName: 'Image type',
@@ -63,7 +61,7 @@ const propertyBagConfig: PropertyBagColumnRendererConfig<ImagesOfTextPropertyBag
     },
 ];
 
-export const TextAlternative: Requirement = {
+export const Graphics: Requirement = {
     key: ContrastTestStep.graphics,
     name: 'Graphics',
     description,

--- a/src/assessments/contrast/test-steps/graphics.tsx
+++ b/src/assessments/contrast/test-steps/graphics.tsx
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { MacContrastCheckerAppLink, WindowsContrastCheckerAppLink } from 'common/components/contrast-checker-app-links';
+import { ImagesOfTextPropertyBag } from 'common/types/property-bag/image-of-text';
+import { link } from 'content/link';
+import * as content from 'content/test/contrast/ui-components';
+import * as React from 'react';
+
+import { VisualizationType } from '../../../common/types/visualization-type';
+import { AssessmentVisualizationEnabledToggle } from '../../../DetailsView/components/assessment-visualization-enabled-toggle';
+import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';
+import { AssistedTestRecordYourResults } from '../../common/assisted-test-record-your-results';
+import { NoValue, PropertyBagColumnRendererConfig } from '../../common/property-bag-column-renderer';
+import { PropertyBagColumnRendererFactory } from '../../common/property-bag-column-renderer-factory';
+import { ReportInstanceField } from '../../types/report-instance-field';
+import { Requirement } from '../../types/requirement';
+import { ContrastTestStep } from './test-steps';
+
+const description: JSX.Element = <span>Graphics must have sufficient contrast.</span>;
+
+const howToTest: JSX.Element = (
+    <div>
+        Use Accessibility Insights for Windows to verify that each necessary part has a contrast ratio of at least 3:1 against the adjacent
+        background. Exception: A lower contrast ratio is allowed for logos, photos, and other cases where a specific visual presentation is
+        essential.
+        <p>The visual helper for this requirement highlights images coded as meaningful.</p>
+        <ol>
+            <li>
+                In the target page, examine each highlighted image to identify any of the following graphics:
+                <ol>
+                    <li>Stand-alone icons (no text)</li>
+                    <li>Charts</li>
+                    <li>Diagrams</li>
+                    <li>Illustrations</li>
+                </ol>
+            </li>
+            <li>For each graphic, identify the parts that are necessary for the graphic to be understood. (This is subjective.)</li>
+            <li>
+                <p>
+                    Use <WindowsContrastCheckerAppLink /> to verify that each necessary part has a contrast ratio of at least 3:1 against
+                    the adjacent background. (If you are testing on a Mac, you can use the <MacContrastCheckerAppLink />
+                    .)
+                </p>
+                <p>
+                    Exception: A lower contrast ratio is allowed for logos, photos, and other cases where a specific visual presentation is
+                    essential.
+                </p>
+            </li>
+            <AssistedTestRecordYourResults />
+        </ol>
+    </div>
+);
+
+const propertyBagConfig: PropertyBagColumnRendererConfig<ImagesOfTextPropertyBag>[] = [
+    {
+        propertyName: 'imageType',
+        displayName: 'Image type',
+    },
+    {
+        propertyName: 'accessibleName',
+        displayName: 'Accessible name',
+        defaultValue: NoValue,
+    },
+];
+
+export const TextAlternative: Requirement = {
+    key: ContrastTestStep.graphics,
+    name: 'Graphics',
+    description,
+    howToTest,
+    ...content,
+    guidanceLinks: [link.WCAG_1_4_11],
+    isManual: false,
+    columnsConfig: [
+        {
+            key: 'image-info',
+            name: 'Image info',
+            onRender: PropertyBagColumnRendererFactory.getRenderer(propertyBagConfig),
+        },
+    ],
+    reportInstanceFields: ReportInstanceField.fromColumns(propertyBagConfig),
+    getAnalyzer: provider =>
+        provider.createRuleAnalyzer(
+            AnalyzerConfigurationFactory.forScanner({
+                rules: ['accessible-image'],
+                key: ContrastTestStep.graphics,
+                testType: VisualizationType.ContrastAssessment,
+            }),
+        ),
+    getDrawer: provider => provider.createHighlightBoxDrawer(),
+    getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
+};

--- a/src/assessments/contrast/test-steps/test-steps.ts
+++ b/src/assessments/contrast/test-steps/test-steps.ts
@@ -3,4 +3,5 @@
 export const enum ContrastTestStep {
     uiComponents = 'ui-components',
     stateChanges = 'state-changes',
+    graphics = 'graphics',
 }

--- a/src/assessments/images/test-steps/images-of-text.tsx
+++ b/src/assessments/images/test-steps/images-of-text.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ImagesOfTextPropertyBag } from 'common/types/property-bag/image-of-text';
+import { MeaningfulImagePropertyBag } from 'common/types/property-bag/meaningful-image';
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
@@ -32,7 +32,7 @@ const howToTest: JSX.Element = (
 
 const key = ImagesTestStep.imageOfText;
 
-const propertyBagConfig: PropertyBagColumnRendererConfig<ImagesOfTextPropertyBag>[] = [
+const propertyBagConfig: PropertyBagColumnRendererConfig<MeaningfulImagePropertyBag>[] = [
     {
         propertyName: 'imageType',
         displayName: 'Image type',

--- a/src/common/types/property-bag/meaningful-image.ts
+++ b/src/common/types/property-bag/meaningful-image.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { ColumnValueBag } from './column-value-bag';
 
-export interface ImagesOfTextPropertyBag extends ColumnValueBag {
+export interface MeaningfulImagePropertyBag extends ColumnValueBag {
     imageType: string;
     accessibleName: string;
 }

--- a/src/content/test/contrast/graphics.tsx
+++ b/src/content/test/contrast/graphics.tsx
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { create, React } from '../../common';
+
+export const infoAndExamples = create(({ Markup }) => (
+    <>
+        <h1>Graphics</h1>
+        <p>TODO</p>
+    </>
+));

--- a/src/content/test/contrast/index.ts
+++ b/src/content/test/contrast/index.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as graphics from './graphics';
 import { guidance } from './guidance';
 import * as stateChanges from './state-changes';
 import * as uiComponents from './ui-components';
@@ -8,4 +9,5 @@ export const contrast = {
     guidance,
     stateChanges,
     uiComponents,
+    graphics,
 };

--- a/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
@@ -1875,6 +1875,28 @@ exports[`A11Y for content pages High Contrast mode test/automatedChecks/guidance
 </DocumentFragment>
 `;
 
+exports[`A11Y for content pages High Contrast mode test/contrast/graphics/infoAndExamples 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        Cannot find test/contrast/graphics/infoAndExamples
+      </h1>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`A11Y for content pages High Contrast mode test/contrast/guidance 1`] = `
 <DocumentFragment>
   <div
@@ -34292,6 +34314,28 @@ exports[`A11Y for content pages Normal mode test/automatedChecks/guidance 1`] = 
       <p>
         We recommend fixing any issues detected through automated checks before proceeding to the remaining tests, which require human judgement. The human-powered tests are easier, faster, and more reliable when the auto-detected issues have already been eliminated.
       </p>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`A11Y for content pages Normal mode test/contrast/graphics/infoAndExamples 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        Cannot find test/contrast/graphics/infoAndExamples
+      </h1>
     </div>
     <div
       class="content-right"

--- a/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
@@ -1887,8 +1887,11 @@ exports[`A11Y for content pages High Contrast mode test/contrast/graphics/infoAn
       class="content"
     >
       <h1>
-        Cannot find test/contrast/graphics/infoAndExamples
+        Graphics
       </h1>
+      <p>
+        TODO
+      </p>
     </div>
     <div
       class="content-right"
@@ -34334,8 +34337,11 @@ exports[`A11Y for content pages Normal mode test/contrast/graphics/infoAndExampl
       class="content"
     >
       <h1>
-        Cannot find test/contrast/graphics/infoAndExamples
+        Graphics
       </h1>
+      <p>
+        TODO
+      </p>
     </div>
     <div
       class="content-right"


### PR DESCRIPTION
#### Description of changes

Adds the new Graphics requirement, using the existing visualizer rules for meaningful images.

Filled in the test content per the spec document, left the guidance content as a TODO placeholder since we don't have a written yet.

![image](https://user-images.githubusercontent.com/376284/63893195-5a638c80-c99e-11e9-8579-7e3ba0f4ea48.png)

#### Pull request checklist

- [x] Addresses an existing issue: Implements 1590693
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
