### PR TITLE
fix: assorted minor text issues caught during 2.9.0 validation

### DIFF
--- a/src/assessments/custom-widgets/test-steps/expected-input.tsx
+++ b/src/assessments/custom-widgets/test-steps/expected-input.tsx
@@ -6,7 +6,7 @@ import { CustomWidgetPropertyBag } from 'common/types/property-bag/icustom-widge
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
-import * as content from 'content/test/custom-widgets/label';
+import * as content from 'content/test/custom-widgets/expected-input';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from 'injected/scanner-utils';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';

--- a/src/assessments/native-widgets/test-steps/autocomplete.tsx
+++ b/src/assessments/native-widgets/test-steps/autocomplete.tsx
@@ -34,8 +34,8 @@ const howToTest: JSX.Element = (
             </li>
 
             <li>
-                If a text field does serve an identified input purpose, verify that it has an <Markup.Term>autocomplete</Markup.Term>{' '}
-                attribute with the correct value.
+                If a text field <Markup.Emphasis>does</Markup.Emphasis> serve an identified input purpose, verify that it has an{' '}
+                <Markup.Term>autocomplete</Markup.Term> attribute with the correct value.
             </li>
 
             <AssistedTestRecordYourResults />

--- a/src/assessments/native-widgets/test-steps/expected-input.tsx
+++ b/src/assessments/native-widgets/test-steps/expected-input.tsx
@@ -6,7 +6,7 @@ import { DefaultWidgetPropertyBag } from 'common/types/property-bag/default-widg
 import { VisualizationType } from 'common/types/visualization-type';
 import { link } from 'content/link';
 import { productName } from 'content/strings/application';
-import * as content from 'content/test/native-widgets/label';
+import * as content from 'content/test/native-widgets/expected-input';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
 import { ScannerUtils } from 'injected/scanner-utils';
 import { AnalyzerConfigurationFactory } from '../../common/analyzer-configuration-factory';

--- a/src/assessments/text-legibility/test-steps/text-spacing.tsx
+++ b/src/assessments/text-legibility/test-steps/text-spacing.tsx
@@ -20,8 +20,12 @@ const textSpacingHowToTest: JSX.Element = (
         bookmarklet to adjust text spacing in the target page.
         <ol>
             <li>
-                Add the <NewTabLink href="https://www.html5accessibility.com/tests/tsbookmarklet.html">Text spacing</NewTabLink> bookmarklet
-                to your browser's bookmarks. (Mouse users can simply drag the link into the bookmarks bar.)
+                Open <NewTabLink href="https://www.html5accessibility.com/tests/tsbookmarklet.html">Text spacing</NewTabLink> in a new
+                browser window.
+            </li>
+            <li>
+                Add the "Bookmarklet: Text Spacing" link from that page to your browser's bookmarks. (Mouse users can simply drag the link
+                into the bookmarks bar.)
             </li>
             <li>Use your browser's settings to set the target page's zoom to 400%.</li>
             <li>

--- a/src/content/test/custom-widgets/expected-input.tsx
+++ b/src/content/test/custom-widgets/expected-input.tsx
@@ -4,8 +4,8 @@ import { create, React } from '../../common';
 
 export const infoAndExamples = create(({ Markup, Link }) => (
     <>
-        <h1>Label</h1>
-        <p>A native widget must have a label and/or instructions that identify the expected input.</p>
+        <h1>Expected input</h1>
+        <p>A custom widget must have a label and/or instructions that identify the expected input.</p>
 
         <h2>Why it matters</h2>
         <p>When a widget clearly communicates its expected input, all users are likely to make fewer input mistakes.</p>
@@ -29,19 +29,25 @@ export const infoAndExamples = create(({ Markup, Link }) => (
         <Markup.PassFail
             failText={
                 <p>
-                    An online form has fields for entering first and last names, but both fields share the same accessible name. Users are
-                    expected to infer from the placeholder text that the first field is for the first name, and the second field is for the
-                    last name.
+                    The label for this combo box does not clearly communicate that users are expected to enter an abbreviation for their
+                    state.
                 </p>
             }
-            failExample={`<div id="name">Name</div>
-            <input type="text" name="firstname" [placeholder="Mickey" aria-labelledby="name"]>
-            <input type="text" name="lastname" [placeholder="Mouse" aria-labelledby="name"]>`}
-            passText={<p>Each text field has its own label indicating which name is expected.</p>}
-            passExample={`[<label for="firstname">First name</label>]
-            <input type="text" name="firstname" [id="firstname"]>
-            [<label for="lastname">Last name</label>]
-            <input type="text" name="lastname" [id="lastname"]>`}
+            failExample={`<label for="where-input" id="where-label" class="combobox-label">[Location]</label>
+            <div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox">
+            <input type="text" aria-autocomplete="list" aria-controls="where-listbox" id="where-input">
+            </div>`}
+            passText={
+                <p>
+                    An accessible description has been created using <Markup.Code>aria-describedby</Markup.Code>. The description clarifies
+                    the expected input.
+                </p>
+            }
+            passExample={`<label for="where-input" id="where-label" class="combobox-label">[Location]</label>
+            [<p id="where-desc">Enter the 2-letter abbreviation for your state.</p>]
+            <div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox">
+            <input type="text" aria-autocomplete="list" aria-controls="ex1-listbox" id="where-input" [aria-describedby="where-desc"]>
+            </div>`}
         />
 
         <h2>More examples</h2>

--- a/src/content/test/custom-widgets/index.ts
+++ b/src/content/test/custom-widgets/index.ts
@@ -6,7 +6,6 @@ import * as expectedInput from './expected-input';
 import { guidance } from './guidance';
 import * as instructions from './instructions';
 import * as keyboardInteraction from './keyboard-interaction';
-import * as label from './label';
 import * as roleStateProperty from './role-state-property';
 
 export const customWidgets = {

--- a/src/content/test/custom-widgets/index.ts
+++ b/src/content/test/custom-widgets/index.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import * as cues from './cues';
 import * as designPattern from './design-pattern';
+import * as expectedInput from './expected-input';
 import { guidance } from './guidance';
 import * as instructions from './instructions';
 import * as keyboardInteraction from './keyboard-interaction';
@@ -12,7 +13,7 @@ export const customWidgets = {
     guidance,
     designPattern,
     instructions,
-    label,
+    expectedInput,
     roleStateProperty,
     cues,
     keyboardInteraction,

--- a/src/content/test/native-widgets/autocomplete.tsx
+++ b/src/content/test/native-widgets/autocomplete.tsx
@@ -31,11 +31,15 @@ export const infoAndExamples = create(({ Markup }) => (
             failExample={`
             <form method="post" action="step2">
             <div>
-                <label for="username">Username</label>
+                <label for="username">
+                    Username
+                </label>
                 <input id="username" type="text" autocomplete="username">
             </div>
             <div>
-                <label for="password">Password</label>
+                <label for="password">
+                    Password
+                </label>
                 <input id="password" type="password" [autocomplete="password"]>
             </div>
             </form>
@@ -44,11 +48,15 @@ export const infoAndExamples = create(({ Markup }) => (
             passExample={`
             <form method="post" action="step2">
             <div>
-                <label for="username">Username</label>
+                <label for="username">
+                    Username
+                </label>
                 <input id="username" type="text" autocomplete="username">
             </div>
             <div>
-                <label for="password">Password</label>
+                <label for="password">
+                    Password
+                </label>
                 <input id="password" type="password" [autocomplete="current-password"]>
             </div>
             </form>

--- a/src/content/test/native-widgets/expected-input.tsx
+++ b/src/content/test/native-widgets/expected-input.tsx
@@ -4,8 +4,8 @@ import { create, React } from '../../common';
 
 export const infoAndExamples = create(({ Markup, Link }) => (
     <>
-        <h1>Label</h1>
-        <p>A custom widget must have a label and/or instructions that identify the expected input.</p>
+        <h1>Expected input</h1>
+        <p>A native widget must have a label and/or instructions that identify the expected input.</p>
 
         <h2>Why it matters</h2>
         <p>When a widget clearly communicates its expected input, all users are likely to make fewer input mistakes.</p>
@@ -29,25 +29,19 @@ export const infoAndExamples = create(({ Markup, Link }) => (
         <Markup.PassFail
             failText={
                 <p>
-                    The label for this combo box does not clearly communicate that users are expected to enter an abbreviation for their
-                    state.
+                    An online form has fields for entering first and last names, but both fields share the same accessible name. Users are
+                    expected to infer from the placeholder text that the first field is for the first name, and the second field is for the
+                    last name.
                 </p>
             }
-            failExample={`<label for="where-input" id="where-label" class="combobox-label">[Location]</label>
-            <div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox">
-            <input type="text" aria-autocomplete="list" aria-controls="where-listbox" id="where-input">
-            </div>`}
-            passText={
-                <p>
-                    An accessible description has been created using <Markup.Code>aria-describedby</Markup.Code>. The description clarifies
-                    the expected input.
-                </p>
-            }
-            passExample={`<label for="where-input" id="where-label" class="combobox-label">[Location]</label>
-            [<p id="where-desc">Enter the 2-letter abbreviation for your state.</p>]
-            <div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox">
-            <input type="text" aria-autocomplete="list" aria-controls="ex1-listbox" id="where-input" [aria-describedby="where-desc"]>
-            </div>`}
+            failExample={`<div id="name">Name</div>
+            <input type="text" name="firstname" [placeholder="Mickey" aria-labelledby="name"]>
+            <input type="text" name="lastname" [placeholder="Mouse" aria-labelledby="name"]>`}
+            passText={<p>Each text field has its own label indicating which name is expected.</p>}
+            passExample={`[<label for="firstname">First name</label>]
+            <input type="text" name="firstname" [id="firstname"]>
+            [<label for="lastname">Last name</label>]
+            <input type="text" name="lastname" [id="lastname"]>`}
         />
 
         <h2>More examples</h2>

--- a/src/content/test/native-widgets/index.ts
+++ b/src/content/test/native-widgets/index.ts
@@ -2,16 +2,16 @@
 // Licensed under the MIT License.
 import * as autocomplete from './autocomplete';
 import * as cues from './cues';
+import * as expectedInput from './expected-input';
 import { guidance } from './guidance';
 import * as instructions from './instructions';
-import * as label from './label';
 import * as widgetFunction from './widget-function';
 
 export const nativeWidgets = {
     guidance,
     cues,
     instructions,
-    label,
+    expectedInput,
     widgetFunction,
     autocomplete,
 };

--- a/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
@@ -3373,6 +3373,298 @@ exports[`A11Y for content pages High Contrast mode test/customWidgets/designPatt
 </DocumentFragment>
 `;
 
+exports[`A11Y for content pages High Contrast mode test/customWidgets/expectedInput/infoAndExamples 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        Expected input
+      </h1>
+      <p>
+        A custom widget must have a label and/or instructions that identify the expected input.
+      </p>
+      <h2>
+        Why it matters
+      </h2>
+      <p>
+        When a widget clearly communicates its expected input, all users are likely to make fewer input mistakes.
+      </p>
+      <h3>
+        From a user's perspective
+      </h3>
+      <p>
+        <em>
+          "I do not rely on visual cues for reading, I use a screen reader. For any required input you need from me, provide me with general instructions on what is being asked, what is required and, examples of valid input so I can provide the requested information."
+        </em>
+      </p>
+      <h2>
+        How to fix
+      </h2>
+      <p>
+        Make sure the widget's accessible name and/or accessible description communicates the expected input. For example, a button should indicate what action it will initiate. A text field should indicate what type of data is expected and whether a specific format is required.
+      </p>
+      <h2>
+        Example
+      </h2>
+      <div
+        class="pass-fail-grid"
+      >
+        <div
+          class="fail-section"
+        >
+          <div
+            class="fail-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="white"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Fail
+            </h3>
+          </div>
+          <p>
+            The label for this combo box does not clearly communicate that users are expected to enter an abbreviation for their state.
+          </p>
+        </div>
+        <div
+          class="fail-example"
+        >
+          <div
+            class="code-example"
+          >
+            <div
+              class="code-example-code"
+            >
+              <div
+                class="insights-code"
+              >
+                &lt;label for="where-input" id="where-label" class="combobox-label"&gt;
+                <span
+                  class="highlight"
+                >
+                  Location
+                </span>
+                &lt;/label&gt;
+                <br />
+                            &lt;div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox"&gt;
+                <br />
+                            &lt;input type="text" aria-autocomplete="list" aria-controls="where-listbox" id="where-input"&gt;
+                <br />
+                            &lt;/div&gt;
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pass-section"
+        >
+          <div
+            class="pass-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Pass
+            </h3>
+          </div>
+          <p>
+            An accessible description has been created using 
+            <span
+              class="insights-code"
+            >
+              aria-describedby
+            </span>
+            . The description clarifies the expected input.
+          </p>
+        </div>
+        <div
+          class="pass-example"
+        >
+          <div
+            class="code-example"
+          >
+            <div
+              class="code-example-code"
+            >
+              <div
+                class="insights-code"
+              >
+                &lt;label for="where-input" id="where-label" class="combobox-label"&gt;
+                <span
+                  class="highlight"
+                >
+                  Location
+                </span>
+                &lt;/label&gt;
+                <br />
+                            
+                <span
+                  class="highlight"
+                >
+                  &lt;p id="where-desc"&gt;Enter the 2-letter abbreviation for your state.&lt;/p&gt;
+                </span>
+                <br />
+                            &lt;div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox"&gt;
+                <br />
+                            &lt;input type="text" aria-autocomplete="list" aria-controls="ex1-listbox" id="where-input" 
+                <span
+                  class="highlight"
+                >
+                  aria-describedby="where-desc"
+                </span>
+                &gt;
+                <br />
+                            &lt;/div&gt;
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <h2>
+        More examples
+      </h2>
+      <h3>
+        WCAG success criteria
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 3.3.2: Labels or Instructions
+        </a>
+      </div>
+      <h4>
+        Sufficient techniques
+      </h4>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G131"
+          target="_blank"
+        >
+          Providing descriptive labels
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1"
+          target="_blank"
+        >
+          Using the aria-describedby property to provide a descriptive label for user interface controls
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9"
+          target="_blank"
+        >
+          Using aria-labelledby to concatenate a label from several text nodes
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA17"
+          target="_blank"
+        >
+          Using grouping roles to identify related form controls
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G89"
+          target="_blank"
+        >
+          Providing expected data format and example
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G184"
+          target="_blank"
+        >
+          Providing text instructions at the beginning of a form or set of fields that describes the necessary input
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G162"
+          target="_blank"
+        >
+          Positioning labels to maximize predictability of relationships
+        </a>
+      </div>
+      <h3>
+        Common failures
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F82"
+          target="_blank"
+        >
+          Failure of Success Criterion 3.3.2 by visually formatting a set of phone number fields but not including a text label
+        </a>
+      </div>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`A11Y for content pages High Contrast mode test/customWidgets/guidance 1`] = `
 <DocumentFragment>
   <div
@@ -4650,298 +4942,6 @@ exports[`A11Y for content pages High Contrast mode test/customWidgets/keyboardIn
           target="_blank"
         >
           WAI-ARIA Authoring Practices 1.1: Design Patterns and Widgets
-        </a>
-      </div>
-    </div>
-    <div
-      class="content-right"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`A11Y for content pages High Contrast mode test/customWidgets/label/infoAndExamples 1`] = `
-<DocumentFragment>
-  <div
-    class="content-container"
-  >
-    <div
-      class="content-left"
-    />
-    <div
-      class="content"
-    >
-      <h1>
-        Label
-      </h1>
-      <p>
-        A custom widget must have a label and/or instructions that identify the expected input.
-      </p>
-      <h2>
-        Why it matters
-      </h2>
-      <p>
-        When a widget clearly communicates its expected input, all users are likely to make fewer input mistakes.
-      </p>
-      <h3>
-        From a user's perspective
-      </h3>
-      <p>
-        <em>
-          "I do not rely on visual cues for reading, I use a screen reader. For any required input you need from me, provide me with general instructions on what is being asked, what is required and, examples of valid input so I can provide the requested information."
-        </em>
-      </p>
-      <h2>
-        How to fix
-      </h2>
-      <p>
-        Make sure the widget's accessible name and/or accessible description communicates the expected input. For example, a button should indicate what action it will initiate. A text field should indicate what type of data is expected and whether a specific format is required.
-      </p>
-      <h2>
-        Example
-      </h2>
-      <div
-        class="pass-fail-grid"
-      >
-        <div
-          class="fail-section"
-        >
-          <div
-            class="fail-header"
-          >
-            <span
-              class="check-container"
-            >
-              <svg
-                fill="none"
-                height="16"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  fill="#E81123"
-                  r="8"
-                />
-                <path
-                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
-                  fill="white"
-                />
-              </svg>
-            </span>
-             
-            <h3>
-              Fail
-            </h3>
-          </div>
-          <p>
-            The label for this combo box does not clearly communicate that users are expected to enter an abbreviation for their state.
-          </p>
-        </div>
-        <div
-          class="fail-example"
-        >
-          <div
-            class="code-example"
-          >
-            <div
-              class="code-example-code"
-            >
-              <div
-                class="insights-code"
-              >
-                &lt;label for="where-input" id="where-label" class="combobox-label"&gt;
-                <span
-                  class="highlight"
-                >
-                  Location
-                </span>
-                &lt;/label&gt;
-                <br />
-                            &lt;div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox"&gt;
-                <br />
-                            &lt;input type="text" aria-autocomplete="list" aria-controls="where-listbox" id="where-input"&gt;
-                <br />
-                            &lt;/div&gt;
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="pass-section"
-        >
-          <div
-            class="pass-header"
-          >
-            <span
-              class="check-container"
-            >
-              <svg
-                fill="none"
-                height="16"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  fill="#228722"
-                  r="8"
-                />
-                <path
-                  clip-rule="evenodd"
-                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
-                  fill="white"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-             
-            <h3>
-              Pass
-            </h3>
-          </div>
-          <p>
-            An accessible description has been created using 
-            <span
-              class="insights-code"
-            >
-              aria-describedby
-            </span>
-            . The description clarifies the expected input.
-          </p>
-        </div>
-        <div
-          class="pass-example"
-        >
-          <div
-            class="code-example"
-          >
-            <div
-              class="code-example-code"
-            >
-              <div
-                class="insights-code"
-              >
-                &lt;label for="where-input" id="where-label" class="combobox-label"&gt;
-                <span
-                  class="highlight"
-                >
-                  Location
-                </span>
-                &lt;/label&gt;
-                <br />
-                            
-                <span
-                  class="highlight"
-                >
-                  &lt;p id="where-desc"&gt;Enter the 2-letter abbreviation for your state.&lt;/p&gt;
-                </span>
-                <br />
-                            &lt;div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox"&gt;
-                <br />
-                            &lt;input type="text" aria-autocomplete="list" aria-controls="ex1-listbox" id="where-input" 
-                <span
-                  class="highlight"
-                >
-                  aria-describedby="where-desc"
-                </span>
-                &gt;
-                <br />
-                            &lt;/div&gt;
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <h2>
-        More examples
-      </h2>
-      <h3>
-        WCAG success criteria
-      </h3>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html"
-          target="_blank"
-        >
-          Understanding Success Criterion 3.3.2: Labels or Instructions
-        </a>
-      </div>
-      <h4>
-        Sufficient techniques
-      </h4>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G131"
-          target="_blank"
-        >
-          Providing descriptive labels
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1"
-          target="_blank"
-        >
-          Using the aria-describedby property to provide a descriptive label for user interface controls
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9"
-          target="_blank"
-        >
-          Using aria-labelledby to concatenate a label from several text nodes
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA17"
-          target="_blank"
-        >
-          Using grouping roles to identify related form controls
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G89"
-          target="_blank"
-        >
-          Providing expected data format and example
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G184"
-          target="_blank"
-        >
-          Providing text instructions at the beginning of a form or set of fields that describes the necessary input
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G162"
-          target="_blank"
-        >
-          Positioning labels to maximize predictability of relationships
-        </a>
-      </div>
-      <h3>
-        Common failures
-      </h3>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F82"
-          target="_blank"
-        >
-          Failure of Success Criterion 3.3.2 by visually formatting a set of phone number fields but not including a text label
         </a>
       </div>
     </div>
@@ -19411,7 +19411,11 @@ exports[`A11Y for content pages High Contrast mode test/nativeWidgets/autocomple
                 <br />
                             &lt;div&gt;
                 <br />
-                                &lt;label for="username"&gt;Username&lt;/label&gt;
+                                &lt;label for="username"&gt;
+                <br />
+                                    Username
+                <br />
+                                &lt;/label&gt;
                 <br />
                                 &lt;input id="username" type="text" autocomplete="username"&gt;
                 <br />
@@ -19419,7 +19423,11 @@ exports[`A11Y for content pages High Contrast mode test/nativeWidgets/autocomple
                 <br />
                             &lt;div&gt;
                 <br />
-                                &lt;label for="password"&gt;Password&lt;/label&gt;
+                                &lt;label for="password"&gt;
+                <br />
+                                    Password
+                <br />
+                                &lt;/label&gt;
                 <br />
                                 &lt;input id="password" type="password" 
                 <span
@@ -19494,7 +19502,11 @@ exports[`A11Y for content pages High Contrast mode test/nativeWidgets/autocomple
                 <br />
                             &lt;div&gt;
                 <br />
-                                &lt;label for="username"&gt;Username&lt;/label&gt;
+                                &lt;label for="username"&gt;
+                <br />
+                                    Username
+                <br />
+                                &lt;/label&gt;
                 <br />
                                 &lt;input id="username" type="text" autocomplete="username"&gt;
                 <br />
@@ -19502,7 +19514,11 @@ exports[`A11Y for content pages High Contrast mode test/nativeWidgets/autocomple
                 <br />
                             &lt;div&gt;
                 <br />
-                                &lt;label for="password"&gt;Password&lt;/label&gt;
+                                &lt;label for="password"&gt;
+                <br />
+                                    Password
+                <br />
+                                &lt;/label&gt;
                 <br />
                                 &lt;input id="password" type="password" 
                 <span
@@ -19841,6 +19857,298 @@ exports[`A11Y for content pages High Contrast mode test/nativeWidgets/cues/infoA
           target="_blank"
         >
           Using semantic markup whenever color cues are used
+        </a>
+      </div>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`A11Y for content pages High Contrast mode test/nativeWidgets/expectedInput/infoAndExamples 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        Expected input
+      </h1>
+      <p>
+        A native widget must have a label and/or instructions that identify the expected input.
+      </p>
+      <h2>
+        Why it matters
+      </h2>
+      <p>
+        When a widget clearly communicates its expected input, all users are likely to make fewer input mistakes.
+      </p>
+      <h3>
+        From a user's perspective
+      </h3>
+      <p>
+        <em>
+          "I do not rely on visual cues for reading, I use a screen reader. For any required input you need from me, provide me with general instructions on what is being asked, what is required and, examples of valid input so I can provide the requested information."
+        </em>
+      </p>
+      <h2>
+        How to fix
+      </h2>
+      <p>
+        Make sure the widget's accessible name and/or accessible description communicates the expected input. For example, a button should indicate what action it will initiate. A text field should indicate what type of data is expected and whether a specific format is required.
+      </p>
+      <h2>
+        Example
+      </h2>
+      <div
+        class="pass-fail-grid"
+      >
+        <div
+          class="fail-section"
+        >
+          <div
+            class="fail-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="white"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Fail
+            </h3>
+          </div>
+          <p>
+            An online form has fields for entering first and last names, but both fields share the same accessible name. Users are expected to infer from the placeholder text that the first field is for the first name, and the second field is for the last name.
+          </p>
+        </div>
+        <div
+          class="fail-example"
+        >
+          <div
+            class="code-example"
+          >
+            <div
+              class="code-example-code"
+            >
+              <div
+                class="insights-code"
+              >
+                &lt;div id="name"&gt;Name&lt;/div&gt;
+                <br />
+                            &lt;input type="text" name="firstname" 
+                <span
+                  class="highlight"
+                >
+                  placeholder="Mickey" aria-labelledby="name"
+                </span>
+                &gt;
+                <br />
+                            &lt;input type="text" name="lastname" 
+                <span
+                  class="highlight"
+                >
+                  placeholder="Mouse" aria-labelledby="name"
+                </span>
+                &gt;
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pass-section"
+        >
+          <div
+            class="pass-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Pass
+            </h3>
+          </div>
+          <p>
+            Each text field has its own label indicating which name is expected.
+          </p>
+        </div>
+        <div
+          class="pass-example"
+        >
+          <div
+            class="code-example"
+          >
+            <div
+              class="code-example-code"
+            >
+              <div
+                class="insights-code"
+              >
+                <span
+                  class="highlight"
+                >
+                  &lt;label for="firstname"&gt;First name&lt;/label&gt;
+                </span>
+                <br />
+                            &lt;input type="text" name="firstname" 
+                <span
+                  class="highlight"
+                >
+                  id="firstname"
+                </span>
+                &gt;
+                <br />
+                            
+                <span
+                  class="highlight"
+                >
+                  &lt;label for="lastname"&gt;Last name&lt;/label&gt;
+                </span>
+                <br />
+                            &lt;input type="text" name="lastname" 
+                <span
+                  class="highlight"
+                >
+                  id="lastname"
+                </span>
+                &gt;
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <h2>
+        More examples
+      </h2>
+      <h3>
+        WCAG success criteria
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 3.3.2: Labels or Instructions
+        </a>
+      </div>
+      <h4>
+        Sufficient techniques
+      </h4>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G131"
+          target="_blank"
+        >
+          Providing descriptive labels
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1"
+          target="_blank"
+        >
+          Using the aria-describedby property to provide a descriptive label for user interface controls
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9"
+          target="_blank"
+        >
+          Using aria-labelledby to concatenate a label from several text nodes
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA17"
+          target="_blank"
+        >
+          Using grouping roles to identify related form controls
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G89"
+          target="_blank"
+        >
+          Providing expected data format and example
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G184"
+          target="_blank"
+        >
+          Providing text instructions at the beginning of a form or set of fields that describes the necessary input
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G162"
+          target="_blank"
+        >
+          Positioning labels to maximize predictability of relationships
+        </a>
+      </div>
+      <h3>
+        Common failures
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F82"
+          target="_blank"
+        >
+          Failure of Success Criterion 3.3.2 by visually formatting a set of phone number fields but not including a text label
         </a>
       </div>
     </div>
@@ -20729,298 +21037,6 @@ exports[`A11Y for content pages High Contrast mode test/nativeWidgets/instructio
           target="_blank"
         >
           Using the aria-describedby property to provide a descriptive label for user interface controls
-        </a>
-      </div>
-    </div>
-    <div
-      class="content-right"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`A11Y for content pages High Contrast mode test/nativeWidgets/label/infoAndExamples 1`] = `
-<DocumentFragment>
-  <div
-    class="content-container"
-  >
-    <div
-      class="content-left"
-    />
-    <div
-      class="content"
-    >
-      <h1>
-        Label
-      </h1>
-      <p>
-        A native widget must have a label and/or instructions that identify the expected input.
-      </p>
-      <h2>
-        Why it matters
-      </h2>
-      <p>
-        When a widget clearly communicates its expected input, all users are likely to make fewer input mistakes.
-      </p>
-      <h3>
-        From a user's perspective
-      </h3>
-      <p>
-        <em>
-          "I do not rely on visual cues for reading, I use a screen reader. For any required input you need from me, provide me with general instructions on what is being asked, what is required and, examples of valid input so I can provide the requested information."
-        </em>
-      </p>
-      <h2>
-        How to fix
-      </h2>
-      <p>
-        Make sure the widget's accessible name and/or accessible description communicates the expected input. For example, a button should indicate what action it will initiate. A text field should indicate what type of data is expected and whether a specific format is required.
-      </p>
-      <h2>
-        Example
-      </h2>
-      <div
-        class="pass-fail-grid"
-      >
-        <div
-          class="fail-section"
-        >
-          <div
-            class="fail-header"
-          >
-            <span
-              class="check-container"
-            >
-              <svg
-                fill="none"
-                height="16"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  fill="#E81123"
-                  r="8"
-                />
-                <path
-                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
-                  fill="white"
-                />
-              </svg>
-            </span>
-             
-            <h3>
-              Fail
-            </h3>
-          </div>
-          <p>
-            An online form has fields for entering first and last names, but both fields share the same accessible name. Users are expected to infer from the placeholder text that the first field is for the first name, and the second field is for the last name.
-          </p>
-        </div>
-        <div
-          class="fail-example"
-        >
-          <div
-            class="code-example"
-          >
-            <div
-              class="code-example-code"
-            >
-              <div
-                class="insights-code"
-              >
-                &lt;div id="name"&gt;Name&lt;/div&gt;
-                <br />
-                            &lt;input type="text" name="firstname" 
-                <span
-                  class="highlight"
-                >
-                  placeholder="Mickey" aria-labelledby="name"
-                </span>
-                &gt;
-                <br />
-                            &lt;input type="text" name="lastname" 
-                <span
-                  class="highlight"
-                >
-                  placeholder="Mouse" aria-labelledby="name"
-                </span>
-                &gt;
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="pass-section"
-        >
-          <div
-            class="pass-header"
-          >
-            <span
-              class="check-container"
-            >
-              <svg
-                fill="none"
-                height="16"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  fill="#228722"
-                  r="8"
-                />
-                <path
-                  clip-rule="evenodd"
-                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
-                  fill="white"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-             
-            <h3>
-              Pass
-            </h3>
-          </div>
-          <p>
-            Each text field has its own label indicating which name is expected.
-          </p>
-        </div>
-        <div
-          class="pass-example"
-        >
-          <div
-            class="code-example"
-          >
-            <div
-              class="code-example-code"
-            >
-              <div
-                class="insights-code"
-              >
-                <span
-                  class="highlight"
-                >
-                  &lt;label for="firstname"&gt;First name&lt;/label&gt;
-                </span>
-                <br />
-                            &lt;input type="text" name="firstname" 
-                <span
-                  class="highlight"
-                >
-                  id="firstname"
-                </span>
-                &gt;
-                <br />
-                            
-                <span
-                  class="highlight"
-                >
-                  &lt;label for="lastname"&gt;Last name&lt;/label&gt;
-                </span>
-                <br />
-                            &lt;input type="text" name="lastname" 
-                <span
-                  class="highlight"
-                >
-                  id="lastname"
-                </span>
-                &gt;
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <h2>
-        More examples
-      </h2>
-      <h3>
-        WCAG success criteria
-      </h3>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html"
-          target="_blank"
-        >
-          Understanding Success Criterion 3.3.2: Labels or Instructions
-        </a>
-      </div>
-      <h4>
-        Sufficient techniques
-      </h4>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G131"
-          target="_blank"
-        >
-          Providing descriptive labels
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1"
-          target="_blank"
-        >
-          Using the aria-describedby property to provide a descriptive label for user interface controls
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9"
-          target="_blank"
-        >
-          Using aria-labelledby to concatenate a label from several text nodes
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA17"
-          target="_blank"
-        >
-          Using grouping roles to identify related form controls
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G89"
-          target="_blank"
-        >
-          Providing expected data format and example
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G184"
-          target="_blank"
-        >
-          Providing text instructions at the beginning of a form or set of fields that describes the necessary input
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G162"
-          target="_blank"
-        >
-          Positioning labels to maximize predictability of relationships
-        </a>
-      </div>
-      <h3>
-        Common failures
-      </h3>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F82"
-          target="_blank"
-        >
-          Failure of Success Criterion 3.3.2 by visually formatting a set of phone number fields but not including a text label
         </a>
       </div>
     </div>
@@ -36908,6 +36924,298 @@ exports[`A11Y for content pages Normal mode test/customWidgets/designPattern/inf
 </DocumentFragment>
 `;
 
+exports[`A11Y for content pages Normal mode test/customWidgets/expectedInput/infoAndExamples 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        Expected input
+      </h1>
+      <p>
+        A custom widget must have a label and/or instructions that identify the expected input.
+      </p>
+      <h2>
+        Why it matters
+      </h2>
+      <p>
+        When a widget clearly communicates its expected input, all users are likely to make fewer input mistakes.
+      </p>
+      <h3>
+        From a user's perspective
+      </h3>
+      <p>
+        <em>
+          "I do not rely on visual cues for reading, I use a screen reader. For any required input you need from me, provide me with general instructions on what is being asked, what is required and, examples of valid input so I can provide the requested information."
+        </em>
+      </p>
+      <h2>
+        How to fix
+      </h2>
+      <p>
+        Make sure the widget's accessible name and/or accessible description communicates the expected input. For example, a button should indicate what action it will initiate. A text field should indicate what type of data is expected and whether a specific format is required.
+      </p>
+      <h2>
+        Example
+      </h2>
+      <div
+        class="pass-fail-grid"
+      >
+        <div
+          class="fail-section"
+        >
+          <div
+            class="fail-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="white"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Fail
+            </h3>
+          </div>
+          <p>
+            The label for this combo box does not clearly communicate that users are expected to enter an abbreviation for their state.
+          </p>
+        </div>
+        <div
+          class="fail-example"
+        >
+          <div
+            class="code-example"
+          >
+            <div
+              class="code-example-code"
+            >
+              <div
+                class="insights-code"
+              >
+                &lt;label for="where-input" id="where-label" class="combobox-label"&gt;
+                <span
+                  class="highlight"
+                >
+                  Location
+                </span>
+                &lt;/label&gt;
+                <br />
+                            &lt;div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox"&gt;
+                <br />
+                            &lt;input type="text" aria-autocomplete="list" aria-controls="where-listbox" id="where-input"&gt;
+                <br />
+                            &lt;/div&gt;
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pass-section"
+        >
+          <div
+            class="pass-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Pass
+            </h3>
+          </div>
+          <p>
+            An accessible description has been created using 
+            <span
+              class="insights-code"
+            >
+              aria-describedby
+            </span>
+            . The description clarifies the expected input.
+          </p>
+        </div>
+        <div
+          class="pass-example"
+        >
+          <div
+            class="code-example"
+          >
+            <div
+              class="code-example-code"
+            >
+              <div
+                class="insights-code"
+              >
+                &lt;label for="where-input" id="where-label" class="combobox-label"&gt;
+                <span
+                  class="highlight"
+                >
+                  Location
+                </span>
+                &lt;/label&gt;
+                <br />
+                            
+                <span
+                  class="highlight"
+                >
+                  &lt;p id="where-desc"&gt;Enter the 2-letter abbreviation for your state.&lt;/p&gt;
+                </span>
+                <br />
+                            &lt;div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox"&gt;
+                <br />
+                            &lt;input type="text" aria-autocomplete="list" aria-controls="ex1-listbox" id="where-input" 
+                <span
+                  class="highlight"
+                >
+                  aria-describedby="where-desc"
+                </span>
+                &gt;
+                <br />
+                            &lt;/div&gt;
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <h2>
+        More examples
+      </h2>
+      <h3>
+        WCAG success criteria
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 3.3.2: Labels or Instructions
+        </a>
+      </div>
+      <h4>
+        Sufficient techniques
+      </h4>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G131"
+          target="_blank"
+        >
+          Providing descriptive labels
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1"
+          target="_blank"
+        >
+          Using the aria-describedby property to provide a descriptive label for user interface controls
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9"
+          target="_blank"
+        >
+          Using aria-labelledby to concatenate a label from several text nodes
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA17"
+          target="_blank"
+        >
+          Using grouping roles to identify related form controls
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G89"
+          target="_blank"
+        >
+          Providing expected data format and example
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G184"
+          target="_blank"
+        >
+          Providing text instructions at the beginning of a form or set of fields that describes the necessary input
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G162"
+          target="_blank"
+        >
+          Positioning labels to maximize predictability of relationships
+        </a>
+      </div>
+      <h3>
+        Common failures
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F82"
+          target="_blank"
+        >
+          Failure of Success Criterion 3.3.2 by visually formatting a set of phone number fields but not including a text label
+        </a>
+      </div>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
 exports[`A11Y for content pages Normal mode test/customWidgets/guidance 1`] = `
 <DocumentFragment>
   <div
@@ -38185,298 +38493,6 @@ exports[`A11Y for content pages Normal mode test/customWidgets/keyboardInteracti
           target="_blank"
         >
           WAI-ARIA Authoring Practices 1.1: Design Patterns and Widgets
-        </a>
-      </div>
-    </div>
-    <div
-      class="content-right"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`A11Y for content pages Normal mode test/customWidgets/label/infoAndExamples 1`] = `
-<DocumentFragment>
-  <div
-    class="content-container"
-  >
-    <div
-      class="content-left"
-    />
-    <div
-      class="content"
-    >
-      <h1>
-        Label
-      </h1>
-      <p>
-        A custom widget must have a label and/or instructions that identify the expected input.
-      </p>
-      <h2>
-        Why it matters
-      </h2>
-      <p>
-        When a widget clearly communicates its expected input, all users are likely to make fewer input mistakes.
-      </p>
-      <h3>
-        From a user's perspective
-      </h3>
-      <p>
-        <em>
-          "I do not rely on visual cues for reading, I use a screen reader. For any required input you need from me, provide me with general instructions on what is being asked, what is required and, examples of valid input so I can provide the requested information."
-        </em>
-      </p>
-      <h2>
-        How to fix
-      </h2>
-      <p>
-        Make sure the widget's accessible name and/or accessible description communicates the expected input. For example, a button should indicate what action it will initiate. A text field should indicate what type of data is expected and whether a specific format is required.
-      </p>
-      <h2>
-        Example
-      </h2>
-      <div
-        class="pass-fail-grid"
-      >
-        <div
-          class="fail-section"
-        >
-          <div
-            class="fail-header"
-          >
-            <span
-              class="check-container"
-            >
-              <svg
-                fill="none"
-                height="16"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  fill="#E81123"
-                  r="8"
-                />
-                <path
-                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
-                  fill="white"
-                />
-              </svg>
-            </span>
-             
-            <h3>
-              Fail
-            </h3>
-          </div>
-          <p>
-            The label for this combo box does not clearly communicate that users are expected to enter an abbreviation for their state.
-          </p>
-        </div>
-        <div
-          class="fail-example"
-        >
-          <div
-            class="code-example"
-          >
-            <div
-              class="code-example-code"
-            >
-              <div
-                class="insights-code"
-              >
-                &lt;label for="where-input" id="where-label" class="combobox-label"&gt;
-                <span
-                  class="highlight"
-                >
-                  Location
-                </span>
-                &lt;/label&gt;
-                <br />
-                            &lt;div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox"&gt;
-                <br />
-                            &lt;input type="text" aria-autocomplete="list" aria-controls="where-listbox" id="where-input"&gt;
-                <br />
-                            &lt;/div&gt;
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="pass-section"
-        >
-          <div
-            class="pass-header"
-          >
-            <span
-              class="check-container"
-            >
-              <svg
-                fill="none"
-                height="16"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  fill="#228722"
-                  r="8"
-                />
-                <path
-                  clip-rule="evenodd"
-                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
-                  fill="white"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-             
-            <h3>
-              Pass
-            </h3>
-          </div>
-          <p>
-            An accessible description has been created using 
-            <span
-              class="insights-code"
-            >
-              aria-describedby
-            </span>
-            . The description clarifies the expected input.
-          </p>
-        </div>
-        <div
-          class="pass-example"
-        >
-          <div
-            class="code-example"
-          >
-            <div
-              class="code-example-code"
-            >
-              <div
-                class="insights-code"
-              >
-                &lt;label for="where-input" id="where-label" class="combobox-label"&gt;
-                <span
-                  class="highlight"
-                >
-                  Location
-                </span>
-                &lt;/label&gt;
-                <br />
-                            
-                <span
-                  class="highlight"
-                >
-                  &lt;p id="where-desc"&gt;Enter the 2-letter abbreviation for your state.&lt;/p&gt;
-                </span>
-                <br />
-                            &lt;div role="combobox" aria-expanded="false" aria-owns="where-listbox" aria-haspopup="listbox" id="where-combobox"&gt;
-                <br />
-                            &lt;input type="text" aria-autocomplete="list" aria-controls="ex1-listbox" id="where-input" 
-                <span
-                  class="highlight"
-                >
-                  aria-describedby="where-desc"
-                </span>
-                &gt;
-                <br />
-                            &lt;/div&gt;
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <h2>
-        More examples
-      </h2>
-      <h3>
-        WCAG success criteria
-      </h3>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html"
-          target="_blank"
-        >
-          Understanding Success Criterion 3.3.2: Labels or Instructions
-        </a>
-      </div>
-      <h4>
-        Sufficient techniques
-      </h4>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G131"
-          target="_blank"
-        >
-          Providing descriptive labels
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1"
-          target="_blank"
-        >
-          Using the aria-describedby property to provide a descriptive label for user interface controls
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9"
-          target="_blank"
-        >
-          Using aria-labelledby to concatenate a label from several text nodes
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA17"
-          target="_blank"
-        >
-          Using grouping roles to identify related form controls
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G89"
-          target="_blank"
-        >
-          Providing expected data format and example
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G184"
-          target="_blank"
-        >
-          Providing text instructions at the beginning of a form or set of fields that describes the necessary input
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G162"
-          target="_blank"
-        >
-          Positioning labels to maximize predictability of relationships
-        </a>
-      </div>
-      <h3>
-        Common failures
-      </h3>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F82"
-          target="_blank"
-        >
-          Failure of Success Criterion 3.3.2 by visually formatting a set of phone number fields but not including a text label
         </a>
       </div>
     </div>
@@ -52946,7 +52962,11 @@ exports[`A11Y for content pages Normal mode test/nativeWidgets/autocomplete/info
                 <br />
                             &lt;div&gt;
                 <br />
-                                &lt;label for="username"&gt;Username&lt;/label&gt;
+                                &lt;label for="username"&gt;
+                <br />
+                                    Username
+                <br />
+                                &lt;/label&gt;
                 <br />
                                 &lt;input id="username" type="text" autocomplete="username"&gt;
                 <br />
@@ -52954,7 +52974,11 @@ exports[`A11Y for content pages Normal mode test/nativeWidgets/autocomplete/info
                 <br />
                             &lt;div&gt;
                 <br />
-                                &lt;label for="password"&gt;Password&lt;/label&gt;
+                                &lt;label for="password"&gt;
+                <br />
+                                    Password
+                <br />
+                                &lt;/label&gt;
                 <br />
                                 &lt;input id="password" type="password" 
                 <span
@@ -53029,7 +53053,11 @@ exports[`A11Y for content pages Normal mode test/nativeWidgets/autocomplete/info
                 <br />
                             &lt;div&gt;
                 <br />
-                                &lt;label for="username"&gt;Username&lt;/label&gt;
+                                &lt;label for="username"&gt;
+                <br />
+                                    Username
+                <br />
+                                &lt;/label&gt;
                 <br />
                                 &lt;input id="username" type="text" autocomplete="username"&gt;
                 <br />
@@ -53037,7 +53065,11 @@ exports[`A11Y for content pages Normal mode test/nativeWidgets/autocomplete/info
                 <br />
                             &lt;div&gt;
                 <br />
-                                &lt;label for="password"&gt;Password&lt;/label&gt;
+                                &lt;label for="password"&gt;
+                <br />
+                                    Password
+                <br />
+                                &lt;/label&gt;
                 <br />
                                 &lt;input id="password" type="password" 
                 <span
@@ -53376,6 +53408,298 @@ exports[`A11Y for content pages Normal mode test/nativeWidgets/cues/infoAndExamp
           target="_blank"
         >
           Using semantic markup whenever color cues are used
+        </a>
+      </div>
+    </div>
+    <div
+      class="content-right"
+    />
+  </div>
+</DocumentFragment>
+`;
+
+exports[`A11Y for content pages Normal mode test/nativeWidgets/expectedInput/infoAndExamples 1`] = `
+<DocumentFragment>
+  <div
+    class="content-container"
+  >
+    <div
+      class="content-left"
+    />
+    <div
+      class="content"
+    >
+      <h1>
+        Expected input
+      </h1>
+      <p>
+        A native widget must have a label and/or instructions that identify the expected input.
+      </p>
+      <h2>
+        Why it matters
+      </h2>
+      <p>
+        When a widget clearly communicates its expected input, all users are likely to make fewer input mistakes.
+      </p>
+      <h3>
+        From a user's perspective
+      </h3>
+      <p>
+        <em>
+          "I do not rely on visual cues for reading, I use a screen reader. For any required input you need from me, provide me with general instructions on what is being asked, what is required and, examples of valid input so I can provide the requested information."
+        </em>
+      </p>
+      <h2>
+        How to fix
+      </h2>
+      <p>
+        Make sure the widget's accessible name and/or accessible description communicates the expected input. For example, a button should indicate what action it will initiate. A text field should indicate what type of data is expected and whether a specific format is required.
+      </p>
+      <h2>
+        Example
+      </h2>
+      <div
+        class="pass-fail-grid"
+      >
+        <div
+          class="fail-section"
+        >
+          <div
+            class="fail-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#E81123"
+                  r="8"
+                />
+                <path
+                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
+                  fill="white"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Fail
+            </h3>
+          </div>
+          <p>
+            An online form has fields for entering first and last names, but both fields share the same accessible name. Users are expected to infer from the placeholder text that the first field is for the first name, and the second field is for the last name.
+          </p>
+        </div>
+        <div
+          class="fail-example"
+        >
+          <div
+            class="code-example"
+          >
+            <div
+              class="code-example-code"
+            >
+              <div
+                class="insights-code"
+              >
+                &lt;div id="name"&gt;Name&lt;/div&gt;
+                <br />
+                            &lt;input type="text" name="firstname" 
+                <span
+                  class="highlight"
+                >
+                  placeholder="Mickey" aria-labelledby="name"
+                </span>
+                &gt;
+                <br />
+                            &lt;input type="text" name="lastname" 
+                <span
+                  class="highlight"
+                >
+                  placeholder="Mouse" aria-labelledby="name"
+                </span>
+                &gt;
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="pass-section"
+        >
+          <div
+            class="pass-header"
+          >
+            <span
+              class="check-container"
+            >
+              <svg
+                fill="none"
+                height="16"
+                viewBox="0 0 16 16"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="8"
+                  cy="8"
+                  fill="#228722"
+                  r="8"
+                />
+                <path
+                  clip-rule="evenodd"
+                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
+                  fill="white"
+                  fill-rule="evenodd"
+                />
+              </svg>
+            </span>
+             
+            <h3>
+              Pass
+            </h3>
+          </div>
+          <p>
+            Each text field has its own label indicating which name is expected.
+          </p>
+        </div>
+        <div
+          class="pass-example"
+        >
+          <div
+            class="code-example"
+          >
+            <div
+              class="code-example-code"
+            >
+              <div
+                class="insights-code"
+              >
+                <span
+                  class="highlight"
+                >
+                  &lt;label for="firstname"&gt;First name&lt;/label&gt;
+                </span>
+                <br />
+                            &lt;input type="text" name="firstname" 
+                <span
+                  class="highlight"
+                >
+                  id="firstname"
+                </span>
+                &gt;
+                <br />
+                            
+                <span
+                  class="highlight"
+                >
+                  &lt;label for="lastname"&gt;Last name&lt;/label&gt;
+                </span>
+                <br />
+                            &lt;input type="text" name="lastname" 
+                <span
+                  class="highlight"
+                >
+                  id="lastname"
+                </span>
+                &gt;
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <h2>
+        More examples
+      </h2>
+      <h3>
+        WCAG success criteria
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 3.3.2: Labels or Instructions
+        </a>
+      </div>
+      <h4>
+        Sufficient techniques
+      </h4>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G131"
+          target="_blank"
+        >
+          Providing descriptive labels
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1"
+          target="_blank"
+        >
+          Using the aria-describedby property to provide a descriptive label for user interface controls
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9"
+          target="_blank"
+        >
+          Using aria-labelledby to concatenate a label from several text nodes
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA17"
+          target="_blank"
+        >
+          Using grouping roles to identify related form controls
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G89"
+          target="_blank"
+        >
+          Providing expected data format and example
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G184"
+          target="_blank"
+        >
+          Providing text instructions at the beginning of a form or set of fields that describes the necessary input
+        </a>
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G162"
+          target="_blank"
+        >
+          Positioning labels to maximize predictability of relationships
+        </a>
+      </div>
+      <h3>
+        Common failures
+      </h3>
+      <div
+        class="content-hyperlinks"
+      >
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F82"
+          target="_blank"
+        >
+          Failure of Success Criterion 3.3.2 by visually formatting a set of phone number fields but not including a text label
         </a>
       </div>
     </div>
@@ -54264,298 +54588,6 @@ exports[`A11Y for content pages Normal mode test/nativeWidgets/instructions/info
           target="_blank"
         >
           Using the aria-describedby property to provide a descriptive label for user interface controls
-        </a>
-      </div>
-    </div>
-    <div
-      class="content-right"
-    />
-  </div>
-</DocumentFragment>
-`;
-
-exports[`A11Y for content pages Normal mode test/nativeWidgets/label/infoAndExamples 1`] = `
-<DocumentFragment>
-  <div
-    class="content-container"
-  >
-    <div
-      class="content-left"
-    />
-    <div
-      class="content"
-    >
-      <h1>
-        Label
-      </h1>
-      <p>
-        A native widget must have a label and/or instructions that identify the expected input.
-      </p>
-      <h2>
-        Why it matters
-      </h2>
-      <p>
-        When a widget clearly communicates its expected input, all users are likely to make fewer input mistakes.
-      </p>
-      <h3>
-        From a user's perspective
-      </h3>
-      <p>
-        <em>
-          "I do not rely on visual cues for reading, I use a screen reader. For any required input you need from me, provide me with general instructions on what is being asked, what is required and, examples of valid input so I can provide the requested information."
-        </em>
-      </p>
-      <h2>
-        How to fix
-      </h2>
-      <p>
-        Make sure the widget's accessible name and/or accessible description communicates the expected input. For example, a button should indicate what action it will initiate. A text field should indicate what type of data is expected and whether a specific format is required.
-      </p>
-      <h2>
-        Example
-      </h2>
-      <div
-        class="pass-fail-grid"
-      >
-        <div
-          class="fail-section"
-        >
-          <div
-            class="fail-header"
-          >
-            <span
-              class="check-container"
-            >
-              <svg
-                fill="none"
-                height="16"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  fill="#E81123"
-                  r="8"
-                />
-                <path
-                  d="M10.9837 6.27639C11.3352 5.92491 11.3352 5.35507 10.9837 5.00359C10.6322 4.65212 10.0624 4.65212 9.7109 5.00359L7.99722 6.71728L6.28375 5.00381C5.93227 4.65234 5.36242 4.65234 5.01095 5.00381C4.65948 5.35528 4.65948 5.92513 5.01095 6.2766L6.72443 7.99007L4.9837 9.7308C4.63222 10.0823 4.63222 10.6521 4.9837 11.0036C5.33517 11.3551 5.90502 11.3551 6.25649 11.0036L7.99722 9.26287L9.73816 11.0038C10.0896 11.3553 10.6595 11.3553 11.011 11.0038C11.3624 10.6523 11.3624 10.0825 11.011 9.73101L9.27001 7.99007L10.9837 6.27639Z"
-                  fill="white"
-                />
-              </svg>
-            </span>
-             
-            <h3>
-              Fail
-            </h3>
-          </div>
-          <p>
-            An online form has fields for entering first and last names, but both fields share the same accessible name. Users are expected to infer from the placeholder text that the first field is for the first name, and the second field is for the last name.
-          </p>
-        </div>
-        <div
-          class="fail-example"
-        >
-          <div
-            class="code-example"
-          >
-            <div
-              class="code-example-code"
-            >
-              <div
-                class="insights-code"
-              >
-                &lt;div id="name"&gt;Name&lt;/div&gt;
-                <br />
-                            &lt;input type="text" name="firstname" 
-                <span
-                  class="highlight"
-                >
-                  placeholder="Mickey" aria-labelledby="name"
-                </span>
-                &gt;
-                <br />
-                            &lt;input type="text" name="lastname" 
-                <span
-                  class="highlight"
-                >
-                  placeholder="Mouse" aria-labelledby="name"
-                </span>
-                &gt;
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="pass-section"
-        >
-          <div
-            class="pass-header"
-          >
-            <span
-              class="check-container"
-            >
-              <svg
-                fill="none"
-                height="16"
-                viewBox="0 0 16 16"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <circle
-                  cx="8"
-                  cy="8"
-                  fill="#228722"
-                  r="8"
-                />
-                <path
-                  clip-rule="evenodd"
-                  d="M6.05904 11.1417L6.0616 11.1442C6.10737 11.19 6.15668 11.23 6.20867 11.2643C6.57256 11.5046 7.06707 11.4646 7.38742 11.1442C7.38861 11.143 7.38982 11.1418 7.391 11.1406L11.9312 6.60041C12.2974 6.23427 12.2974 5.64071 11.9312 5.27457C11.5651 4.90848 10.9715 4.90848 10.6054 5.27457L6.72452 9.15545L5.60041 8.03134C5.2343 7.66524 4.64071 7.66524 4.27459 8.03134C3.90847 8.39747 3.90847 8.99104 4.27459 9.35718L6.05904 11.1417Z"
-                  fill="white"
-                  fill-rule="evenodd"
-                />
-              </svg>
-            </span>
-             
-            <h3>
-              Pass
-            </h3>
-          </div>
-          <p>
-            Each text field has its own label indicating which name is expected.
-          </p>
-        </div>
-        <div
-          class="pass-example"
-        >
-          <div
-            class="code-example"
-          >
-            <div
-              class="code-example-code"
-            >
-              <div
-                class="insights-code"
-              >
-                <span
-                  class="highlight"
-                >
-                  &lt;label for="firstname"&gt;First name&lt;/label&gt;
-                </span>
-                <br />
-                            &lt;input type="text" name="firstname" 
-                <span
-                  class="highlight"
-                >
-                  id="firstname"
-                </span>
-                &gt;
-                <br />
-                            
-                <span
-                  class="highlight"
-                >
-                  &lt;label for="lastname"&gt;Last name&lt;/label&gt;
-                </span>
-                <br />
-                            &lt;input type="text" name="lastname" 
-                <span
-                  class="highlight"
-                >
-                  id="lastname"
-                </span>
-                &gt;
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <h2>
-        More examples
-      </h2>
-      <h3>
-        WCAG success criteria
-      </h3>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html"
-          target="_blank"
-        >
-          Understanding Success Criterion 3.3.2: Labels or Instructions
-        </a>
-      </div>
-      <h4>
-        Sufficient techniques
-      </h4>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G131"
-          target="_blank"
-        >
-          Providing descriptive labels
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA1"
-          target="_blank"
-        >
-          Using the aria-describedby property to provide a descriptive label for user interface controls
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA9"
-          target="_blank"
-        >
-          Using aria-labelledby to concatenate a label from several text nodes
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA17"
-          target="_blank"
-        >
-          Using grouping roles to identify related form controls
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G89"
-          target="_blank"
-        >
-          Providing expected data format and example
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G184"
-          target="_blank"
-        >
-          Providing text instructions at the beginning of a form or set of fields that describes the necessary input
-        </a>
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/general/G162"
-          target="_blank"
-        >
-          Positioning labels to maximize predictability of relationships
-        </a>
-      </div>
-      <h3>
-        Common failures
-      </h3>
-      <div
-        class="content-hyperlinks"
-      >
-        <a
-          class="ms-Link insights-link root-000"
-          href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F82"
-          target="_blank"
-        >
-          Failure of Success Criterion 3.3.2 by visually formatting a set of phone number fields but not including a text label
         </a>
       </div>
     </div>


### PR DESCRIPTION
#### Description of changes

Fixes a variety of minor text issues caught during 2.9.0 validation (doing these in one batch to avoid having to spend a half hour waiting for snapshot updates)

* #1184: Text legibility -> Text spacing bookmarklet instructions unclear about how to drag link to bookmarks

![screenshot of text spacing instructions with modified instructions highlighted](https://user-images.githubusercontent.com/376284/63986043-0aacc000-ca87-11e9-8f23-8176fbb34c32.png)

* #1185: Autocomplete>more info and examples > example table extra line

![screenshot of more info and examples at 100% without extra line](https://user-images.githubusercontent.com/376284/63986119-72630b00-ca87-11e9-8b0a-59f2c030d635.png)

* #1189: Label requirement name didnt got changed in info & examples section

![screenshot of Native widgets -> Expected input info & examples with updated title](https://user-images.githubusercontent.com/376284/63986072-3465e700-ca87-11e9-9d2a-8f3b4c356c1a.png)
![screenshot of Custom widgets -> Expected input info & examples with updated title](https://user-images.githubusercontent.com/376284/63986062-2021ea00-ca87-11e9-966f-233f6aafe12f.png)

* Item 1 from #1190: Autocomplete requirement has a couple text issues

![screenshot of autocomplete requirement instructions with the newly italicized "does" highlighted](https://user-images.githubusercontent.com/376284/63986098-57909680-ca87-11e9-80a6-80c757418b6b.png)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1184 #1185 #1189, partially addresses #1190
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
