### PR TITLE
Add automated checks command bar

### DIFF
--- a/src/electron/automated-checks/components/automated-checks-command-bar.scss
+++ b/src/electron/automated-checks/components/automated-checks-command-bar.scss
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../common/styles/colors.scss';
+
+.automated-checks-command-bar {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    min-height: fit-content;
+    align-items: center;
+    background-color: $neutral-0;
+    font-size: 14px;
+    font-weight: normal;
+    border-bottom: 1px solid $neutral-alpha-8;
+}

--- a/src/electron/automated-checks/components/automated-checks-command-bar.tsx
+++ b/src/electron/automated-checks/components/automated-checks-command-bar.tsx
@@ -22,7 +22,6 @@ export const AutomatedChecksCommandBar = NamedFC<AutomatedChecksCommandBarProps>
         return (
             <div className={automatedChecksCommandBar}>
                 <ActionButton
-                    className="button-rescan"
                     iconProps={{
                         iconName: 'Refresh',
                     }}

--- a/src/electron/automated-checks/components/automated-checks-command-bar.tsx
+++ b/src/electron/automated-checks/components/automated-checks-command-bar.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import * as React from 'react';
+
+import { NamedFC } from 'common/react/named-fc';
+import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
+import { automatedChecksCommandBar } from './automated-checks-command-bar.scss';
+
+export type AutomatedChecksCommandBarDeps = {
+    deviceConnectActionCreator: DeviceConnectActionCreator;
+};
+
+export interface AutomatedChecksCommandBarProps {
+    deps: AutomatedChecksCommandBarDeps;
+}
+
+export const AutomatedChecksCommandBar = NamedFC<AutomatedChecksCommandBarProps>(
+    'AutomatedChecksCommandBar',
+    (props: AutomatedChecksCommandBarProps) => {
+        const onClick = () => props.deps.deviceConnectActionCreator.resetConnection();
+        return (
+            <div className={automatedChecksCommandBar}>
+                <ActionButton
+                    className="button-rescan"
+                    iconProps={{
+                        iconName: 'Refresh',
+                    }}
+                    onClick={onClick}
+                    text="Rescan"
+                />
+            </div>
+        );
+    },
+);

--- a/src/tests/unit/tests/electron/automated-checks/components/__snapshots__/automated-checks-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/automated-checks/components/__snapshots__/automated-checks-command-bar.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`AutomatedChecksCommandBar render 1`] = `
   className="automatedChecksCommandBar"
 >
   <CustomizedActionButton
-    className="button-rescan"
     iconProps={
       Object {
         "iconName": "Refresh",

--- a/src/tests/unit/tests/electron/automated-checks/components/__snapshots__/automated-checks-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/automated-checks/components/__snapshots__/automated-checks-command-bar.test.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AutomatedChecksCommandBar render 1`] = `
+<div
+  className="automatedChecksCommandBar"
+>
+  <CustomizedActionButton
+    className="button-rescan"
+    iconProps={
+      Object {
+        "iconName": "Refresh",
+      }
+    }
+    onClick={[Function]}
+    text="Rescan"
+  />
+</div>
+`;

--- a/src/tests/unit/tests/electron/automated-checks/components/automated-checks-command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/automated-checks/components/automated-checks-command-bar.test.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import { Button } from 'office-ui-fabric-react/lib/Button';
+import * as React from 'react';
+import { Mock, MockBehavior, Times } from 'typemoq';
+
+import {
+    AutomatedChecksCommandBar,
+    AutomatedChecksCommandBarProps,
+} from 'electron/automated-checks/components/automated-checks-command-bar';
+import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
+import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
+
+describe('AutomatedChecksCommandBar', () => {
+    test('render', () => {
+        const props: AutomatedChecksCommandBarProps = { deps: { deviceConnectActionCreator: null } };
+        const rendered = shallow(<AutomatedChecksCommandBar {...props} />);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    test('rescan click', () => {
+        const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
+
+        const deviceConnectActionCreatorMock = Mock.ofType<DeviceConnectActionCreator>(undefined, MockBehavior.Strict);
+        deviceConnectActionCreatorMock.setup(creator => creator.resetConnection()).verifiable(Times.once());
+
+        const props = {
+            deps: {
+                deviceConnectActionCreator: deviceConnectActionCreatorMock.object,
+            },
+        } as AutomatedChecksCommandBarProps;
+
+        const rendered = shallow(<AutomatedChecksCommandBar {...props} />);
+        const button = rendered.find('.button-rescan');
+
+        button.simulate('click', eventStub);
+
+        deviceConnectActionCreatorMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/electron/automated-checks/components/automated-checks-command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/automated-checks/components/automated-checks-command-bar.test.tsx
@@ -33,7 +33,7 @@ describe('AutomatedChecksCommandBar', () => {
         } as AutomatedChecksCommandBarProps;
 
         const rendered = shallow(<AutomatedChecksCommandBar {...props} />);
-        const button = rendered.find('.button-rescan');
+        const button = rendered.find('[text="Rescan"]');
 
         button.simulate('click', eventStub);
 


### PR DESCRIPTION
#### Description of changes
The ongoing automated checks results from Android feature calls for the addition of a command bar that will ultimately look like this:
![image](https://user-images.githubusercontent.com/4615491/66082374-da8d8c80-e51e-11e9-9a4e-04674d2747d7.png)

For now, the only command with an actual purpose is the rescan button. We could add the rest now, but they will not do anything until future features are complete.

We don't yet have the UI to house this bar, so for now it is just waiting to be used.


#### Pull request checklist

- [-] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [-] (UI changes only) Added screenshots/GIFs to description above
- [-] (UI changes only) Verified usability with NVDA/JAWS
