### PR TITLE
Add placeholder to comment field in failure instance panel details

### DIFF
--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -142,6 +142,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                     value={this.state.currentInstance.failureDescription}
                     onChange={this.onFailureDescriptionChange}
                     resizable={false}
+                    placeholder="Comment"
                 />
                 {this.getActionCancelButtons()}
             </GenericPanel>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: cre
       label="Comment"
       multiline={true}
       onChange={[Function]}
+      placeholder="Comment"
       resizable={false}
       rows={8}
       styles={[Function]}
@@ -95,6 +96,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
       label="Comment"
       multiline={true}
       onChange={[Function]}
+      placeholder="Comment"
       resizable={false}
       rows={8}
       styles={[Function]}
@@ -154,6 +156,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: par
       label="Comment"
       multiline={true}
       onChange={[Function]}
+      placeholder="Comment"
       resizable={false}
       rows={8}
       styles={[Function]}


### PR DESCRIPTION
#### Description of changes

The mocks in #1167 show a placeholder for the comment textbox. This PR adds the placeholder.

![comment placeholder screenshot](https://user-images.githubusercontent.com/7775527/63985404-74779a80-ca84-11e9-9c46-67316f91b98b.png)


#### Pull request checklist

- [x] Addresses **some of** an existing issue: #1167
- [x] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
