### PR TITLE
refactor: introduce deps pattern into DeviceConnectPortEntry

### DIFF
--- a/src/electron/device-connect-view/components/device-connect-body.tsx
+++ b/src/electron/device-connect-view/components/device-connect-body.tsx
@@ -48,9 +48,11 @@ export class DeviceConnectBody extends React.Component<DeviceConnectBodyProps, D
             <div className="device-connect-body">
                 <DeviceConnectHeader />
                 <DeviceConnectPortEntry
+                    deps={{
+                        updateStateCallback: this.OnConnectedCallback,
+                        fetchScanResults: fetchScanResults,
+                    }}
                     needsValidation={needsValidation}
-                    updateStateCallback={this.OnConnectedCallback}
-                    fetchScanResults={fetchScanResults}
                 />
                 <DeviceConnectConnectedDevice
                     isConnecting={isConnecting}

--- a/src/electron/device-connect-view/components/device-connect-body.tsx
+++ b/src/electron/device-connect-view/components/device-connect-body.tsx
@@ -16,8 +16,13 @@ export enum DeviceConnectState {
     Connected,
     Error,
 }
-export interface DeviceConnectBodyProps {
+
+export type DeviceConnectBodyDeps = {
     currentWindow: BrowserWindow;
+};
+
+export interface DeviceConnectBodyProps {
+    deps: DeviceConnectBodyDeps;
 }
 
 export interface DeviceConnectBodyState {
@@ -52,7 +57,10 @@ export class DeviceConnectBody extends React.Component<DeviceConnectBodyProps, D
                     connectedDevice={this.state.connectedDevice}
                     hasFailed={hasFailedConnecting}
                 />
-                <DeviceConnectFooter cancelClick={this.props.currentWindow.close} canStartTesting={canStartTesting}></DeviceConnectFooter>
+                <DeviceConnectFooter
+                    cancelClick={this.props.deps.currentWindow.close}
+                    canStartTesting={canStartTesting}
+                ></DeviceConnectFooter>
             </div>
         );
     }

--- a/src/electron/device-connect-view/components/device-connect-body.tsx
+++ b/src/electron/device-connect-view/components/device-connect-body.tsx
@@ -2,11 +2,10 @@
 // Licensed under the MIT License.
 import { BrowserWindow } from 'electron';
 import * as React from 'react';
-import { fetchScanResults } from '../../platform/android/fetch-scan-results';
 import { DeviceConnectConnectedDevice } from './device-connect-connected-device';
 import { DeviceConnectFooter } from './device-connect-footer';
 import { DeviceConnectHeader } from './device-connect-header';
-import { DeviceConnectPortEntry } from './device-connect-port-entry';
+import { DeviceConnectPortEntry, DeviceConnectPortEntryDeps } from './device-connect-port-entry';
 
 export type UpdateStateCallback = (newState: DeviceConnectState, deviceName?: string) => void;
 
