### PR TITLE
use bundled details-view styles in reports

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -144,14 +144,6 @@ module.exports = function(grunt) {
                 ],
             },
         },
-        'embed-styles': {
-            code: {
-                cwd: extensionPath,
-                src: '**/*bundle.js',
-                dest: extensionPath,
-                expand: true,
-            },
-        },
         exec: {
             'webpack-dev': `${path.resolve('./node_modules/.bin/webpack')} --config-name dev`,
             'webpack-prod': `${path.resolve('./node_modules/.bin/webpack')} --config-name prod`,
@@ -185,12 +177,12 @@ module.exports = function(grunt) {
             },
             scss: {
                 files: ['src/**/*.scss'],
-                tasks: ['sass', 'copy:styles', 'embed-styles:dev', 'drop:dev'],
+                tasks: ['sass', 'copy:styles', 'drop:dev'],
             },
             // We assume webpack --watch is running separately (usually via 'yarn watch')
             'webpack-output': {
                 files: ['extension/devBundle/**/*.*'],
-                tasks: ['embed-styles:dev', 'drop:dev'],
+                tasks: ['drop:dev'],
             },
         },
     });

--- a/src/DetailsView/bundled-details-view-styles.ts
+++ b/src/DetailsView/bundled-details-view-styles.ts
@@ -1,3 +1,3 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-export const styleSheet = `<<CSS:../reports/automated-checks-report.css>>`;
+export const styleSheet = `<<CSS:detailsView.css>>`;

--- a/src/DetailsView/components/cards/collapsible-component-cards.scss
+++ b/src/DetailsView/components/cards/collapsible-component-cards.scss
@@ -35,10 +35,6 @@
         width: 100%;
         height: fit-content;
 
