### PR TITLE
chore: update tests to use %p rather than node version dependent %o

### DIFF
--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -140,7 +140,7 @@ describe('UserConfigurationStoreTest', () => {
         { enableTelemetry: true, isFirstTime: false, enableHighContrastMode: false } as SetUserConfigTestCase,
         { enableTelemetry: false, isFirstTime: false, enableHighContrastMode: false } as SetUserConfigTestCase,
         { enableTelemetry: false, isFirstTime: true, enableHighContrastMode: false } as SetUserConfigTestCase,
-    ])('setTelemetryConfig action: %o', (testCase: SetUserConfigTestCase) => {
+    ])('setTelemetryConfig action: %p', (testCase: SetUserConfigTestCase) => {
         const storeTester = createStoreToTestAction('setTelemetryState');
         initialStoreData = {
             enableTelemetry: testCase.enableTelemetry,
@@ -173,7 +173,7 @@ describe('UserConfigurationStoreTest', () => {
     test.each([
         { enableTelemetry: false, isFirstTime: false, enableHighContrastMode: true } as SetUserConfigTestCase,
         { enableTelemetry: false, isFirstTime: false, enableHighContrastMode: false } as SetUserConfigTestCase,
-    ])('setHighContrast action: %o', (testCase: SetUserConfigTestCase) => {
+    ])('setHighContrast action: %p', (testCase: SetUserConfigTestCase) => {
         const storeTester = createStoreToTestAction('setHighContrastMode');
         initialStoreData = {
             enableTelemetry: false,
@@ -236,7 +236,7 @@ describe('UserConfigurationStoreTest', () => {
     );
 
     test.each([undefined, null, {}, { 'test-service': {} }, { 'test-service': { 'test-name': 'test-value' } }])(
-        'setIssueFilingServiceProperty with initial map state %o',
+        'setIssueFilingServiceProperty with initial map state %p',
         (initialMapState: IssueFilingServicePropertiesMap) => {
             const storeTester = createStoreToTestAction('setIssueFilingServiceProperty');
             initialStoreData = {

--- a/src/tests/unit/tests/background/telemetry/telemetry-state-listener.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-state-listener.test.ts
@@ -64,7 +64,7 @@ describe('TelemetryStateListenerTest', () => {
             },
         ];
 
-        test.each(disableCases)('disable telemetry: %o', (testCase: TestCase) => {
+        test.each(disableCases)('disable telemetry: %p', (testCase: TestCase) => {
             userConfigState = testCase.userConfigState;
 
             setupDisableTelemetry();

--- a/src/tests/unit/tests/common/components/__snapshots__/guidance-tags.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/guidance-tags.test.tsx.snap
@@ -13,6 +13,6 @@ exports[`GuidanceTags renders tags 1`] = `
 </span>
 `;
 
-exports[`GuidanceTags tags is: [ [length]: 0 ] 1`] = `null`;
+exports[`GuidanceTags tags is: [] 1`] = `null`;
 
 exports[`GuidanceTags tags is: null 1`] = `null`;

--- a/src/tests/unit/tests/common/components/guidance-tags.test.tsx
+++ b/src/tests/unit/tests/common/components/guidance-tags.test.tsx
@@ -15,7 +15,7 @@ describe('GuidanceTags', () => {
         getGuidanceTagsFromGuidanceLinksMock = Mock.ofType<GetGuidanceTagsFromGuidanceLinks>(null, MockBehavior.Strict);
     });
 
-    test.each([null, []])('tags is: %o', (tags: GuidanceLink[]) => {
+    test.each([null, []])('tags is: %p', (tags: GuidanceLink[]) => {
         const props: GuidanceTagsProps = {
             deps: {
                 getGuidanceTagsFromGuidanceLinks: getGuidanceTagsFromGuidanceLinksMock.object,

--- a/src/tests/unit/tests/common/get-guidance-tags-from-guidance-links.test.ts
+++ b/src/tests/unit/tests/common/get-guidance-tags-from-guidance-links.test.ts
@@ -4,7 +4,7 @@ import { GetGuidanceTagsFromGuidanceLinks } from '../../../../common/get-guidanc
 import { GuidanceLink } from '../../../../scanner/rule-to-links-mappings';
 
 describe('GetGuidanceTagsFromGuidanceLinks', () => {
-    it.each([null, [], [undefined]])('handles invalid arg %o', (links: GuidanceLink[]) => {
+    it.each([null, [], [undefined]])('handles invalid arg %p', (links: GuidanceLink[]) => {
         expect(GetGuidanceTagsFromGuidanceLinks(links)).toEqual([]);
     });
 

--- a/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
@@ -1,9 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: false,
-  shadowDialog: false,
-  helpUrl: 'help-relative',
-  expectedHelpUrl: 'http://extension/help-relative' } 1`] = `
+exports[`DetailsDialog renders with: {"expectedHelpUrl": "http://extension/help-relative", "helpUrl": "help-relative", "isDevToolsOpen": false, "shadowDialog": false} 1`] = `
 <StyledWithResponsiveMode
   dialogContentProps={
     Object {
@@ -549,15 +546,9 @@ exports[`DetailsDialog renders with: { isDevToolsOpen: false,
 </StyledWithResponsiveMode>
 `;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: false,
-  shadowDialog: false,
-  helpUrl: 'help-relative',
-  expectedHelpUrl: 'http://extension/help-relative' }: verify close button for non shadow dom 1`] = `<CancelIcon />`;
+exports[`DetailsDialog renders with: {"expectedHelpUrl": "http://extension/help-relative", "helpUrl": "help-relative", "isDevToolsOpen": false, "shadowDialog": false}: verify close button for non shadow dom 1`] = `<CancelIcon />`;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: false,
-  shadowDialog: false,
-  helpUrl: 'help-relative',
-  expectedHelpUrl: 'http://extension/help-relative' }: verify initial state 1`] = `
+exports[`DetailsDialog renders with: {"expectedHelpUrl": "http://extension/help-relative", "helpUrl": "help-relative", "isDevToolsOpen": false, "shadowDialog": false}: verify initial state 1`] = `
 Object {
   "canInspect": true,
   "currentRuleIndex": 0,
@@ -567,7 +558,7 @@ Object {
 }
 `;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: false, shadowDialog: false } 1`] = `
+exports[`DetailsDialog renders with: {"isDevToolsOpen": false, "shadowDialog": false} 1`] = `
 <StyledWithResponsiveMode
   dialogContentProps={
     Object {
@@ -1113,9 +1104,9 @@ exports[`DetailsDialog renders with: { isDevToolsOpen: false, shadowDialog: fals
 </StyledWithResponsiveMode>
 `;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: false, shadowDialog: false }: verify close button for non shadow dom 1`] = `<CancelIcon />`;
+exports[`DetailsDialog renders with: {"isDevToolsOpen": false, "shadowDialog": false}: verify close button for non shadow dom 1`] = `<CancelIcon />`;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: false, shadowDialog: false }: verify initial state 1`] = `
+exports[`DetailsDialog renders with: {"isDevToolsOpen": false, "shadowDialog": false}: verify initial state 1`] = `
 Object {
   "canInspect": true,
   "currentRuleIndex": 0,
@@ -1125,7 +1116,7 @@ Object {
 }
 `;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: false, shadowDialog: true } 1`] = `
+exports[`DetailsDialog renders with: {"isDevToolsOpen": false, "shadowDialog": true} 1`] = `
 <div
   className="insights-dialog-main-override-shadow"
   style={
@@ -1683,7 +1674,7 @@ exports[`DetailsDialog renders with: { isDevToolsOpen: false, shadowDialog: true
 </div>
 `;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: false, shadowDialog: true }: verify initial state 1`] = `
+exports[`DetailsDialog renders with: {"isDevToolsOpen": false, "shadowDialog": true}: verify initial state 1`] = `
 Object {
   "canInspect": true,
   "currentRuleIndex": 0,
@@ -1693,7 +1684,7 @@ Object {
 }
 `;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: true, shadowDialog: false } 1`] = `
+exports[`DetailsDialog renders with: {"isDevToolsOpen": true, "shadowDialog": false} 1`] = `
 <StyledWithResponsiveMode
   dialogContentProps={
     Object {
@@ -2239,9 +2230,9 @@ exports[`DetailsDialog renders with: { isDevToolsOpen: true, shadowDialog: false
 </StyledWithResponsiveMode>
 `;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: true, shadowDialog: false }: verify close button for non shadow dom 1`] = `<CancelIcon />`;
+exports[`DetailsDialog renders with: {"isDevToolsOpen": true, "shadowDialog": false}: verify close button for non shadow dom 1`] = `<CancelIcon />`;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: true, shadowDialog: false }: verify initial state 1`] = `
+exports[`DetailsDialog renders with: {"isDevToolsOpen": true, "shadowDialog": false}: verify initial state 1`] = `
 Object {
   "canInspect": true,
   "currentRuleIndex": 0,
@@ -2251,7 +2242,7 @@ Object {
 }
 `;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: true, shadowDialog: true } 1`] = `
+exports[`DetailsDialog renders with: {"isDevToolsOpen": true, "shadowDialog": true} 1`] = `
 <div
   className="insights-dialog-main-override-shadow"
   style={
@@ -2809,7 +2800,7 @@ exports[`DetailsDialog renders with: { isDevToolsOpen: true, shadowDialog: true 
 </div>
 `;
 
-exports[`DetailsDialog renders with: { isDevToolsOpen: true, shadowDialog: true }: verify initial state 1`] = `
+exports[`DetailsDialog renders with: {"isDevToolsOpen": true, "shadowDialog": true}: verify initial state 1`] = `
 Object {
   "canInspect": true,
   "currentRuleIndex": 0,

--- a/src/tests/unit/tests/injected/components/__snapshots__/issue-details-navigation-controls.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/issue-details-navigation-controls.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IssueDetailsNavigationControls render handles button states: { backButtonDisabled: false, nextButtonDisabled: false } 1`] = `
+exports[`IssueDetailsNavigationControls render handles button states: {"backButtonDisabled": false, "nextButtonDisabled": false} 1`] = `
 <div
   className="ms-Grid insights-dialog-next-and-back-container"
 >
@@ -34,7 +34,7 @@ exports[`IssueDetailsNavigationControls render handles button states: { backButt
 </div>
 `;
 
-exports[`IssueDetailsNavigationControls render handles button states: { backButtonDisabled: false, nextButtonDisabled: true } 1`] = `
+exports[`IssueDetailsNavigationControls render handles button states: {"backButtonDisabled": false, "nextButtonDisabled": true} 1`] = `
 <div
   className="ms-Grid insights-dialog-next-and-back-container"
 >
@@ -62,7 +62,7 @@ exports[`IssueDetailsNavigationControls render handles button states: { backButt
 </div>
 `;
 
-exports[`IssueDetailsNavigationControls render handles button states: { backButtonDisabled: true, nextButtonDisabled: false } 1`] = `
+exports[`IssueDetailsNavigationControls render handles button states: {"backButtonDisabled": true, "nextButtonDisabled": false} 1`] = `
 <div
   className="ms-Grid insights-dialog-next-and-back-container"
 >
@@ -90,7 +90,7 @@ exports[`IssueDetailsNavigationControls render handles button states: { backButt
 </div>
 `;
 
-exports[`IssueDetailsNavigationControls render handles button states: { backButtonDisabled: true, nextButtonDisabled: true } 1`] = `
+exports[`IssueDetailsNavigationControls render handles button states: {"backButtonDisabled": true, "nextButtonDisabled": true} 1`] = `
 <div
   className="ms-Grid insights-dialog-next-and-back-container"
 >

--- a/src/tests/unit/tests/injected/components/details-dialog.test.tsx
+++ b/src/tests/unit/tests/injected/components/details-dialog.test.tsx
@@ -87,7 +87,7 @@ describe('DetailsDialog', () => {
             },
         ];
 
-        test.each(testCases)('with: %o', (testCase: DetailsDialogTestCase) => {
+        test.each(testCases)('with: %p', (testCase: DetailsDialogTestCase) => {
             const {
                 isDevToolsOpen,
                 shadowDialog,

--- a/src/tests/unit/tests/injected/components/issue-details-navigation-controls.test.tsx
+++ b/src/tests/unit/tests/injected/components/issue-details-navigation-controls.test.tsx
@@ -51,7 +51,7 @@ describe('IssueDetailsNavigationControls', () => {
             },
         ];
 
-        it.each(testCases)('handles button states: %o', testCase => {
+        it.each(testCases)('handles button states: %p', testCase => {
             navigationHandlerMock
                 .setup(handler => handler.isBackButtonDisabled(controlProps.container))
                 .returns(() => testCase.backButtonDisabled);

--- a/src/tests/unit/tests/injected/layered-details-dialog-component.test.tsx
+++ b/src/tests/unit/tests/injected/layered-details-dialog-component.test.tsx
@@ -29,7 +29,7 @@ describe('LayeredDetailsDialogComponent', () => {
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 
-    test.each([true, false])('render component when shadow dom is enabled - isRTL - %o', isRTL => {
+    test.each([true, false])('render component when shadow dom is enabled - isRTL - %p', isRTL => {
         featureFlagStoreData[FeatureFlags.shadowDialog] = true;
 
         getRTLMock.setup(g => g()).returns(() => isRTL);

--- a/src/tests/unit/tests/issue-filing/common/__snapshots__/http-query-builder.test.ts.snap
+++ b/src/tests/unit/tests/issue-filing/common/__snapshots__/http-query-builder.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HTTPQueryBuilder encodes { name: '[param]', value: '(value)' } 1`] = `"https://some-test-url?%5Bparam%5D=(value)"`;
+exports[`HTTPQueryBuilder encodes {"name": "[param]", "value": "(value)"} 1`] = `"https://some-test-url?%5Bparam%5D=(value)"`;
 
-exports[`HTTPQueryBuilder encodes { name: 'a param', value: 'value&' } 1`] = `"https://some-test-url?a%20param=value%26"`;
+exports[`HTTPQueryBuilder encodes {"name": "a param", "value": "value&"} 1`] = `"https://some-test-url?a%20param=value%26"`;
 
-exports[`HTTPQueryBuilder encodes { name: 'name?', value: 'value"' } 1`] = `"https://some-test-url?name%3F=value%22"`;
+exports[`HTTPQueryBuilder encodes {"name": "name?", "value": "value\\""} 1`] = `"https://some-test-url?name%3F=value%22"`;

--- a/src/tests/unit/tests/issue-filing/common/http-query-builder.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/http-query-builder.test.ts
@@ -35,7 +35,7 @@ describe('HTTPQueryBuilder', () => {
             { name: 'name?', value: 'value"' },
         ];
 
-        it.each(testCases)('%o', param => {
+        it.each(testCases)('%p', param => {
             const result = testSubject
                 .withBaseUrl(testUrl)
                 .withParam(param.name, param.value)

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-issue-filing-service.test.tsx
@@ -49,7 +49,7 @@ describe('AzureBoardsIssueFilingServiceTest', () => {
             { projectURL: '', issueDetailsField: 'some issue details location' as AzureBoardsIssueDetailField },
         ];
 
-        it.each(invalidTestSettings)('handles invalid settings: %o', settings => {
+        it.each(invalidTestSettings)('handles invalid settings: %p', settings => {
             expect(AzureBoardsIssueFilingService.isSettingsValid(settings)).toBe(false);
         });
 

--- a/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
@@ -57,7 +57,7 @@ describe('GithubIssueFilingServiceTest', () => {
     });
 
     describe('isSettingsValid', () => {
-        it.each(invalidTestSettings)('invalid settings with %o', (settings: GitHubIssueFilingSettings) => {
+        it.each(invalidTestSettings)('invalid settings with %p', (settings: GitHubIssueFilingSettings) => {
             expect(GitHubIssueFilingService.isSettingsValid(settings)).toBe(false);
         });
 

--- a/src/tests/unit/tests/issue-filing/services/null-issue-filing-service/null-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/null-issue-filing-service/null-issue-filing-service.test.tsx
@@ -27,7 +27,7 @@ describe('NullIssueFilingService', () => {
     });
 
     describe('check settings', () => {
-        it.each(testSettings)('with %o', settings => {
+        it.each(testSettings)('with %p', settings => {
             expect(NullIssueFilingService.isSettingsValid(settings)).toBe(false);
         });
     });

--- a/src/tests/unit/tests/popup/target-tab-finder.test.ts
+++ b/src/tests/unit/tests/popup/target-tab-finder.test.ts
@@ -61,7 +61,7 @@ describe('TargetTabFinderTest', () => {
         },
     ];
 
-    test.each(testCases)('get target tab info - %o', async (testCase: TestCase) => {
+    test.each(testCases)('get target tab info - %p', async (testCase: TestCase) => {
         if (testCase.hasTabIdInUrl) {
             setupGetTabIdParamFromUrl(tabId);
             setupGetTabCall();

--- a/src/tests/unit/tests/scanner/custom-rules/css-content-rule.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/css-content-rule.test.ts
@@ -63,7 +63,7 @@ describe('verify matches', () => {
         { pseudoSelectorContent: 'none', testExpectation: false },
         { pseudoSelectorContent: 'non-none', testExpectation: true },
     ];
-    test.each(contentSwitchParameters)('element isVisible but pseudo selector content is toggled: %o', testCaseParameters => {
+    test.each(contentSwitchParameters)('element isVisible but pseudo selector content is toggled: %p', testCaseParameters => {
         axeVisibilityMock
             .setup(isVisible => isVisible(headingElementFixture))
             .returns(() => true)

--- a/src/tests/unit/tests/scanner/custom-rules/css-positioning-rule.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/css-positioning-rule.test.ts
@@ -74,7 +74,7 @@ describe('verify evaluate', () => {
         },
     ];
 
-    it.each(testFixture)('check for different combinations of nodeStyleStub and visibility %o', testStub => {
+    it.each(testFixture)('check for different combinations of nodeStyleStub and visibility %p', testStub => {
         testMeaningfulSequence(testStub.nodeStyleStub, testStub.isVisible, testStub.expectedResult);
     });
 


### PR DESCRIPTION
#### Description of changes

Some of the tests had a `snapshot` obsolete problem on my MacOS.
When trying to figure out the reason for that, i figured it out and @dbjorge confirmed, that it might be because of the usage of `%o` in the `test.each` statement rather than `%p`; which results in different snapshot value for different node version.

With this change; we make sure that the tests pass for users who are using node version higher than 10.16.3.

PS: `%p` also makes the snapshots more readable as it doesn't prints out the unwanted properties from the object as done by `%o`

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
