### PR TITLE
Add APP_INITIALIZED telemetry event

### DIFF
--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -75,6 +75,7 @@ export enum TelemetryEventSource {
     NewBugButton,
     TargetPage,
     ContentPage,
+    ElectronDeviceConnect,
 }
 
 export type BaseTelemetryData = {

--- a/src/electron/common/send-app-initialized-telemetry-sender.ts
+++ b/src/electron/common/send-app-initialized-telemetry-sender.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { TelemetryEventHandler } from '../../background/telemetry/telemetry-event-handler';
+import { TelemetryEventSource, TriggeredByNotApplicable } from '../../common/extension-telemetry-events';
+import { APP_INITIALIZED } from './electron-telemetry-events';
+
+export const sendAppInitializedTelemetryEvent = (
+    userConfigurationData: UserConfigurationStoreData,
+    telemetryEventHandler: TelemetryEventHandler,
+) => {
+    // not sending the telemetry event the first time the user opens the app
+    // this way, we let the user opt in or out before sending the first event
+    if (userConfigurationData.isFirstTime) {
+        return;
+    }
+
+    telemetryEventHandler.publishTelemetry(APP_INITIALIZED, {
+        telemetry: {
+            triggeredBy: TriggeredByNotApplicable,
+            source: TelemetryEventSource.ElectronDeviceConnect,
+        },
+    });
+};

--- a/src/tests/unit/tests/electron/common/send-app-initialized-telemetry-event.test.ts
+++ b/src/tests/unit/tests/electron/common/send-app-initialized-telemetry-event.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { sendAppInitializedTelemetryEvent } from 'electron/common/send-app-initialized-telemetry-sender';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+import { BaseActionPayload } from '../../../../../background/actions/action-payloads';
+import { TelemetryEventSource, TriggeredByNotApplicable } from '../../../../../common/extension-telemetry-events';
+import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
+import { APP_INITIALIZED } from '../../../../../electron/common/electron-telemetry-events';
+
+describe('sendAppInitializedTelemetrySender', () => {
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+
+    const testSubject = sendAppInitializedTelemetryEvent;
+
+    beforeEach(() => {
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+    });
+
+    it('send telemetry if it is not the first time', () => {
+        const userData = { isFirstTime: false } as UserConfigurationStoreData;
+
+        testSubject(userData, telemetryEventHandlerMock.object);
+
+        const expectedTelemetry: BaseActionPayload = {
+            telemetry: {
+                source: TelemetryEventSource.ElectronDeviceConnect,
+                triggeredBy: TriggeredByNotApplicable,
+            },
+        };
+
+        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(APP_INITIALIZED, It.isValue(expectedTelemetry)), Times.once());
+    });
+
+    it('does not send telemetry if it is the first time', () => {
+        const userData = { isFirstTime: true } as UserConfigurationStoreData;
+
+        testSubject(userData, telemetryEventHandlerMock.object);
+
+        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(APP_INITIALIZED, It.isAny()), Times.never());
+    });
+});


### PR DESCRIPTION
#### Description of changes

Sending APP_INITIALIZED telemetry event when the device connect view is loaded.
We only try to send the event if the user configuration flag `isFirstTime` is false. `isFirstTime` will trigger the telemetry opt in dialog, giving the user a change to opt in or out before we actually send any telemetry, thus is specific event uses both `isFirstTime` and `enableTelemetry` to decide.

#### Pull request checklist

- [x] Addresses an existing issue: Completes WI # 1604608
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
