### PR TITLE
refactor: telemetry client provider refactor

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -56,7 +56,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
         const telemetryDataFactory = new TelemetryDataFactory();
         const telemetryLogger = new TelemetryLogger();
 
-        const telemetryClient = getTelemetryClient(userData, browserAdapter, telemetryLogger, AppInsights, browserAdapter);
+        const telemetryClient = getTelemetryClient(userData.installationData, browserAdapter, telemetryLogger, AppInsights, browserAdapter);
 
         const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
 

--- a/src/background/telemetry/telemetry-client-provider.ts
+++ b/src/background/telemetry/telemetry-client-provider.ts
@@ -7,7 +7,7 @@ import { DateProvider } from '../../common/date-provider';
 import { generateUID } from '../../common/uid-generator';
 import { ApplicationBuildGenerator } from '../application-build-generator';
 import { InstallDataGenerator } from '../install-data-generator';
-import { LocalStorageData } from '../storage-data';
+import { InstallationData } from '../installation-data';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
 import { ApplicationTelemetryDataFactory } from './application-telemetry-data-factory';
 import { NullTelemetryClient } from './null-telemetry-client';
@@ -15,7 +15,7 @@ import { TelemetryClient } from './telemetry-client';
 import { TelemetryLogger } from './telemetry-logger';
 
 export const getTelemetryClient = (
-    userData: LocalStorageData,
+    installationData: InstallationData,
     appDataAdapter: AppDataAdapter,
     logger: TelemetryLogger,
     appInsights: Microsoft.ApplicationInsights.IAppInsights,
@@ -27,12 +27,7 @@ export const getTelemetryClient = (
         return new NullTelemetryClient(logger);
     }
 
-    const installDataGenerator = new InstallDataGenerator(
-        userData.installationData,
-        generateUID,
-        DateProvider.getCurrentDate,
-        storageAdapter,
-    );
+    const installDataGenerator = new InstallDataGenerator(installationData, generateUID, DateProvider.getCurrentDate, storageAdapter);
     const applicationBuildGenerator = new ApplicationBuildGenerator();
     const coreTelemetryDataFactory = new ApplicationTelemetryDataFactory(appDataAdapter, applicationBuildGenerator, installDataGenerator);
 

--- a/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
@@ -1,20 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { LocalStorageData } from 'background/storage-data';
 import { AppInsightsTelemetryClient } from 'background/telemetry/app-insights-telemetry-client';
 import { NullTelemetryClient } from 'background/telemetry/null-telemetry-client';
 import { getTelemetryClient } from 'background/telemetry/telemetry-client-provider';
 import { TelemetryLogger } from 'background/telemetry/telemetry-logger';
 import { Mock } from 'typemoq';
+import { InstallationData } from '../../../../../background/installation-data';
 import { AppDataAdapter } from '../../../../../common/browser-adapters/app-data-adapter';
 import { StorageAdapter } from '../../../../../common/browser-adapters/storage-adapter';
 import { configMutator } from '../../../../../common/configuration';
 
 describe('TelemetryClientProvider', () => {
+    const installationData: InstallationData = {
+        id: 'test-id',
+        month: 9,
+        year: 2019,
+    };
+
     beforeEach(() => configMutator.reset());
     afterAll(() => configMutator.reset());
 
-    test('with instrumentation key', () => {
+    it('builds a telemetry client using the instrumentation key', () => {
         configMutator.setOption('appInsightsInstrumentationKey', 'test-key');
 
         const appAdapterMock = Mock.ofType<AppDataAdapter>();
@@ -22,7 +28,7 @@ describe('TelemetryClientProvider', () => {
         appAdapterMock.setup(adapter => adapter.getVersion()).returns(() => 'test');
 
         const result = getTelemetryClient(
-            {} as LocalStorageData,
+            installationData,
             appAdapterMock.object,
             Mock.ofType<TelemetryLogger>().object,
             Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>().object,
@@ -32,11 +38,11 @@ describe('TelemetryClientProvider', () => {
         expect(result).toBeInstanceOf(AppInsightsTelemetryClient);
     });
 
-    test('without instrumentation key', () => {
+    it('builds a telemetry client when there is no instrumentation key', () => {
         configMutator.setOption('appInsightsInstrumentationKey', null);
 
         const result = getTelemetryClient(
-            {} as LocalStorageData,
+            installationData,
             Mock.ofType<AppDataAdapter>().object,
             Mock.ofType<TelemetryLogger>().object,
             Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>().object,


### PR DESCRIPTION
#### Description of changes

Currently, `getTelemetryClient` receives `userData: LocalStorageData` as it's first parameter. `LocalStorageData` includes feature flags, launch panel settings and installation data (among others) but `getTelemetryClient` only uses installation data, hence, it violates ISP.

Additionally, we would like to reuse `getTelemetryClient` on AI-mobile too, but right now, there is no need for launch panel settings or feature flag data.

This PR, update `getTelemetryClient` to use `InstallationData` directly making it abide ISP and to be more easy to reuse on AI-mobile.

#### Pull request checklist

- [x] Addresses an existing issue: Part of WI # 1600256
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
