### PR TITLE
refactor: introduce feature flag checker

### DIFF
--- a/src/background/feature-flag-checker.ts
+++ b/src/background/feature-flag-checker.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export type FeatureFlagChecker = {
+    isEnabled: (feature: string) => boolean;
+};

--- a/src/background/telemetry/telemetry-logger.ts
+++ b/src/background/telemetry/telemetry-logger.ts
@@ -3,20 +3,20 @@
 import { FeatureFlags } from '../../common/feature-flags';
 import { createDefaultLogger } from '../../common/logging/default-logger';
 import { Logger } from '../../common/logging/logger';
-import { FeatureFlagsController } from '../feature-flags-controller';
+import { FeatureFlagChecker } from '../feature-flag-checker';
 import { TelemetryBaseData } from './telemetry-base-data';
 
 export class TelemetryLogger {
-    private featureFlagsController: FeatureFlagsController;
+    private featureFlagChecker: FeatureFlagChecker;
 
     constructor(private logger: Logger = createDefaultLogger()) {}
 
-    public initialize(featureFlagsController: FeatureFlagsController): void {
-        this.featureFlagsController = featureFlagsController;
+    public initialize(featureFlagChecker: FeatureFlagChecker): void {
+        this.featureFlagChecker = featureFlagChecker;
     }
 
     public log(data: TelemetryBaseData): void {
-        if (this.featureFlagsController.isEnabled(FeatureFlags.logTelemetryToConsole)) {
+        if (this.featureFlagChecker.isEnabled(FeatureFlags.logTelemetryToConsole)) {
             this.logger.log('eventName: ', data.name, '; customProperties: ', data.properties);
         }
     }

--- a/src/electron/common/rigged-feature-flag-checker.ts
+++ b/src/electron/common/rigged-feature-flag-checker.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { FeatureFlagChecker } from 'background/feature-flag-checker';
+
+// To be used on AI-Android until we get proper feature flag implementation.
+export class RiggedFeatureFlagChecker implements FeatureFlagChecker {
+    public isEnabled(feature: string): boolean {
+        return true;
+    }
+}

--- a/src/tests/unit/tests/electron/common/rigged-feature-flag-checker.test.ts
+++ b/src/tests/unit/tests/electron/common/rigged-feature-flag-checker.test.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { RiggedFeatureFlagChecker } from 'electron/common/rigged-feature-flag-checker';
+
+describe('RiggedFeatureFlagChecker', () => {
+    it('checks if a feature flag is enabled', () => {
+        const testSubject = new RiggedFeatureFlagChecker();
+
+        expect(testSubject.isEnabled('any feature flag should work')).toBe(true);
+    });
+});


### PR DESCRIPTION
#### Description of changes

As part of reusing the Telemetry Opt In dialog from AI-Web on AI-Android, we need to reuse `TelemetryLogger`.

Currently, the logic of the logger is based on the `FeatureFlagController` (basically, log only when `logTelemetryToConsole` feature flag is on)

At this point, AI-Mobile doesn't have feature flags implemented.

In this PR we are:

- creating a type/interface for use in the `TelemetryLogger`
- creating a "fake" feature flag checker to be used on AI-Android.

#### Pull request checklist

- [x] Addresses an existing issue: Part of WI # 1600256
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected