### PR TITLE
refactor: create new classes with smaller scope in responsibilities to eventually replace client-view-controller

### DIFF
--- a/src/injected/is-visualization-enabled.ts
+++ b/src/injected/is-visualization-enabled.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TestMode } from '../common/configs/test-mode';
+import { VisualizationConfiguration } from '../common/configs/visualization-configuration';
+import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
+import { TabStoreData } from '../common/types/store-data/tab-store-data';
+import { VisualizationStoreData } from '../common/types/store-data/visualization-store-data';
+
+export type IsVisualizationEnabledCallback = (
+    config: VisualizationConfiguration,
+    step: string,
+    visualizationState: VisualizationStoreData,
+    assessmentState: AssessmentStoreData,
+    tabState: TabStoreData,
+) => boolean;
+
+export const isVisualizationEnabled: IsVisualizationEnabledCallback = (
+    config: VisualizationConfiguration,
+    step: string,
+    visualizationState: VisualizationStoreData,
+    assessmentState: AssessmentStoreData,
+    tabState: TabStoreData,
+) => {
+    const scanData = config.getStoreData(visualizationState.tests);
+    return (
+        config.getTestStatus(scanData, step) &&
+        (!isAssessment(config) || assessmentState.persistedTabInfo === null || tabState.id === assessmentState.persistedTabInfo.id)
+    );
+};
+
+function isAssessment(config: VisualizationConfiguration): boolean {
+    return config.testMode === TestMode.Assessments;
+}

--- a/src/injected/is-visualization-enabled.ts
+++ b/src/injected/is-visualization-enabled.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { TestMode } from '../common/configs/test-mode';
-import { VisualizationConfiguration } from '../common/configs/visualization-configuration';
-import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
-import { TabStoreData } from '../common/types/store-data/tab-store-data';
-import { VisualizationStoreData } from '../common/types/store-data/visualization-store-data';
+import { TestMode } from 'common/configs/test-mode';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 
 export type IsVisualizationEnabledCallback = (
     config: VisualizationConfiguration,

--- a/src/injected/target-page-visualization-updater.ts
+++ b/src/injected/target-page-visualization-updater.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { VisualizationType } from 'common/types/visualization-type';
+import { cloneDeep } from 'lodash';
+import { DictionaryNumberTo, DictionaryStringTo } from 'types/common-types';
+
+import { TargetPageStoreData } from './client-store-listener';
+import { DrawingInitiator } from './drawing-initiator';
+import { AssessmentVisualizationInstance } from './frameCommunicators/html-element-axe-results-helper';
+import { IsVisualizationEnabledCallback } from './is-visualization-enabled';
+import { SelectorMapHelper } from './selector-map-helper';
+import { VisualizationNeedsUpdateCallback } from './visualization-needs-update';
+
+export type VisualizationSelectorMapContainer = DictionaryNumberTo<DictionaryStringTo<AssessmentVisualizationInstance>>;
+export type UpdateVisualization = (visualizationType: VisualizationType, step: string, storeData: TargetPageStoreData) => void;
+export class TargetPageVisualizationUpdater {
+    private previousVisualizationSelectorMapStates: VisualizationSelectorMapContainer = {};
+    private previousVisualizationStates: DictionaryStringTo<boolean> = {};
+
+    constructor(
+        private visualizationConfigurationFactory: VisualizationConfigurationFactory,
+        private selectorMapHelper: SelectorMapHelper,
+        private drawingInitiator: DrawingInitiator,
+        private getVisualizationState: IsVisualizationEnabledCallback,
+        private visualizationNeedsToBeUpdated: VisualizationNeedsUpdateCallback,
+    ) {}
+
+    public updateVisualization: UpdateVisualization = (
+        visualizationType: VisualizationType,
+        step: string,
+        storeData: TargetPageStoreData,
+    ) => {
+        const selectorMap = this.selectorMapHelper.getSelectorMap(visualizationType);
+        this.executeUpdate(visualizationType, step, storeData, selectorMap);
+        this.previousVisualizationSelectorMapStates[visualizationType] = selectorMap;
+    };
+
+    private executeUpdate = (
+        visualizationType: VisualizationType,
+        step: string,
+        storeData: TargetPageStoreData,
+        selectorMap: DictionaryStringTo<AssessmentVisualizationInstance>,
+    ) => {
+        const configuration = this.visualizationConfigurationFactory.getConfiguration(visualizationType);
+        const id = configuration.getIdentifier(step);
+        const newVisualizationEnabledState = this.getVisualizationState(
+            configuration,
+            step,
+            storeData.visualizationStoreData,
+            storeData.assessmentStoreData,
+            storeData.tabStoreData,
+        );
+
+        if (this.visualizationNeedsToBeUpdated(visualizationType, id, newVisualizationEnabledState, selectorMap, null, null) === false) {
+            return;
+        }
+
+        this.previousVisualizationStates[id] = newVisualizationEnabledState;
+
+        if (newVisualizationEnabledState) {
+            this.drawingInitiator.enableVisualization(
+                visualizationType,
+                storeData.featureFlagStoreData,
+                cloneDeep(selectorMap),
+                id,
+                configuration.visualizationInstanceProcessor(step),
+            );
+        } else {
+            this.drawingInitiator.disableVisualization(visualizationType, storeData.featureFlagStoreData, id);
+        }
+    };
+}

--- a/src/injected/target-page-visualization-updater.ts
+++ b/src/injected/target-page-visualization-updater.ts
@@ -31,7 +31,11 @@ export class TargetPageVisualizationUpdater {
         stepKey: string,
         storeData: TargetPageStoreData,
     ) => {
-        const selectorMap = this.selectorMapHelper.getSelectorMap(visualizationType);
+        const selectorMap = this.selectorMapHelper.getSelectorMap(
+            visualizationType,
+            storeData.visualizationScanResultStoreData,
+            storeData.assessmentStoreData,
+        );
         this.executeUpdate(visualizationType, stepKey, storeData, selectorMap);
         this.previousVisualizationSelectorMapStates[visualizationType] = selectorMap;
     };

--- a/src/injected/visualization-needs-update.ts
+++ b/src/injected/visualization-needs-update.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { VisualizationType } from 'common/types/visualization-type';
+import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
+import { VisualizationSelectorMapContainer } from 'injected/target-page-visualization-updater';
+import { isEqual } from 'lodash';
+import { DictionaryStringTo } from 'types/common-types';
+
+export type VisualizationNeedsUpdateCallback = (
+    visualizationType: VisualizationType,
+    id: string,
+    newVisualizationEnabledState: boolean,
+    newSelectorMapState: DictionaryStringTo<AssessmentVisualizationInstance>,
+    previousVisualizationStates: DictionaryStringTo<boolean>,
+    previousVisualizationSelectorMapData: VisualizationSelectorMapContainer,
+) => boolean;
+
+export const visualizationNeedsUpdate: VisualizationNeedsUpdateCallback = (
+    visualizationType,
+    id,
+    newVisualizationEnabledState,
+    newSelectorMapState,
+    previousVisualizationStates,
+    previousVisualizationSelectorMapData,
+) => {
+    if (id in previousVisualizationStates === false) {
+        return newVisualizationEnabledState;
+    }
+
+    return (
+        previousVisualizationStates[id] !== newVisualizationEnabledState ||
+        !isEqual(newSelectorMapState, previousVisualizationSelectorMapData[visualizationType])
+    );
+};

--- a/src/injected/visualization-state-change-handler.ts
+++ b/src/injected/visualization-state-change-handler.ts
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { isEqual } from 'lodash';
+
+import { AssessmentsProvider } from '../assessments/types/assessments-provider';
+import { TestMode } from '../common/configs/test-mode';
+import { VisualizationConfiguration } from '../common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
+import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
+import { TabStoreData } from '../common/types/store-data/tab-store-data';
+import { AssessmentScanData, VisualizationStoreData } from '../common/types/store-data/visualization-store-data';
+import { VisualizationType } from '../common/types/visualization-type';
+import { DictionaryNumberTo, DictionaryStringTo } from '../types/common-types';
+import { TargetPageStoreData } from './client-store-listener';
+import { DrawingInitiator } from './drawing-initiator';
+import { AssessmentVisualizationInstance } from './frameCommunicators/html-element-axe-results-helper';
+import { SelectorMapHelper } from './selector-map-helper';
+
+export class VisualizationStateChangeHandler {
+    private previousVisualizationSelectorMapStates: DictionaryNumberTo<DictionaryStringTo<AssessmentVisualizationInstance>> = {};
+    protected previousVisualizationStates: DictionaryStringTo<boolean> = {};
+
+    constructor(
+        private visualizations: VisualizationType[],
+        private visualizationConfigurationFactory: VisualizationConfigurationFactory,
+        private selectorMapHelper: SelectorMapHelper,
+        private drawingInitiator: DrawingInitiator,
+        private assessmentProvider: AssessmentsProvider,
+    ) {}
+
+    public executeUpdates(storeData: TargetPageStoreData): void {
+        this.visualizations.forEach(visualizationType => {
+            const configuration = this.visualizationConfigurationFactory.getConfiguration(visualizationType);
+
+            if (this.assessmentProvider.isValidType(visualizationType)) {
+                const stepMap = this.assessmentProvider.getStepMap(visualizationType);
+                Object.values(stepMap).forEach(step => {
+                    this.executeUpdate(visualizationType, step.name, configuration, storeData);
+                });
+            } else {
+                this.executeUpdate(visualizationType, null, configuration, storeData);
+            }
+            const selectorMap = this.selectorMapHelper.getSelectorMap(visualizationType);
+            this.previousVisualizationSelectorMapStates[visualizationType] = selectorMap;
+        });
+    }
+
+    private executeUpdate(
+        visualizationType: VisualizationType,
+        step: string,
+        configuration: VisualizationConfiguration,
+        storeData: TargetPageStoreData,
+    ): void {
+        const selectorMap = this.selectorMapHelper.getSelectorMap(visualizationType);
+        const id = configuration.getIdentifier(step);
+        const newVisualizationEnabledState = this.isVisualizationEnabled(
+            configuration,
+            storeData.visualizationStoreData,
+            storeData.assessmentStoreData,
+            storeData.tabStoreData,
+            step,
+        );
+
+        if (this.isVisualizationStateUnchanged(visualizationType, newVisualizationEnabledState, selectorMap, id)) {
+            return;
+        }
+
+        this.previousVisualizationStates[id] = newVisualizationEnabledState;
+
+        if (newVisualizationEnabledState) {
+            this.drawingInitiator.enableVisualization(
+                visualizationType,
+                storeData.featureFlagStoreData,
+                selectorMap,
+                id,
+                configuration.visualizationInstanceProcessor(step),
+            );
+        } else {
+            this.drawingInitiator.disableVisualization(visualizationType, storeData.featureFlagStoreData, id);
+        }
+    }
+
+    private isVisualizationStateUnchanged(
+        visualizationType: VisualizationType,
+        newVisualizationEnabledState: boolean,
+        newSelectorMapState: DictionaryStringTo<AssessmentVisualizationInstance>,
+        id: string,
+    ): boolean {
+        if (id in this.previousVisualizationStates === false && newVisualizationEnabledState === false) {
+            this.previousVisualizationStates[id] = false;
+        }
+        return (
+            id in this.previousVisualizationStates &&
+            this.previousVisualizationStates[id] === newVisualizationEnabledState &&
+            isEqual(this.previousVisualizationSelectorMapStates[visualizationType], newSelectorMapState)
+        );
+    }
+
+    private isVisualizationEnabled(
+        config: VisualizationConfiguration,
+        visualizationState: VisualizationStoreData,
+        assessmentState: AssessmentStoreData,
+        tabState: TabStoreData,
+        step: string,
+    ): boolean {
+        const scanData = config.getStoreData(visualizationState.tests);
+        return (
+            config.getTestStatus(scanData, step) &&
+            (!this.isAssessment(config) || assessmentState.persistedTabInfo === null || tabState.id === assessmentState.persistedTabInfo.id)
+        );
+    }
+
+    private isAssessment(config: VisualizationConfiguration): boolean {
+        return config.testMode === TestMode.Assessments;
+    }
+}

--- a/src/injected/visualization-state-change-handler.ts
+++ b/src/injected/visualization-state-change-handler.ts
@@ -1,116 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isEqual } from 'lodash';
+import { VisualizationType } from 'common/types/visualization-type';
 
 import { AssessmentsProvider } from '../assessments/types/assessments-provider';
