### PR TITLE
refactor: telemetry permission privacy statement text

### DIFF
--- a/src/common/components/enable-telemetry-setting-description.tsx
+++ b/src/common/components/enable-telemetry-setting-description.tsx
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { privacyStatementText } from '../../content/settings/improve-accessibility-insights';
 import { NamedFC } from '../react/named-fc';
-import { LinkComponentType } from '../types/link-component-type';
-import { TelemetryNotice } from './telemetry-notice';
+import { PrivacyStatementText, PrivacyStatementTextDeps } from './privacy-statement-text';
+import { TelemetryNotice, TelemetryNoticeDeps } from './telemetry-notice';
 
-export type EnableTelemetrySettingDescriptionDeps = {
-    LinkComponent: LinkComponentType;
-};
+export type EnableTelemetrySettingDescriptionDeps = TelemetryNoticeDeps & PrivacyStatementTextDeps;
 
 export type EnableTelemetrySettingDescriptionProps = {
     deps: EnableTelemetrySettingDescriptionDeps;
@@ -19,7 +16,7 @@ export const EnableTelemetrySettingDescription = NamedFC<EnableTelemetrySettingD
     props => (
         <>
             <TelemetryNotice deps={props.deps} />
-            {privacyStatementText}
+            <PrivacyStatementText deps={props.deps} />
         </>
     ),
 );

--- a/src/common/components/privacy-statement-text.tsx
+++ b/src/common/components/privacy-statement-text.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+import { NamedFC } from '../react/named-fc';
+import { LinkComponentType } from '../types/link-component-type';
+
+export type PrivacyStatementTextDeps = {
+    LinkComponent: LinkComponentType;
+};
+
+export type PrivacyStatementTextProps = {
+    deps: PrivacyStatementTextDeps;
+};
+
+export const PrivacyStatementText = NamedFC<PrivacyStatementTextProps>('PrivacyStatementText', props => (
+    <>
+        Read our{' '}
+        <props.deps.LinkComponent href="http://go.microsoft.com/fwlink/?LinkId=521839"> privacy statement</props.deps.LinkComponent> to
+        learn more.
+    </>
+));
+
+export const PrivacyStatementPopupText = NamedFC<PrivacyStatementTextProps>('PrivacyStatementPopupText', props => (
+    <>
+        You can change this choice anytime in settings. <PrivacyStatementText deps={props.deps}></PrivacyStatementText>
+    </>
+));

--- a/src/common/components/telemetry-permission-dialog.tsx
+++ b/src/common/components/telemetry-permission-dialog.tsx
@@ -1,15 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import {
-    privacyStatementPopupText,
-    telemetryPopupCheckboxTitle,
-    telemetryPopupTitle,
-} from 'content/settings/improve-accessibility-insights';
+import { telemetryPopupCheckboxTitle, telemetryPopupTitle } from 'content/settings/improve-accessibility-insights';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import * as React from 'react';
 import { UserConfigMessageCreator } from '../message-creators/user-config-message-creator';
