### PR TITLE
chore: change popup panel selector to an id selector

### DIFF
--- a/src/tests/end-to-end/common/element-identifiers/popup-page-element-identifiers.ts
+++ b/src/tests/end-to-end/common/element-identifiers/popup-page-element-identifiers.ts
@@ -5,7 +5,7 @@ export const popupPageElementIdentifiers = {
     startUsingProductButton: 'button.start-using-product-button',
     launchPad: '#new-launch-pad',
     launchPadItemTitle: '.launch-pad-item-title',
-    adhocPanel: '.ad-hoc-tools-panel',
+    adhocPanel: '#popup-container',
     adhocLaunchPadLinkXPath: "//button[text()='Ad hoc tools']",
     backToLaunchPadLink: '#back-to-launchpad-link',
     hamburgerMenuButton: '#feedback-collapse-menu-button',


### PR DESCRIPTION
#### Description of changes

We do a `verifyAdhocPanelLoaded` function to verify that adhoc panel loaded; that function was testing for a `.ad-hoc-tools-panel` classname selector and it was causing some errors. 
This is a change to see if changing that selector to the id : `#popup-container` makes any stability improvements.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