-import { TestMode } from '../common/configs/test-mode';
-import { VisualizationConfiguration } from '../common/configs/visualization-configuration';
-import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
-import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
-import { TabStoreData } from '../common/types/store-data/tab-store-data';
-import { AssessmentScanData, VisualizationStoreData } from '../common/types/store-data/visualization-store-data';
-import { VisualizationType } from '../common/types/visualization-type';
-import { DictionaryNumberTo, DictionaryStringTo } from '../types/common-types';
 import { TargetPageStoreData } from './client-store-listener';
-import { DrawingInitiator } from './drawing-initiator';
-import { AssessmentVisualizationInstance } from './frameCommunicators/html-element-axe-results-helper';
-import { SelectorMapHelper } from './selector-map-helper';
+import { UpdateVisualization } from './target-page-visualization-updater';
 
 export class VisualizationStateChangeHandler {
-    private previousVisualizationSelectorMapStates: DictionaryNumberTo<DictionaryStringTo<AssessmentVisualizationInstance>> = {};
-    protected previousVisualizationStates: DictionaryStringTo<boolean> = {};
-
     constructor(
         private visualizations: VisualizationType[],
-        private visualizationConfigurationFactory: VisualizationConfigurationFactory,
-        private selectorMapHelper: SelectorMapHelper,
-        private drawingInitiator: DrawingInitiator,
+        private visualizationUpdater: UpdateVisualization,
         private assessmentProvider: AssessmentsProvider,
     ) {}
 
-    public executeUpdates(storeData: TargetPageStoreData): void {
+    public updateVisualizationsWithStoreData(storeData: TargetPageStoreData): void {
         this.visualizations.forEach(visualizationType => {
-            const configuration = this.visualizationConfigurationFactory.getConfiguration(visualizationType);
-
             if (this.assessmentProvider.isValidType(visualizationType)) {
                 const stepMap = this.assessmentProvider.getStepMap(visualizationType);
                 Object.values(stepMap).forEach(step => {
-                    this.executeUpdate(visualizationType, step.name, configuration, storeData);
+                    this.visualizationUpdater(visualizationType, step.name, storeData);
                 });
             } else {
-                this.executeUpdate(visualizationType, null, configuration, storeData);
+                this.visualizationUpdater(visualizationType, null, storeData);
             }
-            const selectorMap = this.selectorMapHelper.getSelectorMap(visualizationType);
-            this.previousVisualizationSelectorMapStates[visualizationType] = selectorMap;
         });
-    }
-
-    private executeUpdate(
-        visualizationType: VisualizationType,
-        step: string,
-        configuration: VisualizationConfiguration,
-        storeData: TargetPageStoreData,
-    ): void {
-        const selectorMap = this.selectorMapHelper.getSelectorMap(visualizationType);
-        const id = configuration.getIdentifier(step);
-        const newVisualizationEnabledState = this.isVisualizationEnabled(
-            configuration,
-            storeData.visualizationStoreData,
-            storeData.assessmentStoreData,
-            storeData.tabStoreData,
-            step,
-        );
-
-        if (this.isVisualizationStateUnchanged(visualizationType, newVisualizationEnabledState, selectorMap, id)) {
-            return;
-        }
-
-        this.previousVisualizationStates[id] = newVisualizationEnabledState;
-
-        if (newVisualizationEnabledState) {
-            this.drawingInitiator.enableVisualization(
-                visualizationType,
-                storeData.featureFlagStoreData,
-                selectorMap,
-                id,
-                configuration.visualizationInstanceProcessor(step),
-            );
-        } else {
-            this.drawingInitiator.disableVisualization(visualizationType, storeData.featureFlagStoreData, id);
-        }
-    }
-
-    private isVisualizationStateUnchanged(
-        visualizationType: VisualizationType,
-        newVisualizationEnabledState: boolean,
-        newSelectorMapState: DictionaryStringTo<AssessmentVisualizationInstance>,
-        id: string,
-    ): boolean {
-        if (id in this.previousVisualizationStates === false && newVisualizationEnabledState === false) {
-            this.previousVisualizationStates[id] = false;
-        }
-        return (
-            id in this.previousVisualizationStates &&
-            this.previousVisualizationStates[id] === newVisualizationEnabledState &&
-            isEqual(this.previousVisualizationSelectorMapStates[visualizationType], newSelectorMapState)
-        );
-    }
-
-    private isVisualizationEnabled(
-        config: VisualizationConfiguration,
-        visualizationState: VisualizationStoreData,
-        assessmentState: AssessmentStoreData,
-        tabState: TabStoreData,
-        step: string,
-    ): boolean {
-        const scanData = config.getStoreData(visualizationState.tests);
-        return (
-            config.getTestStatus(scanData, step) &&
-            (!this.isAssessment(config) || assessmentState.persistedTabInfo === null || tabState.id === assessmentState.persistedTabInfo.id)
-        );
-    }
-
-    private isAssessment(config: VisualizationConfiguration): boolean {
-        return config.testMode === TestMode.Assessments;
     }
 }

--- a/src/injected/visualization-state-change-handler.ts
+++ b/src/injected/visualization-state-change-handler.ts
@@ -13,16 +13,16 @@ export class VisualizationStateChangeHandler {
         private assessmentProvider: AssessmentsProvider,
     ) {}
 
-    public updateVisualizationsWithStoreData(storeData: TargetPageStoreData): void {
+    public updateVisualizationsWithStoreData = (storeData: TargetPageStoreData) => {
         this.visualizations.forEach(visualizationType => {
             if (this.assessmentProvider.isValidType(visualizationType)) {
                 const stepMap = this.assessmentProvider.getStepMap(visualizationType);
                 Object.values(stepMap).forEach(step => {
-                    this.visualizationUpdater(visualizationType, step.name, storeData);
+                    this.visualizationUpdater(visualizationType, step.key, storeData);
                 });
             } else {
                 this.visualizationUpdater(visualizationType, null, storeData);
             }
         });
-    }
+    };
 }

--- a/src/tests/unit/tests/injected/is-visualization-enabled.test.ts
+++ b/src/tests/unit/tests/injected/is-visualization-enabled.test.ts
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { IMock, Mock } from 'typemoq';
+
+import { TestMode } from '../../../../common/configs/test-mode';
+import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
+import { AssessmentStoreData } from '../../../../common/types/store-data/assessment-result-data';
+import { TabStoreData } from '../../../../common/types/store-data/tab-store-data';
+import { ScanData, VisualizationStoreData } from '../../../../common/types/store-data/visualization-store-data';
+import { isVisualizationEnabled, IsVisualizationEnabledCallback } from '../../../../injected/is-visualization-enabled';
+
+describe('isVisualizationEnabled', () => {
+    let visualizationConfigurationMock: IMock<VisualizationConfiguration>;
+    let visualizationState: VisualizationStoreData;
+    let assessmentState: AssessmentStoreData;
+    let tabState: TabStoreData;
+    let stepStub: string;
+    let testSubject: IsVisualizationEnabledCallback;
+    let scanDataStub: ScanData;
+
+    beforeEach(() => {
+        visualizationConfigurationMock = Mock.ofType<VisualizationConfiguration>();
+        visualizationState = {
+            tests: {},
+        } as VisualizationStoreData;
+        scanDataStub = {} as ScanData;
+        stepStub = 'some step';
+
+        visualizationConfigurationMock.setup(config => config.getStoreData(visualizationState.tests)).returns(() => scanDataStub);
+
+        testSubject = isVisualizationEnabled;
+    });
+
+    test('testStatus is false', () => {
+        visualizationConfigurationMock.setup(config => config.getTestStatus(scanDataStub, stepStub)).returns(() => false);
+
+        expect(testSubject(visualizationConfigurationMock.object, stepStub, visualizationState, assessmentState, tabState)).toEqual(false);
+    });
+
+    test('testStatus is true & is not an assessment test', () => {
+        visualizationConfigurationMock.setup(config => config.getTestStatus(scanDataStub, stepStub)).returns(() => true);
+        visualizationConfigurationMock.setup(config => config.testMode).returns(() => TestMode.Adhoc);
+
+        expect(testSubject(visualizationConfigurationMock.object, stepStub, visualizationState, assessmentState, tabState)).toEqual(true);
+    });
+
+    test('testStatus is true & is an assessment test and there is no persisted tab info', () => {
+        visualizationConfigurationMock.setup(config => config.getTestStatus(scanDataStub, stepStub)).returns(() => true);
+        visualizationConfigurationMock.setup(config => config.testMode).returns(() => TestMode.Assessments);
+
+        assessmentState = {
+            persistedTabInfo: null,
+        } as AssessmentStoreData;
+
+        expect(testSubject(visualizationConfigurationMock.object, stepStub, visualizationState, assessmentState, tabState)).toEqual(true);
+    });
+
+    test('testStatus is true & is an assessment test and persisted tab does not match tabState', () => {
+        visualizationConfigurationMock.setup(config => config.getTestStatus(scanDataStub, stepStub)).returns(() => true);
+        visualizationConfigurationMock.setup(config => config.testMode).returns(() => TestMode.Assessments);
+
+        assessmentState = {
+            persistedTabInfo: {
+                id: 1,
+            },
+        } as AssessmentStoreData;
+
+        tabState = {
+            id: 2,
+        } as TabStoreData;
+
+        expect(testSubject(visualizationConfigurationMock.object, stepStub, visualizationState, assessmentState, tabState)).toEqual(false);
+    });
+
+    test('testStatus is true & is an assessment test and persisted tab does match tabState', () => {
+        visualizationConfigurationMock.setup(config => config.getTestStatus(scanDataStub, stepStub)).returns(() => true);
+        visualizationConfigurationMock.setup(config => config.testMode).returns(() => TestMode.Assessments);
+
+        assessmentState = {
+            persistedTabInfo: {
+                id: 1,
+            },
+        } as AssessmentStoreData;
+
+        tabState = {
+            id: 1,
+        } as TabStoreData;
+
+        expect(testSubject(visualizationConfigurationMock.object, stepStub, visualizationState, assessmentState, tabState)).toEqual(true);
+    });
+});

--- a/src/tests/unit/tests/injected/is-visualization-enabled.test.ts
+++ b/src/tests/unit/tests/injected/is-visualization-enabled.test.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TestMode } from 'common/configs/test-mode';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { ScanData, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { IMock, Mock } from 'typemoq';
 
-import { TestMode } from '../../../../common/configs/test-mode';
-import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
-import { AssessmentStoreData } from '../../../../common/types/store-data/assessment-result-data';
-import { TabStoreData } from '../../../../common/types/store-data/tab-store-data';
-import { ScanData, VisualizationStoreData } from '../../../../common/types/store-data/visualization-store-data';
 import { isVisualizationEnabled, IsVisualizationEnabledCallback } from '../../../../injected/is-visualization-enabled';
 
 describe('isVisualizationEnabled', () => {

--- a/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
+++ b/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { VisualizationType } from 'common/types/visualization-type';
+import { TargetPageStoreData } from 'injected/client-store-listener';
+import { DrawingInitiator } from 'injected/drawing-initiator';
+import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
+import { IsVisualizationEnabledCallback } from 'injected/is-visualization-enabled';
+import { SelectorMapHelper } from 'injected/selector-map-helper';
+import { TargetPageVisualizationUpdater, VisualizationSelectorMapContainer } from 'injected/target-page-visualization-updater';
+import { VisualizationNeedsUpdateCallback } from 'injected/visualization-needs-update';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { DictionaryStringTo } from 'types/common-types';
+
+describe('TargetPageVisualizationUpdater', () => {
+    let visualizationConfigurationFactoryMock: IMock<VisualizationConfigurationFactory>;
+    let selectorMapHelperMock: IMock<SelectorMapHelper>;
+    let drawingInitiatorMock: IMock<DrawingInitiator>;
+    let isVisualizationEnabledMock: IMock<IsVisualizationEnabledCallback>;
+    let visualizationNeedsUpdateMock: IMock<VisualizationNeedsUpdateCallback>;
+    let configMock: IMock<VisualizationConfiguration>;
+    let testSubject: TargetPageVisualizationUpdater;
+
+    let selectorMapStub: DictionaryStringTo<AssessmentVisualizationInstance>;
+    let stepKeyStub: string;
+    let storeDataStub: TargetPageStoreData;
+    let newVisualizationEnabledStateStub: boolean;
+    let visualizationTypeStub: VisualizationType;
+    let configIdStub: string;
+
+    beforeEach(() => {
+        visualizationConfigurationFactoryMock = Mock.ofType<VisualizationConfigurationFactory>();
+        selectorMapHelperMock = Mock.ofType<SelectorMapHelper>();
+        drawingInitiatorMock = Mock.ofType<DrawingInitiator>();
+        isVisualizationEnabledMock = Mock.ofType<IsVisualizationEnabledCallback>();
+        visualizationNeedsUpdateMock = Mock.ofType<VisualizationNeedsUpdateCallback>();
+        configMock = Mock.ofType<VisualizationConfiguration>();
+
+        selectorMapStub = {};
+        stepKeyStub = 'some step key';
+        configIdStub = 'some config id';
+        storeDataStub = {
+            visualizationStoreData: {},
+            assessmentStoreData: {},
+            tabStoreData: {},
+            featureFlagStoreData: {},
+        } as TargetPageStoreData;
+        visualizationTypeStub = -1;
+
+        newVisualizationEnabledStateStub = true;
+
+        selectorMapHelperMock.setup(smhm => smhm.getSelectorMap(visualizationTypeStub)).returns(() => selectorMapStub);
+        visualizationConfigurationFactoryMock.setup(vcfm => vcfm.getConfiguration(visualizationTypeStub)).returns(() => configMock.object);
+        configMock.setup(cm => cm.getIdentifier(stepKeyStub)).returns(() => configIdStub);
+        isVisualizationEnabledMock
+            .setup(vnum =>
+                vnum(
+                    configMock.object,
+                    stepKeyStub,
+                    storeDataStub.visualizationStoreData,
+                    storeDataStub.assessmentStoreData,
+                    storeDataStub.tabStoreData,
+                ),
+            )
+            .returns(() => newVisualizationEnabledStateStub);
+
+        testSubject = new TargetPageVisualizationUpdater(
+            visualizationConfigurationFactoryMock.object,
+            selectorMapHelperMock.object,
+            drawingInitiatorMock.object,
+            isVisualizationEnabledMock.object,
+            visualizationNeedsUpdateMock.object,
+        );
+    });
+
+    test('visualization does need not to be updated', () => {
+        setupVisualizationNeedsUpdateMock(false);
+        drawingInitiatorMock.setup(dim => dim.disableVisualization(It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
+        drawingInitiatorMock
+            .setup(dim => dim.enableVisualization(It.isAny(), It.isAny(), It.isAny(), It.isAny(), It.isAny()))
+            .verifiable(Times.never());
+
+        testSubject.updateVisualization(visualizationTypeStub, stepKeyStub, storeDataStub);
+
+        drawingInitiatorMock.verifyAll();
+        verifyPreviousStates({}, { [visualizationTypeStub]: selectorMapStub });
+    });
+
+    test('visualization needs to be enabled', () => {
+        const visualizationInstanceProcessorStub = () => null;
+        configMock.setup(cm => cm.visualizationInstanceProcessor(stepKeyStub)).returns(() => visualizationInstanceProcessorStub);
+        setupVisualizationNeedsUpdateMock(true);
+        drawingInitiatorMock
+            .setup(dim =>
+                dim.enableVisualization(
+                    visualizationTypeStub,
+                    storeDataStub.featureFlagStoreData,
+                    It.isValue(selectorMapStub),
+                    configIdStub,
+                    visualizationInstanceProcessorStub,
+                ),
+            )
+            .verifiable();
+
+        testSubject.updateVisualization(visualizationTypeStub, stepKeyStub, storeDataStub);
+
+        drawingInitiatorMock.verifyAll();
+        verifyPreviousStates({ [configIdStub]: newVisualizationEnabledStateStub }, { [visualizationTypeStub]: selectorMapStub });
+    });
+
+    test('visualization needs to be disabled', () => {
+        setupVisualizationNeedsUpdateMock(true);
+        newVisualizationEnabledStateStub = false;
+        drawingInitiatorMock
+            .setup(dim => dim.disableVisualization(visualizationTypeStub, storeDataStub.featureFlagStoreData, configIdStub))
+            .verifiable();
+
+        testSubject.updateVisualization(visualizationTypeStub, stepKeyStub, storeDataStub);
+
+        drawingInitiatorMock.verifyAll();
+        verifyPreviousStates({ [configIdStub]: newVisualizationEnabledStateStub }, { [visualizationTypeStub]: selectorMapStub });
+    });
+
+    function setupVisualizationNeedsUpdateMock(needsUpdate: boolean): void {
+        visualizationNeedsUpdateMock
+            .setup(vnum =>
+                vnum(
+                    visualizationTypeStub,
+                    configIdStub,
+                    newVisualizationEnabledStateStub,
+                    selectorMapStub,
+                    It.isValue({}),
+                    It.isValue({}),
+                ),
+            )
+            .returns(() => needsUpdate);
+    }
+
+    function verifyPreviousStates(
+        expectedVisualizationStates: DictionaryStringTo<boolean>,
+        expectedSelectorMapStates: VisualizationSelectorMapContainer,
+    ): void {
+        visualizationNeedsUpdateMock.reset();
+        visualizationNeedsUpdateMock
+            .setup(vnum =>
+                vnum(
+                    visualizationTypeStub,
+                    configIdStub,
+                    newVisualizationEnabledStateStub,
+                    selectorMapStub,
+                    It.isValue(expectedVisualizationStates),
+                    It.isValue(expectedSelectorMapStates),
+                ),
+            )
+            .returns(() => false)
+            .verifiable();
+
+        testSubject.updateVisualization(visualizationTypeStub, stepKeyStub, storeDataStub);
+
+        visualizationNeedsUpdateMock.verifyAll();
+    }
+});

--- a/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
+++ b/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
@@ -50,7 +50,15 @@ describe('TargetPageVisualizationUpdater', () => {
 
         newVisualizationEnabledStateStub = true;
 
-        selectorMapHelperMock.setup(smhm => smhm.getSelectorMap(visualizationTypeStub)).returns(() => selectorMapStub);
+        selectorMapHelperMock
+            .setup(smhm =>
+                smhm.getSelectorMap(
+                    visualizationTypeStub,
+                    storeDataStub.visualizationScanResultStoreData,
+                    storeDataStub.assessmentStoreData,
+                ),
+            )
+            .returns(() => selectorMapStub);
         visualizationConfigurationFactoryMock.setup(vcfm => vcfm.getConfiguration(visualizationTypeStub)).returns(() => configMock.object);
         configMock.setup(cm => cm.getIdentifier(stepKeyStub)).returns(() => configIdStub);
         isVisualizationEnabledMock

--- a/src/tests/unit/tests/injected/visualization-needs-update.test.ts
+++ b/src/tests/unit/tests/injected/visualization-needs-update.test.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { VisualizationType } from 'common/types/visualization-type';
+import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
+import { VisualizationSelectorMapContainer } from 'injected/target-page-visualization-updater';
+import { visualizationNeedsUpdate } from 'injected/visualization-needs-update';
+import { DictionaryStringTo } from 'types/common-types';
+
+describe('visualizationNeedsUpdate', () => {
+    let visualizationType: VisualizationType;
+    let id: string;
+    let newSelectorMapState: DictionaryStringTo<AssessmentVisualizationInstance>;
+    let previousVisualizationStates: DictionaryStringTo<boolean>;
+    let previousVisualizationSelectorMapData: VisualizationSelectorMapContainer;
+
+    beforeEach(() => {
+        visualizationType = -1;
+        id = 'some id';
+        previousVisualizationStates = {};
+    });
+
+    [true, false].forEach(newVisualizationEnabledState => {
+        test(`config id does not exist in previous visualization state should return new visualization state ${newVisualizationEnabledState}`, () => {
+            expect(
+                visualizationNeedsUpdate(
+                    visualizationType,
+                    id,
+                    newVisualizationEnabledState,
+                    newSelectorMapState,
+                    previousVisualizationStates,
+                    previousVisualizationSelectorMapData,
+                ),
+            ).toEqual(newVisualizationEnabledState);
+        });
+    });
+
+    test('previous visualization state for given config id is not the same as the new visualization state', () => {
+        previousVisualizationStates = {
+            [id]: false,
+        };
+        const newVisualizationEnabledState = true;
+
+        expect(
+            visualizationNeedsUpdate(
+                visualizationType,
+                id,
+                newVisualizationEnabledState,
+                newSelectorMapState,
+                previousVisualizationStates,
+                previousVisualizationSelectorMapData,
+            ),
+        ).toEqual(true);
+    });
+});

--- a/src/tests/unit/tests/injected/visualization-needs-update.test.ts
+++ b/src/tests/unit/tests/injected/visualization-needs-update.test.ts
@@ -17,6 +17,7 @@ describe('visualizationNeedsUpdate', () => {
         visualizationType = -1;
         id = 'some id';
         previousVisualizationStates = {};
+        previousVisualizationSelectorMapData = {};
     });
 
     [true, false].forEach(newVisualizationEnabledState => {
@@ -50,5 +51,47 @@ describe('visualizationNeedsUpdate', () => {
                 previousVisualizationSelectorMapData,
             ),
         ).toEqual(true);
+    });
+
+    test('previous visualization state for given config id is the same as the new visualization state but selector map has changed', () => {
+        const newVisualizationEnabledState = true;
+        previousVisualizationStates = {
+            [id]: newVisualizationEnabledState,
+        };
+
+        newSelectorMapState = {};
+        previousVisualizationSelectorMapData[visualizationType] = null;
+
+        expect(
+            visualizationNeedsUpdate(
+                visualizationType,
+                id,
+                newVisualizationEnabledState,
+                newSelectorMapState,
+                previousVisualizationStates,
+                previousVisualizationSelectorMapData,
+            ),
+        ).toEqual(true);
+    });
+
+    test('previous visualization state for given config id is equivalent to new visualization state and selector map has not changed', () => {
+        const newVisualizationEnabledState = true;
+        previousVisualizationStates = {
+            [id]: newVisualizationEnabledState,
+        };
+
+        newSelectorMapState = {};
+        previousVisualizationSelectorMapData[visualizationType] = newSelectorMapState;
+
+        expect(
+            visualizationNeedsUpdate(
+                visualizationType,
+                id,
+                newVisualizationEnabledState,
+                newSelectorMapState,
+                previousVisualizationStates,
+                previousVisualizationSelectorMapData,
+            ),
+        ).toEqual(false);
     });
 });

--- a/src/tests/unit/tests/injected/visualization-state-change-handler.test.ts
+++ b/src/tests/unit/tests/injected/visualization-state-change-handler.test.ts
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { Requirement } from 'assessments/types/requirement';
+import { VisualizationType } from 'common/types/visualization-type';
+import { TargetPageStoreData } from 'injected/client-store-listener';
+import { UpdateVisualization } from 'injected/target-page-visualization-updater';
+import { VisualizationStateChangeHandler } from 'injected/visualization-state-change-handler';
+import { forOwn } from 'lodash';
+import { IMock, Mock } from 'typemoq';
+
+describe('VisualizationStateChangeHandler', () => {
+    let assessmentProviderMock: IMock<AssessmentsProvider>;
+    let visualizationUpdaterMock: IMock<UpdateVisualization>;
+    let storeDataStub: TargetPageStoreData;
+    let testSubject: VisualizationStateChangeHandler;
+    let visualizations: VisualizationType[];
+
+    beforeEach(() => {
+        assessmentProviderMock = Mock.ofType<AssessmentsProvider>();
+        visualizationUpdaterMock = Mock.ofType<UpdateVisualization>();
+        storeDataStub = {} as TargetPageStoreData;
+        visualizations = [-1, -2];
+        testSubject = new VisualizationStateChangeHandler(visualizations, visualizationUpdaterMock.object, assessmentProviderMock.object);
+    });
+
+    test('non-assessment visualizations', () => {
+        visualizations.forEach(visualizationType => {
+            assessmentProviderMock.setup(apm => apm.isValidType(visualizationType)).returns(() => false);
+            visualizationUpdaterMock.setup(vum => vum(visualizationType, null, storeDataStub)).verifiable();
+        });
+        testSubject.updateVisualizationsWithStoreData(storeDataStub);
+
+        visualizationUpdaterMock.verifyAll();
+    });
+
+    test('assessment visualizations', () => {
+        const requirementOneStub = {
+            key: 'some key',
+        } as Requirement;
+        const requirementTwoStub = {
+            key: 'some other key',
+        } as Requirement;
+        const stepMapStub = {
+            step1: requirementOneStub,
+            step2: requirementTwoStub,
+        };
+
+        visualizations.forEach(visualizationType => {
+            assessmentProviderMock.setup(apm => apm.isValidType(visualizationType)).returns(() => true);
+            assessmentProviderMock.setup(apm => apm.getStepMap(visualizationType)).returns(() => stepMapStub);
+            forOwn(stepMapStub, step => {
+                visualizationUpdaterMock.setup(vum => vum(visualizationType, step.key, storeDataStub)).verifiable();
+            });
+        });
+
+        testSubject.updateVisualizationsWithStoreData(storeDataStub);
+
+        visualizationUpdaterMock.verifyAll();
+    });
+});


### PR DESCRIPTION
#### Description of changes

This PR breaks apart the client view controller into another 4 pieces and they are as such:

1. Function isVisualizationEnabled: determine's whether a visualization is enabled or disabled based on the data provided.

2. Function visualizationNeedsUpdate: determine whether a visualization needs to be updated based on data provided.

3. Object VisualizationUpdateChangeHandler: this is the callback that listens to the store hub changes and calls the update visualization callback on all visualization types provided.

4. Object TargetPageVisualizationUpdater: for a visualization, this will update the visualization's state in the target page.

After this PR is complete, I will make a change to start relying on these new classes and remove the client-view-controller.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
