### PR TITLE
feat: validate port telemetry event

### DIFF
--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -75,6 +75,7 @@ export enum TelemetryEventSource {
     NewBugButton,
     TargetPage,
     ContentPage,
+    ElectronDeviceConnect,
 }
 
 export type BaseTelemetryData = {

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -165,6 +165,10 @@ export type IssuesAnalyzerScanTelemetryData = {
     failedRuleResults: string;
 } & RuleAnalyzerScanTelemetryData;
 
+export type ValidatePortTelemetryData = {
+    port: number;
+};
+
 export type TelemetryData =
     | BaseTelemetryData
     | ToggleTelemetryData
@@ -184,4 +188,5 @@ export type TelemetryData =
     | RuleAnalyzerScanTelemetryData
     | IssuesAnalyzerScanTelemetryData
     | AssessmentRequirementScanTelemetryData
-    | RequirementStatusTelemetryData;
+    | RequirementStatusTelemetryData
+    | ValidatePortTelemetryData;

--- a/src/electron/adapters/electron-storage-adapter.ts
+++ b/src/electron/adapters/electron-storage-adapter.ts
@@ -14,7 +14,7 @@ export class ElectronStorageAdapter implements StorageAdapter {
     public setUserData(items: Object, callback?: () => void): void {
         this.indexedDBInstance
             .setItem(IndexedDBDataKeys.installation, items)
-            .then(() => callback())
+            .then(() => callback && callback())
             .catch(error => {
                 this.logger.error('Error occurred when trying to set user data: ', error);
             });

--- a/src/electron/common/electron-telemetry-events.ts
+++ b/src/electron/common/electron-telemetry-events.ts
@@ -2,3 +2,4 @@
 // Licensed under the MIT License.
 
 export const APP_INITIALIZED: string = 'AppInitialized';
+export const VALIDATE_PORT: string = 'ValidatePort';

--- a/src/electron/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/device-connect-view/components/device-connect-port-entry.tsx
@@ -3,11 +3,13 @@
 import { Button } from 'office-ui-fabric-react/lib/Button';
 import { MaskedTextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
+import { DeviceConnectActionCreator } from '../../flux/action-creator/device-connect-action-creator';
 import { FetchScanResultsType } from '../../platform/android/fetch-scan-results';
 import { DeviceConnectState, UpdateStateCallback } from './device-connect-body';
 
 export type DeviceConnectPortEntryDeps = {
     fetchScanResults: FetchScanResultsType;
+    deviceConnectActionCreator: DeviceConnectActionCreator;
 };
 
 export interface DeviceConnectPortEntryProps {
@@ -58,10 +60,14 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
 
     private onValidateClick = async (event: React.MouseEvent<HTMLButtonElement>): Promise<void> => {
         this.setState({ isValidateButtonDisabled: true });
+
+        const port = parseInt(this.state.port, 10);
+
+        this.props.deps.deviceConnectActionCreator.validatePort(port);
         this.props.updateStateCallback(DeviceConnectState.Connecting);
 
         await this.props.deps
-            .fetchScanResults(parseInt(this.state.port, 10))
+            .fetchScanResults(port)
             .then(data => {
                 this.props.updateStateCallback(DeviceConnectState.Connected, `${data.deviceName} - ${data.appIdentifier}`);
             })

--- a/src/electron/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/device-connect-view/device-connect-view-initializer.ts
@@ -4,7 +4,6 @@ import { AppInsights } from 'applicationinsights-js';
 import { remote } from 'electron';
 import { fetchScanResults } from 'electron/platform/android/fetch-scan-results';
 import * as ReactDOM from 'react-dom';
-
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
 import { UserConfigurationActionCreator } from '../../background/global-action-creators/user-configuration-action-creator';
@@ -22,6 +21,7 @@ import { telemetryAppTitle } from '../../content/strings/application';
 import { ElectronAppDataAdapter } from '../adapters/electron-app-data-adapter';
 import { ElectronStorageAdapter } from '../adapters/electron-storage-adapter';
 import { RiggedFeatureFlagChecker } from '../common/rigged-feature-flag-checker';
+import { DeviceConnectActionCreator } from '../flux/action-creator/device-connect-action-creator';
 import { ElectronLink } from './components/electron-link';
 import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
 
@@ -59,7 +59,8 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
 
     const userConfigMessageCreator = new UserConfigurationActionCreator(userConfigActions);
 
-    const dom = document;
+    const deviceConnectActionCreator = new DeviceConnectActionCreator(telemetryEventHandler);
+
     const props = {
         deps: {
             currentWindow: remote.getCurrentWindow(),
@@ -67,9 +68,10 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
             userConfigMessageCreator,
             LinkComponent: ElectronLink,
             fetchScanResults,
+            deviceConnectActionCreator,
         },
     };
 
-    const renderer = new DeviceConnectViewRenderer(ReactDOM.render, dom, props);
+    const renderer = new DeviceConnectViewRenderer(ReactDOM.render, document, props);
     renderer.render();
 });

--- a/src/electron/flux/action-creator/device-connect-action-creator.ts
+++ b/src/electron/flux/action-creator/device-connect-action-creator.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { VALIDATE_PORT } from '../../common/electron-telemetry-events';
+
+export class DeviceConnectActionCreator {
+    constructor(private readonly telemetryEventHandler: TelemetryEventHandler) {}
+
+    public validatePort(port: number): void {
+        this.telemetryEventHandler.publishTelemetry(VALIDATE_PORT, { telemetry: { port } });
+    }
+}

--- a/src/electron/flux/action-creator/device-connect-action-creator.ts
+++ b/src/electron/flux/action-creator/device-connect-action-creator.ts
@@ -1,12 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { VALIDATE_PORT } from '../../common/electron-telemetry-events';
+import { TelemetryEventSource } from 'common/extension-telemetry-events';
+import { VALIDATE_PORT } from 'electron/common/electron-telemetry-events';
 
 export class DeviceConnectActionCreator {
     constructor(private readonly telemetryEventHandler: TelemetryEventHandler) {}
 
     public validatePort(port: number): void {
-        this.telemetryEventHandler.publishTelemetry(VALIDATE_PORT, { telemetry: { port } });
+        this.telemetryEventHandler.publishTelemetry(VALIDATE_PORT, {
+            telemetry: { port, source: TelemetryEventSource.ElectronDeviceConnect },
+        });
     }
 }

--- a/src/tests/unit/tests/electron/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { DeviceConnectState, UpdateStateCallback } from 'electron/device-connect-view/components/device-connect-body';
 import { DeviceConnectPortEntry, DeviceConnectPortEntryProps } from 'electron/device-connect-view/components/device-connect-port-entry';
+import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
 import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import { shallow } from 'enzyme';
@@ -9,7 +10,6 @@ import { Button } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-
 import { tick } from '../../common/tick';
 
 describe('DeviceConnectPortEntryTest', () => {
@@ -18,10 +18,12 @@ describe('DeviceConnectPortEntryTest', () => {
 
     let fetchScanResultsMock: IMock<FetchScanResultsType>;
     let updateStateCallbackMock: IMock<UpdateStateCallback>;
+    let deviceConnectActionCreatorMock: IMock<DeviceConnectActionCreator>;
 
     beforeEach(() => {
         fetchScanResultsMock = Mock.ofType<FetchScanResultsType>(undefined, MockBehavior.Strict);
         updateStateCallbackMock = Mock.ofType<UpdateStateCallback>(undefined, MockBehavior.Strict);
+        deviceConnectActionCreatorMock = Mock.ofType<DeviceConnectActionCreator>(undefined, MockBehavior.Strict);
     });
 
     describe('renders', () => {
@@ -69,10 +71,12 @@ describe('DeviceConnectPortEntryTest', () => {
 
             beforeEach(() => {
                 updateStateCallbackMock.setup(r => r(DeviceConnectState.Connecting)).verifiable(Times.once());
+                deviceConnectActionCreatorMock.setup(creator => creator.validatePort(testPortNumber)).verifiable(Times.once());
 
                 props = {
                     deps: {
                         fetchScanResults: fetchScanResultsMock.object,
+                        deviceConnectActionCreator: deviceConnectActionCreatorMock.object,
                     },
                     updateStateCallback: updateStateCallbackMock.object,
                 } as DeviceConnectPortEntryProps;
@@ -97,7 +101,9 @@ describe('DeviceConnectPortEntryTest', () => {
                 await tick();
 
                 expect(rendered.state()).toEqual({ isValidateButtonDisabled: false, port: testPortNumber });
+
                 updateStateCallbackMock.verifyAll();
+                deviceConnectActionCreatorMock.verifyAll();
             });
 
             const setupFetchScanResultsMock = (fetch: FetchScanResultsType) => {

--- a/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { VALIDATE_PORT } from '../../../../../../electron/common/electron-telemetry-events';
+
+describe('DeviceConnectActionCreator', () => {
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let testSubject: DeviceConnectActionCreator;
+
+    beforeEach(() => {
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        testSubject = new DeviceConnectActionCreator(telemetryEventHandlerMock.object);
+    });
+
+    it('validates port', () => {
+        const port = 1111;
+
+        testSubject.validatePort(port);
+
+        const expectedTelemetry = {
+            telemetry: {
+                port,
+            },
+        };
+
+        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(VALIDATE_PORT, It.isValue(expectedTelemetry)), Times.once());
+    });
+});

--- a/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { TelemetryEventSource } from 'common/extension-telemetry-events';
+import { VALIDATE_PORT } from 'electron/common/electron-telemetry-events';
 import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
 import { IMock, It, Mock, Times } from 'typemoq';
-import { VALIDATE_PORT } from '../../../../../../electron/common/electron-telemetry-events';
 
 describe('DeviceConnectActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -22,6 +23,7 @@ describe('DeviceConnectActionCreator', () => {
         const expectedTelemetry = {
             telemetry: {
                 port,
+                source: TelemetryEventSource.ElectronDeviceConnect,
             },
         };
 


### PR DESCRIPTION
#### Description of changes

When the user clicks the "Validate port" button and if the user opt in to the telemetry, we'll be sending a `'VALIDATE_PORT'` telemetry event.

![image](https://user-images.githubusercontent.com/2837582/65547868-2dd45f00-decf-11e9-935b-98aa7d9273d8.png)

**Notes**
`applicationBuild` is properly set during the release process, that's why in the screenshot is `"unknownBuild"` which is a default value defined on `src\common\configuration\configuration-defaults.ts`, `telemetryBuildName` property.

#### Pull request checklist

- [x] Addresses an existing issue: Completes WI # 1604607
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
