### PR TITLE
build(deps-dev): bump @types/react-helmet from 5.0.10 to 5.0.11 and fix imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "@types/react": "^16.9.3",
         "@types/react-copy-to-clipboard": "^4.3.0",
         "@types/react-dom": "^16.9.1",
-        "@types/react-helmet": "^5.0.10",
+        "@types/react-helmet": "^5.0.11",
         "@types/react-router-dom": "^5.1.0",
         "@types/serve-static": "^1.13.3",
         "@types/ua-parser-js": "^0.7.33",

--- a/src/common/components/theme.tsx
+++ b/src/common/components/theme.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
 import * as React from 'react';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 
 import { DefaultThemePalette } from '../styles/default-theme-palette';
 import { HighContrastThemePalette } from '../styles/high-contrast-theme-palette';

--- a/src/views/content/guidance-title.tsx
+++ b/src/views/content/guidance-title.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { productName } from 'content/strings/application';
 import * as React from 'react';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { NamedFC } from '../../common/react/named-fc';
 
 export type GuidanceTitleProps = {

--- a/src/views/content/markup.tsx
+++ b/src/views/content/markup.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import Helmet from 'react-helmet';
+import { Helmet } from 'react-helmet';
 
 import { Code, Emphasis, Tag, Term } from 'assessments/markup';
 import { productName } from 'content/strings/application';

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,10 +598,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-helmet@^5.0.10":
-  version "5.0.10"
-  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-5.0.10.tgz#f47fdda88fe750880089904fde4446612f79b63d"
-  integrity sha512-wGr0J7yncqwOS4ae+yYeMd4L3Gh43CgYcbq9bXEeSozB4d/+Z/XLT9wyMUwfWImWtOLCFLP6Xnt7w5P6+02gZg==
+"@types/react-helmet@^5.0.11":
+  version "5.0.11"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-5.0.11.tgz#d2642af4658e7b97accb46ea8b00d6dc614c99fa"
+  integrity sha512-id9DjHp/+Cm+x3etN+EWs5OP76PPpz8jXw+iN9xcXltssF0KHNjAzlan///ASXegEewaItlw5FhFnoLxRUJQ9g==
   dependencies:
     "@types/react" "*"
 


### PR DESCRIPTION
#### Description of changes

Dependabot suggested updating [@types/react-helmet](https://www.npmjs.com/package/@types/react-helmet) to 5.0.11, but their [PR 38557](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/38557) to remove the default export broke our imports. ([We're not the only ones broken.](https://dependabot.com/compatibility-score/?dependency-name=@types/react-helmet&package-manager=npm_and_yarn&previous-version=5.0.10&new-version=5.0.11)). This change updates our imports to work with the change.

#### Pull request checklist

- [ ] Addresses an existing issue: _(dependency update and fix, not tracked by an issue)_
- [ ] Added relevant unit test for your changes. (`yarn test`) _(no functional code change)_
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage` _(no functional code change)_
- [X] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above _(no UI change)_
- [ ] (UI changes only) Verified usability with NVDA/JAWS _(no UI change)_