+import { PrivacyStatementPopupText, PrivacyStatementTextDeps } from './privacy-statement-text';
 import { TelemetryNotice, TelemetryNoticeDeps } from './telemetry-notice';
 
 export interface TelemetryPermissionDialogState {
@@ -23,7 +20,8 @@ export interface TelemetryPermissionDialogProps {
 
 export type TelemetryPermissionDialogDeps = {
     userConfigMessageCreator: UserConfigMessageCreator;
-} & TelemetryNoticeDeps;
+} & TelemetryNoticeDeps &
+    PrivacyStatementTextDeps;
 
 export class TelemetryPermissionDialog extends React.Component<TelemetryPermissionDialogProps, TelemetryPermissionDialogState> {
     constructor(props) {
@@ -61,7 +59,7 @@ export class TelemetryPermissionDialog extends React.Component<TelemetryPermissi
                         checked={this.state.isEnableTelemetryChecked}
                         className="telemetry-agree-checkbox"
                     />
-                    {privacyStatementPopupText}
+                    <PrivacyStatementPopupText deps={this.props.deps}></PrivacyStatementPopupText>
                 </div>
                 <DialogFooter>
                     <PrimaryButton

--- a/src/content/settings/improve-accessibility-insights.tsx
+++ b/src/content/settings/improve-accessibility-insights.tsx
@@ -1,19 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
-import { NewTabLink } from '../../common/components/new-tab-link';
 import { title } from '../strings/application';
 
 export const telemetryPopupTitle = `We need your help`;
 
 export const telemetryPopupCheckboxTitle = `I agree to enable telemetry`;
-
-export const privacyStatementText = (
-    <>
-        Read our <NewTabLink href="http://go.microsoft.com/fwlink/?LinkId=521839"> privacy statement</NewTabLink> to learn more.
-    </>
-);
-
-export const privacyStatementPopupText = <>You can change this choice anytime in settings. {privacyStatementText}</>;
 
 export const enableTelemetrySettingsPanelTitle = `Help improve ${title}`;

--- a/src/tests/unit/tests/common/components/__snapshots__/enable-telemetry-setting-description.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/enable-telemetry-setting-description.test.tsx.snap
@@ -9,14 +9,12 @@ exports[`EnableTelemetrySettingDescription renders 1`] = `
       }
     }
   />
-  <React.Fragment>
-    Read our 
-    <NewTabLink
-      href="http://go.microsoft.com/fwlink/?LinkId=521839"
-    >
-       privacy statement
-    </NewTabLink>
-     to learn more.
-  </React.Fragment>
+  <PrivacyStatementText
+    deps={
+      Object {
+        "LinkComponent": [Function],
+      }
+    }
+  />
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/common/components/__snapshots__/privacy-statement-text.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/privacy-statement-text.test.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PrivacyStatementPopupText renders 1`] = `
+<React.Fragment>
+  You can change this choice anytime in settings. 
+  <PrivacyStatementText
+    deps={
+      Object {
+        "LinkComponent": [Function],
+      }
+    }
+  />
+</React.Fragment>
+`;
+
+exports[`PrivacyStatementText renders 1`] = `
+<React.Fragment>
+  Read our
+   
+  <NewTabLink
+    href="http://go.microsoft.com/fwlink/?LinkId=521839"
+  >
+     privacy statement
+  </NewTabLink>
+   to learn more.
+</React.Fragment>
+`;

--- a/src/tests/unit/tests/common/components/__snapshots__/telemetry-permission-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/telemetry-permission-dialog.test.tsx.snap
@@ -38,18 +38,13 @@ exports[`TelemetryPermissionDialogTest render dialog 1`] = `
       label="I agree to enable telemetry"
       onChange={[Function]}
     />
-    <React.Fragment>
-      You can change this choice anytime in settings. 
-      <React.Fragment>
-        Read our 
-        <NewTabLink
-          href="http://go.microsoft.com/fwlink/?LinkId=521839"
-        >
-           privacy statement
-        </NewTabLink>
-         to learn more.
-      </React.Fragment>
-    </React.Fragment>
+    <PrivacyStatementPopupText
+      deps={
+        Object {
+          "LinkComponent": [Function],
+        }
+      }
+    />
   </div>
   <StyledDialogFooterBase>
     <CustomizedPrimaryButton

--- a/src/tests/unit/tests/common/components/enable-telemetry-setting-description.test.tsx
+++ b/src/tests/unit/tests/common/components/enable-telemetry-setting-description.test.tsx
@@ -7,6 +7,8 @@ import {
     EnableTelemetrySettingDescriptionDeps,
 } from '../../../../../common/components/enable-telemetry-setting-description';
 import { NewTabLink } from '../../../../../common/components/new-tab-link';
+import { PrivacyStatementText } from '../../../../../common/components/privacy-statement-text';
+import { TelemetryNotice } from '../../../../../common/components/telemetry-notice';
 
 describe('EnableTelemetrySettingDescription', () => {
     it('renders', () => {
@@ -15,7 +17,11 @@ describe('EnableTelemetrySettingDescription', () => {
         };
 
         const wrapper = shallow(<EnableTelemetrySettingDescription deps={deps} />);
+        const telemetryNotice = wrapper.find(TelemetryNotice);
+        const privacyStatementText = wrapper.find(PrivacyStatementText);
 
         expect(wrapper.getElement()).toMatchSnapshot();
+        expect(telemetryNotice.prop('deps').LinkComponent).toBe(deps.LinkComponent);
+        expect(privacyStatementText.prop('deps').LinkComponent).toBe(deps.LinkComponent);
     });
 });

--- a/src/tests/unit/tests/common/components/privacy-statement-text.test.tsx
+++ b/src/tests/unit/tests/common/components/privacy-statement-text.test.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { NewTabLink } from '../../../../../common/components/new-tab-link';
+import {
+    PrivacyStatementPopupText,
+    PrivacyStatementText,
+    PrivacyStatementTextDeps,
+} from '../../../../../common/components/privacy-statement-text';
+
+describe('PrivacyStatementText', () => {
+    it('renders', () => {
+        const deps: PrivacyStatementTextDeps = {
+            LinkComponent: NewTabLink,
+        };
+
+        const wrapper = shallow(<PrivacyStatementText deps={deps}></PrivacyStatementText>);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});
+
+describe('PrivacyStatementPopupText', () => {
+    it('renders', () => {
+        const deps: PrivacyStatementTextDeps = {
+            LinkComponent: NewTabLink,
+        };
+
+        const wrapper = shallow(<PrivacyStatementPopupText deps={deps}></PrivacyStatementPopupText>);
+        const privacyStatementText = wrapper.find(PrivacyStatementText);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+        expect(privacyStatementText.prop('deps').LinkComponent).toBe(deps.LinkComponent);
+    });
+});

--- a/src/tests/unit/tests/common/components/telemetry-permission-dialog.test.tsx
+++ b/src/tests/unit/tests/common/components/telemetry-permission-dialog.test.tsx
@@ -5,6 +5,7 @@ import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import * as React from 'react';
 import { NewTabLink } from '../../../../../common/components/new-tab-link';
+import { PrivacyStatementPopupText } from '../../../../../common/components/privacy-statement-text';
 import { TelemetryNotice } from '../../../../../common/components/telemetry-notice';
 import {
     TelemetryPermissionDialog,
@@ -44,8 +45,12 @@ describe('TelemetryPermissionDialogTest', () => {
 
         expect(wrapper.getElement()).toMatchSnapshot();
         expect(wrapper.state()).toMatchObject({ isEnableTelemetryChecked: true });
+
         const telemetryNotice = wrapper.find(TelemetryNotice);
         expect(telemetryNotice.prop('deps').LinkComponent).toBe(props.deps.LinkComponent);
+
+        const privacyStatementPopupText = wrapper.find(PrivacyStatementPopupText);
+        expect(privacyStatementPopupText.prop('deps').LinkComponent).toBe(props.deps.LinkComponent);
     });
 
     test('toggle check box', () => {


### PR DESCRIPTION
#### Description of changes

- Updated `PrivacyStatementText` and `PrivacyStatementPopupText` to be components that use `PrivacyStatementTextProps` and moved them to a new file `privacy-statement-text.tsx` from `improve-accessibility-insights`, so they can be reused in `TelemetryPermissionDialog` for web and electron
- Updated files where `PrivacyStatementText` and `PrivacyStatementPopupText` are used
- Updated relevant tests and snapshots

#### Pull request checklist

- [x] Partially addresses an existing issue: WI # 1596167
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
