### PR TITLE
Convert android results to unified rule format

### DIFF
--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -61,6 +61,6 @@ export class RuleInformationProvider {
 
     public getRuleInformation(ruleId: string): RuleInformation {
         const ruleInfo = this.supportedRules[ruleId];
-        return ruleInfo ? ruleInfo : null;
+        return ruleInfo || null;
     }
 }

--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { RuleInformation } from './rule-information';
+import { RuleResultsData } from './scan-results';
+
+export class RuleInformationProvider {
+    private supportedRules: RuleInformation[];
+
+    constructor() {
+        this.supportedRules = [];
+        this.supportedRules.push(
+            new RuleInformation(
+                'ColorContrast',
+                'Text elements must have sufficient contrast against the background.',
+                this.getColorContrastHowToFix,
+            ),
+        );
+        this.supportedRules.push(
+            new RuleInformation('TouchSizeWcag', 'Touch inputs must have a sufficient target size.', this.getTouchSizeHowToFix),
+        );
+        this.supportedRules.push(
+            new RuleInformation(
+                'ActiveViewName',
+                "Active views must have a name that's available to assistive technologies.",
+                () =>
+                    'The view is active but has no name available to assistive technologies. Provide a name for the view using its contentDescription, hint, labelFor, or text attribute (depending on the view type)',
+            ),
+        );
+        this.supportedRules.push(
+            new RuleInformation(
+                'ImageViewName',
+                'Meaningful images must have alternate text.',
+                () =>
+                    'The image has no alternate text and is not identified as decorative. If the image conveys meaningful content, provide alternate text using the contentDescription attribute. If the image is decorative, give it an empty contentDescription, or set its isImportantForAccessibility attribute to false.',
+            ),
+        );
+        this.supportedRules.push(
+            new RuleInformation(
+                'EditTextValue',
+                'EditText elements must expose their entered text value to assistive technologies',
+                () =>
+                    "The element's contentDescription overrides the text value required by assistive technologies. Remove the element’s contentDescription attribute.",
+            ),
+        );
+    }
+
+    private getColorContrastHowToFix(ruleResultsData: RuleResultsData): string {
+        const ratio = ruleResultsData.props['Color Contrast Ratio'] as string;
+        const foreground = (ruleResultsData.props['Foreground Color'] as string).substring(2);
+        const background = (ruleResultsData.props['Background Color'] as string).substring(2);
+
+        return `The text element has insufficient contrast of ${ratio}. Foreground color: #${foreground}, background color: #${background}). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).`;
+    }
+
+    private getTouchSizeHowToFix(ruleResultsData: RuleResultsData): string {
+        const dpi = ruleResultsData.props['Screen Dots Per Inch'] as number;
+        const physicalWidth = ruleResultsData.props['width'] as number;
+        const physicalHeight = ruleResultsData.props['height'] as number;
+        const logicalWidth = physicalWidth / dpi;
+        const logicalHeight = physicalHeight / dpi;
+
+        return `The element has an insufficient target size (width: ${logicalWidth}dp, height: ${logicalHeight}dp). Set the element's minWidth and minHeight attributes to at least 48dp.`;
+    }
+
+    public getRuleInformation(ruleId: string): RuleInformation {
+        for (const ruleInformation of this.supportedRules) {
+            if (ruleId === ruleInformation.ruleId) {
+                return ruleInformation;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -1,48 +1,44 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { DictionaryStringTo } from '../../../types/common-types';
 import { RuleInformation } from './rule-information';
 import { RuleResultsData } from './scan-results';
 
 export class RuleInformationProvider {
-    private supportedRules: RuleInformation[];
+    private supportedRules: DictionaryStringTo<RuleInformation>;
 
     constructor() {
-        this.supportedRules = [];
-        this.supportedRules.push(
-            new RuleInformation(
+        this.supportedRules = {
+            ColorContrast: new RuleInformation(
                 'ColorContrast',
                 'Text elements must have sufficient contrast against the background.',
                 this.getColorContrastHowToFix,
             ),
-        );
-        this.supportedRules.push(
-            new RuleInformation('TouchSizeWcag', 'Touch inputs must have a sufficient target size.', this.getTouchSizeHowToFix),
-        );
-        this.supportedRules.push(
-            new RuleInformation(
+            TouchSizeWcag: new RuleInformation(
+                'TouchSizeWcag',
+                'Touch inputs must have a sufficient target size.',
+                this.getTouchSizeHowToFix,
+            ),
+            ActiveViewName: new RuleInformation(
                 'ActiveViewName',
                 "Active views must have a name that's available to assistive technologies.",
                 () =>
                     'The view is active but has no name available to assistive technologies. Provide a name for the view using its contentDescription, hint, labelFor, or text attribute (depending on the view type)',
             ),
-        );
-        this.supportedRules.push(
-            new RuleInformation(
+            ImageViewName: new RuleInformation(
                 'ImageViewName',
                 'Meaningful images must have alternate text.',
                 () =>
                     'The image has no alternate text and is not identified as decorative. If the image conveys meaningful content, provide alternate text using the contentDescription attribute. If the image is decorative, give it an empty contentDescription, or set its isImportantForAccessibility attribute to false.',
             ),
-        );
-        this.supportedRules.push(
-            new RuleInformation(
+            EditTextValue: new RuleInformation(
                 'EditTextValue',
                 'EditText elements must expose their entered text value to assistive technologies',
                 () =>
                     "The element's contentDescription overrides the text value required by assistive technologies. Remove the element’s contentDescription attribute.",
             ),
-        );
+        };
     }
 
     private getColorContrastHowToFix(ruleResultsData: RuleResultsData): string {
@@ -64,12 +60,7 @@ export class RuleInformationProvider {
     }
 
     public getRuleInformation(ruleId: string): RuleInformation {
-        for (const ruleInformation of this.supportedRules) {
-            if (ruleId === ruleInformation.ruleId) {
-                return ruleInformation;
-            }
-        }
-
-        return null;
+        const ruleInfo = this.supportedRules[ruleId];
+        return ruleInfo ? ruleInfo : null;
     }
 }

--- a/src/electron/platform/android/rule-information.ts
+++ b/src/electron/platform/android/rule-information.ts
@@ -6,15 +6,7 @@ import { RuleResultsData } from './scan-results';
 export type HowToFixDelegate = (ruleResultsData: RuleResultsData) => string;
 
 export class RuleInformation {
-    private RuleId: string;
-    private RuleDescription: string;
-    private HowToFixDelegate: HowToFixDelegate;
-
-    constructor(ruleId: string, ruleDescription: string, howToFixDelegate: HowToFixDelegate) {
-        this.RuleId = ruleId;
-        this.RuleDescription = ruleDescription;
-        this.HowToFixDelegate = howToFixDelegate;
-    }
+    constructor(readonly RuleId: string, readonly RuleDescription: string, readonly howToFixDelegate: HowToFixDelegate) {}
 
     public get ruleId(): string {
         return this.RuleId;
@@ -25,6 +17,6 @@ export class RuleInformation {
     }
 
     public howToFix(ruleResultsData: RuleResultsData): string {
-        return this.HowToFixDelegate(ruleResultsData);
+        return this.howToFixDelegate(ruleResultsData);
     }
 }

--- a/src/electron/platform/android/rule-information.ts
+++ b/src/electron/platform/android/rule-information.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { RuleResultsData } from './scan-results';
+
+export type HowToFixDelegate = (ruleResultsData: RuleResultsData) => string;
+
+export class RuleInformation {
+    private RuleId: string;
+    private RuleDescription: string;
+    private HowToFixDelegate: HowToFixDelegate;
+
+    constructor(ruleId: string, ruleDescription: string, howToFixDelegate: HowToFixDelegate) {
+        this.RuleId = ruleId;
+        this.RuleDescription = ruleDescription;
+        this.HowToFixDelegate = howToFixDelegate;
+    }
+
+    public get ruleId(): string {
+        return this.RuleId;
+    }
+
+    public get ruleDescription(): string {
+        return this.RuleDescription;
+    }
+
+    public howToFix(ruleResultsData: RuleResultsData): string {
+        return this.HowToFixDelegate(ruleResultsData);
+    }
+}

--- a/src/electron/platform/android/rule-information.ts
+++ b/src/electron/platform/android/rule-information.ts
@@ -6,15 +6,7 @@ import { RuleResultsData } from './scan-results';
 export type HowToFixDelegate = (ruleResultsData: RuleResultsData) => string;
 
 export class RuleInformation {
-    constructor(readonly RuleId: string, readonly RuleDescription: string, readonly howToFixDelegate: HowToFixDelegate) {}
-
-    public get ruleId(): string {
-        return this.RuleId;
-    }
-
-    public get ruleDescription(): string {
-        return this.RuleDescription;
-    }
+    constructor(readonly ruleId: string, readonly ruleDescription: string, readonly howToFixDelegate: HowToFixDelegate) {}
 
     public howToFix(ruleResultsData: RuleResultsData): string {
         return this.howToFixDelegate(ruleResultsData);

--- a/src/electron/platform/android/scan-results-to-unified-results.ts
+++ b/src/electron/platform/android/scan-results-to-unified-results.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { InstanceResultStatus, UnifiedResult } from 'common/types/store-data/unified-data-interface';
+import { UUIDGeneratorType } from 'common/uid-generator';
+import { RuleInformation } from './rule-information';
+import { RuleInformationProvider } from './rule-information-provider';
+import { RuleResultsData, ScanResults } from './scan-results';
+
+export type ConvertScanResultsToUnifiedResultsDelegate = (scanResults: ScanResults, uuidGenerator: UUIDGeneratorType) => UnifiedResult[];
+
+export function convertScanResultsToUnifiedResults(scanResults: ScanResults, uuidGenerator: UUIDGeneratorType): UnifiedResult[] {
+    if (scanResults == null || scanResults.ruleResults == null) {
+        return [];
+    }
+
+    return createUnifiedResultsFromScanResults(scanResults.ruleResults, uuidGenerator);
+}
+
+function createUnifiedResultsFromScanResults(ruleResults: RuleResultsData[], uuidGenerator: UUIDGeneratorType): UnifiedResult[] {
+    const ruleInformationProvider: RuleInformationProvider = new RuleInformationProvider();
+
+    const unifiedResults: UnifiedResult[] = [];
+
+    for (const ruleResult of ruleResults) {
+        const ruleInformation: RuleInformation = ruleInformationProvider.getRuleInformation(ruleResult.ruleId);
+
+        if (ruleInformation != null) {
+            unifiedResults.push(createUnifiedResult(ruleInformation, ruleResult, uuidGenerator));
+        }
+    }
+
+    return unifiedResults;
+}
+
+function createUnifiedResult(
+    ruleInformation: RuleInformation,
+    ruleResult: RuleResultsData,
+    uuidGenerator: UUIDGeneratorType,
+): UnifiedResult {
+    return {
+        uid: uuidGenerator(),
+        ruleId: ruleInformation.ruleId,
+        status: getStatus(ruleResult.status),
+        identifiers: null,
+        descriptors: null,
+        resolution: {
+            'how-to-fix': ruleInformation.howToFix(ruleResult),
+        },
+    };
+}
+
+function getStatus(status: string): InstanceResultStatus {
+    switch (status) {
+        case 'PASS':
+            return 'pass';
+        case 'FAIL':
+            return 'fail';
+        default:
+            return 'unknown';
+    }
+}

--- a/src/electron/platform/android/scan-results-to-unified-results.ts
+++ b/src/electron/platform/android/scan-results-to-unified-results.ts
@@ -10,7 +10,7 @@ import { RuleResultsData, ScanResults } from './scan-results';
 export type ConvertScanResultsToUnifiedResultsDelegate = (scanResults: ScanResults, uuidGenerator: UUIDGeneratorType) => UnifiedResult[];
 
 export function convertScanResultsToUnifiedResults(scanResults: ScanResults, uuidGenerator: UUIDGeneratorType): UnifiedResult[] {
-    if (scanResults == null || scanResults.ruleResults == null) {
+    if (!scanResults || !scanResults.ruleResults) {
         return [];
     }
 
@@ -25,7 +25,7 @@ function createUnifiedResultsFromScanResults(ruleResults: RuleResultsData[], uui
     for (const ruleResult of ruleResults) {
         const ruleInformation: RuleInformation = ruleInformationProvider.getRuleInformation(ruleResult.ruleId);
 
-        if (ruleInformation != null) {
+        if (ruleInformation) {
             unifiedResults.push(createUnifiedResult(ruleInformation, ruleResult, uuidGenerator));
         }
     }

--- a/src/electron/platform/android/scan-results-to-unified-rules.ts
+++ b/src/electron/platform/android/scan-results-to-unified-rules.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { UnifiedRule } from 'common/types/store-data/unified-data-interface';
+import { UUIDGeneratorType } from 'common/uid-generator';
+import { RuleInformation } from './rule-information';
+import { RuleInformationProvider } from './rule-information-provider';
+import { ScanResults } from './scan-results';
+
+export type ConvertScanResultsToUnifiedRulesDelegate = (scanResults: ScanResults, uuidGenerator: UUIDGeneratorType) => UnifiedRule[];
+
+export function ConvertScanResultsToUnifiedRules(scanResults: ScanResults, uuidGenerator: UUIDGeneratorType): UnifiedRule[] {
+    if (!scanResults) {
+        return [];
+    }
+
+    const unifiedRules: UnifiedRule[] = [];
+    const ruleIds: Set<string> = new Set();
+    const supportedRuleInformation: RuleInformationProvider = new RuleInformationProvider();
+
+    for (const result of scanResults.ruleResults) {
+        const ruleId = result.ruleId;
+        if (!ruleIds.has(ruleId)) {
+            const ruleInformation = supportedRuleInformation.getRuleInformation(ruleId);
+
+            if (ruleInformation != null) {
+                unifiedRules.push(createUnifiedRuleFromRuleResult(ruleInformation, uuidGenerator));
+                ruleIds.add(ruleId);
+            }
+        }
+    }
+
+    return unifiedRules;
+}
+
+function createUnifiedRuleFromRuleResult(ruleInformation: RuleInformation, uuidGenerator: UUIDGeneratorType): UnifiedRule {
+    return {
+        uid: uuidGenerator(),
+        id: ruleInformation.ruleId,
+        description: ruleInformation.ruleDescription,
+        url: null,
+        guidance: [],
+    };
+}

--- a/src/electron/platform/android/scan-results-to-unified-rules.ts
+++ b/src/electron/platform/android/scan-results-to-unified-rules.ts
@@ -9,7 +9,7 @@ import { ScanResults } from './scan-results';
 
 export type ConvertScanResultsToUnifiedRulesDelegate = (scanResults: ScanResults, uuidGenerator: UUIDGeneratorType) => UnifiedRule[];
 
-export function ConvertScanResultsToUnifiedRules(scanResults: ScanResults, uuidGenerator: UUIDGeneratorType): UnifiedRule[] {
+export function convertScanResultsToUnifiedRules(scanResults: ScanResults, uuidGenerator: UUIDGeneratorType): UnifiedRule[] {
     if (!scanResults) {
         return [];
     }

--- a/src/electron/platform/android/scan-results-to-unified-rules.ts
+++ b/src/electron/platform/android/scan-results-to-unified-rules.ts
@@ -23,7 +23,7 @@ export function convertScanResultsToUnifiedRules(scanResults: ScanResults, uuidG
         if (!ruleIds.has(ruleId)) {
             const ruleInformation = supportedRuleInformation.getRuleInformation(ruleId);
 
-            if (ruleInformation != null) {
+            if (ruleInformation) {
                 unifiedRules.push(createUnifiedRuleFromRuleResult(ruleInformation, uuidGenerator));
                 ruleIds.add(ruleId);
             }

--- a/src/electron/platform/android/scan-results.ts
+++ b/src/electron/platform/android/scan-results.ts
@@ -8,11 +8,7 @@ export interface RuleResultsData {
 }
 
 export class ScanResults {
-    private rawData: any;
-
-    constructor(rawData: any) {
-        this.rawData = rawData;
-    }
+    constructor(readonly rawData: any) {}
 
     public get deviceName(): string {
         try {

--- a/src/electron/platform/android/scan-results.ts
+++ b/src/electron/platform/android/scan-results.ts
@@ -1,5 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+export interface RuleResultsData {
+    ruleId: string;
+    status: string;
+    props: any;
+}
+
 export class ScanResults {
     private rawData: any;
 
@@ -20,6 +27,15 @@ export class ScanResults {
             return this.rawData.axeContext.axeMetaData.appIdentifier;
         } catch {
             return null;
+        }
+    }
+
+    public get ruleResults(): RuleResultsData[] {
+        try {
+            const results = this.rawData.axeRuleResults;
+            return results ? results : [];
+        } catch {
+            return [];
         }
     }
 }

--- a/src/electron/platform/android/scan-results.ts
+++ b/src/electron/platform/android/scan-results.ts
@@ -29,7 +29,7 @@ export class ScanResults {
     public get ruleResults(): RuleResultsData[] {
         try {
             const results = this.rawData.axeRuleResults;
-            return results ? results : [];
+            return results || [];
         } catch {
             return [];
         }

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/rule-information-provider.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/rule-information-provider.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RuleInformationProvider getRuleInformation returns correct data for ActiveViewName rule 1`] = `"The view is active but has no name available to assistive technologies. Provide a name for the view using its contentDescription, hint, labelFor, or text attribute (depending on the view type)"`;
+
+exports[`RuleInformationProvider getRuleInformation returns correct data for ColorContrast rule 1`] = `"The text element has insufficient contrast of 2.798498811425733. Foreground color: #979797, background color: #fafafa). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold)."`;
+
+exports[`RuleInformationProvider getRuleInformation returns correct data for EditTextValue rule 1`] = `"The element's contentDescription overrides the text value required by assistive technologies. Remove the element’s contentDescription attribute."`;
+
+exports[`RuleInformationProvider getRuleInformation returns correct data for ImageViewName rule 1`] = `"The image has no alternate text and is not identified as decorative. If the image conveys meaningful content, provide alternate text using the contentDescription attribute. If the image is decorative, give it an empty contentDescription, or set its isImportantForAccessibility attribute to false."`;
+
+exports[`RuleInformationProvider getRuleInformation returns correct data for TouchSizeWcag rule 1`] = `"The element has an insufficient target size (width: 42.22222222222222dp, height: 38.22222222222222dp). Set the element's minWidth and minHeight attributes to at least 48dp."`;

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-results.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-results.test.ts.snap
@@ -46,5 +46,15 @@ Array [
     "status": "pass",
     "uid": "gguid-mock-stub",
   },
+  Object {
+    "descriptors": null,
+    "identifiers": null,
+    "resolution": Object {
+      "how-to-fix": "The element has an insufficient target size (width: 0dp, height: 0dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
+    },
+    "ruleId": "TouchSizeWcag",
+    "status": "unknown",
+    "uid": "gguid-mock-stub",
+  },
 ]
 `;

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-results.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-results.test.ts.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ScanResultsToUnifiedResults Null ScanResults input returns empty output 1`] = `Array []`;
+
+exports[`ScanResultsToUnifiedResults ScanResults with no RuleResults returns empty output 1`] = `Array []`;
+
+exports[`ScanResultsToUnifiedResults ScanResults with passes, failures, and excluded results 1`] = `
+Array [
+  Object {
+    "descriptors": null,
+    "identifiers": null,
+    "resolution": Object {
+      "how-to-fix": "The text element has insufficient contrast of 1. Foreground color: #ffffff, background color: #ffffff). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
+    },
+    "ruleId": "ColorContrast",
+    "status": "fail",
+    "uid": "gguid-mock-stub",
+  },
+  Object {
+    "descriptors": null,
+    "identifiers": null,
+    "resolution": Object {
+      "how-to-fix": "The element has an insufficient target size (width: 32dp, height: 32dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
+    },
+    "ruleId": "TouchSizeWcag",
+    "status": "fail",
+    "uid": "gguid-mock-stub",
+  },
+  Object {
+    "descriptors": null,
+    "identifiers": null,
+    "resolution": Object {
+      "how-to-fix": "The element has an insufficient target size (width: 48dp, height: 48dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
+    },
+    "ruleId": "TouchSizeWcag",
+    "status": "pass",
+    "uid": "gguid-mock-stub",
+  },
+  Object {
+    "descriptors": null,
+    "identifiers": null,
+    "resolution": Object {
+      "how-to-fix": "The text element has insufficient contrast of 21. Foreground color: #ffffff, background color: #000000). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
+    },
+    "ruleId": "ColorContrast",
+    "status": "pass",
+    "uid": "gguid-mock-stub",
+  },
+]
+`;

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-rules.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-rules.test.ts.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ScanResultsToUnifiedResults Null ScanResults input returns empty output 1`] = `Array []`;
+
+exports[`ScanResultsToUnifiedResults ScanResults with 1 supported rule 1`] = `
+Array [
+  Object {
+    "description": "Text elements must have sufficient contrast against the background.",
+    "guidance": Array [],
+    "id": "ColorContrast",
+    "uid": "gguid-mock-stub",
+    "url": null,
+  },
+]
+`;
+
+exports[`ScanResultsToUnifiedResults ScanResults with 1 supported rule that repeats 1`] = `
+Array [
+  Object {
+    "description": "Text elements must have sufficient contrast against the background.",
+    "guidance": Array [],
+    "id": "ColorContrast",
+    "uid": "gguid-mock-stub",
+    "url": null,
+  },
+]
+`;
+
+exports[`ScanResultsToUnifiedResults ScanResults with a mix of supported and unsupported rules 1`] = `
+Array [
+  Object {
+    "description": "Text elements must have sufficient contrast against the background.",
+    "guidance": Array [],
+    "id": "ColorContrast",
+    "uid": "gguid-mock-stub",
+    "url": null,
+  },
+  Object {
+    "description": "Touch inputs must have a sufficient target size.",
+    "guidance": Array [],
+    "id": "TouchSizeWcag",
+    "uid": "gguid-mock-stub",
+    "url": null,
+  },
+  Object {
+    "description": "Meaningful images must have alternate text.",
+    "guidance": Array [],
+    "id": "ImageViewName",
+    "uid": "gguid-mock-stub",
+    "url": null,
+  },
+  Object {
+    "description": "EditText elements must expose their entered text value to assistive technologies",
+    "guidance": Array [],
+    "id": "EditTextValue",
+    "uid": "gguid-mock-stub",
+    "url": null,
+  },
+  Object {
+    "description": "Active views must have a name that's available to assistive technologies.",
+    "guidance": Array [],
+    "id": "ActiveViewName",
+    "uid": "gguid-mock-stub",
+    "url": null,
+  },
+]
+`;
+
+exports[`ScanResultsToUnifiedResults ScanResults with no RuleResults returns empty output 1`] = `Array []`;
+
+exports[`ScanResultsToUnifiedResults ScanResults with only unsupported rules 1`] = `Array []`;

--- a/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
@@ -4,7 +4,7 @@
 import { RuleInformation } from '../../../../../../electron/platform/android/rule-information';
 import { RuleInformationProvider } from '../../../../../../electron/platform/android/rule-information-provider';
 import { RuleResultsData } from '../../../../../../electron/platform/android/scan-results';
-import { buildRuleResultObject } from './scan-results-helpers';
+import { buildColorContastRuleResultObject, buildTouchSizeWcagRuleResultObject } from './scan-results-helpers';
 
 describe('RuleInformationProvider', () => {
     let provider: RuleInformationProvider;
@@ -19,7 +19,7 @@ describe('RuleInformationProvider', () => {
 
     function validateHowToFix(ruleId: string, ruleResult: RuleResultsData): string {
         const ruleInformation: RuleInformation = provider.getRuleInformation(ruleId);
-        const howToFix = ruleInformation.howToFix(ruleResult);
+        const howToFix: string = ruleInformation.howToFix(ruleResult);
 
         expect(ruleInformation).toBeTruthy();
         expect(ruleInformation.ruleId).toEqual(ruleId);
@@ -31,43 +31,30 @@ describe('RuleInformationProvider', () => {
 
     test('getRuleInformation returns correct data for ColorContrast rule', () => {
         const testRuleId: string = 'ColorContrast';
-        // This is built from an actual Android result
-        const props = {};
-        props['Color Contrast Ratio'] = 2.798498811425733;
-        props['Foreground Color'] = 'ff979797';
-        props['Background Color'] = 'fffafafa';
-        const ruleResult = buildRuleResultObject(testRuleId, 'FAIL', props) as RuleResultsData;
+        const ruleResult: RuleResultsData = buildColorContastRuleResultObject('FAIL', 2.798498811425733, 'ff979797', 'fffafafa');
         const howToFix: string = validateHowToFix(testRuleId, ruleResult);
-
-        expect(howToFix.indexOf('contrast of 2.798498811425733.')).toBeGreaterThan(0);
-        expect(howToFix.indexOf('Foreground color: #979797,')).toBeGreaterThan(0);
-        expect(howToFix.indexOf('background color: #fafafa)')).toBeGreaterThan(0);
+        expect(howToFix).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for TouchSizeWcag rule', () => {
         const testRuleId: string = 'TouchSizeWcag';
-        const props = {};
-        // This is built from an actual Android result
-        props['Screen Dots Per Inch'] = 2.25;
-        props['height'] = 86;
-        props['width'] = 95;
-
-        const ruleResult = buildRuleResultObject(testRuleId, 'FAIL', props) as RuleResultsData;
+        const ruleResult: RuleResultsData = buildTouchSizeWcagRuleResultObject('FAIL', 2.25, 86, 95);
         const howToFix: string = validateHowToFix(testRuleId, ruleResult);
-
-        expect(howToFix.indexOf('width: 42.22222222222222dp')).toBeGreaterThan(0);
-        expect(howToFix.indexOf('height: 38.22222222222222dp')).toBeGreaterThan(0);
+        expect(howToFix).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for ActiveViewName rule', () => {
-        validateHowToFix('ActiveViewName', null);
+        const howToFix: string = validateHowToFix('ActiveViewName', null);
+        expect(howToFix).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for EditTextValue rule', () => {
-        validateHowToFix('EditTextValue', null);
+        const howToFix: string = validateHowToFix('EditTextValue', null);
+        expect(howToFix).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for ImageViewName rule', () => {
-        validateHowToFix('ImageViewName', null);
+        const howToFix: string = validateHowToFix('ImageViewName', null);
+        expect(howToFix).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
@@ -4,7 +4,7 @@
 import { RuleInformation } from '../../../../../../electron/platform/android/rule-information';
 import { RuleInformationProvider } from '../../../../../../electron/platform/android/rule-information-provider';
 import { RuleResultsData } from '../../../../../../electron/platform/android/scan-results';
-import { buildColorContastRuleResultObject, buildTouchSizeWcagRuleResultObject } from './scan-results-helpers';
+import { buildColorContrastRuleResultObject, buildTouchSizeWcagRuleResultObject } from './scan-results-helpers';
 
 describe('RuleInformationProvider', () => {
     let provider: RuleInformationProvider;
@@ -31,7 +31,7 @@ describe('RuleInformationProvider', () => {
 
     test('getRuleInformation returns correct data for ColorContrast rule', () => {
         const testRuleId: string = 'ColorContrast';
-        const ruleResult: RuleResultsData = buildColorContastRuleResultObject('FAIL', 2.798498811425733, 'ff979797', 'fffafafa');
+        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject('FAIL', 2.798498811425733, 'ff979797', 'fffafafa');
         const howToFix: string = validateHowToFix(testRuleId, ruleResult);
         expect(howToFix).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { RuleInformation } from '../../../../../../electron/platform/android/rule-information';
+import { RuleInformationProvider } from '../../../../../../electron/platform/android/rule-information-provider';
+import { RuleResultsData } from '../../../../../../electron/platform/android/scan-results';
+import { buildRuleResultObject } from './scan-results-helpers';
+
+describe('RuleInformationProvider', () => {
+    let provider: RuleInformationProvider;
+
+    beforeAll(() => {
+        provider = new RuleInformationProvider();
+    });
+
+    test('getRuleInformation returns null for an unknown ruleId', () => {
+        expect(provider.getRuleInformation('unknown rule')).toBeNull();
+    });
+
+    function validateHowToFix(ruleId: string, ruleResult: RuleResultsData): string {
+        const ruleInformation: RuleInformation = provider.getRuleInformation(ruleId);
+        const howToFix = ruleInformation.howToFix(ruleResult);
+
+        expect(ruleInformation).toBeTruthy();
+        expect(ruleInformation.ruleId).toEqual(ruleId);
+        expect(ruleInformation.ruleDescription.length).toBeGreaterThan(0);
+        expect(howToFix.length).toBeGreaterThan(0);
+
+        return howToFix;
+    }
+
+    test('getRuleInformation returns correct data for ColorContrast rule', () => {
+        const testRuleId: string = 'ColorContrast';
+        // This is built from an actual Android result
+        const props = {};
+        props['Color Contrast Ratio'] = 2.798498811425733;
+        props['Foreground Color'] = 'ff979797';
+        props['Background Color'] = 'fffafafa';
+        const ruleResult = buildRuleResultObject(testRuleId, 'FAIL', props) as RuleResultsData;
+        const howToFix: string = validateHowToFix(testRuleId, ruleResult);
+
+        expect(howToFix.indexOf('contrast of 2.798498811425733.')).toBeGreaterThan(0);
+        expect(howToFix.indexOf('Foreground color: #979797,')).toBeGreaterThan(0);
+        expect(howToFix.indexOf('background color: #fafafa)')).toBeGreaterThan(0);
+    });
+
+    test('getRuleInformation returns correct data for TouchSizeWcag rule', () => {
+        const testRuleId: string = 'TouchSizeWcag';
+        const props = {};
+        // This is built from an actual Android result
+        props['Screen Dots Per Inch'] = 2.25;
+        props['height'] = 86;
+        props['width'] = 95;
+
+        const ruleResult = buildRuleResultObject(testRuleId, 'FAIL', props) as RuleResultsData;
+        const howToFix: string = validateHowToFix(testRuleId, ruleResult);
+
+        expect(howToFix.indexOf('width: 42.22222222222222dp')).toBeGreaterThan(0);
+        expect(howToFix.indexOf('height: 38.22222222222222dp')).toBeGreaterThan(0);
+    });
+
+    test('getRuleInformation returns correct data for ActiveViewName rule', () => {
+        validateHowToFix('ActiveViewName', null);
+    });
+
+    test('getRuleInformation returns correct data for EditTextValue rule', () => {
+        validateHowToFix('EditTextValue', null);
+    });
+
+    test('getRuleInformation returns correct data for ImageViewName rule', () => {
+        validateHowToFix('ImageViewName', null);
+    });
+});

--- a/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
@@ -4,26 +4,25 @@
 import { RuleInformation } from '../../../../../../electron/platform/android/rule-information';
 
 describe('RuleInformation', () => {
+    const testInputs = ['abc', 'xyz', 'this should work'];
+
     test('RuleId works correctly', () => {
-        const ruleIds = ['abc', 'xyz', 'this should work'];
-        for (const ruleId of ruleIds) {
-            const ruleInformation = new RuleInformation(ruleId, 'b', () => 'c');
+        for (const ruleId of testInputs) {
+            const ruleInformation = new RuleInformation(ruleId, null, null);
             expect(ruleId === ruleInformation.ruleId);
         }
     });
 
     test('RuleDescription works correctly', () => {
-        const ruleDescriptions = ['abc', 'xyz', 'this should work'];
-        for (const ruleDescription of ruleDescriptions) {
-            const ruleInformation = new RuleInformation('a', ruleDescription, () => 'c');
+        for (const ruleDescription of testInputs) {
+            const ruleInformation = new RuleInformation(null, ruleDescription, null);
             expect(ruleDescription === ruleInformation.ruleDescription);
         }
     });
 
     test('HowToFix works correctly', () => {
-        const howToFixStrings = ['abc', 'xyz', 'this should work'];
-        for (const howToFixString of howToFixStrings) {
-            const ruleInformation = new RuleInformation('a', 'b', () => howToFixString);
+        for (const howToFixString of testInputs) {
+            const ruleInformation = new RuleInformation(null, null, () => howToFixString);
             expect(howToFixString === ruleInformation.howToFix(null));
         }
     });

--- a/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { RuleInformation } from '../../../../../../electron/platform/android/rule-information';
+
+describe('RuleInformation', () => {
+    test('RuleId works correctly', () => {
+        const ruleIds = ['abc', 'xyz', 'this should work'];
+        for (const ruleId of ruleIds) {
+            const ruleInformation = new RuleInformation(ruleId, 'b', () => 'c');
+            expect(ruleId === ruleInformation.ruleId);
+        }
+    });
+
+    test('RuleDescription works correctly', () => {
+        const ruleDescriptions = ['abc', 'xyz', 'this should work'];
+        for (const ruleDescription of ruleDescriptions) {
+            const ruleInformation = new RuleInformation('a', ruleDescription, () => 'c');
+            expect(ruleDescription === ruleInformation.ruleDescription);
+        }
+    });
+
+    test('HowToFix works correctly', () => {
+        const howToFixStrings = ['abc', 'xyz', 'this should work'];
+        for (const howToFixString of howToFixStrings) {
+            const ruleInformation = new RuleInformation('a', 'b', () => howToFixString);
+            expect(howToFixString === ruleInformation.howToFix(null));
+        }
+    });
+});

--- a/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ScanResults } from 'electron/platform/android/scan-results';
+
+export function buildScanResultsObject(deviceName: string = null, appIdentifier: string = null, resultsArray: any = null): ScanResults {
+    const scanResults = {};
+    const axeContext = {};
+    let addContext = false;
+
+    if (deviceName != null) {
+        const axeDevice = {};
+        axeDevice['name'] = deviceName;
+        axeContext['axeDevice'] = axeDevice;
+        addContext = true;
+    }
+
+    if (appIdentifier != null) {
+        const axeMetaData = {};
+        axeMetaData['appIdentifier'] = appIdentifier;
+        axeContext['axeMetaData'] = axeMetaData;
+        addContext = true;
+    }
+
+    if (resultsArray != null) {
+        scanResults['axeRuleResults'] = resultsArray;
+    }
+
+    if (addContext) {
+        scanResults['axeContext'] = axeContext;
+    }
+
+    return new ScanResults(scanResults);
+}
+
+export function buildRuleResultObject(ruleId: string, status: string, props: any = null): object {
+    const result = {};
+    result['ruleId'] = ruleId;
+    result['status'] = status;
+    if (props != null) {
+        result['props'] = props;
+    }
+
+    return result;
+}

--- a/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
@@ -8,21 +8,21 @@ export function buildScanResultsObject(deviceName: string = null, appIdentifier:
     const axeContext = {};
     let addContext = false;
 
-    if (deviceName != null) {
+    if (deviceName) {
         const axeDevice = {};
         axeDevice['name'] = deviceName;
         axeContext['axeDevice'] = axeDevice;
         addContext = true;
     }
 
-    if (appIdentifier != null) {
+    if (appIdentifier) {
         const axeMetaData = {};
         axeMetaData['appIdentifier'] = appIdentifier;
         axeContext['axeMetaData'] = axeMetaData;
         addContext = true;
     }
 
-    if (resultsArray != null) {
+    if (resultsArray) {
         scanResults['axeRuleResults'] = resultsArray;
     }
 
@@ -37,7 +37,7 @@ export function buildRuleResultObject(ruleId: string, status: string, props: any
     const result = {};
     result['ruleId'] = ruleId;
     result['status'] = status;
-    if (props != null) {
+    if (props) {
         result['props'] = props;
     }
 

--- a/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
@@ -54,7 +54,7 @@ export function buildTouchSizeWcagRuleResultObject(status: string, dpi: number, 
     return buildRuleResultObject('TouchSizeWcag', status, props);
 }
 
-export function buildColorContastRuleResultObject(status: string, ratio: number, foreground: string, background: string): RuleResultsData {
+export function buildColorContrastRuleResultObject(status: string, ratio: number, foreground: string, background: string): RuleResultsData {
     const props = {};
     // This is based on the output of the Android service
     props['Color Contrast Ratio'] = ratio;

--- a/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ScanResults } from 'electron/platform/android/scan-results';
+import { RuleResultsData, ScanResults } from 'electron/platform/android/scan-results';
 
 export function buildScanResultsObject(deviceName: string = null, appIdentifier: string = null, resultsArray: any = null): ScanResults {
     const scanResults = {};
@@ -33,7 +33,7 @@ export function buildScanResultsObject(deviceName: string = null, appIdentifier:
     return new ScanResults(scanResults);
 }
 
-export function buildRuleResultObject(ruleId: string, status: string, props: any = null): object {
+export function buildRuleResultObject(ruleId: string, status: string, props: any = null): RuleResultsData {
     const result = {};
     result['ruleId'] = ruleId;
     result['status'] = status;
@@ -41,5 +41,25 @@ export function buildRuleResultObject(ruleId: string, status: string, props: any
         result['props'] = props;
     }
 
-    return result;
+    return result as RuleResultsData;
+}
+
+export function buildTouchSizeWcagRuleResultObject(status: string, dpi: number, height: number, width: number): RuleResultsData {
+    const props = {};
+    // This is based on the output of the Android service
+    props['Screen Dots Per Inch'] = dpi;
+    props['height'] = height;
+    props['width'] = width;
+
+    return buildRuleResultObject('TouchSizeWcag', status, props);
+}
+
+export function buildColorContastRuleResultObject(status: string, ratio: number, foreground: string, background: string): RuleResultsData {
+    const props = {};
+    // This is based on the output of the Android service
+    props['Color Contrast Ratio'] = ratio;
+    props['Foreground Color'] = foreground;
+    props['Background Color'] = background;
+
+    return buildRuleResultObject('ColorContrast', status, props);
 }

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { IMock, Mock, MockBehavior } from 'typemoq';
+
+import { UnifiedResult } from 'common/types/store-data/unified-data-interface';
+import { generateUID } from 'common/uid-generator';
+import { RuleResultsData, ScanResults } from '../../../../../../electron/platform/android/scan-results';
+import { convertScanResultsToUnifiedResults } from '../../../../../../electron/platform/android/scan-results-to-unified-results';
+import {
+    buildColorContastRuleResultObject,
+    buildRuleResultObject,
+    buildScanResultsObject,
+    buildTouchSizeWcagRuleResultObject,
+} from './scan-results-helpers';
+
+describe('ScanResultsToUnifiedResults', () => {
+    let generateGuidMock: IMock<() => string>;
+
+    beforeEach(() => {
+        const guidStub = 'gguid-mock-stub';
+        generateGuidMock = Mock.ofInstance(generateUID, MockBehavior.Strict);
+        generateGuidMock.setup(ggm => ggm()).returns(() => guidStub);
+    });
+
+    test('Null ScanResults input returns empty output', () => {
+        const results: UnifiedResult[] = convertScanResultsToUnifiedResults(null, null);
+        expect(results).toMatchSnapshot();
+    });
+
+    test('ScanResults with no RuleResults returns empty output', () => {
+        const scanResults: ScanResults = buildScanResultsObject();
+        const results: UnifiedResult[] = convertScanResultsToUnifiedResults(scanResults, null);
+        expect(results).toMatchSnapshot();
+    });
+
+    test('ScanResults with passes, failures, and excluded results', () => {
+        const ruleResults: RuleResultsData[] = [
+            buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
+            buildRuleResultObject('unsupprted Rule #1', 'PASS'),
+            buildTouchSizeWcagRuleResultObject('FAIL', 1.5, 48, 48),
+            buildTouchSizeWcagRuleResultObject('PASS', 1.0, 48, 48),
+            buildRuleResultObject('unsupprted Rule #2', 'FAIL'),
+            buildColorContastRuleResultObject('PASS', 21.0, 'ffffffff', 'ff000000'),
+        ];
+
+        const scanResults: ScanResults = buildScanResultsObject('Some device', 'Some app', ruleResults);
+        const results: UnifiedResult[] = convertScanResultsToUnifiedResults(scanResults, generateGuidMock.object);
+        expect(results).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
@@ -42,6 +42,7 @@ describe('ScanResultsToUnifiedResults', () => {
             buildTouchSizeWcagRuleResultObject('PASS', 1.0, 48, 48),
             buildRuleResultObject('unsupprted Rule #2', 'FAIL'),
             buildColorContastRuleResultObject('PASS', 21.0, 'ffffffff', 'ff000000'),
+            buildTouchSizeWcagRuleResultObject('UNKNOWN', 1.0, 0, 0), // Force "unknown" case
         ];
 
         const scanResults: ScanResults = buildScanResultsObject('Some device', 'Some app', ruleResults);

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
@@ -8,7 +8,7 @@ import { generateUID } from 'common/uid-generator';
 import { RuleResultsData, ScanResults } from '../../../../../../electron/platform/android/scan-results';
 import { convertScanResultsToUnifiedResults } from '../../../../../../electron/platform/android/scan-results-to-unified-results';
 import {
-    buildColorContastRuleResultObject,
+    buildColorContrastRuleResultObject,
     buildRuleResultObject,
     buildScanResultsObject,
     buildTouchSizeWcagRuleResultObject,
@@ -36,12 +36,12 @@ describe('ScanResultsToUnifiedResults', () => {
 
     test('ScanResults with passes, failures, and excluded results', () => {
         const ruleResults: RuleResultsData[] = [
-            buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
+            buildColorContrastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
             buildRuleResultObject('unsupprted Rule #1', 'PASS'),
             buildTouchSizeWcagRuleResultObject('FAIL', 1.5, 48, 48),
             buildTouchSizeWcagRuleResultObject('PASS', 1.0, 48, 48),
             buildRuleResultObject('unsupprted Rule #2', 'FAIL'),
-            buildColorContastRuleResultObject('PASS', 21.0, 'ffffffff', 'ff000000'),
+            buildColorContrastRuleResultObject('PASS', 21.0, 'ffffffff', 'ff000000'),
             buildTouchSizeWcagRuleResultObject('UNKNOWN', 1.0, 0, 0), // Force "unknown" case
         ];
 

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-rules.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-rules.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { IMock, Mock, MockBehavior } from 'typemoq';
+
+import { UnifiedRule } from 'common/types/store-data/unified-data-interface';
+import { generateUID } from 'common/uid-generator';
+import { RuleResultsData, ScanResults } from '../../../../../../electron/platform/android/scan-results';
+import { convertScanResultsToUnifiedRules } from '../../../../../../electron/platform/android/scan-results-to-unified-rules';
+import {
+    buildColorContastRuleResultObject,
+    buildRuleResultObject,
+    buildScanResultsObject,
+    buildTouchSizeWcagRuleResultObject,
+} from './scan-results-helpers';
+
+describe('ScanResultsToUnifiedResults', () => {
+    let generateGuidMock: IMock<() => string>;
+    const deviceName: string = 'Super-duper device';
+    const appIdentifier: string = 'Spectacular app';
+
+    beforeEach(() => {
+        const guidStub = 'gguid-mock-stub';
+        generateGuidMock = Mock.ofInstance(generateUID, MockBehavior.Strict);
+        generateGuidMock.setup(ggm => ggm()).returns(() => guidStub);
+    });
+
+    test('Null ScanResults input returns empty output', () => {
+        const results: UnifiedRule[] = convertScanResultsToUnifiedRules(null, null);
+        expect(results).toMatchSnapshot();
+    });
+
+    test('ScanResults with no RuleResults returns empty output', () => {
+        const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier);
+        const results: UnifiedRule[] = convertScanResultsToUnifiedRules(scanResults, null);
+        expect(results).toMatchSnapshot();
+    });
+
+    test('ScanResults with only unsupported rules', () => {
+        const ruleResults: RuleResultsData[] = [
+            buildRuleResultObject('unsupported 1', 'PASS'),
+            buildRuleResultObject('unsupported 2', 'FAIL'),
+            buildRuleResultObject('unsupported 3', 'PASS'),
+        ];
+
+        const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier, ruleResults);
+        const results: UnifiedRule[] = convertScanResultsToUnifiedRules(scanResults, generateGuidMock.object);
+        expect(results).toMatchSnapshot();
+    });
+
+    test('ScanResults with 1 supported rule', () => {
+        const ruleResults: RuleResultsData[] = [buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff')];
+
+        const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier, ruleResults);
+        const results: UnifiedRule[] = convertScanResultsToUnifiedRules(scanResults, generateGuidMock.object);
+        expect(results).toMatchSnapshot();
+    });
+
+    test('ScanResults with 1 supported rule that repeats', () => {
+        const ruleResults: RuleResultsData[] = [
+            buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
+            buildColorContastRuleResultObject('PASS', 1.0, 'ff000000', 'ffffffff'),
+            buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
+        ];
+
+        const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier, ruleResults);
+        const results: UnifiedRule[] = convertScanResultsToUnifiedRules(scanResults, generateGuidMock.object);
+        expect(results).toMatchSnapshot();
+    });
+
+    test('ScanResults with a mix of supported and unsupported rules', () => {
+        const ruleResults: RuleResultsData[] = [
+            buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
+            buildColorContastRuleResultObject('PASS', 1.0, 'ff000000', 'ffffffff'),
+            buildTouchSizeWcagRuleResultObject('PASS', 1.0, 50, 100),
+            buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
+            buildRuleResultObject('not supported', 'PASS'),
+            buildRuleResultObject('ImageViewName', 'FAIL'),
+            buildRuleResultObject('sorry', 'FAIL'),
+            buildRuleResultObject('EditTextValue', 'PASS'),
+            buildRuleResultObject('ActiveViewName', 'FAIL'),
+            buildRuleResultObject('ActiveViewName', 'PASS'),
+            buildTouchSizeWcagRuleResultObject('FAIL', 1.5, 50, 100),
+            buildRuleResultObject('EditTextValue', 'PASS'),
+        ];
+
+        const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier, ruleResults);
+        const results: UnifiedRule[] = convertScanResultsToUnifiedRules(scanResults, generateGuidMock.object);
+        expect(results).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-rules.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-rules.test.ts
@@ -8,7 +8,7 @@ import { generateUID } from 'common/uid-generator';
 import { RuleResultsData, ScanResults } from '../../../../../../electron/platform/android/scan-results';
 import { convertScanResultsToUnifiedRules } from '../../../../../../electron/platform/android/scan-results-to-unified-rules';
 import {
-    buildColorContastRuleResultObject,
+    buildColorContrastRuleResultObject,
     buildRuleResultObject,
     buildScanResultsObject,
     buildTouchSizeWcagRuleResultObject,
@@ -49,7 +49,7 @@ describe('ScanResultsToUnifiedResults', () => {
     });
 
     test('ScanResults with 1 supported rule', () => {
-        const ruleResults: RuleResultsData[] = [buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff')];
+        const ruleResults: RuleResultsData[] = [buildColorContrastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff')];
 
         const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier, ruleResults);
         const results: UnifiedRule[] = convertScanResultsToUnifiedRules(scanResults, generateGuidMock.object);
@@ -58,9 +58,9 @@ describe('ScanResultsToUnifiedResults', () => {
 
     test('ScanResults with 1 supported rule that repeats', () => {
         const ruleResults: RuleResultsData[] = [
-            buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
-            buildColorContastRuleResultObject('PASS', 1.0, 'ff000000', 'ffffffff'),
-            buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
+            buildColorContrastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
+            buildColorContrastRuleResultObject('PASS', 1.0, 'ff000000', 'ffffffff'),
+            buildColorContrastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
         ];
 
         const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier, ruleResults);
@@ -70,10 +70,10 @@ describe('ScanResultsToUnifiedResults', () => {
 
     test('ScanResults with a mix of supported and unsupported rules', () => {
         const ruleResults: RuleResultsData[] = [
-            buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
-            buildColorContastRuleResultObject('PASS', 1.0, 'ff000000', 'ffffffff'),
+            buildColorContrastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
+            buildColorContrastRuleResultObject('PASS', 1.0, 'ff000000', 'ffffffff'),
             buildTouchSizeWcagRuleResultObject('PASS', 1.0, 50, 100),
-            buildColorContastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
+            buildColorContrastRuleResultObject('FAIL', 1.0, 'ffffffff', 'ffffffff'),
             buildRuleResultObject('not supported', 'PASS'),
             buildRuleResultObject('ImageViewName', 'FAIL'),
             buildRuleResultObject('sorry', 'FAIL'),

--- a/src/tests/unit/tests/electron/platform/android/scan-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ScanResults } from 'electron/platform/android/scan-results';
 import { buildRuleResultObject, buildScanResultsObject } from './scan-results-helpers';
 
 describe('ScanResultsTest', () => {

--- a/src/tests/unit/tests/electron/platform/android/scan-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results.test.ts
@@ -2,53 +2,40 @@
 // Licensed under the MIT License.
 
 import { ScanResults } from 'electron/platform/android/scan-results';
-
-function buildTestObject(deviceName: string = null, appIdentifier: string = null): ScanResults {
-    const scanResults = {};
-    const axeContext = {};
-    let addContext = false;
-
-    if (deviceName != null) {
-        const axeDevice = {};
-        axeDevice['name'] = deviceName;
-        axeContext['axeDevice'] = axeDevice;
-        addContext = true;
-    }
-
-    if (appIdentifier != null) {
-        const axeMetaData = {};
-        axeMetaData['appIdentifier'] = appIdentifier;
-        axeContext['axeMetaData'] = axeMetaData;
-        addContext = true;
-    }
-
-    if (addContext) {
-        scanResults['axeContext'] = axeContext;
-    }
-
-    return new ScanResults(scanResults);
-}
+import { buildRuleResultObject, buildScanResultsObject } from './scan-results-helpers';
 
 describe('ScanResultsTest', () => {
     test('deviceName is null if missing from input', () => {
-        const scanResults = buildTestObject();
+        const scanResults = buildScanResultsObject();
         expect(scanResults.deviceName).toBeNull();
     });
 
     test('deviceName is correct if specified in input', () => {
         const expectedDeviceName = 'Super WhizBang Gadget';
-        const scanResults = buildTestObject(expectedDeviceName, null);
+        const scanResults = buildScanResultsObject(expectedDeviceName, null);
         expect(scanResults.deviceName).toEqual(expectedDeviceName);
     });
 
     test('appIdentifier is null if missing from input', () => {
-        const scanResults = buildTestObject();
+        const scanResults = buildScanResultsObject();
         expect(scanResults.appIdentifier).toBeNull();
     });
 
     test('appIdentifier is correct if specified in input', () => {
         const expectedAppIdentifier = 'My Absolutely Amazing Application';
-        const scanResults = buildTestObject(null, expectedAppIdentifier);
+        const scanResults = buildScanResultsObject(null, expectedAppIdentifier);
         expect(scanResults.appIdentifier).toEqual(expectedAppIdentifier);
+    });
+
+    test('ruleResults is empty array if missing from input', () => {
+        const scanResults = buildScanResultsObject();
+        expect(scanResults.ruleResults).toHaveLength(0);
+    });
+
+    test('ruleResults is correct if specified in input', () => {
+        const resultsArray = [buildRuleResultObject('Rule1', 'PASS'), buildRuleResultObject('Rule2', 'FAIL')];
+        const scanResults = buildScanResultsObject(null, null, resultsArray);
+        expect(scanResults.ruleResults).toHaveLength(2);
+        expect(scanResults.ruleResults).toEqual(resultsArray);
     });
 });


### PR DESCRIPTION
#### Description of changes

Convert android results to unified rule format. Includes only the conversion code, with none of the plumbing of data in or data out.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
