### PR TITLE
chore: Clean detailsview.scss by moving component css to modules + remove some dead styles

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -436,14 +436,6 @@ div.insights-file-issue-details-dialog-container {
         padding-right: 0px;
         flex-grow: 1;
         min-height: 0;
-        .details-view-nav-pivots {
-            > :first-child {
-                height: $detailsViewNavPivotsHeight;
-            }
-            .details-view-test-nav-area {
-                max-height: calc(100vh - #{detailsViewNavPivotsHeight} - #{$detailsViewHeaderBarHeight} - #{$detailsViewCommandBarHeight});
-            }
-        }
         .details-view-test-nav-area {
             max-height: calc(100vh - #{$detailsViewHeaderBarHeight} - #{$detailsViewCommandBarHeight} - 12px);
             .ms-Nav-groupContent,
@@ -472,24 +464,6 @@ div.insights-file-issue-details-dialog-container {
             .ms-Nav-groupContent,
             .ms-Nav-navItems {
                 margin-bottom: 0px;
-            }
-            .req-description {
-                line-height: initial;
-                text-align: left;
-                white-space: initial;
-                font-size: 14px;
-                width: 100%;
-                .req-index,
-                .req-name {
-                    font-weight: bolder;
-                    font-size: 14px;
-                }
-                .req-index {
-                    margin-right: 8px;
-                }
-                .req-name {
-                    margin-right: 3px;
-                }
             }
             .button-flex-container .status-icon {
                 margin-left: 24px;

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -1371,23 +1371,6 @@ div.insights-file-issue-details-dialog-container {
                         align-items: flex-start;
                         width: 90%;
                         margin-right: 32px;
-                        .overview-heading {
-                            h1 {
-                                font-weight: bold;
-                                line-height: 40px;
-                                font-size: 28px;
-                                letter-spacing: -0.04em;
-                                color: $primary-text;
-                                padding-bottom: 16px;
-                                padding-top: 24px;
-                            }
-                            .overview-heading-content {
-                                color: $secondary-text;
-                                font-weight: normal;
-                                line-height: 20px;
-                                font-size: 15px;
-                            }
-                        }
                         .assessment-report-summary {
                             margin-top: 40px;
                             width: 100%;
@@ -1420,35 +1403,6 @@ div.insights-file-issue-details-dialog-container {
                                 font-size: 17px;
                                 color: $primary-text;
                             }
-                        }
-                    }
-                    .overview-help-section {
-                        width: 308px;
-                        height: 168px;
-                        padding-top: 24px;
-                        margin-right: 32px;
-                        .help-heading {
-                            font-size: 17px;
-                            padding: 0px;
-                            margin-block-end: 1em;
-                            margin-inline-start: 0px;
-                            margin-inline-end: 0px;
-                        }
-                        .overview-help-container {
-                            padding-top: 20px;
-                            padding-left: 24px;
-                            padding-bottom: 24px;
-                            border-radius: 4px;
-                            background-color: $help-links-section-background;
-                            border: 1px solid $help-links-section-border;
-                            box-sizing: border-box;
-                        }
-                        .help-link {
-                            padding: 5px 0px 5px 0px;
-                            font-family: $fontFamily;
-                            line-height: 20px;
-                            font-size: 15px;
-                            color: $communication-primary;
                         }
                     }
                 }

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -908,10 +908,6 @@ div.insights-file-issue-details-dialog-container {
                                 font-size: 16px;
                             }
                         }
-                        .start-over-button {
-                            margin-right: 24px;
-                            height: fit-content;
-                        }
                     }
                     .details-view-assessment-content {
                         flex-grow: 1;
@@ -947,10 +943,6 @@ div.insights-file-issue-details-dialog-container {
                         height: 100%;
                         width: 100%;
                     }
-                }
-                .target-page-closed {
-                    position: absolute;
-                    left: 24px;
                 }
                 h1 {
                     margin: 0px;

--- a/src/DetailsView/components/overview-content/help-links.scss
+++ b/src/DetailsView/components/overview-content/help-links.scss
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../common/styles/colors.scss';
+@import '../../../common/styles/fonts.scss';
+
+.help-link {
+    padding: 5px 0px 5px 0px;
+    font-family: $fontFamily;
+    line-height: 20px;
+    font-size: 15px;
+    color: $communication-primary;
+}

--- a/src/DetailsView/components/overview-content/help-links.tsx
+++ b/src/DetailsView/components/overview-content/help-links.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-
 import { HyperlinkDefinition } from 'views/content/content-page';
+
 import { ExternalLink, ExternalLinkDeps } from '../../../common/components/external-link';
 import { NamedSFC } from '../../../common/react/named-sfc';
+import { helpLink } from './help-links.scss';
 
 export type HelpLinksDeps = ExternalLinkDeps;
 
@@ -18,7 +19,7 @@ export const HelpLinks = NamedSFC('HelpLinks', (props: HelpLinksProps) => {
     return (
         <>
             {linkInformation.map((link: HyperlinkDefinition) => (
-                <div className="help-link" key={link.href}>
+                <div className={helpLink} key={link.href}>
                     <ExternalLink deps={props.deps} href={link.href}>
                         {link.text}
                     </ExternalLink>

--- a/src/DetailsView/components/overview-content/overview-content-container.scss
+++ b/src/DetailsView/components/overview-content/overview-content-container.scss
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.overview-help-section {
+    width: 308px;
+    height: 168px;
+    padding-top: 24px;
+    margin-right: 32px;
+}

--- a/src/DetailsView/components/overview-content/overview-content-container.tsx
+++ b/src/DetailsView/components/overview-content/overview-content-container.tsx
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
-
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import * as React from 'react';
 import { OverviewSummaryReportModel } from 'reports/assessment-report-model';
 import { AssessmentReportSummary } from 'reports/components/assessment-report-summary';
 import { GetAssessmentSummaryModelFromProviderAndStoreData } from 'reports/get-assessment-summary-model';
 import { HyperlinkDefinition } from 'views/content/content-page';
+
 import { NamedSFC } from '../../../common/react/named-sfc';
 import { AssessmentStoreData } from '../../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../../common/types/store-data/tab-store-data';
 import { DetailsViewActionMessageCreator } from '../../actions/details-view-action-message-creator';
 import { TargetChangeDialog, TargetChangeDialogDeps } from '../target-change-dialog';
+import { overviewHelpSection } from './overview-content-container.scss';
 import { OverviewHeading } from './overview-heading';
 import { OverviewHelpSection, OverviewHelpSectionDeps } from './overview-help-section';
 
@@ -78,7 +79,7 @@ export const OverviewContainer = NamedSFC<OverviewContainerProps>('OverviewConta
                 <OverviewHeading />
                 <AssessmentReportSummary summary={summaryData} />
             </section>
-            <section className="overview-help-section">
+            <section className={overviewHelpSection}>
                 <OverviewHelpSection linkDataSource={linkDataSource} deps={deps} />
             </section>
         </div>

--- a/src/DetailsView/components/overview-content/overview-heading.scss
+++ b/src/DetailsView/components/overview-content/overview-heading.scss
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../common/styles/colors.scss';
+.overview-heading-content {
+    color: $secondary-text;
+    font-weight: normal;
+    line-height: 20px;
+    font-size: 15px;
+}
+
+.overview-heading {
+    h1 {
+        font-weight: bold !important;
+        line-height: 40px;
+        font-size: 28px !important;
+        letter-spacing: -0.04em;
+        color: $primary-text !important;
+        padding-bottom: 16px;
+        padding-top: 24px;
+    }
+}

--- a/src/DetailsView/components/overview-content/overview-heading.tsx
+++ b/src/DetailsView/components/overview-content/overview-heading.tsx
@@ -1,16 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { productName } from 'content/strings/application';
 import * as React from 'react';
 
-import { productName } from 'content/strings/application';
 import { NamedSFC } from '../../../common/react/named-sfc';
+import { overviewHeading, overviewHeadingContent } from './overview-heading.scss';
 
 export const OverviewHeading = NamedSFC('OverviewHeading', () => {
     return (
         <>
-            <div className="overview-heading">
+            <div className={overviewHeading}>
                 <h1>Overview</h1>
-                <div className="overview-heading-content">
+                <div className={overviewHeadingContent}>
                     This page contains a summary that indicates the progress of your assessment. An assessment is a manual experience in
                     which you navigate through a set of tests that cover all WCAG 2.1 AA success criteria. Each test has one or more
                     requirements that can be:

--- a/src/DetailsView/components/overview-content/overview-help-section.scss
+++ b/src/DetailsView/components/overview-content/overview-help-section.scss
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../common/styles/colors.scss';
+
+.overview-help-container {
+    padding-top: 20px;
+    padding-left: 24px;
+    padding-bottom: 24px;
+    border-radius: 4px;
+    background-color: $help-links-section-background;
+    border: 1px solid $help-links-section-border;
+    box-sizing: border-box;
+}
+
+.help-heading {
+    font-size: 17px;
+    padding: 0px;
+    margin-block-end: 1em;
+    margin-inline-start: 0px;
+    margin-inline-end: 0px;
+}

--- a/src/DetailsView/components/overview-content/overview-help-section.tsx
+++ b/src/DetailsView/components/overview-content/overview-help-section.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-
 import { HyperlinkDefinition } from 'views/content/content-page';
+
 import { NamedSFC } from '../../../common/react/named-sfc';
 import { HelpLinks, HelpLinksDeps } from './help-links';
+import { helpHeading, overviewHelpContainer } from './overview-help-section.scss';
 
 export type OverviewHelpSectionDeps = HelpLinksDeps;
 
@@ -15,8 +16,8 @@ export interface OverviewHelpSectionProps {
 
 export const OverviewHelpSection = NamedSFC('OverviewHelpSection', (props: OverviewHelpSectionProps) => {
     return (
-        <section className="overview-help-container">
-            <h3 className="help-heading">Help</h3>
+        <section className={overviewHelpContainer}>
+            <h3 className={helpHeading}>Help</h3>
             <HelpLinks linkInformation={props.linkDataSource} deps={props.deps} />
         </section>
     );

--- a/src/DetailsView/components/requirement-link.scss
+++ b/src/DetailsView/components/requirement-link.scss
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.req-description {
+    line-height: initial;
+    text-align: left;
+    white-space: initial;
+    font-size: 14px;
+    width: 100%;
+    .req-index,
+    .req-name {
+        font-weight: bolder;
+        font-size: 14px;
+    }
+    .req-index {
+        margin-right: 8px;
+    }
+    .req-name {
+        margin-right: 3px;
+    }
+}

--- a/src/DetailsView/components/requirement-link.tsx
+++ b/src/DetailsView/components/requirement-link.tsx
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { css } from '@uifabric/utilities';
 import { INavLink } from 'office-ui-fabric-react/lib/Nav';
 import * as React from 'react';
 
 import { ManualTestStatus } from '../../common/types/manual-test-status';
+import { reqDescription, reqIndex, reqName } from './requirement-link.scss';
 import { StatusIcon } from './status-icon';
 
 export interface RequirementLinkProps {
@@ -24,9 +26,9 @@ export class RequirementLink extends React.Component<RequirementLinkProps> {
 
     public renderRequirementDescriptionWithIndex(): JSX.Element {
         return (
-            <div className={'ms-Button-label req-description'}>
-                <span className="req-index">{this.props.link.index}</span>
-                <span className="req-name">{this.props.link.name}.</span>
+            <div className={css('ms-Button-label', reqDescription)}>
+                <span className={reqIndex}>{this.props.link.index}</span>
+                <span className={reqName}>{this.props.link.name}.</span>
                 {this.props.link.description}
             </div>
         );
@@ -34,8 +36,8 @@ export class RequirementLink extends React.Component<RequirementLinkProps> {
 
     public renderRequirementDescriptionWithoutIndex(): JSX.Element {
         return (
-            <div className={'ms-Button-label req-description'}>
-                <span className="req-name">{this.props.link.name}.</span>
+            <div className={css('ms-Button-label', reqDescription)}>
+                <span className={reqName}>{this.props.link.name}.</span>
                 {this.props.link.description}
             </div>
         );

--- a/src/DetailsView/components/target-page-closed-view.scss
+++ b/src/DetailsView/components/target-page-closed-view.scss
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.target-page-closed {
+    padding: 24px;
+}

--- a/src/DetailsView/components/target-page-closed-view.tsx
+++ b/src/DetailsView/components/target-page-closed-view.tsx
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
+import { targetPageClosed } from './target-page-closed-view.scss';
+
 export class TargetPageClosedView extends React.Component {
     public render(): JSX.Element {
         return (
-            <div className="target-page-closed">
+            <div className={targetPageClosed}>
                 <h1>No content available</h1>
                 <p>The target page was closed. You can close this tab or reuse it for something else.</p>
             </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-link.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-link.test.tsx.snap
@@ -6,15 +6,15 @@ exports[`RequirementLink renders with index 1`] = `
   className="button-flex-container"
 >
   <div
-    className="ms-Button-label req-description"
+    className="ms-Button-label reqDescription"
   >
     <span
-      className="req-index"
+      className="reqIndex"
     >
       5
     </span>
     <span
-      className="req-name"
+      className="reqName"
     >
       Link with index name
       .
@@ -36,10 +36,10 @@ exports[`RequirementLink renders without index 1`] = `
   className="button-flex-container"
 >
   <div
-    className="ms-Button-label req-description"
+    className="ms-Button-label reqDescription"
   >
     <span
-      className="req-name"
+      className="reqName"
     >
       Link without index name
       .

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-closed-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-closed-view.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StaleView render stale view for default 1`] = `
+<div
+  className="targetPageClosed"
+>
+  <h1>
+    No content available
+  </h1>
+  <p>
+    The target page was closed. You can close this tab or reuse it for something else.
+  </p>
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/help-links.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/help-links.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`HelpLinks linkInformation is shown properly 1`] = `
 <React.Fragment>
   <div
-    className="help-link"
+    className="helpLink"
   >
     <ExternalLink
       deps={Object {}}
@@ -13,7 +13,7 @@ exports[`HelpLinks linkInformation is shown properly 1`] = `
     </ExternalLink>
   </div>
   <div
-    className="help-link"
+    className="helpLink"
   >
     <ExternalLink
       deps={Object {}}
@@ -23,7 +23,7 @@ exports[`HelpLinks linkInformation is shown properly 1`] = `
     </ExternalLink>
   </div>
   <div
-    className="help-link"
+    className="helpLink"
   >
     <ExternalLink
       deps={Object {}}

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/help-links.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/help-links.test.tsx.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HelpLinks linkInformation is shown properly 1`] = `
+<React.Fragment>
+  <div
+    className="help-link"
+  >
+    <ExternalLink
+      deps={Object {}}
+      href="https://www.test1.com"
+    >
+      test1
+    </ExternalLink>
+  </div>
+  <div
+    className="help-link"
+  >
+    <ExternalLink
+      deps={Object {}}
+      href="https://www.test2.com"
+    >
+      test2
+    </ExternalLink>
+  </div>
+  <div
+    className="help-link"
+  >
+    <ExternalLink
+      deps={Object {}}
+      href="https://www.test3.com"
+    >
+      test3
+    </ExternalLink>
+  </div>
+</React.Fragment>
+`;

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-content-container.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`OverviewContainer component is defined and matches snapshot 1`] = `
     <AssessmentReportSummary />
   </section>
   <section
-    className="overview-help-section"
+    className="overviewHelpSection"
   >
     <OverviewHelpSection
       deps={

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-heading.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-heading.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`OverviewHeading match snapshot 1`] = `
 <React.Fragment>
   <div
-    className="overview-heading"
+    className="overviewHeading"
   >
     <h1>
       Overview
     </h1>
     <div
-      className="overview-heading-content"
+      className="overviewHeadingContent"
     >
       This page contains a summary that indicates the progress of your assessment. An assessment is a manual experience in which you navigate through a set of tests that cover all WCAG 2.1 AA success criteria. Each test has one or more requirements that can be:
       <ul>

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-help-section.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-help-section.test.tsx.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`OverviewHelpSection help text is shown properly 1`] = `
+<section
+  className="overviewHelpContainer"
+>
+  <h3
+    className="helpHeading"
+  >
+    Help
+  </h3>
+  <HelpLinks
+    deps={Object {}}
+    linkInformation={Array []}
+  />
+</section>
+`;

--- a/src/tests/unit/tests/DetailsView/components/overview-content/help-links.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/help-links.test.tsx
@@ -2,12 +2,11 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Mock } from 'typemoq';
 
 import { HelpLinks, HelpLinksDeps, HelpLinksProps } from '../../../../../../DetailsView/components/overview-content/help-links';
 
 describe('HelpLinks', () => {
-    const deps = Mock.ofType<HelpLinksDeps>().object;
+    const deps = {} as HelpLinksDeps;
 
     test('linkInformation is shown properly', () => {
         const props: HelpLinksProps = {
@@ -29,11 +28,6 @@ describe('HelpLinks', () => {
         };
 
         const helpLinkSection = shallow(<HelpLinks {...props} />);
-
-        expect(helpLinkSection.exists()).toBe(true);
-
-        const helpLinkDivs = helpLinkSection.find('.help-link');
-        expect(helpLinkDivs.exists()).toBe(true);
-        expect(helpLinkDivs.length).toBe(props.linkInformation.length);
+        expect(helpLinkSection.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/overview-content/overview-heading.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/overview-heading.test.tsx
@@ -6,24 +6,6 @@ import * as React from 'react';
 import { OverviewHeading } from '../../../../../../DetailsView/components/overview-content/overview-heading';
 
 describe('OverviewHeading', () => {
-    test('overview-heading content is defined', () => {
-        expect(<OverviewHeading />).toBeDefined();
-    });
-
-    test('overview heading has proper classname', () => {
-        const wrapper = shallow(<OverviewHeading />);
-        const overviewHeadingDiv = wrapper.find('.overview-heading');
-        expect(overviewHeadingDiv.exists()).toBe(true);
-    });
-
-    test('overview heading has h1 heading and it contains proper text', () => {
-        const wrapper = shallow(<OverviewHeading />);
-
-        const h1Element = wrapper.find('h1');
-        expect(h1Element.exists()).toBe(true);
-        expect(h1Element.text()).toBe('Overview');
-    });
-
     test('match snapshot', () => {
         const wrapper = shallow(<OverviewHeading />);
         expect(wrapper.getElement()).toMatchSnapshot();

--- a/src/tests/unit/tests/DetailsView/components/overview-content/overview-help-section.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/overview-help-section.test.tsx
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Mock } from 'typemoq';
-
 import { HyperlinkDefinition } from 'views/content/content-page';
+
 import {
     OverviewHelpSection,
     OverviewHelpSectionDeps,
@@ -12,26 +11,12 @@ import {
 } from '../../../../../../DetailsView/components/overview-content/overview-help-section';
 
 describe('OverviewHelpSection', () => {
-    const deps = Mock.ofType<OverviewHelpSectionDeps>().object;
-
-    test('the component is defined', () => {
-        expect(<OverviewHelpSection linkDataSource={[]} deps={deps} />).toBeDefined();
-    });
-
     test('help text is shown properly', () => {
         const props: OverviewHelpSectionProps = {
             linkDataSource: [] as HyperlinkDefinition[],
             deps: {} as OverviewHelpSectionDeps,
         };
         const wrapper = shallow(<OverviewHelpSection {...props} />);
-
-        const overviewParentSection = wrapper.find('.overview-help-container');
-        expect(overviewParentSection.exists()).toBe(true);
-
-        const h2 = wrapper.find('h3');
-
-        expect(h2.exists()).toBe(true);
-        expect(h2.hasClass('help-heading')).toBe(true);
-        expect(h2.text()).toBe('Help');
+        expect(wrapper.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/target-page-closed-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/target-page-closed-view.test.tsx
@@ -1,20 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { TargetPageClosedView } from '../../../../../DetailsView/components/target-page-closed-view';
 
 describe('StaleView', () => {
     test('render stale view for default', () => {
-        const staleView = new TargetPageClosedView(undefined);
+        const testSubject = shallow(<TargetPageClosedView />);
 
-        const expectedComponent = (
-            <div className="target-page-closed">
-                <h1>No content available</h1>
-                <p>The target page was closed. You can close this tab or reuse it for something else.</p>
-            </div>
-        );
-
-        expect(staleView.render()).toEqual(expectedComponent);
+        expect(testSubject.getElement()).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Description of changes

The commits do a good job of telling the general update in this PR. I've created css modules for:
- requirement link
- target page closed view
- overview components (help, heading, etc)

and additionally improve the css a bit for target page closed view (screenshot added) and removing some dead css which was not being used. I also updated to only have snapshot tests to align with our current testing methodology.

Updated view of the target paged closed view:
![image](https://user-images.githubusercontent.com/32555133/64290457-fd765200-cf1a-11e9-98bf-b72e474ec382.png)


#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
