### PR TITLE
refactor: improve StoreActionMessageCreatorFactory API

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -174,7 +174,7 @@ if (isNaN(tabId) === false) {
             );
 
             const userConfigMessageCreator = new UserConfigMessageCreator(actionMessageDispatcher);
-            const storeActionMessageCreator = storeActionMessageCreatorFactory.forDetailsView();
+            const storeActionMessageCreator = storeActionMessageCreatorFactory.fromStores(storesHub.stores);
 
             const visualizationActionCreator = new VisualizationActionMessageCreator(actionMessageDispatcher);
 

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -80,7 +80,7 @@ export class ActionCreator {
         this.registerTypeToPayloadCallback(visualizationMessages.State.InjectionCompleted, this.injectionCompleted);
         this.registerTypeToPayloadCallback(visualizationMessages.State.InjectionStarted, this.injectionStarted);
         this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.VisualizationStore), this.getVisualizationToggleCurrentState);
-        this.registerTypeToPayloadCallback(visualizationMessages.State.GetCurrentVisualizationResultState, this.getScanResultsCurrentState);
+        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.VisualizationScanResultStore), this.getScanResultsCurrentState);
 
         this.registerTypeToPayloadCallback(visualizationMessages.TabStops.TabbedElementAdded, this.onTabbedElementAdded);
         this.registerTypeToPayloadCallback(visualizationMessages.TabStops.RecordingCompleted, this.onRecordingCompleted);

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -3,8 +3,9 @@
 import { TestMode } from '../../common/configs/test-mode';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
 import { NotificationCreator } from '../../common/notification-creator';
+import { StoreNames } from '../../common/stores/store-names';
 import * as TelemetryEvents from '../../common/telemetry-events';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { ScanCompletedPayload } from '../../injected/analyzers/analyzer';
@@ -78,10 +79,7 @@ export class ActionCreator {
 
         this.registerTypeToPayloadCallback(visualizationMessages.State.InjectionCompleted, this.injectionCompleted);
         this.registerTypeToPayloadCallback(visualizationMessages.State.InjectionStarted, this.injectionStarted);
-        this.registerTypeToPayloadCallback(
-            visualizationMessages.State.GetCurrentVisualizationToggleState,
-            this.getVisualizationToggleCurrentState,
-        );
+        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.VisualizationStore), this.getVisualizationToggleCurrentState);
         this.registerTypeToPayloadCallback(visualizationMessages.State.GetCurrentVisualizationResultState, this.getScanResultsCurrentState);
 
         this.registerTypeToPayloadCallback(visualizationMessages.TabStops.TabbedElementAdded, this.onTabbedElementAdded);

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 import { capitalize } from 'lodash';
 import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { StoreNames } from '../../common/stores/store-names';
 import * as TelemetryEvents from '../../common/telemetry-events';
 import { ScanBasePayload, ScanCompletedPayload, ScanUpdatePayload } from '../../injected/analyzers/analyzer';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
@@ -41,7 +42,7 @@ export class AssessmentActionCreator {
 
     public registerCallbacks(): void {
         this.registerTypeToPayloadCallback(AssessmentMessages.SelectTestRequirement, this.onSelectTestStep);
-        this.registerTypeToPayloadCallback(AssessmentMessages.GetCurrentState, this.onGetAssessmentCurrentState);
+        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.AssessmentStore), this.onGetAssessmentCurrentState);
         this.registerTypeToPayloadCallback(AssessmentMessages.AssessmentScanCompleted, this.onAssessmentScanCompleted);
         this.registerTypeToPayloadCallback(AssessmentMessages.StartOver, this.onStartOverAssessment);
         this.registerTypeToPayloadCallback(AssessmentMessages.StartOverAllAssessments, this.onStartOverAllAssessments);

--- a/src/background/actions/details-view-action-creator.ts
+++ b/src/background/actions/details-view-action-creator.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { StoreNames } from '../../common/stores/store-names';
 import { SETTINGS_PANEL_CLOSE, SETTINGS_PANEL_OPEN } from '../../common/telemetry-events';
 import { DetailsViewRightContentPanelType } from '../../DetailsView/components/left-nav/details-view-right-content-panel-type';
 import { DetailsViewController } from '../details-view-controller';
@@ -20,7 +21,7 @@ export class DetailsViewActionCreator {
     public registerCallback(): void {
         this.registerTypeToPayloadCallback(Messages.SettingsPanel.OpenPanel, this.onOpenSettingsPanel);
         this.registerTypeToPayloadCallback(Messages.SettingsPanel.ClosePanel, this.onCloseSettingsPanel);
-        this.registerTypeToPayloadCallback(Messages.Visualizations.DetailsView.GetState, this.onGetDetailsViewCurrentState);
+        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.DetailsViewStore), this.onGetDetailsViewCurrentState);
         this.registerTypeToPayloadCallback(
             Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
             this.onSetDetailsViewRightContentPanel,

--- a/src/background/actions/dev-tools-action-creator.ts
+++ b/src/background/actions/dev-tools-action-creator.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { StoreNames } from '../../common/stores/store-names';
 import * as TelemetryEvents from '../../common/telemetry-events';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { InspectElementPayload, InspectFrameUrlPayload, OnDevToolOpenPayload } from './action-payloads';
@@ -29,7 +30,7 @@ export class DevToolsActionCreator {
 
         this.registerTypeToPayloadCallback(Messages.DevTools.InspectFrameUrl, payload => this.onDevToolInspectFrameUrl(payload));
 
-        this.registerTypeToPayloadCallback(Messages.DevTools.Get, () => this.onDevToolGetCurrentState());
+        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.DevToolsStore), () => this.onDevToolGetCurrentState());
     }
 
     private onDevToolOpened(payload: OnDevToolOpenPayload): void {

--- a/src/background/actions/inspect-action-creator.ts
+++ b/src/background/actions/inspect-action-creator.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
 import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { StoreNames } from '../../common/stores/store-names';
 import * as TelemetryEvents from '../../common/telemetry-events';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { InspectActions, InspectPayload } from './inspect-actions';
@@ -29,7 +30,7 @@ export class InspectActionCreator {
         this.registerTypeToPayloadCallback(Messages.Inspect.ChangeInspectMode, (payload: InspectPayload, tabId: number) =>
             this.onChangeInspectMode(payload, tabId),
         );
-        this.registerTypeToPayloadCallback(Messages.Inspect.GetCurrentState, () => this.onGetInspectCurrentState());
+        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.InspectStore), () => this.onGetInspectCurrentState());
     }
 
     private onChangeInspectMode(payload: InspectPayload, tabId: number): void {

--- a/src/background/actions/path-snippet-action-creator.ts
+++ b/src/background/actions/path-snippet-action-creator.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { StoreNames } from '../../common/stores/store-names';
 import { PathSnippetActions } from './path-snippet-actions';
 
 export class PathSnippetActionCreator {
@@ -11,7 +12,7 @@ export class PathSnippetActionCreator {
     ) {}
 
     public registerCallbacks(): void {
-        this.registerTypeToPayloadCallback(Messages.PathSnippet.GetCurrentState, this.onGetPathSnippetCurrentState);
+        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.PathSnippetStore), this.onGetPathSnippetCurrentState);
         this.registerTypeToPayloadCallback(Messages.PathSnippet.AddPathForValidation, this.onAddPathForValidation);
         this.registerTypeToPayloadCallback(Messages.PathSnippet.AddCorrespondingSnippet, this.onAddCorrespondingSnippet);
         this.registerTypeToPayloadCallback(Messages.PathSnippet.ClearPathSnippetData, this.onClearPathSnippetData);

--- a/src/background/actions/tab-action-creator.ts
+++ b/src/background/actions/tab-action-creator.ts
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
 import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { StoreNames } from '../../common/stores/store-names';
 import { SWITCH_BACK_TO_TARGET } from '../../common/telemetry-events';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { SwitchToTargetTabPayload } from './action-payloads';
@@ -28,7 +29,7 @@ export class TabActionCreator {
 
     public registerCallbacks(): void {
         this.registerTypeToPayloadCallback(Messages.Tab.Update, payload => this.tabActions.tabUpdate.invoke(payload));
-        this.registerTypeToPayloadCallback(Messages.Tab.GetCurrent, () => this.tabActions.getCurrentState.invoke(null));
+        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.TabStore), () => this.tabActions.getCurrentState.invoke(null));
         this.registerTypeToPayloadCallback(Messages.Tab.Remove, () => this.tabActions.tabRemove.invoke(null));
         this.registerTypeToPayloadCallback(Messages.Tab.Change, payload => this.tabActions.tabChange.invoke(payload));
         this.registerTypeToPayloadCallback(Messages.Tab.Switch, (payload, tabId) => this.onSwitchToTargetTab(payload, tabId));

--- a/src/background/actions/unified-scan-result-action-creator.ts
+++ b/src/background/actions/unified-scan-result-action-creator.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { StoreNames } from '../../common/stores/store-names';
 import { UnifiedScanCompletedPayload } from './action-payloads';
 import { UnifiedScanResultActions } from './unified-scan-result-actions';
 
@@ -13,7 +14,7 @@ export class UnifiedScanResultActionCreator {
 
     public registerCallbacks(): void {
         this.registerTypeToPayloadCallback(Messages.UnifiedScan.ScanCompleted, this.onScanCompleted);
-        this.registerTypeToPayloadCallback(Messages.UnifiedScan.GetCurrentState, this.onGetScanCurrentState);
+        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.UnifiedScanResultStore), this.onGetScanCurrentState);
     }
 
     private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {

--- a/src/background/global-action-creators/feature-flags-action-creator.ts
+++ b/src/background/global-action-creators/feature-flags-action-creator.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { StoreNames } from '../../common/stores/store-names';
 import { PREVIEW_FEATURES_TOGGLE } from '../../common/telemetry-events';
 import { FeatureFlagActions, FeatureFlagPayload } from '../actions/feature-flag-actions';
 import { Interpreter } from '../interpreter';
@@ -14,7 +15,7 @@ export class FeatureFlagsActionCreator {
     ) {}
 
     public registerCallbacks(): void {
-        this.interpreter.registerTypeToPayloadCallback(Messages.FeatureFlags.GetFeatureFlags, this.onGetFeatureFlags);
+        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.FeatureFlagStore), this.onGetFeatureFlags);
         this.interpreter.registerTypeToPayloadCallback(Messages.FeatureFlags.SetFeatureFlag, this.onSetFeatureFlags);
         this.interpreter.registerTypeToPayloadCallback(Messages.FeatureFlags.ResetFeatureFlag, this.onResetFeatureFlags);
     }

--- a/src/background/global-action-creators/global-action-creator.ts
+++ b/src/background/global-action-creators/global-action-creator.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CommandsAdapter } from '../../common/browser-adapters/commands-adapter';
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { StoreNames } from '../../common/stores/store-names';
 import { PayloadWithEventName, SetLaunchPanelState } from '../actions/action-payloads';
 import { CommandActions, GetCommandsPayload } from '../actions/command-actions';
 import { GlobalActionHub } from '../actions/global-action-hub';
@@ -31,7 +32,7 @@ export class GlobalActionCreator {
     }
 
     public registerCallbacks(): void {
-        this.interpreter.registerTypeToPayloadCallback(Messages.Command.GetCommands, this.onGetCommands);
+        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.CommandStore), this.onGetCommands);
 
         this.interpreter.registerTypeToPayloadCallback(Messages.LaunchPanel.Get, this.onGetLaunchPanelState);
         this.interpreter.registerTypeToPayloadCallback(Messages.LaunchPanel.Set, this.onSetLaunchPanelState);

--- a/src/background/global-action-creators/global-action-creator.ts
+++ b/src/background/global-action-creators/global-action-creator.ts
@@ -34,7 +34,7 @@ export class GlobalActionCreator {
     public registerCallbacks(): void {
         this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.CommandStore), this.onGetCommands);
 
-        this.interpreter.registerTypeToPayloadCallback(Messages.LaunchPanel.Get, this.onGetLaunchPanelState);
+        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.LaunchPanelStateStore), this.onGetLaunchPanelState);
         this.interpreter.registerTypeToPayloadCallback(Messages.LaunchPanel.Set, this.onSetLaunchPanelState);
 
         this.interpreter.registerTypeToPayloadCallback(Messages.Telemetry.Send, this.onSendTelemetry);

--- a/src/background/global-action-creators/scoping-action-creator.ts
+++ b/src/background/global-action-creators/scoping-action-creator.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { StoreNames } from '../../common/stores/store-names';
 import { ScopingActions, ScopingPayload } from '../actions/scoping-actions';
 import { Interpreter } from '../interpreter';
 
@@ -8,7 +9,7 @@ export class ScopingActionCreator {
     constructor(private readonly interpreter: Interpreter, private readonly scopingActions: ScopingActions) {}
 
     public registerCallback(): void {
-        this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.GetCurrentState, this.onGetScopingState);
+        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.ScopingPanelStateStore), this.onGetScopingState);
         this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.AddSelector, this.onAddSelector);
         this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.DeleteSelector, this.onDeleteSelector);
     }

--- a/src/background/global-action-creators/user-configuration-action-creator.ts
+++ b/src/background/global-action-creators/user-configuration-action-creator.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Messages } from '../../common/messages';
+import { getStoreStateMessage, Messages } from '../../common/messages';
+import { StoreNames } from '../../common/stores/store-names';
 import {
     SaveIssueFilingSettingsPayload,
     SetHighContrastModePayload,
@@ -15,7 +16,7 @@ export class UserConfigurationActionCreator {
     constructor(private readonly interpreter: Interpreter, private readonly userConfigActions: UserConfigurationActions) {}
 
     public registerCallback(): void {
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.GetCurrentState, this.onGetUserConfigState);
+        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.UserConfigurationStore), this.onGetUserConfigState);
         this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetTelemetryConfig, this.onSetTelemetryConfiguration);
         this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetHighContrastConfig, this.onSetHighContrastMode);
         this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetIssueFilingService, this.onSetBugService);

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -32,7 +32,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.ScopingPanelStateStore),
             getStoreStateMessage(StoreNames.UserConfigurationStore),
             getStoreStateMessage(StoreNames.PathSnippetStore),
