### PR TITLE
chore: upgrade ts from 3.5.3 to 3.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
         "tslint-microsoft-contrib": "6.2.0",
         "typed-scss-modules": "^0.0.11",
         "typemoq": "^2.1.0",
-        "typescript": "^3.5.3",
+        "typescript": "^3.6.2",
         "webdriverio": "^4.13.0",
         "webpack": "^4.39.3",
         "webpack-cli": "^3.3.7"

--- a/src/tests/unit/tests/injected/visualization/drawer.test.ts
+++ b/src/tests/unit/tests/injected/visualization/drawer.test.ts
@@ -921,7 +921,7 @@ describe('Drawer', () => {
         // invoke scroll listener
         let timeOutCallback: Function;
         const timeOutId = 10;
-        const registerTimeOutHandlerFunc: typeof window.setTimeout = (handler, timeout, ...args): number => {
+        const registerTimeOutHandlerFunc = (handler, timeout, ...args): number => {
             timeOutCallback = handler as Function;
             return timeout;
         };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8560,10 +8560,10 @@ typemoq@^2.1.0:
     lodash "^4.17.4"
     postinstall-build "^5.0.1"
 
-typescript@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
-  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
+typescript@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
+  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
 
 typeson-registry@^1.0.0-alpha.20:
   version "1.0.0-alpha.28"


### PR DESCRIPTION
#### Description of changes

- upgrade Typescript from 3.5.3 to 3.6.2
- make it happen by removing a function's type which was `typeof window.setTimeout`.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
