### PR TITLE
refactor: use collapsible control specified in report factory in all cases in report

### DIFF
--- a/src/DetailsView/components/cards/instance-details-v2.tsx
+++ b/src/DetailsView/components/cards/instance-details-v2.tsx
@@ -9,7 +9,7 @@ import { CardRowDeps, PropertyConfiguration } from '../../../common/configs/unif
 import { StoredInstancePropertyBag, UnifiedResult } from '../../../common/types/store-data/unified-data-interface';
 
 export type InstanceDetailsV2Deps = {
-    getPropertyConfigById?: (id: string) => PropertyConfiguration;
+    getPropertyConfigById: (id: string) => PropertyConfiguration;
 } & CardRowDeps;
 export type InstanceDetailsV2Props = {
     deps: InstanceDetailsV2Deps;

--- a/src/DetailsView/components/cards/rule-content-v2.tsx
+++ b/src/DetailsView/components/cards/rule-content-v2.tsx
@@ -3,17 +3,16 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { InstanceDetailsGroupV2, InstanceDetailsGroupV2Deps, InstanceDetailsGroupV2Props } from './instance-details-group-v2';
-import { RuleResourcesV2, RuleResourcesV2Deps, RuleResourcesV2Props } from './rule-resources-v2';
+import { UnifiedRuleResult } from './failed-instances-section-v2';
+import { InstanceDetailsGroupV2, InstanceDetailsGroupV2Deps } from './instance-details-group-v2';
+import { RuleResourcesV2, RuleResourcesV2Deps } from './rule-resources-v2';
 
 export type RuleContentV2Deps = InstanceDetailsGroupV2Deps & RuleResourcesV2Deps;
 
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
-
-export type RuleContentV2Props = Omit<InstanceDetailsGroupV2Props, 'deps'> &
-    RuleResourcesV2Props & {
-        deps: RuleContentV2Deps;
-    };
+export type RuleContentV2Props = {
+    deps: RuleContentV2Deps;
+    rule: UnifiedRuleResult;
+};
 
 export const RuleContentV2 = NamedFC<RuleContentV2Props>('RuleContentV2', props => {
     return (

--- a/src/reports/components/report-sections/collapsible-result-section.tsx
+++ b/src/reports/components/report-sections/collapsible-result-section.tsx
@@ -3,27 +3,29 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
+import { CollapsibleComponentCardsProps } from '../../../DetailsView/components/cards/collapsible-component-cards';
 import { ResultSectionTitle } from '../../../DetailsView/components/cards/result-section-title';
-import { CollapsibleContainer } from './collapsible-container';
 import { ResultSectionProps } from './result-section';
-import { RulesOnly, RulesOnlyProps } from './rules-only';
+import { RulesOnly, RulesOnlyDeps, RulesOnlyProps } from './rules-only';
+
+export type CollapsibleResultSectionDeps = {
+    collapsibleControl: (props: CollapsibleComponentCardsProps) => JSX.Element;
+} & RulesOnlyDeps;
 
 export type CollapsibleResultSectionProps = RulesOnlyProps &
     ResultSectionProps & {
+        deps: CollapsibleResultSectionDeps;
         containerId: string;
     };
 
 export const CollapsibleResultSection = NamedFC<CollapsibleResultSectionProps>('CollapsibleResultSection', props => {
-    const { containerClassName, containerId } = props;
+    const { containerClassName, containerId, deps } = props;
+    const CollapsibleContent = deps.collapsibleControl({
+        id: containerId,
+        header: <ResultSectionTitle {...props} />,
+        content: <RulesOnly {...props} />,
+        headingLevel: 2,
+    });
 
-    return (
-        <div className={containerClassName}>
-            <CollapsibleContainer
-                id={containerId}
-                visibleHeadingContent={<ResultSectionTitle {...props} />}
-                collapsibleContent={<RulesOnly {...props} />}
-                titleHeadingLevel={2}
-            />
-        </div>
-    );
+    return <div className={containerClassName}>{CollapsibleContent}</div>;
 });

--- a/src/reports/components/report-sections/not-applicable-checks-section.tsx
+++ b/src/reports/components/report-sections/not-applicable-checks-section.tsx
@@ -3,26 +3,25 @@
 import * as React from 'react';
 
 import { NamedFC } from 'common/react/named-fc';
-import { CollapsibleResultSection } from './collapsible-result-section';
+import { CollapsibleResultSection, CollapsibleResultSectionDeps } from './collapsible-result-section';
 import { SectionProps } from './report-section-factory';
 
-export type NotApplicableChecksSectionProps = Pick<SectionProps, 'scanResult' | 'getGuidanceTagsFromGuidanceLinks'>;
+export type NotApplicableChecksSectionDeps = CollapsibleResultSectionDeps;
 
-export const NotApplicableChecksSection = NamedFC<NotApplicableChecksSectionProps>(
-    'NotApplicableChecksSection',
-    ({ scanResult, getGuidanceTagsFromGuidanceLinks }) => {
-        const rules = scanResult.inapplicable;
+export type NotApplicableChecksSectionProps = Pick<SectionProps, 'scanResult' | 'deps'>;
 
-        return (
-            <CollapsibleResultSection
-                deps={{ getGuidanceTagsFromGuidanceLinks }}
-                title="Not applicable checks"
-                rules={rules}
-                containerClassName="result-section"
-                outcomeType="inapplicable"
-                badgeCount={rules.length}
-                containerId="not-applicable-checks-section"
-            />
-        );
-    },
-);
+export const NotApplicableChecksSection = NamedFC<NotApplicableChecksSectionProps>('NotApplicableChecksSection', ({ scanResult, deps }) => {
+    const rules = scanResult.inapplicable;
+
+    return (
+        <CollapsibleResultSection
+            deps={deps}
+            title="Not applicable checks"
+            rules={rules}
+            containerClassName="result-section"
+            outcomeType="inapplicable"
+            badgeCount={rules.length}
+            containerId="not-applicable-checks-section"
+        />
+    );
+});

--- a/src/reports/components/report-sections/passed-checks-section.tsx
+++ b/src/reports/components/report-sections/passed-checks-section.tsx
@@ -1,27 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { NamedFC } from 'common/react/named-fc';
-import { CollapsibleResultSection } from './collapsible-result-section';
+import { CollapsibleResultSection, CollapsibleResultSectionDeps } from './collapsible-result-section';
 import { SectionProps } from './report-section-factory';
 
-export type PassedChecksSectionProps = Pick<SectionProps, 'scanResult' | 'getGuidanceTagsFromGuidanceLinks'>;
+export type PassedChecksSectionDeps = CollapsibleResultSectionDeps;
 
-export const PassedChecksSection = NamedFC<PassedChecksSectionProps>(
-    'PassedChecksSection',
-    ({ scanResult, getGuidanceTagsFromGuidanceLinks }) => {
-        const rules = scanResult.passes;
-        return (
-            <CollapsibleResultSection
-                deps={{ getGuidanceTagsFromGuidanceLinks }}
-                title="Passed checks"
-                rules={rules}
-                containerClassName="result-section"
-                outcomeType="pass"
-                badgeCount={rules.length}
-                containerId="passed-checks-section"
-            />
-        );
-    },
-);
+export type PassedChecksSectionProps = Pick<SectionProps, 'scanResult' | 'deps'>;
+
+export const PassedChecksSection = NamedFC<PassedChecksSectionProps>('PassedChecksSection', ({ scanResult, deps }) => {
+    const rules = scanResult.passes;
+    return (
+        <CollapsibleResultSection
+            deps={deps}
+            title="Passed checks"
+            rules={rules}
+            containerClassName="result-section"
+            outcomeType="pass"
+            badgeCount={rules.length}
+            containerId="passed-checks-section"
+        />
+    );
+});

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -7,9 +7,13 @@ import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import { ScanResults } from 'scanner/iruleresults';
 
 import { FailedInstancesSectionV2Deps, UnifiedStatusResults } from '../../../DetailsView/components/cards/failed-instances-section-v2';
+import { NotApplicableChecksSectionDeps } from './not-applicable-checks-section';
+import { PassedChecksSectionDeps } from './passed-checks-section';
+
+export type SectionDeps = NotApplicableChecksSectionDeps & FailedInstancesSectionV2Deps & PassedChecksSectionDeps;
 
 export type SectionProps = {
-    deps: FailedInstancesSectionV2Deps;
+    deps: SectionDeps;
     fixInstructionProcessor: FixInstructionProcessor;
     pageTitle: string;
     pageUrl: string;

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-result-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-result-section.test.tsx.snap
@@ -3,22 +3,5 @@
 exports[`CollapsibleResultSection renders 1`] = `
 <div
   className="result-section-class-name"
->
-  <CollapsibleContainer
-    collapsibleContent={
-      <RulesOnly
-        containerClassName="result-section-class-name"
-        containerId="container-id"
-      />
-    }
-    id="container-id"
-    titleHeadingLevel={2}
-    visibleHeadingContent={
-      <ResultSectionTitle
-        containerClassName="result-section-class-name"
-        containerId="container-id"
-      />
-    }
-  />
-</div>
+/>
 `;

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/not-applicable-checks-sections.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/not-applicable-checks-sections.test.tsx.snap
@@ -5,11 +5,7 @@ exports[`NotApplicableChecksSection renders 1`] = `
   badgeCount={3}
   containerClassName="result-section"
   containerId="not-applicable-checks-section"
-  deps={
-    Object {
-      "getGuidanceTagsFromGuidanceLinks": [Function],
-    }
-  }
+  deps={Object {}}
   outcomeType="inapplicable"
   rules={
     Array [

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/passed-checks-sections.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/passed-checks-sections.test.tsx.snap
@@ -5,11 +5,7 @@ exports[`PassedChecksSection renders 1`] = `
   badgeCount={3}
   containerClassName="result-section"
   containerId="passed-checks-section"
-  deps={
-    Object {
-      "getGuidanceTagsFromGuidanceLinks": [Function],
-    }
-  }
+  deps={Object {}}
   outcomeType="pass"
   rules={
     Array [

--- a/src/tests/unit/tests/reports/components/report-sections/collapsible-result-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/collapsible-result-section.test.tsx
@@ -2,18 +2,27 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import {
+    CollapsibleResultSection,
+    CollapsibleResultSectionDeps,
+    CollapsibleResultSectionProps,
+} from 'reports/components/report-sections/collapsible-result-section';
+import { Mock } from 'typemoq';
 
-import { CollapsibleResultSection, CollapsibleResultSectionProps } from 'reports/components/report-sections/collapsible-result-section';
+import { CollapsibleComponentCardsProps } from '../../../../../../DetailsView/components/cards/collapsible-component-cards';
 
 describe('CollapsibleResultSection', () => {
     it('renders', () => {
+        const collapsibleControlMock = Mock.ofType<(props: CollapsibleComponentCardsProps) => JSX.Element>();
         const props: CollapsibleResultSectionProps = {
+            deps: {
+                collapsibleControl: collapsibleControlMock.object,
+            } as CollapsibleResultSectionDeps,
             containerClassName: 'result-section-class-name',
             containerId: 'container-id',
         } as CollapsibleResultSectionProps;
 
         const wrapper = shallow(<CollapsibleResultSection {...props} />);
-
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/reports/components/report-sections/not-applicable-checks-sections.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/not-applicable-checks-sections.test.tsx
@@ -2,19 +2,18 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-
-import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import {
     NotApplicableChecksSection,
     NotApplicableChecksSectionProps,
 } from 'reports/components/report-sections/not-applicable-checks-section';
 import { RuleResult } from 'scanner/iruleresults';
 
+import { SectionDeps } from '../../../../../../reports/components/report-sections/report-section-factory';
+
 describe('NotApplicableChecksSection', () => {
     it('renders', () => {
-        const getGuidanceTagsStub: GetGuidanceTagsFromGuidanceLinks = () => [];
         const props: NotApplicableChecksSectionProps = {
-            getGuidanceTagsFromGuidanceLinks: getGuidanceTagsStub,
+            deps: {} as SectionDeps,
             scanResult: {
                 inapplicable: [{} as RuleResult, {} as RuleResult, {} as RuleResult],
                 violations: [],

--- a/src/tests/unit/tests/reports/components/report-sections/passed-checks-sections.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/passed-checks-sections.test.tsx
@@ -2,16 +2,15 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-
-import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { PassedChecksSection, PassedChecksSectionProps } from 'reports/components/report-sections/passed-checks-section';
 import { RuleResult } from 'scanner/iruleresults';
 
+import { SectionDeps } from '../../../../../../reports/components/report-sections/report-section-factory';
+
 describe('PassedChecksSection', () => {
     it('renders', () => {
-        const getGuidanceTagsStub: GetGuidanceTagsFromGuidanceLinks = () => [];
         const props: PassedChecksSectionProps = {
-            getGuidanceTagsFromGuidanceLinks: getGuidanceTagsStub,
+            deps: {} as SectionDeps,
             scanResult: {
                 passes: [{} as RuleResult, {} as RuleResult, {} as RuleResult],
                 violations: [],


### PR DESCRIPTION
#### Description of changes

This change removes any use of the collapsible-container in our code-base by using the specified collapsible control in the report factory (which uses a new report specific collapsible control).

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
