### PR TITLE
chore: removed dead styles in injected.scss

### DIFF
--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -169,22 +169,6 @@
         margin-top: 3px !important;
     }
 
-    .insights-dialog-main-override .insights-dialog-rule-link,
-    .insights-dialog-main-override-shadow .insights-dialog-rule-link {
-        margin-top: 5px !important;
-        margin-bottom: 6px !important;
-        padding: 0 !important;
-
-        .ms-Link {
-            color: $communication-primary;
-        }
-    }
-
-    .insights-dialog-main-override .insights-dialog-rule-container,
-    .insights-dialog-main-override-shadow .insights-dialog-rule-container {
-        margin-bottom: 12px !important;
-    }
-
     .insights-dialog-main-override-shadow .insights-dialog-container {
         margin-bottom: 12px !important;
         position: relative;
@@ -223,7 +207,6 @@
                 }
 
                 display: inline;
-                float: right;
 
                 i {
                     font-style: normal;
@@ -280,9 +263,6 @@
             float: right;
             text-align: right;
         }
-    }
-
-    .insights-dialog-main-override .insights-dialog-target-button-container {
     }
 
     .insights-dialog-main-override-shadow .insights-dialog-target-button-container {


### PR DESCRIPTION
#### Description of changes

Same process as before:

Search for the class name across our file base: if it only appears in the scss files, it's highly unlikely to be used.
Remove these styles.
Locally build the app and try to find these classes in html; if none were found, then we can be fairly certain this is dead css.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
