### PR TITLE
feat: view model provider handles null case separately than empty/pass scenario

### DIFF
--- a/src/DetailsView/components/cards/failed-instances-section-v2.tsx
+++ b/src/DetailsView/components/cards/failed-instances-section-v2.tsx
@@ -26,6 +26,10 @@ export type UnifiedStatusResults = {
 };
 
 export const FailedInstancesSectionV2 = NamedSFC<FailedInstancesSectionV2Props>('FailedInstancesSectionV2', ({ result, deps }) => {
+    if (result == null) {
+        return null;
+    }
+
     return (
         <ResultSectionV2
             deps={deps}

--- a/src/common/rule-based-view-model-provider.ts
+++ b/src/common/rule-based-view-model-provider.ts
@@ -9,11 +9,15 @@ export const getUnifiedRuleResults: GetUnifiedRuleResultsDelegate = function(
     rules: UnifiedRule[],
     results: UnifiedResult[],
 ): UnifiedStatusResults {
+    if (results == null || rules == null) {
+        return null;
+    }
+
     const statusResults = getEmptyStatusResults();
     const ruleIdsWithResultNodes: Set<string> = new Set();
 
-    const resultList = results || [];
-    const ruleList = rules || [];
+    const resultList = results;
+    const ruleList = rules;
 
     for (const result of resultList) {
         const ruleResults = statusResults[result.status];

--- a/src/common/rule-based-view-model-provider.ts
+++ b/src/common/rule-based-view-model-provider.ts
@@ -16,17 +16,14 @@ export const getUnifiedRuleResults: GetUnifiedRuleResultsDelegate = function(
     const statusResults = getEmptyStatusResults();
     const ruleIdsWithResultNodes: Set<string> = new Set();
 
-    const resultList = results;
-    const ruleList = rules;
-
-    for (const result of resultList) {
+    for (const result of results) {
         const ruleResults = statusResults[result.status];
         const ruleResultIndex: number = getRuleResultIndex(result, ruleResults);
 
         if (ruleResultIndex !== -1) {
             ruleResults[ruleResultIndex].nodes.push(result);
         } else {
-            const unifiedRule: UnifiedRule = getUnifiedRule(result.ruleId, ruleList);
+            const unifiedRule: UnifiedRule = getUnifiedRule(result.ruleId, rules);
             if (unifiedRule) {
                 ruleResults.push(createUnifiedRuleResult(result, unifiedRule));
             }
@@ -35,7 +32,7 @@ export const getUnifiedRuleResults: GetUnifiedRuleResultsDelegate = function(
         ruleIdsWithResultNodes.add(result.ruleId);
     }
 
-    for (const rule of ruleList) {
+    for (const rule of rules) {
         if (!ruleIdsWithResultNodes.has(rule.id)) {
             statusResults.inapplicable.push(createRuleResultWithoutNodes('inapplicable', rule));
         }

--- a/src/tests/unit/common/rule-based-view-model-provider.test.ts
+++ b/src/tests/unit/common/rule-based-view-model-provider.test.ts
@@ -5,17 +5,24 @@ import { InstanceResultStatus, UnifiedResult, UnifiedRule } from '../../../commo
 import { UnifiedRuleResult, UnifiedStatusResults } from '../../../DetailsView/components/cards/failed-instances-section-v2';
 
 describe('RuleBasedViewModelProvider', () => {
-    test('getUnifiedRuleResults with null inputs', () => {
-        const emptyResults: UnifiedStatusResults = {
-            fail: [],
-            pass: [],
-            inapplicable: [],
-            unknown: [],
-        };
+    test('getUnifiedRuleResults with null rules and results', () => {
         const actualResults: UnifiedStatusResults = getUnifiedRuleResults(null, null);
 
-        expect(actualResults).toEqual(emptyResults);
+        expect(actualResults).toEqual(null);
     });
+
+    test('getUnifiedRuleResults with null rules', () => {
+        const actualResults: UnifiedStatusResults = getUnifiedRuleResults(null, []);
+
+        expect(actualResults).toEqual(null);
+    });
+
+    test('getUnifiedRuleResults with null results', () => {
+        const actualResults: UnifiedStatusResults = getUnifiedRuleResults([], null);
+
+        expect(actualResults).toEqual(null);
+    });
+
     test('getUnifiedRuleResults', () => {
         const rules = getSampleRules();
 

--- a/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/failed-instances-section-v2.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/failed-instances-section-v2.test.tsx.snap
@@ -43,3 +43,5 @@ exports[`FailedInstancesSectionV2 renders 1`] = `
   title="Failed instances"
 />
 `;
+
+exports[`FailedInstancesSectionV2 renders null when result is null 1`] = `null`;

--- a/src/tests/unit/tests/DetailsView/components/cards/failed-instances-section-v2.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/cards/failed-instances-section-v2.test.tsx
@@ -26,4 +26,15 @@ describe('FailedInstancesSectionV2', () => {
 
         expect(wrapper.getElement()).toMatchSnapshot();
     });
+
+    it('renders null when result is null', () => {
+        const props: FailedInstancesSectionV2Props = {
+            deps: {} as FailedInstancesSectionV2Deps,
+            result: null,
+        };
+
+        const wrapper = shallow(<FailedInstancesSectionV2 {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Description of changes

Previously, we were treating the null scenario as the empty scenario and this was causing some issues in the UI.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
