### PR TITLE
feature: create UserConfigStore in electron view initializer

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -7,6 +7,7 @@ import { Store } from 'idb-keyval';
 import { AxeInfo } from '../common/axe-info';
 import { ChromeAdapter } from '../common/browser-adapters/chrome-adapter';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
+import { COMMON_CONSTANTS } from '../common/constants';
 import { EnvironmentInfoProvider } from '../common/environment-info-provider';
 import { IndexedDBAPI, IndexedDBUtil } from '../common/indexedDB/indexedDB';
 import { InsightsFeatureFlags } from '../common/insights-feature-flags';
@@ -39,13 +40,10 @@ import { UserStoredDataCleaner } from './user-stored-data-cleaner';
 
 declare var window: Window & InsightsFeatureFlags;
 
-const defaultIndexedDBName: string = 'default-db';
-const defaultIndexedDBStoreName: string = 'default-store';
-
 const browserAdapter = new ChromeAdapter();
 const urlValidator = new UrlValidator(browserAdapter);
 const backgroundInitCleaner = new UserStoredDataCleaner(browserAdapter);
-const store = new Store(defaultIndexedDBName, defaultIndexedDBStoreName);
+const store = new Store(COMMON_CONSTANTS.defaultIndexedDBName, COMMON_CONSTANTS.defaultIndexedDBStoreName);
 const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(store);
 
 backgroundInitCleaner.cleanUserData(deprecatedStorageDataKeys);

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -2,13 +2,12 @@
 // Licensed under the MIT License.
 import { AppInsights } from 'applicationinsights-js';
 import { Assessments } from 'assessments/assessments';
-import { Store } from 'idb-keyval';
 
 import { AxeInfo } from '../common/axe-info';
 import { ChromeAdapter } from '../common/browser-adapters/chrome-adapter';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
-import { COMMON_CONSTANTS } from '../common/constants';
 import { EnvironmentInfoProvider } from '../common/environment-info-provider';
+import { getIndexedDBStore } from '../common/indexedDB/get-indexeddb-store';
 import { IndexedDBAPI, IndexedDBUtil } from '../common/indexedDB/indexedDB';
 import { InsightsFeatureFlags } from '../common/insights-feature-flags';
 import { createDefaultLogger } from '../common/logging/default-logger';
@@ -44,8 +43,7 @@ declare var window: Window & InsightsFeatureFlags;
 const browserAdapter = new ChromeAdapter();
 const urlValidator = new UrlValidator(browserAdapter);
 const backgroundInitCleaner = new UserStoredDataCleaner(browserAdapter);
-const store = new Store(COMMON_CONSTANTS.defaultIndexedDBName, COMMON_CONSTANTS.defaultIndexedDBStoreName);
-const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(store);
+const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(getIndexedDBStore());
 const indexedDBDataKeysToFetch = [IndexedDBDataKeys.assessmentStore, IndexedDBDataKeys.userConfiguration];
 
 backgroundInitCleaner.cleanUserData(deprecatedStorageDataKeys);

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -24,6 +24,7 @@ import { DetailsViewController } from './details-view-controller';
 import { DevToolsListener } from './dev-tools-listener';
 import { getPersistedData, PersistedData } from './get-persisted-data';
 import { GlobalContextFactory } from './global-context-factory';
+import { IndexedDBDataKeys } from './IndexedDBDataKeys';
 import { deprecatedStorageDataKeys, storageDataKeys } from './local-storage-data-keys';
 import { MessageDistributor } from './message-distributor';
 import { LocalStorageData } from './storage-data';
@@ -45,11 +46,12 @@ const urlValidator = new UrlValidator(browserAdapter);
 const backgroundInitCleaner = new UserStoredDataCleaner(browserAdapter);
 const store = new Store(COMMON_CONSTANTS.defaultIndexedDBName, COMMON_CONSTANTS.defaultIndexedDBStoreName);
 const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(store);
+const indexedDBDataKeysToFetch = [IndexedDBDataKeys.assessmentStore, IndexedDBDataKeys.userConfiguration];
 
 backgroundInitCleaner.cleanUserData(deprecatedStorageDataKeys);
 
 // tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
