### PR TITLE
refactor: wrap ElectronExternalLink to not need shell prop

### DIFF
--- a/src/electron/device-connect-view/components/device-connect-header.tsx
+++ b/src/electron/device-connect-view/components/device-connect-header.tsx
@@ -1,17 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { shell } from 'electron';
 import * as React from 'react';
+
 import { NamedFC } from '../../../common/react/named-fc';
-import { ElectronExternalLink } from './electron-external-link';
+import { ElectronLink } from './electron-link';
 
 export const DeviceConnectHeader = NamedFC('DeviceConnectHeader', () => {
     return (
         <header className="device-connect-header">
             <h2>Connect to your android device</h2>
-            <ElectronExternalLink href="https://go.microsoft.com/fwlink/?linkid=2101252" shell={shell}>
-                How do I connect to my device?
-            </ElectronExternalLink>
+            <ElectronLink href="https://go.microsoft.com/fwlink/?linkid=2101252">How do I connect to my device?</ElectronLink>
         </header>
     );
 });

--- a/src/electron/device-connect-view/components/electron-link.tsx
+++ b/src/electron/device-connect-view/components/electron-link.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shell } from 'electron';
+import * as React from 'react';
+import { NamedFC } from '../../../common/react/named-fc';
+import { ElectronExternalLink } from './electron-external-link';
+
+export type ElectronLinkProps = {
+    href: string;
+    children: React.ReactNode;
+};
+
+export const ElectronLink = NamedFC<ElectronLinkProps>('ElectronLink', props => {
+    return <ElectronExternalLink {...props} shell={shell} />;
+});

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-header.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-header.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`DeviceConnectHeaderTest render 1`] = `
   <h2>
     Connect to your android device
   </h2>
-  <ElectronExternalLink
+  <ElectronLink
     href="https://go.microsoft.com/fwlink/?linkid=2101252"
   >
     How do I connect to my device?
-  </ElectronExternalLink>
+  </ElectronLink>
 </header>
 `;

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/electron-link.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/electron-link.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ElectronLink renders and uses electron shell 1`] = `
+<ElectronExternalLink
+  href="test-href"
+>
+  test-text
+</ElectronExternalLink>
+`;

--- a/src/tests/unit/tests/electron/device-connect-view/components/electron-link.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/electron-link.test.tsx
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shell } from 'electron';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { ElectronExternalLink } from '../../../../../../electron/device-connect-view/components/electron-external-link';
+import { ElectronLink } from '../../../../../../electron/device-connect-view/components/electron-link';
+
+describe('ElectronLink', () => {
+    it('renders and uses electron shell', () => {
+        const wrapped = shallow(<ElectronLink href="test-href">test-text</ElectronLink>);
+
+        expect(wrapped.getElement()).toMatchSnapshot();
+
+        expect(wrapped.find(ElectronExternalLink).prop('shell')).toEqual(shell);
+    });
+});


### PR DESCRIPTION
#### Description of changes

While working on #1258 I found out we do not have a suitable candidate for the `LinkComponent` dependency of the telemetry opt in. The plan was to reuse `ElectronExternalLink` but this component expect a `shell` prop (which comes from the electron api).

This PR adds a wrapper component around the `ElectronExternalLink` so we don't need to pass the `shell` prop and we can use it for the `LinkComponent` dependency.

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1597959
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
