### PR TITLE
feature: create UserConfigStore in electron view initializer

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -7,6 +7,7 @@ import { Store } from 'idb-keyval';
 import { AxeInfo } from '../common/axe-info';
 import { ChromeAdapter } from '../common/browser-adapters/chrome-adapter';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
+import { COMMON_CONSTANTS } from '../common/constants';
 import { EnvironmentInfoProvider } from '../common/environment-info-provider';
 import { IndexedDBAPI, IndexedDBUtil } from '../common/indexedDB/indexedDB';
 import { InsightsFeatureFlags } from '../common/insights-feature-flags';
@@ -39,13 +40,10 @@ import { UserStoredDataCleaner } from './user-stored-data-cleaner';
 
 declare var window: Window & InsightsFeatureFlags;
 
-const defaultIndexedDBName: string = 'default-db';
-const defaultIndexedDBStoreName: string = 'default-store';
-
 const browserAdapter = new ChromeAdapter();
 const urlValidator = new UrlValidator(browserAdapter);
 const backgroundInitCleaner = new UserStoredDataCleaner(browserAdapter);
-const store = new Store(defaultIndexedDBName, defaultIndexedDBStoreName);
+const store = new Store(COMMON_CONSTANTS.defaultIndexedDBName, COMMON_CONSTANTS.defaultIndexedDBStoreName);
 const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(store);
 
 backgroundInitCleaner.cleanUserData(deprecatedStorageDataKeys);

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -27,3 +27,11 @@ export function getPersistedData(indexedDBInstance: IndexedDBAPI): Promise<Persi
 
     return Promise.all(promises).then(() => persistedData);
 }