-getPersistedData(indexedDBInstance).then((persistedData: PersistedData) => {
+getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedData: PersistedData) => {
     browserAdapter.getUserData(storageDataKeys, (userData: LocalStorageData) => {
         const assessmentsProvider = Assessments;
         const windowUtils = new WindowUtils();

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -9,29 +9,14 @@ export interface PersistedData {
     assessmentStoreData: AssessmentStoreData;
     userConfigurationData: UserConfigurationStoreData;
 }
-export function getPersistedData(indexedDBInstance: IndexedDBAPI): Promise<PersistedData> {
+export function getPersistedData(indexedDBInstance: IndexedDBAPI, dataKeysToFetch: string[]): Promise<PersistedData> {
     const persistedData = {} as PersistedData;
 
-    const promises: Array<Promise<any>> = [];
-
-    promises.push(
-        indexedDBInstance.getItem(IndexedDBDataKeys.assessmentStore).then(assessmentData => {
+    const promises: Array<Promise<any>> = dataKeysToFetch.map(key => {
+        return indexedDBInstance.getItem(key).then(assessmentData => {
             persistedData.assessmentStoreData = assessmentData;
-        }),
-    );
-    promises.push(
-        indexedDBInstance.getItem(IndexedDBDataKeys.userConfiguration).then(userConfig => {
-            persistedData.userConfigurationData = userConfig;
-        }),
-    );
+        });
+    });
 
     return Promise.all(promises).then(() => persistedData);
-}
-
-export async function getPersistedUserConfigData(indexedDBInstance: IndexedDBAPI): Promise<Partial<PersistedData>> {
-    const persistedData = {} as Partial<PersistedData>;
-    await indexedDBInstance.getItem(IndexedDBDataKeys.userConfiguration).then(userConfig => {
-        persistedData.userConfigurationData = userConfig;
-    });
-    return persistedData;
 }

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -9,12 +9,17 @@ export interface PersistedData {
     assessmentStoreData: AssessmentStoreData;
     userConfigurationData: UserConfigurationStoreData;
 }
+
+const keyToPersistedDataMapping = {
+    [IndexedDBDataKeys.assessmentStore]: 'assessmentStoreData',
+    [IndexedDBDataKeys.userConfiguration]: 'userConfigurationData',
+};
 export function getPersistedData(indexedDBInstance: IndexedDBAPI, dataKeysToFetch: string[]): Promise<PersistedData> {
     const persistedData = {} as PersistedData;
 
     const promises: Array<Promise<any>> = dataKeysToFetch.map(key => {
         return indexedDBInstance.getItem(key).then(assessmentData => {
-            persistedData.assessmentStoreData = assessmentData;
+            persistedData[keyToPersistedDataMapping[key]] = assessmentData;
         });
     });
 

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -27,3 +27,11 @@ export function getPersistedData(indexedDBInstance: IndexedDBAPI): Promise<Persi
 
     return Promise.all(promises).then(() => persistedData);
 }
+
+export async function getPersistedUserConfigData(indexedDBInstance: IndexedDBAPI): Promise<Partial<PersistedData>> {
+    const persistedData = {} as Partial<PersistedData>;
+    await indexedDBInstance.getItem(IndexedDBDataKeys.userConfiguration).then(userConfig => {
+        persistedData.userConfigurationData = userConfig;
+    });
+    return persistedData;
+}

--- a/src/background/get-persisted-data.ts
+++ b/src/background/get-persisted-data.ts
@@ -14,12 +14,13 @@ const keyToPersistedDataMapping = {
     [IndexedDBDataKeys.assessmentStore]: 'assessmentStoreData',
     [IndexedDBDataKeys.userConfiguration]: 'userConfigurationData',
 };
+
 export function getPersistedData(indexedDBInstance: IndexedDBAPI, dataKeysToFetch: string[]): Promise<PersistedData> {
     const persistedData = {} as PersistedData;
 
     const promises: Array<Promise<any>> = dataKeysToFetch.map(key => {
-        return indexedDBInstance.getItem(key).then(assessmentData => {
-            persistedData[keyToPersistedDataMapping[key]] = assessmentData;
+        return indexedDBInstance.getItem(key).then(data => {
+            persistedData[keyToPersistedDataMapping[key]] = data;
         });
     });
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 export const COMMON_CONSTANTS = {
     defaultIndexedDBName: 'default-db',
     defaultIndexedDBStoreName: 'default-store',

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,4 @@
+export const COMMON_CONSTANTS = {
+    defaultIndexedDBName: 'default-db',
+    defaultIndexedDBStoreName: 'default-store',
+};

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,7 +1,0 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
-export const COMMON_CONSTANTS = {
-    defaultIndexedDBName: 'default-db',
-    defaultIndexedDBStoreName: 'default-store',
-};

--- a/src/common/indexedDB/get-indexeddb-store.ts
+++ b/src/common/indexedDB/get-indexeddb-store.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Store as IndexedDBStore } from 'idb-keyval';
+
+enum IndexedDBConstants {
+    defaultIndexedDBName = 'default-db',
+    defaultIndexedDBStoreName = 'default-store',
+}
+
+export const getIndexedDBStore: () => IndexedDBStore = () => {
+    const store = new IndexedDBStore(IndexedDBConstants.defaultIndexedDBName, IndexedDBConstants.defaultIndexedDBStoreName);
+    return store;
+};

--- a/src/common/indexedDB/indexedDB.ts
+++ b/src/common/indexedDB/indexedDB.ts
@@ -48,11 +48,7 @@ export interface IndexedDBAPI {
  * Read more on IndexedDB: https://developers.google.com/web/ilt/pwa/working-with-indexeddb
  */
 export class IndexedDBUtil implements IndexedDBAPI {
-    private store;
-
-    constructor(store: Store) {
-        this.store = store;
-    }
+    constructor(private readonly store: Store) {}
 
     public async getItem(key: string): Promise<any> {
         try {

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { remote } from 'electron';
-import { Store } from 'idb-keyval';
+import { Store as IndexedDBStore } from 'idb-keyval';
 import * as ReactDOM from 'react-dom';
 
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
@@ -10,28 +10,18 @@ import { UserConfigurationStore } from '../../background/stores/global/user-conf
 import { COMMON_CONSTANTS } from '../../common/constants';
 import { initializeFabricIcons } from '../../common/fabric-icons';
 import { IndexedDBAPI, IndexedDBUtil } from '../../common/indexedDB/indexedDB';
-import { StoreNames } from '../../common/stores/store-names';
-import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
-
-function createUserConfigStore(
-    persistedState: UserConfigurationStoreData,
-    userConfigActionsLocal: UserConfigurationActions,
-    indexedDBAPI: IndexedDBAPI,
-): UserConfigurationStore {
-    const userConfigurationStore = new UserConfigurationStore(persistedState, userConfigActionsLocal, indexedDBAPI);
-    return userConfigurationStore;
-}
 
 initializeFabricIcons();
 
-const store = new Store(COMMON_CONSTANTS.defaultIndexedDBName, COMMON_CONSTANTS.defaultIndexedDBStoreName);
-const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(store);
+const indexedDBStore = new IndexedDBStore(COMMON_CONSTANTS.defaultIndexedDBName, COMMON_CONSTANTS.defaultIndexedDBStoreName);
+const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(indexedDBStore);
 const userConfigActions = new UserConfigurationActions();
 
 // tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
 getPersistedUserConfigData(indexedDBInstance).then((persistedData: Partial<PersistedData>) => {
-    createUserConfigStore(persistedData.userConfigurationData, userConfigActions, indexedDBInstance);
+    const userConfigurationStore = new UserConfigurationStore(persistedData.userConfigurationData, userConfigActions, indexedDBInstance);
+
     const dom = document;
     const renderer = new DeviceConnectViewRenderer(ReactDOM.render, dom, remote.getCurrentWindow());
     renderer.render();

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -5,7 +5,8 @@ import { Store as IndexedDBStore } from 'idb-keyval';
 import * as ReactDOM from 'react-dom';
 
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
-import { getPersistedUserConfigData, PersistedData } from '../../background/get-persisted-data';
+import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
+import { IndexedDBDataKeys } from '../../background/IndexedDBDataKeys';
 import { UserConfigurationStore } from '../../background/stores/global/user-configuration-store';
 import { COMMON_CONSTANTS } from '../../common/constants';
 import { initializeFabricIcons } from '../../common/fabric-icons';
@@ -18,8 +19,10 @@ const indexedDBStore = new IndexedDBStore(COMMON_CONSTANTS.defaultIndexedDBName,
 const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(indexedDBStore);
 const userConfigActions = new UserConfigurationActions();
 
+const indexedDBDataKeysToFetch = [IndexedDBDataKeys.userConfiguration];
+
 // tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
-getPersistedUserConfigData(indexedDBInstance).then((persistedData: Partial<PersistedData>) => {
+getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedData: Partial<PersistedData>) => {
     // tslint:disable-next-line:no-unused-variable
     const userConfigurationStore = new UserConfigurationStore(persistedData.userConfigurationData, userConfigActions, indexedDBInstance);
 

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -1,22 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { remote } from 'electron';
-import { Store as IndexedDBStore } from 'idb-keyval';
 import * as ReactDOM from 'react-dom';
 
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
 import { IndexedDBDataKeys } from '../../background/IndexedDBDataKeys';
 import { UserConfigurationStore } from '../../background/stores/global/user-configuration-store';
-import { COMMON_CONSTANTS } from '../../common/constants';
 import { initializeFabricIcons } from '../../common/fabric-icons';
+import { getIndexedDBStore } from '../../common/indexedDB/get-indexeddb-store';
 import { IndexedDBAPI, IndexedDBUtil } from '../../common/indexedDB/indexedDB';
 import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
 
 initializeFabricIcons();
 
-const indexedDBStore = new IndexedDBStore(COMMON_CONSTANTS.defaultIndexedDBName, COMMON_CONSTANTS.defaultIndexedDBStoreName);
-const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(indexedDBStore);
+const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(getIndexedDBStore());
 const userConfigActions = new UserConfigurationActions();
 
 const indexedDBDataKeysToFetch = [IndexedDBDataKeys.userConfiguration];

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -1,12 +1,38 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { remote } from 'electron';
+import { Store } from 'idb-keyval';
 import * as ReactDOM from 'react-dom';
+
+import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
+import { getPersistedUserConfigData, PersistedData } from '../../background/get-persisted-data';
+import { UserConfigurationStore } from '../../background/stores/global/user-configuration-store';
+import { COMMON_CONSTANTS } from '../../common/constants';
 import { initializeFabricIcons } from '../../common/fabric-icons';
+import { IndexedDBAPI, IndexedDBUtil } from '../../common/indexedDB/indexedDB';
+import { StoreNames } from '../../common/stores/store-names';
+import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
+
+function createUserConfigStore(
+    persistedState: UserConfigurationStoreData,
+    userConfigActionsLocal: UserConfigurationActions,
+    indexedDBAPI: IndexedDBAPI,
+): UserConfigurationStore {
+    const userConfigurationStore = new UserConfigurationStore(persistedState, userConfigActionsLocal, indexedDBAPI);
+    return userConfigurationStore;
+}
 
 initializeFabricIcons();
 
-const dom = document;
-const renderer = new DeviceConnectViewRenderer(ReactDOM.render, dom, remote.getCurrentWindow());
-renderer.render();
+const store = new Store(COMMON_CONSTANTS.defaultIndexedDBName, COMMON_CONSTANTS.defaultIndexedDBStoreName);
+const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(store);
+const userConfigActions = new UserConfigurationActions();
+
+// tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
+getPersistedUserConfigData(indexedDBInstance).then((persistedData: Partial<PersistedData>) => {
+    createUserConfigStore(persistedData.userConfigurationData, userConfigActions, indexedDBInstance);
+    const dom = document;
+    const renderer = new DeviceConnectViewRenderer(ReactDOM.render, dom, remote.getCurrentWindow());
+    renderer.render();
+});

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -20,6 +20,7 @@ const userConfigActions = new UserConfigurationActions();
 
 // tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
 getPersistedUserConfigData(indexedDBInstance).then((persistedData: Partial<PersistedData>) => {
+    // tslint:disable-next-line:no-unused-variable
     const userConfigurationStore = new UserConfigurationStore(persistedData.userConfigurationData, userConfigActions, indexedDBInstance);
 
     const dom = document;

--- a/src/tests/unit/tests/background/get-persisted-data.test.ts
+++ b/src/tests/unit/tests/background/get-persisted-data.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getPersistedData, getPersistedUserConfigData, PersistedData } from 'background/get-persisted-data';
+import { getPersistedData, PersistedData } from 'background/get-persisted-data';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { IMock, Mock } from 'typemoq';
 
@@ -31,10 +31,12 @@ describe('GetPersistedDataTest', () => {
     });
 
     it('propagates the results of IndexedDBAPI.getItem for the appropriate keys', async () => {
+        const indexedDataKeysToFetch = [IndexedDBDataKeys.assessmentStore, IndexedDBDataKeys.userConfiguration];
+
         indexedDBInstanceStrictMock.setup(i => i.getItem(IndexedDBDataKeys.assessmentStore)).returns(async () => assessmentStoreData);
         indexedDBInstanceStrictMock.setup(i => i.getItem(IndexedDBDataKeys.userConfiguration)).returns(async () => userConfigurationData);
 
-        const data = await getPersistedData(indexedDBInstanceStrictMock.object);
+        const data = await getPersistedData(indexedDBInstanceStrictMock.object, indexedDataKeysToFetch);
 
         expect(data).toEqual({
             assessmentStoreData: assessmentStoreData,
@@ -43,8 +45,10 @@ describe('GetPersistedDataTest', () => {
     });
 
     it('gets only the userconfigData when its called for', async () => {
+        const indexedDataKeysToFetch = [IndexedDBDataKeys.userConfiguration];
+
         indexedDBInstanceStrictMock.setup(i => i.getItem(IndexedDBDataKeys.userConfiguration)).returns(async () => userConfigurationData);
-        const data = await getPersistedUserConfigData(indexedDBInstanceStrictMock.object);
+        const data = await getPersistedData(indexedDBInstanceStrictMock.object, indexedDataKeysToFetch);
 
         expect(data).toEqual({
             userConfigurationData: userConfigurationData,

--- a/src/tests/unit/tests/background/get-persisted-data.test.ts
+++ b/src/tests/unit/tests/background/get-persisted-data.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { getPersistedData, getPersistedUserConfigData, PersistedData } from 'background/get-persisted-data';
+import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { IMock, Mock } from 'typemoq';
 
-import { getPersistedData, PersistedData } from 'background/get-persisted-data';
-import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { IndexedDBAPI } from '../../../../common/indexedDB/indexedDB';
 import { AssessmentStoreData, PersistedTabInfo } from '../../../../common/types/store-data/assessment-result-data';
 import { UserConfigurationStoreData } from '../../../../common/types/store-data/user-configuration-store';
@@ -40,5 +40,14 @@ describe('GetPersistedDataTest', () => {
             assessmentStoreData: assessmentStoreData,
             userConfigurationData: userConfigurationData,
         } as PersistedData);
+    });
+
+    it('gets only the userconfigData when its called for', async () => {
+        indexedDBInstanceStrictMock.setup(i => i.getItem(IndexedDBDataKeys.userConfiguration)).returns(async () => userConfigurationData);
+        const data = await getPersistedUserConfigData(indexedDBInstanceStrictMock.object);
+
+        expect(data).toEqual({
+            userConfigurationData: userConfigurationData,
+        } as Partial<PersistedData>);
     });
 });


### PR DESCRIPTION
#### Description of changes

Create UserConfigStore in device-connect-view-initializer.ts for electron initialization with UserConfig persisted data.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
