### PR TITLE
fix: removed the unnecessary line from the text spacing instructions

### DIFF
--- a/src/assessments/text-legibility/test-steps/text-spacing.tsx
+++ b/src/assessments/text-legibility/test-steps/text-spacing.tsx
@@ -27,7 +27,6 @@ const textSpacingHowToTest: JSX.Element = (
                 Add the "Bookmarklet: Text Spacing" link from that page to your browser's bookmarks. (Mouse users can simply drag the link
                 into the bookmarks bar.)
             </li>
-            <li>Use your browser's settings to set the target page's zoom to 400%.</li>
             <li>
                 Run the bookmarklet in the browser tab containing your target page. Text styling will automatically be adjusted as follows:
                 <ol>


### PR DESCRIPTION
#### Description of changes

removed the unnecessary line from the text spacing instructions; no longer tells users to change their zoom to 400%

Updated instructions pictured below: 

![image](https://user-images.githubusercontent.com/19158512/64037726-370a2000-cb0b-11e9-984c-5d6bbceb0a8b.png)

#### Pull request checklist

- [X] Addresses an existing issue: Fixes #1195 
- N/A Added relevant unit test for your changes. (`yarn test`)
- N/A Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [X] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS
