### PR TITLE
refactor: convert NewTabLink to a NamedSFC

### DIFF
--- a/src/common/components/new-tab-link.tsx
+++ b/src/common/components/new-tab-link.tsx
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseComponent, css } from '@uifabric/utilities';
-import { omit } from 'lodash';
+import { css } from '@uifabric/utilities';
 import { ILinkProps, Link } from 'office-ui-fabric-react/lib/Link';
 import * as React from 'react';
 
-export class NewTabLink extends BaseComponent<ILinkProps> {
-    public render(): JSX.Element {
-        const classNames = ['insights-link', this.props.className];
-        const allPropsExceptClassName = omit(this.props, 'className');
+import { NamedSFC } from '../react/named-sfc';
 
-        return <Link className={css(...classNames)} {...allPropsExceptClassName} target="_blank" />;
-    }
-}
+export const NewTabLink = NamedSFC<ILinkProps>('NewTabLink', ({ className, ...props }) => {
+    const classNames = ['insights-link', className];
+
+    return <Link className={css(...classNames)} {...props} target="_blank" />;
+});

--- a/src/tests/unit/tests/common/components/__snapshots__/new-tab-link.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/new-tab-link.test.tsx.snap
@@ -1,6 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NewTabLink render content with custom className 1`] = `
+exports[`NewTabLink handles children 1`] = `
+<StyledLinkBase
+  className="insights-link"
+  href="test"
+  target="_blank"
+>
+  link text
+</StyledLinkBase>
+`;
+
+exports[`NewTabLink renders content with custom className 1`] = `
 <StyledLinkBase
   className="insights-link custom-class"
   href="test"
@@ -8,7 +18,7 @@ exports[`NewTabLink render content with custom className 1`] = `
 />
 `;
 
-exports[`NewTabLink render content without custom className 1`] = `
+exports[`NewTabLink renders content without custom className 1`] = `
 <StyledLinkBase
   className="insights-link"
   href="test"

--- a/src/tests/unit/tests/common/components/new-tab-link.test.tsx
+++ b/src/tests/unit/tests/common/components/new-tab-link.test.tsx
@@ -6,8 +6,8 @@ import * as React from 'react';
 
 import { NewTabLink } from '../../../../../common/components/new-tab-link';
 
-describe(NewTabLink, () => {
-    test('render content with custom className', () => {
+describe('NewTabLink', () => {
+    it('renders content with custom className', () => {
         const props: ILinkProps = {
             href: 'test',
             className: 'custom-class',
@@ -18,12 +18,22 @@ describe(NewTabLink, () => {
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 
-    test('render content without custom className', () => {
+    it('renders content without custom className', () => {
         const props: ILinkProps = {
             href: 'test',
         };
 
         const wrapper = shallow(<NewTabLink {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    it('handles children', () => {
+        const props: ILinkProps = {
+            href: 'test',
+        };
+
+        const wrapper = shallow(<NewTabLink {...props}>link text</NewTabLink>);
 
         expect(wrapper.getElement()).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

Make our `NewTabLink` component a `NamedSFC`.

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1596167
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
