### PR TITLE
Refactor CardSelectionStore interface and add unit tests

### DIFF
--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -42,7 +42,7 @@ export class CardSelectionStore extends BaseStoreImpl<CardSelectionStoreData> {
     };
 
     private toggleRuleExpandCollapse = (payload: RuleExpandCollapsePayload): void => {
-        if (!payload || !payload.ruleId || !this.state.rules || !this.state.rules[payload.ruleId]) {
+        if (!payload || !payload.ruleId || !this.state.rules[payload.ruleId]) {
             return;
         }
 

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { forOwn } from 'lodash';
 import { StoreNames } from '../../common/stores/store-names';
 import { CardSelectionStoreData, RuleExpandCollapseData } from '../../common/types/store-data/card-selection-store-data';
 import { RuleExpandCollapsePayload, UnifiedScanCompletedPayload } from '../actions/action-payloads';
@@ -35,9 +36,9 @@ export class CardSelectionStore extends BaseStoreImpl<CardSelectionStoreData> {
             return;
         }
 
-        for (const resultInstanceUid of Object.keys(rule.cards)) {
-            rule.cards[resultInstanceUid] = false;
-        }
+        forOwn(rule.cards, (isSelected, resultInstanceUid, cards) => {
+            cards[resultInstanceUid] = false;
+        });
     };
 
     private toggleRuleExpandCollapse = (payload: RuleExpandCollapsePayload): void => {
@@ -59,11 +60,10 @@ export class CardSelectionStore extends BaseStoreImpl<CardSelectionStoreData> {
     private toggleCardSelection = (): void => {};
 
     private collapseAllRules = (): void => {
-        for (const ruleId of Object.keys(this.state.rules)) {
-            const rule = this.state.rules[ruleId];
+        forOwn(this.state.rules, (rule, ruleId) => {
             rule.isExpanded = false;
             this.deselectAllCardsInRule(rule);
-        }
+        });
 
         this.emitChanged();
     };

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -18,7 +18,7 @@ export class CardSelectionStore extends BaseStoreImpl<CardSelectionStoreData> {
     protected addActionListeners(): void {
         this.cardSelectionActions.toggleRuleExpandCollapse.addListener(this.toggleRuleExpandCollapse);
         this.cardSelectionActions.toggleCardSelection.addListener(this.toggleCardSelection);
-        this.cardSelectionActions.collapseAllRules.addListener(this.CollapseAllRules);
+        this.cardSelectionActions.collapseAllRules.addListener(this.collapseAllRules);
         this.unifiedScanResultActions.scanCompleted.addListener(this.onScanCompleted);
     }
 
@@ -40,7 +40,7 @@ export class CardSelectionStore extends BaseStoreImpl<CardSelectionStoreData> {
         }
     };
 
-    public toggleRuleExpandCollapse = (payload: RuleExpandCollapsePayload): void => {
+    private toggleRuleExpandCollapse = (payload: RuleExpandCollapsePayload): void => {
         if (!payload || !payload.ruleId || !this.state.rules || !this.state.rules[payload.ruleId]) {
             return;
         }
@@ -53,19 +53,19 @@ export class CardSelectionStore extends BaseStoreImpl<CardSelectionStoreData> {
             this.deselectAllCardsInRule(rule);
         }
 
-        super.emitChanged();
+        this.emitChanged();
     };
 
-    public toggleCardSelection = (): void => {};
+    private toggleCardSelection = (): void => {};
 
-    public CollapseAllRules = (): void => {
+    private collapseAllRules = (): void => {
         for (const ruleId of Object.keys(this.state.rules)) {
             const rule = this.state.rules[ruleId];
             rule.isExpanded = false;
             this.deselectAllCardsInRule(rule);
         }
 
-        super.emitChanged();
+        this.emitChanged();
     };
 
     private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
@@ -90,6 +90,6 @@ export class CardSelectionStore extends BaseStoreImpl<CardSelectionStoreData> {
             this.state.rules[result.ruleId].cards[result.uid] = false;
         });
 
-        super.emitChanged();
+        this.emitChanged();
     };
 }

--- a/src/common/types/store-data/card-selection-store-data.ts
+++ b/src/common/types/store-data/card-selection-store-data.ts
@@ -1,5 +1,3 @@
-import { CardSelectionPayload } from '../../../background/actions/action-payloads';
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 

--- a/src/common/types/store-data/card-selection-store-data.ts
+++ b/src/common/types/store-data/card-selection-store-data.ts
@@ -1,11 +1,19 @@
+import { CardSelectionPayload } from '../../../background/actions/action-payloads';
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+export type CardSelectionData = { [resultInstanceUid: string]: boolean };
+
 export interface RuleExpandCollapseData {
     isExpanded: boolean;
-    cards: { [resultInstanceUid: string]: boolean };
+    cards: CardSelectionData;
+}
+
+export interface RuleExpandCollapseDataDictionary {
+    [ruleId: string]: RuleExpandCollapseData;
 }
 
 export interface CardSelectionStoreData {
-    rules: { [ruleId: string]: RuleExpandCollapseData };
+    rules: RuleExpandCollapseDataDictionary;
 }

--- a/src/common/types/store-data/card-selection-store-data.ts
+++ b/src/common/types/store-data/card-selection-store-data.ts
@@ -1,17 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export interface CardSelectionData {
-    resultInstanceUid: string;
-    isSelected: boolean;
-}
-
 export interface RuleExpandCollapseData {
-    ruleId: string;
     isExpanded: boolean;
-    cards: CardSelectionData[];
+    cards: { [resultInstanceUid: string]: boolean };
 }
 
 export interface CardSelectionStoreData {
-    rules: RuleExpandCollapseData[];
+    rules: { [ruleId: string]: RuleExpandCollapseData };
 }

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -1,0 +1,250 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { RuleExpandCollapsePayload, UnifiedScanCompletedPayload } from '../../../../../background/actions/action-payloads';
+import { CardSelectionActions } from '../../../../../background/actions/card-selection-actions';
+import { UnifiedScanResultActions } from '../../../../../background/actions/unified-scan-result-actions';
+import { CardSelectionStore } from '../../../../../background/stores/card-selection-store';
+import { StoreNames } from '../../../../../common/stores/store-names';
+import { CardSelectionStoreData } from '../../../../../common/types/store-data/card-selection-store-data';
+import { UnifiedResult } from '../../../../../common/types/store-data/unified-data-interface';
+import { createStoreWithNullParams, StoreTester } from '../../../common/store-tester';
+
+describe('CardSelectionStore Test', () => {
+    test('constructor has no side effects', () => {
+        const testObject = createStoreWithNullParams(CardSelectionStore);
+        expect(testObject).toBeDefined();
+    });
+
+    test('getId', () => {
+        const testObject = createStoreWithNullParams(CardSelectionStore);
+
+        expect(testObject.getId()).toEqual(StoreNames[StoreNames.CardSelectionStore]);
+    });
+
+    test('check defaultState is as expected', () => {
+        const defaultState = getDefaultState();
+
+        expect(defaultState.rules).toBeDefined();
+    });
+
+    test('onScanCompleted', () => {
+        const initialState = getDefaultState();
+
+        const payload: UnifiedScanCompletedPayload = {
+            scanResult: [
+                {
+                    ruleId: 'sampleRuleId',
+                    uid: 'sampleUid',
+                    status: 'fail',
+                } as UnifiedResult,
+            ],
+            rules: [],
+        } as UnifiedScanCompletedPayload;
+
+        const expectedState: CardSelectionStoreData = {
+            rules: {
+                sampleRuleId: {
+                    isExpanded: false,
+                    cards: {
+                        sampleUid: false,
+                    },
+                },
+            },
+        };
+
+        createStoreForUnifiedScanResultActions('scanCompleted')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('ToggleRuleExpandCollapse expanded', () => {
+        const initialState: CardSelectionStoreData = {
+            rules: {
+                sampleRuleId: {
+                    isExpanded: false,
+                    cards: {
+                        sampleUid: false,
+                    },
+                },
+            },
+        };
+
+        const expectedState: CardSelectionStoreData = {
+            rules: {
+                sampleRuleId: {
+                    isExpanded: true,
+                    cards: {
+                        sampleUid: false,
+                    },
+                },
+            },
+        };
+
+        const payload: RuleExpandCollapsePayload = {
+            ruleId: 'sampleRuleId',
+        };
+
+        createStoreForCardSelectionActions('toggleRuleExpandCollapse')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('ToggleRuleExpandCollapse collapsed', () => {
+        const initialState: CardSelectionStoreData = {
+            rules: {
+                sampleRuleId: {
+                    isExpanded: true,
+                    cards: {
+                        sampleUid: true,
+                    },
+                },
+            },
+        };
+
+        const expectedState: CardSelectionStoreData = {
+            rules: {
+                sampleRuleId: {
+                    isExpanded: false,
+                    cards: {
+                        sampleUid: false,
+                    },
+                },
+            },
+        };
+
+        const payload: RuleExpandCollapsePayload = {
+            ruleId: 'sampleRuleId',
+        };
+
+        createStoreForCardSelectionActions('toggleRuleExpandCollapse')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    test('ToggleRuleExpandCollapse invalid rule', () => {
+        const initialState: CardSelectionStoreData = {
+            rules: {
+                sampleRuleId: {
+                    isExpanded: true,
+                    cards: {
+                        sampleUid: true,
+                    },
+                },
+            },
+        };
+
+        const expectedState = initialState;
+
+        const payload: RuleExpandCollapsePayload = {
+            ruleId: 'invalid-rule-id',
+        };
+
+        createStoreForCardSelectionActions('toggleRuleExpandCollapse')
+            .withActionParam(payload)
+            .testListenerToNeverBeCalled(initialState, expectedState);
+    });
+
+    test('ToggleRuleExpandCollapse no payload', () => {
+        const initialState: CardSelectionStoreData = {
+            rules: {
+                sampleRuleId: {
+                    isExpanded: true,
+                    cards: {
+                        sampleUid: true,
+                    },
+                },
+            },
+        };
+
+        const expectedState = initialState;
+
+        createStoreForCardSelectionActions('toggleRuleExpandCollapse')
+            .withActionParam(null)
+            .testListenerToNeverBeCalled(initialState, expectedState);
+    });
+
+    test('ToggleRuleExpandCollapse invalid payload', () => {
+        const initialState: CardSelectionStoreData = {
+            rules: {
+                sampleRuleId: {
+                    isExpanded: true,
+                    cards: {
+                        sampleUid: true,
+                    },
+                },
+            },
+        };
+
+        const expectedState = initialState;
+
+        const payload: RuleExpandCollapsePayload = {
+            ruleId: null,
+        };
+
+        createStoreForCardSelectionActions('toggleRuleExpandCollapse')
+            .withActionParam(payload)
+            .testListenerToNeverBeCalled(initialState, expectedState);
+    });
+
+    test('CollapseAllRules', () => {
+        const initialState: CardSelectionStoreData = {
+            rules: {
+                sampleRuleId1: {
+                    isExpanded: true,
+                    cards: {
+                        sampleUid1: true,
+                        sampleUid2: true,
+                    },
+                },
+                sampleRuleId2: {
+                    isExpanded: true,
+                    cards: {
+                        sampleUid1: true,
+                        sampleUid2: true,
+                    },
+                },
+            },
+        };
+
+        const expectedState: CardSelectionStoreData = {
+            rules: {
+                sampleRuleId1: {
+                    isExpanded: false,
+                    cards: {
+                        sampleUid1: false,
+                        sampleUid2: false,
+                    },
+                },
+                sampleRuleId2: {
+                    isExpanded: false,
+                    cards: {
+                        sampleUid1: false,
+                        sampleUid2: false,
+                    },
+                },
+            },
+        };
+
+        createStoreForCardSelectionActions('collapseAllRules').testListenerToBeCalledOnce(initialState, expectedState);
+    });
+
+    function getDefaultState(): CardSelectionStoreData {
+        return createStoreWithNullParams(CardSelectionStore).getDefaultState();
+    }
+
+    function createStoreForUnifiedScanResultActions(
+        actionName: keyof UnifiedScanResultActions,
+    ): StoreTester<CardSelectionStoreData, UnifiedScanResultActions> {
+        const factory = (actions: UnifiedScanResultActions) => new CardSelectionStore(new CardSelectionActions(), actions);
+
+        return new StoreTester(UnifiedScanResultActions, actionName, factory);
+    }
+
+    function createStoreForCardSelectionActions(
+        actionName: keyof CardSelectionActions,
+    ): StoreTester<CardSelectionStoreData, CardSelectionActions> {
+        const factory = (actions: CardSelectionActions) => new CardSelectionStore(actions, new UnifiedScanResultActions());
+
+        return new StoreTester(CardSelectionActions, actionName, factory);
+    }
+});


### PR DESCRIPTION
#### Description of changes

- Refactor the store to use a dictionary of rule ids and result instance ids as the keys, rather than using arrays with the ids as fields. This makes it more efficient in code to locate a given rule or card to be expanded or selected.
- Implement the scanCompleted, toggleExpandCollapseRule, and collapseAllRules functions
- create unit tests for the above three functions

The toggleCardSelection function remains undone only to make this PR slightly smaller.

(give an overview. Add technical description describing your changes)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
