### PR TITLE
chore: remove unnecessary/malformatted style from .left-nav

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -646,7 +646,6 @@ div.insights-file-issue-details-dialog-container {
             max-height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
             height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
             overflow-y: auto;
-            width: calc($detailsViewLeftNavWidth - 1px); // border
             border-right: 1px solid $neutral-8;
             .dark-gray {
                 color: $neutral-60;


### PR DESCRIPTION
#### Description of changes

Resolving @peterdur's post-merge comment in #1334

Removes a malformated/unnecessary width style (it has no effect because `$detailsViewLeftNavWidth` isn't propertly enclosed in a `#{}` block, but the style doesn't make any difference anyway)

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
