### PR TITLE
refactor: updated failure instance panel styles to be utilized via css modules + remove dead css

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -216,56 +216,6 @@ div.insights-file-issue-details-dialog-container {
     }
 }
 
-.failure-instance-panel {
-    .observed-failure-textfield {
-        padding-bottom: 12px;
-    }
-    .add-failure-instruction {
-        font-weight: 500;
-        margin: 20px 0px 20px 0px;
-    }
-    .header-text {
-        font-size: 21px;
-    }
-    .learn-more {
-        color: $communication-primary;
-        text-decoration: none;
-        display: inline-block;
-        margin-bottom: 24px;
-    }
-    .failure-instance-snippet-title {
-        margin: 24px 0px 8px 0px;
-        color: $primary-text;
-    }
-
-    .failure-instance-snippet-empty-body {
-        margin: 8px 0px 24px 0px;
-        color: $secondary-text;
-    }
-    .failure-instance-snippet-filled-body {
-        margin: 8px 0px 24px 0px;
-        padding: 12px 16px 12px 16px;
-        max-height: 200px;
-        color: $primary-text;
-        background-color: $neutral-4;
-        overflow-y: scroll;
-        word-wrap: break-word;
-    }
-    .failure-instance-snippet-error {
-        margin: 9px 0px 50px 9px;
-        color: $secondary-text;
-        display: flex;
-        flex-direction: row;
-    }
-    .failure-instance-snippet-error-icon {
-        color: $negative-outcome;
-        padding: 3px 8px;
-    }
-}
-.failure-instance-selector-note {
-    color: $secondary-text;
-    margin: 8px 0px 8px 0px;
-}
 .preview-features-panel {
     .preview-feature-toggle-list {
         margin-top: 2vh;
@@ -655,11 +605,6 @@ div.insights-file-issue-details-dialog-container {
                 font-size: 16px;
                 line-height: 24px;
                 color: $negative-outcome;
-            }
-            .edit-button {
-                font-size: 16px;
-                line-height: 24px;
-                color: $neutral-100;
             }
         }
         .assessment-getting-started-container {

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -15,6 +15,7 @@ import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag
 import { VisualizationType } from '../../common/types/visualization-type';
 import { ActionAndCancelButtonsComponent } from './action-and-cancel-buttons-component';
 import { FailureInstancePanelDetails } from './failure-instance-panel-details';
+import { editButton, failureInstancePanel, observedFailureTextfield } from './failure-instance-panel.scss';
 import { GenericPanel, GenericPanelProps } from './generic-panel';
 
 export interface FailureInstancePanelControlProps {
@@ -103,7 +104,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
             );
         } else {
             return (
-                <Link className="edit-button" onClick={this.openFailureInstancePanel}>
+                <Link className={editButton} onClick={this.openFailureInstancePanel}>
                     <Icon iconName="edit" ariaLabel={'edit instance'} />
                 </Link>
             );
@@ -115,7 +116,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
 
         const panelProps: GenericPanelProps = {
             isOpen: this.state.isPanelOpen,
-            className: 'failure-instance-panel',
+            className: failureInstancePanel,
             onDismiss: this.closeFailureInstancePanel,
             title:
                 this.props.actionType === CapturedInstanceActionType.CREATE
@@ -134,7 +135,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                     featureFlagStoreData={this.props.featureFlagStoreData}
                 />
                 <TextField
-                    className="observed-failure-textfield"
+                    className={observedFailureTextfield}
                     label="Comment"
                     styles={getStyles}
                     multiline={true}
@@ -159,7 +160,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
         }
 
         return (
-            <div className="footer">
+            <div>
                 <ActionAndCancelButtonsComponent
                     isHidden={false}
                     primaryButtonDisabled={

--- a/src/DetailsView/components/failure-instance-panel-details.tsx
+++ b/src/DetailsView/components/failure-instance-panel-details.tsx
@@ -5,7 +5,17 @@ import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ILabelStyles } from 'office-ui-fabric-react/lib/Label';
 import { ITextFieldStyles, TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
+
 import { NamedFC } from '../../common/react/named-fc';
+import {
+    failureInstanceSelectorNote,
+    failureInstanceSnippetEmptyBody,
+    failureInstanceSnippetError,
+    failureInstanceSnippetErrorIcon,
+    failureInstanceSnippetFilledBody,
+    failureInstanceSnippetTitle,
+    learnMore,
+} from './failure-instance-panel.scss';
 
 export type FailureInstancePanelDetailsProps = {
     path: string;
@@ -17,23 +27,21 @@ export type FailureInstancePanelDetailsProps = {
 export const FailureInstancePanelDetails = NamedFC<FailureInstancePanelDetailsProps>('FailureInstancePanelDetails', props => {
     const getSnippetInfo = (): JSX.Element => {
         if (!props.snippet) {
-            return (
-                <div className="failure-instance-snippet-empty-body">Code snippet will auto-populate based on the CSS selector input.</div>
-            );
+            return <div className={failureInstanceSnippetEmptyBody}>Code snippet will auto-populate based on the CSS selector input.</div>;
         } else if (props.snippet.startsWith('No code snippet is map')) {
             return (
-                <div className="failure-instance-snippet-error">
-                    <Icon iconName="statusErrorFull" className="failure-instance-snippet-error-icon" />
+                <div className={failureInstanceSnippetError}>
+                    <Icon iconName="statusErrorFull" className={failureInstanceSnippetErrorIcon} />
                     <div>{props.snippet}</div>
                 </div>
             );
         } else {
-            return <div className="failure-instance-snippet-filled-body">{props.snippet}</div>;
+            return <div className={failureInstanceSnippetFilledBody}>{props.snippet}</div>;
         }
     };
     return (
         <div>
-            <a href="#" className="learn-more">
+            <a href="#" className={learnMore}>
                 Learn more about adding failure instances
             </a>
             <TextField
@@ -46,14 +54,14 @@ export const FailureInstancePanelDetails = NamedFC<FailureInstancePanelDetailsPr
                 resizable={false}
                 placeholder="CSS Selector"
             />
-            <div className="failure-instance-selector-note">
+            <div className={failureInstanceSelectorNote}>
                 Note: If the CSS selector maps to multiple snippets, the first will be selected
             </div>
             <div>
                 <DefaultButton text="Validate CSS selector" onClick={props.onValidateSelector} disabled={props.path === null} />
             </div>
             <div aria-live="polite" aria-atomic="true">
-                <div className="failure-instance-snippet-title">Code Snippet</div>
+                <div className={failureInstanceSnippetTitle}>Code Snippet</div>
                 {getSnippetInfo()}
             </div>
         </div>

--- a/src/DetailsView/components/failure-instance-panel.scss
+++ b/src/DetailsView/components/failure-instance-panel.scss
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+
+.failure-instance-panel {
+    .observed-failure-textfield {
+        padding-bottom: 12px;
+    }
+    :global(.header-text) {
+        font-size: 21px;
+    }
+}
+
+.failure-instance-snippet-empty-body {
+    margin: 8px 0px 24px 0px;
+    color: $secondary-text;
+}
+
+.failure-instance-snippet-title {
+    margin: 24px 0px 8px 0px;
+    color: $primary-text;
+}
+
+.learn-more {
+    color: $communication-primary;
+    text-decoration: none;
+    display: inline-block;
+    margin-bottom: 24px;
+}
+
+.failure-instance-selector-note {
+    color: $secondary-text;
+    margin: 8px 0px 8px 0px;
+}
+
+.failure-instance-snippet-filled-body {
+    margin: 8px 0px 24px 0px;
+    padding: 12px 16px 12px 16px;
+    max-height: 200px;
+    color: $primary-text;
+    background-color: $neutral-4;
+    overflow-y: scroll;
+    word-wrap: break-word;
+}
+
+.failure-instance-snippet-error {
+    margin: 9px 0px 50px 9px;
+    color: $secondary-text;
+    display: flex;
+    flex-direction: row;
+}
+
+.failure-instance-snippet-error-icon {
+    color: $negative-outcome;
+    padding: 3px 8px;
+}
+
+.edit-button {
+    font-size: 16px !important;
+    line-height: 24px !important;
+    color: $neutral-100 !important;
+}

--- a/src/reports/automated-checks-report.scss
+++ b/src/reports/automated-checks-report.scss
@@ -38,44 +38,6 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     margin-bottom: 24px;
 }
 
-.failed-instances-section {
-    .how-to-fix-content {
-        margin-bottom: 16px;
-        ul {
-            padding-left: 16px;
-            li {
-                list-style-type: disc;
-                margin-bottom: 4px;
-            }
-        }
-    }
-
-    .rule-more-resources {
-        display: flex;
-        flex-direction: column;
-
-        margin-left: 24px;
-        margin-bottom: 16px;
-        padding: 14px 20px;
-
-        background-color: $always-white;
-
-        box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108), 0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
-
-        border-radius: 4px;
-
-        line-height: 20px;
-
-        .more-resources-title {
-            font-family: $semiBoldFontFamily;
-        }
-
-        .rule-details-id {
-            padding: 12px 0;
-        }
-    }
-}
-
 .result-section {
     padding-bottom: 58px;
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: cre
     Add a failure instance
   </CustomizedActionButton>
   <GenericPanel
-    className="failure-instance-panel"
+    className="failureInstancePanel"
     closeButtonAriaLabel="Close failure instance panel"
     hasCloseButton={true}
     isOpen={false}
@@ -35,7 +35,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: cre
       featureFlagStoreData={Object {}}
     />
     <StyledTextFieldBase
-      className="observed-failure-textfield"
+      className="observedFailureTextfield"
       label="Comment"
       multiline={true}
       onChange={[Function]}
@@ -45,9 +45,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: cre
       styles={[Function]}
       value={null}
     />
-    <div
-      className="footer"
-    >
+    <div>
       <ActionAndCancelButtonsComponent
         cancelButtonOnClick={[Function]}
         isHidden={false}
@@ -63,7 +61,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: cre
 exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edit without instance 1`] = `
 <React.Fragment>
   <StyledLinkBase
-    className="edit-button"
+    className="editButton"
     onClick={[Function]}
   >
     <StyledIconBase
@@ -72,7 +70,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
     />
   </StyledLinkBase>
   <GenericPanel
-    className="failure-instance-panel"
+    className="failureInstancePanel"
     closeButtonAriaLabel="Close failure instance panel"
     hasCloseButton={true}
     isOpen={false}
@@ -92,7 +90,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
       featureFlagStoreData={Object {}}
     />
     <StyledTextFieldBase
-      className="observed-failure-textfield"
+      className="observedFailureTextfield"
       label="Comment"
       multiline={true}
       onChange={[Function]}
@@ -102,9 +100,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
       styles={[Function]}
       value={null}
     />
-    <div
-      className="footer"
-    >
+    <div>
       <ActionAndCancelButtonsComponent
         cancelButtonOnClick={[Function]}
         isHidden={false}
@@ -132,7 +128,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: par
     Add a failure instance
   </CustomizedActionButton>
   <GenericPanel
-    className="failure-instance-panel"
+    className="failureInstancePanel"
     closeButtonAriaLabel="Close failure instance panel"
     hasCloseButton={true}
     isOpen={false}
@@ -152,7 +148,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: par
       featureFlagStoreData={null}
     />
     <StyledTextFieldBase
-      className="observed-failure-textfield"
+      className="observedFailureTextfield"
       label="Comment"
       multiline={true}
       onChange={[Function]}
@@ -162,9 +158,7 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: par
       styles={[Function]}
       value="original text"
     />
-    <div
-      className="footer"
-    >
+    <div>
       <ActionAndCancelButtonsComponent
         cancelButtonOnClick={[Function]}
         isHidden={false}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-details.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-details.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FailureInstancePanelDetailsTest renders 1`] = `
 <div>
   <a
-    className="learn-more"
+    className="learnMore"
     href="#"
   >
     Learn more about adding failure instances
@@ -19,7 +19,7 @@ exports[`FailureInstancePanelDetailsTest renders 1`] = `
     value="Given Path"
   />
   <div
-    className="failure-instance-selector-note"
+    className="failureInstanceSelectorNote"
   >
     Note: If the CSS selector maps to multiple snippets, the first will be selected
   </div>
@@ -35,12 +35,12 @@ exports[`FailureInstancePanelDetailsTest renders 1`] = `
     aria-live="polite"
   >
     <div
-      className="failure-instance-snippet-title"
+      className="failureInstanceSnippetTitle"
     >
       Code Snippet
     </div>
     <div
-      className="failure-instance-snippet-filled-body"
+      className="failureInstanceSnippetFilledBody"
     >
       Snippet for Given Path
     </div>


### PR DESCRIPTION
#### Description of changes

This moves the css for failure instance panel to it's own scss file and starts using it via css modules in the panel.

Also removed some more dead css.

![image](https://user-images.githubusercontent.com/32555133/65642547-685bfb80-dfa4-11e9-8bd8-6ad72589b9b1.png)

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
