### PR TITLE
refactor: electron external link props

### DIFF
--- a/src/electron/device-connect-view/components/device-connect-header.tsx
+++ b/src/electron/device-connect-view/components/device-connect-header.tsx
@@ -9,11 +9,9 @@ export const DeviceConnectHeader = NamedSFC('DeviceConnectHeader', () => {
     return (
         <header className="device-connect-header">
             <h2>Connect to your android device</h2>
-            <ElectronExternalLink
-                href="https://go.microsoft.com/fwlink/?linkid=2101252"
-                text="How do I connect to my device?"
-                shell={shell}
-            />
+            <ElectronExternalLink href="https://go.microsoft.com/fwlink/?linkid=2101252" shell={shell}>
+                How do I connect to my device?
+            </ElectronExternalLink>
         </header>
     );
 });

--- a/src/electron/device-connect-view/components/electron-external-link.tsx
+++ b/src/electron/device-connect-view/components/electron-external-link.tsx
@@ -13,5 +13,5 @@ export interface ElectronExternalLinkProps {
 
 export const ElectronExternalLink = NamedSFC<ElectronExternalLinkProps>('ElectronExternalLink', (props: ElectronExternalLinkProps) => {
     const onClick = () => props.shell.openExternal(props.href);
-    return <Link onClick={onClick} {...props.children}></Link>;
+    return <Link onClick={onClick}>{props.children}</Link>;
 });

--- a/src/electron/device-connect-view/components/electron-external-link.tsx
+++ b/src/electron/device-connect-view/components/electron-external-link.tsx
@@ -7,11 +7,11 @@ import { NamedSFC } from '../../../common/react/named-sfc';
 
 export interface ElectronExternalLinkProps {
     href: string;
-    text: string;
     shell: Shell;
+    children: React.ReactNode;
 }
 
 export const ElectronExternalLink = NamedSFC<ElectronExternalLinkProps>('ElectronExternalLink', (props: ElectronExternalLinkProps) => {
     const onClick = () => props.shell.openExternal(props.href);
-    return <Link onClick={onClick}>{props.text}</Link>;
+    return <Link onClick={onClick} {...props.children}></Link>;
 });

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-header.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-header.test.tsx.snap
@@ -9,7 +9,8 @@ exports[`DeviceConnectHeaderTest render 1`] = `
   </h2>
   <ElectronExternalLink
     href="https://go.microsoft.com/fwlink/?linkid=2101252"
-    text="How do I connect to my device?"
-  />
+  >
+    How do I connect to my device?
+  </ElectronExternalLink>
 </header>
 `;

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
@@ -2,15 +2,8 @@
 
 exports[`ElectronExternalLinkTest render 1`] = `
 <StyledLinkBase
-  0="t"
-  1="e"
-  2="s"
-  3="t"
-  4="-"
-  5="t"
-  6="e"
-  7="x"
-  8="t"
   onClick={[Function]}
-/>
+>
+  test-text
+</StyledLinkBase>
 `;

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
@@ -2,8 +2,10 @@
 
 exports[`ElectronExternalLinkTest render 1`] = `
 <StyledLinkBase
+  0="B"
+  1="i"
+  2="n"
+  3="g"
   onClick={[Function]}
->
-  Bing
-</StyledLinkBase>
+/>
 `;

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
@@ -2,10 +2,15 @@
 
 exports[`ElectronExternalLinkTest render 1`] = `
 <StyledLinkBase
-  0="B"
-  1="i"
-  2="n"
-  3="g"
+  0="t"
+  1="e"
+  2="s"
+  3="t"
+  4="-"
+  5="t"
+  6="e"
+  7="x"
+  8="t"
   onClick={[Function]}
 />
 `;

--- a/src/tests/unit/tests/electron/device-connect-view/components/electron-external-link.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/electron-external-link.test.tsx
@@ -12,7 +12,7 @@ describe('ElectronExternalLinkTest', () => {
     test('render', () => {
         const props: ElectronExternalLinkProps = {
             href: 'www.bing.com',
-            text: 'Bing',
+            children: 'Bing',
             shell: null,
         };
 
@@ -29,7 +29,7 @@ describe('ElectronExternalLinkTest', () => {
 
         const props: ElectronExternalLinkProps = {
             href: href,
-            text: 'Bing',
+            children: 'Bing',
             shell: renderMock.object,
         };
 


### PR DESCRIPTION
#### Description of changes

Updated `ElectronExternalLinkProps` to contain 'children' property instead of 'text' so its usage is similar to that of `NewTabLink`. This is one of the steps to allow for the reuse of the `TelementryPermissionDialog`, which contains the `telemetryPopupNotice` that uses `NewTabLink`. Will update `telemetryPopupNotice` to be able to use `NewTabLink` or `ElectronExternalLink` in a future PR.

#### Pull request checklist

- [x] Addresses an existing issue: Partially addresses WI # 1596167
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
