### PR TITLE
feat: wiring up telemetry opt in dialog

### DIFF
--- a/src/electron/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/device-connect-view/components/device-connect-view-container.tsx
@@ -2,9 +2,8 @@
 // Licensed under the MIT License.
 import { BrowserWindow } from 'electron';
 import * as React from 'react';
-
-import { UserConfigurationStore } from '../../../background/stores/global/user-configuration-store';
 import { BaseStore } from '../../../common/base-store';
+import { TelemetryPermissionDialog, TelemetryPermissionDialogDeps } from '../../../common/components/telemetry-permission-dialog';
 import { UserConfigurationStoreData } from '../../../common/types/store-data/user-configuration-store';
 import { brand } from '../../../content/strings/application';
 import { BrandBlue } from '../../../icons/brand/blue/brand-blue';
@@ -14,7 +13,7 @@ import { WindowTitle } from './window-title';
 export type DeviceConnectViewContainerDeps = {
     currentWindow: BrowserWindow;
     userConfigurationStore: BaseStore<UserConfigurationStoreData>;
-};
+} & TelemetryPermissionDialogDeps;
 
 export type DeviceConnectViewContainerProps = {
     deps: DeviceConnectViewContainerDeps;
@@ -39,6 +38,7 @@ export class DeviceConnectViewContainer extends React.Component<DeviceConnectVie
                     <BrandBlue />
                 </WindowTitle>
                 <DeviceConnectBody currentWindow={this.props.deps.currentWindow} />
+                <TelemetryPermissionDialog deps={this.props.deps} isFirstTime={this.state.userConfigurationStoreData.isFirstTime} />
             </>
         );
     }

--- a/src/electron/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/device-connect-view/components/device-connect-view-container.tsx
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 import { BrowserWindow } from 'electron';
 import * as React from 'react';
+
+import { UserConfigurationStore } from '../../../background/stores/global/user-configuration-store';
+import { BaseStore } from '../../../common/base-store';
+import { UserConfigurationStoreData } from '../../../common/types/store-data/user-configuration-store';
 import { brand } from '../../../content/strings/application';
 import { BrandBlue } from '../../../icons/brand/blue/brand-blue';
 import { DeviceConnectBody } from './device-connect-body';
@@ -9,13 +13,25 @@ import { WindowTitle } from './window-title';
 
 export type DeviceConnectViewContainerDeps = {
     currentWindow: BrowserWindow;
+    userConfigurationStore: BaseStore<UserConfigurationStoreData>;
 };
 
 export type DeviceConnectViewContainerProps = {
     deps: DeviceConnectViewContainerDeps;
 };
 
-export class DeviceConnectViewContainer extends React.Component<DeviceConnectViewContainerProps> {
+export type DeviceConnectViewContainerState = {
+    userConfigurationStoreData: UserConfigurationStoreData;
+};
+
+export class DeviceConnectViewContainer extends React.Component<DeviceConnectViewContainerProps, DeviceConnectViewContainerState> {
+    constructor(props: DeviceConnectViewContainerProps) {
+        super(props);
+        this.state = {
+            userConfigurationStoreData: props.deps.userConfigurationStore.getState(),
+        };
+    }
+
     public render(): JSX.Element {
         return (
             <>
@@ -25,5 +41,14 @@ export class DeviceConnectViewContainer extends React.Component<DeviceConnectVie
                 <DeviceConnectBody currentWindow={this.props.deps.currentWindow} />
             </>
         );
+    }
+
+    public componentDidMount(): void {
+        this.props.deps.userConfigurationStore.addChangedListener(() => {
+            const newState = this.props.deps.userConfigurationStore.getState();
+            this.setState({
+                userConfigurationStoreData: newState,
+            });
+        });
     }
 }

--- a/src/electron/device-connect-view/components/telemetry-permission-dialog.scss
+++ b/src/electron/device-connect-view/components/telemetry-permission-dialog.scss
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+.telemetry-permission-dialog {
+    width: 416px !important;
+    min-width: 416px !important;
+}

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -2,14 +2,15 @@
 // Licensed under the MIT License.
 import { remote } from 'electron';
 import * as ReactDOM from 'react-dom';
-
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
+import { UserConfigurationActionCreator } from '../../background/global-action-creators/user-configuration-action-creator';
 import { IndexedDBDataKeys } from '../../background/IndexedDBDataKeys';
 import { UserConfigurationStore } from '../../background/stores/global/user-configuration-store';
 import { initializeFabricIcons } from '../../common/fabric-icons';
 import { getIndexedDBStore } from '../../common/indexedDB/get-indexeddb-store';
 import { IndexedDBAPI, IndexedDBUtil } from '../../common/indexedDB/indexedDB';
+import { ElectronExternalLink } from './components/electron-external-link';
 import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
 
 initializeFabricIcons();
@@ -21,14 +22,18 @@ const indexedDBDataKeysToFetch = [IndexedDBDataKeys.userConfiguration];
 
 // tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises
 getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedData: Partial<PersistedData>) => {
-    // tslint:disable-next-line:no-unused-variable
     const userConfigurationStore = new UserConfigurationStore(persistedData.userConfigurationData, userConfigActions, indexedDBInstance);
+    userConfigurationStore.initialize();
+
+    const userConfigMessageCreator = new UserConfigurationActionCreator(userConfigActions);
 
     const dom = document;
     const props = {
         deps: {
             currentWindow: remote.getCurrentWindow(),
             userConfigurationStore,
+            userConfigMessageCreator,
+            LinkComponent: ElectronExternalLink,
         },
     };
 

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -28,6 +28,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
     const props = {
         deps: {
             currentWindow: remote.getCurrentWindow(),
+            userConfigurationStore,
         },
     };
 

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -10,7 +10,7 @@ import { UserConfigurationStore } from '../../background/stores/global/user-conf
 import { initializeFabricIcons } from '../../common/fabric-icons';
 import { getIndexedDBStore } from '../../common/indexedDB/get-indexeddb-store';
 import { IndexedDBAPI, IndexedDBUtil } from '../../common/indexedDB/indexedDB';
-import { ElectronExternalLink } from './components/electron-external-link';
+import { ElectronLink } from './components/electron-link';
 import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
 
 initializeFabricIcons();
@@ -33,7 +33,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
             currentWindow: remote.getCurrentWindow(),
             userConfigurationStore,
             userConfigMessageCreator,
-            LinkComponent: ElectronExternalLink,
+            LinkComponent: ElectronLink,
         },
     };
 

