### PR TITLE
clarified the Sensory Test, Use of Color instructions per Lisa Louise's suggestions

### DIFF
--- a/src/assessments/color/test-steps/use-of-color.tsx
+++ b/src/assessments/color/test-steps/use-of-color.tsx
@@ -18,7 +18,8 @@ const useOfColorHowToTest: JSX.Element = (
             <li>
                 Examine the target page to identify any instances where color is used to communicate meaning, such as:
                 <ol>
-                    <li>Communicating status</li>
+                    <li>Communicating the status of a task or process</li>
+                    <li>Indicating the state of a UI component (such as selected or focused)</li>
                     <li>Prompting a response</li>
                     <li>Identifying an error</li>
                 </ol>


### PR DESCRIPTION
#### Description of changes

I clarified the instructions for the Sensory test, Use of Color, per Lisa Louise's suggestion. 

The text now reads as:

![image](https://user-images.githubusercontent.com/19158512/64275748-2ab30800-cefb-11e9-9906-135a8b859575.png)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1205 
- [N/A] Added relevant unit test for your changes. (`yarn test`)
- [N/A] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [X] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS
