### PR TITLE
chore: using non-relative imports for typescript code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "tslint.configFile": "tslint.json",
     "typescript.reportStyleChecksAsWarnings": true,
-    "typescript.preferences.importModuleSpecifier": "relative",
+    "typescript.preferences.importModuleSpecifier": "non-relative",
 
     "psi-header.changes-tracking": {
         "autoHeader": "autoSave",


### PR DESCRIPTION
#### Description of changes

Using:
```json
    "typescript.preferences.importModuleSpecifier": "non-relative",
```
on `.vscode/settings.json` file to make it easier to move to non-relative import paths

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