--- a/src/electron/device-connect-view/device-connect-view.scss
+++ b/src/electron/device-connect-view/device-connect-view.scss
@@ -6,6 +6,7 @@
 @import './components/device-connect-footer.scss';
 @import './components/device-connect-header.scss';
 @import './components/device-connect-port-entry.scss';
+@import './components/telemetry-permission-dialog.scss';
 
 body {
     -webkit-app-region: drag;

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -11,7 +11,7 @@ const createWindow = () => {
         webPreferences: { nodeIntegration: true },
         frame: false,
         width: 600,
-        height: 500,
+        height: 391,
     });
 
     mainWindow

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -11,7 +11,7 @@ const createWindow = () => {
         webPreferences: { nodeIntegration: true },
         frame: false,
         width: 600,
-        height: 391,
+        height: 500,
     });
 
     mainWindow

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
@@ -32,5 +32,31 @@ exports[`DeviceConnectViewContainer renders 1`] = `
       }
     }
   />
+  <TelemetryPermissionDialog
+    deps={
+      Object {
+        "currentWindow": Object {
+          "close": [Function],
+        },
+        "userConfigurationStore": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "changedHandlers": EventHandlerList {
+            "handlers": Array [],
+          },
+          "indexDbApi": undefined,
+          "onGetCurrentState": [Function],
+          "onSaveIssueSettings": [Function],
+          "onSetHighContrastMode": [Function],
+          "onSetIssueFilingService": [Function],
+          "onSetIssueFilingServiceProperty": [Function],
+          "onSetTelemetryState": [Function],
+          "persistedState": undefined,
+          "storeName": 11,
+          "userConfigActions": undefined,
+        },
+      }
+    }
+    isFirstTime={true}
+  />
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DeviceConnectViewContainer listen to user configuration store: state from constructor 1`] = `
+Object {
+  "userConfigurationStoreData": Object {
+    "enableTelemetry": false,
+    "isFirstTime": true,
+  },
+}
+`;
+
+exports[`DeviceConnectViewContainer listen to user configuration store: updated state 1`] = `
+Object {
+  "userConfigurationStoreData": Object {
+    "enableTelemetry": true,
+    "isFirstTime": false,
+  },
+}
+`;
+
 exports[`DeviceConnectViewContainer renders 1`] = `
 <React.Fragment>
   <WindowTitle

--- a/src/tests/unit/tests/electron/device-connect-view/components/device-connect-view-container.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/device-connect-view-container.test.tsx
@@ -3,7 +3,11 @@
 
 import { BrowserWindow } from 'electron';
 import { shallow } from 'enzyme';
+import { isFunction } from 'lodash';
 import * as React from 'react';
+import { It, Mock, Times } from 'typemoq';
+import { BaseStore } from '../../../../../../common/base-store';
+import { UserConfigurationStoreData } from '../../../../../../common/types/store-data/user-configuration-store';
 import {
     DeviceConnectViewContainer,
     DeviceConnectViewContainerDeps,
@@ -11,15 +15,16 @@ import {
 } from '../../../../../../electron/device-connect-view/components/device-connect-view-container';
 
 describe('DeviceConnectViewContainer', () => {
-    it('renders', () => {
-        const currentWindowStub = {
-            close: () => {
-                return;
-            },
-        } as BrowserWindow;
+    const currentWindowStub = {
+        close: () => {
+            return;
+        },
+    } as BrowserWindow;
 
+    it('renders', () => {
         const deps: DeviceConnectViewContainerDeps = {
             currentWindow: currentWindowStub,
+            userConfigurationStore: Mock.ofType<BaseStore<UserConfigurationStoreData>>().object,
         };
 
         const props: DeviceConnectViewContainerProps = { deps };
@@ -27,5 +32,50 @@ describe('DeviceConnectViewContainer', () => {
         const wrapped = shallow(<DeviceConnectViewContainer {...props} />);
 
         expect(wrapped.getElement()).toMatchSnapshot();
+    });
+
+    it('listen to user configuration store', () => {
+        const userConfigurationStoreMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>();
+
+        userConfigurationStoreMock
+            .setup(store => store.getState())
+            .returns(() => {
+                return {
+                    isFirstTime: true,
+                    enableTelemetry: false,
+                } as UserConfigurationStoreData;
+            });
+
+        userConfigurationStoreMock
+            .setup(store => store.getState())
+            .returns(() => {
+                return {
+                    isFirstTime: false,
+                    enableTelemetry: true,
+                } as UserConfigurationStoreData;
+            });
+
+        let storeListener: Function;
+
+        userConfigurationStoreMock
+            .setup(store => store.addChangedListener(It.is(isFunction)))
+            .callback(listener => {
+                storeListener = listener;
+            });
+
+        const deps: DeviceConnectViewContainerDeps = {
+            currentWindow: currentWindowStub,
+            userConfigurationStore: userConfigurationStoreMock.object,
+        };
+
+        const props: DeviceConnectViewContainerProps = { deps };
+
+        const wrapped = shallow(<DeviceConnectViewContainer {...props} />);
+
+        expect(wrapped.instance().state).toMatchSnapshot('state from constructor');
+
+        storeListener();
+
+        expect(wrapped.instance().state).toMatchSnapshot('updated state');
     });
 });

--- a/src/tests/unit/tests/electron/device-connect-view/components/device-connect-view-container.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/device-connect-view-container.test.tsx
@@ -5,7 +5,8 @@ import { BrowserWindow } from 'electron';
 import { shallow } from 'enzyme';
 import { isFunction } from 'lodash';
 import * as React from 'react';
-import { It, Mock, Times } from 'typemoq';
+import { It, Mock } from 'typemoq';
+import { UserConfigurationStore } from '../../../../../../background/stores/global/user-configuration-store';
 import { BaseStore } from '../../../../../../common/base-store';
 import { UserConfigurationStoreData } from '../../../../../../common/types/store-data/user-configuration-store';
 import {
@@ -22,10 +23,20 @@ describe('DeviceConnectViewContainer', () => {
     } as BrowserWindow;
 
     it('renders', () => {
+        const userConfigurationStoreMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>(UserConfigurationStore);
+
+        userConfigurationStoreMock
+            .setup(store => store.getState())
+            .returns(() => {
+                return {
+                    isFirstTime: true,
+                } as UserConfigurationStoreData;
+            });
+
         const deps: DeviceConnectViewContainerDeps = {
             currentWindow: currentWindowStub,
-            userConfigurationStore: Mock.ofType<BaseStore<UserConfigurationStoreData>>().object,
-        };
+            userConfigurationStore: userConfigurationStoreMock.object,
+        } as DeviceConnectViewContainerDeps;
 
         const props: DeviceConnectViewContainerProps = { deps };
 
@@ -64,9 +75,8 @@ describe('DeviceConnectViewContainer', () => {
             });
 
         const deps: DeviceConnectViewContainerDeps = {
-            currentWindow: currentWindowStub,
             userConfigurationStore: userConfigurationStoreMock.object,
-        };
+        } as DeviceConnectViewContainerDeps;
 
         const props: DeviceConnectViewContainerProps = { deps };
 

--- a/src/tests/unit/tests/electron/device-connect-view/device-connect-view-renderer.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/device-connect-view-renderer.test.tsx
@@ -5,7 +5,10 @@ import { DeviceConnectViewRenderer } from 'electron/device-connect-view/device-c
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { IMock, It, Mock } from 'typemoq';
-import { DeviceConnectViewContainer } from '../../../../../electron/device-connect-view/components/device-connect-view-container';
+import {
+    DeviceConnectViewContainer,
+    DeviceConnectViewContainerProps,
+} from '../../../../../electron/device-connect-view/components/device-connect-view-container';
 
 describe('DeviceConnectViewRendererTest', () => {
     test('render', () => {
@@ -26,7 +29,7 @@ describe('DeviceConnectViewRendererTest', () => {
             deps: {
                 currentWindow: browserWindow,
             },
-        };
+        } as DeviceConnectViewContainerProps;
 
         const expectedComponent = <DeviceConnectViewContainer {...props} />;
 


### PR DESCRIPTION
#### Description of changes

Wire up store, actions and action creator and render the telemetry opt in dialog base on user configuration from the persisted local storage.

![01 - telemetry opt in dialog](https://user-images.githubusercontent.com/2837582/65184015-8a400600-da19-11e9-83e4-c719fd955360.gif)

#### Pull request checklist

- [x] Addresses an existing issue: completes WI # 1597959
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [] (UI changes only) Added screenshots/GIFs to description above
- [] (UI changes only) Verified usability with NVDA/JAWS
