### PR TITLE
refactor: using Interpreter across all action creators

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { TestMode } from '../../common/configs/test-mode';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
-import { RegisterTypeToPayloadCallback } from '../../common/message';
 import { getStoreStateMessage, Messages } from '../../common/messages';
 import { NotificationCreator } from '../../common/notification-creator';
 import { StoreNames } from '../../common/stores/store-names';
@@ -13,6 +12,7 @@ import { DictionaryNumberTo } from '../../types/common-types';
 import { VisualizationActions } from '../actions/visualization-actions';
 import { VisualizationScanResultActions } from '../actions/visualization-scan-result-actions';
 import { DetailsViewController } from '../details-view-controller';
+import { Interpreter } from '../interpreter';
 import { TargetTabController } from '../target-tab-controller';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { ActionHub } from './action-hub';
@@ -33,13 +33,7 @@ export class ActionCreator {
     private visualizationActions: VisualizationActions;
     private visualizationScanResultActions: VisualizationScanResultActions;
     private previewFeaturesActions: PreviewFeaturesActions;
-    private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
-    private detailsViewController: DetailsViewController;
-    private telemetryEventHandler: TelemetryEventHandler;
-    private notificationCreator: NotificationCreator;
-    private visualizationConfigurationFactory: VisualizationConfigurationFactory;
-    private targetTabController: TargetTabController;
-    private adhocTestTypeToTelemetryEvent: DictionaryNumberTo<string> = {
+    private adHocTestTypeToTelemetryEvent: DictionaryNumberTo<string> = {
         [VisualizationType.Color]: TelemetryEvents.COLOR_TOGGLE,
         [VisualizationType.Headings]: TelemetryEvents.HEADINGS_TOGGLE,
         [VisualizationType.Issues]: TelemetryEvents.AUTOMATED_CHECKS_TOGGLE,
@@ -49,62 +43,71 @@ export class ActionCreator {
     private inspectActions: InspectActions;
 
     constructor(
-        actionHub: ActionHub,
-        registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
-        detailsViewController: DetailsViewController,
-        telemetryEventHandler: TelemetryEventHandler,
-        notificationCreator: NotificationCreator,
-        visualizationConfigurationFactory: VisualizationConfigurationFactory,
-        targetTabController: TargetTabController,
+        private readonly interpreter: Interpreter,
+        readonly actionHub: ActionHub,
+        private readonly detailsViewController: DetailsViewController,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly notificationCreator: NotificationCreator,
+        private readonly visualizationConfigurationFactory: VisualizationConfigurationFactory,
+        private readonly targetTabController: TargetTabController,
     ) {
         this.visualizationActions = actionHub.visualizationActions;
         this.previewFeaturesActions = actionHub.previewFeaturesActions;
         this.visualizationScanResultActions = actionHub.visualizationScanResultActions;
         this.inspectActions = actionHub.inspectActions;
-        this.registerTypeToPayloadCallback = registerTypeToPayloadCallback;
-        this.detailsViewController = detailsViewController;
-        this.telemetryEventHandler = telemetryEventHandler;
-        this.notificationCreator = notificationCreator;
-        this.visualizationConfigurationFactory = visualizationConfigurationFactory;
-        this.targetTabController = targetTabController;
     }
 
     public registerCallbacks(): void {
-        this.registerTypeToPayloadCallback(visualizationMessages.Common.Toggle, this.onVisualizationToggle);
-        this.registerTypeToPayloadCallback(visualizationMessages.Common.ScanCompleted, this.onScanCompleted);
-        this.registerTypeToPayloadCallback(visualizationMessages.Common.ScrollRequested, this.onScrollRequested);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.Common.Toggle, this.onVisualizationToggle);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.Common.ScanCompleted, this.onScanCompleted);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.Common.ScrollRequested, this.onScrollRequested);
 
-        this.registerTypeToPayloadCallback(visualizationMessages.Issues.UpdateSelectedTargets, this.onUpdateIssuesSelectedTargets);
-        this.registerTypeToPayloadCallback(visualizationMessages.Issues.UpdateFocusedInstance, this.onUpdateFocusedInstance);
+        this.interpreter.registerTypeToPayloadCallback(
+            visualizationMessages.Issues.UpdateSelectedTargets,
+            this.onUpdateIssuesSelectedTargets,
+        );
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.Issues.UpdateFocusedInstance, this.onUpdateFocusedInstance);
 
-        this.registerTypeToPayloadCallback(visualizationMessages.State.InjectionCompleted, this.injectionCompleted);
-        this.registerTypeToPayloadCallback(visualizationMessages.State.InjectionStarted, this.injectionStarted);
-        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.VisualizationStore), this.getVisualizationToggleCurrentState);
-        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.VisualizationScanResultStore), this.getScanResultsCurrentState);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.State.InjectionCompleted, this.injectionCompleted);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.State.InjectionStarted, this.injectionStarted);
+        this.interpreter.registerTypeToPayloadCallback(
+            getStoreStateMessage(StoreNames.VisualizationStore),
+            this.getVisualizationToggleCurrentState,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            getStoreStateMessage(StoreNames.VisualizationScanResultStore),
+            this.getScanResultsCurrentState,
+        );
 
-        this.registerTypeToPayloadCallback(visualizationMessages.TabStops.TabbedElementAdded, this.onTabbedElementAdded);
-        this.registerTypeToPayloadCallback(visualizationMessages.TabStops.RecordingCompleted, this.onRecordingCompleted);
-        this.registerTypeToPayloadCallback(visualizationMessages.TabStops.TerminateScan, this.onRecordingTerminated);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.TabStops.TabbedElementAdded, this.onTabbedElementAdded);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.TabStops.RecordingCompleted, this.onRecordingCompleted);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.TabStops.TerminateScan, this.onRecordingTerminated);
 
-        this.registerTypeToPayloadCallback(visualizationMessages.DetailsView.Open, this.onDetailsViewOpen);
-        this.registerTypeToPayloadCallback(visualizationMessages.DetailsView.Select, this.onPivotChildSelected);
-        this.registerTypeToPayloadCallback(visualizationMessages.DetailsView.PivotSelect, this.onDetailsViewPivotSelected);
-        this.registerTypeToPayloadCallback(visualizationMessages.DetailsView.Close, this.onDetailsViewClosed);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.DetailsView.Open, this.onDetailsViewOpen);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.DetailsView.Select, this.onPivotChildSelected);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.DetailsView.PivotSelect, this.onDetailsViewPivotSelected);
+        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.DetailsView.Close, this.onDetailsViewClosed);
 
-        this.registerTypeToPayloadCallback(Messages.PreviewFeatures.OpenPanel, this.onOpenPreviewFeaturesPanel);
-        this.registerTypeToPayloadCallback(Messages.PreviewFeatures.ClosePanel, this.onClosePreviewFeaturesPanel);
+        this.interpreter.registerTypeToPayloadCallback(Messages.PreviewFeatures.OpenPanel, this.onOpenPreviewFeaturesPanel);
+        this.interpreter.registerTypeToPayloadCallback(Messages.PreviewFeatures.ClosePanel, this.onClosePreviewFeaturesPanel);
 
-        this.registerTypeToPayloadCallback(Messages.Assessment.AssessmentScanCompleted, this.onAssessmentScanCompleted);
-        this.registerTypeToPayloadCallback(Messages.Assessment.StartOver, this.onStartOver);
-        this.registerTypeToPayloadCallback(Messages.Assessment.CancelStartOver, this.onCancelStartOver);
-        this.registerTypeToPayloadCallback(Messages.Assessment.StartOverAllAssessments, this.onStartOverAllAssessments);
-        this.registerTypeToPayloadCallback(Messages.Assessment.CancelStartOverAllAssessments, this.onCancelStartOverAllAssessments);
-        this.registerTypeToPayloadCallback(Messages.Assessment.EnableVisualHelper, this.onEnableVisualHelper);
-        this.registerTypeToPayloadCallback(Messages.Assessment.DisableVisualHelperForTest, this.onDisableVisualHelpersForTest);
-        this.registerTypeToPayloadCallback(Messages.Assessment.DisableVisualHelper, this.onDisableVisualHelper);
-        this.registerTypeToPayloadCallback(Messages.Assessment.EnableVisualHelperWithoutScan, this.onEnableVisualHelperWithoutScan);
+        this.interpreter.registerTypeToPayloadCallback(Messages.Assessment.AssessmentScanCompleted, this.onAssessmentScanCompleted);
+        this.interpreter.registerTypeToPayloadCallback(Messages.Assessment.StartOver, this.onStartOver);
+        this.interpreter.registerTypeToPayloadCallback(Messages.Assessment.CancelStartOver, this.onCancelStartOver);
+        this.interpreter.registerTypeToPayloadCallback(Messages.Assessment.StartOverAllAssessments, this.onStartOverAllAssessments);
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.Assessment.CancelStartOverAllAssessments,
+            this.onCancelStartOverAllAssessments,
+        );
+        this.interpreter.registerTypeToPayloadCallback(Messages.Assessment.EnableVisualHelper, this.onEnableVisualHelper);
+        this.interpreter.registerTypeToPayloadCallback(Messages.Assessment.DisableVisualHelperForTest, this.onDisableVisualHelpersForTest);
+        this.interpreter.registerTypeToPayloadCallback(Messages.Assessment.DisableVisualHelper, this.onDisableVisualHelper);
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.Assessment.EnableVisualHelperWithoutScan,
+            this.onEnableVisualHelperWithoutScan,
+        );
 
