### PR TITLE
refactor: Make PayloadCallback a more strict type

### DIFF
--- a/src/background/actions/content-action-creator.ts
+++ b/src/background/actions/content-action-creator.ts
@@ -18,22 +18,20 @@ export class ContentActionCreator {
     ) {}
 
     public registerCallbacks(): void {
-        this.interpreter.registerTypeToPayloadCallback(Messages.ContentPanel.OpenPanel, (payload, tabId) =>
-            this.onOpenContentPanel(payload, tabId),
-        );
-        this.interpreter.registerTypeToPayloadCallback(Messages.ContentPanel.ClosePanel, payload => this.onCloseContentPanel(payload));
+        this.interpreter.registerTypeToPayloadCallback(Messages.ContentPanel.OpenPanel, this.onOpenContentPanel);
+        this.interpreter.registerTypeToPayloadCallback(Messages.ContentPanel.ClosePanel, this.onCloseContentPanel);
     }
 
-    private onOpenContentPanel(payload: ContentPayload, tabId: number): void {
+    private onOpenContentPanel = (payload: ContentPayload, tabId: number): void => {
         this.contentActions.openContentPanel.invoke(payload);
         this.showDetailsView(tabId);
         this.telemetryEventHandler.publishTelemetry(CONTENT_PANEL_OPENED, payload);
-    }
+    };
 
-    private onCloseContentPanel(payload: BaseActionPayload): void {
+    private onCloseContentPanel = (payload: BaseActionPayload): void => {
         this.contentActions.closeContentPanel.invoke(null);
         this.telemetryEventHandler.publishTelemetry(CONTENT_PANEL_CLOSED, payload);
-    }
+    };
 
     private showDetailsView(tabId: number): void {
         this.detailsViewController.showDetailsView(tabId);

--- a/src/background/actions/dev-tools-action-creator.ts
+++ b/src/background/actions/dev-tools-action-creator.ts
@@ -17,33 +17,24 @@ export class DevToolsActionCreator {
     ) {}
 
     public registerCallbacks(): void {
-        this.interpreter.registerTypeToPayloadCallback(Messages.DevTools.DevtoolStatus, payload => this.onDevToolOpened(payload));
-
-        this.interpreter.registerTypeToPayloadCallback(Messages.DevTools.InspectElement, payload => this.onDevToolInspectElement(payload));
-
-        this.interpreter.registerTypeToPayloadCallback(Messages.DevTools.InspectFrameUrl, payload =>
-            this.onDevToolInspectFrameUrl(payload),
-        );
-
-        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.DevToolsStore), () =>
-            this.onDevToolGetCurrentState(),
-        );
+        this.interpreter.registerTypeToPayloadCallback(Messages.DevTools.DevtoolStatus, this.onDevToolOpened);
+        this.interpreter.registerTypeToPayloadCallback(Messages.DevTools.InspectElement, this.onDevToolInspectElement);
+        this.interpreter.registerTypeToPayloadCallback(Messages.DevTools.InspectFrameUrl, this.onDevToolInspectFrameUrl);
+        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.DevToolsStore), this.onDevToolGetCurrentState);
     }
 
-    private onDevToolOpened(payload: OnDevToolOpenPayload): void {
+    private onDevToolOpened = (payload: OnDevToolOpenPayload): void => {
         this.devToolActions.setDevToolState.invoke(payload.status);
-    }
+    };
 
-    private onDevToolInspectElement(payload: InspectElementPayload): void {
+    private onDevToolInspectElement = (payload: InspectElementPayload): void => {
         this.devToolActions.setInspectElement.invoke(payload.target);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.INSPECT_OPEN, payload);
-    }
+    };
 
-    private onDevToolInspectFrameUrl(payload: InspectFrameUrlPayload): void {
+    private onDevToolInspectFrameUrl = (payload: InspectFrameUrlPayload): void => {
         this.devToolActions.setFrameUrl.invoke(payload.frameUrl);
-    }
+    };
 
-    private onDevToolGetCurrentState(): void {
-        this.devToolActions.getCurrentState.invoke(null);
-    }
+    private onDevToolGetCurrentState = (): void => this.devToolActions.getCurrentState.invoke(null);
 }

