### PR TITLE
fix: prevent double-scrollbars in various details view pages

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -293,6 +293,7 @@ div.insights-file-issue-details-dialog-container {
         width: 100%;
     }
     .details-view-command-bar {
+        height: $detailsViewCommandBarHeight;
         width: 100%;
         display: flex;
         justify-content: space-between;
@@ -301,11 +302,11 @@ div.insights-file-issue-details-dialog-container {
         background-color: $neutral-0;
         font-size: 14px;
         font-weight: normal;
-        border-bottom: 1px solid $neutral-alpha-8;
+        border-bottom: $detailsViewCommandBarBorderHeight solid $neutral-alpha-8;
 
         .details-view-target-page {
             margin-left: 12px;
-            padding: 13px 8px;
+            padding: 8px 8px;
             display: inherit;
             white-space: nowrap;
             overflow: hidden;
@@ -384,10 +385,15 @@ div.insights-file-issue-details-dialog-container {
     .details-view-main-content {
         padding-left: 0px;
         padding-right: 0px;
-        flex-grow: 1;
+        display: grid;
+        grid-template-columns: 230px 1fr;
+        grid-template-rows: 1fr;
+        width: 100%;
         min-height: 0;
+
         .details-view-test-nav-area {
-            max-height: calc(100vh - #{$detailsViewHeaderBarHeight} - #{$detailsViewCommandBarHeight} - 12px);
+            box-sizing: border-box;
+            max-height: calc(100vh - #{detailsViewNavPivotsHeight} - #{$detailsViewHeaderBarHeight} - #{$detailsViewCommandBarHeight});
             .ms-Nav-groupContent,
             .ms-Nav-navItems {
                 margin-bottom: 0px;
@@ -742,6 +748,8 @@ div.insights-file-issue-details-dialog-container {
             width: 100%;
             padding-bottom: 1px;
             overflow: auto;
+            box-sizing: border-box;
+            max-height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
             > div {
                 min-width: 600px;
                 height: auto;

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -15,6 +15,11 @@ body {
     color: $neutral-100;
     font-family: $fontFamily;
     font-size: 14px;
+    height: 100vh;
+    max-height: 100vh;
+    width: 100vw;
+    min-width: 100vw;
+    overflow: hidden;
 }
 
 .target-change-dialog-modal {
@@ -288,10 +293,6 @@ div.insights-file-issue-details-dialog-container {
             }
         }
     }
-    .main-wrapper {
-        height: 100%;
-        width: 100%;
-    }
     .details-view-command-bar {
         height: $detailsViewCommandBarHeight;
         width: 100%;
@@ -386,7 +387,7 @@ div.insights-file-issue-details-dialog-container {
         padding-left: 0px;
         padding-right: 0px;
         display: grid;
-        grid-template-columns: 230px 1fr;
+        grid-template-columns: $detailsViewLeftNavWidth 1fr;
         grid-template-rows: 1fr;
         width: 100%;
         min-height: 0;
@@ -642,7 +643,10 @@ div.insights-file-issue-details-dialog-container {
             padding-left: calc(0.5vw + 13px); // 13px is Chevron width.
         }
         .left-nav {
-            width: 200px;
+            max-height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
+            height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
+            overflow-y: auto;
+            width: calc($detailsViewLeftNavWidth - 1px); // border
             border-right: 1px solid $neutral-8;
             .dark-gray {
                 color: $neutral-60;
@@ -650,7 +654,7 @@ div.insights-file-issue-details-dialog-container {
             .button-flex-container {
                 padding-left: 5%;
                 padding-right: 8%;
-                width: 200px;
+                width: $detailsViewLeftNavWidth;
                 .status-icon {
                     font-size: 24px;
                 }

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -96,8 +96,9 @@ $pivotItemBorderStyle: solid !default;
 $detailsViewHeaderBarHeight: 40px !default;
 $detailsViewNavPivotsHeight: 41px !default;
 $detailsViewCommandBarHeight: 40px !default;
-
+$detailsViewCommandBarBorderHeight: 1px !default;
 $detailsViewManNavWidth: 185px !default;
+$detailsViewTotalHeaderHeight: (#{$detailsViewCommandBarBorderHeight} + #{$detailsViewCommandBarHeight} + #{$detailsViewHeaderBarHeight});
 
 $fastPassRightPanelMarginRight: 24px !default;
 $fastPassRightPanelMarginLeft: 24px !default;

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -93,11 +93,12 @@ $normalTitleFontWeight: 300 !default;
 
 $pivotItemLeftBorderWidth: 3px !default;
 $pivotItemBorderStyle: solid !default;
+
 $detailsViewHeaderBarHeight: 40px !default;
 $detailsViewNavPivotsHeight: 41px !default;
 $detailsViewCommandBarHeight: 40px !default;
 $detailsViewCommandBarBorderHeight: 1px !default;
-$detailsViewManNavWidth: 185px !default;
+$detailsViewLeftNavWidth: 200px !default;
 $detailsViewTotalHeaderHeight: (#{$detailsViewCommandBarBorderHeight} + #{$detailsViewCommandBarHeight} + #{$detailsViewHeaderBarHeight});
 
 $fastPassRightPanelMarginRight: 24px !default;


### PR DESCRIPTION
## Description of changes

Addresses #1118 and #1289.

Verified behavior in Chrome 77 (stable) and 79 (dev). Screenshots below are all on 77.

Verified that this doesn't re-introduce #1112 on Chrome 77 or 79.

### FastPass automated checks:

**Before**
![animated screenshot of current prod fastpass automated checks scrolling behavior](https://user-images.githubusercontent.com/376284/65990435-6da3c500-e440-11e9-94cb-49a5e9de5f39.gif)

**After**
![animated screenshot of updated fastpass automated checks scrolling behavior](https://user-images.githubusercontent.com/376284/65990550-a5ab0800-e440-11e9-97b7-11dbc27a344b.gif)

### Assessment overview

**Before**
![animated screenshot of current prod assessment overview scrolling behavior](https://user-images.githubusercontent.com/376284/65990282-261d3900-e440-11e9-84db-0f385c02e662.gif)

**After**
![animated screenshot of updated assessment overview scrolling behavior](https://user-images.githubusercontent.com/376284/65990162-f2daaa00-e43f-11e9-842e-b67d619a9dc9.gif)

## Pull request checklist

- [x] Addresses an existing issue: #1118 and #1289 
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
