### PR TITLE
Add 'formatAsCode' property to HowToFix property bag, update tests

### DIFF
--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -27,11 +27,13 @@ export class RuleInformationProvider {
                 () =>
                     this.buildHowtoFixPropertyBag(
                         'The view is active but has no name available to assistive technologies. Provide a name for the view using its contentDescription, hint, labelFor, or text attribute (depending on the view type)',
+                        ['contentDescription', 'hint', 'labelFor', 'text'],
                     ),
             ),
             ImageViewName: new RuleInformation('ImageViewName', 'Meaningful images must have alternate text.', () =>
                 this.buildHowtoFixPropertyBag(
                     'The image has no alternate text and is not identified as decorative. If the image conveys meaningful content, provide alternate text using the contentDescription attribute. If the image is decorative, give it an empty contentDescription, or set its isImportantForAccessibility attribute to false.',
+                    ['contentDescription', 'isImportantForAccessibility'],
                 ),
             ),
             EditTextValue: new RuleInformation(
@@ -40,6 +42,7 @@ export class RuleInformationProvider {
                 () =>
                     this.buildHowtoFixPropertyBag(
                         "The element's contentDescription overrides the text value required by assistive technologies. Remove the element’s contentDescription attribute.",
+                        ['contentDescription'],
                     ),
             ),
         };
@@ -64,11 +67,12 @@ export class RuleInformationProvider {
 
         return this.buildHowtoFixPropertyBag(
             `The element has an insufficient target size (width: ${logicalWidth}dp, height: ${logicalHeight}dp). Set the element's minWidth and minHeight attributes to at least 48dp.`,
+            ['minWidth', 'minHeight'],
         );
     };
 
-    private buildHowtoFixPropertyBag(unformattedText: string): InstancePropertyBag {
-        return { unformattedText: unformattedText };
+    private buildHowtoFixPropertyBag(unformattedText: string, codeStrings: string[] = null): InstancePropertyBag {
+        return { unformattedText: unformattedText, formatAsCode: codeStrings };
     }
 
     public getRuleInformation(ruleId: string): RuleInformation {

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/rule-information-provider.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/rule-information-provider.test.ts.snap
@@ -2,30 +2,48 @@
 
 exports[`RuleInformationProvider getRuleInformation returns correct data for ActiveViewName rule 1`] = `
 Object {
+  "formatAsCode": Array [
+    "contentDescription",
+    "hint",
+    "labelFor",
+    "text",
+  ],
   "unformattedText": "The view is active but has no name available to assistive technologies. Provide a name for the view using its contentDescription, hint, labelFor, or text attribute (depending on the view type)",
 }
 `;
 
 exports[`RuleInformationProvider getRuleInformation returns correct data for ColorContrast rule 1`] = `
 Object {
+  "formatAsCode": null,
   "unformattedText": "The text element has insufficient contrast of 2.798498811425733. Foreground color: #979797, background color: #fafafa). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
 }
 `;
 
 exports[`RuleInformationProvider getRuleInformation returns correct data for EditTextValue rule 1`] = `
 Object {
+  "formatAsCode": Array [
+    "contentDescription",
+  ],
   "unformattedText": "The element's contentDescription overrides the text value required by assistive technologies. Remove the element’s contentDescription attribute.",
 }
 `;
 
 exports[`RuleInformationProvider getRuleInformation returns correct data for ImageViewName rule 1`] = `
 Object {
+  "formatAsCode": Array [
+    "contentDescription",
+    "isImportantForAccessibility",
+  ],
   "unformattedText": "The image has no alternate text and is not identified as decorative. If the image conveys meaningful content, provide alternate text using the contentDescription attribute. If the image is decorative, give it an empty contentDescription, or set its isImportantForAccessibility attribute to false.",
 }
 `;
 
 exports[`RuleInformationProvider getRuleInformation returns correct data for TouchSizeWcag rule 1`] = `
 Object {
+  "formatAsCode": Array [
+    "minWidth",
+    "minHeight",
+  ],
   "unformattedText": "The element has an insufficient target size (width: 42.22222222222222dp, height: 38.22222222222222dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
 }
 `;

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-results.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-results.test.ts.snap
@@ -21,6 +21,7 @@ Array [
     "identifiers": null,
     "resolution": Object {
       "how-to-fix": Object {
+        "formatAsCode": null,
         "unformattedText": "The text element has insufficient contrast of 1. Foreground color: #ffffff, background color: #ffffff). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
       },
     },
@@ -38,6 +39,10 @@ Array [
     "identifiers": null,
     "resolution": Object {
       "how-to-fix": Object {
+        "formatAsCode": Array [
+          "minWidth",
+          "minHeight",
+        ],
         "unformattedText": "The element has an insufficient target size (width: 32dp, height: 32dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
       },
     },
@@ -60,6 +65,10 @@ Array [
     "identifiers": null,
     "resolution": Object {
       "how-to-fix": Object {
+        "formatAsCode": Array [
+          "minWidth",
+          "minHeight",
+        ],
         "unformattedText": "The element has an insufficient target size (width: 48dp, height: 48dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
       },
     },
@@ -82,6 +91,7 @@ Array [
     "identifiers": null,
     "resolution": Object {
       "how-to-fix": Object {
+        "formatAsCode": null,
         "unformattedText": "The text element has insufficient contrast of 21. Foreground color: #ffffff, background color: #000000). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
       },
     },
@@ -94,6 +104,10 @@ Array [
     "identifiers": null,
     "resolution": Object {
       "how-to-fix": Object {
+        "formatAsCode": Array [
+          "minWidth",
+          "minHeight",
+        ],
         "unformattedText": "The element has an insufficient target size (width: 0dp, height: 0dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
       },
     },


### PR DESCRIPTION
#### Description of changes

The cards feature calls for certain portions of the text to be rendered in a style similar to markdown's backtick styling (example: "Set the `isImportantForAccessibility` attribute to false"), but we currently have no way to apply intra-string styling. We discussed various options, including what the web UI currently does for Axe-core results. This PR takes the approach of treating the styling as "hints" that are specified by the data provider (in this case, the converter), and those get applied (as appropriate) at the data consumer (in this case, the cards UI). In essence, the data provider is using the property bag to specify input parameters to the consumer, and the consumer owns the actual application of the parameters. This puts the authoring into one place, and the consuming into one (different) place, so we have loose coupling. It also makes it easy to create per-rule custom formatting.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
