### PR TITLE
refactor: minor clean up on components/tests

### DIFF
--- a/src/electron/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/device-connect-view/components/device-connect-port-entry.tsx
@@ -24,17 +24,12 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
     }
 
     public render(): JSX.Element {
-        const onPortTextChanged = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
-            this.setState({ isValidateButtonDisabled: !newValue || newValue === '', port: newValue });
-            this.props.updateStateCallback(DeviceConnectState.Default);
-        };
-
         return (
             <div className="device-connect-port-entry">
                 <h3>Android device port number</h3>
                 <MaskedTextField
                     ariaLabel="Port number"
-                    onChange={onPortTextChanged}
+                    onChange={this.onPortTextChanged}
                     placeholder="12345"
                     className="port-number-field"
                     maskChar=""
@@ -51,6 +46,11 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
             </div>
         );
     }
+
+    private onPortTextChanged = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
+        this.setState({ isValidateButtonDisabled: !newValue || newValue === '', port: newValue });
+        this.props.updateStateCallback(DeviceConnectState.Default);
+    };
 
     private onValidateClick = async (event: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
         this.setState({ isValidateButtonDisabled: true });

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -66,42 +66,42 @@ exports[`DeviceConnectPortEntryTest renders with needsValidation = true 1`] = `
 </div>
 `;
 
-exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "" 1`] = `
+exports[`DeviceConnectPortEntryTest user interaction change port number handles port text = "" 1`] = `
 Object {
   "isValidateButtonDisabled": true,
   "port": "",
 }
 `;
 
-exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "" 2`] = `
+exports[`DeviceConnectPortEntryTest user interaction change port number handles port text = "" 2`] = `
 Object {
   "isValidateButtonDisabled": true,
   "port": "",
 }
 `;
 
-exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "111" 1`] = `
+exports[`DeviceConnectPortEntryTest user interaction change port number handles port text = "111" 1`] = `
 Object {
   "isValidateButtonDisabled": true,
   "port": "",
 }
 `;
 
-exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "111" 2`] = `
+exports[`DeviceConnectPortEntryTest user interaction change port number handles port text = "111" 2`] = `
 Object {
   "isValidateButtonDisabled": false,
   "port": "111",
 }
 `;
 
-exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "null" 1`] = `
+exports[`DeviceConnectPortEntryTest user interaction change port number handles port text = "null" 1`] = `
 Object {
   "isValidateButtonDisabled": true,
   "port": "",
 }
 `;
 
-exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "null" 2`] = `
+exports[`DeviceConnectPortEntryTest user interaction change port number handles port text = "null" 2`] = `
 Object {
   "isValidateButtonDisabled": true,
   "port": null,

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -14,7 +14,7 @@ Object {
 }
 `;
 
-exports[`DeviceConnectPortEntryTest render 1`] = `
+exports[`DeviceConnectPortEntryTest renders with needsValidation = false 1`] = `
 <div
   className="device-connect-port-entry"
 >
@@ -40,6 +40,40 @@ exports[`DeviceConnectPortEntryTest render 1`] = `
     className="button-validate-port"
     disabled={true}
     onClick={[Function]}
+    primary={false}
+  >
+    Validate port number
+  </Button>
+</div>
+`;
+
+exports[`DeviceConnectPortEntryTest renders with needsValidation = true 1`] = `
+<div
+  className="device-connect-port-entry"
+>
+  <h3>
+    Android device port number
+  </h3>
+  <MaskedTextField
+    ariaLabel="Port number"
+    className="port-number-field"
+    mask="99999"
+    maskChar=""
+    maskFormat={
+      Object {
+        "*": /\\[a-zA-Z0-9\\]/,
+        "9": /\\[0-9\\]/,
+        "a": /\\[a-zA-Z\\]/,
+      }
+    }
+    onChange={[Function]}
+    placeholder="12345"
+  />
+  <Button
+    className="button-validate-port"
+    disabled={true}
+    onClick={[Function]}
+    primary={true}
   >
     Validate port number
   </Button>

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -1,19 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DeviceConnectPortEntryTest onChange updates state 1`] = `
-Object {
-  "isValidateButtonDisabled": true,
-  "port": "",
-}
-`;
-
-exports[`DeviceConnectPortEntryTest onChange updates state 2`] = `
-Object {
-  "isValidateButtonDisabled": false,
-  "port": "111",
-}
-`;
-
 exports[`DeviceConnectPortEntryTest renders with needsValidation = false 1`] = `
 <div
   className="device-connect-port-entry"
@@ -78,4 +64,46 @@ exports[`DeviceConnectPortEntryTest renders with needsValidation = true 1`] = `
     Validate port number
   </Button>
 </div>