@@ -19,7 +18,7 @@ export enum DeviceConnectState {
 
 export type DeviceConnectBodyDeps = {
     currentWindow: BrowserWindow;
-};
+} & DeviceConnectPortEntryDeps;
 
 export interface DeviceConnectBodyProps {
     deps: DeviceConnectBodyDeps;
@@ -48,11 +47,9 @@ export class DeviceConnectBody extends React.Component<DeviceConnectBodyProps, D
             <div className="device-connect-body">
                 <DeviceConnectHeader />
                 <DeviceConnectPortEntry
-                    deps={{
-                        updateStateCallback: this.OnConnectedCallback,
-                        fetchScanResults: fetchScanResults,
-                    }}
+                    deps={this.props.deps}
                     needsValidation={needsValidation}
+                    updateStateCallback={this.OnConnectedCallback}
                 />
                 <DeviceConnectConnectedDevice
                     isConnecting={isConnecting}

--- a/src/electron/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/device-connect-view/components/device-connect-port-entry.tsx
@@ -12,10 +12,8 @@ export type DeviceConnectPortEntryDeps = {
 };
 
 export interface DeviceConnectPortEntryProps {
-    deps?: DeviceConnectPortEntryDeps;
+    deps: DeviceConnectPortEntryDeps;
     needsValidation: boolean;
-    updateStateCallback: UpdateStateCallback;
-    fetchScanResults: FetchScanResultsType;
 }
 
 export interface DeviceConnectPortEntryState {

--- a/src/electron/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/device-connect-view/components/device-connect-port-entry.tsx
@@ -6,7 +6,13 @@ import * as React from 'react';
 import { FetchScanResultsType } from '../../platform/android/fetch-scan-results';
 import { DeviceConnectState, UpdateStateCallback } from './device-connect-body';
 
+export type DeviceConnectPortEntryDeps = {
+    updateStateCallback: UpdateStateCallback;
+    fetchScanResults: FetchScanResultsType;
+};
+
 export interface DeviceConnectPortEntryProps {
+    deps?: DeviceConnectPortEntryDeps;
     needsValidation: boolean;
     updateStateCallback: UpdateStateCallback;
     fetchScanResults: FetchScanResultsType;
@@ -49,19 +55,19 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
 
     private onPortTextChanged = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         this.setState({ isValidateButtonDisabled: !newValue || newValue === '', port: newValue });
-        this.props.updateStateCallback(DeviceConnectState.Default);
+        this.props.deps.updateStateCallback(DeviceConnectState.Default);
     };
 
     private onValidateClick = async (event: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
         this.setState({ isValidateButtonDisabled: true });
-        this.props.updateStateCallback(DeviceConnectState.Connecting);
+        this.props.deps.updateStateCallback(DeviceConnectState.Connecting);
 
-        await this.props
+        await this.props.deps
             .fetchScanResults(parseInt(this.state.port, 10))
             .then(data => {
-                this.props.updateStateCallback(DeviceConnectState.Connected, `${data.deviceName} - ${data.appIdentifier}`);
+                this.props.deps.updateStateCallback(DeviceConnectState.Connected, `${data.deviceName} - ${data.appIdentifier}`);
             })
-            .catch(err => this.props.updateStateCallback(DeviceConnectState.Error));
+            .catch(err => this.props.deps.updateStateCallback(DeviceConnectState.Error));
 
         this.setState({ isValidateButtonDisabled: false });
     };

--- a/src/electron/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/device-connect-view/components/device-connect-port-entry.tsx
@@ -7,13 +7,13 @@ import { FetchScanResultsType } from '../../platform/android/fetch-scan-results'
 import { DeviceConnectState, UpdateStateCallback } from './device-connect-body';
 
 export type DeviceConnectPortEntryDeps = {
-    updateStateCallback: UpdateStateCallback;
     fetchScanResults: FetchScanResultsType;
 };
 
 export interface DeviceConnectPortEntryProps {
     deps: DeviceConnectPortEntryDeps;
     needsValidation: boolean;
+    updateStateCallback: UpdateStateCallback;
 }
 
 export interface DeviceConnectPortEntryState {
@@ -53,19 +53,19 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
 
     private onPortTextChanged = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         this.setState({ isValidateButtonDisabled: !newValue || newValue === '', port: newValue });
-        this.props.deps.updateStateCallback(DeviceConnectState.Default);
+        this.props.updateStateCallback(DeviceConnectState.Default);
     };
 
     private onValidateClick = async (event: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
         this.setState({ isValidateButtonDisabled: true });
-        this.props.deps.updateStateCallback(DeviceConnectState.Connecting);
+        this.props.updateStateCallback(DeviceConnectState.Connecting);
 
         await this.props.deps
             .fetchScanResults(parseInt(this.state.port, 10))
             .then(data => {
-                this.props.deps.updateStateCallback(DeviceConnectState.Connected, `${data.deviceName} - ${data.appIdentifier}`);
+                this.props.updateStateCallback(DeviceConnectState.Connected, `${data.deviceName} - ${data.appIdentifier}`);
             })
-            .catch(err => this.props.deps.updateStateCallback(DeviceConnectState.Error));
+            .catch(err => this.props.updateStateCallback(DeviceConnectState.Error));
 
         this.setState({ isValidateButtonDisabled: false });
     };

--- a/src/electron/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/device-connect-view/components/device-connect-view-container.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserWindow } from 'electron';
 import * as React from 'react';
 import { BaseStore } from '../../../common/base-store';
 import { TelemetryPermissionDialog, TelemetryPermissionDialogDeps } from '../../../common/components/telemetry-permission-dialog';

--- a/src/electron/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/device-connect-view/components/device-connect-view-container.tsx
@@ -7,13 +7,13 @@ import { TelemetryPermissionDialog, TelemetryPermissionDialogDeps } from '../../
 import { UserConfigurationStoreData } from '../../../common/types/store-data/user-configuration-store';
 import { brand } from '../../../content/strings/application';
 import { BrandBlue } from '../../../icons/brand/blue/brand-blue';
-import { DeviceConnectBody } from './device-connect-body';
+import { DeviceConnectBody, DeviceConnectBodyDeps } from './device-connect-body';
 import { WindowTitle } from './window-title';
 
 export type DeviceConnectViewContainerDeps = {
-    currentWindow: BrowserWindow;
     userConfigurationStore: BaseStore<UserConfigurationStoreData>;
-} & TelemetryPermissionDialogDeps;
+} & TelemetryPermissionDialogDeps &
+    DeviceConnectBodyDeps;
 
 export type DeviceConnectViewContainerProps = {
     deps: DeviceConnectViewContainerDeps;
@@ -37,7 +37,7 @@ export class DeviceConnectViewContainer extends React.Component<DeviceConnectVie
                 <WindowTitle title={brand}>
                     <BrandBlue />
                 </WindowTitle>
-                <DeviceConnectBody currentWindow={this.props.deps.currentWindow} />
+                <DeviceConnectBody deps={this.props.deps} />
                 <TelemetryPermissionDialog deps={this.props.deps} isFirstTime={this.state.userConfigurationStoreData.isFirstTime} />
             </>
         );

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { remote } from 'electron';
+import { fetchScanResults } from 'electron/platform/android/fetch-scan-results';
 import * as ReactDOM from 'react-dom';
