### PR TITLE
Add VALIDATE_PORT telemetry event

### DIFF
--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -165,6 +165,10 @@ export type IssuesAnalyzerScanTelemetryData = {
     failedRuleResults: string;
 } & RuleAnalyzerScanTelemetryData;
 
+export type ValidatePortTelemetryData = {
+    port: number;
+};
+
 export type TelemetryData =
     | BaseTelemetryData
     | ToggleTelemetryData
@@ -184,4 +188,5 @@ export type TelemetryData =
     | RuleAnalyzerScanTelemetryData
     | IssuesAnalyzerScanTelemetryData
     | AssessmentRequirementScanTelemetryData
-    | RequirementStatusTelemetryData;
+    | RequirementStatusTelemetryData
+    | ValidatePortTelemetryData;

--- a/src/electron/common/electron-telemetry-events.ts
+++ b/src/electron/common/electron-telemetry-events.ts
@@ -2,3 +2,4 @@
 // Licensed under the MIT License.
 
 export const APP_INITIALIZED: string = 'AppInitialized';
+export const VALIDATE_PORT: string = 'ValidatePort';

--- a/src/electron/flux/action-creator/device-connect-action-creator.ts
+++ b/src/electron/flux/action-creator/device-connect-action-creator.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { VALIDATE_PORT } from '../../common/electron-telemetry-events';
+
+export class DeviceConnectActionCreator {
+    constructor(private readonly telemetryEventHandler: TelemetryEventHandler) {}
+
+    public validatePort(port: number): void {
+        this.telemetryEventHandler.publishTelemetry(VALIDATE_PORT, { telemetry: { port } });
+    }
+}

--- a/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { VALIDATE_PORT } from '../../../../../../electron/common/electron-telemetry-events';
+
+describe('DeviceConnectActionCreator', () => {
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let testSubject: DeviceConnectActionCreator;
+
+    beforeEach(() => {
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        testSubject = new DeviceConnectActionCreator(telemetryEventHandlerMock.object);
+    });
+
+    it('validates port', () => {
+        const port = 1111;
+
+        testSubject.validatePort(port);
+
+        const expectedTelemetry = {
+            telemetry: {
+                port,
+            },
+        };
+
+        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(VALIDATE_PORT, It.isValue(expectedTelemetry)), Times.once());
+    });
+});


### PR DESCRIPTION
#### Description of changes

Sending telemetry event `VALIDATE_PORT` when the user click the "Validate port" button on the device connect view.

#### Pull request checklist

- [x] Addresses an existing issue: Completes WI # 1604607
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
