### PR TITLE
add tool info to unified scan result store

### DIFF
--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -5,7 +5,7 @@ import { BaseTelemetryData, TelemetryData, ToggleTelemetryData } from '../../com
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
 import { ManualTestStatus } from '../../common/types/manual-test-status';
-import { UnifiedResult, UnifiedRule } from '../../common/types/store-data/unified-data-interface';
+import { ToolData, UnifiedResult, UnifiedRule } from '../../common/types/store-data/unified-data-interface';
 import { IssueFilingServiceProperties } from '../../common/types/store-data/user-configuration-store';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { FailureInstanceData } from '../../DetailsView/components/failure-instance-panel-control';
@@ -154,6 +154,7 @@ export interface FileIssuePayload extends BaseActionPayload {
 export interface UnifiedScanCompletedPayload extends BaseActionPayload {
     scanResult: UnifiedResult[];
     rules: UnifiedRule[];
+    toolInfo: ToolData;
 }
 
 export interface RuleExpandCollapsePayload extends BaseActionPayload {

--- a/src/background/stores/unified-scan-result-store.ts
+++ b/src/background/stores/unified-scan-result-store.ts
@@ -15,6 +15,7 @@ export class UnifiedScanResultStore extends BaseStoreImpl<UnifiedScanResultStore
         const defaultValue: UnifiedScanResultStoreData = {
             results: null,
             rules: null,
+            toolInfo: null,
         };
 
         return defaultValue;
@@ -28,6 +29,7 @@ export class UnifiedScanResultStore extends BaseStoreImpl<UnifiedScanResultStore
     private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
         this.state.results = payload.scanResult;
         this.state.rules = payload.rules;
+        this.state.toolInfo = payload.toolInfo;
         this.emitChanged();
     };
 }

--- a/src/common/environment-info-provider.ts
+++ b/src/common/environment-info-provider.ts
@@ -1,5 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { toolName } from '../content/strings/application';
+import { ToolData } from './types/store-data/unified-data-interface';
+
 export type EnvironmentInfo = {
     extensionVersion: string;
     browserSpec: string;
@@ -13,6 +16,19 @@ export class EnvironmentInfoProvider {
             extensionVersion: this.extensionVersion,
             browserSpec: this.browserSpec,
             axeCoreVersion: this.axeVersion,
+        };
+    }
+
+    public getToolData(): ToolData {
+        return {
+            scanEngineProperties: {
+                name: 'axe-core',
+                version: this.axeVersion,
+            },
+            applicationProperties: {
+                name: toolName,
+                version: this.extensionVersion,
+            },
         };
     }
 }

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -8,6 +8,11 @@ export interface ScanEngineProperties {
     version: string;
 }
 
