### PR TITLE
feat: Introduce new collapsible component for cards UI

### DIFF
--- a/src/DetailsView/components/cards/collapsible-component-cards.scss
+++ b/src/DetailsView/components/cards/collapsible-component-cards.scss
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+@import '../../../common/styles/colors.scss';
+
+.collapsible-container {
+    @mixin transform($property) {
+        -webkit-transform: $property;
+        -ms-transform: $property;
+        transform: $property;
+    }
+
+    %common-control-chevron {
+        display: inline-block;
+        border-right: 1px solid $secondary-text;
+        border-bottom: 1px solid $secondary-text;
+        min-width: 7px;
+        width: 7px;
+        height: 7px;
+        content: '';
+        transform-origin: 50% 50%;
+        transition: transform 0.1s linear 0s;
+    }
+
+    .collapsible-control {
+        font-family: 'Segoe UI Web (West European)', 'Segoe UI', '-apple-system', BlinkMacSystemFont, Roboto, 'Helvetica Neue', Helvetica,
+            Ubuntu, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+        background-color: transparent;
+        cursor: pointer;
+        border: none;
+
+        display: flex;
+        align-items: baseline;
+
+        width: 100%;
+        height: fit-content;
+
+        .result-section-title {
+            padding-left: 14px;
+        }
+
+        &:hover {
+            background-color: $neutral-alpha-4;
+            color: unset;
+        }
+    }
+
+    .collapsible-control[aria-expanded='false']:before {
+        @extend %common-control-chevron;
+        @include transform(rotate(-45deg));
+    }
+
+    .collapsible-control[aria-expanded='true']:before {
+        @extend %common-control-chevron;
+        @include transform(rotate(45deg));
+    }
+
+    .collapsible-content {
+        &[aria-hidden='true'] {
+            display: none;
+        }
+    }
+}
+
+.collapsible-title {
+    padding-left: 0.5vw;
+}