+
+export async function getPersistedUserConfigData(indexedDBInstance: IndexedDBAPI): Promise<Partial<PersistedData>> {
+    const persistedData = {} as Partial<PersistedData>;
+    await indexedDBInstance.getItem(IndexedDBDataKeys.userConfiguration).then(userConfig => {
+        persistedData.userConfigurationData = userConfig;
+    });
+    return persistedData;
+}

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 export const COMMON_CONSTANTS = {
     defaultIndexedDBName: 'default-db',
     defaultIndexedDBStoreName: 'default-store',

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,4 @@
+export const COMMON_CONSTANTS = {
+    defaultIndexedDBName: 'default-db',
+    defaultIndexedDBStoreName: 'default-store',
+};

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { remote } from 'electron';
-import { Store } from 'idb-keyval';
+import { Store as IndexedDBStore } from 'idb-keyval';
 import * as ReactDOM from 'react-dom';
 
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
@@ -10,28 +10,18 @@ import { UserConfigurationStore } from '../../background/stores/global/user-conf
 import { COMMON_CONSTANTS } from '../../common/constants';
 import { initializeFabricIcons } from '../../common/fabric-icons';
 import { IndexedDBAPI, IndexedDBUtil } from '../../common/indexedDB/indexedDB';
-import { StoreNames } from '../../common/stores/store-names';
-import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
-
-function createUserConfigStore(
-    persistedState: UserConfigurationStoreData,
-    userConfigActionsLocal: UserConfigurationActions,
-    indexedDBAPI: IndexedDBAPI,
-): UserConfigurationStore {
-    const userConfigurationStore = new UserConfigurationStore(persistedState, userConfigActionsLocal, indexedDBAPI);
-    return userConfigurationStore;
-}
 
 initializeFabricIcons();
 
-const store = new Store(COMMON_CONSTANTS.defaultIndexedDBName, COMMON_CONSTANTS.defaultIndexedDBStoreName);
-const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(store);
+const indexedDBStore = new IndexedDBStore(COMMON_CONSTANTS.defaultIndexedDBName, COMMON_CONSTANTS.defaultIndexedDBStoreName);
+const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(indexedDBStore);
 const userConfigActions = new UserConfigurationActions();
 
 // tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
 getPersistedUserConfigData(indexedDBInstance).then((persistedData: Partial<PersistedData>) => {
-    createUserConfigStore(persistedData.userConfigurationData, userConfigActions, indexedDBInstance);
+    const userConfigurationStore = new UserConfigurationStore(persistedData.userConfigurationData, userConfigActions, indexedDBInstance);
+
     const dom = document;
     const renderer = new DeviceConnectViewRenderer(ReactDOM.render, dom, remote.getCurrentWindow());
     renderer.render();

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -1,12 +1,38 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { remote } from 'electron';
+import { Store } from 'idb-keyval';
 import * as ReactDOM from 'react-dom';
+
+import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
+import { getPersistedUserConfigData, PersistedData } from '../../background/get-persisted-data';
+import { UserConfigurationStore } from '../../background/stores/global/user-configuration-store';
+import { COMMON_CONSTANTS } from '../../common/constants';
 import { initializeFabricIcons } from '../../common/fabric-icons';
+import { IndexedDBAPI, IndexedDBUtil } from '../../common/indexedDB/indexedDB';
+import { StoreNames } from '../../common/stores/store-names';
+import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
+
+function createUserConfigStore(
+    persistedState: UserConfigurationStoreData,
+    userConfigActionsLocal: UserConfigurationActions,
+    indexedDBAPI: IndexedDBAPI,
+): UserConfigurationStore {
+    const userConfigurationStore = new UserConfigurationStore(persistedState, userConfigActionsLocal, indexedDBAPI);
+    return userConfigurationStore;
+}
 
 initializeFabricIcons();
 
-const dom = document;
-const renderer = new DeviceConnectViewRenderer(ReactDOM.render, dom, remote.getCurrentWindow());
-renderer.render();
+const store = new Store(COMMON_CONSTANTS.defaultIndexedDBName, COMMON_CONSTANTS.defaultIndexedDBStoreName);
+const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(store);
+const userConfigActions = new UserConfigurationActions();
+
+// tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
+getPersistedUserConfigData(indexedDBInstance).then((persistedData: Partial<PersistedData>) => {
+    createUserConfigStore(persistedData.userConfigurationData, userConfigActions, indexedDBInstance);
+    const dom = document;
+    const renderer = new DeviceConnectViewRenderer(ReactDOM.render, dom, remote.getCurrentWindow());
+    renderer.render();
+});

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -20,6 +20,7 @@ const userConfigActions = new UserConfigurationActions();
 
 // tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
 getPersistedUserConfigData(indexedDBInstance).then((persistedData: Partial<PersistedData>) => {
+    // tslint:disable-next-line:no-unused-variable
     const userConfigurationStore = new UserConfigurationStore(persistedData.userConfigurationData, userConfigActions, indexedDBInstance);
 
     const dom = document;

--- a/src/tests/unit/tests/background/get-persisted-data.test.ts
+++ b/src/tests/unit/tests/background/get-persisted-data.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { getPersistedData, getPersistedUserConfigData, PersistedData } from 'background/get-persisted-data';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { IMock, Mock } from 'typemoq';
 
-import { getPersistedData, PersistedData } from 'background/get-persisted-data';
-import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { IndexedDBAPI } from '../../../../common/indexedDB/indexedDB';
 import { AssessmentStoreData, PersistedTabInfo } from '../../../../common/types/store-data/assessment-result-data';
 import { UserConfigurationStoreData } from '../../../../common/types/store-data/user-configuration-store';
@@ -40,5 +40,14 @@ describe('GetPersistedDataTest', () => {
             assessmentStoreData: assessmentStoreData,
             userConfigurationData: userConfigurationData,
         } as PersistedData);
+    });
+
+    it('gets only the userconfigData when its called for', async () => {
+        indexedDBInstanceStrictMock.setup(i => i.getItem(IndexedDBDataKeys.userConfiguration)).returns(async () => userConfigurationData);
+        const data = await getPersistedUserConfigData(indexedDBInstanceStrictMock.object);
+
+        expect(data).toEqual({
+            userConfigurationData: userConfigurationData,
+        } as Partial<PersistedData>);
     });
 });


### PR DESCRIPTION
#### Description of changes

Create UserConfigStore in `device-connect-view-initializer.ts` for electron initialization with UserConfig persisted data.


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes AD #1597951
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
