### PR TITLE
refactor: use snapshot to test component render

### DIFF
--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-dropdown.test.tsx.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DetailsViewDropDownTest renders with isContextMenuVisible = false 1`] = `
+<div
+  className="details-view-dropdown"
+>
+  <StyledLinkBase
+    className="gear-button"
+    onClick={[Function]}
+  >
+    <StyledIconBase
+      ariaLabel="Manage Settings"
+      className="gear-options-icon"
+      iconName="Gear"
+    />
+  </StyledLinkBase>
+</div>
+`;
+
+exports[`DetailsViewDropDownTest renders with isContextMenuVisible = true 1`] = `
+<div
+  className="details-view-dropdown"
+>
+  <StyledLinkBase
+    className="gear-button"
+    onClick={[Function]}
+  >
+    <StyledIconBase
+      ariaLabel="Manage Settings"
+      className="gear-options-icon"
+      iconName="Gear"
+    />
+  </StyledLinkBase>
+  <StyledWithResponsiveMode
+    directionalHint={6}
+    directionalHintForRTL={4}
+    doNotLayer={false}
+    gapSpace={12}
+    id="settings-dropdown-menu"
+    items={
+      Array [
+        Object {
+          "iconProps": Object {
+            "iconName": "contactCard",
+          },
+          "key": "my-test-item",
+          "name": "My test item",
+          "onClick": null,
+        },
+      ]
+    }
+    onDismiss={[Function]}
+    shouldFocusOnMount={true}
+    target={null}
+  />
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/details-view-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-dropdown.test.tsx
@@ -1,65 +1,37 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import * as React from 'react';
-import * as TestUtils from 'react-dom/test-utils';
 
 import { DetailsViewDropDown, DetailsViewDropDownProps } from '../../../../../DetailsView/components/details-view-dropdown';
 
-class TestableDetailsViewDropDown extends DetailsViewDropDown {
-    public getOpenDropdown(): (target: React.MouseEvent<HTMLElement>) => void {
-        return this.openDropdown;
-    }
-
-    public getDismissDropdown(): () => void {
-        return this.dismissDropdown;
-    }
-}
-
 describe('DetailsViewDropDownTest', () => {
-    test('render', () => {
-        const menuItemsStub: IContextualMenuItem[] = [
-            {
-                key: 'my-test-item',
-                iconProps: {
-                    iconName: 'contactCard',
+    describe('renders', () => {
+        const contextMenuVisibleValues = [true, false];
+
+        it.each(contextMenuVisibleValues)('with isContextMenuVisible = %s', isContextMenuVisible => {
+            const menuItemsStub: IContextualMenuItem[] = [
+                {
+                    key: 'my-test-item',
+                    iconProps: {
+                        iconName: 'contactCard',
+                    },
+                    onClick: null,
+                    name: 'My test item',
                 },
-                onClick: null,
-                name: 'My test item',
-            },
-        ];
-        const props: DetailsViewDropDownProps = {
-            menuItems: menuItemsStub,
-        };
-        const component = React.createElement(TestableDetailsViewDropDown, props);
-        const testObject = TestUtils.renderIntoDocument(component);
+            ];
 
-        testObject.setState({ target: null, isContextMenuVisible: true });
+            const props: DetailsViewDropDownProps = {
+                menuItems: menuItemsStub,
+            };
 
-        const expectedComponent = (
-            <div className="details-view-dropdown">
-                <Link className={'gear-button'} onClick={testObject.getOpenDropdown()}>
-                    <Icon className="gear-options-icon" iconName="Gear" ariaLabel={'Manage Settings'} />
-                </Link>
-                <ContextualMenu
-                    doNotLayer={false}
-                    gapSpace={12}
-                    shouldFocusOnMount={true}
-                    target={null}
-                    onDismiss={testObject.getDismissDropdown()}
-                    directionalHint={DirectionalHint.bottomRightEdge}
-                    directionalHintForRTL={DirectionalHint.bottomLeftEdge}
-                    items={menuItemsStub}
-                    id="settings-dropdown-menu"
-                />
-            </div>
-        );
+            const wrapper = shallow(<DetailsViewDropDown {...props} />);
+            wrapper.setState({ isContextMenuVisible });
 
-        expect(testObject.render()).toEqual(expectedComponent);
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
     });
 
     test('verify open/close menu', () => {
@@ -75,7 +47,7 @@ describe('DetailsViewDropDownTest', () => {
             isContextMenuVisible: false,
             target: null,
         };
-        const testObject = shallow(<TestableDetailsViewDropDown {...props} />);
+        const testObject = shallow(<DetailsViewDropDown {...props} />);
         const link = testObject.find(Link);
         link.prop('onClick')(target as React.MouseEvent<HTMLElement>);
 


### PR DESCRIPTION
#### Description of changes

We have some warnings showing up on our unit test runs. Some of them are around react deprecated notices:
![image](https://user-images.githubusercontent.com/2837582/64725657-e5a64d00-d489-11e9-8e5a-0f0c81229aa2.png)

In this case, we're not explicitly using `componentWillMount` but I noticed that updating the test to use snapshot fix the warning.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