-        this.registerTypeToPayloadCallback(Messages.Inspect.SetHoveredOverSelector, this.onSetHoveredOverSelector);
+        this.interpreter.registerTypeToPayloadCallback(Messages.Inspect.SetHoveredOverSelector, this.onSetHoveredOverSelector);
     }
 
     private onEnableVisualHelperWithoutScan = (payload: ToggleActionPayload): void => {
@@ -249,7 +252,7 @@ export class ActionCreator {
     };
 
     private onVisualizationToggle = (payload: VisualizationTogglePayload): void => {
-        const telemetryEvent = this.adhocTestTypeToTelemetryEvent[payload.test];
+        const telemetryEvent = this.adHocTestTypeToTelemetryEvent[payload.test];
         this.telemetryEventHandler.publishTelemetry(telemetryEvent, payload);
 
         if (payload.enabled) {

--- a/src/background/actions/content-action-creator.ts
+++ b/src/background/actions/content-action-creator.ts
@@ -1,24 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { Messages } from '../../common/messages';
-import { CONTENT_PANEL_CLOSED, CONTENT_PANEL_OPENED } from '../../common/telemetry-events';
+import { Messages } from 'common/messages';
+import { CONTENT_PANEL_CLOSED, CONTENT_PANEL_OPENED } from 'common/telemetry-events';
+
 import { DetailsViewController } from '../details-view-controller';
+import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { BaseActionPayload } from './action-payloads';
 import { ContentActions, ContentPayload } from './content-actions';
 
 export class ContentActionCreator {
     constructor(
+        private readonly interpreter: Interpreter,
         private readonly contentActions: ContentActions,
         private readonly telemetryEventHandler: TelemetryEventHandler,
-        private readonly registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
         private readonly detailsViewController: DetailsViewController,
     ) {}
 
     public registerCallbacks(): void {
-        this.registerTypeToPayloadCallback(Messages.ContentPanel.OpenPanel, (payload, tabId) => this.onOpenContentPanel(payload, tabId));
-        this.registerTypeToPayloadCallback(Messages.ContentPanel.ClosePanel, payload => this.onCloseContentPanel(payload));
+        this.interpreter.registerTypeToPayloadCallback(Messages.ContentPanel.OpenPanel, (payload, tabId) =>
+            this.onOpenContentPanel(payload, tabId),
+        );
+        this.interpreter.registerTypeToPayloadCallback(Messages.ContentPanel.ClosePanel, payload => this.onCloseContentPanel(payload));
     }
 
     private onOpenContentPanel(payload: ContentPayload, tabId: number): void {

--- a/src/background/actions/details-view-action-creator.ts
+++ b/src/background/actions/details-view-action-creator.ts
@@ -1,28 +1,32 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { getStoreStateMessage, Messages } from '../../common/messages';
-import { StoreNames } from '../../common/stores/store-names';
-import { SETTINGS_PANEL_CLOSE, SETTINGS_PANEL_OPEN } from '../../common/telemetry-events';
-import { DetailsViewRightContentPanelType } from '../../DetailsView/components/left-nav/details-view-right-content-panel-type';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { StoreNames } from 'common/stores/store-names';
+import { SETTINGS_PANEL_CLOSE, SETTINGS_PANEL_OPEN } from 'common/telemetry-events';
+import { DetailsViewRightContentPanelType } from 'DetailsView/components/left-nav/details-view-right-content-panel-type';
+
 import { DetailsViewController } from '../details-view-controller';
+import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { BaseActionPayload } from './action-payloads';
 import { DetailsViewActions } from './details-view-actions';
 
 export class DetailsViewActionCreator {
     constructor(
-        private readonly registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
+        private readonly interpreter: Interpreter,
         private readonly detailsViewActions: DetailsViewActions,
         private readonly detailsViewController: DetailsViewController,
         private readonly telemetryEventHandler: TelemetryEventHandler,
     ) {}
 
     public registerCallback(): void {
-        this.registerTypeToPayloadCallback(Messages.SettingsPanel.OpenPanel, this.onOpenSettingsPanel);
-        this.registerTypeToPayloadCallback(Messages.SettingsPanel.ClosePanel, this.onCloseSettingsPanel);
-        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.DetailsViewStore), this.onGetDetailsViewCurrentState);
-        this.registerTypeToPayloadCallback(
+        this.interpreter.registerTypeToPayloadCallback(Messages.SettingsPanel.OpenPanel, this.onOpenSettingsPanel);
+        this.interpreter.registerTypeToPayloadCallback(Messages.SettingsPanel.ClosePanel, this.onCloseSettingsPanel);
+        this.interpreter.registerTypeToPayloadCallback(
+            getStoreStateMessage(StoreNames.DetailsViewStore),
+            this.onGetDetailsViewCurrentState,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
             Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
             this.onSetDetailsViewRightContentPanel,
         );

--- a/src/background/actions/dev-tools-action-creator.ts
+++ b/src/background/actions/dev-tools-action-creator.ts
@@ -1,52 +1,49 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { getStoreStateMessage, Messages } from '../../common/messages';
-import { StoreNames } from '../../common/stores/store-names';
-import * as TelemetryEvents from '../../common/telemetry-events';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { StoreNames } from 'common/stores/store-names';
+import * as TelemetryEvents from 'common/telemetry-events';
+
+import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { InspectElementPayload, InspectFrameUrlPayload, OnDevToolOpenPayload } from './action-payloads';
 import { DevToolActions } from './dev-tools-actions';
 
 export class DevToolsActionCreator {
-    private devtoolActions: DevToolActions;
-    private telemetryEventHandler: TelemetryEventHandler;
-    private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
-
     constructor(
-        devToolsAction: DevToolActions,
-        telemetryEventHandler: TelemetryEventHandler,
-        registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
-    ) {
-        this.devtoolActions = devToolsAction;
-        this.telemetryEventHandler = telemetryEventHandler;
-        this.registerTypeToPayloadCallback = registerTypeToPayloadCallback;
-    }
+        private readonly interpreter: Interpreter,
+        private readonly devToolActions: DevToolActions,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+    ) {}
 
     public registerCallbacks(): void {
-        this.registerTypeToPayloadCallback(Messages.DevTools.DevtoolStatus, payload => this.onDevToolOpened(payload));
+        this.interpreter.registerTypeToPayloadCallback(Messages.DevTools.DevtoolStatus, payload => this.onDevToolOpened(payload));
 
-        this.registerTypeToPayloadCallback(Messages.DevTools.InspectElement, payload => this.onDevToolInspectElement(payload));
+        this.interpreter.registerTypeToPayloadCallback(Messages.DevTools.InspectElement, payload => this.onDevToolInspectElement(payload));
 
-        this.registerTypeToPayloadCallback(Messages.DevTools.InspectFrameUrl, payload => this.onDevToolInspectFrameUrl(payload));
+        this.interpreter.registerTypeToPayloadCallback(Messages.DevTools.InspectFrameUrl, payload =>
+            this.onDevToolInspectFrameUrl(payload),
+        );
 
-        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.DevToolsStore), () => this.onDevToolGetCurrentState());
+        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.DevToolsStore), () =>
+            this.onDevToolGetCurrentState(),
+        );
     }
 
     private onDevToolOpened(payload: OnDevToolOpenPayload): void {
-        this.devtoolActions.setDevToolState.invoke(payload.status);
+        this.devToolActions.setDevToolState.invoke(payload.status);
     }
 
     private onDevToolInspectElement(payload: InspectElementPayload): void {
-        this.devtoolActions.setInspectElement.invoke(payload.target);
+        this.devToolActions.setInspectElement.invoke(payload.target);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.INSPECT_OPEN, payload);
     }
 
     private onDevToolInspectFrameUrl(payload: InspectFrameUrlPayload): void {
-        this.devtoolActions.setFrameUrl.invoke(payload.frameUrl);
+        this.devToolActions.setFrameUrl.invoke(payload.frameUrl);
     }
 
     private onDevToolGetCurrentState(): void {
-        this.devtoolActions.getCurrentState.invoke(null);
+        this.devToolActions.getCurrentState.invoke(null);
     }
 }

--- a/src/background/actions/inspect-action-creator.ts
+++ b/src/background/actions/inspect-action-creator.ts
@@ -1,36 +1,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
-import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { getStoreStateMessage, Messages } from '../../common/messages';
-import { StoreNames } from '../../common/stores/store-names';
-import * as TelemetryEvents from '../../common/telemetry-events';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { StoreNames } from 'common/stores/store-names';
+import * as TelemetryEvents from 'common/telemetry-events';
+
+import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { InspectActions, InspectPayload } from './inspect-actions';
 
 export class InspectActionCreator {
-    private inspectActions: InspectActions;
-    private browserAdapter: BrowserAdapter;
-    private telemetryEventHandler: TelemetryEventHandler;
-    private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
-
     constructor(
-        inspectActions: InspectActions,
-        telemetryEventHandler: TelemetryEventHandler,
-        browserAdapter: BrowserAdapter,
-        registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
-    ) {
-        this.inspectActions = inspectActions;
-        this.telemetryEventHandler = telemetryEventHandler;
-        this.browserAdapter = browserAdapter;
-        this.registerTypeToPayloadCallback = registerTypeToPayloadCallback;
-    }
+        private readonly interpreter: Interpreter,
+        private readonly inspectActions: InspectActions,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly browserAdapter: BrowserAdapter,
+    ) {}
 
     public registerCallbacks(): void {
-        this.registerTypeToPayloadCallback(Messages.Inspect.ChangeInspectMode, (payload: InspectPayload, tabId: number) =>
+        this.interpreter.registerTypeToPayloadCallback(Messages.Inspect.ChangeInspectMode, (payload: InspectPayload, tabId: number) =>
             this.onChangeInspectMode(payload, tabId),
         );
-        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.InspectStore), () => this.onGetInspectCurrentState());
+        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.InspectStore), () =>
+            this.onGetInspectCurrentState(),
+        );
     }
 
     private onChangeInspectMode(payload: InspectPayload, tabId: number): void {

--- a/src/background/actions/path-snippet-action-creator.ts
+++ b/src/background/actions/path-snippet-action-creator.ts
@@ -1,21 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { RegisterTypeToPayloadCallback } from '../../common/message';
 import { getStoreStateMessage, Messages } from '../../common/messages';
 import { StoreNames } from '../../common/stores/store-names';
+import { Interpreter } from '../interpreter';
 import { PathSnippetActions } from './path-snippet-actions';
 
 export class PathSnippetActionCreator {
-    constructor(
-        private readonly pathSnippetActions: PathSnippetActions,
-        private readonly registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
-    ) {}
+    constructor(private readonly interpreter: Interpreter, private readonly pathSnippetActions: PathSnippetActions) {}
 
     public registerCallbacks(): void {
-        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.PathSnippetStore), this.onGetPathSnippetCurrentState);
-        this.registerTypeToPayloadCallback(Messages.PathSnippet.AddPathForValidation, this.onAddPathForValidation);
-        this.registerTypeToPayloadCallback(Messages.PathSnippet.AddCorrespondingSnippet, this.onAddCorrespondingSnippet);
-        this.registerTypeToPayloadCallback(Messages.PathSnippet.ClearPathSnippetData, this.onClearPathSnippetData);
+        this.interpreter.registerTypeToPayloadCallback(
+            getStoreStateMessage(StoreNames.PathSnippetStore),
+            this.onGetPathSnippetCurrentState,
+        );
+        this.interpreter.registerTypeToPayloadCallback(Messages.PathSnippet.AddPathForValidation, this.onAddPathForValidation);
+        this.interpreter.registerTypeToPayloadCallback(Messages.PathSnippet.AddCorrespondingSnippet, this.onAddCorrespondingSnippet);
+        this.interpreter.registerTypeToPayloadCallback(Messages.PathSnippet.ClearPathSnippetData, this.onClearPathSnippetData);
     }
 
     private onAddPathForValidation = (payload: string): void => {

--- a/src/background/actions/scoping-panel-action-creator.ts
+++ b/src/background/actions/scoping-panel-action-creator.ts
@@ -1,34 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { Messages } from '../../common/messages';
-import { SCOPING_CLOSE, SCOPING_OPEN } from '../../common/telemetry-events';
+import { Messages } from 'common/messages';
+import { SCOPING_CLOSE, SCOPING_OPEN } from 'common/telemetry-events';
 import { DetailsViewController } from '../details-view-controller';
+import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { BaseActionPayload } from './action-payloads';
 import { ScopingActions } from './scoping-actions';
 
 export class ScopingPanelActionCreator {
-    private scopingActions: ScopingActions;
-    private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
-    private telemetryEventHandler: TelemetryEventHandler;
-    private detailsViewController: DetailsViewController;
-
     constructor(
-        scopingActions: ScopingActions,
-        telemetryEventHandler: TelemetryEventHandler,
-        registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
-        detailsViewController: DetailsViewController,
-    ) {
-        this.scopingActions = scopingActions;
-        this.telemetryEventHandler = telemetryEventHandler;
-        this.detailsViewController = detailsViewController;
-        this.registerTypeToPayloadCallback = registerTypeToPayloadCallback;
-    }
+        private readonly interpreter: Interpreter,
+        private readonly scopingActions: ScopingActions,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly detailsViewController: DetailsViewController,
+    ) {}
 
     public registerCallbacks(): void {
-        this.registerTypeToPayloadCallback(Messages.Scoping.OpenPanel, (payload, tabId) => this.onOpenScopingPanel(payload, tabId));
-        this.registerTypeToPayloadCallback(Messages.Scoping.ClosePanel, payload => this.onCloseScopingPanel(payload));
+        this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.OpenPanel, (payload, tabId) =>
+            this.onOpenScopingPanel(payload, tabId),
+        );
+        this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.ClosePanel, payload => this.onCloseScopingPanel(payload));
     }
 
     private onOpenScopingPanel(payload: BaseActionPayload, tabId: number): void {

--- a/src/background/actions/tab-action-creator.ts
+++ b/src/background/actions/tab-action-creator.ts
@@ -1,39 +1,32 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
-import { RegisterTypeToPayloadCallback } from '../../common/message';
-import { getStoreStateMessage, Messages } from '../../common/messages';
-import { StoreNames } from '../../common/stores/store-names';
-import { SWITCH_BACK_TO_TARGET } from '../../common/telemetry-events';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { StoreNames } from 'common/stores/store-names';
+import { SWITCH_BACK_TO_TARGET } from 'common/telemetry-events';
+
+import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { SwitchToTargetTabPayload } from './action-payloads';
 import { TabActions } from './tab-actions';
 
 export class TabActionCreator {
-    private tabActions: TabActions;
-    private registerTypeToPayloadCallback: RegisterTypeToPayloadCallback;
-    private browserAdapter: BrowserAdapter;
-    private telemetryEventHandler: TelemetryEventHandler;
-
     constructor(
-        registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
-        browserAdapter: BrowserAdapter,
-        telemetryEventHandler: TelemetryEventHandler,
-        tabActions: TabActions,
-    ) {
-        this.registerTypeToPayloadCallback = registerTypeToPayloadCallback;
-        this.browserAdapter = browserAdapter;
-        this.telemetryEventHandler = telemetryEventHandler;
-        this.tabActions = tabActions;
-    }
+        private readonly interpreter: Interpreter,
+        private readonly tabActions: TabActions,
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+    ) {}
 
     public registerCallbacks(): void {
-        this.registerTypeToPayloadCallback(Messages.Tab.Update, payload => this.tabActions.tabUpdate.invoke(payload));
-        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.TabStore), () => this.tabActions.getCurrentState.invoke(null));
-        this.registerTypeToPayloadCallback(Messages.Tab.Remove, () => this.tabActions.tabRemove.invoke(null));
-        this.registerTypeToPayloadCallback(Messages.Tab.Change, payload => this.tabActions.tabChange.invoke(payload));
-        this.registerTypeToPayloadCallback(Messages.Tab.Switch, (payload, tabId) => this.onSwitchToTargetTab(payload, tabId));
-        this.registerTypeToPayloadCallback(Messages.Tab.VisibilityChange, payload =>
+        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Update, payload => this.tabActions.tabUpdate.invoke(payload));
+        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.TabStore), () =>
+            this.tabActions.getCurrentState.invoke(null),
+        );
+        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Remove, () => this.tabActions.tabRemove.invoke(null));
+        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Change, payload => this.tabActions.tabChange.invoke(payload));
+        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Switch, (payload, tabId) => this.onSwitchToTargetTab(payload, tabId));
+        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.VisibilityChange, payload =>
             this.tabActions.tabVisibilityChange.invoke(payload.hidden),
         );
     }

--- a/src/background/actions/unified-scan-result-action-creator.ts
+++ b/src/background/actions/unified-scan-result-action-creator.ts
@@ -1,20 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { RegisterTypeToPayloadCallback } from '../../common/message';
 import { getStoreStateMessage, Messages } from '../../common/messages';
 import { StoreNames } from '../../common/stores/store-names';
