### PR TITLE
chore: make minor change to better debug failing e2e test on linux system

### DIFF
--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -184,8 +184,8 @@ export class Page {
     }
 
     public async clickSelector(selector: string): Promise<void> {
-        const element = await this.waitForSelector(selector);
         await this.screenshotOnError(async () => {
+            const element = await this.waitForSelector(selector);
             await element.click();
         });
     }


### PR DESCRIPTION
#### Description of changes

This change is to wrap the `clickSelector`'s `waitForSelector` call; that we use everywhere in the `takeScreenshotOnError` function to know why a `clickSelector` failed by looking at the generated screenshot.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