-        .result-section-title {
-            padding-left: 14px;
-        }
-
         &:hover {
             background-color: $neutral-alpha-4;
             color: unset;

--- a/src/DetailsView/components/cards/result-section-title-v2.tsx
+++ b/src/DetailsView/components/cards/result-section-title-v2.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import { InstanceOutcomeType } from '../../../reports/components/instance-outcome-type';
 import { OutcomeChip } from '../../../reports/components/outcome-chip';
-import { resultSectionTitle, title } from './result-section-title.scss';
+import { outcomeChipContainer, resultSectionTitle, title } from './result-section-title.scss';
 
 export type ResultSectionTitleV2Props = {
     title: string;
@@ -22,7 +22,7 @@ export const ResultSectionTitleV2 = NamedSFC<ResultSectionTitleV2Props>('ResultS
             <span className={title} aria-hidden="true">
                 {props.title}
             </span>
-            <span aria-hidden="true">
+            <span className={outcomeChipContainer} aria-hidden="true">
                 <OutcomeChip outcomeType={props.outcomeType} count={props.badgeCount} />
             </span>
         </span>

--- a/src/DetailsView/components/cards/result-section-title.scss
+++ b/src/DetailsView/components/cards/result-section-title.scss
@@ -9,9 +9,13 @@
     margin-bottom: 8px;
 
     :global(.outcome-chip) {
+        :global(.count) {
+            line-height: 11px;
+        }
+
         &:global(.outcome-chip-fail) {
-            .count {
-                line-height: 11px;
+            :global(.count) {
+                line-height: 13px;
             }
 
             svg {
@@ -24,5 +28,9 @@
         font-size: 17px;
         line-height: 24px;
         font-weight: 700;
+    }
+
+    .outcome-chip-container {
+        display: flex;
     }
 }

--- a/src/reports/assessment-report-html-generator.tsx
+++ b/src/reports/assessment-report-html-generator.tsx
@@ -8,10 +8,9 @@ import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import * as React from 'react';
 
+import * as bundledStyles from '../DetailsView/bundled-details-view-styles';
 import { AssessmentReportModelBuilderFactory } from './assessment-report-model-builder-factory';
 import * as reportStyles from './assessment-report.styles';
-import * as bundledStyles from '../DetailsView/bundled-details-view-styles';
-
 import { AssessmentReport, AssessmentReportDeps } from './components/assessment-report';
 import { ReactStaticRenderer } from './react-static-renderer';
 

--- a/src/reports/assessment-report-html-generator.tsx
+++ b/src/reports/assessment-report-html-generator.tsx
@@ -10,6 +10,8 @@ import * as React from 'react';
 
 import { AssessmentReportModelBuilderFactory } from './assessment-report-model-builder-factory';
 import * as reportStyles from './assessment-report.styles';
+import * as bundledStyles from '../DetailsView/bundled-details-view-styles';
+
 import { AssessmentReport, AssessmentReportDeps } from './components/assessment-report';
 import { ReactStaticRenderer } from './react-static-renderer';
 
@@ -51,6 +53,7 @@ export class AssessmentReportHtmlGenerator {
                 <head>
                     <title>Assessment report</title>
                     <style dangerouslySetInnerHTML={{ __html: reportStyles.styleSheet }} />
+                    <style dangerouslySetInnerHTML={{ __html: bundledStyles.styleSheet }} />
                 </head>
                 <body>
                     <AssessmentReport

--- a/src/reports/assessment-report.styles.ts
+++ b/src/reports/assessment-report.styles.ts
@@ -1,3 +1,3 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-export const styleSheet = `<<CSS:reports/assessment-report.css>>`;
+export const styleSheet = `<<CSS:../reports/assessment-report.css>>`;

--- a/src/reports/automated-checks-report.scss
+++ b/src/reports/automated-checks-report.scss
@@ -38,37 +38,6 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     margin-bottom: 24px;
 }
 
-.result-section-title {
-    display: flex;
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-    align-items: center;
-    margin-top: 8px;
-    margin-bottom: 8px;
-
-    .outcome-chip {
-        margin-top: 5px;
-
-        &.outcome-chip-fail {
-            margin-top: 10px;
-
-            .count {
-                line-height: 11px;
-            }
-
-            svg {
-                margin-bottom: 3px;
-            }
-        }
-    }
-
-    .title {
-        font-size: 17px;
-        line-height: 24px;
-        font-weight: 700;
-    }
-}
-
 .failed-instances-section {
     .how-to-fix-content {
         margin-bottom: 16px;
@@ -114,6 +83,7 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
         .collapsible-control::before {
             position: relative;
             bottom: 2px;
+            margin-right: 14px;
         }
     }
 }
@@ -203,10 +173,6 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
         align-items: baseline;
 
         width: 100%;
-
-        .result-section-title {
-            padding-left: 14px;
-        }
 
         &:hover {
             background-color: $neutral-alpha-4;

--- a/src/reports/components/report-head.tsx
+++ b/src/reports/components/report-head.tsx
@@ -5,6 +5,7 @@ import { title } from 'content/strings/application';
 import * as React from 'react';
 
 import * as reportStyles from '../automated-checks-report.styles';
+import * as bundledStyles from '../../DetailsView/bundled-details-view-styles';
 
 export const ReportHead = NamedSFC('ReportHead', () => {
     return (
@@ -12,6 +13,7 @@ export const ReportHead = NamedSFC('ReportHead', () => {
             <meta httpEquiv="Content-Type" content="text/html;charset=utf-8" />
             <title>{title} automated checks result</title>
             <style dangerouslySetInnerHTML={{ __html: reportStyles.styleSheet }} />
+            <style dangerouslySetInnerHTML={{ __html: bundledStyles.styleSheet }} />
         </head>
     );
 });

--- a/src/reports/components/report-head.tsx
+++ b/src/reports/components/report-head.tsx
@@ -4,8 +4,8 @@ import { NamedSFC } from 'common/react/named-sfc';
 import { title } from 'content/strings/application';
 import * as React from 'react';
 
-import * as reportStyles from '../automated-checks-report.styles';
 import * as bundledStyles from '../../DetailsView/bundled-details-view-styles';
+import * as reportStyles from '../automated-checks-report.styles';
 
 export const ReportHead = NamedSFC('ReportHead', () => {
     return (

--- a/src/reports/components/report-sections/collapsible-result-section.tsx
+++ b/src/reports/components/report-sections/collapsible-result-section.tsx
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 import { NamedSFC } from 'common/react/named-sfc';
 import * as React from 'react';
+
+import { ResultSectionTitleV2 } from '../../../DetailsView/components/cards/result-section-title-v2';
 import { CollapsibleContainer } from './collapsible-container';
 import { ResultSectionProps } from './result-section';
-import { ResultSectionTitle } from './result-section-title';
 import { RulesOnly, RulesOnlyProps } from './rules-only';
 
 export type CollapsibleResultSectionProps = RulesOnlyProps &
@@ -19,7 +20,7 @@ export const CollapsibleResultSection = NamedSFC<CollapsibleResultSectionProps>(
         <div className={containerClassName}>
             <CollapsibleContainer
                 id={containerId}
-                visibleHeadingContent={<ResultSectionTitle {...props} />}
+                visibleHeadingContent={<ResultSectionTitleV2 {...props} />}
                 collapsibleContent={<RulesOnly {...props} />}
                 titleHeadingLevel={2}
             />

--- a/src/reports/components/report-sections/result-section.tsx
+++ b/src/reports/components/report-sections/result-section.tsx
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 import { NamedSFC } from 'common/react/named-sfc';
 import * as React from 'react';
+
+import { ResultSectionTitleV2 } from '../../../DetailsView/components/cards/result-section-title-v2';
 import { ResultSectionContent, ResultSectionContentDeps, ResultSectionContentProps } from './result-section-content';
-import { ResultSectionTitle, ResultSectionTitleProps } from './result-section-title';
+import { ResultSectionTitleProps } from './result-section-title';
 
 export type ResultSectionDeps = ResultSectionContentDeps;
 
@@ -19,7 +21,7 @@ export const ResultSection = NamedSFC<ResultSectionProps>('ResultSection', props
     return (
         <div className={containerClassName}>
             <h2>
-                <ResultSectionTitle {...props} />
+                <ResultSectionTitleV2 {...props} />
             </h2>
             <ResultSectionContent {...props} />
         </div>

--- a/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/result-section-title-v2.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/cards/__snapshots__/result-section-title-v2.test.tsx.snap
@@ -19,6 +19,7 @@ exports[`ResultSectionTitleV2 renders 1`] = `
   </span>
   <span
     aria-hidden="true"
+    className="outcomeChipContainer"
   >
     <OutcomeChip
       count={10}

--- a/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
@@ -5,8 +5,6 @@ import { AssessmentStoreData } from 'common/types/store-data/assessment-result-d
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import * as React from 'react';
-import { It, Mock, MockBehavior } from 'typemoq';
-
 import { AssessmentReportHtmlGenerator, AssessmentReportHtmlGeneratorDeps } from 'reports/assessment-report-html-generator';
 import { ReportModel } from 'reports/assessment-report-model';
 import { AssessmentReportModelBuilder } from 'reports/assessment-report-model-builder';
@@ -14,6 +12,9 @@ import { AssessmentReportModelBuilderFactory } from 'reports/assessment-report-m
 import * as reportStyles from 'reports/assessment-report.styles';
 import { AssessmentReport } from 'reports/components/assessment-report';
 import { ReactStaticRenderer } from 'reports/react-static-renderer';
+import { It, Mock, MockBehavior } from 'typemoq';
+
+import * as detailsViewBundledCSS from '../../../../DetailsView/bundled-details-view-styles';
 import { CreateTestAssessmentProviderWithFeatureFlag } from '../../common/test-assessment-provider';
 
 describe('AssessmentReportHtmlGenerator', () => {
@@ -42,6 +43,7 @@ describe('AssessmentReportHtmlGenerator', () => {
                 <head>
                     <title>Assessment report</title>
                     <style dangerouslySetInnerHTML={{ __html: reportStyles.styleSheet }} />
+                    <style dangerouslySetInnerHTML={{ __html: detailsViewBundledCSS.styleSheet }} />
                 </head>
                 <body>
                     <AssessmentReport

--- a/src/tests/unit/tests/reports/components/__snapshots__/report-head.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/report-head.test.tsx.snap
@@ -13,7 +13,14 @@ exports[`ReportHead renders 1`] = `
   <style
     dangerouslySetInnerHTML={
       Object {
-        "__html": "<<CSS:reports/automated-checks-report.css>>",
+        "__html": "<<CSS:../reports/automated-checks-report.css>>",
+      }
+    }
+  />
+  <style
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "<<CSS:detailsView.css>>",
       }
     }
   />

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-result-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-result-section.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`CollapsibleResultSection renders 1`] = `
     id="container-id"
     titleHeadingLevel={2}
     visibleHeadingContent={
-      <ResultSectionTitle
+      <ResultSectionTitleV2
         containerClassName="result-section-class-name"
         containerId="container-id"
       />

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/result-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/result-section.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ResultSection renders 1`] = `
   className="result-section-class-name"
 >
   <h2>
-    <ResultSectionTitle
+    <ResultSectionTitleV2
       containerClassName="result-section-class-name"
       deps={Object {}}
     />


### PR DESCRIPTION
#### Description of changes

We embed styles for report components. Previously, we had a specific "report-wide" css file we would embed for each report. However, ideally we'd like to be able to share components across reports and our normal UI, where we can use css-modules. This PR allows us to do that.

Effectively, we have to move embed styles to become a task that will happen after webpack has run so that we have the generated bundle css file. As a result, you'll see that embed styles now looks at the bundled folder and happens as a part of drop (before anything else; this part is open to changing to be honest). This also means that we have to modify our older scss file references slightly as the working directly changes to the bundled folder. We also need to copy these scss files to the extension folder so they can be utilized in the later steps (which embed styles now is).

Additionally, I've started using one component (report-section-title) in both reports and details view. Since there were some cross-cutting CSS concerns in automated-checks-reports.scss, I've modified the css module for the component and a few other places to ensure the styling is appropriate.

Note: due to dev webpack build not hashing the css names, I've noticed a couple of conflicting css rules. However, if you build like you would for insider/prod, those conflicting css rules will not cause any effect. Ideally, after we move some of these components from outside of the global/report-wide css files, we should stop seeing them locally as well.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