+
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
 import { UserConfigurationActionCreator } from '../../background/global-action-creators/user-configuration-action-creator';
@@ -10,6 +12,7 @@ import { UserConfigurationStore } from '../../background/stores/global/user-conf
 import { initializeFabricIcons } from '../../common/fabric-icons';
 import { getIndexedDBStore } from '../../common/indexedDB/get-indexeddb-store';
 import { IndexedDBAPI, IndexedDBUtil } from '../../common/indexedDB/indexedDB';
+import { DeviceConnectBodyProps } from './components/device-connect-body';
 import { ElectronLink } from './components/electron-link';
 import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
 
@@ -34,6 +37,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
             userConfigurationStore,
             userConfigMessageCreator,
             LinkComponent: ElectronLink,
+            fetchScanResults,
         },
     };
 

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -12,7 +12,6 @@ import { UserConfigurationStore } from '../../background/stores/global/user-conf
 import { initializeFabricIcons } from '../../common/fabric-icons';
 import { getIndexedDBStore } from '../../common/indexedDB/get-indexeddb-store';
 import { IndexedDBAPI, IndexedDBUtil } from '../../common/indexedDB/indexedDB';
-import { DeviceConnectBodyProps } from './components/device-connect-body';
 import { ElectronLink } from './components/electron-link';
 import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
 

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-body.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-body.test.tsx.snap
@@ -8,11 +8,13 @@ exports[`DeviceConnectBodyTest render 1`] = `
   <DeviceConnectPortEntry
     deps={
       Object {
-        "fetchScanResults": [Function],
-        "updateStateCallback": [Function],
+        "currentWindow": Object {
+          "close": [Function],
+        },
       }
     }
     needsValidation={true}
+    updateStateCallback={[Function]}
   />
   <DeviceConnectConnectedDevice
     hasFailed={false}

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-body.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-body.test.tsx.snap
@@ -6,9 +6,13 @@ exports[`DeviceConnectBodyTest render 1`] = `
 >
   <DeviceConnectHeader />
   <DeviceConnectPortEntry
-    fetchScanResults={[Function]}
+    deps={
+      Object {
+        "fetchScanResults": [Function],
+        "updateStateCallback": [Function],
+      }
+    }
     needsValidation={true}
-    updateStateCallback={[Function]}
   />
   <DeviceConnectConnectedDevice
     hasFailed={false}