+`;
+
+exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "" 1`] = `
+Object {
+  "isValidateButtonDisabled": true,
+  "port": "",
+}
+`;
+
+exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "" 2`] = `
+Object {
+  "isValidateButtonDisabled": true,
+  "port": "",
+}
+`;
+
+exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "111" 1`] = `
+Object {
+  "isValidateButtonDisabled": true,
+  "port": "",
+}
+`;
+
+exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "111" 2`] = `
+Object {
+  "isValidateButtonDisabled": false,
+  "port": "111",
+}
+`;
+
+exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "null" 1`] = `
+Object {
+  "isValidateButtonDisabled": true,
+  "port": "",
+}
+`;
+
+exports[`DeviceConnectPortEntryTest user interaction port input handles port text = "null" 2`] = `
+Object {
+  "isValidateButtonDisabled": true,
+  "port": null,
+}
 `;

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
@@ -4,6 +4,6 @@ exports[`ElectronExternalLinkTest render 1`] = `
 <StyledLinkBase
   onClick={[Function]}
 >
-  Bing
+  test-text
 </StyledLinkBase>
 `;

--- a/src/tests/unit/tests/electron/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -62,27 +62,8 @@ describe('DeviceConnectPortEntryTest', () => {
         describe('validate port number', () => {
             let props: DeviceConnectPortEntryProps;
 
-            type ValidatePortTestCase = {
-                fetch: FetchScanResultsType;
-                connectState: DeviceConnectState;
-                deviceName: string;
-                description: string;
-            };
-
-            const testCases: ValidatePortTestCase[] = [
-                {
-                    fetch: () => Promise.resolve({ deviceName: 'dev', appIdentifier: 'app' } as ScanResults),
-                    connectState: DeviceConnectState.Connected,
-                    deviceName: 'dev - app',
-                    description: 'fetch succeed',
-                },
-                {
-                    fetch: () => Promise.reject({} as ScanResults),
-                    connectState: DeviceConnectState.Error,
-                    deviceName: undefined,
-                    description: 'fetch fail',
-                },
-            ];
+            const fetchResultResolved = () => Promise.resolve({ deviceName: 'dev', appIdentifier: 'app' } as ScanResults);
+            const fetchResultRejected = () => Promise.reject({} as ScanResults);
 
             beforeEach(() => {
                 updateStateCallbackMock.setup(r => r(DeviceConnectState.Connecting)).verifiable(Times.once());
@@ -93,7 +74,11 @@ describe('DeviceConnectPortEntryTest', () => {
                 } as DeviceConnectPortEntryProps;
             });
 
-            test.each(testCases)('%p', async ({ fetch, connectState, deviceName }) => {
+            test.each`
+                description        | fetch                  | connectState                    | deviceName
+                ${'fetch success'} | ${fetchResultResolved} | ${DeviceConnectState.Connected} | ${'dev - app'}
+                ${'fetch fail'}    | ${fetchResultRejected} | ${DeviceConnectState.Error}     | ${undefined}
+            `('$description', async ({ fetch, connectState, deviceName }) => {
                 setupFetchScanResultsMock(fetch);
                 setupUpdateStateCallbackMock(connectState, deviceName);
 

--- a/src/tests/unit/tests/electron/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -36,22 +36,28 @@ describe('DeviceConnectPortEntryTest', () => {
         });
     });
 
-    test('onChange updates state', () => {
-        const fetch: FetchScanResultsType = _ => Promise.reject({} as ScanResults);
-        const props = SetupPropsMocks(fetch, DeviceConnectState.Default, undefined);
-        const rendered = shallow(<DeviceConnectPortEntry {...props} />);
+    describe('user interaction', () => {
+        describe('port input', () => {
+            const portNumberCases = [testPortNumber.toString(), '', null];
 
-        expect(rendered.state()).toMatchSnapshot();
+            it.each(portNumberCases)('handles port text = "%s"', portNumberText => {
+                updateStateCallbackMock.setup(callback => callback(DeviceConnectState.Default, undefined));
 
-        const onChangeHandler = rendered.find('.port-number-field').prop('onChange') as (
-            event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
-            newValue?: string,
-        ) => void;
+                const props = {
+                    updateStateCallback: updateStateCallbackMock.object,
+                } as DeviceConnectPortEntryProps;
 
-        onChangeHandler(null, testPortNumber.toString());
+                const rendered = shallow(<DeviceConnectPortEntry {...props} />);
 
-        updateStateCallbackMock.verifyAll();
-        expect(rendered.state()).toMatchSnapshot();
+                expect(rendered.state()).toMatchSnapshot();
+
+                rendered.find('.port-number-field').simulate('change', null, portNumberText);
+
+                updateStateCallbackMock.verifyAll();
+
+                expect(rendered.state()).toMatchSnapshot();
+            });
+        });
     });
 
     test('validate click fetch succeeds', () => {

--- a/src/tests/unit/tests/electron/device-connect-view/components/electron-external-link.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/electron-external-link.test.tsx
@@ -6,13 +6,16 @@ import { shallow } from 'enzyme';
 import { Button } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
-import { IMock, It, Mock } from 'typemoq';
+import { Mock, Times } from 'typemoq';
 
 describe('ElectronExternalLinkTest', () => {
+    const testHref = 'test-href';
+    const testText = 'test-text';
+
     test('render', () => {
         const props: ElectronExternalLinkProps = {
-            href: 'www.bing.com',
-            text: 'Bing',
+            href: testHref,
+            text: testText,
             shell: null,
         };
 
@@ -22,20 +25,19 @@ describe('ElectronExternalLinkTest', () => {
     });
 
     test('click', () => {
-        const renderMock: IMock<Shell> = Mock.ofType<Shell>();
+        const shellMock = Mock.ofType<Shell>();
         const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
-        const href = 'www.bing.com';
-        renderMock.setup(r => r.openExternal(It.isValue(href))).verifiable();
+        shellMock.setup(shell => shell.openExternal(testHref)).verifiable(Times.once());
 
         const props: ElectronExternalLinkProps = {
-            href: href,
-            text: 'Bing',
-            shell: renderMock.object,
+            href: testHref,
+            text: testText,
+            shell: shellMock.object,
         };
 
         const rendered = shallow(<ElectronExternalLink {...props} />);
         rendered.simulate('click', eventStub);
 
-        renderMock.verifyAll();
+        shellMock.verifyAll();
     });
 });


### PR DESCRIPTION
#### Description of changes

While looking at the electron app code to get familiar before starting a new feature, @JGibson2019 and I did some small clean up refactoring on components and tests.

One thing that caught our attention: `DeviceConnectPortEntry` uses an `async` `onClick` function for the primary `Button` it uses. I think this is the first time I see and async onClick function on our code base. Looking at the tests, we found a call to `setInmediate`. Again, this was odd as is the first time I see this on our code base. Playing around with the test code, we figure out this two things were related (async onClick function and setInmediate on the test). Because the onClick function is async, you need to wait (somehow) for it to finish before asserting on the tests (e.g calling `verifyAll` on a mock) but enzyme doesn't expose onClick handlers in a way that we can directly use `await` or `then`, hence, the use of `setInmediate`. We decided to change this a little bit (after some discussion with @dbjorge) to match our code style better. We introduce a `tick` function to wrap the waiting code (the call to `setInmediate` although, we end up using `setTimeout` with 0 ms delay). This way we can write `await tick();` and not have to either inline a function inside `setInmediate` (which kind of looks odd because of indentation, etc) or create a private function of sort to pass to `setInmediate`.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
