### PR TITLE
fix: set tabId of unified results store

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -239,6 +239,7 @@ if (isNaN(tabId) === false) {
             assessmentStore.setTabId(tab.id);
             scopingStore.setTabId(tab.id);
             inspectStore.setTabId(tab.id);
+            unifiedScanResultStore.setTabId(tab.id);
 
             const actionInitiators = {
                 ...contentActionMessageCreator.initiators,


### PR DESCRIPTION
## Description of changes

We were missing the tab id in our unified results store. This leads to problems where opening a new tab resets the existing store state. This PR adds the tab id to our store so that messages are appropriately scoped to their tabs. We should consider refactoring this in the future so that the tab id is not set separately from the constructor.

#### Pull request checklist

- [] Addresses an existing issue: Fixes #0000
- [] Added relevant unit test for your changes. (`yarn test`)
- [] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