+import { Interpreter } from '../interpreter';
 import { UnifiedScanCompletedPayload } from './action-payloads';
 import { UnifiedScanResultActions } from './unified-scan-result-actions';
 
 export class UnifiedScanResultActionCreator {
-    constructor(
-        private readonly unifiedScanResultActions: UnifiedScanResultActions,
-        private readonly registerTypeToPayloadCallback: RegisterTypeToPayloadCallback,
-    ) {}
+    constructor(private readonly interpreter: Interpreter, private readonly unifiedScanResultActions: UnifiedScanResultActions) {}
 
     public registerCallbacks(): void {
-        this.registerTypeToPayloadCallback(Messages.UnifiedScan.ScanCompleted, this.onScanCompleted);
-        this.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.UnifiedScanResultStore), this.onGetScanCurrentState);
+        this.interpreter.registerTypeToPayloadCallback(Messages.UnifiedScan.ScanCompleted, this.onScanCompleted);
+        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.UnifiedScanResultStore), this.onGetScanCurrentState);
     }
 
     private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {

--- a/src/background/actions/unified-scan-result-action-creator.ts
+++ b/src/background/actions/unified-scan-result-action-creator.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getStoreStateMessage, Messages } from '../../common/messages';
-import { StoreNames } from '../../common/stores/store-names';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { StoreNames } from 'common/stores/store-names';
+
 import { Interpreter } from '../interpreter';
 import { UnifiedScanCompletedPayload } from './action-payloads';
 import { UnifiedScanResultActions } from './unified-scan-result-actions';

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -68,11 +68,7 @@ export class GlobalContextFactory {
         const scopingActionCreator = new ScopingActionCreator(interpreter, globalActionsHub.scopingActions);
         const issueFilingActionCreator = new IssueFilingActionCreator(interpreter, telemetryEventHandler, issueFilingController);
         const actionCreator = new GlobalActionCreator(globalActionsHub, interpreter, commandsAdapter, telemetryEventHandler);
-        const assessmentActionCreator = new AssessmentActionCreator(
-            globalActionsHub.assessmentActions,
-            telemetryEventHandler,
-            interpreter.registerTypeToPayloadCallback,
-        );
+        const assessmentActionCreator = new AssessmentActionCreator(interpreter, globalActionsHub.assessmentActions, telemetryEventHandler);
         const userConfigurationActionCreator = new UserConfigurationActionCreator(interpreter, globalActionsHub.userConfigurationActions);
         const featureFlagsActionCreator = new FeatureFlagsActionCreator(
             interpreter,

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -59,8 +59,8 @@ export class TabContextFactory {
         const shortcutsPageActionCreator = new ShortcutsPageActionCreator(interpreter, shortcutsPageController, this.telemetryEventHandler);
 
         const actionCreator = new ActionCreator(
+            interpreter,
             actionsHub,
-            interpreter.registerTypeToPayloadCallback,
             detailsViewController,
             this.telemetryEventHandler,
             notificationCreator,

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -75,12 +75,7 @@ export class TabContextFactory {
             this.telemetryEventHandler,
         );
 
-        const tabActionCreator = new TabActionCreator(
-            interpreter.registerTypeToPayloadCallback,
-            browserAdapter,
-            this.telemetryEventHandler,
-            actionsHub.tabActions,
-        );
+        const tabActionCreator = new TabActionCreator(interpreter, actionsHub.tabActions, browserAdapter, this.telemetryEventHandler);
 
         const devToolsActionCreator = new DevToolsActionCreator(interpreter, actionsHub.devToolActions, this.telemetryEventHandler);
 

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -89,10 +89,10 @@ export class TabContextFactory {
         );
 
         const inspectActionsCreator = new InspectActionCreator(
+            interpreter,
             actionsHub.inspectActions,
             this.telemetryEventHandler,
             browserAdapter,
-            interpreter.registerTypeToPayloadCallback,
         );
 
         const pathSnippetActionCreator = new PathSnippetActionCreator(interpreter, actionsHub.pathSnippetActions);

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -82,11 +82,7 @@ export class TabContextFactory {
             actionsHub.tabActions,
         );
 
-        const devToolsActionCreator = new DevToolsActionCreator(
-            actionsHub.devToolActions,
-            this.telemetryEventHandler,
-            interpreter.registerTypeToPayloadCallback,
-        );
+        const devToolsActionCreator = new DevToolsActionCreator(interpreter, actionsHub.devToolActions, this.telemetryEventHandler);
 
         const inspectActionsCreator = new InspectActionCreator(
             interpreter,

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -103,9 +103,9 @@ export class TabContextFactory {
         );
 
         const contentActionCreator = new ContentActionCreator(
+            interpreter,
             actionsHub.contentActions,
             this.telemetryEventHandler,
-            interpreter.registerTypeToPayloadCallback,
             detailsViewController,
         );
 

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
-import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
-import { NotificationCreator } from '../common/notification-creator';
-import { PromiseFactory } from '../common/promises/promise-factory';
-import { StateDispatcher } from '../common/state-dispatcher';
-import { WindowUtils } from '../common/window-utils';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { NotificationCreator } from 'common/notification-creator';
+import { PromiseFactory } from 'common/promises/promise-factory';
+import { StateDispatcher } from 'common/state-dispatcher';
+import { WindowUtils } from 'common/window-utils';
+
 import { ActionCreator } from './actions/action-creator';
 import { ActionHub } from './actions/action-hub';
 import { ContentActionCreator } from './actions/content-action-creator';
@@ -102,9 +103,9 @@ export class TabContextFactory {
         const scanResultActionCreator = new UnifiedScanResultActionCreator(interpreter, actionsHub.scanResultActions);
 
         const scopingPanelActionCreator = new ScopingPanelActionCreator(
+            interpreter,
             actionsHub.scopingActions,
             this.telemetryEventHandler,
-            interpreter.registerTypeToPayloadCallback,
             detailsViewController,
         );
 

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -99,10 +99,7 @@ export class TabContextFactory {
             interpreter.registerTypeToPayloadCallback,
         );
 
-        const scanResultActionCreator = new UnifiedScanResultActionCreator(
-            actionsHub.scanResultActions,
-            interpreter.registerTypeToPayloadCallback,
-        );
+        const scanResultActionCreator = new UnifiedScanResultActionCreator(interpreter, actionsHub.scanResultActions);
 
         const scopingPanelActionCreator = new ScopingPanelActionCreator(
             actionsHub.scopingActions,

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -95,10 +95,7 @@ export class TabContextFactory {
             interpreter.registerTypeToPayloadCallback,
         );
 
-        const pathSnippetActionCreator = new PathSnippetActionCreator(
-            actionsHub.pathSnippetActions,
-            interpreter.registerTypeToPayloadCallback,
-        );
+        const pathSnippetActionCreator = new PathSnippetActionCreator(interpreter, actionsHub.pathSnippetActions);
 
         const scanResultActionCreator = new UnifiedScanResultActionCreator(interpreter, actionsHub.scanResultActions);
 

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -69,7 +69,7 @@ export class TabContextFactory {
         );
 
         const detailsViewActionCreator = new DetailsViewActionCreator(
-            interpreter.registerTypeToPayloadCallback,
+            interpreter,
             actionsHub.detailsViewActions,
             detailsViewController,
             this.telemetryEventHandler,

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -6,12 +6,14 @@ import { AssessmentActions } from 'background/actions/assessment-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { isFunction } from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { Action } from '../../../../../common/flux/action';
 import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import * as TelemetryEvents from '../../../../../common/telemetry-events';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
+import { createActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('AssessmentActionCreatorTest', () => {
     let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
@@ -350,13 +352,6 @@ describe('AssessmentActionCreatorTest', () => {
 
         actionMock.verifyAll();
     });
-
-    function createActionMock<T>(actionPayload: T): IMock<Action<T>> {
-        const actionMock = Mock.ofType<Action<T>>(Action);
-        actionMock.setup(action => action.invoke(actionPayload)).verifiable(Times.once());
-
-        return actionMock;
-    }
 
     function setupAssessmentActionsMock(actionName: keyof AssessmentActions, actionMock: IMock<Action<any>>): void {
         assessmentActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -1,365 +1,472 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseActionPayload, ToggleActionPayload } from 'background/actions/action-payloads';
+import {
+    AddFailureInstancePayload,
+    AddResultDescriptionPayload,
+    AssessmentActionInstancePayload,
+    BaseActionPayload,
+    ChangeInstanceSelectionPayload,
+    ChangeRequirementStatusPayload,
+    EditFailureInstancePayload,
+    OnDetailsViewOpenPayload,
+    RemoveFailureInstancePayload,
+    SelectRequirementPayload,
+    ToggleActionPayload,
+    UpdateVisibilityPayload,
+} from 'background/actions/action-payloads';
 import { AssessmentActionCreator } from 'background/actions/assessment-action-creator';
 import { AssessmentActions } from 'background/actions/assessment-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { isFunction } from 'lodash';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { Action } from 'common/flux/action';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { StoreNames } from 'common/stores/store-names';
+import * as TelemetryEvents from 'common/telemetry-events';
+import { TelemetryEventSource } from 'common/telemetry-events';
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { VisualizationType } from 'common/types/visualization-type';
+import { ScanBasePayload, ScanCompletedPayload, ScanUpdatePayload } from 'injected/analyzers/analyzer';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
-import { Action } from '../../../../../common/flux/action';
-import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
-import { getStoreStateMessage, Messages } from '../../../../../common/messages';
-import { StoreNames } from '../../../../../common/stores/store-names';
-import * as TelemetryEvents from '../../../../../common/telemetry-events';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { createActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('AssessmentActionCreatorTest', () => {
-    let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
     let assessmentActionsMock: IMock<AssessmentActions>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
-    const testTabId = -1;
-    let testObject: AssessmentActionCreator;
+
     const AssessmentMessages = Messages.Assessment;
+    const testTabId = -1;
+    const telemetryOnlyPayload: BaseActionPayload = {
+        telemetry: {
+            source: -1 as TelemetryEventSource,
+            triggeredBy: 'N/A',
+        },
+    };
 
     beforeEach(() => {
         assessmentActionsMock = Mock.ofType(AssessmentActions, MockBehavior.Strict);
-        telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
-        registerTypeToPayloadCallbackMock = Mock.ofInstance((theType, callback) => {});
-
-        testObject = new AssessmentActionCreator(
-            assessmentActionsMock.object,
-            telemetryEventHandlerMock.object,
-            registerTypeToPayloadCallbackMock.object,
-        );
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
     });
 
-    afterEach(() => {
-        telemetryEventHandlerMock.verifyAll();
-    });
-
-    test('onPassUnmarkedInstances', () => {
-        const payload: BaseActionPayload = {};
-
-        telemetryEventHandlerMock
-            .setup(tp => tp.publishTelemetry(TelemetryEvents.PASS_UNMARKED_INSTANCES, payload))
-            .verifiable(Times.once());
-
+    it('handles PassUnmarkedInstances message', () => {
         const updateTabIdActionMock = createActionMock(testTabId);
-        const passUnmarkedInstanceActionMock = createActionMock(payload);
+        const passUnmarkedInstanceActionMock = createActionMock(telemetryOnlyPayload);
+
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('passUnmarkedInstance', passUnmarkedInstanceActionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.PassUnmarkedInstances, payload, testTabId);
 
-        testObject.registerCallbacks();
+        const interpreterMock = createInterpreterMock(AssessmentMessages.PassUnmarkedInstances, telemetryOnlyPayload, testTabId);
+
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            assessmentActionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
 
         updateTabIdActionMock.verifyAll();
         passUnmarkedInstanceActionMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.PASS_UNMARKED_INSTANCES, telemetryOnlyPayload),
+            Times.once(),
+        );
     });
 
-    test('onContinuePreviousAssessment', () => {
-        const payload = {};
+    it('handles ContinuePreviousAssessment message', () => {
+        const continuePreviousAssessmentMock = createActionMock(testTabId);
+        const actionsMock = createActionsMock('continuePreviousAssessment', continuePreviousAssessmentMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.ContinuePreviousAssessment, telemetryOnlyPayload, testTabId);
 
-        telemetryEventHandlerMock
-            .setup(tp => tp.publishTelemetry(TelemetryEvents.CONTINUE_PREVIOUS_ASSESSMENT, payload))
-            .verifiable(Times.once());
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
 
-        const actionMock = createActionMock(testTabId);
-        setupAssessmentActionsMock('continuePreviousAssessment', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.ContinuePreviousAssessment, payload, testTabId);
+        testSubject.registerCallbacks();
 
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
+        continuePreviousAssessmentMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.CONTINUE_PREVIOUS_ASSESSMENT, telemetryOnlyPayload),
+            Times.once(),
+        );
     });
 
-    test('onEditFailureInstance', () => {
-        const payload: BaseActionPayload = {};
+    it('handles EditFailureInstance message', () => {
+        const payload: EditFailureInstancePayload = {
+            id: 'test-id',
+            ...telemetryOnlyPayload,
+        } as EditFailureInstancePayload;
 
-        telemetryEventHandlerMock.setup(tp => tp.publishTelemetry(TelemetryEvents.EDIT_FAILURE_INSTANCE, payload)).verifiable(Times.once());
+        const editFailureInstanceMock = createActionMock(payload);
+        const actionsMock = createActionsMock('editFailureInstance', editFailureInstanceMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.EditFailureInstance, payload, testTabId);
 
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('editFailureInstance', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.EditFailureInstance, payload, testTabId);
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
 
-        testObject.registerCallbacks();
+        testSubject.registerCallbacks();
 
-        actionMock.verifyAll();
+        editFailureInstanceMock.verifyAll();
+        telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(TelemetryEvents.EDIT_FAILURE_INSTANCE, payload), Times.once());
     });
 
-    test('onRemoveFailureInstance', () => {
-        const payload: BaseActionPayload = {};
+    it('handles RemoveFailureInstance message', () => {
+        const payload: RemoveFailureInstancePayload = {
+            id: 'test-id',
+            ...telemetryOnlyPayload,
+        } as RemoveFailureInstancePayload;
 
-        telemetryEventHandlerMock
-            .setup(tp => tp.publishTelemetry(TelemetryEvents.REMOVE_FAILURE_INSTANCE, payload))
-            .verifiable(Times.once());
+        const removeFailureInstanceMock = createActionMock(payload);
+        const actionsMock = createActionsMock('removeFailureInstance', removeFailureInstanceMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.RemoveFailureInstance, payload);
 
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('removeFailureInstance', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.RemoveFailureInstance, payload, testTabId);
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
 
-        testObject.registerCallbacks();
+        testSubject.registerCallbacks();
 
-        actionMock.verifyAll();
+        removeFailureInstanceMock.verifyAll();
+        telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(TelemetryEvents.REMOVE_FAILURE_INSTANCE, payload), Times.once());
     });
 
-    test('onAddFailureInstance', () => {
-        const payload: BaseActionPayload = {};
+    it('handles AddFailureInstance message', () => {
+        const payload: AddFailureInstancePayload = {
+            test: -1 as VisualizationType,
+            ...telemetryOnlyPayload,
+        } as AddFailureInstancePayload;
 
-        telemetryEventHandlerMock.setup(tp => tp.publishTelemetry(TelemetryEvents.ADD_FAILURE_INSTANCE, payload)).verifiable(Times.once());
+        const addFailureInstanceMock = createActionMock(payload);
+        const actionsMock = createActionsMock('addFailureInstance', addFailureInstanceMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.AddFailureInstance, payload);
 
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('addFailureInstance', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.AddFailureInstance, payload, testTabId);
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
 
-        testObject.registerCallbacks();
+        testSubject.registerCallbacks();
 
-        actionMock.verifyAll();
+        addFailureInstanceMock.verifyAll();
+        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(TelemetryEvents.ADD_FAILURE_INSTANCE, payload), Times.once());
     });
 
-    test('onAddResultDescription', () => {
-        const payload: BaseActionPayload = {};
-
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('addResultDescription', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.AddResultDescription, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-    });
-
-    test('onChangeManualRequirementStatus', () => {
-        const payload: BaseActionPayload = {};
-
-        telemetryEventHandlerMock
-            .setup(tp => tp.publishTelemetry(TelemetryEvents.CHANGE_INSTANCE_STATUS, payload))
-            .verifiable(Times.once());
-
-        const updateTabIdActionMock = createActionMock(testTabId);
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
-        setupAssessmentActionsMock('changeRequirementStatus', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.ChangeRequirementStatus, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-        updateTabIdActionMock.verifyAll();
-    });
-
-    test('onUndoChangeManualRequirementStatus', () => {
-        const payload: BaseActionPayload = {};
-
-        telemetryEventHandlerMock
-            .setup(tp => tp.publishTelemetry(TelemetryEvents.UNDO_REQUIREMENT_STATUS_CHANGE, payload))
-            .verifiable(Times.once());
-
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('undoRequirementStatusChange', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.UndoChangeRequirementStatus, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-    });
-
-    test('onUndoAssessmentInstanceStatusChange', () => {
-        const payload: BaseActionPayload = {};
-
-        telemetryEventHandlerMock
-            .setup(tp => tp.publishTelemetry(TelemetryEvents.UNDO_TEST_STATUS_CHANGE, payload))
-            .verifiable(Times.once());
-
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('undoInstanceStatusChange', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.Undo, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-    });
-
-    test('onChangeAssessmentInstanceStatus', () => {
-        const payload: BaseActionPayload = {};
-
-        telemetryEventHandlerMock
-            .setup(tp => tp.publishTelemetry(TelemetryEvents.CHANGE_INSTANCE_STATUS, payload))
-            .verifiable(Times.once());
-
-        const updateTabIdActionMock = createActionMock(testTabId);
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
-        setupAssessmentActionsMock('changeInstanceStatus', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.ChangeStatus, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-        updateTabIdActionMock.verifyAll();
-    });
-
-    test('onChangeAssessmentVisualizationState', () => {
-        const payload: BaseActionPayload = {};
-
-        telemetryEventHandlerMock
-            .setup(tp => tp.publishTelemetry(TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS, payload))
-            .verifiable(Times.once());
-
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('changeAssessmentVisualizationState', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.ChangeVisualizationState, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-    });
-
-    test('onChangeVisualizationStateForAll', () => {
-        const payload: BaseActionPayload = {};
-
-        telemetryEventHandlerMock
-            .setup(tp => tp.publishTelemetry(TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS_FOR_ALL, payload))
-            .verifiable(Times.once());
-
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('changeAssessmentVisualizationStateForAll', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.ChangeVisualizationStateForAll, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-    });
-
-    test('onStartOverAssessment', () => {
-        const payload: BaseActionPayload = {};
-
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('resetData', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.StartOver, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-    });
-
-    test('onUpdateInstanceVisibility', () => {
-        const payload: ToggleActionPayload = { test: -1 as VisualizationType };
-
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('updateInstanceVisibility', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.UpdateInstanceVisibility, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-    });
-
-    test('onStartOverAllAssessments', () => {
-        const payload: BaseActionPayload = {};
-
-        const actionMock = createActionMock(testTabId);
-        setupAssessmentActionsMock('resetAllAssessmentsData', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.StartOverAllAssessments, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-    });
-
-    test('onAssessmentScanCompleted', () => {
-        const payload: BaseActionPayload = {};
-        const updateTabIdActionMock = createActionMock(testTabId);
-        const actionMock = createActionMock(payload);
-
-        setupAssessmentActionsMock('scanCompleted', actionMock);
-        setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.AssessmentScanCompleted, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-    });
-
-    test('onGetAssessmentCurrentState', () => {
-        const actionMock = createActionMock(null);
-        setupAssessmentActionsMock('getCurrentState', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(getStoreStateMessage(StoreNames.AssessmentStore), null, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-    });
-
-    test('onSelectTestStep', () => {
-        const payload: BaseActionPayload = {};
-
-        telemetryEventHandlerMock.setup(tp => tp.publishTelemetry(TelemetryEvents.SELECT_REQUIREMENT, payload)).verifiable(Times.once());
-
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('selectRequirement', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.SelectTestRequirement, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
-    });
-
-    test('onScanUpdate', () => {
-        const payload = {
-            key: 'hello',
+    it('handles AddResultDescription message', () => {
+        const payload: AddResultDescriptionPayload = {
+            description: 'test-description',
         };
 
+        const addResultDescriptionMock = createActionMock(payload);
+        const actionsMock = createActionsMock('addResultDescription', addResultDescriptionMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.AddResultDescription, payload);
+
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        addResultDescriptionMock.verifyAll();
+    });
+
+    it('handles ChangeManualRequirementStatus message', () => {
+        const payload: ChangeRequirementStatusPayload = {
+            test: -1 as VisualizationType,
+            ...telemetryOnlyPayload,
+        } as ChangeRequirementStatusPayload;
+
+        const updateTabIdActionMock = createActionMock(testTabId);
+        const changeRequirementStatusMock = createActionMock(payload);
+
+        setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
+        setupAssessmentActionsMock('changeRequirementStatus', changeRequirementStatusMock);
+
+        const interpreterMock = createInterpreterMock(AssessmentMessages.ChangeRequirementStatus, payload, testTabId);
+
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            assessmentActionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        changeRequirementStatusMock.verifyAll();
+        updateTabIdActionMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.CHANGE_INSTANCE_STATUS, payload),
+            Times.once(),
+        );
+    });
+
+    it('handles UndoChangeManualRequirementStatus message', () => {
+        const payload: ChangeRequirementStatusPayload = {
+            test: -1 as VisualizationType,
+            ...telemetryOnlyPayload,
+        } as ChangeRequirementStatusPayload;
+
+        const undoRequirementStatusChange = createActionMock(payload);
+        const actionsMock = createActionsMock('undoRequirementStatusChange', undoRequirementStatusChange.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.UndoChangeRequirementStatus, payload, testTabId);
+
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        undoRequirementStatusChange.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.UNDO_REQUIREMENT_STATUS_CHANGE, payload),
+            Times.once(),
+        );
+    });
+
+    it('handles UndoAssessmentInstanceStatusChange message', () => {
+        const payload: AssessmentActionInstancePayload = {
+            test: -1 as VisualizationType,
+            ...telemetryOnlyPayload,
+        } as AssessmentActionInstancePayload;
+
+        const undoInstanceStatusChangeMock = createActionMock(payload);
+        const actionsMock = createActionsMock('undoInstanceStatusChange', undoInstanceStatusChangeMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.Undo, payload);
+
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        undoInstanceStatusChangeMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.UNDO_TEST_STATUS_CHANGE, payload),
+            Times.once(),
+        );
+    });
+
+    it('handles ChangeAssessmentInstanceStatus message', () => {
+        const payload: ChangeInstanceSelectionPayload = {
+            selector: 'test-selector',
+            ...telemetryOnlyPayload,
+        } as ChangeInstanceSelectionPayload;
+
+        const updateTabIdActionMock = createActionMock(testTabId);
+        const changeInstanceStatusMock = createActionMock(payload);
+
+        setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
+        setupAssessmentActionsMock('changeInstanceStatus', changeInstanceStatusMock);
+
+        const interpreterMock = createInterpreterMock(AssessmentMessages.ChangeStatus, payload, testTabId);
+
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            assessmentActionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        changeInstanceStatusMock.verifyAll();
+        updateTabIdActionMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.CHANGE_INSTANCE_STATUS, payload),
+            Times.once(),
+        );
+    });
+
+    it('handles ChangeAssessmentVisualizationState message', () => {
+        const payload: ChangeInstanceSelectionPayload = {
+            isVisualizationEnabled: true,
+            ...telemetryOnlyPayload,
+        } as ChangeInstanceSelectionPayload;
+
+        const changeAssessmentVisualizationStateMock = createActionMock(payload);
+        const actionsMock = createActionsMock('changeAssessmentVisualizationState', changeAssessmentVisualizationStateMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.ChangeVisualizationState, payload);
+
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        changeAssessmentVisualizationStateMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS, payload),
+            Times.once(),
+        );
+    });
+
+    it('handles ChangeVisualizationStateForAll message', () => {
+        const payload: ChangeInstanceSelectionPayload = {
+            isVisualizationEnabled: true,
+            ...telemetryOnlyPayload,
+        } as ChangeInstanceSelectionPayload;
+
+        const changeAssessmentVisualizationStateForAllMock = createActionMock(payload);
+        const actionsMock = createActionsMock(
+            'changeAssessmentVisualizationStateForAll',
+            changeAssessmentVisualizationStateForAllMock.object,
+        );
+        const interpreterMock = createInterpreterMock(AssessmentMessages.ChangeVisualizationStateForAll, payload, testTabId);
+
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        changeAssessmentVisualizationStateForAllMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS_FOR_ALL, payload),
+            Times.once(),
+        );
+    });
+
+    it('handles StartOverAssessment message', () => {
+        const payload: ToggleActionPayload = {
+            test: -1 as VisualizationType,
+        };
+
+        const resetDataMock = createActionMock(payload);
+        const actionsMock = createActionsMock('resetData', resetDataMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.StartOver, payload);
+
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        resetDataMock.verifyAll();
+    });
+
+    it('handles UpdateInstanceVisibility message', () => {
+        const payload: UpdateVisibilityPayload = { payloadBatch: [] };
+
+        const updateInstanceVisibilityMock = createActionMock(payload);
+        const actionsMock = createActionsMock('updateInstanceVisibility', updateInstanceVisibilityMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.UpdateInstanceVisibility, payload, testTabId);
+
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        updateInstanceVisibilityMock.verifyAll();
+    });
+
+    it('handles StartOverAllAssessments message', () => {
+        const payload = {};
+
+        const resetAllAssessmentsData = createActionMock(testTabId);
+        const actionsMock = createActionsMock('resetAllAssessmentsData', resetAllAssessmentsData.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.StartOverAllAssessments, payload, testTabId);
+
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        resetAllAssessmentsData.verifyAll();
+    });
+
+    it('handles AssessmentScanCompleted message', () => {
+        const payload: ScanCompletedPayload<any> = {
+            key: 'test-key',
+        } as ScanCompletedPayload<any>;
+
+        const updateTabIdActionMock = createActionMock(testTabId);
+        const scanCompleteMock = createActionMock(payload);
+
+        setupAssessmentActionsMock('scanCompleted', scanCompleteMock);
+        setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
+
+        const interpreterMock = createInterpreterMock(AssessmentMessages.AssessmentScanCompleted, payload, testTabId);
+
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            assessmentActionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        scanCompleteMock.verifyAll();
+    });
+
+    it('handles GetCurrentState message', () => {
+        const getCurrentStateMock = createActionMock<void>(null);
+        const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
+        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.AssessmentStore), null);
+
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        getCurrentStateMock.verifyAll();
+    });
+
+    it('handles SelectTestRequirement message', () => {
+        const payload: SelectRequirementPayload = {
+            selectedRequirement: 'test-requirement',
+            ...telemetryOnlyPayload,
+        } as SelectRequirementPayload;
+
+        const selectRequirementMock = createActionMock(payload);
+        const actionsMock = createActionsMock('selectRequirement', selectRequirementMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.SelectTestRequirement, payload);
+
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        selectRequirementMock.verifyAll();
+        telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(TelemetryEvents.SELECT_REQUIREMENT, payload), Times.once());
+    });
+
+    it('handles ScanUpdate message', () => {
+        const payload: ScanUpdatePayload = {
+            key: 'hello',
+            ...telemetryOnlyPayload,
+        } as ScanUpdatePayload;
+
+        const scanUpdateMock = createActionMock(payload);
+        const actionsMock = createActionsMock('scanUpdate', scanUpdateMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.ScanUpdate, payload);
+
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        scanUpdateMock.verifyAll();
         telemetryEventHandlerMock
             .setup(tp => tp.publishTelemetry('ScanUpdateHello', payload as BaseActionPayload))
             .verifiable(Times.once());
-
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('scanUpdate', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.ScanUpdate, payload, testTabId);
-
-        testObject.registerCallbacks();
-
-        actionMock.verifyAll();
     });
 
-    test('onTrackingCompleted', () => {
-        const payload = {
+    it('handles TrackingCompleted message', () => {
+        const payload: ScanBasePayload = {
             key: 'hello',
-        };
+            ...telemetryOnlyPayload,
+        } as ScanBasePayload;
 
-        telemetryEventHandlerMock
-            .setup(tp => tp.publishTelemetry('TrackingCompletedHello', payload as BaseActionPayload))
-            .verifiable(Times.once());
+        const trackingCompletedMock = createActionMock(payload);
+        const actionsMock = createActionsMock('trackingCompleted', trackingCompletedMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.TrackingCompleted, payload);
 
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('trackingCompleted', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(AssessmentMessages.TrackingCompleted, payload, testTabId);
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
 
-        testObject.registerCallbacks();
+        testSubject.registerCallbacks();
 
-        actionMock.verifyAll();
+        trackingCompletedMock.verifyAll();
+        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry('TrackingCompletedHello', payload), Times.once());
     });
 
-    test('onPivotChildSelected', () => {
-        const payload: BaseActionPayload = {};
-        const actionMock = createActionMock(payload);
-        setupAssessmentActionsMock('updateSelectedPivotChild', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.Visualizations.DetailsView.Select, payload, testTabId);
+    it('handles PivotChildSelected message', () => {
+        const payload: OnDetailsViewOpenPayload = {
+            pivotType: -1 as DetailsViewPivotType,
+        } as OnDetailsViewOpenPayload;
 
-        testObject.registerCallbacks();
+        const updateSelectedPivotChildMock = createActionMock(payload);
+        const actionsMock = createActionsMock('updateSelectedPivotChild', updateSelectedPivotChildMock.object);
+        const interpreterMock = createInterpreterMock(Messages.Visualizations.DetailsView.Select, payload);
 
-        actionMock.verifyAll();
+        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        updateSelectedPivotChildMock.verifyAll();
     });
 
     function setupAssessmentActionsMock(actionName: keyof AssessmentActions, actionMock: IMock<Action<any>>): void {
         assessmentActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);
     }
 
-    function setupRegisterTypeToPayloadCallbackMock(message: string, actionPayload: any, tabId: number): void {
-        registerTypeToPayloadCallbackMock
-            .setup(regitrar => regitrar(message, It.is(isFunction)))
-            .callback((theMessage, handler) => handler(actionPayload, tabId));
+    function createActionsMock<ActionName extends keyof AssessmentActions>(
+        actionName: ActionName,
+        action: AssessmentActions[ActionName],
+    ): IMock<AssessmentActions> {
+        const actionsMock = Mock.ofType<AssessmentActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
     }
 });

--- a/src/tests/unit/tests/background/actions/content-panel-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/content-panel-action-creator.test.ts
@@ -1,65 +1,80 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Mock, Times } from 'typemoq';
-
+import { BaseActionPayload } from 'background/actions/action-payloads';
 import { ContentActionCreator } from 'background/actions/content-action-creator';
 import { ContentActions, ContentPayload } from 'background/actions/content-actions';
 import { DetailsViewController } from 'background/details-view-controller';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { Action } from '../../../../../common/flux/action';
-import { Messages } from '../../../../../common/messages';
-import { CONTENT_PANEL_CLOSED, CONTENT_PANEL_OPENED } from '../../../../../common/telemetry-events';
+import { Messages } from 'common/messages';
+import { CONTENT_PANEL_CLOSED, CONTENT_PANEL_OPENED, TelemetryEventSource } from 'common/telemetry-events';
+import { IMock, Mock, Times } from 'typemoq';
+
+import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('ContentPanelActionMessageCreator', () => {
-    let typesRegistered = {};
-    const registerTypeToPayloadCallback = (messageType, callback) => {
-        typesRegistered[messageType] = callback;
-    };
-
-    const openContentPanelMock = Mock.ofType<Action<ContentPayload>>();
-    const closeContentPanelMock = Mock.ofType<Action<void>>();
-    const detailsViewControllerMock = Mock.ofType<DetailsViewController>();
-    const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
-
-    const contentActionsMock = Mock.ofType<ContentActions>();
-    contentActionsMock.setup(cpa => cpa.openContentPanel).returns(() => openContentPanelMock.object);
-    contentActionsMock.setup(cpa => cpa.closeContentPanel).returns(() => closeContentPanelMock.object);
-
-    const tabId = 2112;
-    const payload: ContentPayload = { contentPath: 'content/path' };
-
-    let creator: ContentActionCreator = null;
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
 
     beforeEach(() => {
-        typesRegistered = {};
-        creator = new ContentActionCreator(
-            contentActionsMock.object,
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+    });
+
+    it('handles OpenPanel message', () => {
+        const payload: ContentPayload = {
+            contentPath: 'the path',
+            telemetry: {
+                triggeredBy: 'N/A',
+                source: -1 as TelemetryEventSource,
+            },
+        };
+
+        const tabId = -2;
+
+        const openContentPanelMock = createActionMock(payload);
+        const actionsMock = createActionsMock('openContentPanel', openContentPanelMock.object);
+        const interpreterMock = createInterpreterMock(Messages.ContentPanel.OpenPanel, payload, tabId);
+
+        const detailsViewControllerMock = Mock.ofType<DetailsViewController>();
+
+        const testSubject = new ContentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
             telemetryEventHandlerMock.object,
-            registerTypeToPayloadCallback,
             detailsViewControllerMock.object,
         );
-        creator.registerCallbacks();
 
-        openContentPanelMock.reset();
-        closeContentPanelMock.reset();
-        telemetryEventHandlerMock.reset();
-        detailsViewControllerMock.reset();
+        testSubject.registerCallbacks();
+
+        openContentPanelMock.verifyAll();
+        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(CONTENT_PANEL_OPENED, payload), Times.once());
+        detailsViewControllerMock.verify(controller => controller.showDetailsView(tabId), Times.once());
     });
 
-    it('registers Messages.ContentPanel.OpenPanel', () => {
-        const callback = typesRegistered[Messages.ContentPanel.OpenPanel];
-        callback(payload, tabId);
+    it('handles ClosePanel message', () => {
+        const payload: BaseActionPayload = {
+            telemetry: {
+                triggeredBy: 'N/A',
+                source: -1 as TelemetryEventSource,
+            },
+        };
 
-        openContentPanelMock.verify(action => action.invoke(payload), Times.once());
-        detailsViewControllerMock.verify(ctrlr => ctrlr.showDetailsView(tabId), Times.once());
-        telemetryEventHandlerMock.verify(pub => pub.publishTelemetry(CONTENT_PANEL_OPENED, payload), Times.once());
+        const closeContentPanelMock = createActionMock<void>(null);
+        const actionsMock = createActionsMock('closeContentPanel', closeContentPanelMock.object);
+        const interpreterMock = createInterpreterMock(Messages.ContentPanel.ClosePanel, payload);
+
+        const testSubject = new ContentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object, null);
+
+        testSubject.registerCallbacks();
+
+        closeContentPanelMock.verifyAll();
+        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(CONTENT_PANEL_CLOSED, payload), Times.once());
     });
 
-    it('registers Messages.ContentPanel.ClosedPanel', () => {
-        const callback = typesRegistered[Messages.ContentPanel.ClosePanel];
-        callback(payload, tabId);
-
-        closeContentPanelMock.verify(action => action.invoke(null), Times.once());
-        telemetryEventHandlerMock.verify(pub => pub.publishTelemetry(CONTENT_PANEL_CLOSED, payload), Times.once());
-    });
+    function createActionsMock<ActionName extends keyof ContentActions>(
+        actionName: ActionName,
+        action: ContentActions[ActionName],
+    ): IMock<ContentActions> {
+        const actionsMock = Mock.ofType<ContentActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
+    }
 });

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -1,23 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
-import { IMock, It, Mock, Times } from 'typemoq';
-
 import { BaseActionPayload } from 'background/actions/action-payloads';
 import { DetailsViewActionCreator } from 'background/actions/details-view-action-creator';
 import { DetailsViewActions } from 'background/actions/details-view-actions';
 import { DetailsViewController } from 'background/details-view-controller';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { Action } from '../../../../../common/flux/action';
-import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
-import { getStoreStateMessage, Messages } from '../../../../../common/messages';
-import { StoreNames } from '../../../../../common/stores/store-names';
-import { SETTINGS_PANEL_CLOSE, SETTINGS_PANEL_OPEN, TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
-import { DetailsViewRightContentPanelType } from '../../../../../DetailsView/components/left-nav/details-view-right-content-panel-type';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { StoreNames } from 'common/stores/store-names';
+import { SETTINGS_PANEL_CLOSE, SETTINGS_PANEL_OPEN, TelemetryEventSource, TriggeredBy } from 'common/telemetry-events';
+import { DetailsViewRightContentPanelType } from 'DetailsView/components/left-nav/details-view-right-content-panel-type';
+import { IMock, Mock, Times } from 'typemoq';
+
+import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('DetailsViewActionCreatorTest', () => {
-    let registerCallbackMock: IMock<RegisterTypeToPayloadCallback>;
-    let detailsViewActionsMock: IMock<DetailsViewActions>;
     let detailsViewControllerMock: IMock<DetailsViewController>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
 
@@ -28,87 +24,95 @@ describe('DetailsViewActionCreatorTest', () => {
         },
     };
 
-    let testSubject: DetailsViewActionCreator;
-
     beforeEach(() => {
-        registerCallbackMock = Mock.ofType<RegisterTypeToPayloadCallback>();
-        detailsViewActionsMock = Mock.ofType<DetailsViewActions>();
-
         detailsViewControllerMock = Mock.ofType<DetailsViewController>();
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+    });
 
-        testSubject = new DetailsViewActionCreator(
-            registerCallbackMock.object,
-            detailsViewActionsMock.object,
+    it('handles SettingsPanel.OpenPanel message', () => {
+        const tabId = -1;
+
+        const openSettingsPanelMock = createActionMock<void>(null);
+        const actionsMock = createActionsMock('openSettingsPanel', openSettingsPanelMock.object);
+        const interpreterMock = createInterpreterMock(Messages.SettingsPanel.OpenPanel, defaultBasePayload, tabId);
+
+        const testObject = new DetailsViewActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
             detailsViewControllerMock.object,
             telemetryEventHandlerMock.object,
         );
-    });
 
-    test('on SettingsPanel.OpenPanel', () => {
-        const openSettingsPanelMock = Mock.ofType<Action<null>>();
+        testObject.registerCallback();
 
-        detailsViewActionsMock.setup(actions => actions['openSettingsPanel']).returns(() => openSettingsPanelMock.object);
-
-        const tabId = -1;
-
-        registerCallbackMock
-            .setup(register => register(Messages.SettingsPanel.OpenPanel, It.is(isFunction)))
-            .callback((message, listener) => listener(defaultBasePayload, tabId));
-
-        testSubject.registerCallback();
-
-        openSettingsPanelMock.verify(action => action.invoke(null), Times.once());
+        openSettingsPanelMock.verifyAll();
         detailsViewControllerMock.verify(controller => controller.showDetailsView(tabId), Times.once());
         telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(SETTINGS_PANEL_OPEN, defaultBasePayload), Times.once());
     });
 
-    test('on SettingsPanel.ClosePanel', () => {
-        const closeSeetingsPanelMock = Mock.ofType<Action<null>>();
+    it('handles SettingsPanel.ClosePanel message', () => {
+        const closeSettingsPanelMock = createActionMock<void>(null);
+        const actionsMock = createActionsMock('closeSettingsPanel', closeSettingsPanelMock.object);
+        const interpreterMock = createInterpreterMock(Messages.SettingsPanel.ClosePanel, defaultBasePayload);
 
-        detailsViewActionsMock.setup(actions => actions['closeSettingsPanel']).returns(() => closeSeetingsPanelMock.object);
+        const testObject = new DetailsViewActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            detailsViewControllerMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
-        const tabId = -1;
+        testObject.registerCallback();
 
-        registerCallbackMock
-            .setup(register => register(Messages.SettingsPanel.ClosePanel, It.is(isFunction)))
-            .callback((message, listener) => listener(defaultBasePayload, tabId));
-
-        testSubject.registerCallback();
-
-        closeSeetingsPanelMock.verify(action => action.invoke(null), Times.once());
+        closeSettingsPanelMock.verifyAll();
         telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(SETTINGS_PANEL_CLOSE, defaultBasePayload), Times.once());
     });
 
-    test('on Visualization.DetailsView.SetDetailsViewRightContentPanel', () => {
-        const setSelectedPanelMock = Mock.ofType<Action<DetailsViewRightContentPanelType>>();
-
-        detailsViewActionsMock
-            .setup(actions => actions['setSelectedDetailsViewRightContentPanel'])
-            .returns(() => setSelectedPanelMock.object);
-
+    it('handles Visualization.DetailsView.SetDetailsViewRightContentPanel message', () => {
         const payload: DetailsViewRightContentPanelType = 'Overview';
 
-        registerCallbackMock
-            .setup(register => register(Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel, It.is(isFunction)))
-            .callback((message, listener) => listener(payload));
+        const setSelectedDetailsViewRightContentPanelMock = createActionMock(payload);
+        const actionsMock = createActionsMock(
+            'setSelectedDetailsViewRightContentPanel',
+            setSelectedDetailsViewRightContentPanelMock.object,
+        );
+        const interpreterMock = createInterpreterMock(Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel, payload);
 
-        testSubject.registerCallback();
+        const testObject = new DetailsViewActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            detailsViewControllerMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
-        setSelectedPanelMock.verify(action => action.invoke(payload), Times.once());
+        testObject.registerCallback();
+
+        setSelectedDetailsViewRightContentPanelMock.verifyAll();
     });
 
-    test('on Visualization.DetailsView.GetState', () => {
-        const getCurrentStateMock = Mock.ofType<Action<null>>();
+    it('handles Visualization.DetailsView.GetState message', () => {
+        const getCurrentStateMock = createActionMock<void>(null);
+        const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
+        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.DetailsViewStore), null);
 
-        detailsViewActionsMock.setup(actions => actions['getCurrentState']).returns(() => getCurrentStateMock.object);
+        const testObject = new DetailsViewActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            detailsViewControllerMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
-        registerCallbackMock
-            .setup(register => register(getStoreStateMessage(StoreNames.DetailsViewStore), It.is(isFunction)))
-            .callback((message, listener) => listener());
+        testObject.registerCallback();
 
-        testSubject.registerCallback();
-
-        getCurrentStateMock.verify(action => action.invoke(null), Times.once());
+        getCurrentStateMock.verifyAll();
     });
+
+    function createActionsMock<ActionName extends keyof DetailsViewActions>(
+        actionName: ActionName,
+        action: DetailsViewActions[ActionName],
+    ): IMock<DetailsViewActions> {
+        const actionsMock = Mock.ofType<DetailsViewActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
+    }
 });

--- a/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
@@ -12,6 +12,7 @@ import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import * as TelemetryEvents from '../../../../../common/telemetry-events';
+import { createActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('DevToolsActionCreatorTest', () => {
     const tabId: number = -1;
@@ -100,14 +101,6 @@ describe('DevToolsActionCreatorTest', () => {
 
     function setupDevToolsActionsMock(actionName: keyof DevToolActions, actionMock: IMock<Action<any>>): void {
         devtoolActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);
-    }
-
-    function createActionMock<TPayload>(actionPayload: TPayload): IMock<Action<TPayload>> {
-        const getCurrentStateAction = Mock.ofType<Action<TPayload>>(Action, MockBehavior.Strict);
-
-        getCurrentStateAction.setup(action => action.invoke(actionPayload)).verifiable(Times.once());
-
-        return getCurrentStateAction;
     }
 
     function setupRegisterTypeToPayloadCallbackMock(message: string, payload: any, listeningTabId: number): void {

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as _ from 'lodash';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { InspectActionCreator } from 'background/actions/inspect-action-creator';
 import { InspectActions, InspectPayload } from 'background/actions/inspect-actions';
 import { InspectMode } from 'background/inspect-modes';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import * as _ from 'lodash';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
 import { Action } from '../../../../../common/flux/action';
 import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import * as TelemetryEvents from '../../../../../common/telemetry-events';
+import { createActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('InspectActionCreatorTest', () => {
     const tabId: number = -1;
@@ -68,13 +69,6 @@ describe('InspectActionCreatorTest', () => {
         testObject.registerCallbacks();
         changeInspectModeMock.verifyAll();
     });
-
-    function createActionMock<TPayload>(actionPayload: TPayload): IMock<Action<TPayload>> {
-        const getCurrentStateMock = Mock.ofType<Action<TPayload>>(Action, MockBehavior.Strict);
-        getCurrentStateMock.setup(action => action.invoke(actionPayload)).verifiable(Times.once());
-
-        return getCurrentStateMock;
-    }
 
     function setupInspectActionMock(actionName: keyof InspectActions, actionMock: IMock<Action<any>>): void {
         inspectActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);

--- a/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as _ from 'lodash';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { PathSnippetActionCreator } from 'background/actions/path-snippet-action-creator';
 import { PathSnippetActions } from 'background/actions/path-snippet-actions';
+import * as _ from 'lodash';
+import { IMock, It, Mock, MockBehavior } from 'typemoq';
+
 import { Action } from '../../../../../common/flux/action';
 import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
+import { createActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('PathSnippetActionCreatorTest', () => {
     let pathSnippetActionsMock: IMock<PathSnippetActions>;
@@ -74,13 +75,6 @@ describe('PathSnippetActionCreatorTest', () => {
         testObject.registerCallbacks();
         clearPathSnippetDataMock.verifyAll();
     });
-
-    function createActionMock<TPayload>(actionPayload: TPayload): IMock<Action<TPayload>> {
-        const getCurrentStateMock = Mock.ofType<Action<TPayload>>(Action, MockBehavior.Strict);
-        getCurrentStateMock.setup(action => action.invoke(actionPayload)).verifiable(Times.once());
-
-        return getCurrentStateMock;
-    }
 
     function setupPathSnippetActionMock(actionName: keyof PathSnippetActions, actionMock: IMock<Action<any>>): void {
         pathSnippetActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);

--- a/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
@@ -2,87 +2,71 @@
 // Licensed under the MIT License.
 import { PathSnippetActionCreator } from 'background/actions/path-snippet-action-creator';
 import { PathSnippetActions } from 'background/actions/path-snippet-actions';
-import * as _ from 'lodash';
-import { IMock, It, Mock, MockBehavior } from 'typemoq';
+import { IMock, Mock } from 'typemoq';
 
-import { Action } from '../../../../../common/flux/action';
-import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import { createActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('PathSnippetActionCreatorTest', () => {
-    let pathSnippetActionsMock: IMock<PathSnippetActions>;
-    let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
+    it('handles AddPathForValidation message', () => {
+        const payload = 'test path';
 
-    let testObject: PathSnippetActionCreator;
+        const onAddPathMock = createActionMock(payload);
+        const actionsMock = createActionsMock('onAddPath', onAddPathMock.object);
+        const interpreterMock = createInterpreterMock(Messages.PathSnippet.AddPathForValidation, payload);
 
-    beforeAll(() => {
-        pathSnippetActionsMock = Mock.ofType(PathSnippetActions, MockBehavior.Strict);
-        registerTypeToPayloadCallbackMock = Mock.ofInstance((payloadType, callback) => {});
+        const newTestObject = new PathSnippetActionCreator(interpreterMock.object, actionsMock.object);
 
-        testObject = new PathSnippetActionCreator(pathSnippetActionsMock.object, registerTypeToPayloadCallbackMock.object);
+        newTestObject.registerCallbacks();
+
+        onAddPathMock.verifyAll();
     });
 
-    test('registerCallbacks for onAddPathForValidation', () => {
-        const path = 'test path';
-        const actionName = 'onAddPath';
+    it('handles AddCorrespondingSnippet message', () => {
+        const payload = 'test snippet';
 
-        const payload = path;
-        const addPathForValidationMock = createActionMock(payload);
+        const onAddSnippetMock = createActionMock(payload);
+        const actionsMock = createActionsMock('onAddSnippet', onAddSnippetMock.object);
+        const interpreterMock = createInterpreterMock(Messages.PathSnippet.AddCorrespondingSnippet, payload);
 
-        setupPathSnippetActionMock(actionName, addPathForValidationMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.PathSnippet.AddPathForValidation, payload);
+        const newTestObject = new PathSnippetActionCreator(interpreterMock.object, actionsMock.object);
 
-        testObject.registerCallbacks();
-        addPathForValidationMock.verifyAll();
+        newTestObject.registerCallbacks();
+
+        onAddSnippetMock.verifyAll();
     });
 
-    test('registerCallbacks for onAddCorrespondingSnippet', () => {
-        const snippet = 'test corresponding snippet';
-        const actionName = 'onAddSnippet';
+    it('handles GetPathSnippetCurrentState message', () => {
+        const getCurrentStateMock = createActionMock(null);
+        const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
+        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.PathSnippetStore), null);
 
-        const payload = snippet;
-        const addCorrespondingSnippetMock = createActionMock(payload);
+        const newTestObject = new PathSnippetActionCreator(interpreterMock.object, actionsMock.object);
 
-        setupPathSnippetActionMock(actionName, addCorrespondingSnippetMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.PathSnippet.AddCorrespondingSnippet, payload);
+        newTestObject.registerCallbacks();
 
-        testObject.registerCallbacks();
-        addCorrespondingSnippetMock.verifyAll();
+        getCurrentStateMock.verifyAll();
     });
 
-    test('registerCallbacks for onGetPathSnippetCurrentState', () => {
-        const actionName = 'getCurrentState';
+    it('handles ClearPathSnippetData message', () => {
+        const onClearDataMock = createActionMock(null);
+        const actionsMock = createActionsMock('onClearData', onClearDataMock.object);
+        const interpreterMock = createInterpreterMock(Messages.PathSnippet.ClearPathSnippetData, null);
 
-        const getPathSnippetCurrentStateMock = createActionMock(null);
+        const newTestObject = new PathSnippetActionCreator(interpreterMock.object, actionsMock.object);
 
-        setupPathSnippetActionMock(actionName, getPathSnippetCurrentStateMock);
-        setupRegisterTypeToPayloadCallbackMock(getStoreStateMessage(StoreNames.PathSnippetStore), null);
+        newTestObject.registerCallbacks();
 
-        testObject.registerCallbacks();
-        getPathSnippetCurrentStateMock.verifyAll();
+        onClearDataMock.verifyAll();
     });
 
-    test('registerCallbacks for onClearPathSnippetData', () => {
-        const actionName = 'onClearData';
-
-        const clearPathSnippetDataMock = createActionMock(null);
-
-        setupPathSnippetActionMock(actionName, clearPathSnippetDataMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.PathSnippet.ClearPathSnippetData, null);
-
-        testObject.registerCallbacks();
-        clearPathSnippetDataMock.verifyAll();
-    });
-
-    function setupPathSnippetActionMock(actionName: keyof PathSnippetActions, actionMock: IMock<Action<any>>): void {
-        pathSnippetActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);
-    }
-
-    function setupRegisterTypeToPayloadCallbackMock(message: string, payload: any): void {
-        registerTypeToPayloadCallbackMock
-            .setup(registrar => registrar(message, It.is(_.isFunction)))
-            .callback((passedMessage, listener) => listener(payload));
+    function createActionsMock<ActionName extends keyof PathSnippetActions>(
+        actionName: ActionName,
+        action: PathSnippetActions[ActionName],
+    ): IMock<PathSnippetActions> {
+        const actionsMock = Mock.ofType<PathSnippetActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
     }
 });

--- a/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
@@ -5,77 +5,75 @@ import { ScopingActions } from 'background/actions/scoping-actions';
 import { ScopingPanelActionCreator } from 'background/actions/scoping-panel-action-creator';
 import { DetailsViewController } from 'background/details-view-controller';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import * as _ from 'lodash';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { Messages } from 'common/messages';
+import { SCOPING_CLOSE, SCOPING_OPEN } from 'common/telemetry-events';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
-import { Action } from '../../../../../common/flux/action';
-import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
-import { Messages } from '../../../../../common/messages';
-import { SCOPING_CLOSE, SCOPING_OPEN } from '../../../../../common/telemetry-events';
-import { createActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('ScopingPanelActionCreatorTest', () => {
-    let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
-    let scopingActionsMock: IMock<ScopingActions>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let detailsViewControllerStrictMock: IMock<DetailsViewController>;
-    const tabId = -1;
-    let testObject: ScopingPanelActionCreator;
 
     beforeEach(() => {
-        scopingActionsMock = Mock.ofType(ScopingActions, MockBehavior.Strict);
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
         detailsViewControllerStrictMock = Mock.ofType<DetailsViewController>(null, MockBehavior.Strict);
-        registerTypeToPayloadCallbackMock = Mock.ofInstance((theType, callback) => {});
-
-        testObject = new ScopingPanelActionCreator(
-            scopingActionsMock.object,
-            telemetryEventHandlerMock.object,
-            registerTypeToPayloadCallbackMock.object,
-            detailsViewControllerStrictMock.object,
-        );
     });
 
-    test('on OpenPanel', () => {
+    it('should handle OpenPanel message', () => {
+        const tabId = -1;
         const payload: BaseActionPayload = {};
 
         telemetryEventHandlerMock.setup(tp => tp.publishTelemetry(SCOPING_OPEN, payload)).verifiable(Times.once());
 
         detailsViewControllerStrictMock.setup(dc => dc.showDetailsView(tabId)).verifiable(Times.once());
 
-        const actionMock = createActionMock(null);
-        setupScopingActionsMock('openScopingPanel', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.Scoping.OpenPanel, payload, tabId);
+        const openScopingPanelMock = createActionMock(null);
+        const actionsMocks = createActionsMock('openScopingPanel', openScopingPanelMock.object);
+        const interpreterMock = createInterpreterMock(Messages.Scoping.OpenPanel, payload, tabId);
 
-        testObject.registerCallbacks();
-        actionMock.verifyAll();
+        const newTestObject = new ScopingPanelActionCreator(
+            interpreterMock.object,
+            actionsMocks.object,
+            telemetryEventHandlerMock.object,
+            detailsViewControllerStrictMock.object,
+        );
 
+        newTestObject.registerCallbacks();
+
+        openScopingPanelMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
         detailsViewControllerStrictMock.verifyAll();
     });
 
-    test('on ClosePanel', () => {
+    test('should handle ClosePanel message', () => {
         const payload: BaseActionPayload = {};
 
         telemetryEventHandlerMock.setup(tp => tp.publishTelemetry(SCOPING_CLOSE, payload)).verifiable(Times.once());
 
         const closeScopingPanelActionMock = createActionMock(null);
-        setupScopingActionsMock('closeScopingPanel', closeScopingPanelActionMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.Scoping.ClosePanel, payload, tabId);
+        const actionsMocks = createActionsMock('closeScopingPanel', closeScopingPanelActionMock.object);
+        const interpreterMock = createInterpreterMock(Messages.Scoping.ClosePanel, payload);
 
-        testObject.registerCallbacks();
+        const newTestObject = new ScopingPanelActionCreator(
+            interpreterMock.object,
+            actionsMocks.object,
+            telemetryEventHandlerMock.object,
+            detailsViewControllerStrictMock.object,
+        );
+
+        newTestObject.registerCallbacks();
+
         closeScopingPanelActionMock.verifyAll();
-
         telemetryEventHandlerMock.verifyAll();
     });
 
-    function setupScopingActionsMock(actionName: keyof ScopingActions, actionMock: IMock<Action<any>>): void {
-        scopingActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);
-    }
-
-    function setupRegisterTypeToPayloadCallbackMock(message: string, actionPayload: any, listeningTabId: number): void {
-        registerTypeToPayloadCallbackMock
-            .setup(regitrar => regitrar(message, It.is(param => _.isFunction(param))))
-            .callback((passedMessage, handler) => handler(actionPayload, listeningTabId));
+    function createActionsMock<ActionName extends keyof ScopingActions>(
+        actionName: ActionName,
+        action: ScopingActions[ActionName],
+    ): IMock<ScopingActions> {
+        const actionsMock = Mock.ofType<ScopingActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
     }
 });

--- a/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
@@ -7,10 +7,12 @@ import { DetailsViewController } from 'background/details-view-controller';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import * as _ from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { Action } from '../../../../../common/flux/action';
 import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
 import { Messages } from '../../../../../common/messages';
 import { SCOPING_CLOSE, SCOPING_OPEN } from '../../../../../common/telemetry-events';
+import { createActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('ScopingPanelActionCreatorTest', () => {
     let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
@@ -66,13 +68,6 @@ describe('ScopingPanelActionCreatorTest', () => {
 
         telemetryEventHandlerMock.verifyAll();
     });
-
-    function createActionMock<T>(actionPayload: T): IMock<Action<T>> {
-        const actionMock = Mock.ofType<Action<T>>(Action);
-        actionMock.setup(action => action.invoke(actionPayload)).verifiable(Times.once());
-
-        return actionMock;
-    }
 
     function setupScopingActionsMock(actionName: keyof ScopingActions, actionMock: IMock<Action<any>>): void {
         scopingActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as _ from 'lodash';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { PageVisibilityChangeTabPayload, SwitchToTargetTabPayload } from 'background/actions/action-payloads';
 import { TabActionCreator } from 'background/actions/tab-action-creator';
 import { TabActions } from 'background/actions/tab-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import * as _ from 'lodash';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
 import { Action } from '../../../../../common/flux/action';
 import { Tab } from '../../../../../common/itab';
@@ -14,6 +14,7 @@ import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import { SWITCH_BACK_TO_TARGET, TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
+import { createActionMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('TestActionCreatorTest', () => {
     let tabActionsMock: IMock<TabActions>;
@@ -110,13 +111,6 @@ describe('TestActionCreatorTest', () => {
         testObject.registerCallbacks();
         actionMock.verifyAll();
     });
-
-    function createActionMock<T>(actionPayload: T): IMock<Action<T>> {
-        const actionMock = Mock.ofType<Action<T>>(Action);
-        actionMock.setup(action => action.invoke(actionPayload)).verifiable(Times.once());
-
-        return actionMock;
-    }
 
     function setupTabActionsMock(actionName: keyof TabActions, actionMock: IMock<Action<any>>): void {
         tabActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -4,84 +4,85 @@ import { PageVisibilityChangeTabPayload, SwitchToTargetTabPayload } from 'backgr
 import { TabActionCreator } from 'background/actions/tab-action-creator';
 import { TabActions } from 'background/actions/tab-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import * as _ from 'lodash';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { Tab } from 'common/itab';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { StoreNames } from 'common/stores/store-names';
+import { SWITCH_BACK_TO_TARGET, TelemetryEventSource, TriggeredBy } from 'common/telemetry-events';
+import { IMock, Mock, Times } from 'typemoq';
 
-import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
-import { Action } from '../../../../../common/flux/action';
-import { Tab } from '../../../../../common/itab';
-import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
-import { getStoreStateMessage, Messages } from '../../../../../common/messages';
-import { StoreNames } from '../../../../../common/stores/store-names';
-import { SWITCH_BACK_TO_TARGET, TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
-import { createActionMock } from '../global-action-creators/action-creator-test-helpers';
+import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('TestActionCreatorTest', () => {
-    let tabActionsMock: IMock<TabActions>;
     let browserAdapterMock: IMock<BrowserAdapter>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
-    let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
-    let testObject: TabActionCreator;
-    const tabId: number = -1;
-    const iTabPayload: Tab = {
-        id: -1,
-        url: 'url',
-        title: 'title',
-    };
 
     beforeEach(() => {
-        tabActionsMock = Mock.ofType(TabActions, MockBehavior.Strict);
-        browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
-        telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
-        registerTypeToPayloadCallbackMock = Mock.ofInstance((theType, callback) => {});
-
-        testObject = new TabActionCreator(
-            registerTypeToPayloadCallbackMock.object,
-            browserAdapterMock.object,
-            telemetryEventHandlerMock.object,
-            tabActionsMock.object,
-        );
+        browserAdapterMock = Mock.ofType<BrowserAdapter>();
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
     });
 
-    test('on Tab.Update', () => {
-        const actionMock = createActionMock(iTabPayload);
-        setupTabActionsMock('tabUpdate', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.Tab.Update, iTabPayload, tabId);
+    it('handles Tab.Update message', () => {
+        const payload: Tab = {
+            id: -1,
+            title: 'test tab title',
+            url: 'test url',
+        };
 
-        testObject.registerCallbacks();
-        actionMock.verifyAll();
+        const tabUpdateMock = createActionMock(payload);
+        const actionsMock = createActionsMock('tabUpdate', tabUpdateMock.object);
+        const interpreterMock = createInterpreterMock(Messages.Tab.Update, payload);
+
+        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null);
+
+        testSubject.registerCallbacks();
+
+        tabUpdateMock.verifyAll();
     });
 
-    test('on Tab.GetCurrent', () => {
-        const actionMock = createActionMock(null);
-        setupTabActionsMock('getCurrentState', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(getStoreStateMessage(StoreNames.TabStore), null, tabId);
+    it('handles Tab.GetCurrent message', () => {
+        const getCurrentStateMock = createActionMock<void>(null);
+        const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
+        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.TabStore), null);
 
-        testObject.registerCallbacks();
-        actionMock.verifyAll();
+        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null);
+
+        testSubject.registerCallbacks();
+
+        getCurrentStateMock.verifyAll();
     });
 
-    test('on Tab.Remove', () => {
-        const actionMock = createActionMock(null);
-        setupTabActionsMock('tabRemove', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.Tab.Remove, null, tabId);
+    it('handles Tab.Remove message', () => {
+        const tabRemoveMock = createActionMock<void>(null);
+        const actionsMock = createActionsMock('tabRemove', tabRemoveMock.object);
+        const interpreterMock = createInterpreterMock(Messages.Tab.Remove, null);
 
-        testObject.registerCallbacks();
-        actionMock.verifyAll();
+        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null);
+
+        testSubject.registerCallbacks();
+
+        tabRemoveMock.verifyAll();
     });
 
-    test('on Tab.Change', () => {
-        const actionMock = createActionMock(iTabPayload);
-        setupTabActionsMock('tabChange', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.Tab.Change, iTabPayload, tabId);
+    it('handles Tab.Change message', () => {
+        const payload: Tab = {
+            id: -1,
+            title: 'test tab title',
+            url: 'test url',
+        };
 
-        testObject.registerCallbacks();
-        actionMock.verifyAll();
+        const tabChangeMock = createActionMock(payload);
+        const actionsMock = createActionsMock('tabChange', tabChangeMock.object);
+        const interpreterMock = createInterpreterMock(Messages.Tab.Change, payload);
+
+        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null);
+
+        testSubject.registerCallbacks();
+
+        tabChangeMock.verifyAll();
     });
 
-    test('on Tab.Switch', () => {
-        browserAdapterMock.setup(ba => ba.switchToTab(tabId)).verifiable(Times.once());
-
+    it('handles Tab.Switch message', () => {
         const payload: SwitchToTargetTabPayload = {
             telemetry: {
                 triggeredBy: 'test' as TriggeredBy,
@@ -89,36 +90,40 @@ describe('TestActionCreatorTest', () => {
             },
         };
 
-        telemetryEventHandlerMock.setup(tp => tp.publishTelemetry(SWITCH_BACK_TO_TARGET, payload)).verifiable(Times.once());
+        const tabId: number = -1;
 
-        setupRegisterTypeToPayloadCallbackMock(Messages.Tab.Switch, payload, tabId);
+        const interpreterMock = createInterpreterMock(Messages.Tab.Switch, payload, tabId);
 
-        testObject.registerCallbacks();
+        const testSubject = new TabActionCreator(interpreterMock.object, null, browserAdapterMock.object, telemetryEventHandlerMock.object);
 
-        telemetryEventHandlerMock.verifyAll();
-        browserAdapterMock.verifyAll();
+        testSubject.registerCallbacks();
+
+        browserAdapterMock.verify(ba => ba.switchToTab(tabId), Times.once());
+        telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(SWITCH_BACK_TO_TARGET, payload), Times.once());
     });
 
-    test('on Tab.VisibilityChange', () => {
+    it('handles Tab.VisibilityChange message', () => {
         const payload: PageVisibilityChangeTabPayload = {
             hidden: true,
         };
 
-        const actionMock = createActionMock(payload.hidden);
-        setupTabActionsMock('tabVisibilityChange', actionMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.Tab.VisibilityChange, payload, tabId);
+        const tabVisibilityChangeMock = createActionMock(payload.hidden);
+        const actionsMock = createActionsMock('tabVisibilityChange', tabVisibilityChangeMock.object);
+        const interpreterMock = createInterpreterMock(Messages.Tab.VisibilityChange, payload);
 
-        testObject.registerCallbacks();
-        actionMock.verifyAll();
+        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null);
+
+        testSubject.registerCallbacks();
+
+        tabVisibilityChangeMock.verifyAll();
     });
 
-    function setupTabActionsMock(actionName: keyof TabActions, actionMock: IMock<Action<any>>): void {
-        tabActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);
-    }
-
-    function setupRegisterTypeToPayloadCallbackMock(message: string, actionPayload: any, listeningTabId: number): void {
-        registerTypeToPayloadCallbackMock
-            .setup(regitrar => regitrar(message, It.is(param => _.isFunction(param))))
-            .callback((passedMessage, handler) => handler(actionPayload, listeningTabId));
+    function createActionsMock<ActionName extends keyof TabActions>(
+        actionName: ActionName,
+        action: TabActions[ActionName],
+    ): IMock<TabActions> {
+        const actionsMock = Mock.ofType<TabActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
     }
 });

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -1,14 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseActionPayload, UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
-import { isFunction } from 'lodash';
-import { IMock, It, Mock, Times } from 'typemoq';
+import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
+import { IMock, Mock } from 'typemoq';
+
 import { UnifiedScanResultActionCreator } from '../../../../../background/actions/unified-scan-result-action-creator';
 import { UnifiedScanResultActions } from '../../../../../background/actions/unified-scan-result-actions';
-import { Interpreter } from '../../../../../background/interpreter';
-import { Action } from '../../../../../common/flux/action';
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
+import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('UnifiedScanResultActionCreator', () => {
     it('should handle ScanCompleted message', () => {
@@ -42,12 +41,6 @@ describe('UnifiedScanResultActionCreator', () => {
         getCurrentStateMock.verifyAll();
     });
 
-    function createActionMock<Payload>(payload: Payload): IMock<Action<Payload>> {
-        const actionMock = Mock.ofType<Action<Payload>>(Action);
-        actionMock.setup(action => action.invoke(payload)).verifiable(Times.once());
-        return actionMock;
-    }
-
     function createActionsMock<ActionName extends keyof UnifiedScanResultActions>(
         actionName: ActionName,
         action: UnifiedScanResultActions[ActionName],
@@ -55,13 +48,5 @@ describe('UnifiedScanResultActionCreator', () => {
         const actionsMock = Mock.ofType<UnifiedScanResultActions>();
         actionsMock.setup(actions => actions[actionName]).returns(() => action);
         return actionsMock;
-    }
-
-    function createInterpreterMock<Payload>(message: string, payload: Payload): IMock<Interpreter> {
-        const interpreterMock = Mock.ofType<Interpreter>();
-        interpreterMock
-            .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
-            .callback((_, handler) => handler(payload));
-        return interpreterMock;
     }
 });

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -1,66 +1,67 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseActionPayload } from 'background/actions/action-payloads';
+import { BaseActionPayload, UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
 import { isFunction } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { UnifiedScanResultActionCreator } from '../../../../../background/actions/unified-scan-result-action-creator';
 import { UnifiedScanResultActions } from '../../../../../background/actions/unified-scan-result-actions';
+import { Interpreter } from '../../../../../background/interpreter';
 import { Action } from '../../../../../common/flux/action';
-import { RegisterTypeToPayloadCallback } from '../../../../../common/message';
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
 
 describe('UnifiedScanResultActionCreator', () => {
-    let scanResultActionsMock: IMock<UnifiedScanResultActions>;
-    let registerTypeToPayloadCallbackMock: IMock<RegisterTypeToPayloadCallback>;
-
-    let testSubject: UnifiedScanResultActionCreator;
-
-    beforeEach(() => {
-        scanResultActionsMock = Mock.ofType<UnifiedScanResultActions>();
-        registerTypeToPayloadCallbackMock = Mock.ofType<RegisterTypeToPayloadCallback>();
-
-        testSubject = new UnifiedScanResultActionCreator(scanResultActionsMock.object, registerTypeToPayloadCallbackMock.object);
-    });
-
-    it('registerCallbacks for ScanCompleted', () => {
-        const payload: BaseActionPayload = {};
+    it('should handle ScanCompleted message', () => {
+        const payload: UnifiedScanCompletedPayload = {
+            scanResult: [],
+            rules: [],
+        };
 
         const scanCompletedMock = createActionMock(payload);
-        setupScanResultActionsMock('scanCompleted', scanCompletedMock);
-        setupRegisterTypeToPayloadCallbackMock(Messages.UnifiedScan.ScanCompleted, payload);
+        const actionsMock = createActionsMock('scanCompleted', scanCompletedMock.object);
+        const interpreterMock = createInterpreterMock(Messages.UnifiedScan.ScanCompleted, payload);
+
+        const testSubject = new UnifiedScanResultActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallbacks();
 
         scanCompletedMock.verifyAll();
     });
 
-    it('registerCallbacks for getCurrentState', () => {
-        const payload: BaseActionPayload = null;
+    it('should handle GetState message', () => {
+        const payload = null;
 
-        const getCurrentStateMock = createActionMock(payload);
-        setupScanResultActionsMock('getCurrentState', getCurrentStateMock);
-        setupRegisterTypeToPayloadCallbackMock(getStoreStateMessage(StoreNames.UnifiedScanResultStore), payload);
+        const getCurrentStateMock = createActionMock<null>(payload);
+        const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
+        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.UnifiedScanResultStore), payload);
+
+        const testSubject = new UnifiedScanResultActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallbacks();
 
         getCurrentStateMock.verifyAll();
     });
 
-    function createActionMock<T>(actionPayload: T): IMock<Action<T>> {
-        const actionMock = Mock.ofType<Action<T>>(Action);
-        actionMock.setup(action => action.invoke(actionPayload)).verifiable(Times.once());
-
+    function createActionMock<Payload>(payload: Payload): IMock<Action<Payload>> {
+        const actionMock = Mock.ofType<Action<Payload>>(Action);
+        actionMock.setup(action => action.invoke(payload)).verifiable(Times.once());
         return actionMock;
     }
 
-    function setupScanResultActionsMock(actionName: keyof UnifiedScanResultActions, actionMock: IMock<Action<any>>): void {
-        scanResultActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);
+    function createActionsMock<ActionName extends keyof UnifiedScanResultActions>(
+        actionName: ActionName,
+        action: UnifiedScanResultActions[ActionName],
+    ): IMock<UnifiedScanResultActions> {
+        const actionsMock = Mock.ofType<UnifiedScanResultActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
     }
 
-    function setupRegisterTypeToPayloadCallbackMock(message: string, payload: any): void {
-        registerTypeToPayloadCallbackMock
-            .setup(registrar => registrar(message, It.is(isFunction)))
-            .callback((passedMessage, listener) => listener(payload));
+    function createInterpreterMock<Payload>(message: string, payload: Payload): IMock<Interpreter> {
+        const interpreterMock = Mock.ofType<Interpreter>();
+        interpreterMock
+            .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
+            .callback((_, handler) => handler(payload));
+        return interpreterMock;
     }
 });

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
+import { UnifiedScanResultActionCreator } from 'background/actions/unified-scan-result-action-creator';
+import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { StoreNames } from 'common/stores/store-names';
 import { IMock, Mock } from 'typemoq';
 
-import { UnifiedScanResultActionCreator } from '../../../../../background/actions/unified-scan-result-action-creator';
-import { UnifiedScanResultActions } from '../../../../../background/actions/unified-scan-result-actions';
-import { getStoreStateMessage, Messages } from '../../../../../common/messages';
-import { StoreNames } from '../../../../../common/stores/store-names';
 import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('UnifiedScanResultActionCreator', () => {

--- a/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
+++ b/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Action } from 'common/flux/action';
+import { isFunction } from 'lodash';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { Interpreter } from '../../../../../background/interpreter';
+
+export const createActionMock = <Payload>(payload: Payload): IMock<Action<Payload>> => {
+    const actionMock = Mock.ofType<Action<Payload>>(Action);
+    actionMock.setup(action => action.invoke(payload)).verifiable(Times.once());
+    return actionMock;
+};
+
+export const createInterpreterMock = <Payload>(message: string, payload: Payload): IMock<Interpreter> => {
+    const interpreterMock = Mock.ofType<Interpreter>();
+    interpreterMock
+        .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
+        .callback((_, handler) => handler(payload));
+    return interpreterMock;
+};

--- a/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
+++ b/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Interpreter } from 'background/interpreter';
 import { Action } from 'common/flux/action';
 import { isFunction } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
-import { Interpreter } from '../../../../../background/interpreter';
 
 export const createActionMock = <Payload>(payload: Payload): IMock<Action<Payload>> => {
     const actionMock = Mock.ofType<Action<Payload>>(Action);

--- a/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
+++ b/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
@@ -11,10 +11,16 @@ export const createActionMock = <Payload>(payload: Payload): IMock<Action<Payloa
     return actionMock;
 };
 
-export const createInterpreterMock = <Payload>(message: string, payload: Payload): IMock<Interpreter> => {
+export const createInterpreterMock = <Payload>(message: string, payload: Payload, tabId?: number): IMock<Interpreter> => {
     const interpreterMock = Mock.ofType<Interpreter>();
     interpreterMock
         .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
-        .callback((_, handler) => handler(payload));
+        .callback((_, handler) => {
+            if (tabId) {
+                handler(payload, tabId);
+            } else {
+                handler(payload);
+            }
+        });
     return interpreterMock;
 };

--- a/src/tests/unit/tests/background/global-action-creators/feature-flags-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/feature-flags-action-creator.test.ts
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
-import { IMock, It, Mock, Times } from 'typemoq';
-
 import { FeatureFlagActions, FeatureFlagPayload } from 'background/actions/feature-flag-actions';
 import { FeatureFlagsActionCreator } from 'background/global-action-creators/feature-flags-action-creator';
 import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { Action } from '../../../../../common/flux/action';
+import { isFunction } from 'lodash';
+import { IMock, It, Mock } from 'typemoq';
+
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
+import { createActionMock } from './action-creator-test-helpers';
 
 describe('FeatureFlagsActionCreator', () => {
     let interpreterMock: IMock<Interpreter>;
@@ -31,7 +31,7 @@ describe('FeatureFlagsActionCreator', () => {
 
         setupInterpreterMock(expectedMessage);
 
-        const getCurrentStateMock = createActionMock();
+        const getCurrentStateMock = createActionMock(null);
 
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
 
@@ -64,7 +64,7 @@ describe('FeatureFlagsActionCreator', () => {
 
         setupInterpreterMock(expectedMessage);
 
-        const resetFeatureFlagMock = createActionMock();
+        const resetFeatureFlagMock = createActionMock(null);
 
         setupActionsMock('resetFeatureFlags', resetFeatureFlagMock.object);
 
@@ -83,14 +83,6 @@ describe('FeatureFlagsActionCreator', () => {
                     handler();
                 }
             });
-    };
-
-    const createActionMock = <Payload = void>(payload: Payload = null): IMock<Action<Payload>> => {
-        const actionMock = Mock.ofType<Action<Payload>>();
-
-        actionMock.setup(action => action.invoke(payload)).verifiable(Times.once());
-
-        return actionMock;
     };
 
     const setupActionsMock = <ActionName extends keyof FeatureFlagActions>(

--- a/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
-import { IMock, It, Mock, Times } from 'typemoq';
-
 import { ScopingActions, ScopingPayload } from 'background/actions/scoping-actions';
 import { ScopingActionCreator } from 'background/global-action-creators/scoping-action-creator';
 import { Interpreter } from 'background/interpreter';
-import { Action } from '../../../../../common/flux/action';
+import { isFunction } from 'lodash';
+import { IMock, It, Mock } from 'typemoq';
+
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
+import { createActionMock } from './action-creator-test-helpers';
 
 describe('ScopingActionCreator', () => {
     let interpreterMock: IMock<Interpreter>;
@@ -28,7 +28,7 @@ describe('ScopingActionCreator', () => {
 
         setupInterpreterMock(expectedMessage);
 
-        const getCurrentStateMock = createActionMock();
+        const getCurrentStateMock = createActionMock(null);
 
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
 
@@ -85,14 +85,6 @@ describe('ScopingActionCreator', () => {
                     handler();
                 }
             });
-    };
-
-    const createActionMock = <Payload = void>(payload: Payload = null): IMock<Action<Payload>> => {
-        const actionMock = Mock.ofType<Action<Payload>>();
-
-        actionMock.setup(action => action.invoke(payload)).verifiable(Times.once());
-
-        return actionMock;
     };
 
     const setupActionsMock = <ActionName extends keyof ScopingActions>(actionName: ActionName, action: ScopingActions[ActionName]) => {

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -9,14 +9,12 @@ import {
 } from 'background/actions/action-payloads';
 import { UserConfigurationActions } from 'background/actions/user-configuration-actions';
 import { UserConfigurationActionCreator } from 'background/global-action-creators/user-configuration-action-creator';
-import { Interpreter } from 'background/interpreter';
-import { isFunction } from 'lodash';
-import { IMock, It, Mock, Times } from 'typemoq';
+import { IMock, Mock } from 'typemoq';
 
-import { Action } from '../../../../../common/flux/action';
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import { TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
+import { createActionMock, createInterpreterMock } from './action-creator-test-helpers';
 
 describe('UserConfigurationActionCreator', () => {
     it('handles GetCurrentState message', () => {
@@ -83,14 +81,14 @@ describe('UserConfigurationActionCreator', () => {
             propertyName: 'property-name',
             propertyValue: 'property-value',
         };
-        const setIssuFilingServicePropertyMock = createActionMock(payload);
-        const actionsMock = createActionsMock('setIssueFilingServiceProperty', setIssuFilingServicePropertyMock.object);
+        const setIssueFilingServicePropertyMock = createActionMock(payload);
+        const actionsMock = createActionsMock('setIssueFilingServiceProperty', setIssueFilingServicePropertyMock.object);
         const interpreterMock = createInterpreterMock(Messages.UserConfig.SetIssueFilingServiceProperty, payload);
         const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
 
         testSubject.registerCallback();
 
-        setIssuFilingServicePropertyMock.verifyAll();
+        setIssueFilingServicePropertyMock.verifyAll();
     });
 
     it('should SaveIssueFilingSettings message', () => {
@@ -108,12 +106,6 @@ describe('UserConfigurationActionCreator', () => {
         setIssueFilingSettings.verifyAll();
     });
 
-    function createActionMock<Payload>(payload: Payload): IMock<Action<Payload>> {
-        const actionMock = Mock.ofType<Action<Payload>>();
-        actionMock.setup(action => action.invoke(payload)).verifiable(Times.once());
-        return actionMock;
-    }
-
     function createActionsMock<ActionName extends keyof UserConfigurationActions>(
         actionName: ActionName,
         action: UserConfigurationActions[ActionName],
@@ -121,13 +113,5 @@ describe('UserConfigurationActionCreator', () => {
         const actionsMock = Mock.ofType<UserConfigurationActions>();
         actionsMock.setup(actions => actions[actionName]).returns(() => action);
         return actionsMock;
-    }
-
-    function createInterpreterMock<Payload>(message: string, payload: Payload): IMock<Interpreter> {
-        const interpreterMock = Mock.ofType<Interpreter>();
-        interpreterMock
-            .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))
-            .callback((_, handler) => handler(payload));
-        return interpreterMock;
     }
 });


### PR DESCRIPTION
#### Description of changes

While working on implementing the flux architecture for the electron app, I found we should be able to reuse the background-side action creators from the browser extension, but in order to do so, it is needed that all action creators are "created equal" (in the sense of using the `Interpreter` to register callbacks for messages instead of directly using `registerTypeToPayloadCallback` to do so).

This PR update all action creators (and tests) to use `Interpreter` directly.

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1597954
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
