### PR TITLE
chore: clean up dead CSS in detailsview.scss and popup.scss

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -746,36 +746,11 @@ div.insights-file-issue-details-dialog-container {
                 min-width: 600px;
                 height: auto;
             }
-            .info-message-bar {
-                background-color: $communication-tint-40;
-                .ms-MessageBar-icon {
-                    color: $communication-primary;
-                }
-                .ms-link {
-                    font-weight: 700;
-                    padding: 0 !important;
-                }
-            }
             .ms-MessageBar {
                 padding-left: 24px;
             }
             .ms-MessageBar-icon i {
                 color: $secondary-text;
-            }
-            .target-tab-info {
-                font-size: 14px;
-                color: $secondary-text;
-                padding-top: 24px;
-                padding-left: 24px;
-                padding-right: 24px;
-                word-break: break-all;
-                font-weight: 600;
-                .ms-Link {
-                    color: $communication-primary;
-                }
-                .target-page-link {
-                    font-family: $fontFamily;
-                }
             }
             .view {
                 flex-grow: 1;
@@ -921,29 +896,9 @@ div.insights-file-issue-details-dialog-container {
                         color: $communication-primary;
                     }
                 }
-                .landmark-roles-table {
-                    list-style: none;
-                    margin-top: 12px;
-                    display: table;
-                    border-collapse: separate;
-                    border-spacing: 5px;
-                    padding-left: 18px;
-                }
-                .insights-list {
-                    padding-left: 18px;
-                    margin-top: 0px;
-                }
-                .insights-list li {
-                    margin-top: 4px;
-                    font-size: 14px;
-                }
                 .tab-stops-accessibility-problems-list {
                     background: $neutral-6;
                     list-style-type: disc;
-                }
-                .landmark-roles-table li {
-                    margin-top: 4px;
-                    display: table-row;
                 }
                 .landmarks-legend-description {
                     padding-left: 12px;
@@ -1038,12 +993,6 @@ div.insights-file-issue-details-dialog-container {
                     margin-top: 5px;
                     margin-bottom: 5px;
                     font-size: $fontSizeM;
-                }
-                .bugs-details-view .file-issue-button {
-                    margin-right: 7px;
-                    font-size: 16px;
-                    float: left;
-                    margin-top: 1px;
                 }
                 .details-list {
                     min-width: 100%;

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -109,15 +109,6 @@ html {
     margin: 4px;
 }
 
-#popup-container .getting-started-dialog {
-    width: 38em;
-}
-
-#popup-container .feedback-dialog {
-    width: 38em;
-    margin: 20px 14px 20px 14px;
-}
-
 #popup-container .unsupported-url-info-panel {
     width: 28em;
     margin: 20px 14px 20px 14px;
@@ -125,17 +116,6 @@ html {
 
 #popup-container .toggle-label {
     font-size: 16px;
-}
-
-#popup-container .popup-submit-button {
-    margin-top: 19px;
-}
-
-#popup-container .getting-started-dialog-header {
-    margin: 0 0 5px 0;
-    width: 100%;
-    padding: 3%;
-    background: $neutral-100;
 }
 
 #popup-container .main-section {
@@ -175,10 +155,6 @@ html {
     }
 }
 
-#popup-container .feedback-dialog-header {
-    margin-bottom: 12px;
-}
-
 .popup-menu .ms-ContextualMenu-icon {
     color: $communication-primary;
     max-height: 30px;
@@ -196,10 +172,6 @@ html {
     padding-right: 0;
     padding-left: 0;
     float: right;
-}
-
-#popup-container .getting-started-dialog-exit-button {
-    color: $neutral-0;
 }
 
 #popup-container .main-section .shortcut-label {
@@ -225,14 +197,6 @@ html {
     }
 }
 
-#popup-container #getting-started-main-section {
-    margin: 0 8px;
-}
-
-#popup-container #feed-back-dialog-main-section {
-    margin: 0 8px;
-}
-
 #popup-container .main-section h3 {
     margin-top: 7px;
     margin-bottom: 7px;
@@ -241,22 +205,6 @@ html {
 #popup-container .main-section p {
     margin-top: 8px;
     margin-bottom: 8px;
-}
-
-#popup-container .main-section .italic-text-container {
-    margin-left: 0px;
-    margin-top: 5px;
-}
-
-#popup-container .main-section .ms-Grid-row .italic-text-container {
-    margin-left: 20px;
-    margin-top: -2px;
-    color: $secondary-text;
-}
-
-#popup-container .main-section .getting-started-hr {
-    margin-top: 10px;
-    margin-bottom: 3px;
 }
 
 #popup-container .main-section .launch-panel-hr {
@@ -312,10 +260,6 @@ button[disabled]:focus:not(.ms-ContextualMenu-link) {
     border: none;
 }
 
-#popup-container .feedback-dialog-button {
-    width: 92px;
-}
-
 #popup-container .right-float-button-row {
     float: right;
 }
@@ -336,16 +280,8 @@ button[disabled]:focus:not(.ms-ContextualMenu-link) {
     text-align: right;
 }
 
-#popup-container .feedback-dialog .ms-TextField-field {
-    height: 100px;
-}
-
 #popup-container .launch-panel-general-container {
     margin-bottom: 20px;
-}
-
-#popup-container .ask-a-question-button {
-    height: 0px;
 }
 
 #popup-container {
