### PR TITLE
Update to axe-core 3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     },
     "dependencies": {
         "applicationinsights-js": "^1.0.20",
-        "axe-core": "3.2.2",
+        "axe-core": "3.3.2",
         "axios": "^0.19.0",
         "classnames": "^2.2.6",
         "idb-keyval": "^3.2.0",

--- a/src/content/adhoc/color/guidance.tsx
+++ b/src/content/adhoc/color/guidance.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { create, GuidanceTitle, React } from '../../common';
 
-export const guidance = create(({ Markup }) => (
+export const guidance = create(({ Markup, Link }) => (
     <React.Fragment>
         <GuidanceTitle name={'Color'} />
 
@@ -13,6 +13,9 @@ export const guidance = create(({ Markup }) => (
             response, or distinguishing a visible element), that meaning is not available to people who are blind or colorblind. To ensure
             that meaning conveyed through color is available to everyone, it must also be conveyed through other visual aspects. (It must
             also be communicated textually to assistive technology, but that's beyond the scope of this test.)
+        </p>
+        <p>
+            To learn more, see <Link.WCAG21UnderstandingUseOfColor />.
         </p>
 
         <h2>About the Color visualization</h2>

--- a/src/content/link.tsx
+++ b/src/content/link.tsx
@@ -79,6 +79,10 @@ export const link = {
         'WAI-ARIA Authoring Practices 1.1: Design Patterns and Widgets',
         'https://www.w3.org/TR/wai-aria-practices-1.1/',
     ),
+    WCAG21UnderstandingUseOfColor: linkTo(
+        'Understanding Success Criterion 1.4.1: Use of Color',
+        'https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html',
+    ),
     WCAG21UnderstandingAudioOnlyViewOnlyPrerecorded: linkTo(
         'Understanding Success Criterion 1.2.1: Audio-only and Video-only (Prerecorded)',
         'https://www.w3.org/WAI/WCAG21/Understanding/audio-only-and-video-only-prerecorded.html',

--- a/src/scanner/axe-options.ts
+++ b/src/scanner/axe-options.ts
@@ -4,7 +4,7 @@ import * as Axe from 'axe-core';
 
 export interface AxeOptions {
     runOnly?: Axe.RunOnly;
-    restoreScroll?: Boolean; // missing from axe options.
+    restoreScroll?: boolean;
 }
 export type AxeScanContext = string | Document | IncludeExcludeOptions | NodeList;
 export interface IncludeExcludeOptions {

--- a/src/scanner/rule-to-links-mappings.ts
+++ b/src/scanner/rule-to-links-mappings.ts
@@ -23,7 +23,7 @@ export const ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]> 
     'input-button-name': [link.WCAG_4_1_2],
     'landmark-unique': [BestPractice],
     'role-img-alt': [link.WCAG_1_1_1],
-    'scrollable-region-focusable': [BestPractice],
+    'scrollable-region-focusable': [link.WCAG_2_1_1, BestPractice],
     'area-alt': [link.WCAG_1_1_1],
     'image-alt': [link.WCAG_1_1_1],
     'image-redundant-alt': [BestPractice],

--- a/src/scanner/rule-to-links-mappings.ts
+++ b/src/scanner/rule-to-links-mappings.ts
@@ -17,6 +17,13 @@ const BestPractice: HyperlinkDefinition = {
 };
 
 export const ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]> = {
+    'aria-input-field-name': [link.WCAG_4_1_2],
+    'aria-toggle-field-name': [link.WCAG_4_1_2],
+    'avoid-inline-spacing': [link.WCAG_1_4_12],
+    'input-button-name': [link.WCAG_4_1_2],
+    'landmark-unique': [BestPractice],
+    'role-img-alt': [link.WCAG_1_1_1],
+    'scrollable-region-focusable': [BestPractice],
     'area-alt': [link.WCAG_1_1_1],
     'image-alt': [link.WCAG_1_1_1],
     'image-redundant-alt': [BestPractice],
@@ -94,7 +101,7 @@ export const ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]> 
     'aria-allowed-role': [BestPractice],
     'autocomplete-valid': [link.WCAG_1_3_5],
     'css-orientation-lock': [BestPractice],
-    'aria-hidden-focus': [link.WCAG_4_1_2],
+    'aria-hidden-focus': [link.WCAG_4_1_2, link.WCAG_1_3_1],
     'form-field-multiple-labels': [BestPractice],
     'label-content-name-mismatch': [BestPractice],
     'landmark-complementary-is-top-level': [link.WCAG_1_3_1, BestPractice],

--- a/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/a11y-content.test.ts.snap
@@ -20,6 +20,17 @@ exports[`A11Y for content pages High Contrast mode adhoc/color/guidance 1`] = `
       <p>
         When color is the only visual means of conveying meaning (such as communicating information, indicating an action, prompting a response, or distinguishing a visible element), that meaning is not available to people who are blind or colorblind. To ensure that meaning conveyed through color is available to everyone, it must also be conveyed through other visual aspects. (It must also be communicated textually to assistive technology, but that's beyond the scope of this test.)
       </p>
+      <p>
+        To learn more, see 
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 1.4.1: Use of Color
+        </a>
+        .
+      </p>
       <h2>
         About the Color visualization
       </h2>
@@ -33352,6 +33363,17 @@ exports[`A11Y for content pages Normal mode adhoc/color/guidance 1`] = `
       </h2>
       <p>
         When color is the only visual means of conveying meaning (such as communicating information, indicating an action, prompting a response, or distinguishing a visible element), that meaning is not available to people who are blind or colorblind. To ensure that meaning conveyed through color is available to everyone, it must also be conveyed through other visual aspects. (It must also be communicated textually to assistive technology, but that's beyond the scope of this test.)
+      </p>
+      <p>
+        To learn more, see 
+        <a
+          class="ms-Link insights-link root-000"
+          href="https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html"
+          target="_blank"
+        >
+          Understanding Success Criterion 1.4.1: Use of Color
+        </a>
+        .
       </p>
       <h2>
         About the Color visualization

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -259,7 +259,7 @@ exports[`Launch Pad Normal mode content should match snapshot 1`] = `
           >
             axe-core
           </a>
-           3.2.2
+           3.3.2
         </div>
       </div>
     </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1258,10 +1258,10 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axe-core@3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.2.2.tgz#b06d6e9ae4636d706068843272bfaeed3fe97362"
-  integrity sha512-gAy4kMSPpuRJV3mwictJqlg5LhE84Vw2CydKdC4tvrLhR6+G3KW51zbL/vYujcLA2jvWOq3HMHrVeNuw+mrLVA==
+axe-core@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.3.2.tgz#7baf3c55a5cf1621534a2c38735f5a1bf2f7e1a8"
+  integrity sha512-lRdxsRt7yNhqpcXQk1ao1BL73OZDzmFCWOG0mC4tGR/r14ohH2payjHwCMQjHGbBKm924eDlmG7utAGHiX/A6g==
 
 axios@^0.19.0:
   version "0.19.0"


### PR DESCRIPTION
#### Description of changes

This PR consumes axe-core 3.3.2 and includes:
- updates to rule-to-WCAG mappings, including `scrollable-region-focusable` and `label-content-name-mismatch` as `BestPractice` so they aren't run in the standard set
- an update to our `restoreScroll` option type, which [worked internally](https://github.com/dequelabs/axe-core/commit/d55f3cda4598320f8ee496684a01f8b9e1598f8d?short_path=8be2f64#diff-8be2f642524623d5012c7b2cf4fa4eb9) but wasn't included in axe.d.ts [until now](https://github.com/dequelabs/axe-core/pull/1697/files)
- updated launchpad & guidance snapshot
- update to color guidance to include interactive link to improve keyboard accessibility

example new rule result:
![role-img-alt screenshot](https://user-images.githubusercontent.com/7775527/65288806-f6476a80-dafc-11e9-9c36-993d8a66a22e.png)

updated use-of-color guidance to include WCAG link:
![use of color screenshot](https://user-images.githubusercontent.com/7775527/65461883-82150b80-de09-11e9-835d-053e78e7833e.png)


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
