### PR TITLE
add dependabot config that ignores OF >=7 updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,19 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    version_requirement_updates: "increase_versions"
+    default_labels:
+      - "category: engineering"
+      - "dependencies"
+    commit_message:
+      prefix: "chore"
+      include_scope: true
+    ignored_updates:
+      - match:
+          # Major Office Fabric updates require enough extra validation
+          # that we schedule them as feature work, rather than having
+          # dependabot auto-update them like other deps.
+          dependency_name: "office-ui-fabric-react"
+          version_requirement: ">=7.0.0"

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,7 @@
 **/Dockerfile
 
 .DS_Store
+.dependabot/
 .github/
 .prettierignore
 .yarnrc

--- a/copyright-header.config.json
+++ b/copyright-header.config.json
@@ -1,6 +1,7 @@
 {
     "license": "copyright-header.txt",
     "ignore": [
+        "./.dependabot",
         "./.git",
         "./.github",
         "./.vscode",


### PR DESCRIPTION
#### Description of changes

Adds a dependabot config file ([reference docs](https://dependabot.com/docs/config-file/)) to ignore office fabric major version bumps, per #1302.

I've verified that the config file passes [dependabot's config file validator](https://dependabot.com/docs/config-file/validator/)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1302
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