--- a/src/DetailsView/components/cards/collapsible-component-cards.tsx
+++ b/src/DetailsView/components/cards/collapsible-component-cards.tsx
@@ -11,6 +11,7 @@ export interface CollapsibleComponentCardsProps {
     content: JSX.Element;
     contentClassName?: string;
     containerClassName?: string;
+    buttonAriaLabel?: string;
 }
 
 interface CollapsibleComponentCardsState {
@@ -40,7 +41,12 @@ export class CollapsibleComponentCards extends React.Component<CollapsibleCompon
 
         return (
             <div className={css(this.props.containerClassName, collapsibleContainer, collapsedCSSClassName)}>
-                <ActionButton className={collapsibleControl} onClick={this.onClick} aria-expanded={showContent}>
+                <ActionButton
+                    className={collapsibleControl}
+                    onClick={this.onClick}
+                    aria-expanded={showContent}
+                    ariaLabel={this.props.buttonAriaLabel}
+                >
                     <span className={collapsibleTitle}>{this.props.header}</span>
                 </ActionButton>
                 {content}

--- a/src/DetailsView/components/cards/collapsible-component-cards.tsx
+++ b/src/DetailsView/components/cards/collapsible-component-cards.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { css } from '@uifabric/utilities';
+import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import * as React from 'react';
+
+import { collapsibleContainer, collapsibleContent, collapsibleControl, collapsibleTitle } from './collapsible-component-cards.scss';
+
+export interface CollapsibleComponentCardsProps {
+    header: JSX.Element;
+    content: JSX.Element;
+    contentClassName?: string;
+    containerClassName?: string;
+}
+
+interface CollapsibleComponentCardsState {
+    showContent: boolean;
+}
+
+export class CollapsibleComponentCards extends React.Component<CollapsibleComponentCardsProps, CollapsibleComponentCardsState> {
+    constructor(props: CollapsibleComponentCardsProps) {
+        super(props);
+        this.state = { showContent: true };
+    }
+
+    private onClick = (): void => {
+        const newState = !this.state.showContent;
+        this.setState({ showContent: newState });
+    };
+
+    public render(): JSX.Element {
+        const showContent = this.state.showContent;
+        let content = null;
+        let collapsedCSSClassName = 'collapsed';
+
+        if (showContent) {
+            content = <div className={css(this.props.contentClassName, collapsibleContent)}>{this.props.content}</div>;
+            collapsedCSSClassName = null;
+        }
+
+        return (
+            <div className={css(this.props.containerClassName, collapsibleContainer, collapsedCSSClassName)}>
+                <ActionButton className={collapsibleControl} onClick={this.onClick} aria-expanded={showContent}>
+                    <span className={collapsibleTitle}>{this.props.header}</span>
+                </ActionButton>
+                {content}
+            </div>
+        );
+    }
+}

--- a/src/DetailsView/components/cards/rules-with-instances-v2.scss
+++ b/src/DetailsView/components/cards/rules-with-instances-v2.scss
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../common/styles/colors.scss';
+@import '../../../common/styles/fonts.scss';
+
+.rule-details-group {
+    :global(.rule-detail) {
+        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+        font-size: 14px;
+
+        padding: 16px 8px;
+
+        display: flex;
+        align-items: center;
+
+        .outcome-chip {
+            vertical-align: middle;
+            margin-bottom: 2px;
+        }
+
+        .rule-details-id {
+            font-family: $semiBoldFontFamily;
+            color: $primary-text;
+
+            a {
+                font-family: $semiBoldFontFamily;
+                color: $primary-text !important;
+            }
+        }
+
+        .rule-detail-description {
+            color: $secondary-text !important;
+        }
+
+        .guidance-links {
+            a {
+                color: $secondary-text !important;
+            }
+        }
+    }
+}
+
+.collapsible-rule-details-group {
+    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
+
+    global {
+        .rule-detail {
+            box-shadow: unset;
+        }
+
+        &:not(.collapsed) {
+            box-shadow: unset;
+        }
+    }
+}

--- a/src/DetailsView/components/cards/rules-with-instances-v2.tsx
+++ b/src/DetailsView/components/cards/rules-with-instances-v2.tsx
@@ -1,15 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { css } from '@uifabric/utilities';
 import { NamedSFC } from 'common/react/named-sfc';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 
 import { InstanceOutcomeType } from '../../../reports/components/instance-outcome-type';
 import { outcomeTypeSemantics } from '../../../reports/components/outcome-type';
-import { CollapsibleContainer } from '../../../reports/components/report-sections/collapsible-container';
 import { MinimalRuleHeader } from '../../../reports/components/report-sections/minimal-rule-header';
+import { CollapsibleComponentCards } from './collapsible-component-cards';
 import { UnifiedRuleResult } from './failed-instances-section-v2';
 import { RuleContentV2, RuleContentV2Deps } from './rule-content-v2';
+import { collapsibleRuleDetailsGroup, ruleDetailsGroup } from './rules-with-instances-v2.scss';
 
 export type RulesWithInstancesV2Deps = RuleContentV2Deps;
 
@@ -24,16 +26,16 @@ export const RulesWithInstancesV2 = NamedSFC<RulesWithInstancesV2Props>(
     'RulesWithInstancesV2',
     ({ rules, outcomeType, fixInstructionProcessor, deps }) => {
         return (
-            <div className="rule-details-group">
+            <div className={ruleDetailsGroup}>
                 {rules.map((rule, idx) => {
                     const { pastTense } = outcomeTypeSemantics[outcomeType];
                     const buttonAriaLabel = `${rule.id} ${rule.nodes.length} ${pastTense} ${rule.description}`;
                     return (
-                        <CollapsibleContainer
+                        <CollapsibleComponentCards
                             key={`summary-details-${idx + 1}`}
                             id={rule.id}
-                            visibleHeadingContent={<MinimalRuleHeader key={rule.id} rule={rule} outcomeType={outcomeType} />}
-                            collapsibleContent={
+                            header={<MinimalRuleHeader key={rule.id} rule={rule} outcomeType={outcomeType} />}
+                            content={
                                 <RuleContentV2
                                     key={`${rule.id}-rule-group`}
                                     deps={deps}
@@ -41,9 +43,8 @@ export const RulesWithInstancesV2 = NamedSFC<RulesWithInstancesV2Props>(
                                     fixInstructionProcessor={fixInstructionProcessor}
                                 />
                             }
-                            containerClassName="collapsible-rule-details-group"
+                            containerClassName={css(collapsibleRuleDetailsGroup)}
                             titleHeadingLevel={3}
-                            buttonAriaLabel={buttonAriaLabel}
                         />
                     );
                 })}

--- a/src/DetailsView/components/cards/rules-with-instances-v2.tsx
+++ b/src/DetailsView/components/cards/rules-with-instances-v2.tsx
@@ -44,6 +44,7 @@ export const RulesWithInstancesV2 = NamedSFC<RulesWithInstancesV2Props>(
                                 />
                             }
                             containerClassName={css(collapsibleRuleDetailsGroup)}
+                            buttonAriaLabel={buttonAriaLabel}
                             titleHeadingLevel={3}
                         />
                     );

--- a/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/rules-with-instances-v2.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/rules-with-instances-v2.test.tsx.snap
@@ -2,11 +2,11 @@
 
 exports[`RulesWithInstancesV2 renders 1`] = `
 <div
-  className="rule-details-group"
+  className="ruleDetailsGroup"
 >
-  <CollapsibleContainer
-    buttonAriaLabel="some-rule 1 Passed sample-description"
-    collapsibleContent={
+  <CollapsibleComponentCards
+    containerClassName="collapsibleRuleDetailsGroup"
+    content={
       <RuleContentV2
         deps={Object {}}
         fixInstructionProcessor={
@@ -54,10 +54,7 @@ exports[`RulesWithInstancesV2 renders 1`] = `
         }
       />
     }
-    containerClassName="collapsible-rule-details-group"
-    id="some-rule"
-    titleHeadingLevel={3}
-    visibleHeadingContent={
+    header={
       <MinimalRuleHeader
         outcomeType="pass"
         rule={
@@ -94,6 +91,8 @@ exports[`RulesWithInstancesV2 renders 1`] = `
         }
       />
     }
+    id="some-rule"
+    titleHeadingLevel={3}
   />
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/rules-with-instances-v2.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/rules-with-instances-v2.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`RulesWithInstancesV2 renders 1`] = `
   className="ruleDetailsGroup"
 >
   <CollapsibleComponentCards
+    buttonAriaLabel="some-rule 1 Passed sample-description"
     containerClassName="collapsibleRuleDetailsGroup"
     content={
       <RuleContentV2

--- a/src/tests/unit/tests/DetailsView/components/cards/rules-with-instances-v2.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/cards/rules-with-instances-v2.test.tsx
@@ -27,7 +27,6 @@ describe('RulesWithInstancesV2', () => {
                 rules={rules}
             />,
         );
-
         expect(wrapped.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/common/components/__snapshots__/collapsible-component-cards.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/collapsible-component-cards.test.tsx.snap
@@ -1,11 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CollapsibleComponentCardsTest render expanded with content-class-name 1`] = `
+exports[`CollapsibleComponentCardsTest render with buttonAriaLabel set to: some button label 1`] = `
 <div
   className="collapsibleContainer"
 >
   <CustomizedActionButton
     aria-expanded={true}
+    ariaLabel="some button label"
     className="collapsibleControl"
     onClick={[Function]}
   >
@@ -18,7 +19,7 @@ exports[`CollapsibleComponentCardsTest render expanded with content-class-name 1
     </span>
   </CustomizedActionButton>
   <div
-    className="content-class-name-a collapsibleContent"
+    className="collapsibleContent"
   >
     <div>
       Some content
@@ -27,7 +28,7 @@ exports[`CollapsibleComponentCardsTest render expanded with content-class-name 1
 </div>
 `;
 
-exports[`CollapsibleComponentCardsTest render expanded without content-class-name 1`] = `
+exports[`CollapsibleComponentCardsTest render with buttonAriaLabel set to: undefined 1`] = `
 <div
   className="collapsibleContainer"
 >
@@ -54,7 +55,7 @@ exports[`CollapsibleComponentCardsTest render expanded without content-class-nam
 </div>
 `;
 
-exports[`CollapsibleComponentCardsTest render with container-class-name 1`] = `
+exports[`CollapsibleComponentCardsTest render with containerClassName set to: a-container 1`] = `
 <div
   className="a-container collapsibleContainer"
 >
@@ -81,7 +82,61 @@ exports[`CollapsibleComponentCardsTest render with container-class-name 1`] = `
 </div>
 `;
 
-exports[`CollapsibleComponentCardsTest render without container-class-name 1`] = `
+exports[`CollapsibleComponentCardsTest render with containerClassName set to: undefined 1`] = `
+<div
+  className="collapsibleContainer"
+>
+  <CustomizedActionButton
+    aria-expanded={true}
+    className="collapsibleControl"
+    onClick={[Function]}
+  >
+    <span
+      className="collapsibleTitle"
+    >
+      <div>
+        Some header
+      </div>
+    </span>
+  </CustomizedActionButton>
+  <div
+    className="collapsibleContent"
+  >
+    <div>
+      Some content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollapsibleComponentCardsTest render with contentClassName set to: content-class-name-a 1`] = `
+<div
+  className="collapsibleContainer"
+>
+  <CustomizedActionButton
+    aria-expanded={true}
+    className="collapsibleControl"
+    onClick={[Function]}
+  >
+    <span
+      className="collapsibleTitle"
+    >
+      <div>
+        Some header
+      </div>
+    </span>
+  </CustomizedActionButton>
+  <div
+    className="content-class-name-a collapsibleContent"
+  >
+    <div>
+      Some content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollapsibleComponentCardsTest render with contentClassName set to: undefined 1`] = `
 <div
   className="collapsibleContainer"
 >

--- a/src/tests/unit/tests/common/components/__snapshots__/collapsible-component-cards.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/collapsible-component-cards.test.tsx.snap
@@ -1,0 +1,156 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CollapsibleComponentCardsTest render expanded with content-class-name 1`] = `
+<div
+  className="collapsibleContainer"
+>
+  <CustomizedActionButton
+    aria-expanded={true}
+    className="collapsibleControl"
+    onClick={[Function]}
+  >
+    <span
+      className="collapsibleTitle"
+    >
+      <div>
+        Some header
+      </div>
+    </span>
+  </CustomizedActionButton>
+  <div
+    className="content-class-name-a collapsibleContent"
+  >
+    <div>
+      Some content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollapsibleComponentCardsTest render expanded without content-class-name 1`] = `
+<div
+  className="collapsibleContainer"
+>
+  <CustomizedActionButton
+    aria-expanded={true}
+    className="collapsibleControl"
+    onClick={[Function]}
+  >
+    <span
+      className="collapsibleTitle"
+    >
+      <div>
+        Some header
+      </div>
+    </span>
+  </CustomizedActionButton>
+  <div
+    className="collapsibleContent"
+  >
+    <div>
+      Some content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollapsibleComponentCardsTest render with container-class-name 1`] = `
+<div
+  className="a-container collapsibleContainer"
+>
+  <CustomizedActionButton
+    aria-expanded={true}
+    className="collapsibleControl"
+    onClick={[Function]}
+  >
+    <span
+      className="collapsibleTitle"
+    >
+      <div>
+        Some header
+      </div>
+    </span>
+  </CustomizedActionButton>
+  <div
+    className="collapsibleContent"
+  >
+    <div>
+      Some content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollapsibleComponentCardsTest render without container-class-name 1`] = `
+<div
+  className="collapsibleContainer"
+>
+  <CustomizedActionButton
+    aria-expanded={true}
+    className="collapsibleControl"
+    onClick={[Function]}
+  >
+    <span
+      className="collapsibleTitle"
+    >
+      <div>
+        Some header
+      </div>
+    </span>
+  </CustomizedActionButton>
+  <div
+    className="collapsibleContent"
+  >
+    <div>
+      Some content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: collapsed 1`] = `
+<div
+  className="collapsibleContainer collapsed"
+>
+  <CustomizedActionButton
+    aria-expanded={false}
+    className="collapsibleControl"
+    onClick={[Function]}
+  >
+    <span
+      className="collapsibleTitle"
+    >
+      <div>
+        Some header
+      </div>
+    </span>
+  </CustomizedActionButton>
+</div>
+`;
+
+exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: expanded 1`] = `
+<div
+  className="collapsibleContainer"
+>
+  <CustomizedActionButton
+    aria-expanded={true}
+    className="collapsibleControl"
+    onClick={[Function]}
+  >
+    <span
+      className="collapsibleTitle"
+    >
+      <div>
+        Some header
+      </div>
+    </span>
+  </CustomizedActionButton>
+  <div
+    className="collapsibleContent"
+  >
+    <div>
+      Some content
+    </div>
+  </div>
+</div>
+`;

--- a/src/tests/unit/tests/common/components/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/collapsible-component-cards.test.tsx
@@ -3,50 +3,32 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
+import { forOwn } from 'lodash';
 import {
     CollapsibleComponentCards,
     CollapsibleComponentCardsProps,
 } from '../../../../../DetailsView/components/cards/collapsible-component-cards';
 
 describe('CollapsibleComponentCardsTest', () => {
-    test('render expanded with content-class-name', () => {
-        const props: CollapsibleComponentCardsProps = {
-            header: <div>Some header</div>,
-            content: <div>Some content</div>,
-            contentClassName: 'content-class-name-a',
-        };
-        const result = shallow(<CollapsibleComponentCards {...props} />);
-        expect(result.getElement()).toMatchSnapshot();
-    });
+    const optionalPropertiesObject = {
+        contentClassName: [undefined, 'content-class-name-a'],
+        containerClassName: [undefined, 'a-container'],
+        buttonAriaLabel: [undefined, 'some button label'],
+    };
 
-    test('render expanded without content-class-name', () => {
-        const props: CollapsibleComponentCardsProps = {
-            header: <div>Some header</div>,
-            content: <div>Some content</div>,
-        };
-        const result = shallow(<CollapsibleComponentCards {...props} />);
-        expect(result.getElement()).toMatchSnapshot();
-    });
+    forOwn(optionalPropertiesObject, (propertyValues, propertyName) => {
+        propertyValues.forEach(value => {
+            test(`render with ${propertyName} set to: ${value}`, () => {
+                const props: CollapsibleComponentCardsProps = {
+                    header: <div>Some header</div>,
+                    content: <div>Some content</div>,
+                    [propertyName]: value,
+                };
 
-    test('render with container-class-name', () => {
-        const props: CollapsibleComponentCardsProps = {
-            header: <div>Some header</div>,
-            content: <div>Some content</div>,
-            containerClassName: 'a-container',
-        };
-
-        const result = shallow(<CollapsibleComponentCards {...props} />);
-        expect(result.getElement()).toMatchSnapshot();
-    });
-
-    test('render without container-class-name', () => {
-        const props: CollapsibleComponentCardsProps = {
-            header: <div>Some header</div>,
-            content: <div>Some content</div>,
-        };
-
-        const result = shallow(<CollapsibleComponentCards {...props} />);
-        expect(result.getElement()).toMatchSnapshot();
+                const result = shallow(<CollapsibleComponentCards {...props} />);
+                expect(result.getElement()).toMatchSnapshot();
+            });
+        });
     });
 
     test('toggle from expanded to collapsed', () => {

--- a/src/tests/unit/tests/common/components/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/collapsible-component-cards.test.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import {
+    CollapsibleComponentCards,
+    CollapsibleComponentCardsProps,
+} from '../../../../../DetailsView/components/cards/collapsible-component-cards';
+
+describe('CollapsibleComponentCardsTest', () => {
+    test('render expanded with content-class-name', () => {
+        const props: CollapsibleComponentCardsProps = {
+            header: <div>Some header</div>,
+            content: <div>Some content</div>,
+            contentClassName: 'content-class-name-a',
+        };
+        const result = shallow(<CollapsibleComponentCards {...props} />);
+        expect(result.getElement()).toMatchSnapshot();
+    });
+
+    test('render expanded without content-class-name', () => {
+        const props: CollapsibleComponentCardsProps = {
+            header: <div>Some header</div>,
+            content: <div>Some content</div>,
+        };
+        const result = shallow(<CollapsibleComponentCards {...props} />);
+        expect(result.getElement()).toMatchSnapshot();
+    });
+
+    test('render with container-class-name', () => {
+        const props: CollapsibleComponentCardsProps = {
+            header: <div>Some header</div>,
+            content: <div>Some content</div>,
+            containerClassName: 'a-container',
+        };
+
+        const result = shallow(<CollapsibleComponentCards {...props} />);
+        expect(result.getElement()).toMatchSnapshot();
+    });
+
+    test('render without container-class-name', () => {
+        const props: CollapsibleComponentCardsProps = {
+            header: <div>Some header</div>,
+            content: <div>Some content</div>,
+        };
+
+        const result = shallow(<CollapsibleComponentCards {...props} />);
+        expect(result.getElement()).toMatchSnapshot();
+    });
+
+    test('toggle from expanded to collapsed', () => {
+        const props: CollapsibleComponentCardsProps = {
+            header: <div>Some header</div>,
+            content: <div>Some content</div>,
+        };
+        const result = shallow(<CollapsibleComponentCards {...props} />);
+        expect(result.getElement()).toMatchSnapshot('expanded');
+        const button = result.find('CustomizedActionButton');
+        button.simulate('click');
+        expect(result.getElement()).toMatchSnapshot('collapsed');
+    });
+});


### PR DESCRIPTION
#### Description of changes

Re-uses the original collapsible component we have but modifies classes heavily based on the styles we are using in the report. As such, made sense to separate this out. Eventually, I can see the collapsible styles from details-view belonging to a component that wraps this component with the styles in it's own scss files.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
