### PR TITLE
refactor: Wrapping the output of path.resolve in Gruntfile with double quotes.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -145,10 +145,10 @@ module.exports = function(grunt) {
             },
         },
         exec: {
-            'webpack-dev': `${path.resolve('./node_modules/.bin/webpack')} --config-name dev`,
-            'webpack-prod': `${path.resolve('./node_modules/.bin/webpack')} --config-name prod`,
-            'webpack-electron': `${path.resolve('./node_modules/.bin/webpack')} --config-name electron`,
-            'generate-scss-typings': `${path.resolve('./node_modules/.bin/tsm')} src`,
+            'webpack-dev': `"${path.resolve('./node_modules/.bin/webpack')}" --config-name dev`,
+            'webpack-prod': `"${path.resolve('./node_modules/.bin/webpack')}" --config-name prod`,
+            'webpack-electron': `"${path.resolve('./node_modules/.bin/webpack')}" --config-name electron`,
+            'generate-scss-typings': `"${path.resolve('./node_modules/.bin/tsm')}" src`,
         },
         sass: {
             options: {


### PR DESCRIPTION
### Description of changes
`yarn build` failed when being run from a file path where a folder had a space in it. Wrapping path.resolve() calls in Gruntfile tasks with double quotes to prevent the issue.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
