### PR TITLE
refactor: update TelemetryPermissionDialog to be used on electron app

### DIFF
--- a/src/background/actions/user-configuration-actions.ts
+++ b/src/background/actions/user-configuration-actions.ts
@@ -10,7 +10,7 @@ import {
 } from './action-payloads';
 
 export class UserConfigurationActions {
-    public readonly setTelemetryState = new Action<SetTelemetryStatePayload>();
+    public readonly setTelemetryState = new Action<boolean>();
     public readonly getCurrentState = new Action<void>();
     public readonly setHighContrastMode = new Action<SetHighContrastModePayload>();
     public readonly setIssueFilingService = new Action<SetIssueFilingServicePayload>();

--- a/src/background/actions/user-configuration-actions.ts
+++ b/src/background/actions/user-configuration-actions.ts
@@ -6,7 +6,6 @@ import {
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
-    SetTelemetryStatePayload,
 } from './action-payloads';
 
 export class UserConfigurationActions {

--- a/src/background/global-action-creators/registrar/register-user-configuration-message-callbacks.ts
+++ b/src/background/global-action-creators/registrar/register-user-configuration-message-callbacks.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { getStoreStateMessage, Messages } from '../../../common/messages';
+import { StoreNames } from '../../../common/stores/store-names';
+import { Interpreter } from '../../interpreter';
+import { UserConfigurationActionCreator } from '../user-configuration-action-creator';
+
+export const registerUserConfigurationMessageCallback = (
+    interpreter: Interpreter,
+    userConfigurationActionCreator: UserConfigurationActionCreator,
+) => {
+    interpreter.registerTypeToPayloadCallback(
+        getStoreStateMessage(StoreNames.UserConfigurationStore),
+        userConfigurationActionCreator.getUserConfigurationState,
+    );
+    interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetTelemetryConfig, userConfigurationActionCreator.setTelemetryState);
+    interpreter.registerTypeToPayloadCallback(
+        Messages.UserConfig.SetHighContrastConfig,
+        userConfigurationActionCreator.setHighContrastMode,
+    );
+    interpreter.registerTypeToPayloadCallback(
+        Messages.UserConfig.SetIssueFilingService,
+        userConfigurationActionCreator.setIssueFilingService,
+    );
+    interpreter.registerTypeToPayloadCallback(
+        Messages.UserConfig.SetIssueFilingServiceProperty,
+        userConfigurationActionCreator.setIssueFilingServiceProperty,
+    );
+    interpreter.registerTypeToPayloadCallback(
+        Messages.UserConfig.SaveIssueFilingSettings,
+        userConfigurationActionCreator.saveIssueFilingSettings,
+    );
+};

--- a/src/background/global-action-creators/registrar/register-user-configuration-message-callbacks.ts
+++ b/src/background/global-action-creators/registrar/register-user-configuration-message-callbacks.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { getStoreStateMessage, Messages } from '../../../common/messages';
 import { StoreNames } from '../../../common/stores/store-names';
+import { SetTelemetryStatePayload } from '../../actions/action-payloads';
 import { Interpreter } from '../../interpreter';
 import { UserConfigurationActionCreator } from '../user-configuration-action-creator';
 
@@ -13,7 +14,9 @@ export const registerUserConfigurationMessageCallback = (
         getStoreStateMessage(StoreNames.UserConfigurationStore),
         userConfigurationActionCreator.getUserConfigurationState,
     );
-    interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetTelemetryConfig, userConfigurationActionCreator.setTelemetryState);
+    interpreter.registerTypeToPayloadCallback<SetTelemetryStatePayload>(Messages.UserConfig.SetTelemetryConfig, payload =>
+        userConfigurationActionCreator.setTelemetryState(payload.enableTelemetry),
+    );
     interpreter.registerTypeToPayloadCallback(
         Messages.UserConfig.SetHighContrastConfig,
         userConfigurationActionCreator.setHighContrastMode,

--- a/src/background/global-action-creators/user-configuration-action-creator.ts
+++ b/src/background/global-action-creators/user-configuration-action-creator.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getStoreStateMessage, Messages } from '../../common/messages';
-import { StoreNames } from '../../common/stores/store-names';
 import {
     SaveIssueFilingSettingsPayload,
     SetHighContrastModePayload,
@@ -10,47 +8,21 @@ import {
     SetTelemetryStatePayload,
 } from '../actions/action-payloads';
 import { UserConfigurationActions } from '../actions/user-configuration-actions';
-import { Interpreter } from '../interpreter';
 
 export class UserConfigurationActionCreator {
-    constructor(private readonly interpreter: Interpreter, private readonly userConfigActions: UserConfigurationActions) {}
+    constructor(private readonly userConfigActions: UserConfigurationActions) {}
 
-    public registerCallback(): void {
-        this.interpreter.registerTypeToPayloadCallback(
-            getStoreStateMessage(StoreNames.UserConfigurationStore),
-            this.getUserConfigurationState,
-        );
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetTelemetryConfig, this.setTelemetryState);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetHighContrastConfig, this.setHighContrastMode);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetIssueFilingService, this.setIssueFilingService);
-        this.interpreter.registerTypeToPayloadCallback(
-            Messages.UserConfig.SetIssueFilingServiceProperty,
-            this.setIssueFilingServiceProperty,
-        );
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SaveIssueFilingSettings, this.saveIssueFilingSettings);
-    }
+    public getUserConfigurationState = () => this.userConfigActions.getCurrentState.invoke(null);
 