@@ -404,55 +340,6 @@ button[disabled]:focus:not(.ms-ContextualMenu-link) {
 #popup-container .launch-panel {
     width: 296px;
 
-    .launch-pad-main-section #getting-started-heading {
-        margin: 0px;
-        height: 20px;
-        padding: 0px;
-    }
-
-    .getting-started-dialog-header-title {
-        height: 28px;
-        width: 180px;
-        color: $neutral-100;
-        font-family: $fontFamily;
-        font-size: 21px;
-        line-height: 25px;
-        padding: 0px 8px;
-    }
-
-    .getting-started-dialog-header-subtitle {
-        color: $neutral-100;
-        height: 15px;
-        font-size: 11px;
-        line-height: 13px;
-        font-style: normal;
-        font-family: $fontFamily;
-        padding: 0px;
-    }
-
-    .getting-started-dialog-exit-button {
-        color: $secondary-text;
-        height: 17px;
-        width: 17px;
-        font-size: 17px;
-        line-height: 20px;
-        font-style: normal;
-        position: relative;
-        left: 10px;
-    }
-
-    .popup-submit-button {
-        margin: 0px;
-    }
-
-    .getting-started-dialog-header-fast-pass {
-        margin: 0px 0px 12px 0px;
-        width: 256px;
-        height: 42px;
-        background: $neutral-0;
-        padding: 0px;
-    }
-
     .launch-pad-main-section {
         width: 100%;
         margin: 0px;
@@ -460,30 +347,6 @@ button[disabled]:focus:not(.ms-ContextualMenu-link) {
 
     .launch-pad-item-description {
         width: 280px;
-    }
-
-    .popup-submit-button-disabled {
-        color: $neutral-20;
-        background-color: $neutral-8;
-        border-style: solid;
-        border-width: 1px 1px 1px 0px;
-        border-color: $neutral-20;
-    }
-
-    .popup-submit-button-enabled {
-        color: $neutral-0;
-        background-color: $communication-primary;
-        border-style: solid;
-        border-width: 1px 1px 1px 0px;
-        border-color: $communication-primary;
-    }
-
-    .popup-submit-button-submitted {
-        color: $accent2-dark;
-        background-color: $neutral-0;
-        border-style: solid;
-        border-width: 1px 1px 1px 0px;
-        border-color: $neutral-20;
     }
 
     .popup-start-dialog-icon-circle {
@@ -513,176 +376,11 @@ button[disabled]:focus:not(.ms-ContextualMenu-link) {
             color: $secondary-text;
             font-style: normal;
         }
-
-        .getting-started-dialog-panel-item-description {
-            margin: 0px;
-            font-size: 14px;
-            white-space: nowrap;
-        }
     }
 
     ::placeholder {
         font-style: italic;
     }
-}
-
-#popup-container #getting-started-dialog-fast-pass {
-    width: 296px;
-    height: 502px;
-    padding: 20px;
-
-    #getting-started-main-section #getting-started-heading {
-        margin: 0px;
-        height: 20px;
-        padding: 0px;
-    }
-
-    .getting-started-dialog-header-title {
-        height: 28px;
-        width: 180px;
-        color: $neutral-100;
-        font-family: $fontFamily;
-        font-size: 21px;
-        line-height: 25px;
-        padding: 0px 8px;
-    }
-
-    .getting-started-dialog-header-subtitle {
-        color: $neutral-100;
-        height: 15px;
-        font-size: 11px;
-        line-height: 13px;
-        font-style: normal;
-        font-family: $fontFamily;
-        padding: 0px;
-    }
-
-    .getting-started-dialog-exit-button {
-        color: $secondary-text;
-        height: 17px;
-        width: 17px;
-        font-size: 17px;
-        line-height: 20px;
-        font-style: normal;
-        position: relative;
-        left: 10px;
-    }
-
-    .popup-submit-button {
-        margin: 0px;
-    }
-
-    .getting-started-dialog-header-fast-pass {
-        margin: 0px 0px 12px 0px;
-        width: 256px;
-        height: 42px;
-        background: $neutral-0;
-        padding: 0px;
-    }
-
-    #getting-started-main-section {
-        width: 100%;
-        margin: 0px;
-    }
-
-    #getting-started-main-section .getting-started-hr {
-        margin: 12px 0px 0px 0px;
-        border-width: 1px 0px 0px 0px;
-        padding: 0px;
-        border-style: solid;
-        border-color: $neutral-8;
-    }
-
-    .popup-submit-button-disabled {
-        color: $neutral-20;
-        background-color: $neutral-8;
-        border-style: solid;
-        border-width: 1px 1px 1px 0px;
-        border-color: $neutral-20;
-    }
-
-    .popup-submit-button-enabled {
-        color: $neutral-0;
-        background-color: $communication-primary;
-        border-style: solid;
-        border-width: 1px 1px 1px 0px;
-        border-color: $communication-primary;
-    }
-
-    .popup-submit-button-submitted {
-        color: $accent2-dark;
-        background-color: $neutral-0;
-        border-style: solid;
-        border-width: 1px 1px 1px 0px;
-        border-color: $neutral-20;
-    }
-
-    .popup-start-dialog-icon-circle {
-        border-radius: 50%;
-        width: 59px;
-        height: 59px;
-        background-color: $neutral-10;
-        margin-top: 16px;
-        padding: 12px 14px 14px 14px;
-    }
-
-    #getting-started-main-section .getting-started-dialog-panel {
-        h3 {
-            margin: 16px 0px 0px 0px;
-            padding: 0px;
-            height: 20px;
-        }
-
-        .ms-Button-icon {
-            width: 31px;
-            height: 31px;
-            font-size: 31px;
-            line-height: 36px;
-            color: $secondary-text;
-            font-style: normal;
-        }
-
-        .popup-start-dialog-icon {
-            width: 31px;
-            height: 31px;
-            font-size: 31px;
-            line-height: 36px;
-            color: $secondary-text;
-            font-style: normal;
-        }
-
-        .getting-started-dialog-panel-item-description {
-            height: 38px;
-            margin: 0px;
-        }
-    }
-
-    ::placeholder {
-        font-style: italic;
-    }
-}
-
-#popup-container .fast-pass-launch-panel {
-    padding-left: 16px;
-    padding-right: 16px;
-    padding-top: 16px;
-    padding-bottom: 16px;
-    background: $communication-tint-40;
-    line-height: 16px;
-    margin-bottom: 14px;
-}
-
-#popup-container .fast-pass-title,
-#popup-container .fast-pass-description {
-    padding-bottom: 10px;
-}
-
-#popup-container .fast-pass-rocket-large {
-    position: absolute;
-    font-size: 124px;
-    top: 87px;
-    left: 155px;
-    color: $communication-alpha-5;
 }
 
 .gear-options-icon {


### PR DESCRIPTION
#### Description of changes

This was my process for finding dead css:
1) Search for the class name across our file base: if it only appears in the scss files, it's highly unlikely to be used.
2) Remove these styles.
3) Locally build the app and try to find these classes in html; if none were found, then we can be fairly certain this is dead css.

For certain scenarios, I did not do step 3 as components being referred to were quite clearly no longer being used (for example, lots of styles in popup refer to a getting started dialog which no longer exists).

I've added a gif for sanity-check reasons of me going through the popup and details view; feel free to check this out and check for yourself. 😄 

![deadcssfrominjectedanddetailsview](https://user-images.githubusercontent.com/32555133/65730451-a295cd80-e076-11e9-8b55-f482ed6e00c0.gif)

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
