### PR TITLE
Added electron to watch command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -130,20 +130,24 @@ module.exports = function(grunt) {
         watch: {
             images: {
                 files: ['src/**/*.png'],
-                tasks: ['copy:images', 'drop:dev'],
+                tasks: ['copy:images', 'drop:dev', 'drop:electron'],
             },
             'non-webpack-code': {
                 files: ['src/**/*.html', 'src/manifest.json'],
-                tasks: ['copy:code', 'drop:dev'],
+                tasks: ['copy:code', 'drop:dev', 'drop:electron'],
             },
             scss: {
                 files: ['src/**/*.scss'],
-                tasks: ['sass', 'copy:styles', 'drop:dev'],
+                tasks: ['sass', 'copy:styles', 'drop:dev', 'drop:electron'],
             },
             // We assume webpack --watch is running separately (usually via 'yarn watch')
-            'webpack-output': {
+            'webpack-dev-output': {
                 files: ['extension/devBundle/**/*.*'],
                 tasks: ['drop:dev'],
+            },
+            'webpack-electron-output': {
+                files: ['extension/electronBundle/**/*.*'],
+                tasks: ['drop:electron'],
             },
         },
     });

--- a/package.json
+++ b/package.json
@@ -33,12 +33,13 @@
         "test:electron": "jest --projects src/tests/electron --runInBand",
         "tslint": "tslint -c ./tslint.json -p ./tsconfig.json",
         "tslint:fix": "tslint --fix -c ./tslint.json -p ./tsconfig.json",
-        "watch": "npm-run-all --parallel --race --print-label watch:scss watch:grunt watch:test watch:webpack",
-        "watch:build": "npm-run-all --parallel --race --print-label watch:scss watch:grunt watch:webpack",
+        "watch": "npm-run-all --parallel --race --print-label watch:scss watch:grunt watch:test watch:webpack watch:webpack-electron",
+        "watch:build": "npm-run-all --parallel --race --print-label watch:scss watch:grunt watch:webpack watch:webpack-electron",
         "watch:scss": "tsm src/**/*.scss --watch",
         "watch:grunt": "grunt watch",
         "watch:test": "jest --watch --coverage false --colors",
-        "watch:webpack": "webpack --watch --config-name dev --colors --progress"
+        "watch:webpack": "webpack --watch --config-name dev --colors --progress",
+        "watch:webpack-electron": "webpack --watch --config-name electron --colors --progress"
     },
     "devDependencies": {
         "@types/applicationinsights-js": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
         "test:electron": "jest --projects src/tests/electron --runInBand",
         "tslint": "tslint -c ./tslint.json -p ./tsconfig.json",
         "tslint:fix": "tslint --fix -c ./tslint.json -p ./tsconfig.json",
-        "watch": "npm-run-all --parallel --race --print-label watch:scss watch:grunt watch:test watch:webpack watch:webpack-electron",
-        "watch:build": "npm-run-all --parallel --race --print-label watch:scss watch:grunt watch:webpack watch:webpack-electron",
+        "watch": "npm-run-all --parallel --race --print-label watch:scss watch:grunt watch:test watch:webpack-dev-browser watch:webpack-electron",
+        "watch:build": "npm-run-all --parallel --race --print-label watch:scss watch:grunt watch:webpack-dev-browser watch:webpack-electron",
         "watch:scss": "tsm src/**/*.scss --watch",
         "watch:grunt": "grunt watch",
         "watch:test": "jest --watch --coverage false --colors",
-        "watch:webpack": "webpack --watch --config-name dev --colors --progress",
+        "watch:webpack-dev-browser": "webpack --watch --config-name dev --colors --progress",
         "watch:webpack-electron": "webpack --watch --config-name electron --colors --progress"
     },
     "devDependencies": {


### PR DESCRIPTION
#### Description of changes

We added a watch command for electron. We are going to move electron out of the watch command in a later PR. 

#### Pull request checklist

- [N/A] Addresses an existing issue: Fixes #0000
- [N/A] Added relevant unit test for your changes. (`yarn test`)
- [N/A] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [N/A] Ran precheckin (`yarn precheckin`)
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [N/A] (UI changes only) Verified usability with NVDA/JAWS
