### PR TITLE
refactor: NullTelemetryClient to use ApplicationTelemetryDataFactory

### DIFF
--- a/src/background/telemetry/null-telemetry-client.ts
+++ b/src/background/telemetry/null-telemetry-client.ts
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ApplicationTelemetryDataFactory } from './application-telemetry-data-factory';
 import { TelemetryBaseData } from './telemetry-base-data';
 import { TelemetryClient } from './telemetry-client';
 import { TelemetryLogger } from './telemetry-logger';
 
 export class NullTelemetryClient implements TelemetryClient {
-    constructor(private readonly logger: TelemetryLogger) {}
+    constructor(private readonly telemetryDataFactory: ApplicationTelemetryDataFactory, private readonly logger: TelemetryLogger) {}
 
     public enableTelemetry(): void {
         // no op
@@ -14,6 +15,11 @@ export class NullTelemetryClient implements TelemetryClient {
         // no op
     }
     public trackEvent(name: string, properties?: { [name: string]: string }): void {
+        properties = {
+            ...properties,
+            ...this.telemetryDataFactory.getData(),
+        };
+
         const data: TelemetryBaseData = {
             name,
             properties,

--- a/src/background/telemetry/telemetry-client-provider.ts
+++ b/src/background/telemetry/telemetry-client-provider.ts
@@ -21,15 +21,15 @@ export const getTelemetryClient = (
     appInsights: Microsoft.ApplicationInsights.IAppInsights,
     storageAdapter: StorageAdapter,
 ): TelemetryClient => {
-    const appInsightsInstrumentationKey = config.getOption('appInsightsInstrumentationKey');
-
-    if (appInsightsInstrumentationKey == null) {
-        return new NullTelemetryClient(logger);
-    }
-
     const installDataGenerator = new InstallDataGenerator(installationData, generateUID, DateProvider.getCurrentDate, storageAdapter);
     const applicationBuildGenerator = new ApplicationBuildGenerator();
     const coreTelemetryDataFactory = new ApplicationTelemetryDataFactory(appDataAdapter, applicationBuildGenerator, installDataGenerator);
+
+    const appInsightsInstrumentationKey = config.getOption('appInsightsInstrumentationKey');
+
+    if (appInsightsInstrumentationKey == null) {
+        return new NullTelemetryClient(coreTelemetryDataFactory, logger);
+    }
 
     return new AppInsightsTelemetryClient(appInsights, coreTelemetryDataFactory, logger);
 };

--- a/src/tests/unit/tests/background/telemetry/null-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/null-telemetry-client.test.ts
@@ -5,12 +5,15 @@ import { NullTelemetryClient } from 'background/telemetry/null-telemetry-client'
 import { TelemetryBaseData } from 'background/telemetry/telemetry-base-data';
 import { TelemetryLogger } from 'background/telemetry/telemetry-logger';
 import { IMock, Mock, Times } from 'typemoq';
+import { ApplicationTelemetryDataFactory } from '../../../../../background/telemetry/application-telemetry-data-factory';
 
 describe('Null telemetry client', () => {
     let loggerMock: IMock<TelemetryLogger>;
+    let telemetryDataFactoryMock: IMock<ApplicationTelemetryDataFactory>;
 
     beforeEach(() => {
         loggerMock = Mock.ofType<TelemetryLogger>();
+        telemetryDataFactoryMock = Mock.ofType<ApplicationTelemetryDataFactory>();
     });
 
     describe('no op, no side effects', () => {
@@ -46,6 +49,6 @@ describe('Null telemetry client', () => {
     });
 
     function createDefaultTestObject(): NullTelemetryClient {
-        return new NullTelemetryClient(loggerMock.object);
+        return new NullTelemetryClient(telemetryDataFactoryMock.object, loggerMock.object);
     }
 });

--- a/src/tests/unit/tests/background/telemetry/null-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/null-telemetry-client.test.ts
@@ -5,7 +5,10 @@ import { NullTelemetryClient } from 'background/telemetry/null-telemetry-client'
 import { TelemetryBaseData } from 'background/telemetry/telemetry-base-data';
 import { TelemetryLogger } from 'background/telemetry/telemetry-logger';
 import { IMock, Mock, Times } from 'typemoq';
-import { ApplicationTelemetryDataFactory } from '../../../../../background/telemetry/application-telemetry-data-factory';
+import {
+    ApplicationTelemetryData,
+    ApplicationTelemetryDataFactory,
+} from '../../../../../background/telemetry/application-telemetry-data-factory';
 
 describe('Null telemetry client', () => {
     let loggerMock: IMock<TelemetryLogger>;
@@ -31,22 +34,33 @@ describe('Null telemetry client', () => {
     describe('trackEvent', () => {
         it('should log telemetry', () => {
             const name = 'test-event-name';
-            const properties = {};
+            const appDataStub = {
+                applicationVersion: 'test version',
+            } as ApplicationTelemetryData;
 
-            const expected: TelemetryBaseData = {
+            const properties = {
+                testProperty: 'test property',
+                ...appDataStub,
+            };
+
+            const expectedLogData: TelemetryBaseData = {
                 name,
                 properties,
             };
 
-            loggerMock.setup(logger => logger.log(expected)).verifiable(Times.once());
-            telemetryDataFactoryMock.setup(factory => factory.getData()).verifiable(Times.once());
+            telemetryDataFactoryMock
+                .setup(factory => factory.getData())
+                .returns(() => appDataStub)
+                .verifiable(Times.once());
+
+            loggerMock.setup(logger => logger.log(expectedLogData)).verifiable(Times.once());
 
             const testObject = createDefaultTestObject();
 
             testObject.trackEvent(name, properties);
 
-            loggerMock.verifyAll();
             telemetryDataFactoryMock.verifyAll();
+            loggerMock.verifyAll();
         });
     });
 

--- a/src/tests/unit/tests/background/telemetry/null-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/null-telemetry-client.test.ts
@@ -39,12 +39,14 @@ describe('Null telemetry client', () => {
             };
 
             loggerMock.setup(logger => logger.log(expected)).verifiable(Times.once());
+            telemetryDataFactoryMock.setup(factory => factory.getData()).verifiable(Times.once());
 
             const testObject = createDefaultTestObject();
 
             testObject.trackEvent(name, properties);
 
             loggerMock.verifyAll();
+            telemetryDataFactoryMock.verifyAll();
         });
     });
 


### PR DESCRIPTION
#### Description of changes

Currently, `AppInsightsTelemetryClient` takes in an instance of `ApplicationTelemetryDataFactory` as part of its constructor. `ApplicationTelemetryDataFactory` has data specific to the application, such as version, build, and installation ID. Refactoring `NullTelemetryClient` to also take in an instance of `ApplicationTelemetryDataFactory`, since the information provided by it could still be useful.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