+export interface ApplicationProperties {
+    name: string;
+    version: string;
+}
+
 export interface OSProperties {
     name: string;
     version: string;
@@ -26,6 +31,7 @@ export interface PlatformData {
 
 export interface ToolData {
     scanEngineProperties: ScanEngineProperties;
+    applicationProperties: ApplicationProperties;
 }
 
 export interface UnifiedRule {

--- a/src/injected/analyzers/unified-result-sender.ts
+++ b/src/injected/analyzers/unified-result-sender.ts
@@ -4,7 +4,6 @@ import { UnifiedScanCompletedPayload } from '../../background/actions/action-pay
 import { EnvironmentInfoProvider } from '../../common/environment-info-provider';
 import { Messages } from '../../common/messages';
 import { UUIDGeneratorType } from '../../common/uid-generator';
-import { toolName } from '../../content/strings/application';
 import { ConvertScanResultsToUnifiedResultsDelegate } from '../adapters/scan-results-to-unified-results';
 import { ConvertScanResultsToUnifiedRulesDelegate } from '../adapters/scan-results-to-unified-rules';
 import { AxeAnalyzerResult } from './analyzer';
@@ -23,16 +22,7 @@ export class UnifiedResultSender {
         const payload: UnifiedScanCompletedPayload = {
             scanResult: this.convertScanResultsToUnifiedResults(axeResults.originalResult, this.generateUID),
             rules: this.convertScanResultsToUnifiedRules(axeResults.originalResult),
-            toolInfo: {
-                scanEngineProperties: {
-                    name: 'axe-core',
-                    version: this.environmentInfoProvider.getEnvironmentInfo().axeCoreVersion,
-                },
-                applicationProperties: {
-                    name: toolName,
-                    version: this.environmentInfoProvider.getEnvironmentInfo().extensionVersion,
-                },
-            },
+            toolInfo: this.environmentInfoProvider.getToolData(),
         };
 
         this.sendMessage({

--- a/src/injected/analyzers/unified-result-sender.ts
+++ b/src/injected/analyzers/unified-result-sender.ts
@@ -4,7 +4,7 @@ import { UnifiedScanCompletedPayload } from '../../background/actions/action-pay
 import { EnvironmentInfoProvider } from '../../common/environment-info-provider';
 import { Messages } from '../../common/messages';
 import { UUIDGeneratorType } from '../../common/uid-generator';
-import { title } from '../../content/strings/application';
+import { toolName } from '../../content/strings/application';
 import { ConvertScanResultsToUnifiedResultsDelegate } from '../adapters/scan-results-to-unified-results';
 import { ConvertScanResultsToUnifiedRulesDelegate } from '../adapters/scan-results-to-unified-rules';
 import { AxeAnalyzerResult } from './analyzer';
@@ -25,7 +25,7 @@ export class UnifiedResultSender {
             rules: this.convertScanResultsToUnifiedRules(axeResults.originalResult),
             toolInfo: {
                 scanEngineProperties: {
-                    name: title,
+                    name: toolName,
                     version: this.environmentInfoProvider.getEnvironmentInfo().extensionVersion,
                 },
             },

--- a/src/injected/analyzers/unified-result-sender.ts
+++ b/src/injected/analyzers/unified-result-sender.ts
@@ -25,6 +25,10 @@ export class UnifiedResultSender {
             rules: this.convertScanResultsToUnifiedRules(axeResults.originalResult),
             toolInfo: {
                 scanEngineProperties: {
+                    name: 'axe-core',
+                    version: this.environmentInfoProvider.getEnvironmentInfo().axeCoreVersion,
+                },
+                applicationProperties: {
                     name: toolName,
                     version: this.environmentInfoProvider.getEnvironmentInfo().extensionVersion,
                 },

--- a/src/injected/analyzers/unified-result-sender.ts
+++ b/src/injected/analyzers/unified-result-sender.ts
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { UnifiedScanCompletedPayload } from '../../background/actions/action-payloads';
+import { EnvironmentInfoProvider } from '../../common/environment-info-provider';
 import { Messages } from '../../common/messages';
 import { UUIDGeneratorType } from '../../common/uid-generator';
+import { title } from '../../content/strings/application';
 import { ConvertScanResultsToUnifiedResultsDelegate } from '../adapters/scan-results-to-unified-results';
 import { ConvertScanResultsToUnifiedRulesDelegate } from '../adapters/scan-results-to-unified-rules';
 import { AxeAnalyzerResult } from './analyzer';
@@ -13,6 +15,7 @@ export class UnifiedResultSender {
         private readonly sendMessage: MessageDelegate,
         private readonly convertScanResultsToUnifiedResults: ConvertScanResultsToUnifiedResultsDelegate,
         private readonly convertScanResultsToUnifiedRules: ConvertScanResultsToUnifiedRulesDelegate,
+        private readonly environmentInfoProvider: EnvironmentInfoProvider,
         private readonly generateUID: UUIDGeneratorType,
     ) {}
 
@@ -20,6 +23,12 @@ export class UnifiedResultSender {
         const payload: UnifiedScanCompletedPayload = {
             scanResult: this.convertScanResultsToUnifiedResults(axeResults.originalResult, this.generateUID),
             rules: this.convertScanResultsToUnifiedRules(axeResults.originalResult),
+            toolInfo: {
+                scanEngineProperties: {
+                    name: title,
+                    version: this.environmentInfoProvider.getEnvironmentInfo().extensionVersion,
+                },
+            },
         };
 
         this.sendMessage({

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -166,10 +166,11 @@ export class MainWindowInitializer extends WindowInitializer {
 
         this.frameUrlSearchInitiator.listenToStore();
 
-        const unifedResultSender = new UnifiedResultSender(
+        const unifiedResultSender = new UnifiedResultSender(
             this.browserAdapter.sendMessageToFrames,
             convertScanResultsToUnifiedResults,
             convertScanResultsToUnifiedRules,
+            environmentInfoProvider,
             generateUID,
         );
 
@@ -182,7 +183,7 @@ export class MainWindowInitializer extends WindowInitializer {
             DateProvider.getCurrentDate,
             this.visualizationConfigurationFactory,
             filterResultsByRules,
-            unifedResultSender.sendResults,
+            unifiedResultSender.sendResults,
         );
 
         const analyzerStateUpdateHandler = new AnalyzerStateUpdateHandler(this.visualizationConfigurationFactory);

--- a/src/tests/unit/common/environment-info-provider.test.ts
+++ b/src/tests/unit/common/environment-info-provider.test.ts
@@ -1,20 +1,46 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ToolData } from '../../../common/types/store-data/unified-data-interface';
+import { toolName } from '../../../content/strings/application';
 import { EnvironmentInfoProvider } from './../../../common/environment-info-provider';
+
 describe('EnvironmentInfoProvider', () => {
-    test('constructor', () => {
-        expect(new EnvironmentInfoProvider('extensionVersion', 'spec', 'axeVersion')).not.toBeNull();
+    const extensionVersion = '1.1.1';
+    const axeCoreVersion = '2.2.2';
+    const browserSpec = 'test-browser-spec';
+
+    let environmentInfoProvider: EnvironmentInfoProvider;
+
+    beforeEach(() => {
+        environmentInfoProvider = new EnvironmentInfoProvider(extensionVersion, browserSpec, axeCoreVersion);
     });
 
-    test('get', () => {
-        const extensionVersion = '1.1.1';
-        const browserSpec = 'chrome';
-        const axeCoreVersion = '2.2.2';
+    test('constructor', () => {
+        expect(environmentInfoProvider).not.toBeNull();
+    });
+
+    test('getEnvironmentInfo', () => {
         const expected = {
             extensionVersion,
             browserSpec,
             axeCoreVersion,
         };
-        expect(new EnvironmentInfoProvider(extensionVersion, browserSpec, axeCoreVersion).getEnvironmentInfo()).toEqual(expected);
+
+        expect(environmentInfoProvider.getEnvironmentInfo()).toEqual(expected);
+    });
+
+    test('getToolData', () => {
+        const expected: ToolData = {
+            scanEngineProperties: {
+                name: 'axe-core',
+                version: axeCoreVersion,
+            },
+            applicationProperties: {
+                name: toolName,
+                version: extensionVersion,
+            },
+        };
+
+        expect(environmentInfoProvider.getToolData()).toEqual(expected);
     });
 });

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -6,7 +6,7 @@ import { UnifiedScanResultActions } from 'background/actions/unified-scan-result
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { IMock, Mock } from 'typemoq';
-
+import { ToolData } from '../../../../../common/types/store-data/unified-data-interface';
 import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('UnifiedScanResultActionCreator', () => {
@@ -14,6 +14,7 @@ describe('UnifiedScanResultActionCreator', () => {
         const payload: UnifiedScanCompletedPayload = {
             scanResult: [],
             rules: [],
+            toolInfo: {} as ToolData,
         };
 
         const scanCompletedMock = createActionMock(payload);

--- a/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
@@ -4,7 +4,13 @@ import { UnifiedScanCompletedPayload } from '../../../../../background/actions/a
 import { UnifiedScanResultActions } from '../../../../../background/actions/unified-scan-result-actions';
 import { UnifiedScanResultStore } from '../../../../../background/stores/unified-scan-result-store';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import { UnifiedScanResultStoreData } from '../../../../../common/types/store-data/unified-data-interface';
+import {
+    ScanEngineProperties,
+    ToolData,
+    UnifiedResult,
+    UnifiedRule,
+    UnifiedScanResultStoreData,
+} from '../../../../../common/types/store-data/unified-data-interface';
 import { createStoreWithNullParams, StoreTester } from '../../../common/store-tester';
 
 describe('UnifiedScanResultStore Test', () => {
@@ -24,6 +30,7 @@ describe('UnifiedScanResultStore Test', () => {
 
         expect(defaultState.results).toEqual(null);
         expect(defaultState.rules).toEqual(null);
+        expect(defaultState.toolInfo).toEqual(null);
     });
 
     test('onGetCurrentState', () => {
@@ -37,13 +44,27 @@ describe('UnifiedScanResultStore Test', () => {
         const initialState = getDefaultState();
 
         const payload: UnifiedScanCompletedPayload = {
-            scanResult: [],
-            rules: [],
+            scanResult: [
+                {
+                    uid: 'test-uid',
+                } as UnifiedResult,
+            ],
+            rules: [
+                {
+                    id: 'test-rule-id',
+                } as UnifiedRule,
+            ],
+            toolInfo: {
+                scanEngineProperties: {
+                    name: 'test-scan-engine-name',
+                } as ScanEngineProperties,
+            } as ToolData,
         };
 
         const expectedState: UnifiedScanResultStoreData = {
             rules: payload.rules,
             results: payload.scanResult,
+            toolInfo: payload.toolInfo,
         };
 
         createStoreForUnifiedScanResultActions('scanCompleted')

--- a/src/tests/unit/tests/injected/analyzers/unified-result-sender.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/unified-result-sender.test.ts
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 import { IMock, Mock, Times } from 'typemoq';
 import { UnifiedScanCompletedPayload } from '../../../../../background/actions/action-payloads';
+import { EnvironmentInfoProvider } from '../../../../../common/environment-info-provider';
 import { Message } from '../../../../../common/message';
 import { Messages } from '../../../../../common/messages';
-import { UnifiedResult, UnifiedRule } from '../../../../../common/types/store-data/unified-data-interface';
+import { ToolData, UnifiedResult, UnifiedRule } from '../../../../../common/types/store-data/unified-data-interface';
 import { ConvertScanResultsToUnifiedResultsDelegate } from '../../../../../injected/adapters/scan-results-to-unified-results';
 import { ConvertScanResultsToUnifiedRulesDelegate } from '../../../../../injected/adapters/scan-results-to-unified-rules';
 import { MessageDelegate } from '../../../../../injected/analyzers/rule-analyzer';
@@ -20,17 +21,20 @@ describe('sendConvertedResults', () => {
         const convertToUnifiedRulesMock: IMock<ConvertScanResultsToUnifiedRulesDelegate> = Mock.ofInstance(
             (scanResults: ScanResults) => null,
         );
+        const environmentInfoProviderMock: IMock<EnvironmentInfoProvider> = Mock.ofType(EnvironmentInfoProvider);
         const uuidGeneratorStub = () => null;
         const testSubject = new UnifiedResultSender(
             sendDelegate.object,
             convertToUnifiedMock.object,
             convertToUnifiedRulesMock.object,
+            environmentInfoProviderMock.object,
             uuidGeneratorStub,
         );
 
         const axeInputResults = {} as any;
         const unifiedResults: UnifiedResult[] = [];
         const unifiedRules: UnifiedRule[] = [];
+        const toolInfo = {} as ToolData;
         convertToUnifiedMock.setup(m => m(axeInputResults, uuidGeneratorStub)).returns(val => unifiedResults);
         convertToUnifiedRulesMock.setup(m => m(axeInputResults)).returns(val => unifiedRules);
         testSubject.sendResults({
@@ -42,6 +46,7 @@ describe('sendConvertedResults', () => {
         const expectedPayload: UnifiedScanCompletedPayload = {
             scanResult: unifiedResults,
             rules: unifiedRules,
+            toolInfo: toolInfo,
         };
         const expectedMessage: Message = {
             messageType: Messages.UnifiedScan.ScanCompleted,


### PR DESCRIPTION
#### Description of changes

- Added a `getToolData()` function to `EnvironmentDataProvider` because `EnvironmentDataProvider` already has all the environment data needed to populate and return a ToolData object.
- Added `toolInfo` property to `UnifiedScanCompletedPayload` to send tool data to the `UnifiedScanResultStore` as part of the payload in `UnifiedResultSender`
- Created `ApplicationProperties` interface in `unified-data-interface.ts` to be able to specify application data, which is different from scan engine data, as part of the ToolData
- Updated relevant tests

#### Pull request checklist

- [x] Addresses an existing issue: WI # 1584979
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
