### PR TITLE
chore: add test:electron step to yarn precheckin

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "format-check": "prettier --config prettier.config.js --check \"**/*\"",
         "generate-scss-typings": "tsm \"src/**/*.scss\"",
         "clean:scss-typings": "grunt clean:scss",
-        "precheckin": "npm-run-all --serial clean:scss-typings format-check tslint copyrightheaders build:all test test:e2e",
+        "precheckin": "npm-run-all --serial clean:scss-typings format-check tslint copyrightheaders build:all test test:e2e test:electron",
         "start:electron": "electron drop/electron/extension/bundle/main.bundle.js",
         "test": "jest --projects src/tests/unit",
         "test:e2e": "jest --projects src/tests/end-to-end --runInBand",


### PR DESCRIPTION
#### Description of changes

This PR adds a `test:electron` step to `yarn precheckin` script in our `package.json`. This is to ensure that when developers run `precheckin` they can replicate all the checks that a normal `PR build/check` will have on github/azure-devops.
The build step; `build:all` is already validating build for electron.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