--- a/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
@@ -26,9 +26,27 @@ exports[`DeviceConnectViewContainer renders 1`] = `
     <BrandBlue />
   </WindowTitle>
   <DeviceConnectBody
-    currentWindow={
+    deps={
       Object {
-        "close": [Function],
+        "currentWindow": Object {
+          "close": [Function],
+        },
+        "userConfigurationStore": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "changedHandlers": EventHandlerList {
+            "handlers": Array [],
+          },
+          "indexDbApi": undefined,
+          "onGetCurrentState": [Function],
+          "onSaveIssueSettings": [Function],
+          "onSetHighContrastMode": [Function],
+          "onSetIssueFilingService": [Function],
+          "onSetIssueFilingServiceProperty": [Function],
+          "onSetTelemetryState": [Function],
+          "persistedState": undefined,
+          "storeName": 11,
+          "userConfigActions": undefined,
+        },
       }
     }
   />

--- a/src/tests/unit/tests/electron/device-connect-view/components/device-connect-body.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/device-connect-body.test.tsx
@@ -3,6 +3,7 @@
 import { BrowserWindow } from 'electron';
 import {
     DeviceConnectBody,
+    DeviceConnectBodyDeps,
     DeviceConnectBodyProps,
     DeviceConnectBodyState,
     DeviceConnectState,
@@ -19,7 +20,7 @@ describe('DeviceConnectBodyTest', () => {
                     return;
                 },
             } as BrowserWindow,
-        },
+        } as DeviceConnectBodyDeps,
     };
 
     const expectedBeforeState: DeviceConnectBodyState = {
@@ -52,7 +53,7 @@ describe('DeviceConnectBodyTest', () => {
         const propsWithCallback = rendered.find('DeviceConnectPortEntry').props() as DeviceConnectPortEntryProps;
 
         expect(rendered.state()).toEqual(expectedBeforeState);
-        propsWithCallback.deps.updateStateCallback(DeviceConnectState.Connecting);
+        propsWithCallback.updateStateCallback(DeviceConnectState.Connecting);
         expect(rendered.state()).toEqual(expectedStateWhileConnecting);
     });
 
@@ -61,7 +62,7 @@ describe('DeviceConnectBodyTest', () => {
         const propsWithCallback = rendered.find('DeviceConnectPortEntry').props() as DeviceConnectPortEntryProps;
 
         expect(rendered.state()).toEqual(expectedBeforeState);
-        propsWithCallback.deps.updateStateCallback(DeviceConnectState.Connected, expectedStateConnectedSuccess.connectedDevice);
+        propsWithCallback.updateStateCallback(DeviceConnectState.Connected, expectedStateConnectedSuccess.connectedDevice);
         expect(rendered.state()).toEqual(expectedStateConnectedSuccess);
     });
 
@@ -70,7 +71,7 @@ describe('DeviceConnectBodyTest', () => {
         const propsWithCallback = rendered.find('DeviceConnectPortEntry').props() as DeviceConnectPortEntryProps;
 
         expect(rendered.state()).toEqual(expectedBeforeState);
-        propsWithCallback.deps.updateStateCallback(DeviceConnectState.Error, expectedStateConnectedFail.connectedDevice);
+        propsWithCallback.updateStateCallback(DeviceConnectState.Error, expectedStateConnectedFail.connectedDevice);
         expect(rendered.state()).toEqual(expectedStateConnectedFail);
     });
 });

--- a/src/tests/unit/tests/electron/device-connect-view/components/device-connect-body.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/device-connect-body.test.tsx
@@ -13,11 +13,13 @@ import * as React from 'react';
 
 describe('DeviceConnectBodyTest', () => {
     const props: DeviceConnectBodyProps = {
-        currentWindow: {
-            close: () => {
-                return;
-            },
-        } as BrowserWindow,
+        deps: {
+            currentWindow: {
+                close: () => {
+                    return;
+                },
+            } as BrowserWindow,
+        },
     };
 
     const expectedBeforeState: DeviceConnectBodyState = {

--- a/src/tests/unit/tests/electron/device-connect-view/components/device-connect-body.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/device-connect-body.test.tsx
@@ -52,7 +52,7 @@ describe('DeviceConnectBodyTest', () => {
         const propsWithCallback = rendered.find('DeviceConnectPortEntry').props() as DeviceConnectPortEntryProps;
 
         expect(rendered.state()).toEqual(expectedBeforeState);
-        propsWithCallback.updateStateCallback(DeviceConnectState.Connecting);
+        propsWithCallback.deps.updateStateCallback(DeviceConnectState.Connecting);
         expect(rendered.state()).toEqual(expectedStateWhileConnecting);
     });
 
@@ -61,7 +61,7 @@ describe('DeviceConnectBodyTest', () => {
         const propsWithCallback = rendered.find('DeviceConnectPortEntry').props() as DeviceConnectPortEntryProps;
 
         expect(rendered.state()).toEqual(expectedBeforeState);
-        propsWithCallback.updateStateCallback(DeviceConnectState.Connected, expectedStateConnectedSuccess.connectedDevice);
+        propsWithCallback.deps.updateStateCallback(DeviceConnectState.Connected, expectedStateConnectedSuccess.connectedDevice);
         expect(rendered.state()).toEqual(expectedStateConnectedSuccess);
     });
 
@@ -70,7 +70,7 @@ describe('DeviceConnectBodyTest', () => {
         const propsWithCallback = rendered.find('DeviceConnectPortEntry').props() as DeviceConnectPortEntryProps;
 
         expect(rendered.state()).toEqual(expectedBeforeState);
-        propsWithCallback.updateStateCallback(DeviceConnectState.Error, expectedStateConnectedFail.connectedDevice);
+        propsWithCallback.deps.updateStateCallback(DeviceConnectState.Error, expectedStateConnectedFail.connectedDevice);
         expect(rendered.state()).toEqual(expectedStateConnectedFail);
     });
 });

--- a/src/tests/unit/tests/electron/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -44,9 +44,7 @@ describe('DeviceConnectPortEntryTest', () => {
                 updateStateCallbackMock.setup(callback => callback(DeviceConnectState.Default, undefined));
 
                 const props = {
-                    deps: {
-                        updateStateCallback: updateStateCallbackMock.object,
-                    },
+                    updateStateCallback: updateStateCallbackMock.object,
                 } as DeviceConnectPortEntryProps;
 
                 const rendered = shallow(<DeviceConnectPortEntry {...props} />);
@@ -73,8 +71,8 @@ describe('DeviceConnectPortEntryTest', () => {
                 props = {
                     deps: {
                         fetchScanResults: fetchScanResultsMock.object,
-                        updateStateCallback: updateStateCallbackMock.object,
                     },
+                    updateStateCallback: updateStateCallbackMock.object,
                 } as DeviceConnectPortEntryProps;
             });
 

--- a/src/tests/unit/tests/electron/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -44,7 +44,9 @@ describe('DeviceConnectPortEntryTest', () => {
                 updateStateCallbackMock.setup(callback => callback(DeviceConnectState.Default, undefined));
 
                 const props = {
-                    updateStateCallback: updateStateCallbackMock.object,
+                    deps: {
+                        updateStateCallback: updateStateCallbackMock.object,
+                    },
                 } as DeviceConnectPortEntryProps;
 
                 const rendered = shallow(<DeviceConnectPortEntry {...props} />);
@@ -69,8 +71,10 @@ describe('DeviceConnectPortEntryTest', () => {
                 updateStateCallbackMock.setup(r => r(DeviceConnectState.Connecting)).verifiable(Times.once());
 
                 props = {
-                    fetchScanResults: fetchScanResultsMock.object,
-                    updateStateCallback: updateStateCallbackMock.object,
+                    deps: {
+                        fetchScanResults: fetchScanResultsMock.object,
+                        updateStateCallback: updateStateCallbackMock.object,
+                    },
                 } as DeviceConnectPortEntryProps;
             });
 


### PR DESCRIPTION
#### Description of changes

As part of 'User Story 1604607: [4] add new telemetry event: validate port', we need to pass an action creator to 'DeviceConnectPortEntry' but right now we have not set up `deps` pattern into this component.

As part of this PR:
- Introduce `deps` into `DeviceConnectPortEntry`
- Pull up `fetchScanResults` dependency to the composition root and pass it down through the deps

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1604607
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