-    public getUserConfigurationState = (): void => {
-        this.userConfigActions.getCurrentState.invoke(null);
-    };
+    public setTelemetryState = (payload: SetTelemetryStatePayload) => this.userConfigActions.setTelemetryState.invoke(payload);
 
-    public setTelemetryState = (payload: SetTelemetryStatePayload): void => {
-        this.userConfigActions.setTelemetryState.invoke(payload);
-    };
+    public setHighContrastMode = (payload: SetHighContrastModePayload) => this.userConfigActions.setHighContrastMode.invoke(payload);
 
-    public setHighContrastMode = (payload: SetHighContrastModePayload): void => {
-        this.userConfigActions.setHighContrastMode.invoke(payload);
-    };
+    public setIssueFilingService = (payload: SetIssueFilingServicePayload) => this.userConfigActions.setIssueFilingService.invoke(payload);
 
-    public setIssueFilingService = (payload: SetIssueFilingServicePayload): void => {
-        this.userConfigActions.setIssueFilingService.invoke(payload);
-    };
-
-    public setIssueFilingServiceProperty = (payload: SetIssueFilingServicePropertyPayload): void => {
+    public setIssueFilingServiceProperty = (payload: SetIssueFilingServicePropertyPayload) =>
         this.userConfigActions.setIssueFilingServiceProperty.invoke(payload);
-    };
 
-    public saveIssueFilingSettings = (payload: SaveIssueFilingSettingsPayload): void => {
+    public saveIssueFilingSettings = (payload: SaveIssueFilingSettingsPayload) =>
         this.userConfigActions.saveIssueFilingSettings.invoke(payload);
-    };
 }

--- a/src/background/global-action-creators/user-configuration-action-creator.ts
+++ b/src/background/global-action-creators/user-configuration-action-creator.ts
@@ -30,27 +30,27 @@ export class UserConfigurationActionCreator {
         this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SaveIssueFilingSettings, this.saveIssueFilingSettings);
     }
 
