### PR TITLE
refactor: use shallow to fix react warning

### DIFF
--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { mount, shallow } from 'enzyme';
+import { shallow } from 'enzyme';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
@@ -40,7 +40,7 @@ describe('Switcher', () => {
         actionCreatorMock
             .setup(creator => creator.sendPivotItemClicked(DetailsViewPivotType[DetailsViewPivotType.assessment]))
             .verifiable(Times.once());
-        const wrapper = mount<Switcher>(<Switcher {...defaultProps} />);
+        const wrapper = shallow<Switcher>(<Switcher {...defaultProps} />);
         const dropdown = wrapper.find(Dropdown);
 
         expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.fastPass);


### PR DESCRIPTION
#### Description of changes

Switcher test (`src\tests\unit\tests\DetailsView\components\switcher.test.tsx`) is showing warnings (while running the unit tests): **componentWillRecieveProps has been renamed...**

![image](https://user-images.githubusercontent.com/2837582/64729422-fd81cf00-d491-11e9-957a-bd4967fcaf5a.png)

The warning mention to update `DropdownBase` which is on the office fabric side (one more reason to update our office ui fabric version) but we can fix this warning by not `mount`ing the tested component. Instead, we can use `shallow` which will not call to the base component.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - does not exist
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
   - not affected
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
