### PR TITLE
refactor: ApplicationTelemetryDataFactory

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -17,6 +17,7 @@ import { createDefaultPromiseFactory } from '../common/promises/promise-factory'
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
 import { UrlValidator } from '../common/url-validator';
 import { WindowUtils } from '../common/window-utils';
+import { title } from '../content/strings/application';
 import { IssueFilingServiceProviderImpl } from '../issue-filing/issue-filing-service-provider-impl';
 import { ChromeCommandHandler } from './chrome-command-handler';
 import { DetailsViewController } from './details-view-controller';
@@ -37,7 +38,6 @@ import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
 import { TelemetryLogger } from './telemetry/telemetry-logger';
 import { TelemetryStateListener } from './telemetry/telemetry-state-listener';
 import { UserStoredDataCleaner } from './user-stored-data-cleaner';
-import { title } from '../content/strings/application';
 
 declare var window: Window & InsightsFeatureFlags;
 

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -37,6 +37,7 @@ import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
 import { TelemetryLogger } from './telemetry/telemetry-logger';
 import { TelemetryStateListener } from './telemetry/telemetry-state-listener';
 import { UserStoredDataCleaner } from './user-stored-data-cleaner';
+import { title } from '../content/strings/application';
 
 declare var window: Window & InsightsFeatureFlags;
 
@@ -56,7 +57,14 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
         const telemetryDataFactory = new TelemetryDataFactory();
         const telemetryLogger = new TelemetryLogger();
 
-        const telemetryClient = getTelemetryClient(userData.installationData, browserAdapter, telemetryLogger, AppInsights, browserAdapter);
+        const telemetryClient = getTelemetryClient(
+            title,
+            userData.installationData,
+            browserAdapter,
+            telemetryLogger,
+            AppInsights,
+            browserAdapter,
+        );
 
         const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
 