-    private getUserConfigurationState = (): void => {
+    public getUserConfigurationState = (): void => {
         this.userConfigActions.getCurrentState.invoke(null);
     };
 
-    private setTelemetryState = (payload: SetTelemetryStatePayload): void => {
+    public setTelemetryState = (payload: SetTelemetryStatePayload): void => {
         this.userConfigActions.setTelemetryState.invoke(payload);
     };
 
-    private setHighContrastMode = (payload: SetHighContrastModePayload): void => {
+    public setHighContrastMode = (payload: SetHighContrastModePayload): void => {
         this.userConfigActions.setHighContrastMode.invoke(payload);
     };
 
-    private setIssueFilingService = (payload: SetIssueFilingServicePayload): void => {
+    public setIssueFilingService = (payload: SetIssueFilingServicePayload): void => {
         this.userConfigActions.setIssueFilingService.invoke(payload);
     };
 
-    private setIssueFilingServiceProperty = (payload: SetIssueFilingServicePropertyPayload): void => {
+    public setIssueFilingServiceProperty = (payload: SetIssueFilingServicePropertyPayload): void => {
         this.userConfigActions.setIssueFilingServiceProperty.invoke(payload);
     };
 
-    private saveIssueFilingSettings = (payload: SaveIssueFilingSettingsPayload): void => {
+    public saveIssueFilingSettings = (payload: SaveIssueFilingSettingsPayload): void => {
         this.userConfigActions.saveIssueFilingSettings.invoke(payload);
     };
 }

--- a/src/background/global-action-creators/user-configuration-action-creator.ts
+++ b/src/background/global-action-creators/user-configuration-action-creator.ts
@@ -14,7 +14,7 @@ export class UserConfigurationActionCreator {
 
     public getUserConfigurationState = () => this.userConfigActions.getCurrentState.invoke(null);
 
-    public setTelemetryState = (payload: SetTelemetryStatePayload) => this.userConfigActions.setTelemetryState.invoke(payload);
+    public setTelemetryState = (enableTelemetry: boolean) => this.userConfigActions.setTelemetryState.invoke(enableTelemetry);
 
     public setHighContrastMode = (payload: SetHighContrastModePayload) => this.userConfigActions.setHighContrastMode.invoke(payload);
 

--- a/src/background/global-action-creators/user-configuration-action-creator.ts
+++ b/src/background/global-action-creators/user-configuration-action-creator.ts
@@ -5,7 +5,6 @@ import {
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
-    SetTelemetryStatePayload,
 } from '../actions/action-payloads';
 import { UserConfigurationActions } from '../actions/user-configuration-actions';
 

--- a/src/background/global-action-creators/user-configuration-action-creator.ts
+++ b/src/background/global-action-creators/user-configuration-action-creator.ts
@@ -16,35 +16,41 @@ export class UserConfigurationActionCreator {
     constructor(private readonly interpreter: Interpreter, private readonly userConfigActions: UserConfigurationActions) {}
 
     public registerCallback(): void {
-        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.UserConfigurationStore), this.onGetUserConfigState);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetTelemetryConfig, this.onSetTelemetryConfiguration);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetHighContrastConfig, this.onSetHighContrastMode);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetIssueFilingService, this.onSetBugService);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetIssueFilingServiceProperty, this.onSetBugServiceProperty);
-        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SaveIssueFilingSettings, this.onSaveIssueFilingSettings);
+        this.interpreter.registerTypeToPayloadCallback(
+            getStoreStateMessage(StoreNames.UserConfigurationStore),
+            this.getUserConfigurationState,
+        );
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetTelemetryConfig, this.setTelemetryState);
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetHighContrastConfig, this.setHighContrastMode);
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SetIssueFilingService, this.setIssueFilingService);
+        this.interpreter.registerTypeToPayloadCallback(
+            Messages.UserConfig.SetIssueFilingServiceProperty,
+            this.setIssueFilingServiceProperty,
+        );
+        this.interpreter.registerTypeToPayloadCallback(Messages.UserConfig.SaveIssueFilingSettings, this.saveIssueFilingSettings);
     }
 
