### PR TITLE
Update failure count instance in cards UI so it includes number of elements instead of number of rules

### DIFF
--- a/src/DetailsView/components/cards/failed-instances-section-v2.tsx
+++ b/src/DetailsView/components/cards/failed-instances-section-v2.tsx
@@ -26,6 +26,9 @@ export type UnifiedStatusResults = {
 };
 
 export const FailedInstancesSectionV2 = NamedSFC<FailedInstancesSectionV2Props>('FailedInstancesSectionV2', ({ result, deps }) => {
+    const count = result.fail.reduce((total, rule) => {
+        return total + rule.nodes.length;
+    }, 0);
     return (
         <ResultSectionV2
             deps={deps}
@@ -33,7 +36,7 @@ export const FailedInstancesSectionV2 = NamedSFC<FailedInstancesSectionV2Props>(
             results={result.fail}
             containerClassName={null}
             outcomeType="fail"
-            badgeCount={result.fail.length}
+            badgeCount={count}
         />
     );
 });

--- a/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/failed-instances-section-v2.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/failed-instances-section-v2.test.tsx.snap
@@ -2,12 +2,42 @@
 
 exports[`FailedInstancesSectionV2 renders 1`] = `
 <ResultSectionV2
-  badgeCount={1}
+  badgeCount={2}
   containerClassName={null}
   deps={Object {}}
   outcomeType="fail"
   results={
     Array [
+      Object {
+        "description": "sample-description",
+        "guidance": Array [],
+        "id": "some-rule",
+        "nodes": Array [
+          Object {
+            "descriptors": Object {
+              "snippet": "this is a sample snippet",
+            },
+            "identifiers": Object {
+              "css-selector": "body img",
+            },
+            "resolution": Object {
+              "how-to-fix-web": Object {
+                "all": Array [],
+                "any": Array [
+                  "Element does not have an alt attribute",
+                  "aria-label attribute does not exist or is empty",
+                  "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty",
+                ],
+                "none": Array [],
+              },
+            },
+            "ruleId": "image-alt",
+            "status": "fail",
+            "uid": "some-guid-here",
+          },
+        ],
+        "url": "sample-url",
+      },
       Object {
         "description": "sample-description",
         "guidance": Array [],

--- a/src/tests/unit/tests/DetailsView/components/cards/failed-instances-section-v2.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/cards/failed-instances-section-v2.test.tsx
@@ -16,7 +16,7 @@ describe('FailedInstancesSectionV2', () => {
             deps: {} as FailedInstancesSectionV2Deps,
             result: {
                 pass: [],
-                fail: [exampleUnifiedRuleResult],
+                fail: [exampleUnifiedRuleResult, exampleUnifiedRuleResult],
                 inapplicable: [],
                 unknown: [],
             },


### PR DESCRIPTION
#### Description of changes

This PR updates the failure instance count so it includes the flattened list of results, not the number of rules.

![screenshot of failure instance panel](https://user-images.githubusercontent.com/7775527/63976181-99a8e080-ca65-11e9-8904-94ec41325905.png)


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
