### PR TITLE
test: Part - 2 high contrast e2e - wait for toggle state to be changed to checked before proceeding further when toggling high contrast mode

### DIFF
--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -14,6 +14,7 @@ export const detailsViewSelectors = {
     settingsButton: 'button[name="Settings"]',
     settingsPanel: '.settings-panel',
     highContrastToggle: 'button#enable-high-contrast-mode',
+    highContrastToggleCheckedStateSelector: 'button#enable-high-contrast-mode[aria-checked="true"]',
 };
 
 export const overviewSelectors = {

--- a/src/tests/end-to-end/common/page-controllers/details-view-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/details-view-page.ts
@@ -47,6 +47,7 @@ export class DetailsViewPage extends Page {
         await this.openSettingsPanel();
 
         await this.clickSelector(detailsViewSelectors.highContrastToggle);
+        await this.waitForSelector(detailsViewSelectors.highContrastToggleCheckedStateSelector);
         await this.waitForSelector(CommonSelectors.highContrastThemeSelector);
 
         await this.closeSettingsPanel();


### PR DESCRIPTION
#### Description of changes

##### Part - 2: Toggling high contrast mode should wait for selector to be actually toggled/checked.

This PR' is part of PRs which try to reduce some of the inconsistency that we are getting with our e2e reliability build.

PR tries to improve e2e reliability by waiting for selector (checked=true) when we are trying to toggle high contrast on.
This test was chosen because the high contrast mode validation selector (`body.high-contrast-theme`) was not being found during a lot of test failures (as per ADO test analytics). This changes makes sure that we look for that selector only after toggle is checked to true.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
