### PR TITLE
fix: make it clear that the "start over" button will open a dropdown menu

### DIFF
--- a/src/DetailsView/components/start-over-dropdown.tsx
+++ b/src/DetailsView/components/start-over-dropdown.tsx
@@ -44,6 +44,7 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
                         iconName: 'Refresh',
                     }}
                     text="Start over"
+                    ariaLabel="start over menu"
                     onClick={this.openDropdown}
                     menuIconProps={{
                         iconName: 'ChevronDown',

--- a/src/DetailsView/components/start-over-dropdown.tsx
+++ b/src/DetailsView/components/start-over-dropdown.tsx
@@ -45,6 +45,9 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
                     }}
                     text="Start over"
                     onClick={this.openDropdown}
+                    menuIconProps={{
+                        iconName: 'ChevronDown',
+                    }}
                 />
                 {this.renderContextMenu()}
                 {this.renderStartOverDialog()}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`StartOverDropdownTest render 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} />
+  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} menuIconProps={{...}} />
 </div>"
 `;
 
@@ -12,6 +12,11 @@ exports[`StartOverDropdownTest render ContextualMenu 1`] = `
     iconProps={
       Object {
         "iconName": "Refresh",
+      }
+    }
+    menuIconProps={
+      Object {
+        "iconName": "ChevronDown",
       }
     }
     onClick={[Function]}
@@ -46,6 +51,11 @@ exports[`StartOverDropdownTest render ContextualMenu with only one option 1`] = 
         "iconName": "Refresh",
       }
     }
+    menuIconProps={
+      Object {
+        "iconName": "ChevronDown",
+      }
+    }
     onClick={[Function]}
     text="Start over"
   />
@@ -67,7 +77,7 @@ exports[`StartOverDropdownTest render ContextualMenu with only one option 1`] = 
 
 exports[`StartOverDropdownTest render GenericDialog for start over a test 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} />
+  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} menuIconProps={{...}} />
   <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} />
   <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the test name test. Are you sure you want to start over?\\" onCancelButtonClick={[Function]} onPrimaryButtonClick={[Function]} primaryButtonText=\\"Start over\\" />
 </div>"
@@ -75,7 +85,7 @@ exports[`StartOverDropdownTest render GenericDialog for start over a test 1`] = 
 
 exports[`StartOverDropdownTest render GenericDialog for start over the whole assessment 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} />
+  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} menuIconProps={{...}} />
   <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} />
   <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the Assessment. This will clear results and progress of all tests and requirements. Are you sure you want to start over?\\" onCancelButtonClick={[Function]} onPrimaryButtonClick={[Function]} primaryButtonText=\\"Start over\\" />
 </div>"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
@@ -2,13 +2,14 @@
 
 exports[`StartOverDropdownTest render 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} menuIconProps={{...}} />
+  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" ariaLabel=\\"start over menu\\" onClick={[Function]} menuIconProps={{...}} />
 </div>"
 `;
 
 exports[`StartOverDropdownTest render ContextualMenu 1`] = `
 <div>
   <CustomizedActionButton
+    ariaLabel="start over menu"
     iconProps={
       Object {
         "iconName": "Refresh",
@@ -46,6 +47,7 @@ exports[`StartOverDropdownTest render ContextualMenu 1`] = `
 exports[`StartOverDropdownTest render ContextualMenu with only one option 1`] = `
 <div>
   <CustomizedActionButton
+    ariaLabel="start over menu"
     iconProps={
       Object {
         "iconName": "Refresh",
@@ -77,7 +79,7 @@ exports[`StartOverDropdownTest render ContextualMenu with only one option 1`] = 
 
 exports[`StartOverDropdownTest render GenericDialog for start over a test 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} menuIconProps={{...}} />
+  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" ariaLabel=\\"start over menu\\" onClick={[Function]} menuIconProps={{...}} />
   <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} />
   <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the test name test. Are you sure you want to start over?\\" onCancelButtonClick={[Function]} onPrimaryButtonClick={[Function]} primaryButtonText=\\"Start over\\" />
 </div>"
@@ -85,7 +87,7 @@ exports[`StartOverDropdownTest render GenericDialog for start over a test 1`] = 
 
 exports[`StartOverDropdownTest render GenericDialog for start over the whole assessment 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" onClick={[Function]} menuIconProps={{...}} />
+  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" ariaLabel=\\"start over menu\\" onClick={[Function]} menuIconProps={{...}} />
   <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} />
   <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the Assessment. This will clear results and progress of all tests and requirements. Are you sure you want to start over?\\" onCancelButtonClick={[Function]} onPrimaryButtonClick={[Function]} primaryButtonText=\\"Start over\\" />
 </div>"


### PR DESCRIPTION
#### Description of changes

For visual users, adds a standard ChevronDown menu icon to our "start over" dropdown menu button per @cheade's suggestion in #1316 

For SR users, updates the button's aria-label to make the button read as `start over menu button`, rather than the current `start over button`.

Office Fabric would normally add the chevron implicitly for `ActionButton`s with menus attached, but we're using some custom handling to attach the menu to the button rather than using `menuProps`, so we're instead setting the icon explicitly.

This is using Office Fabric's default styling and attributes for the chevron icon. I verified that:
* The chevron is not announced to screen readers (has `role=presentation` and `aria-hidden=true`)
* The chevron's contrast ratio is 3.69 (meets the 3.0 requirement for non-text contrast from WCAG 1.4.11)

![screenshot of assessment with new chevron icon on start over button](https://user-images.githubusercontent.com/376284/65914736-c9aa1300-e386-11e9-85dd-b684e7e65b51.png)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes  #1316
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
