### PR TITLE
[spike] refactor issue filing types to enable filing from unified results

### DIFF
--- a/src/DetailsView/components/Issues-details-pane.tsx
+++ b/src/DetailsView/components/Issues-details-pane.tsx
@@ -98,7 +98,7 @@ export class IssuesDetailsPane extends React.Component<IssuesDetailsPaneProps, I
             },
             element: {
                 id: result.id,
-                idDisplayName: 'Element path',
+                identifierName: 'Element path',
                 shortId: 'last selector',
             },
             howToFixSummary: result.failureSummary,

--- a/src/DetailsView/components/Issues-details-pane.tsx
+++ b/src/DetailsView/components/Issues-details-pane.tsx
@@ -87,9 +87,22 @@ export class IssuesDetailsPane extends React.Component<IssuesDetailsPaneProps, I
 
     private renderSingleIssue(result: DecoratedAxeNodeResult): JSX.Element {
         const issueData: CreateIssueDetailsTextData = {
-            pageTitle: this.props.pageTitle,
-            pageUrl: this.props.pageUrl,
-            ruleResult: result,
+            rule: {
+                description: result.help,
+                id: result.ruleId,
+                url: result.helpUrl,
+                guidance: result.guidanceLinks,
+            },
+            targetApp: {
+                name: 'name',
+            },
+            element: {
+                id: result.id,
+                idDisplayName: 'Element path',
+                shortId: 'last selector',
+            },
+            howToFixSummary: result.failureSummary,
+            snippet: result.snippet,
         };
 
         return (

--- a/src/background/issue-details-text-generator.ts
+++ b/src/background/issue-details-text-generator.ts
@@ -26,7 +26,7 @@ export class IssueDetailsTextGenerator {
     }
 
     public buildTags(createIssueData: CreateIssueDetailsTextData, standardTags: string[]): string {
-        const tags = ['Accessibility', ...standardTags, createIssueData.ruleResult.ruleId];
+        const tags = ['Accessibility', ...standardTags, createIssueData.rule.id];
         return tags.join(', ');
     }
 }

--- a/src/common/components/copy-issue-details-button.tsx
+++ b/src/common/components/copy-issue-details-button.tsx
@@ -31,13 +31,8 @@ export class CopyIssueDetailsButton extends React.Component<CopyIssueDetailsButt
         this.state = { showingCopyToast: false };
     }
 
-    private getIssueDetailsText(result: DecoratedAxeNodeResult): string {
-        const data: CreateIssueDetailsTextData = {
-            pageTitle: this.props.issueDetailsData.pageTitle,
-            pageUrl: this.props.issueDetailsData.pageUrl,
-            ruleResult: result,
-        };
-        return this.props.deps.issueDetailsTextGenerator.buildText(data);
+    private getIssueDetailsText(): string {
+        return this.props.deps.issueDetailsTextGenerator.buildText(this.props.issueDetailsData);
     }
 
     private copyButtonClicked = (event: React.MouseEvent<any>): void => {
@@ -55,7 +50,7 @@ export class CopyIssueDetailsButton extends React.Component<CopyIssueDetailsButt
                         Failure details copied.
                     </Toast>
                 ) : null}
-                <CopyToClipboard text={this.getIssueDetailsText(this.props.issueDetailsData.ruleResult)}>
+                <CopyToClipboard text={this.getIssueDetailsText()}>
                     <DefaultButton className={'copy-issue-details-button'} onClick={this.copyButtonClicked}>
                         <CopyIcon />
                         <div className="ms-Button-label">Copy failure details</div>

--- a/src/common/types/create-issue-details-text-data.ts
+++ b/src/common/types/create-issue-details-text-data.ts
@@ -14,7 +14,7 @@ export interface CreateIssueDetailsTextData {
     // computed from the unified result
     element: {
         id: string;
-        idDisplayName: string;
+        identifierName: string;
         shortId: string;
     };
     howToFixSummary: string;

--- a/src/common/types/create-issue-details-text-data.ts
+++ b/src/common/types/create-issue-details-text-data.ts
@@ -1,9 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DecoratedAxeNodeResult } from '../../injected/scanner-utils';
+import { EnvironmentInfo } from '../environment-info-provider';
+import { UnifiedRule } from './store-data/unified-data-interface';
 
 export interface CreateIssueDetailsTextData {
-    pageTitle: string;
-    pageUrl: string;
-    ruleResult: DecoratedAxeNodeResult;
+    rule: UnifiedRule; // uses every part of rule in bug filing
+    targetApp: {
+        name: string;
+        url?: string;
+    };
+    // everything below this line needs to be
+    // computed from the unified result
+    element: {
+        id: string;
+        idDisplayName: string;
+        shortId: string;
+    };
+    howToFixSummary: string;
+    snippet?: string;
 }

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -52,10 +52,20 @@ export interface UnifiedResult {
     uid: string;
     status: InstanceResultStatus;
     ruleId: string;
-    identifiers: StoredInstancePropertyBag;
+    identifiers: UnifiedIdentifiers;
     descriptors: StoredInstancePropertyBag;
-    resolution: StoredInstancePropertyBag;
+    resolution: UnifiedResolution;
 }