-    private onGetUserConfigState = (): void => {
+    private getUserConfigurationState = (): void => {
         this.userConfigActions.getCurrentState.invoke(null);
     };
 
-    private onSetTelemetryConfiguration = (payload: SetTelemetryStatePayload): void => {
+    private setTelemetryState = (payload: SetTelemetryStatePayload): void => {
         this.userConfigActions.setTelemetryState.invoke(payload);
     };
 
-    private onSetHighContrastMode = (payload: SetHighContrastModePayload): void => {
+    private setHighContrastMode = (payload: SetHighContrastModePayload): void => {
         this.userConfigActions.setHighContrastMode.invoke(payload);
     };
 
-    private onSetBugService = (payload: SetIssueFilingServicePayload): void => {
+    private setIssueFilingService = (payload: SetIssueFilingServicePayload): void => {
         this.userConfigActions.setIssueFilingService.invoke(payload);
     };
 
-    private onSetBugServiceProperty = (payload: SetIssueFilingServicePropertyPayload): void => {
+    private setIssueFilingServiceProperty = (payload: SetIssueFilingServicePropertyPayload): void => {
         this.userConfigActions.setIssueFilingServiceProperty.invoke(payload);
     };
 
-    private onSaveIssueFilingSettings = (payload: SaveIssueFilingSettingsPayload): void => {
+    private saveIssueFilingSettings = (payload: SaveIssueFilingSettingsPayload): void => {
         this.userConfigActions.saveIssueFilingSettings.invoke(payload);
     };
 }

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -18,6 +18,7 @@ import { PersistedData } from './get-persisted-data';
 import { FeatureFlagsActionCreator } from './global-action-creators/feature-flags-action-creator';
 import { GlobalActionCreator } from './global-action-creators/global-action-creator';
 import { IssueFilingActionCreator } from './global-action-creators/issue-filing-action-creator';
+import { registerUserConfigurationMessageCallback } from './global-action-creators/registrar/register-user-configuration-message-callbacks';
 import { ScopingActionCreator } from './global-action-creators/scoping-action-creator';
 import { UserConfigurationActionCreator } from './global-action-creators/user-configuration-action-creator';
 import { GlobalContext } from './global-context';
@@ -79,7 +80,7 @@ export class GlobalContextFactory {
         issueFilingActionCreator.registerCallbacks();
         actionCreator.registerCallbacks();
         assessmentActionCreator.registerCallbacks();
-        userConfigurationActionCreator.registerCallback();
+        registerUserConfigurationMessageCallback(interpreter, userConfigurationActionCreator);
         scopingActionCreator.registerCallback();
         featureFlagsActionCreator.registerCallbacks();
 

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -70,7 +70,7 @@ export class GlobalContextFactory {
         const issueFilingActionCreator = new IssueFilingActionCreator(interpreter, telemetryEventHandler, issueFilingController);
         const actionCreator = new GlobalActionCreator(globalActionsHub, interpreter, commandsAdapter, telemetryEventHandler);
         const assessmentActionCreator = new AssessmentActionCreator(interpreter, globalActionsHub.assessmentActions, telemetryEventHandler);
-        const userConfigurationActionCreator = new UserConfigurationActionCreator(interpreter, globalActionsHub.userConfigurationActions);
+        const userConfigurationActionCreator = new UserConfigurationActionCreator(globalActionsHub.userConfigurationActions);
         const featureFlagsActionCreator = new FeatureFlagsActionCreator(
             interpreter,
             globalActionsHub.featureFlagActions,

--- a/src/background/stores/global/user-configuration-store.ts
+++ b/src/background/stores/global/user-configuration-store.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { cloneDeep, isPlainObject } from 'lodash';
+
 import { IndexedDBAPI } from '../../../common/indexedDB/indexedDB';
 import { StoreNames } from '../../../common/stores/store-names';
 import { UserConfigurationStoreData } from '../../../common/types/store-data/user-configuration-store';
@@ -9,7 +10,6 @@ import {
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
-    SetTelemetryStatePayload,
 } from '../../actions/action-payloads';
 import { UserConfigurationActions } from '../../actions/user-configuration-actions';
 import { IndexedDBDataKeys } from '../../IndexedDBDataKeys';

--- a/src/background/stores/global/user-configuration-store.ts
+++ b/src/background/stores/global/user-configuration-store.ts
@@ -51,9 +51,9 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
         this.userConfigActions.saveIssueFilingSettings.addListener(this.onSaveIssueSettings);
     }
 
-    private onSetTelemetryState = (payload: SetTelemetryStatePayload): void => {
+    private onSetTelemetryState = (enableTelemetry: boolean): void => {
         this.state.isFirstTime = false;
-        this.state.enableTelemetry = payload.enableTelemetry;
+        this.state.enableTelemetry = enableTelemetry;
         this.saveAndEmitChanged();
     };
 

--- a/src/common/components/telemetry-permission-dialog.tsx
+++ b/src/common/components/telemetry-permission-dialog.tsx
@@ -9,7 +9,7 @@ import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import * as React from 'react';
-import { UserConfigMessageCreator } from '../message-creators/user-config-message-creator';
+
 import { TelemetryNotice, TelemetryNoticeDeps } from './telemetry-notice';
 
 export interface TelemetryPermissionDialogState {
@@ -21,8 +21,12 @@ export interface TelemetryPermissionDialogProps {
     isFirstTime: boolean;
 }
 
+export type SetTelemetryStateMessageCreator = {
+    setTelemetryState: (enableTelemetry: boolean) => void;
+};
+
 export type TelemetryPermissionDialogDeps = {
-    userConfigMessageCreator: UserConfigMessageCreator;
+    userConfigMessageCreator: SetTelemetryStateMessageCreator;
 } & TelemetryNoticeDeps;
 
 export class TelemetryPermissionDialog extends React.Component<TelemetryPermissionDialogProps, TelemetryPermissionDialogState> {

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -5,13 +5,11 @@ import {
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
-    SetTelemetryStatePayload,
 } from 'background/actions/action-payloads';
 import { UserConfigurationActions } from 'background/actions/user-configuration-actions';
 import { UserConfigurationActionCreator } from 'background/global-action-creators/user-configuration-action-creator';
 import { IMock, Mock } from 'typemoq';
 
-import { TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
 import { createActionMock } from './action-creator-test-helpers';
 
 describe('UserConfigurationActionCreator', () => {
@@ -27,18 +25,13 @@ describe('UserConfigurationActionCreator', () => {
     });
 
     it('should SetTelemetryConfig message', () => {
-        const payload: SetTelemetryStatePayload = {
-            enableTelemetry: true,
-            telemetry: {
-                triggeredBy: 'test' as TriggeredBy,
-                source: -1 as TelemetryEventSource,
-            },
-        };
-        const setTelemetryStateMock = createActionMock(payload);
+        const setTelemetryState = true;
+
+        const setTelemetryStateMock = createActionMock(setTelemetryState);
         const actionsMock = createActionsMock('setTelemetryState', setTelemetryStateMock.object);
         const testSubject = new UserConfigurationActionCreator(actionsMock.object);
 
-        testSubject.setTelemetryState(payload);
+        testSubject.setTelemetryState(setTelemetryState);
 
         setTelemetryStateMock.verifyAll();
     });

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -11,20 +11,17 @@ import { UserConfigurationActions } from 'background/actions/user-configuration-
 import { UserConfigurationActionCreator } from 'background/global-action-creators/user-configuration-action-creator';
 import { IMock, Mock } from 'typemoq';
 
-import { getStoreStateMessage, Messages } from '../../../../../common/messages';
-import { StoreNames } from '../../../../../common/stores/store-names';
 import { TelemetryEventSource, TriggeredBy } from '../../../../../common/telemetry-events';
-import { createActionMock, createInterpreterMock } from './action-creator-test-helpers';
+import { createActionMock } from './action-creator-test-helpers';
 
 describe('UserConfigurationActionCreator', () => {
     it('handles GetCurrentState message', () => {
         const payload = null;
         const getCurrentStateMock = createActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.UserConfigurationStore), payload);
-        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
 
-        testSubject.registerCallback();
+        testSubject.getUserConfigurationState();
 
         getCurrentStateMock.verifyAll();
     });
@@ -39,10 +36,9 @@ describe('UserConfigurationActionCreator', () => {
         };
         const setTelemetryStateMock = createActionMock(payload);
         const actionsMock = createActionsMock('setTelemetryState', setTelemetryStateMock.object);
-        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetTelemetryConfig, payload);
-        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
 
-        testSubject.registerCallback();
+        testSubject.setTelemetryState(payload);
 
         setTelemetryStateMock.verifyAll();
     });
@@ -53,10 +49,9 @@ describe('UserConfigurationActionCreator', () => {
         };
         const setHighContrastConfigMock = createActionMock(payload);
         const actionsMock = createActionsMock('setHighContrastMode', setHighContrastConfigMock.object);
-        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetHighContrastConfig, payload);
-        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
 
-        testSubject.registerCallback();
+        testSubject.setHighContrastMode(payload);
 
         setHighContrastConfigMock.verifyAll();
     });
@@ -67,10 +62,9 @@ describe('UserConfigurationActionCreator', () => {
         };
         const setBugServiceMock = createActionMock(payload);
         const actionsMock = createActionsMock('setIssueFilingService', setBugServiceMock.object);
-        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetIssueFilingService, payload);
-        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
 
-        testSubject.registerCallback();
+        testSubject.setIssueFilingService(payload);
 
         setBugServiceMock.verifyAll();
     });
@@ -83,10 +77,9 @@ describe('UserConfigurationActionCreator', () => {
         };
         const setIssueFilingServicePropertyMock = createActionMock(payload);
         const actionsMock = createActionsMock('setIssueFilingServiceProperty', setIssueFilingServicePropertyMock.object);
-        const interpreterMock = createInterpreterMock(Messages.UserConfig.SetIssueFilingServiceProperty, payload);
-        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
 
-        testSubject.registerCallback();
+        testSubject.setIssueFilingServiceProperty(payload);
 
         setIssueFilingServicePropertyMock.verifyAll();
     });
@@ -98,10 +91,9 @@ describe('UserConfigurationActionCreator', () => {
         };
         const setIssueFilingSettings = createActionMock(payload);
         const actionsMock = createActionsMock('saveIssueFilingSettings', setIssueFilingSettings.object);
-        const interpreterMock = createInterpreterMock(Messages.UserConfig.SaveIssueFilingSettings, payload);
-        const testSubject = new UserConfigurationActionCreator(interpreterMock.object, actionsMock.object);
+        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
 
-        testSubject.registerCallback();
+        testSubject.saveIssueFilingSettings(payload);
 
         setIssueFilingSettings.verifyAll();
     });

--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -5,13 +5,13 @@ import {
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
-    SetTelemetryStatePayload,
 } from 'background/actions/action-payloads';
 import { UserConfigurationActions } from 'background/actions/user-configuration-actions';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
 import { cloneDeep } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
+
 import { IndexedDBAPI } from '../../../../../../common/indexedDB/indexedDB';
 import { StoreNames } from '../../../../../../common/stores/store-names';
 import {

--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -150,10 +150,6 @@ describe('UserConfigurationStoreTest', () => {
             bugServicePropertiesMap: {},
         };
 
-        const setTelemetryStateData: SetTelemetryStatePayload = {
-            enableTelemetry: testCase.enableTelemetry,
-        };
-
         const expectedState: UserConfigurationStoreData = {
             enableTelemetry: testCase.enableTelemetry,
             isFirstTime: false,
@@ -165,7 +161,7 @@ describe('UserConfigurationStoreTest', () => {
         indexDbStrictMock.setup(i => i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState))).verifiable(Times.once());
 
         storeTester
-            .withActionParam(setTelemetryStateData)
+            .withActionParam(testCase.enableTelemetry)
             .withPostListenerMock(indexDbStrictMock)
             .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
     });

--- a/src/tests/unit/tests/common/components/telemetry-permission-dialog.test.tsx
+++ b/src/tests/unit/tests/common/components/telemetry-permission-dialog.test.tsx
@@ -7,6 +7,7 @@ import * as React from 'react';
 import { NewTabLink } from '../../../../../common/components/new-tab-link';
 import { TelemetryNotice } from '../../../../../common/components/telemetry-notice';
 import {
+    SetTelemetryStateMessageCreator,
     TelemetryPermissionDialog,
     TelemetryPermissionDialogDeps,
     TelemetryPermissionDialogProps,
@@ -14,7 +15,7 @@ import {
 import { UserConfigMessageCreator } from '../../../../../common/message-creators/user-config-message-creator';
 
 describe('TelemetryPermissionDialogTest', () => {
-    let userConfigMessageCreatorStub: UserConfigMessageCreator;
+    let userConfigMessageCreatorStub: SetTelemetryStateMessageCreator;
     let setTelemetryStateMock: () => null;
 
     beforeEach(() => {


### PR DESCRIPTION
#### Description of changes

Introduce `SetTelemetryStateMessageCreator` (implicitly implemented by `UserConfigMessageCreator` and `UserConfigurationActionCreator`) in order to be able to re-use `TelemetryPermissionDialog` on the electron app.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
  - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
  - not affected