--- a/src/background/telemetry/application-telemetry-data-factory.ts
+++ b/src/background/telemetry/application-telemetry-data-factory.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { InstallDataGenerator } from '../install-data-generator';
-import { title } from './../../content/strings/application';
 
 export interface ApplicationTelemetryData {
     applicationVersion: string;
@@ -13,6 +12,7 @@ export interface ApplicationTelemetryData {
 export class ApplicationTelemetryDataFactory {
     constructor(
         private readonly version: string,
+        private readonly name: string,
         private readonly build: string,
         private readonly installDataGenerator: InstallDataGenerator,
     ) {}
@@ -20,7 +20,7 @@ export class ApplicationTelemetryDataFactory {
     public getData(): ApplicationTelemetryData {
         return {
             applicationVersion: this.version,
-            applicationName: title,
+            applicationName: this.name,
             applicationBuild: this.build,
             installationId: this.installDataGenerator.getInstallationId(),
         };

--- a/src/background/telemetry/application-telemetry-data-factory.ts
+++ b/src/background/telemetry/application-telemetry-data-factory.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AppDataAdapter } from '../../common/browser-adapters/app-data-adapter';
-import { ApplicationBuildGenerator } from '../application-build-generator';
 import { InstallDataGenerator } from '../install-data-generator';
 import { title } from './../../content/strings/application';
 
@@ -13,17 +11,11 @@ export interface ApplicationTelemetryData {
 }
 
 export class ApplicationTelemetryDataFactory {
-    private readonly version: string;
-    private readonly build: string;
-
     constructor(
-        appDataAdapter: AppDataAdapter,
-        buildGenerator: ApplicationBuildGenerator,
+        private readonly version: string,
+        private readonly build: string,
         private readonly installDataGenerator: InstallDataGenerator,
-    ) {
-        this.version = appDataAdapter.getVersion();
-        this.build = buildGenerator.getBuild();
-    }
+    ) {}
 
     public getData(): ApplicationTelemetryData {
         return {

--- a/src/background/telemetry/telemetry-client-provider.ts
+++ b/src/background/telemetry/telemetry-client-provider.ts
@@ -15,6 +15,7 @@ import { TelemetryClient } from './telemetry-client';
 import { TelemetryLogger } from './telemetry-logger';
 
 export const getTelemetryClient = (
+    applicationName: string,
     installationData: InstallationData,
     appDataAdapter: AppDataAdapter,
     logger: TelemetryLogger,
@@ -25,6 +26,7 @@ export const getTelemetryClient = (
     const applicationBuildGenerator = new ApplicationBuildGenerator();
     const coreTelemetryDataFactory = new ApplicationTelemetryDataFactory(
         appDataAdapter.getVersion(),
+        applicationName,
         applicationBuildGenerator.getBuild(),
         installDataGenerator,
     );

--- a/src/background/telemetry/telemetry-client-provider.ts
+++ b/src/background/telemetry/telemetry-client-provider.ts
@@ -23,7 +23,11 @@ export const getTelemetryClient = (
 ): TelemetryClient => {
     const installDataGenerator = new InstallDataGenerator(installationData, generateUID, DateProvider.getCurrentDate, storageAdapter);
     const applicationBuildGenerator = new ApplicationBuildGenerator();
-    const coreTelemetryDataFactory = new ApplicationTelemetryDataFactory(appDataAdapter, applicationBuildGenerator, installDataGenerator);
+    const coreTelemetryDataFactory = new ApplicationTelemetryDataFactory(
+        appDataAdapter.getVersion(),
+        applicationBuildGenerator.getBuild(),
+        installDataGenerator,
+    );
 
     const appInsightsInstrumentationKey = config.getOption('appInsightsInstrumentationKey');
 

--- a/src/tests/unit/tests/background/telemetry/application-telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/background/telemetry/application-telemetry-data-factory.test.ts
@@ -2,12 +2,13 @@
 // Licensed under the MIT License.
 import { InstallDataGenerator } from 'background/install-data-generator';
 import { ApplicationTelemetryData, ApplicationTelemetryDataFactory } from 'background/telemetry/application-telemetry-data-factory';
-import { title } from 'content/strings/application';
 import { IMock, Mock } from 'typemoq';
 
 describe('ApplicationTelemetryDataFactoryTest', () => {
-    const applicationBuildStub: string = 'application build id';
-    const installationId: string = 'some id';
+    const applicationBuild: string = 'application build id';
+    const applicationVersion: string = 'application version';
+    const applicationName: string = 'application name';
+    const installationId: string = 'installation id';
 
     let installDataGeneratorMock: IMock<InstallDataGenerator>;
 
@@ -20,15 +21,20 @@ describe('ApplicationTelemetryDataFactoryTest', () => {
             .returns(() => installationId)
             .verifiable();
 
-        testSubject = new ApplicationTelemetryDataFactory('2', applicationBuildStub, installDataGeneratorMock.object);
+        testSubject = new ApplicationTelemetryDataFactory(
+            applicationVersion,
+            applicationName,
+            applicationBuild,
+            installDataGeneratorMock.object,
+        );
     });
 
     test('verifyCoreData', () => {
         const expectedData: ApplicationTelemetryData = {
-            installationId: installationId,
-            applicationBuild: applicationBuildStub,
-            applicationName: title,
-            applicationVersion: '2',
+            installationId,
+            applicationBuild,
+            applicationName,
+            applicationVersion,
         };
         expect(testSubject.getData()).toEqual(expectedData);
     });

--- a/src/tests/unit/tests/background/telemetry/application-telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/background/telemetry/application-telemetry-data-factory.test.ts
@@ -1,44 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ApplicationBuildGenerator } from 'background/application-build-generator';
 import { InstallDataGenerator } from 'background/install-data-generator';
 import { ApplicationTelemetryData, ApplicationTelemetryDataFactory } from 'background/telemetry/application-telemetry-data-factory';
 import { title } from 'content/strings/application';
-import { IMock, Mock, Times } from 'typemoq';
-import { AppDataAdapter } from '../../../../../common/browser-adapters/app-data-adapter';
+import { IMock, Mock } from 'typemoq';
 
 describe('ApplicationTelemetryDataFactoryTest', () => {
     const applicationBuildStub: string = 'application build id';
     const installationId: string = 'some id';
-    let applicationBuildGeneratorMock: IMock<ApplicationBuildGenerator>;
+
     let installDataGeneratorMock: IMock<InstallDataGenerator>;
-    let appAdapterMock: IMock<AppDataAdapter>;
+
     let testSubject: ApplicationTelemetryDataFactory;
 
     beforeEach(() => {
-        appAdapterMock = Mock.ofType<AppDataAdapter>();
-        appAdapterMock
-            .setup(adapter => adapter.getVersion())
-            .returns(() => '2')
-            .verifiable();
-
-        applicationBuildGeneratorMock = Mock.ofType<ApplicationBuildGenerator>();
-        applicationBuildGeneratorMock
-            .setup(abg => abg.getBuild())
-            .returns(() => applicationBuildStub)
-            .verifiable(Times.once());
-
         installDataGeneratorMock = Mock.ofType(InstallDataGenerator);
         installDataGeneratorMock
             .setup(generator => generator.getInstallationId())
             .returns(() => installationId)
             .verifiable();
 
-        testSubject = new ApplicationTelemetryDataFactory(
-            appAdapterMock.object,
-            applicationBuildGeneratorMock.object,
-            installDataGeneratorMock.object,
-        );
+        testSubject = new ApplicationTelemetryDataFactory('2', applicationBuildStub, installDataGeneratorMock.object);
     });
 
     test('verifyCoreData', () => {

--- a/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
@@ -17,6 +17,8 @@ describe('TelemetryClientProvider', () => {
         year: 2019,
     };
 
+    const applicationName = 'test application name';
+
     beforeEach(() => configMutator.reset());
     afterAll(() => configMutator.reset());
 
@@ -28,6 +30,7 @@ describe('TelemetryClientProvider', () => {
         appAdapterMock.setup(adapter => adapter.getVersion()).returns(() => 'test');
 
         const result = getTelemetryClient(
+            applicationName,
             installationData,
             appAdapterMock.object,
             Mock.ofType<TelemetryLogger>().object,
@@ -42,6 +45,7 @@ describe('TelemetryClientProvider', () => {
         configMutator.setOption('appInsightsInstrumentationKey', null);
 
         const result = getTelemetryClient(
+            applicationName,
             installationData,
             Mock.ofType<AppDataAdapter>().object,
             Mock.ofType<TelemetryLogger>().object,


### PR DESCRIPTION
#### Description of changes

Currently, `ApplicationTelemetryDataFactory` has a couple of issues:
- it uses `title` as a hard dependency for the `applicationName` property. This means we cannot easily reuse this class on AI-Android, where the current value of `title` doesn't work (as it is `"Accessibility Insights for Web"`... note the **Web** in it)
- it expect an instance of a helper class to get the app version... since the app version doesn't change dynamically while running the app (extension or electron) we can change the param to be the version directly
- same goes for the build param

#### Pull request checklist

- [x] Addresses an existing issue: Part of Telemetry Opt In feature
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