+
+export type UnifiedIdentifiers = {
+    id: string;
+    shortId: string;
+    identifierName: string;
+} & InstancePropertyBag;
+
+export type UnifiedResolution = {
+    howToFixSummary: string;
+} & InstancePropertyBag;
 
 export type InstanceResultStatus = 'pass' | 'fail' | 'unknown';
 

--- a/src/injected/components/command-bar.tsx
+++ b/src/injected/components/command-bar.tsx
@@ -54,7 +54,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
             },
             element: {
                 id: result.id,
-                idDisplayName: 'Element path',
+                identifierName: 'Element path',
                 shortId: 'last selector',
             },
             howToFixSummary: result.failureSummary,

--- a/src/injected/components/command-bar.tsx
+++ b/src/injected/components/command-bar.tsx
@@ -41,13 +41,25 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
     const renderIssueButtons = (): JSX.Element => {
         const failedRuleIds: string[] = Object.keys(props.failedRules);
         const ruleName: string = failedRuleIds[props.currentRuleIndex];
-        const ruleResult: DecoratedAxeNodeResult = props.failedRules[ruleName];
+        const result: DecoratedAxeNodeResult = props.failedRules[ruleName];
         const issueData: CreateIssueDetailsTextData = {
-            pageTitle: document.title,
-            pageUrl: document.URL,
-            ruleResult,
+            rule: {
+                description: result.help,
+                id: result.ruleId,
+                url: result.helpUrl,
+                guidance: result.guidanceLinks,
+            },
+            targetApp: {
+                name: 'name',
+            },
+            element: {
+                id: result.id,
+                idDisplayName: 'Element path',
+                shortId: 'last selector',
+            },
+            howToFixSummary: result.failureSummary,
+            snippet: result.snippet,
         };
-
         return (
             <>
                 <CopyIssueDetailsButton deps={props.deps} issueDetailsData={issueData} onClick={props.onClickCopyIssueDetailsButton} />

--- a/src/issue-filing/common/create-issue-details-builder.ts
+++ b/src/issue-filing/common/create-issue-details-builder.ts
@@ -9,37 +9,36 @@ import { MarkupFormatter } from './markup/markup-formatter';
 
 export const createIssueDetailsBuilder = (markup: MarkupFormatter): IssueDetailsBuilder => {
     const getter = (environmentInfo: EnvironmentInfo, data: CreateIssueDetailsTextData): string => {
-        const result = data.ruleResult;
-
         const { howToFixSection, link, sectionHeader, snippet, sectionHeaderSeparator, footerSeparator, sectionSeparator } = markup;
+
+        const snippetSection = data.snippet
+            ? [sectionHeader('Snippet'), sectionHeaderSeparator(), snippet(data.snippet), sectionSeparator()]
+            : null;
 
         const lines = [
             sectionHeader('Issue'),
             sectionHeaderSeparator(),
-            `${snippet(result.help)} (${link(result.helpUrl, result.ruleId)})`,
+            `${snippet(data.rule.description)} (${link(data.rule.url, data.rule.id)})`, // need to make link optional
             sectionSeparator(),
 
             sectionHeader('Target application'),
             sectionHeaderSeparator(),
-            link(data.pageUrl, data.pageTitle),
+            link(data.targetApp.url, data.targetApp.name), // need to make link optional
             sectionSeparator(),
 
-            sectionHeader('Element path'),
+            sectionHeader(data.element.idDisplayName),
             sectionHeaderSeparator(),
-            data.ruleResult.selector,
+            data.element.id,
             sectionSeparator(),
 
-            sectionHeader('Snippet'),
-            sectionHeaderSeparator(),
-            snippet(result.snippet),
-            sectionSeparator(),
+            ...snippetSection,
 
             sectionHeader('How to fix'),
             sectionHeaderSeparator(),
-            howToFixSection(result.failureSummary),
+            howToFixSection(data.howToFixSummary),
             sectionSeparator(),
 
-            sectionHeader('Environment'),
+            sectionHeader('Environment'), // temporary
             sectionHeaderSeparator(),
             environmentInfo.browserSpec,
             sectionSeparator(),

--- a/src/issue-filing/common/create-issue-details-builder.ts
+++ b/src/issue-filing/common/create-issue-details-builder.ts
@@ -26,7 +26,7 @@ export const createIssueDetailsBuilder = (markup: MarkupFormatter): IssueDetails
             link(data.targetApp.url, data.targetApp.name), // need to make link optional
             sectionSeparator(),
 
-            sectionHeader(data.element.idDisplayName),
+            sectionHeader(data.element.identifierName),
             sectionHeaderSeparator(),
             data.element.id,
             sectionSeparator(),

--- a/src/issue-filing/common/issue-filing-url-string-utils.ts
+++ b/src/issue-filing/common/issue-filing-url-string-utils.ts
@@ -14,10 +14,7 @@ const getTitle = (data: CreateIssueDetailsTextData): string => {
     if (prefix.length > 0) {
         prefix = prefix + ': ';
     }
-
-    const selectorLastPart = getSelectorLastPart(data.ruleResult.selector);
-
-    return `${prefix}${data.ruleResult.help} (${selectorLastPart})`;
+    return `${prefix}${data.rule.description} (${data.element.shortId})`;
 };
 
 const getSelectorLastPart = (selector: string): string => {
@@ -34,9 +31,9 @@ const getSelectorLastPart = (selector: string): string => {
 };
 
 const standardizeTags = (data: CreateIssueDetailsTextData): string[] => {
-    const guidanceLinkTextTags = data.ruleResult.guidanceLinks.map(link => link.text.toUpperCase());
+    const guidanceLinkTextTags = data.rule.guidance.map(link => link.text.toUpperCase());
     const tagsFromGuidanceLinkTags = [];
-    data.ruleResult.guidanceLinks.map(link => (link.tags ? link.tags.map(tag => tagsFromGuidanceLinkTags.push(tag.displayText)) : []));
+    data.rule.guidance.map(link => (link.tags ? link.tags.map(tag => tagsFromGuidanceLinkTags.push(tag.displayText)) : []));
     return guidanceLinkTextTags.concat(tagsFromGuidanceLinkTags);
 };
 

--- a/src/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.ts
+++ b/src/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.ts
@@ -11,7 +11,7 @@ import { HTMLFormatter } from '../../common/markup/html-formatter';
 import { AzureBoardsIssueFilingSettings, AzureBoardsWorkItemType } from './azure-boards-issue-filing-settings';
 
 const buildTags = (createIssueData: CreateIssueDetailsTextData, standardTags: string[]): string => {
-    const tags = ['Accessibility', title, `rule: ${createIssueData.ruleResult.ruleId}`, ...standardTags];
+    const tags = ['Accessibility', title, `rule: ${createIssueData.rule.id}`, ...standardTags];
     return tags.join('; ');
 };
 


### PR DESCRIPTION
This PR shows one possible approach to enable issue filing from both old axe-core data and from new unified-store data. It's not production-ready yet but should help drive conversation

summary:
- `CreateIssueDetailsTextData` only holds the fields issue filing needs to create a bug, no more or less
- Each consumer of issue filing converts their data-type (axe-core data or unified-data) to `CreateIssueDetailsTextData` (the cards UI will soon need to do this with unified-data)
- Some strongly typed fields that we expect to exist in all platforms are added to unified-results to make the conversion easier

pros:
- The issue filing plumbing using `CreateIssueDetailsTextData` can stay mostly intact if we convert earlier. Otherwise, we need to make sure the plumbing can work with both `CreateIssueDetailsTextData` and `UnifiedResult`
- `createIssueDetailsBuilder` remains fairly simple, referencing the `CreateIssueDetailsTextData` fields directly
- we share `createIssueDetailsBuilder` between the old consumers (target dialog, etc) and new consumers (card UI buttons)
- ...feel free to add more

cons:
- We lose some flexibility for each field we make strongly-typed. For example, `how-to-fix` is a string instead of the `all/none/any` fields used in card-rows. The existing issue filing implementation treats `how-to-fix` as a string, so this might be OK in some instances
- ...feel free to add more