-            Messages.UnifiedScan.GetCurrentState,
+            getStoreStateMessage(StoreNames.UnifiedScanResultStore),
         ];
 
         return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -24,7 +24,7 @@ export class StoreActionMessageCreatorFactory {
     public forDetailsView(): StoreActionMessageCreator {
         const getStateMessages: string[] = [
             Messages.Visualizations.DetailsView.GetState,
-            Messages.Visualizations.State.GetCurrentVisualizationResultState,
+            getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Tab.GetCurrent,
             Messages.FeatureFlags.GetFeatureFlags,
@@ -49,7 +49,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Scoping.GetCurrentState,
             Messages.Inspect.GetCurrentState,
-            Messages.Visualizations.State.GetCurrentVisualizationResultState,
+            getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.DevTools.Get,
             Messages.Assessment.GetCurrentState,

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -10,12 +10,6 @@ import { StoreActionMessageCreatorImpl } from './store-action-message-creator-im
 export class StoreActionMessageCreatorFactory {
     constructor(private readonly dispatcher: ActionMessageDispatcher) {}
 
-    public forContent(): StoreActionMessageCreator {
-        const getStateMessages: string[] = [getStoreStateMessage(StoreNames.UserConfigurationStore)];
-
-        return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
-    }
-
     public fromStores(stores: BaseStore<any>[]): StoreActionMessageCreator {
         const messages = stores.map(store => getStoreStateMessage(StoreNames[store.getId()]));
 

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -10,18 +10,6 @@ import { StoreActionMessageCreatorImpl } from './store-action-message-creator-im
 export class StoreActionMessageCreatorFactory {
     constructor(private readonly dispatcher: ActionMessageDispatcher) {}
 
-    public forPopup(): StoreActionMessageCreator {
-        const getStateMessages: string[] = [
-            getStoreStateMessage(StoreNames.VisualizationStore),
-            getStoreStateMessage(StoreNames.CommandStore),
-            getStoreStateMessage(StoreNames.FeatureFlagStore),
-            getStoreStateMessage(StoreNames.LaunchPanelStateStore),
-            getStoreStateMessage(StoreNames.UserConfigurationStore),
-        ];
-
-        return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
-    }
-
     public forDetailsView(): StoreActionMessageCreator {
         const getStateMessages: string[] = [
             getStoreStateMessage(StoreNames.DetailsViewStore),

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -12,7 +12,7 @@ export class StoreActionMessageCreatorFactory {
     public forPopup(): StoreActionMessageCreator {
         const getStateMessages: string[] = [
             getStoreStateMessage(StoreNames.VisualizationStore),
-            Messages.Command.GetCommands,
+            getStoreStateMessage(StoreNames.CommandStore),
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.LaunchPanel.Get,
             Messages.UserConfig.GetCurrentState,

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -23,7 +23,7 @@ export class StoreActionMessageCreatorFactory {
 
     public forDetailsView(): StoreActionMessageCreator {
         const getStateMessages: string[] = [
-            Messages.Visualizations.DetailsView.GetState,
+            getStoreStateMessage(StoreNames.DetailsViewStore),
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Tab.GetCurrent,

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -10,23 +10,6 @@ import { StoreActionMessageCreatorImpl } from './store-action-message-creator-im
 export class StoreActionMessageCreatorFactory {
     constructor(private readonly dispatcher: ActionMessageDispatcher) {}
 
-    public forDetailsView(): StoreActionMessageCreator {
-        const getStateMessages: string[] = [
-            getStoreStateMessage(StoreNames.DetailsViewStore),
-            getStoreStateMessage(StoreNames.VisualizationScanResultStore),
-            getStoreStateMessage(StoreNames.VisualizationStore),
-            getStoreStateMessage(StoreNames.TabStore),
-            getStoreStateMessage(StoreNames.FeatureFlagStore),
-            getStoreStateMessage(StoreNames.AssessmentStore),
-            getStoreStateMessage(StoreNames.ScopingPanelStateStore),
-            getStoreStateMessage(StoreNames.UserConfigurationStore),
-            getStoreStateMessage(StoreNames.PathSnippetStore),
-            getStoreStateMessage(StoreNames.UnifiedScanResultStore),
-        ];
-
-        return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
-    }
-
     public forContent(): StoreActionMessageCreator {
         const getStateMessages: string[] = [getStoreStateMessage(StoreNames.UserConfigurationStore)];
 

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -29,7 +29,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.TabStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
             getStoreStateMessage(StoreNames.AssessmentStore),
-            Messages.Scoping.GetCurrentState,
+            getStoreStateMessage(StoreNames.ScopingPanelStateStore),
             getStoreStateMessage(StoreNames.UserConfigurationStore),
             Messages.PathSnippet.GetCurrentState,
             Messages.UnifiedScan.GetCurrentState,
@@ -47,7 +47,7 @@ export class StoreActionMessageCreatorFactory {
     public forInjected(): StoreActionMessageCreator {
         const getStateMessages: string[] = [
             getStoreStateMessage(StoreNames.VisualizationStore),
-            Messages.Scoping.GetCurrentState,
+            getStoreStateMessage(StoreNames.ScopingPanelStateStore),
             Messages.Inspect.GetCurrentState,
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -13,7 +13,7 @@ export class StoreActionMessageCreatorFactory {
         const getStateMessages: string[] = [
             getStoreStateMessage(StoreNames.VisualizationStore),
             getStoreStateMessage(StoreNames.CommandStore),
-            Messages.FeatureFlags.GetFeatureFlags,
+            getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.LaunchPanel.Get,
             Messages.UserConfig.GetCurrentState,
         ];
@@ -27,7 +27,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.VisualizationStore),
             getStoreStateMessage(StoreNames.TabStore),
-            Messages.FeatureFlags.GetFeatureFlags,
+            getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.Assessment.GetCurrentState,
             Messages.Scoping.GetCurrentState,
             Messages.UserConfig.GetCurrentState,
@@ -50,7 +50,7 @@ export class StoreActionMessageCreatorFactory {
             Messages.Scoping.GetCurrentState,
             Messages.Inspect.GetCurrentState,
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
-            Messages.FeatureFlags.GetFeatureFlags,
+            getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.DevTools.Get,
             Messages.Assessment.GetCurrentState,
             getStoreStateMessage(StoreNames.TabStore),

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -31,7 +31,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.AssessmentStore),
             getStoreStateMessage(StoreNames.ScopingPanelStateStore),
             getStoreStateMessage(StoreNames.UserConfigurationStore),
-            Messages.PathSnippet.GetCurrentState,
+            getStoreStateMessage(StoreNames.PathSnippetStore),
             Messages.UnifiedScan.GetCurrentState,
         ];
 

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -48,7 +48,7 @@ export class StoreActionMessageCreatorFactory {
         const getStateMessages: string[] = [
             getStoreStateMessage(StoreNames.VisualizationStore),
             getStoreStateMessage(StoreNames.ScopingPanelStateStore),
-            Messages.Inspect.GetCurrentState,
+            getStoreStateMessage(StoreNames.InspectStore),
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.DevTools.Get,

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -28,7 +28,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.VisualizationStore),
             getStoreStateMessage(StoreNames.TabStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
-            Messages.Assessment.GetCurrentState,
+            getStoreStateMessage(StoreNames.AssessmentStore),
             Messages.Scoping.GetCurrentState,
             getStoreStateMessage(StoreNames.UserConfigurationStore),
             Messages.PathSnippet.GetCurrentState,
@@ -52,7 +52,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.DevTools.Get,
-            Messages.Assessment.GetCurrentState,
+            getStoreStateMessage(StoreNames.AssessmentStore),
             getStoreStateMessage(StoreNames.TabStore),
             getStoreStateMessage(StoreNames.UserConfigurationStore),
         ];

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -26,7 +26,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.DetailsViewStore),
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.VisualizationStore),
-            Messages.Tab.GetCurrent,
+            getStoreStateMessage(StoreNames.TabStore),
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.Assessment.GetCurrentState,
             Messages.Scoping.GetCurrentState,
@@ -53,7 +53,7 @@ export class StoreActionMessageCreatorFactory {
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.DevTools.Get,
             Messages.Assessment.GetCurrentState,
-            Messages.Tab.GetCurrent,
+            getStoreStateMessage(StoreNames.TabStore),
             Messages.UserConfig.GetCurrentState,
         ];
 

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BaseStore } from '../base-store';
 import { getStoreStateMessage } from '../messages';
 import { StoreNames } from '../stores/store-names';
 import { ActionMessageDispatcher } from './action-message-dispatcher';
@@ -58,5 +59,11 @@ export class StoreActionMessageCreatorFactory {
         ];
 
         return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
+    }
+
+    public fromStores(stores: BaseStore<any>[]): StoreActionMessageCreator {
+        const messages = stores.map(store => getStoreStateMessage(StoreNames[store.getId()]));
+
+        return new StoreActionMessageCreatorImpl(messages, this.dispatcher);
     }
 }

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getStoreStateMessage, Messages } from '../messages';
+import { getStoreStateMessage } from '../messages';
 import { StoreNames } from '../stores/store-names';
 import { ActionMessageDispatcher } from './action-message-dispatcher';
 import { StoreActionMessageCreator } from './store-action-message-creator';
@@ -51,7 +51,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.InspectStore),
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
-            Messages.DevTools.Get,
+            getStoreStateMessage(StoreNames.DevToolsStore),
             getStoreStateMessage(StoreNames.AssessmentStore),
             getStoreStateMessage(StoreNames.TabStore),
             getStoreStateMessage(StoreNames.UserConfigurationStore),

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -16,22 +16,6 @@ export class StoreActionMessageCreatorFactory {
         return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
     }
 
-    public forInjected(): StoreActionMessageCreator {
-        const getStateMessages: string[] = [
-            getStoreStateMessage(StoreNames.VisualizationStore),
-            getStoreStateMessage(StoreNames.ScopingPanelStateStore),
-            getStoreStateMessage(StoreNames.InspectStore),
-            getStoreStateMessage(StoreNames.VisualizationScanResultStore),
-            getStoreStateMessage(StoreNames.FeatureFlagStore),
-            getStoreStateMessage(StoreNames.DevToolsStore),
-            getStoreStateMessage(StoreNames.AssessmentStore),
-            getStoreStateMessage(StoreNames.TabStore),
-            getStoreStateMessage(StoreNames.UserConfigurationStore),
-        ];
-
-        return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
-    }
-
     public fromStores(stores: BaseStore<any>[]): StoreActionMessageCreator {
         const messages = stores.map(store => getStoreStateMessage(StoreNames[store.getId()]));
 

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -14,7 +14,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.VisualizationStore),
             getStoreStateMessage(StoreNames.CommandStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
-            Messages.LaunchPanel.Get,
+            getStoreStateMessage(StoreNames.LaunchPanelStateStore),
             Messages.UserConfig.GetCurrentState,
         ];
 

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Messages } from '../messages';
+import { getStoreStateMessage, Messages } from '../messages';
+import { StoreNames } from '../stores/store-names';
 import { ActionMessageDispatcher } from './action-message-dispatcher';
 import { StoreActionMessageCreator } from './store-action-message-creator';
 import { StoreActionMessageCreatorImpl } from './store-action-message-creator-impl';
@@ -10,7 +11,7 @@ export class StoreActionMessageCreatorFactory {
 
     public forPopup(): StoreActionMessageCreator {
         const getStateMessages: string[] = [
-            Messages.Visualizations.State.GetCurrentVisualizationToggleState,
+            getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Command.GetCommands,
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.LaunchPanel.Get,
@@ -24,7 +25,7 @@ export class StoreActionMessageCreatorFactory {
         const getStateMessages: string[] = [
             Messages.Visualizations.DetailsView.GetState,
             Messages.Visualizations.State.GetCurrentVisualizationResultState,
-            Messages.Visualizations.State.GetCurrentVisualizationToggleState,
+            getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Tab.GetCurrent,
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.Assessment.GetCurrentState,
@@ -45,7 +46,7 @@ export class StoreActionMessageCreatorFactory {
 
     public forInjected(): StoreActionMessageCreator {
         const getStateMessages: string[] = [
-            Messages.Visualizations.State.GetCurrentVisualizationToggleState,
+            getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Scoping.GetCurrentState,
             Messages.Inspect.GetCurrentState,
             Messages.Visualizations.State.GetCurrentVisualizationResultState,

--- a/src/common/message-creators/store-action-message-creator-factory.ts
+++ b/src/common/message-creators/store-action-message-creator-factory.ts
@@ -15,7 +15,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.CommandStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
             getStoreStateMessage(StoreNames.LaunchPanelStateStore),
-            Messages.UserConfig.GetCurrentState,
+            getStoreStateMessage(StoreNames.UserConfigurationStore),
         ];
 
         return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
@@ -30,7 +30,7 @@ export class StoreActionMessageCreatorFactory {
             getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.Assessment.GetCurrentState,
             Messages.Scoping.GetCurrentState,
-            Messages.UserConfig.GetCurrentState,
+            getStoreStateMessage(StoreNames.UserConfigurationStore),
             Messages.PathSnippet.GetCurrentState,
             Messages.UnifiedScan.GetCurrentState,
         ];
@@ -39,7 +39,7 @@ export class StoreActionMessageCreatorFactory {
     }
 
     public forContent(): StoreActionMessageCreator {
-        const getStateMessages: string[] = [Messages.UserConfig.GetCurrentState];
+        const getStateMessages: string[] = [getStoreStateMessage(StoreNames.UserConfigurationStore)];
 
         return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);
     }
@@ -54,7 +54,7 @@ export class StoreActionMessageCreatorFactory {
             Messages.DevTools.Get,
             Messages.Assessment.GetCurrentState,
             getStoreStateMessage(StoreNames.TabStore),
-            Messages.UserConfig.GetCurrentState,
+            getStoreStateMessage(StoreNames.UserConfigurationStore),
         ];
 
         return new StoreActionMessageCreatorImpl(getStateMessages, this.dispatcher);

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -93,7 +93,6 @@ export class Messages {
     };
 
     public static readonly UserConfig = {
-        GetCurrentState: `${messagePrefix}/userConfig/getCurrentState`,
         SetTelemetryConfig: `${messagePrefix}/userConfig/setTelemetryConfig`,
         SetHighContrastConfig: `${messagePrefix}/userConfig/setHighContrastConfig`,
         SetIssueFilingService: `${messagePrefix}/userConfig/setIssueFilingService`,

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -149,7 +149,6 @@ export class Messages {
     };
 
     public static readonly LaunchPanel = {
-        Get: `${messagePrefix}/launchpanel/get`,
         Set: `${messagePrefix}/launchpanel/set`,
     };
 

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { StoreNames } from './stores/store-names';
+
 export interface StateMessages {
     GetCurrentVisualizationToggleState: string;
     GetCurrentVisualizationResultState: string;
@@ -49,6 +51,9 @@ export interface VisualizationMessages {
 }
 
 const messagePrefix = 'insights';
+export const getStoreStateMessage = (storeName: StoreNames): string => {
+    return `${messagePrefix}/${StoreNames[storeName]}/state/current`;
+};
 
 export class Messages {
     public static readonly Visualizations: VisualizationMessages = {

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -103,7 +103,6 @@ export class Messages {
 
     public static readonly Tab = {
         Update: `${messagePrefix}/tab/update`,
-        GetCurrent: `${messagePrefix}/tab/current`,
         Remove: `${messagePrefix}/tab/remove`,
         Change: `${messagePrefix}/targetTab/changed`,
         Switch: `${messagePrefix}/targetTab/switch`,

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -190,6 +190,5 @@ export class Messages {
 
     public static readonly UnifiedScan = {
         ScanCompleted: `${messagePrefix}/unifiedScan/scanCompleted`,
-        GetCurrentState: `${messagePrefix}/unifiedScan/getCurrentState`,
     };
 }

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -183,7 +183,6 @@ export class Messages {
     };
 
     public static readonly PathSnippet = {
-        GetCurrentState: `${messagePrefix}/pathSnippet/getCurrentState`,
         AddPathForValidation: `${messagePrefix}/pathSnippet/addPathForValidation`,
         AddCorrespondingSnippet: `${messagePrefix}/pathSnippet/addCorrespondingSnippet`,
         ClearPathSnippetData: `${messagePrefix}/pathSnippet/clearPathSnippetData`,

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -174,7 +174,6 @@ export class Messages {
 
     public static readonly Inspect = {
         ChangeInspectMode: `${messagePrefix}/inspect/changeInspectMode`,
-        GetCurrentState: `${messagePrefix}/inspect/get`,
         SetHoveredOverSelector: `${messagePrefix}/inspect/setHoveredOverSelector`,
     };
 

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -3,7 +3,6 @@
 import { StoreNames } from './stores/store-names';
 
 export interface StateMessages {
-    GetCurrentVisualizationToggleState: string;
     GetCurrentVisualizationResultState: string;
     InjectionCompleted: string;
     InjectionStarted: string;
@@ -72,7 +71,6 @@ export class Messages {
             UpdateFocusedInstance: `${messagePrefix}/visualization/issues/targets/focused/update`,
         },
         State: {
-            GetCurrentVisualizationToggleState: `${messagePrefix}/toggles/state/current`,
             GetCurrentVisualizationResultState: `${messagePrefix}/results/state/current`,
             InjectionCompleted: `${messagePrefix}/visualization/state/injectionCompleted`,
             InjectionStarted: `${messagePrefix}/visualization/state/InjectionStarted`,

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -13,7 +13,6 @@ export interface DetailsViewMessages {
     PivotSelect: string;
     Close: string;
     SetDetailsViewRightContentPanel: string;
-    GetState: string;
 }
 
 export interface IssuesMessages {
@@ -79,7 +78,6 @@ export class Messages {
             PivotSelect: `${messagePrefix}/details-view/pivot/select`,
             Close: `${messagePrefix}/details-view/closed`,
             SetDetailsViewRightContentPanel: `${messagePrefix}/details-view/setRightContentPanel`,
-            GetState: `${messagePrefix}/details-view/state/current`,
         },
     };
 

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -109,10 +109,6 @@ export class Messages {
         VisibilityChange: `${messagePrefix}/targetTab/visibilitychange`,
     };
 
-    public static readonly Command = {
-        GetCommands: `${messagePrefix}/command/get`,
-    };
-
     public static readonly Assessment = {
         GetCurrentState: `${messagePrefix}/assessment/getCurrentState`,
         SelectTestRequirement: `${messagePrefix}/details-view/requirement/select`,

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -36,7 +36,6 @@ export interface DevToolsMessages {
     DevtoolStatus: string;
     InspectElement: string;
     InspectFrameUrl: string;
-    Get: string;
 }
 
 export interface VisualizationMessages {
@@ -85,7 +84,6 @@ export class Messages {
         DevtoolStatus: `${messagePrefix}/devtools/status`,
         InspectElement: `${messagePrefix}/devtools/inspect`,
         InspectFrameUrl: `${messagePrefix}/devtools/inspectFrameUrl`,
-        Get: `${messagePrefix}/devtools/get`,
     };
 
     public static readonly Telemetry = {

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -168,7 +168,6 @@ export class Messages {
     public static readonly Scoping = {
         ClosePanel: `${messagePrefix}/scoping/closePanel`,
         OpenPanel: `${messagePrefix}/scoping/openPanel`,
-        GetCurrentState: `${messagePrefix}/scoping/get`,
         AddSelector: `${messagePrefix}/scoping/addSelector`,
         DeleteSelector: `${messagePrefix}/scoping/deleteSelector`,
     };

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -109,7 +109,6 @@ export class Messages {
     };
 
     public static readonly Assessment = {
-        GetCurrentState: `${messagePrefix}/assessment/getCurrentState`,
         SelectTestRequirement: `${messagePrefix}/details-view/requirement/select`,
         AssessmentScanCompleted: `${messagePrefix}/assessment/scanComplete`,
         TabbedElementAdded: `${messagePrefix}/assessment/tab-stops/element-added`,

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -140,7 +140,6 @@ export class Messages {
     };
 
     public static readonly FeatureFlags = {
-        GetFeatureFlags: `${messagePrefix}/featureFlags/get`,
         SetFeatureFlag: `${messagePrefix}/featureFlags/set`,
         ResetFeatureFlag: `${messagePrefix}/featureFlags/reset`,
     };

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -3,7 +3,6 @@
 import { StoreNames } from './stores/store-names';
 
 export interface StateMessages {
-    GetCurrentVisualizationResultState: string;
     InjectionCompleted: string;
     InjectionStarted: string;
 }
@@ -71,7 +70,6 @@ export class Messages {
             UpdateFocusedInstance: `${messagePrefix}/visualization/issues/targets/focused/update`,
         },
         State: {
-            GetCurrentVisualizationResultState: `${messagePrefix}/results/state/current`,
             InjectionCompleted: `${messagePrefix}/visualization/state/injectionCompleted`,
             InjectionStarted: `${messagePrefix}/visualization/state/InjectionStarted`,
         },

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -100,7 +100,18 @@ export class MainWindowInitializer extends WindowInitializer {
 
         const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(actionMessageDispatcher);
 
-        const storeActionMessageCreator = storeActionMessageCreatorFactory.forInjected();
+        const storeActionMessageCreator = storeActionMessageCreatorFactory.fromStores([
+            this.visualizationStoreProxy,
+            this.scopingStoreProxy,
+            this.featureFlagStoreProxy,
+            this.userConfigStoreProxy,
+            this.visualizationScanResultStoreProxy,
+            this.assessmentStoreProxy,
+            this.tabStoreProxy,
+            this.devToolStoreProxy,
+            this.inspectStoreProxy,
+            this.pathSnippetStoreProxy,
+        ]);
         storeActionMessageCreator.getAllStates();
 
         const telemetryDataFactory = new TelemetryDataFactory();

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -92,10 +92,6 @@ export class PopupInitializer {
 
         const userConfigMessageCreator = new UserConfigMessageCreator(actionMessageDispatcher);
 
-        const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(actionMessageDispatcher);
-
-        const storeActionMessageCreator = storeActionMessageCreatorFactory.forPopup();
-
         const contentActionMessageCreator = new ContentActionMessageCreator(
             telemetryFactory,
             TelemetryEventSource.DetailsView,
@@ -115,6 +111,16 @@ export class PopupInitializer {
         const commandStore = new StoreProxy<CommandStoreData>(commandStoreName, this.browserAdapter);
         const featureFlagStore = new StoreProxy<FeatureFlagStoreData>(featureFlagStoreName, this.browserAdapter);
         const userConfigurationStore = new StoreProxy<UserConfigurationStoreData>(userConfigurationStoreName, this.browserAdapter);
+
+        const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(actionMessageDispatcher);
+
+        const storeActionMessageCreator = storeActionMessageCreatorFactory.fromStores([
+            visualizationStore,
+            launchPanelStateStore,
+            commandStore,
+            featureFlagStore,
+            userConfigurationStore,
+        ]);
 
         visualizationStore.setTabId(this.targetTabInfo.tab.id);
         commandStore.setTabId(this.targetTabInfo.tab.id);

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -566,7 +566,7 @@ describe('ActionCreatorTest', () => {
         const args = [];
         const actionName = 'getCurrentState';
         const builder = new ActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Visualizations.State.GetCurrentVisualizationResultState, args)
+            .setupRegistrationCallback(getStoreStateMessage(StoreNames.VisualizationScanResultStore), args)
             .setupActionOnVisualizationScanResultActions(actionName)
             .setupVisualizationScanResultActionWithInvokeParameter(actionName, null);
 

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -27,8 +27,10 @@ import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-hand
 import { VisualizationConfigurationFactory } from '../../../../../common/configs/visualization-configuration-factory';
 import { Action } from '../../../../../common/flux/action';
 import { PayloadCallback } from '../../../../../common/message';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { NotificationCreator } from '../../../../../common/notification-creator';
+import { StoreNames } from '../../../../../common/stores/store-names';
+import * as TelemetryEvents from '../../../../../common/telemetry-events';
 import {
     BaseTelemetryData,
     DetailsViewOpenTelemetryData,
@@ -37,7 +39,6 @@ import {
     ToggleTelemetryData,
     TriggeredBy,
 } from '../../../../../common/telemetry-events';
-import * as TelemetryEvents from '../../../../../common/telemetry-events';
 import { DetailsViewPivotType } from '../../../../../common/types/details-view-pivot-type';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { ScanCompletedPayload } from '../../../../../injected/analyzers/analyzer';
@@ -550,7 +551,7 @@ describe('ActionCreatorTest', () => {
         const args = [];
         const actionName = 'getCurrentState';
         const builder = new ActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Visualizations.State.GetCurrentVisualizationToggleState, args)
+            .setupRegistrationCallback(getStoreStateMessage(StoreNames.VisualizationStore), args)
             .setupActionOnVisualizationActions(actionName)
             .setupVisualizationActionWithInvokeParameter(actionName, null);
 

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -8,7 +8,8 @@ import { isFunction } from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { Action } from '../../../../../common/flux/action';
 import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 import * as TelemetryEvents from '../../../../../common/telemetry-events';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 
@@ -282,7 +283,7 @@ describe('AssessmentActionCreatorTest', () => {
     test('onGetAssessmentCurrentState', () => {
         const actionMock = createActionMock(null);
         setupAssessmentActionsMock('getCurrentState', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.GetCurrentState, null, testTabId);
+        setupRegisterTypeToPayloadCallbackMock(getStoreStateMessage(StoreNames.AssessmentStore), null, testTabId);
 
         testObject.registerCallbacks();
 

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -10,7 +10,8 @@ import { DetailsViewController } from 'background/details-view-controller';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { Action } from '../../../../../common/flux/action';
 import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 import { SETTINGS_PANEL_CLOSE, SETTINGS_PANEL_OPEN, TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
 import { DetailsViewRightContentPanelType } from '../../../../../DetailsView/components/left-nav/details-view-right-content-panel-type';
 
@@ -103,7 +104,7 @@ describe('DetailsViewActionCreatorTest', () => {
         detailsViewActionsMock.setup(actions => actions['getCurrentState']).returns(() => getCurrentStateMock.object);
 
         registerCallbackMock
-            .setup(register => register(Messages.Visualizations.DetailsView.GetState, It.is(isFunction)))
+            .setup(register => register(getStoreStateMessage(StoreNames.DetailsViewStore), It.is(isFunction)))
             .callback((message, listener) => listener());
 
         testSubject.registerCallback();

--- a/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
@@ -6,9 +6,11 @@ import { DevToolActions } from 'background/actions/dev-tools-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import * as _ from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { Action } from '../../../../../common/flux/action';
 import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 import * as TelemetryEvents from '../../../../../common/telemetry-events';
 
 describe('DevToolsActionCreatorTest', () => {
@@ -52,7 +54,7 @@ describe('DevToolsActionCreatorTest', () => {
 
         setupDevToolsActionsMock('getCurrentState', getCurrentStateAction);
 
-        setupRegisterTypeToPayloadCallbackMock(Messages.DevTools.Get, null, tabId);
+        setupRegisterTypeToPayloadCallbackMock(getStoreStateMessage(StoreNames.DevToolsStore), null, tabId);
 
         testObject.registerCallbacks();
 

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -10,7 +10,8 @@ import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-hand
 import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
 import { Action } from '../../../../../common/flux/action';
 import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 import * as TelemetryEvents from '../../../../../common/telemetry-events';
 
 describe('InspectActionCreatorTest', () => {
@@ -41,7 +42,7 @@ describe('InspectActionCreatorTest', () => {
 
         setupInspectActionMock('getCurrentState', getCurrentStateMock);
 
-        setupRegisterTypeToPayloadCallbackMock(Messages.Inspect.GetCurrentState, null, tabId);
+        setupRegisterTypeToPayloadCallbackMock(getStoreStateMessage(StoreNames.InspectStore), null, tabId);
 
         testObject.registerCallbacks();
         getCurrentStateMock.verifyAll();

--- a/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
@@ -7,7 +7,8 @@ import { PathSnippetActionCreator } from 'background/actions/path-snippet-action
 import { PathSnippetActions } from 'background/actions/path-snippet-actions';
 import { Action } from '../../../../../common/flux/action';
 import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 
 describe('PathSnippetActionCreatorTest', () => {
     let pathSnippetActionsMock: IMock<PathSnippetActions>;
@@ -56,7 +57,7 @@ describe('PathSnippetActionCreatorTest', () => {
         const getPathSnippetCurrentStateMock = createActionMock(null);
 
         setupPathSnippetActionMock(actionName, getPathSnippetCurrentStateMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.PathSnippet.GetCurrentState, null);
+        setupRegisterTypeToPayloadCallbackMock(getStoreStateMessage(StoreNames.PathSnippetStore), null);
 
         testObject.registerCallbacks();
         getPathSnippetCurrentStateMock.verifyAll();

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -11,7 +11,8 @@ import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-a
 import { Action } from '../../../../../common/flux/action';
 import { Tab } from '../../../../../common/itab';
 import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 import { SWITCH_BACK_TO_TARGET, TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
 
 describe('TestActionCreatorTest', () => {
@@ -53,7 +54,7 @@ describe('TestActionCreatorTest', () => {
     test('on Tab.GetCurrent', () => {
         const actionMock = createActionMock(null);
         setupTabActionsMock('getCurrentState', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.Tab.GetCurrent, null, tabId);
+        setupRegisterTypeToPayloadCallbackMock(getStoreStateMessage(StoreNames.TabStore), null, tabId);
 
         testObject.registerCallbacks();
         actionMock.verifyAll();

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -7,7 +7,8 @@ import { UnifiedScanResultActionCreator } from '../../../../../background/action
 import { UnifiedScanResultActions } from '../../../../../background/actions/unified-scan-result-actions';
 import { Action } from '../../../../../common/flux/action';
 import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 
 describe('UnifiedScanResultActionCreator', () => {
     let scanResultActionsMock: IMock<UnifiedScanResultActions>;
@@ -39,7 +40,7 @@ describe('UnifiedScanResultActionCreator', () => {
 
         const getCurrentStateMock = createActionMock(payload);
         setupScanResultActionsMock('getCurrentState', getCurrentStateMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.UnifiedScan.GetCurrentState, payload);
+        setupRegisterTypeToPayloadCallbackMock(getStoreStateMessage(StoreNames.UnifiedScanResultStore), payload);
 
         testSubject.registerCallbacks();
 

--- a/src/tests/unit/tests/background/global-action-creators/feature-flags-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/feature-flags-action-creator.test.ts
@@ -8,7 +8,8 @@ import { FeatureFlagsActionCreator } from 'background/global-action-creators/fea
 import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { Action } from '../../../../../common/flux/action';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 
 describe('FeatureFlagsActionCreator', () => {
     let interpreterMock: IMock<Interpreter>;
@@ -26,7 +27,7 @@ describe('FeatureFlagsActionCreator', () => {
     });
 
     it('handles GetFeatureFlags message', () => {
-        const expectedMessage = Messages.FeatureFlags.GetFeatureFlags;
+        const expectedMessage = getStoreStateMessage(StoreNames.FeatureFlagStore);
 
         setupInterpreterMock(expectedMessage);
 

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -54,7 +54,7 @@ describe('GlobalActionCreatorTest', () => {
     test('registerCallback for on get launch panel state', () => {
         const actionName = 'getCurrentState';
         const validator = new GlobalActionCreatorValidator()
-            .setupRegistrationCallback(Messages.LaunchPanel.Get)
+            .setupRegistrationCallback(getStoreStateMessage(StoreNames.LaunchPanelStateStore))
             .setupActionOnLaunchPanelActions(actionName)
             .setupLaunchPanelActionWithInvokeParameter(actionName, null);
 

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -14,7 +14,8 @@ import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { CommandsAdapter } from '../../../../../common/browser-adapters/commands-adapter';
 import { Action } from '../../../../../common/flux/action';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 import { LaunchPanelType } from '../../../../../popup/components/popup-view';
 import { DictionaryStringTo } from '../../../../../types/common-types';
 
@@ -26,8 +27,9 @@ describe('GlobalActionCreatorTest', () => {
                 name: 'test command',
             },
         ];
+        const getCommandStoreState = getStoreStateMessage(StoreNames.CommandStore);
         const payload = {
-            type: Messages.Command.GetCommands,
+            type: getCommandStoreState,
             tabId: tabId,
         };
         const invokeParameter = {
@@ -39,7 +41,7 @@ describe('GlobalActionCreatorTest', () => {
         const args = [payload, tabId];
         const builder = new GlobalActionCreatorValidator()
             .setupGetCommandsFromAdapter(commands)
-            .setupRegistrationCallback(Messages.Command.GetCommands, args)
+            .setupRegistrationCallback(getCommandStoreState, args)
             .setupCommandActionWithInvokeParameter(actionName, invokeParameter)
             .setupActionOnCommandActions(actionName);
 

--- a/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
@@ -7,7 +7,8 @@ import { ScopingActions, ScopingPayload } from 'background/actions/scoping-actio
 import { ScopingActionCreator } from 'background/global-action-creators/scoping-action-creator';
 import { Interpreter } from 'background/interpreter';
 import { Action } from '../../../../../common/flux/action';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 
 describe('ScopingActionCreator', () => {
     let interpreterMock: IMock<Interpreter>;
@@ -23,7 +24,7 @@ describe('ScopingActionCreator', () => {
     });
 
     it('handles GetCurrentState', () => {
-        const expectedMessage = Messages.Scoping.GetCurrentState;
+        const expectedMessage = getStoreStateMessage(StoreNames.ScopingPanelStateStore);
 
         setupInterpreterMock(expectedMessage);
 

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -12,8 +12,10 @@ import { UserConfigurationActionCreator } from 'background/global-action-creator
 import { Interpreter } from 'background/interpreter';
 import { isFunction } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
+
 import { Action } from '../../../../../common/flux/action';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 import { TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
 
 describe('UserConfigurationActionCreator', () => {
@@ -21,7 +23,7 @@ describe('UserConfigurationActionCreator', () => {
         const payload = null;
         const getCurrentStateMock = createActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(Messages.UserConfig.GetCurrentState, payload);
+        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.UserConfigurationStore), payload);
         const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallback();

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -20,7 +20,7 @@ import { UnifiedScanResultStore } from '../../../../background/stores/unified-sc
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
-import { Messages } from '../../../../common/messages';
+import { getStoreStateMessage } from '../../../../common/messages';
 import { PromiseFactory } from '../../../../common/promises/promise-factory';
 import { StoreNames } from '../../../../common/stores/store-names';
 import { StoreUpdateMessage } from '../../../../common/types/store-update-message';
@@ -100,7 +100,7 @@ describe('TabContextFactoryTest', () => {
             .verifiable(Times.once());
 
         tabContext.interpreter.interpret({
-            messageType: Messages.Visualizations.State.GetCurrentVisualizationResultState,
+            messageType: getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             tabId: null,
         });
 

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -17,7 +17,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
     it('dispatches message types for forPopup', () => {
         const messages: string[] = [
             getStoreStateMessage(StoreNames.VisualizationStore),
-            Messages.Command.GetCommands,
+            getStoreStateMessage(StoreNames.CommandStore),
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.LaunchPanel.Get,
             Messages.UserConfig.GetCurrentState,

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -33,7 +33,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.VisualizationStore),
             getStoreStateMessage(StoreNames.TabStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
-            Messages.Assessment.GetCurrentState,
+            getStoreStateMessage(StoreNames.AssessmentStore),
             Messages.Scoping.GetCurrentState,
             getStoreStateMessage(StoreNames.UserConfigurationStore),
             Messages.PathSnippet.GetCurrentState,
@@ -50,7 +50,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.DevTools.Get,
-            Messages.Assessment.GetCurrentState,
+            getStoreStateMessage(StoreNames.AssessmentStore),
             getStoreStateMessage(StoreNames.TabStore),
             getStoreStateMessage(StoreNames.UserConfigurationStore),
         ];

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 import { Mock, MockBehavior } from 'typemoq';
 
+import { BaseStore } from '../../../../../common/base-store';
+import { EnumHelper } from '../../../../../common/enum-helper';
 import { ActionMessageDispatcher } from '../../../../../common/message-creators/action-message-dispatcher';
 import { StoreActionMessageCreator } from '../../../../../common/message-creators/store-action-message-creator';
 import { StoreActionMessageCreatorFactory } from '../../../../../common/message-creators/store-action-message-creator-factory';
@@ -64,6 +66,22 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         const messages: string[] = [getStoreStateMessage(StoreNames.UserConfigurationStore)];
 
         testWithExpectedMessages(messages, testObject => testObject.forContent());
+    });
+
+    it('dispatches messages for fromStores', () => {
+        const createStoreMock = (storeName: StoreNames) => {
+            const mock = Mock.ofType<BaseStore<any>>(undefined, MockBehavior.Strict);
+            mock.setup(store => store.getId()).returns(() => StoreNames[storeName]);
+            return mock;
+        };
+
+        const storeNames = EnumHelper.getNumericValues<StoreNames>(StoreNames);
+
+        const storeMocks = storeNames.map(createStoreMock).map(mock => mock.object);
+
+        const expectedMessages = storeNames.map(name => getStoreStateMessage(name));
+
+        testWithExpectedMessages(expectedMessages, testObject => testObject.fromStores(storeMocks));
     });
 
     function testWithExpectedMessages(

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -17,18 +17,6 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         dispatcherMock.reset();
     });
 
-    it('dispatches message types for forPopup', () => {
-        const messages: string[] = [
-            getStoreStateMessage(StoreNames.VisualizationStore),
-            getStoreStateMessage(StoreNames.CommandStore),
-            getStoreStateMessage(StoreNames.FeatureFlagStore),
-            getStoreStateMessage(StoreNames.LaunchPanelStateStore),
-            getStoreStateMessage(StoreNames.UserConfigurationStore),
-        ];
-
-        testWithExpectedMessages(messages, testObject => testObject.forPopup());
-    });
-
     it('dispatches message types for forDetailsView', () => {
         const messages: string[] = [
             getStoreStateMessage(StoreNames.DetailsViewStore),

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -29,7 +29,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
     it('dispatches message types for forDetailsView', () => {
         const messages: string[] = [
             Messages.Visualizations.DetailsView.GetState,
-            Messages.Visualizations.State.GetCurrentVisualizationResultState,
+            getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Tab.GetCurrent,
             Messages.FeatureFlags.GetFeatureFlags,
@@ -47,7 +47,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Scoping.GetCurrentState,
             Messages.Inspect.GetCurrentState,
-            Messages.Visualizations.State.GetCurrentVisualizationResultState,
+            getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.DevTools.Get,
             Messages.Assessment.GetCurrentState,

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -31,7 +31,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.DetailsViewStore),
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.VisualizationStore),
-            Messages.Tab.GetCurrent,
+            getStoreStateMessage(StoreNames.TabStore),
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.Assessment.GetCurrentState,
             Messages.Scoping.GetCurrentState,
@@ -51,7 +51,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.DevTools.Get,
             Messages.Assessment.GetCurrentState,
-            Messages.Tab.GetCurrent,
+            getStoreStateMessage(StoreNames.TabStore),
             Messages.UserConfig.GetCurrentState,
         ];
 

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -19,7 +19,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.VisualizationStore),
             getStoreStateMessage(StoreNames.CommandStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
-            Messages.LaunchPanel.Get,
+            getStoreStateMessage(StoreNames.LaunchPanelStateStore),
             Messages.UserConfig.GetCurrentState,
         ];
 

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -17,23 +17,6 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         dispatcherMock.reset();
     });
 
-    it('dispatches message types for forDetailsView', () => {
-        const messages: string[] = [
-            getStoreStateMessage(StoreNames.DetailsViewStore),
-            getStoreStateMessage(StoreNames.VisualizationScanResultStore),
-            getStoreStateMessage(StoreNames.VisualizationStore),
-            getStoreStateMessage(StoreNames.TabStore),
-            getStoreStateMessage(StoreNames.FeatureFlagStore),
-            getStoreStateMessage(StoreNames.AssessmentStore),
-            getStoreStateMessage(StoreNames.ScopingPanelStateStore),
-            getStoreStateMessage(StoreNames.UserConfigurationStore),
-            getStoreStateMessage(StoreNames.PathSnippetStore),
-            getStoreStateMessage(StoreNames.UnifiedScanResultStore),
-        ];
-
-        testWithExpectedMessages(messages, testObject => testObject.forDetailsView());
-    });
-
     it('dispatches message types for forInjected', () => {
         const messages: string[] = [
             getStoreStateMessage(StoreNames.VisualizationStore),

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -17,12 +17,6 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         dispatcherMock.reset();
     });
 
-    it('dispatches message types for forContent', () => {
-        const messages: string[] = [getStoreStateMessage(StoreNames.UserConfigurationStore)];
-
-        testWithExpectedMessages(messages, testObject => testObject.forContent());
-    });
-
     it('dispatches messages for fromStores', () => {
         const createStoreMock = (storeName: StoreNames) => {
             const mock = Mock.ofType<BaseStore<any>>(undefined, MockBehavior.Strict);

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Mock } from 'typemoq';
+import { Mock, MockBehavior } from 'typemoq';
 import { ActionMessageDispatcher } from '../../../../../common/message-creators/action-message-dispatcher';
 import { StoreActionMessageCreator } from '../../../../../common/message-creators/store-action-message-creator';
 import { StoreActionMessageCreatorFactory } from '../../../../../common/message-creators/store-action-message-creator-factory';
@@ -8,7 +8,7 @@ import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
 
 describe('StoreActionMessageCreatorFactoryTest', () => {
-    const dispatcherMock = Mock.ofType<ActionMessageDispatcher>();
+    const dispatcherMock = Mock.ofType<ActionMessageDispatcher>(undefined, MockBehavior.Strict);
 
     beforeEach(() => {
         dispatcherMock.reset();
@@ -37,6 +37,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.ScopingPanelStateStore),
             getStoreStateMessage(StoreNames.UserConfigurationStore),
             getStoreStateMessage(StoreNames.PathSnippetStore),
+            getStoreStateMessage(StoreNames.UnifiedScanResultStore),
         ];
 
         testWithExpectedMessages(messages, testObject => testObject.forDetailsView());

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -36,7 +36,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.AssessmentStore),
             getStoreStateMessage(StoreNames.ScopingPanelStateStore),
             getStoreStateMessage(StoreNames.UserConfigurationStore),
-            Messages.PathSnippet.GetCurrentState,
+            getStoreStateMessage(StoreNames.PathSnippetStore),
         ];
 
         testWithExpectedMessages(messages, testObject => testObject.forDetailsView());

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -17,22 +17,6 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         dispatcherMock.reset();
     });
 
-    it('dispatches message types for forInjected', () => {
-        const messages: string[] = [
-            getStoreStateMessage(StoreNames.VisualizationStore),
-            getStoreStateMessage(StoreNames.ScopingPanelStateStore),
-            getStoreStateMessage(StoreNames.InspectStore),
-            getStoreStateMessage(StoreNames.VisualizationScanResultStore),
-            getStoreStateMessage(StoreNames.FeatureFlagStore),
-            getStoreStateMessage(StoreNames.DevToolsStore),
-            getStoreStateMessage(StoreNames.AssessmentStore),
-            getStoreStateMessage(StoreNames.TabStore),
-            getStoreStateMessage(StoreNames.UserConfigurationStore),
-        ];
-
-        testWithExpectedMessages(messages, testObject => testObject.forInjected());
-    });
-
     it('dispatches message types for forContent', () => {
         const messages: string[] = [getStoreStateMessage(StoreNames.UserConfigurationStore)];
 

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -34,7 +34,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.TabStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
             getStoreStateMessage(StoreNames.AssessmentStore),
-            Messages.Scoping.GetCurrentState,
+            getStoreStateMessage(StoreNames.ScopingPanelStateStore),
             getStoreStateMessage(StoreNames.UserConfigurationStore),
             Messages.PathSnippet.GetCurrentState,
         ];
@@ -45,7 +45,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
     it('dispatches message types for forInjected', () => {
         const messages: string[] = [
             getStoreStateMessage(StoreNames.VisualizationStore),
-            Messages.Scoping.GetCurrentState,
+            getStoreStateMessage(StoreNames.ScopingPanelStateStore),
             Messages.Inspect.GetCurrentState,
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -4,7 +4,8 @@ import { Mock } from 'typemoq';
 import { ActionMessageDispatcher } from '../../../../../common/message-creators/action-message-dispatcher';
 import { StoreActionMessageCreator } from '../../../../../common/message-creators/store-action-message-creator';
 import { StoreActionMessageCreatorFactory } from '../../../../../common/message-creators/store-action-message-creator-factory';
-import { Messages } from '../../../../../common/messages';
+import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { StoreNames } from '../../../../../common/stores/store-names';
 
 describe('StoreActionMessageCreatorFactoryTest', () => {
     const dispatcherMock = Mock.ofType<ActionMessageDispatcher>();
@@ -15,7 +16,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
 
     it('dispatches message types for forPopup', () => {
         const messages: string[] = [
-            Messages.Visualizations.State.GetCurrentVisualizationToggleState,
+            getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Command.GetCommands,
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.LaunchPanel.Get,
@@ -29,7 +30,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         const messages: string[] = [
             Messages.Visualizations.DetailsView.GetState,
             Messages.Visualizations.State.GetCurrentVisualizationResultState,
-            Messages.Visualizations.State.GetCurrentVisualizationToggleState,
+            getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Tab.GetCurrent,
             Messages.FeatureFlags.GetFeatureFlags,
             Messages.Assessment.GetCurrentState,
@@ -43,7 +44,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
 
     it('dispatches message types for forInjected', () => {
         const messages: string[] = [
-            Messages.Visualizations.State.GetCurrentVisualizationToggleState,
+            getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Scoping.GetCurrentState,
             Messages.Inspect.GetCurrentState,
             Messages.Visualizations.State.GetCurrentVisualizationResultState,

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -47,7 +47,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         const messages: string[] = [
             getStoreStateMessage(StoreNames.VisualizationStore),
             getStoreStateMessage(StoreNames.ScopingPanelStateStore),
-            Messages.Inspect.GetCurrentState,
+            getStoreStateMessage(StoreNames.InspectStore),
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.DevTools.Get,

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -20,7 +20,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.CommandStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
             getStoreStateMessage(StoreNames.LaunchPanelStateStore),
-            Messages.UserConfig.GetCurrentState,
+            getStoreStateMessage(StoreNames.UserConfigurationStore),
         ];
 
         testWithExpectedMessages(messages, testObject => testObject.forPopup());
@@ -35,7 +35,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.Assessment.GetCurrentState,
             Messages.Scoping.GetCurrentState,
-            Messages.UserConfig.GetCurrentState,
+            getStoreStateMessage(StoreNames.UserConfigurationStore),
             Messages.PathSnippet.GetCurrentState,
         ];
 
@@ -52,14 +52,14 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             Messages.DevTools.Get,
             Messages.Assessment.GetCurrentState,
             getStoreStateMessage(StoreNames.TabStore),
-            Messages.UserConfig.GetCurrentState,
+            getStoreStateMessage(StoreNames.UserConfigurationStore),
         ];
 
         testWithExpectedMessages(messages, testObject => testObject.forInjected());
     });
 
     it('dispatches message types for forContent', () => {
-        const messages: string[] = [Messages.UserConfig.GetCurrentState];
+        const messages: string[] = [getStoreStateMessage(StoreNames.UserConfigurationStore)];
 
         testWithExpectedMessages(messages, testObject => testObject.forContent());
     });

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -18,7 +18,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
         const messages: string[] = [
             getStoreStateMessage(StoreNames.VisualizationStore),
             getStoreStateMessage(StoreNames.CommandStore),
-            Messages.FeatureFlags.GetFeatureFlags,
+            getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.LaunchPanel.Get,
             Messages.UserConfig.GetCurrentState,
         ];
@@ -32,7 +32,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.VisualizationStore),
             getStoreStateMessage(StoreNames.TabStore),
-            Messages.FeatureFlags.GetFeatureFlags,
+            getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.Assessment.GetCurrentState,
             Messages.Scoping.GetCurrentState,
             Messages.UserConfig.GetCurrentState,
@@ -48,7 +48,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             Messages.Scoping.GetCurrentState,
             Messages.Inspect.GetCurrentState,
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
-            Messages.FeatureFlags.GetFeatureFlags,
+            getStoreStateMessage(StoreNames.FeatureFlagStore),
             Messages.DevTools.Get,
             Messages.Assessment.GetCurrentState,
             getStoreStateMessage(StoreNames.TabStore),

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -28,7 +28,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
 
     it('dispatches message types for forDetailsView', () => {
         const messages: string[] = [
-            Messages.Visualizations.DetailsView.GetState,
+            getStoreStateMessage(StoreNames.DetailsViewStore),
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.VisualizationStore),
             Messages.Tab.GetCurrent,

--- a/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
+++ b/src/tests/unit/tests/common/message-creators/store-action-message-creator-factory.test.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Mock, MockBehavior } from 'typemoq';
+
 import { ActionMessageDispatcher } from '../../../../../common/message-creators/action-message-dispatcher';
 import { StoreActionMessageCreator } from '../../../../../common/message-creators/store-action-message-creator';
 import { StoreActionMessageCreatorFactory } from '../../../../../common/message-creators/store-action-message-creator-factory';
-import { getStoreStateMessage, Messages } from '../../../../../common/messages';
+import { getStoreStateMessage } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
 
 describe('StoreActionMessageCreatorFactoryTest', () => {
@@ -50,7 +51,7 @@ describe('StoreActionMessageCreatorFactoryTest', () => {
             getStoreStateMessage(StoreNames.InspectStore),
             getStoreStateMessage(StoreNames.VisualizationScanResultStore),
             getStoreStateMessage(StoreNames.FeatureFlagStore),
-            Messages.DevTools.Get,
+            getStoreStateMessage(StoreNames.DevToolsStore),
             getStoreStateMessage(StoreNames.AssessmentStore),
             getStoreStateMessage(StoreNames.TabStore),
             getStoreStateMessage(StoreNames.UserConfigurationStore),

--- a/src/views/insights/dependencies.ts
+++ b/src/views/insights/dependencies.ts
@@ -34,7 +34,7 @@ export const rendererDependencies: () => RendererDeps = () => {
     const store = new StoreProxy<UserConfigurationStoreData>(StoreNames[StoreNames.UserConfigurationStore], browserAdapter);
     const storesHub = new BaseClientStoresHub<any>([store]);
     const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(actionMessageDispatcher);
-    const storeActionMessageCreator = storeActionMessageCreatorFactory.forContent();
+    const storeActionMessageCreator = storeActionMessageCreatorFactory.fromStores(storesHub.stores);
 
     return {
         dom: document,


### PR DESCRIPTION
#### Description of changes

Currently, `StoreActionMessageCreatorFactory` exposes 4 methods to create a `StoreActionMessageCreator`: `forPopup`, `forDetailsView`, `forContent` and `forInjected`.

The implementation hides which stores which view needs, which is handy, but at the same time, it forces this factory to know about it's users (the popup, the details view, the target page and the content page).

In order to remove this responsibility from the Factory, we can use the fact the it's being call on initializers (close to the entry point for each of the view where we use it, and at a file/class that is already creating all the needed instances for the view to work properly), which means, we have access to all the stores the view will use. Thus, we can change the Factory API to work base on an array of stores, use `store.getId` and build the "get current state for the store" message programatically.

Doing this will also simplify how we wire up new stores in the different views, specially if we use a stores hub (in which case adding the new store to the hub will be sufficient).

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - no issues has been filed for this
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
