### PR TITLE
feat: device disconnected popup

### DIFF
--- a/src/electron/device-connect-view/device-connect-view.scss
+++ b/src/electron/device-connect-view/device-connect-view.scss
@@ -7,6 +7,7 @@
 @import './components/device-connect-header.scss';
 @import './components/device-connect-port-entry.scss';
 @import './components/telemetry-permission-dialog.scss';
+@import '../device-disconnected-popup/device-disconnected-popup.scss';
 
 body {
     -webkit-app-region: drag;

--- a/src/electron/device-disconnected-popup/device-disconnected-popup.scss
+++ b/src/electron/device-disconnected-popup/device-disconnected-popup.scss
@@ -2,22 +2,26 @@
 // Licensed under the MIT License.
 @import '../../common/styles/fonts.scss';
 
-.title-container {
-    display: flex;
+.device-disconnected-popup {
+    .title-container {
+        display: flex;
 
-    svg {
-        align-self: center;
+        svg {
+            align-self: center;
+        }
     }
-}
 
-.ms-Dialog-header {
-    height: 50px;
-}
+    :global {
+        .ms-Dialog-header {
+            height: 50px;
+        }
+    }
 
-.title-text {
-    margin-left: 8px;
-    font-family: $semiBoldFontFamily;
-    font-size: 20px;
-    font-weight: 600;
-    line-height: 28px;
+    .title-text {
+        margin-left: 8px;
+        font-family: $semiBoldFontFamily;
+        font-size: 20px;
+        font-weight: 600;
+        line-height: 28px;
+    }
 }

--- a/src/electron/device-disconnected-popup/device-disconnected-popup.scss
+++ b/src/electron/device-disconnected-popup/device-disconnected-popup.scss
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/fonts.scss';
+
+.title-container {
+    display: flex;
+
+    svg {
+        align-self: center;
+    }
+}
+
+.ms-Dialog-header {
+    height: 50px;
+}
+
+.title-text {
+    margin-left: 8px;
+    font-family: $semiBoldFontFamily;
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 28px;
+}

--- a/src/electron/device-disconnected-popup/device-disconnected-popup.scss
+++ b/src/electron/device-disconnected-popup/device-disconnected-popup.scss
@@ -11,10 +11,8 @@
         }
     }
 
-    :global {
-        .ms-Dialog-header {
-            height: 50px;
-        }
+    .ms-Dialog-header {
+        height: 50px;
     }
 
     .title-text {

--- a/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
@@ -5,6 +5,7 @@ import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import * as React from 'react';
 
+import { deviceDisconnectedPopup, titleContainer, titleText } from './device-disconnected-popup.scss';
 import { StatusCautionIcon } from './status-caution-icon';
 
 export type DeviceDisconnectedPopupProps = {
@@ -17,9 +18,9 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
     'DeviceDisconnectedPopup',
     ({ deviceName, onConnectNewDevice, onRescanDevice }) => {
         const title: JSX.Element = (
-            <div className="title-container">
+            <div className={titleContainer}>
                 <StatusCautionIcon />
-                <span className="title-text">Device disconnected</span>
+                <span className={titleText}>Device disconnected</span>
             </div>
         );
 
@@ -32,6 +33,7 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
                 }}
                 modalProps={{
                     isBlocking: true,
+                    className: deviceDisconnectedPopup,
                 }}
                 hidden={false}
                 minWidth={416}

--- a/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
+import * as React from 'react';
+
+export type DeviceDisconnectedPopupProps = {
+    onConnectNewDevice: () => void;
+    onRescanDevice: () => void;
+};
+
+export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
+    'DeviceDisconnectedPopup',
+    ({ onConnectNewDevice, onRescanDevice }) => {
+        const title: JSX.Element = <span>Device disconnected</span>;
+
+        return (
+            <Dialog
+                dialogContentProps={{
+                    type: DialogType.normal,
+                    showCloseButton: false,
+                    title,
+                }}
+                modalProps={{
+                    isBlocking: true,
+                }}
+            >
+                <div>
+                    <p>Uh-oh! It seems the [insert device name] device has disconnected before the snapshot completed its analysis.</p>
+                    <p>Make sure your device is properly connected, and try rescanning or connecting a different device.</p>
+                </div>
+                <DialogFooter>
+                    <DefaultButton text="Connect a new device" onClick={onConnectNewDevice} />
+                    <DefaultButton text="Rescan device" onClick={onRescanDevice} />
+                </DialogFooter>
+            </Dialog>
+        );
+    },
+);

--- a/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
@@ -17,10 +17,10 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
     'DeviceDisconnectedPopup',
     ({ deviceName, onConnectNewDevice, onRescanDevice }) => {
         const title: JSX.Element = (
-            <span>
+            <div className="title-container">
                 <StatusCautionIcon />
-                Device disconnected
-            </span>
+                <span className="title-text">Device disconnected</span>
+            </div>
         );
 
         return (

--- a/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
@@ -5,7 +5,6 @@ import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import * as React from 'react';
 
-import { deviceDisconnectedPopup, titleContainer, titleText } from './device-disconnected-popup.scss';
 import { StatusCautionIcon } from './status-caution-icon';
 
 export type DeviceDisconnectedPopupProps = {
@@ -18,9 +17,9 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
     'DeviceDisconnectedPopup',
     ({ deviceName, onConnectNewDevice, onRescanDevice }) => {
         const title: JSX.Element = (
-            <div className={titleContainer}>
+            <div className="title-container">
                 <StatusCautionIcon />
-                <span className={titleText}>Device disconnected</span>
+                <span className="title-text">Device disconnected</span>
             </div>
         );
 
@@ -33,7 +32,7 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
                 }}
                 modalProps={{
                     isBlocking: true,
-                    className: deviceDisconnectedPopup,
+                    className: 'device-disconnected-popup',
                 }}
                 hidden={false}
                 minWidth={416}

--- a/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
@@ -25,6 +25,8 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
                 modalProps={{
                     isBlocking: true,
                 }}
+                hidden={false}
+                minWidth={416}
             >
                 <div>
                     <p>Uh-oh! It seems the [insert device name] device has disconnected before the snapshot completed its analysis.</p>

--- a/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/device-disconnected-popup/device-disconnected-popup.tsx
@@ -5,15 +5,23 @@ import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import * as React from 'react';
 
+import { StatusCautionIcon } from './status-caution-icon';
+
 export type DeviceDisconnectedPopupProps = {
     onConnectNewDevice: () => void;
     onRescanDevice: () => void;
+    deviceName: string;
 };
 
 export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
     'DeviceDisconnectedPopup',
-    ({ onConnectNewDevice, onRescanDevice }) => {
-        const title: JSX.Element = <span>Device disconnected</span>;
+    ({ deviceName, onConnectNewDevice, onRescanDevice }) => {
+        const title: JSX.Element = (
+            <span>
+                <StatusCautionIcon />
+                Device disconnected
+            </span>
+        );
 
         return (
             <Dialog
@@ -29,7 +37,7 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
                 minWidth={416}
             >
                 <div>
-                    <p>Uh-oh! It seems the [insert device name] device has disconnected before the snapshot completed its analysis.</p>
+                    <p>Uh-oh! It seems the {deviceName} device has disconnected before the snapshot completed its analysis.</p>
                     <p>Make sure your device is properly connected, and try rescanning or connecting a different device.</p>
                 </div>
                 <DialogFooter>

--- a/src/electron/device-disconnected-popup/status-caution-icon.tsx
+++ b/src/electron/device-disconnected-popup/status-caution-icon.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import * as React from 'react';
+
+export const StatusCautionIcon = NamedFC('StatusCautionIcon', () => (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+        <path
+            fill-rule="evenodd"
+            clip-rule="evenodd"
+            d="M12 24C18.6274 24 24 18.6274 24 12C24 5.37258 18.6274 0 12 0C5.37258 0 0 5.37258 0 12C0 18.6274 5.37258 24 12 24ZM12 5.25C12.6213 5.25 13.125 5.75368 13.125 6.375V13.125C13.125 13.7463 12.6213 14.25 12 14.25C11.3787 14.25 10.875 13.7463 10.875 13.125V6.375C10.875 5.75368 11.3787 5.25 12 5.25ZM10.875 17.25C10.875 16.6287 11.3787 16.125 12 16.125C12.6213 16.125 13.125 16.6287 13.125 17.25C13.125 17.8713 12.6213 18.375 12 18.375C11.3787 18.375 10.875 17.8713 10.875 17.25Z"
+            fill="#D67F3C"
+        />
+    </svg>
+));

--- a/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -5,10 +5,16 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
   dialogContentProps={
     Object {
       "showCloseButton": false,
-      "title": <span>
+      "title": <div
+        className="title-container"
+      >
         <StatusCautionIcon />
-        Device disconnected
-      </span>,
+        <span
+          className="title-text"
+        >
+          Device disconnected
+        </span>
+      </div>,
       "type": 0,
     }
   }

--- a/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
     Object {
       "showCloseButton": false,
       "title": <span>
+        <StatusCautionIcon />
         Device disconnected
       </span>,
       "type": 0,
@@ -21,7 +22,9 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
 >
   <div>
     <p>
-      Uh-oh! It seems the [insert device name] device has disconnected before the snapshot completed its analysis.
+      Uh-oh! It seems the 
+      test device name
+       device has disconnected before the snapshot completed its analysis.
     </p>
     <p>
       Make sure your device is properly connected, and try rescanning or connecting a different device.

--- a/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DeviceDisconnectedPopup renders 1`] = `
+<StyledWithResponsiveMode
+  dialogContentProps={
+    Object {
+      "showCloseButton": false,
+      "title": <span>
+        Device disconnected
+      </span>,
+      "type": 0,
+    }
+  }
+  modalProps={
+    Object {
+      "isBlocking": true,
+    }
+  }
+>
+  <div>
+    <p>
+      Uh-oh! It seems the [insert device name] device has disconnected before the snapshot completed its analysis.
+    </p>
+    <p>
+      Make sure your device is properly connected, and try rescanning or connecting a different device.
+    </p>
+  </div>
+  <StyledDialogFooterBase>
+    <CustomizedDefaultButton
+      text="Connect a new device"
+    />
+    <CustomizedDefaultButton
+      text="Rescan device"
+    />
+  </StyledDialogFooterBase>
+</StyledWithResponsiveMode>
+`;

--- a/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -11,6 +11,8 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
       "type": 0,
     }
   }
+  hidden={false}
+  minWidth={416}
   modalProps={
     Object {
       "isBlocking": true,

--- a/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
     Object {
       "showCloseButton": false,
       "title": <div
-        className="titleContainer"
+        className="title-container"
       >
         <StatusCautionIcon />
         <span
-          className="titleText"
+          className="title-text"
         >
           Device disconnected
         </span>
@@ -22,7 +22,7 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
   minWidth={416}
   modalProps={
     Object {
-      "className": "deviceDisconnectedPopup",
+      "className": "device-disconnected-popup",
       "isBlocking": true,
     }
   }

--- a/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/electron/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -6,11 +6,11 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
     Object {
       "showCloseButton": false,
       "title": <div
-        className="title-container"
+        className="titleContainer"
       >
         <StatusCautionIcon />
         <span
-          className="title-text"
+          className="titleText"
         >
           Device disconnected
         </span>
@@ -22,6 +22,7 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
   minWidth={416}
   modalProps={
     Object {
+      "className": "deviceDisconnectedPopup",
       "isBlocking": true,
     }
   }

--- a/src/tests/unit/electron/device-disconnected-popup/device-disconnected-popup.test.tsx
+++ b/src/tests/unit/electron/device-disconnected-popup/device-disconnected-popup.test.tsx
@@ -6,7 +6,9 @@ import * as React from 'react';
 
 describe('DeviceDisconnectedPopup', () => {
     it('renders', () => {
-        const props = {} as DeviceDisconnectedPopupProps;
+        const props = {
+            deviceName: 'test device name',
+        } as DeviceDisconnectedPopupProps;
         const wrapper = shallow(<DeviceDisconnectedPopup {...props} />);
 
         expect(wrapper.getElement()).toMatchSnapshot();

--- a/src/tests/unit/electron/device-disconnected-popup/device-disconnected-popup.test.tsx
+++ b/src/tests/unit/electron/device-disconnected-popup/device-disconnected-popup.test.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DeviceDisconnectedPopup, DeviceDisconnectedPopupProps } from 'electron/device-disconnected-popup/device-disconnected-popup';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('DeviceDisconnectedPopup', () => {
+    it('renders', () => {
+        const props = {} as DeviceDisconnectedPopupProps;
+        const wrapper = shallow(<DeviceDisconnectedPopup {...props} />);
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    describe('user interaction', () => {
+        it('handles on connect a new device', () => {
+            const onConnectNewDeviceMock: () => void = jest.fn(() => {});
+
+            const props = {
+                onConnectNewDevice: onConnectNewDeviceMock,
+            } as DeviceDisconnectedPopupProps;
+
+            const wrapper = shallow(<DeviceDisconnectedPopup {...props} />);
+
+            wrapper.find('[text="Connect a new device"]').simulate('click');
+
+            expect(onConnectNewDeviceMock).toBeCalledTimes(1);
+        });
+
+        it('handles on rescan device', () => {
+            const onRescanDeviceMock: () => void = jest.fn(() => {});
+
+            const props = {
+                onRescanDevice: onRescanDeviceMock,
+            } as DeviceDisconnectedPopupProps;
+
+            const wrapper = shallow(<DeviceDisconnectedPopup {...props} />);
+
+            wrapper.find('[text="Rescan device"]').simulate('click');
+
+            expect(onRescanDeviceMock).toBeCalledTimes(1);
+        });
+    });
+});


### PR DESCRIPTION
#### Description of changes

Add the new "Device disconnected" popup.

![01 - device disconnected popup](https://user-images.githubusercontent.com/2837582/65919476-47731c00-e391-11e9-88f5-8cf92b42572d.png)

**Notes:**
- The "MY DEVICE" text is only for the screenshot purpose as that text is a prop that should come from the renderer and it should match the actual device name we get from the service.

**Out of scope:**
- actually render the dialog is not part of this PR as we still don't have the view that will use it.

#### Pull request checklist

- [x] Addresses an existing issue: completes WI # 1606858
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
