### PR TITLE
refactor: re-added float right style to the shadow dom dialog close button

### DIFF
--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -206,7 +206,7 @@
                     }
                 }
 
-                display: inline;
+                float: right;
 
                 i {
                     font-style: normal;


### PR DESCRIPTION
#### Description of changes

In a previous PR I removed float:right from the shadow dom dialog per the suggestion of VSCode; it said it would not be applied. It was wrong! Instead, it was the display property that would not be applied! As such I removed display:inline and re-added float:right.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