--- a/src/background/actions/tab-action-creator.ts
+++ b/src/background/actions/tab-action-creator.ts
@@ -7,7 +7,7 @@ import { SWITCH_BACK_TO_TARGET } from 'common/telemetry-events';
 
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
-import { SwitchToTargetTabPayload } from './action-payloads';
+import { PageVisibilityChangeTabPayload, SwitchToTargetTabPayload } from './action-payloads';
 import { TabActions } from './tab-actions';
 
 export class TabActionCreator {
@@ -25,14 +25,14 @@ export class TabActionCreator {
         );
         this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Remove, () => this.tabActions.tabRemove.invoke(null));
         this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Change, payload => this.tabActions.tabChange.invoke(payload));
-        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Switch, (payload, tabId) => this.onSwitchToTargetTab(payload, tabId));
-        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.VisibilityChange, payload =>
+        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Switch, this.onSwitchToTargetTab);
+        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.VisibilityChange, (payload: PageVisibilityChangeTabPayload) =>
             this.tabActions.tabVisibilityChange.invoke(payload.hidden),
         );
     }
 
-    private onSwitchToTargetTab(payload: SwitchToTargetTabPayload, tabId: number): void {
+    private onSwitchToTargetTab = (payload: SwitchToTargetTabPayload, tabId: number): void => {
         this.browserAdapter.switchToTab(tabId);
         this.telemetryEventHandler.publishTelemetry(SWITCH_BACK_TO_TARGET, payload);
-    }
+    };
 }

--- a/src/background/interpreter.ts
+++ b/src/background/interpreter.ts
@@ -4,9 +4,9 @@ import { InterpreterMessage, PayloadCallback } from '../common/message';
 import { DictionaryStringTo } from '../types/common-types';
 
 export class Interpreter {
-    protected messageToActionMapping: DictionaryStringTo<PayloadCallback> = {};
+    protected messageToActionMapping: DictionaryStringTo<PayloadCallback<any>> = {};
 
-    public registerTypeToPayloadCallback = (messageType: string, callback: PayloadCallback): void => {
+    public registerTypeToPayloadCallback = <Payload>(messageType: string, callback: PayloadCallback<Payload>): void => {
         this.messageToActionMapping[messageType] = callback;
     };
 

--- a/src/common/message.ts
+++ b/src/common/message.ts
@@ -7,10 +7,10 @@ export interface Message {
 
 export type InterpreterMessage = Message & { tabId?: number };
 
-export interface PayloadCallback {
-    (payload: any, tabId): void;
+export interface PayloadCallback<Payload> {
+    (payload: Payload, tabId: number): void;
 }
 
-export interface RegisterTypeToPayloadCallback {
-    (messageType: string, callback: PayloadCallback): void;
+export interface RegisterTypeToPayloadCallback<Payload> {
+    (messageType: string, callback: PayloadCallback<Payload>): void;
 }

--- a/src/tests/unit/tests/background/interpreter.test.ts
+++ b/src/tests/unit/tests/background/interpreter.test.ts
@@ -6,11 +6,11 @@ import { PayloadCallback } from '../../../../common/message';
 import { DictionaryStringTo } from '../../../../types/common-types';
 
 class TestableInterpreter extends Interpreter {
-    public getMessageToActionMapping(): DictionaryStringTo<PayloadCallback> {
+    public getMessageToActionMapping(): DictionaryStringTo<PayloadCallback<any>> {
         return this.messageToActionMapping;
     }
 
-    public setMessageToActionMapping(messageToActionMapping: DictionaryStringTo<PayloadCallback>): void {
+    public setMessageToActionMapping(messageToActionMapping: DictionaryStringTo<PayloadCallback<any>>): void {
         this.messageToActionMapping = messageToActionMapping;
     }
 }


### PR DESCRIPTION
#### Description of changes

_**Note**: This is part of the Telemetry Opt-In feature for electron AI_

Make `PayloadCallback` type use a template type for the `payload` parameter. This way we have type info when calling `RegisterTypeToPayloadCallback` (usually on the action creators).

This is part of a bigger refactor where we're trying to make the action message creator and action creator to have the same public API, this way we can use one or the other on the view. The use case for this is the telemetry opt in dialog, which is currently being use on the popup and we want to reuse on the electron app.

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1597954
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
