### PR TITLE
Improved CSS for cards components

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -756,6 +756,7 @@ div.insights-file-issue-details-dialog-container {
         }
         .left-nav,
         .test-step-nav {
+            width: 200px;
             z-index: 100;
             background-color: $neutral-0;
             .index-circle {
@@ -888,16 +889,13 @@ div.insights-file-issue-details-dialog-container {
                 }
                 .issues-table {
                     height: 100%;
-                    width: 100%;
+                    width: calc(100% - 48px);
                     display: flex;
                     flex-direction: column;
                     margin-top: 24px;
-                    > h1,
-                    .issues-table-subtitle,
-                    .details-view-toggle,
-                    .details-disabled-message {
-                        margin-left: 24px;
-                    }
+
+                    margin-left: 24px;
+                    margin-right: 24px;
                     .issues-table-subtitle {
                         color: $secondary-text;
                         max-width: 570px;
@@ -962,7 +960,6 @@ div.insights-file-issue-details-dialog-container {
                     min-height: 0;
                 }
                 .issues-details-list {
-                    margin-left: 24px;
                     display: flex;
                     flex-direction: column;
                     height: 60%;
@@ -1074,13 +1071,14 @@ div.insights-file-issue-details-dialog-container {
                     }
                 }
                 .details-view-command-bar {
-                    margin-left: 24px;
-                    margin-bottom: 0px;
+                    margin-bottom: 12px;
                     margin-top: 12px;
                     height: $detailsViewCommandBarHeight;
                     background-color: $neutral-4;
                     display: -webkit-inline-box;
                     .automated-checks-details-view-toggle {
+                        margin-bottom: unset;
+
                         .ms-Toggle-label {
                             float: left;
                             margin: 5px 8px 5px 8px;
@@ -1275,9 +1273,9 @@ div.insights-file-issue-details-dialog-container {
                     height: 40%;
                     min-height: 150px;
                     background-color: $neutral-2;
-                    padding-left: 24px;
                     > div {
                         border-top: 1px solid $neutral-8;
+                        padding-left: 24px;
                     }
                     h2 {
                         padding-top: 12px;

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -867,7 +867,10 @@ div.insights-file-issue-details-dialog-container {
                 min-height: 0;
                 .target-page-changed,
                 .static-content-details-view {
-                    margin: $fastPassRightPanelMarginTop $fastPassRightPanelMarginLeft auto $fastPassRightPanelMarginRight;
+                    margin-top: $fastPassRightPanelMarginTop;
+                    margin-right: $fastPassRightPanelMarginRight;
+                    margin-left: $fastPassRightPanelMarginLeft;
+                    margin-bottom: auto;
                     ol {
                         -webkit-padding-start: 16px;
                         li ul li {
@@ -892,7 +895,10 @@ div.insights-file-issue-details-dialog-container {
                     width: calc(100% - #{$fastPassRightPanelMarginRight} - #{$fastPassRightPanelMarginLeft});
                     display: flex;
                     flex-direction: column;
-                    margin: $fastPassRightPanelMarginTop $fastPassRightPanelMarginLeft auto $fastPassRightPanelMarginRight;
+                    margin-top: $fastPassRightPanelMarginTop;
+                    margin-right: $fastPassRightPanelMarginRight;
+                    margin-left: $fastPassRightPanelMarginLeft;
+                    margin-bottom: auto;
 
                     .issues-table-subtitle {
                         color: $secondary-text;

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -717,6 +717,7 @@ div.insights-file-issue-details-dialog-container {
             padding-left: calc(0.5vw + 13px); // 13px is Chevron width.
         }
         .left-nav {
+            width: 200px;
             border-right: 1px solid $neutral-8;
             .dark-gray {
                 color: $neutral-60;
@@ -756,7 +757,6 @@ div.insights-file-issue-details-dialog-container {
         }
         .left-nav,
         .test-step-nav {
-            width: 200px;
             z-index: 100;
             background-color: $neutral-0;
             .index-circle {

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -867,7 +867,7 @@ div.insights-file-issue-details-dialog-container {
                 min-height: 0;
                 .target-page-changed,
                 .static-content-details-view {
-                    margin: 24px 24px 0px 24px;
+                    margin: $fastPassRightPanelMarginTop $fastPassRightPanelMarginLeft auto $fastPassRightPanelMarginLeft;
                     ol {
                         -webkit-padding-start: 16px;
                         li ul li {
@@ -889,10 +889,11 @@ div.insights-file-issue-details-dialog-container {
                 }
                 .issues-table {
                     height: 100%;
-                    width: calc(100% - 48px);
+                    width: calc(100% - #{$fastPassRightPanelMarginRight} - #{$fastPassRightPanelMarginLeft});
                     display: flex;
                     flex-direction: column;
-                    margin: 24px 24px auto 24px;
+                    margin: $fastPassRightPanelMarginTop $fastPassRightPanelMarginLeft auto $fastPassRightPanelMarginLeft;
+
                     .issues-table-subtitle {
                         color: $secondary-text;
                         max-width: 570px;

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -867,7 +867,7 @@ div.insights-file-issue-details-dialog-container {
                 min-height: 0;
                 .target-page-changed,
                 .static-content-details-view {
-                    margin: $fastPassRightPanelMarginTop $fastPassRightPanelMarginLeft auto $fastPassRightPanelMarginLeft;
+                    margin: $fastPassRightPanelMarginTop $fastPassRightPanelMarginLeft auto $fastPassRightPanelMarginRight;
                     ol {
                         -webkit-padding-start: 16px;
                         li ul li {
@@ -892,7 +892,7 @@ div.insights-file-issue-details-dialog-container {
                     width: calc(100% - #{$fastPassRightPanelMarginRight} - #{$fastPassRightPanelMarginLeft});
                     display: flex;
                     flex-direction: column;
-                    margin: $fastPassRightPanelMarginTop $fastPassRightPanelMarginLeft auto $fastPassRightPanelMarginLeft;
+                    margin: $fastPassRightPanelMarginTop $fastPassRightPanelMarginLeft auto $fastPassRightPanelMarginRight;
 
                     .issues-table-subtitle {
                         color: $secondary-text;

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -892,10 +892,7 @@ div.insights-file-issue-details-dialog-container {
                     width: calc(100% - 48px);
                     display: flex;
                     flex-direction: column;
-                    margin-top: 24px;
-
-                    margin-left: 24px;
-                    margin-right: 24px;
+                    margin: 24px 24px auto 24px;
                     .issues-table-subtitle {
                         color: $secondary-text;
                         max-width: 570px;

--- a/src/DetailsView/components/cards/collapsible-component-cards.scss
+++ b/src/DetailsView/components/cards/collapsible-component-cards.scss
@@ -55,7 +55,7 @@
         @include transform(rotate(45deg));
     }
 
-    .content {
+    .collapsible-container-content {
         &[aria-hidden='true'] {
             display: none;
         }

--- a/src/DetailsView/components/cards/collapsible-component-cards.tsx
+++ b/src/DetailsView/components/cards/collapsible-component-cards.tsx
@@ -4,7 +4,12 @@ import { css } from '@uifabric/utilities';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
-import { collapsibleContainer, collapsibleControl, collapsibleTitle, content } from './collapsible-component-cards.scss';
+import {
+    collapsibleContainer,
+    collapsibleContainerContent,
+    collapsibleControl,
+    collapsibleTitle,
+} from './collapsible-component-cards.scss';
 
 export interface CollapsibleComponentCardsProps {
     header: JSX.Element;
@@ -33,11 +38,11 @@ export class CollapsibleComponentCards extends React.Component<CollapsibleCompon
     public render(): JSX.Element {
         const showContent = this.state.showContent;
         const containerProps = { role: 'heading', 'aria-level': this.props.headingLevel };
-        let collapsibleContainerContent = null;
+        let contentWrapper = null;
         let collapsedCSSClassName = 'collapsed';
 
         if (showContent) {
-            collapsibleContainerContent = <div className={css(this.props.contentClassName, content)}>{this.props.content}</div>;
+            contentWrapper = <div className={css(this.props.contentClassName, collapsibleContainerContent)}>{this.props.content}</div>;
             collapsedCSSClassName = null;
         }
 
@@ -53,7 +58,7 @@ export class CollapsibleComponentCards extends React.Component<CollapsibleCompon
                         <span className={collapsibleTitle}>{this.props.header}</span>
                     </ActionButton>
                 </div>
-                {collapsibleContainerContent}
+                {contentWrapper}
             </div>
         );
     }

--- a/src/DetailsView/components/cards/how-to-fix-card-row.scss
+++ b/src/DetailsView/components/cards/how-to-fix-card-row.scss
@@ -12,7 +12,7 @@
     }
     :global(.insights-fix-instruction-list) {
         li {
-            span.fix-instruction-color-box {
+            :global(span.fix-instruction-color-box) {
                 width: 14px;
                 height: 14px;
                 display: inline-block;

--- a/src/DetailsView/components/cards/result-section-title-v2.tsx
+++ b/src/DetailsView/components/cards/result-section-title-v2.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedSFC } from 'common/react/named-sfc';
+import * as React from 'react';
+
+import { InstanceOutcomeType } from '../../../reports/components/instance-outcome-type';
+import { OutcomeChip } from '../../../reports/components/outcome-chip';
+import { resultSectionTitle, title } from './result-section-title.scss';
+
+export type ResultSectionTitleV2Props = {
+    title: string;
+    badgeCount: number;
+    outcomeType: InstanceOutcomeType;
+};
+
+export const ResultSectionTitleV2 = NamedSFC<ResultSectionTitleV2Props>('ResultSectionTitleV2', props => {
+    return (
+        <span className={resultSectionTitle}>
+            <span className="screen-reader-only">
+                {props.title} {props.badgeCount}
+            </span>
+            <span className={title} aria-hidden="true">
+                {props.title}
+            </span>
+            <span aria-hidden="true">
+                <OutcomeChip outcomeType={props.outcomeType} count={props.badgeCount} />
+            </span>
+        </span>
+    );
+});

--- a/src/DetailsView/components/cards/result-section-title.scss
+++ b/src/DetailsView/components/cards/result-section-title.scss
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.result-section-title {
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: center;
+    margin-top: 8px;
+    margin-bottom: 8px;
+
+    :global(.outcome-chip) {
+        &:global(.outcome-chip-fail) {
+            .count {
+                line-height: 11px;
+            }
+
+            svg {
+                margin-bottom: 3px;
+            }
+        }
+    }
+
+    .title {
+        font-size: 17px;
+        line-height: 24px;
+        font-weight: 700;
+    }
+}

--- a/src/DetailsView/components/cards/result-section-v2.tsx
+++ b/src/DetailsView/components/cards/result-section-v2.tsx
@@ -4,8 +4,9 @@ import { css } from '@uifabric/utilities';
 import { NamedSFC } from 'common/react/named-sfc';
 import * as React from 'react';
 
-import { ResultSectionTitle, ResultSectionTitleProps } from '../../../reports/components/report-sections/result-section-title';
+import { ResultSectionTitleProps } from '../../../reports/components/report-sections/result-section-title';
 import { ResultSectionContentV2, ResultSectionContentV2Deps, ResultSectionContentV2Props } from './result-section-content-v2';
+import { ResultSectionTitleV2 } from './result-section-title-v2';
 import { resultSection } from './result-section.scss';
 
 export type ResultSectionV2Deps = ResultSectionContentV2Deps;
@@ -22,7 +23,7 @@ export const ResultSectionV2 = NamedSFC<ResultSectionV2Props>('ResultSectionV2',
     return (
         <div className={css(containerClassName, resultSection)}>
             <h2>
-                <ResultSectionTitle {...props} />
+                <ResultSectionTitleV2 {...props} />
             </h2>
             <ResultSectionContentV2 {...props} />
         </div>

--- a/src/DetailsView/components/cards/result-section.scss
+++ b/src/DetailsView/components/cards/result-section.scss
@@ -9,4 +9,10 @@
             bottom: 2px;
         }
     }
+
+    > h2 {
+        margin: 0px;
+        font-size: 17px;
+        line-height: 24px;
+    }
 }

--- a/src/DetailsView/components/cards/rule-resources.scss
+++ b/src/DetailsView/components/cards/rule-resources.scss
@@ -12,7 +12,7 @@
     margin-bottom: 16px;
     padding: 14px 20px;
 
-    background-color: $always-white;
+    background-color: $neutral-0;
 
     box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108), 0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
 

--- a/src/DetailsView/components/cards/rules-with-instances-v2.scss
+++ b/src/DetailsView/components/cards/rules-with-instances-v2.scss
@@ -12,12 +12,12 @@
         display: flex;
         align-items: center;
 
-        .outcome-chip {
+        :global(.outcome-chip) {
             vertical-align: middle;
             margin-bottom: 2px;
         }
 
-        .rule-details-id {
+        :global(.rule-details-id) {
             font-family: $semiBoldFontFamily;
             color: $primary-text;
 
@@ -27,11 +27,11 @@
             }
         }
 
-        .rule-detail-description {
+        :global(.rule-detail-description) {
             color: $secondary-text !important;
         }
 
-        .guidance-links {
+        :global(.guidance-links) {
             a {
                 color: $secondary-text !important;
             }
@@ -42,13 +42,11 @@
 .collapsible-rule-details-group {
     box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
 
-    global {
-        .rule-detail {
-            box-shadow: unset;
-        }
+    :global(.rule-detail) {
+        box-shadow: unset;
+    }
 
-        &:not(.collapsed) {
-            box-shadow: unset;
-        }
+    &:global(:not(.collapsed)) {
+        box-shadow: unset;
     }
 }

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -99,6 +99,10 @@ $detailsViewCommandBarHeight: 40px !default;
 
 $detailsViewManNavWidth: 185px !default;
 
+$fastPassRightPanelMarginRight: 24px !default;
+$fastPassRightPanelMarginLeft: 24px !default;
+$fastPassRightPanelMarginTop: 24px !default;
+
 .header-bar,
 .report-header-bar {
     background-color: $ada-brand-color;

--- a/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/result-section-title-v2.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/result-section-title-v2.test.tsx.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResultSectionTitleV2 renders 1`] = `
+<span
+  className="resultSectionTitle"
+>
+  <span
+    className="screen-reader-only"
+  >
+    test title
+     
+    10
+  </span>
+  <span
+    aria-hidden="true"
+    className="title"
+  >
+    test title
+  </span>
+  <span
+    aria-hidden="true"
+  >
+    <OutcomeChip
+      count={10}
+      outcomeType="pass"
+    />
+  </span>
+</span>
+`;

--- a/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/result-section-v2.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/result-section-v2.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ResultSectionV2 renders 1`] = `
   className="result-section-class-name resultSection"
 >
   <h2>
-    <ResultSectionTitle
+    <ResultSectionTitleV2
       containerClassName="result-section-class-name"
       deps={Object {}}
     />

--- a/src/tests/unit/tests/DetailsView/components/cards/result-section-title-v2.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/cards/result-section-title-v2.test.tsx
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { ResultSectionTitleV2, ResultSectionTitleV2Props } from '../../../../../../DetailsView/components/cards/result-section-title-v2';
+
+describe('ResultSectionTitleV2', () => {
+    it('renders', () => {
+        const props: ResultSectionTitleV2Props = {
+            title: 'test title',
+            badgeCount: 10,
+            outcomeType: 'pass',
+        };
+
+        const wrapped = shallow(<ResultSectionTitleV2 {...props} />);
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/common/components/__snapshots__/collapsible-component-cards.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/collapsible-component-cards.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`CollapsibleComponentCardsTest render with buttonAriaLabel set to: some 
     </CustomizedActionButton>
   </div>
   <div
-    className="content"
+    className="collapsibleContainerContent"
   >
     <div>
       Some content
@@ -56,7 +56,7 @@ exports[`CollapsibleComponentCardsTest render with buttonAriaLabel set to: undef
     </CustomizedActionButton>
   </div>
   <div
-    className="content"
+    className="collapsibleContainerContent"
   >
     <div>
       Some content
@@ -88,7 +88,7 @@ exports[`CollapsibleComponentCardsTest render with containerClassName set to: a-
     </CustomizedActionButton>
   </div>
   <div
-    className="content"
+    className="collapsibleContainerContent"
   >
     <div>
       Some content
@@ -120,7 +120,7 @@ exports[`CollapsibleComponentCardsTest render with containerClassName set to: un
     </CustomizedActionButton>
   </div>
   <div
-    className="content"
+    className="collapsibleContainerContent"
   >
     <div>
       Some content
@@ -152,7 +152,7 @@ exports[`CollapsibleComponentCardsTest render with contentClassName set to: cont
     </CustomizedActionButton>
   </div>
   <div
-    className="content-class-name-a content"
+    className="content-class-name-a collapsibleContainerContent"
   >
     <div>
       Some content
@@ -184,7 +184,7 @@ exports[`CollapsibleComponentCardsTest render with contentClassName set to: unde
     </CustomizedActionButton>
   </div>
   <div
-    className="content"
+    className="collapsibleContainerContent"
   >
     <div>
       Some content
@@ -241,7 +241,7 @@ exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: expand
     </CustomizedActionButton>
   </div>
   <div
-    className="content"
+    className="collapsibleContainerContent"
   >
     <div>
       Some content

--- a/src/tests/unit/tests/common/components/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/collapsible-component-cards.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
+import { forOwn } from 'lodash';
 import * as React from 'react';
 
-import { forOwn } from 'lodash';
 import {
     CollapsibleComponentCards,
     CollapsibleComponentCardsProps,
@@ -27,6 +27,7 @@ describe('CollapsibleComponentCardsTest', () => {
                 };
 
                 const result = shallow(<CollapsibleComponentCards {...props} />);
+
                 expect(result.getElement()).toMatchSnapshot();
             });
         });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ const getCSSModulesLoadersConfig = isDevMode => {
                 loader: 'css-loader',
                 options: {
                     modules: {
-                        localIdentName: isDevMode ? '[local][hash:base64:5]' : '[local][hash:base64:5]',
+                        localIdentName: isDevMode ? '[local]' : '[local][hash:base64:5]',
                     },
                     localsConvention: 'camelCaseOnly',
                 },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ const getCSSModulesLoadersConfig = isDevMode => {
                 loader: 'css-loader',
                 options: {
                     modules: {
-                        localIdentName: isDevMode ? '[local]' : '[local][hash:base64:5]',
+                        localIdentName: isDevMode ? '[local][hash:base64:5]' : '[local][hash:base64:5]',
                     },
                     localsConvention: 'camelCaseOnly',
                 },


### PR DESCRIPTION
#### Description of changes

This adds css from either reports or modifies CSS in details view css to improve the cards UI.

Changes to details view were required in a few cases to adjust the margins correctly (and also to improve the UI otherwise).

![image](https://user-images.githubusercontent.com/32555133/64055336-a77f6400-cb40-11e9-97ca-6b347838cfbf.png)

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
