### PR TITLE
refactor: selector map helper to not directly depend on assessment/scan result store

### DIFF
--- a/src/injected/client-view-controller.ts
+++ b/src/injected/client-view-controller.ts
@@ -135,7 +135,11 @@ export class ClientViewController {
             } else {
                 this.executeUpdate(visualizationType, null);
             }
-            const selectorMap = this.selectorMapHelper.getSelectorMap(visualizationType);
+            const selectorMap = this.selectorMapHelper.getSelectorMap(
+                visualizationType,
+                this.currentScanResultState,
+                this.currentAssessmentState,
+            );
             this.previousVisualizationSelectorMapStates[visualizationType] = selectorMap;
         });
     }
@@ -155,7 +159,11 @@ export class ClientViewController {
     private executeUpdate(visualizationType: VisualizationType, step: string): void {
         const configuration = this.visualizationConfigurationFactory.getConfiguration(visualizationType);
         const visualizationState = configuration.getStoreData(this.currentVisualizationState.tests);
-        const selectorMap = this.selectorMapHelper.getSelectorMap(visualizationType);
+        const selectorMap = this.selectorMapHelper.getSelectorMap(
+            visualizationType,
+            this.currentScanResultState,
+            this.currentAssessmentState,
+        );
         const id = configuration.getIdentifier(step);
         const enabled = configuration.getTestStatus(visualizationState, step) && this.isAssessmentDataForCurrentPage(configuration);
 

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
+
 import { AxeInfo } from '../common/axe-info';
 import { InspectConfigurationFactory } from '../common/configs/inspect-configuration-factory';
 import { DateProvider } from '../common/date-provider';
+import { EnumHelper } from '../common/enum-helper';
 import { EnvironmentInfoProvider } from '../common/environment-info-provider';
 import { TelemetryEventSource } from '../common/extension-telemetry-events';
 import { HTMLElementUtils } from '../common/html-element-utils';
@@ -28,6 +30,7 @@ import { TabStoreData } from '../common/types/store-data/tab-store-data';
 import { UserConfigurationStoreData } from '../common/types/store-data/user-configuration-store';
 import { VisualizationScanResultData } from '../common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from '../common/types/store-data/visualization-store-data';
+import { VisualizationType } from '../common/types/visualization-type';
 import { generateUID } from '../common/uid-generator';
 import { IssueFilingServiceProviderImpl } from '../issue-filing/issue-filing-service-provider-impl';
 import { scan } from '../scanner/exposed-apis';
@@ -74,6 +77,7 @@ export class MainWindowInitializer extends WindowInitializer {
 
     public async initialize(): Promise<void> {
         const asyncInitializationSteps: Promise<void>[] = [];
+        const allVisualizationTypes = EnumHelper.getNumericValues<VisualizationType>(VisualizationType);
         asyncInitializationSteps.push(super.initialize());
 
         this.visualizationStoreProxy = new StoreProxy<VisualizationStoreData>(
@@ -142,7 +146,7 @@ export class MainWindowInitializer extends WindowInitializer {
         );
 
         const drawingInitiator = new DrawingInitiator(this.drawingController);
-        const selectorMapHelper = new SelectorMapHelper(this.visualizationScanResultStoreProxy, this.assessmentStoreProxy, Assessments);
+        const selectorMapHelper = new SelectorMapHelper(Assessments);
         const frameUrlMessageDispatcher = new FrameUrlMessageDispatcher(devToolActionMessageCreator, this.frameCommunicator);
         frameUrlMessageDispatcher.initialize();
 

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -5,7 +5,6 @@ import { Assessments } from 'assessments/assessments';
 import { AxeInfo } from '../common/axe-info';
 import { InspectConfigurationFactory } from '../common/configs/inspect-configuration-factory';
 import { DateProvider } from '../common/date-provider';
-import { EnumHelper } from '../common/enum-helper';
 import { EnvironmentInfoProvider } from '../common/environment-info-provider';
 import { TelemetryEventSource } from '../common/extension-telemetry-events';
 import { HTMLElementUtils } from '../common/html-element-utils';
@@ -30,7 +29,6 @@ import { TabStoreData } from '../common/types/store-data/tab-store-data';
 import { UserConfigurationStoreData } from '../common/types/store-data/user-configuration-store';
 import { VisualizationScanResultData } from '../common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from '../common/types/store-data/visualization-store-data';
-import { VisualizationType } from '../common/types/visualization-type';
 import { generateUID } from '../common/uid-generator';
 import { IssueFilingServiceProviderImpl } from '../issue-filing/issue-filing-service-provider-impl';
 import { scan } from '../scanner/exposed-apis';
@@ -77,7 +75,6 @@ export class MainWindowInitializer extends WindowInitializer {
 
     public async initialize(): Promise<void> {
         const asyncInitializationSteps: Promise<void>[] = [];
-        const allVisualizationTypes = EnumHelper.getNumericValues<VisualizationType>(VisualizationType);
         asyncInitializationSteps.push(super.initialize());
 
         this.visualizationStoreProxy = new StoreProxy<VisualizationStoreData>(

--- a/src/injected/selector-map-helper.ts
+++ b/src/injected/selector-map-helper.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import * as _ from 'lodash';
 
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { BaseStore } from '../common/base-store';
 import { ManualTestStatus } from '../common/types/manual-test-status';
 import { AssessmentStoreData, GeneratedAssessmentInstance } from '../common/types/store-data/assessment-result-data';
 import { VisualizationScanResultData } from '../common/types/store-data/visualization-scan-result-data';
@@ -12,30 +11,25 @@ import { DictionaryStringTo } from '../types/common-types';
 import { AssessmentVisualizationInstance } from './frameCommunicators/html-element-axe-results-helper';
 
 export class SelectorMapHelper {
-    private scanResultStore: BaseStore<VisualizationScanResultData>;
-    private assessmentStore: BaseStore<AssessmentStoreData>;
     private assessmentsProvider: AssessmentsProvider;
 
-    constructor(
-        scanResultStore: BaseStore<VisualizationScanResultData>,
-        assessmentStore: BaseStore<AssessmentStoreData>,
-        assessmentsProvider: AssessmentsProvider,
-    ) {
-        this.scanResultStore = scanResultStore;
-        this.assessmentStore = assessmentStore;
+    constructor(assessmentsProvider: AssessmentsProvider) {
         this.assessmentsProvider = assessmentsProvider;
     }
 
-    public getSelectorMap(visualizationType: VisualizationType): DictionaryStringTo<AssessmentVisualizationInstance> {
+    public getSelectorMap(
+        visualizationType: VisualizationType,
+        visualizationScanResultData: VisualizationScanResultData,
+        assessmentState: AssessmentStoreData,
+    ): DictionaryStringTo<AssessmentVisualizationInstance> {
         let selectorMap = {};
 
         if (this.isAdHocVisualization(visualizationType)) {
-            selectorMap = this.getAdHocVisualizationSelectorMap(visualizationType);
+            selectorMap = this.getAdHocVisualizationSelectorMap(visualizationType, visualizationScanResultData);
         }
 
         if (this.assessmentsProvider.isValidType(visualizationType)) {
             const key = this.assessmentsProvider.forType(visualizationType).key;
-            const assessmentState = this.assessmentStore.getState();
             selectorMap = this.getFilteredSelectorMap(
                 assessmentState.assessments[key].generatedAssessmentInstancesMap,
                 assessmentState.assessmentNavState.selectedTestStep,
@@ -58,25 +52,27 @@ export class SelectorMapHelper {
         );
     }
 
-    private getAdHocVisualizationSelectorMap(visualizationType: VisualizationType): DictionaryStringTo<AssessmentVisualizationInstance> {
+    private getAdHocVisualizationSelectorMap(
+        visualizationType: VisualizationType,
+        visualizationScanResultData: VisualizationScanResultData,
+    ): DictionaryStringTo<AssessmentVisualizationInstance> {
         let selectorMap = {};
-        const visulizaitonScanResultState = this.scanResultStore.getState();
 
         switch (visualizationType) {
             case VisualizationType.Issues:
-                selectorMap = visulizaitonScanResultState.issues.selectedAxeResultsMap;
+                selectorMap = visualizationScanResultData.issues.selectedAxeResultsMap;
                 break;
             case VisualizationType.Headings:
-                selectorMap = visulizaitonScanResultState.headings.fullAxeResultsMap;
+                selectorMap = visualizationScanResultData.headings.fullAxeResultsMap;
                 break;
             case VisualizationType.Landmarks:
-                selectorMap = visulizaitonScanResultState.landmarks.fullAxeResultsMap;
+                selectorMap = visualizationScanResultData.landmarks.fullAxeResultsMap;
                 break;
             case VisualizationType.TabStops:
-                selectorMap = visulizaitonScanResultState.tabStops.tabbedElements;
+                selectorMap = visualizationScanResultData.tabStops.tabbedElements;
                 break;
             default:
-                selectorMap = visulizaitonScanResultState.color.fullAxeResultsMap;
+                selectorMap = visualizationScanResultData.color.fullAxeResultsMap;
                 break;
         }
 

--- a/src/tests/unit/tests/injected/client-view-controller.test.ts
+++ b/src/tests/unit/tests/injected/client-view-controller.test.ts
@@ -693,7 +693,7 @@ class MocksAndTestSubjectBuilder {
             .verifiable(disableTimes);
 
         this.selectorMapHelperMock
-            .setup(sm => sm.getSelectorMap(visualizationType))
+            .setup(sm => sm.getSelectorMap(visualizationType, this.toVisualizationScanStoreState, this.toAssessmentStoreState))
             .returns(() => this.selectorMap)
             .verifiable(Times.once());
     }


### PR DESCRIPTION
#### Description of changes

I'm trying to limit the places where we directly depend on the stores; it seemed like a good idea to do so here as well since this is only used by the client view controller, which has access to state data that it can pass through.

I also re-factored some of the tests, removing duplicate code.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
