### PR TITLE
Refactor issue filing to enable multiple result data types

### DIFF
--- a/src/DetailsView/components/Issues-details-pane.tsx
+++ b/src/DetailsView/components/Issues-details-pane.tsx
@@ -18,6 +18,7 @@ import { DecoratedAxeNodeResult } from '../../injected/scanner-utils';
 import { DictionaryStringTo } from '../../types/common-types';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { IssueFilingDialog } from './issue-filing-dialog';
+import { AxeResultToIssueFilingDataConverter } from '../../issue-filing/rule-result-to-issue-filing-data';
 
 export type IssuesDetailsPaneDeps = ToastDeps &
     IssueFilingButtonDeps &
@@ -25,6 +26,7 @@ export type IssuesDetailsPaneDeps = ToastDeps &
     GuidanceTagsDeps & {
         issueDetailsTextGenerator: IssueDetailsTextGenerator;
         detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+        axeResultToIssueFilingDataConverter: AxeResultToIssueFilingDataConverter;
     };
 
 export interface IssuesDetailsPaneProps {
@@ -86,11 +88,7 @@ export class IssuesDetailsPane extends React.Component<IssuesDetailsPaneProps, I
     }
 
     private renderSingleIssue(result: DecoratedAxeNodeResult): JSX.Element {
-        const issueData: CreateIssueDetailsTextData = {
-            pageTitle: this.props.pageTitle,
-            pageUrl: this.props.pageUrl,
-            ruleResult: result,
-        };
+        const issueData = this.props.deps.axeResultToIssueFilingDataConverter.convert(result, this.props.pageTitle, this.props.pageUrl);
 
         return (
             <div>

--- a/src/DetailsView/components/Issues-details-pane.tsx
+++ b/src/DetailsView/components/Issues-details-pane.tsx
@@ -15,10 +15,10 @@ import { UserConfigurationStoreData } from '../../common/types/store-data/user-c
 import { CheckType } from '../../injected/components/details-dialog';
 import { FixInstructionPanel, FixInstructionPanelDeps } from '../../injected/components/fix-instruction-panel';
 import { DecoratedAxeNodeResult } from '../../injected/scanner-utils';
+import { AxeResultToIssueFilingDataConverter } from '../../issue-filing/rule-result-to-issue-filing-data';
 import { DictionaryStringTo } from '../../types/common-types';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { IssueFilingDialog } from './issue-filing-dialog';
-import { AxeResultToIssueFilingDataConverter } from '../../issue-filing/rule-result-to-issue-filing-data';
 
 export type IssuesDetailsPaneDeps = ToastDeps &
     IssueFilingButtonDeps &

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -99,6 +99,7 @@ import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-t
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
 import { MasterCheckBoxConfigProvider } from './handlers/master-checkbox-config-provider';
 import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-handler';
+import { AxeResultToIssueFilingDataConverter } from '../issue-filing/rule-result-to-issue-filing-data';
 
 declare const window: AutoChecker & Window;
 
@@ -271,8 +272,13 @@ if (isNaN(tabId) === false) {
 
             const reportGenerator = new ReportGenerator(reportNameGenerator, reportHtmlGenerator, assessmentReportHtmlGenerator);
 
+            const axeResultToIssueFilingDataConverter = new AxeResultToIssueFilingDataConverter(
+                IssueFilingUrlStringUtils.getSelectorLastPart,
+            );
+
             const deps: DetailsViewContainerDeps = {
                 fixInstructionProcessor,
+                axeResultToIssueFilingDataConverter,
                 dropdownClickHandler,
                 issueFilingActionMessageCreator,
                 contentProvider: contentPages,

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -79,6 +79,7 @@ import { ScannerUtils } from '../injected/scanner-utils';
 import { createIssueDetailsBuilder } from '../issue-filing/common/create-issue-details-builder';
 import { IssueFilingUrlStringUtils } from '../issue-filing/common/issue-filing-url-string-utils';
 import { PlainTextFormatter } from '../issue-filing/common/markup/plain-text-formatter';
+import { AxeResultToIssueFilingDataConverter } from '../issue-filing/rule-result-to-issue-filing-data';
 import { getVersion, scan } from '../scanner/exposed-apis';
 import { DictionaryStringTo } from '../types/common-types';
 import { IssueFilingServiceProviderImpl } from './../issue-filing/issue-filing-service-provider-impl';
@@ -99,7 +100,6 @@ import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-t
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
 import { MasterCheckBoxConfigProvider } from './handlers/master-checkbox-config-provider';
 import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-handler';
-import { AxeResultToIssueFilingDataConverter } from '../issue-filing/rule-result-to-issue-filing-data';
 
 declare const window: AutoChecker & Window;
 

--- a/src/background/issue-details-text-generator.ts
+++ b/src/background/issue-details-text-generator.ts
@@ -26,7 +26,7 @@ export class IssueDetailsTextGenerator {
     }
 
     public buildTags(createIssueData: CreateIssueDetailsTextData, standardTags: string[]): string {
-        const tags = ['Accessibility', ...standardTags, createIssueData.ruleResult.ruleId];
+        const tags = ['Accessibility', ...standardTags, createIssueData.rule.id];
         return tags.join(', ');
     }
 }

--- a/src/common/components/copy-issue-details-button.tsx
+++ b/src/common/components/copy-issue-details-button.tsx
@@ -5,7 +5,6 @@ import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import * as CopyToClipboard from 'react-copy-to-clipboard';
 import { CopyIcon } from '../../common/icons/copy-icon';
-import { DecoratedAxeNodeResult } from '../../injected/scanner-utils';
 import { CreateIssueDetailsTextData } from '../types/create-issue-details-text-data';
 import { WindowUtils } from '../window-utils';
 import { Toast } from './toast';
@@ -31,13 +30,8 @@ export class CopyIssueDetailsButton extends React.Component<CopyIssueDetailsButt
         this.state = { showingCopyToast: false };
     }
 
-    private getIssueDetailsText(result: DecoratedAxeNodeResult): string {
-        const data: CreateIssueDetailsTextData = {
-            pageTitle: this.props.issueDetailsData.pageTitle,
-            pageUrl: this.props.issueDetailsData.pageUrl,
-            ruleResult: result,
-        };
-        return this.props.deps.issueDetailsTextGenerator.buildText(data);
+    private getIssueDetailsText(issueData: CreateIssueDetailsTextData): string {
+        return this.props.deps.issueDetailsTextGenerator.buildText(issueData);
     }
 
     private copyButtonClicked = (event: React.MouseEvent<any>): void => {
@@ -55,7 +49,7 @@ export class CopyIssueDetailsButton extends React.Component<CopyIssueDetailsButt
                         Failure details copied.
                     </Toast>
                 ) : null}
-                <CopyToClipboard text={this.getIssueDetailsText(this.props.issueDetailsData.ruleResult)}>
+                <CopyToClipboard text={this.getIssueDetailsText(this.props.issueDetailsData)}>
                     <DefaultButton className={'copy-issue-details-button'} onClick={this.copyButtonClicked}>
                         <CopyIcon />
                         <div className="ms-Button-label">Copy failure details</div>

--- a/src/common/types/create-issue-details-text-data.ts
+++ b/src/common/types/create-issue-details-text-data.ts
@@ -1,9 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DecoratedAxeNodeResult } from '../../injected/scanner-utils';
+import { GuidanceLink } from '../../scanner/rule-to-links-mappings';
 
 export interface CreateIssueDetailsTextData {
-    pageTitle: string;
-    pageUrl: string;
-    ruleResult: DecoratedAxeNodeResult;
+    rule: {
+        id: string;
+        description: string;
+        url: string;
+        guidance: GuidanceLink[];
+    };
+    targetApp: {
+        name: string;
+        url?: string;
+    };
+    element: {
+        identifier: string;
+        conciseName: string;
+    };
+    howToFixSummary: string;
+    snippet?: string;
 }

--- a/src/injected/components/command-bar.tsx
+++ b/src/injected/components/command-bar.tsx
@@ -47,7 +47,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
         const ruleName: string = failedRuleIds[props.currentRuleIndex];
         const ruleResult: DecoratedAxeNodeResult = props.failedRules[ruleName];
 
-        const issueData = this.props.deps.axeToIssueFilingConverter.convert(document.title, document.URL, ruleResult);
+        const issueData = props.deps.axeResultToIssueFilingDataConverter.convert(ruleResult, document.title, document.URL);
 
         return (
             <>

--- a/src/injected/components/command-bar.tsx
+++ b/src/injected/components/command-bar.tsx
@@ -12,8 +12,12 @@ import { CreateIssueDetailsTextData } from '../../common/types/create-issue-deta
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { DictionaryStringTo } from '../../types/common-types';
 import { DecoratedAxeNodeResult } from '../scanner-utils';
+import { AxeResultToIssueFilingDataConverter } from '../../issue-filing/rule-result-to-issue-filing-data';
 
-export type CommandBarDeps = CopyIssueDetailsButtonDeps & IssueFilingButtonDeps;
+export type CommandBarDeps = CopyIssueDetailsButtonDeps &
+    IssueFilingButtonDeps & {
+        axeResultToIssueFilingDataConverter: AxeResultToIssueFilingDataConverter;
+    };
 
 export type CommandBarProps = {
     deps: CommandBarDeps;
@@ -42,11 +46,8 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
         const failedRuleIds: string[] = Object.keys(props.failedRules);
         const ruleName: string = failedRuleIds[props.currentRuleIndex];
         const ruleResult: DecoratedAxeNodeResult = props.failedRules[ruleName];
-        const issueData: CreateIssueDetailsTextData = {
-            pageTitle: document.title,
-            pageUrl: document.URL,
-            ruleResult,
-        };
+
+        const issueData = this.props.deps.axeToIssueFilingConverter.convert(document.title, document.URL, ruleResult);
 
         return (
             <>

--- a/src/injected/components/command-bar.tsx
+++ b/src/injected/components/command-bar.tsx
@@ -10,9 +10,9 @@ import { FileHTMLIcon } from '../../common/icons/file-html-icon';
 import { NamedFC } from '../../common/react/named-fc';
 import { CreateIssueDetailsTextData } from '../../common/types/create-issue-details-text-data';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
+import { AxeResultToIssueFilingDataConverter } from '../../issue-filing/rule-result-to-issue-filing-data';
 import { DictionaryStringTo } from '../../types/common-types';
 import { DecoratedAxeNodeResult } from '../scanner-utils';
-import { AxeResultToIssueFilingDataConverter } from '../../issue-filing/rule-result-to-issue-filing-data';
 
 export type CommandBarDeps = CopyIssueDetailsButtonDeps &
     IssueFilingButtonDeps & {

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -25,6 +25,7 @@ import { LayeredDetailsDialogComponent, LayeredDetailsDialogDeps } from './layer
 import { MainWindowContext } from './main-window-context';
 import { DecoratedAxeNodeResult, HtmlElementAxeResults } from './scanner-utils';
 import { ShadowUtils } from './shadow-utils';
+import { AxeResultToIssueFilingDataConverter } from '../issue-filing/rule-result-to-issue-filing-data';
 
 export interface DetailsDialogWindowMessage {
     data: HtmlElementAxeResults;
@@ -72,7 +73,12 @@ export class DialogRenderer {
 
             const fixInstructionProcessor = new FixInstructionProcessor();
 
+            const axeResultToIssueFilingDataConverter = new AxeResultToIssueFilingDataConverter(
+                IssueFilingUrlStringUtils.getSelectorLastPart,
+            );
+
             const deps: LayeredDetailsDialogDeps = {
+                axeResultToIssueFilingDataConverter,
                 fixInstructionProcessor,
                 issueDetailsTextGenerator,
                 windowUtils: this.windowUtils,

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -14,6 +14,7 @@ import { WindowUtils } from '../common/window-utils';
 import { createIssueDetailsBuilder } from '../issue-filing/common/create-issue-details-builder';
 import { IssueFilingUrlStringUtils } from '../issue-filing/common/issue-filing-url-string-utils';
 import { PlainTextFormatter } from '../issue-filing/common/markup/plain-text-formatter';
+import { AxeResultToIssueFilingDataConverter } from '../issue-filing/rule-result-to-issue-filing-data';
 import { DictionaryStringTo } from '../types/common-types';
 import { rootContainerId } from './constants';
 import { DetailsDialogHandler } from './details-dialog-handler';
@@ -25,7 +26,6 @@ import { LayeredDetailsDialogComponent, LayeredDetailsDialogDeps } from './layer
 import { MainWindowContext } from './main-window-context';
 import { DecoratedAxeNodeResult, HtmlElementAxeResults } from './scanner-utils';
 import { ShadowUtils } from './shadow-utils';
-import { AxeResultToIssueFilingDataConverter } from '../issue-filing/rule-result-to-issue-filing-data';
 
 export interface DetailsDialogWindowMessage {
     data: HtmlElementAxeResults;

--- a/src/issue-filing/common/create-issue-details-builder.ts
+++ b/src/issue-filing/common/create-issue-details-builder.ts
@@ -26,7 +26,7 @@ export const createIssueDetailsBuilder = (markup: MarkupFormatter): IssueDetails
             link(data.targetApp.url, data.targetApp.name),
             sectionSeparator(),
 
-            sectionHeader('Element'),
+            sectionHeader('Element path'),
             sectionHeaderSeparator(),
             data.element.identifier,
             sectionSeparator(),

--- a/src/issue-filing/common/create-issue-details-builder.ts
+++ b/src/issue-filing/common/create-issue-details-builder.ts
@@ -9,34 +9,33 @@ import { MarkupFormatter } from './markup/markup-formatter';
 
 export const createIssueDetailsBuilder = (markup: MarkupFormatter): IssueDetailsBuilder => {
     const getter = (environmentInfo: EnvironmentInfo, data: CreateIssueDetailsTextData): string => {
-        const result = data.ruleResult;
-
         const { howToFixSection, link, sectionHeader, snippet, sectionHeaderSeparator, footerSeparator, sectionSeparator } = markup;
+
+        const snippetSection = data.snippet
+            ? [sectionHeader('Snippet'), sectionHeaderSeparator(), snippet(data.snippet), sectionSeparator()]
+            : null;
 
         const lines = [
             sectionHeader('Issue'),
             sectionHeaderSeparator(),
-            `${snippet(result.help)} (${link(result.helpUrl, result.ruleId)})`,
+            `${snippet(data.rule.description)} (${link(data.rule.url, data.rule.id)})`,
             sectionSeparator(),
 
             sectionHeader('Target application'),
             sectionHeaderSeparator(),
-            link(data.pageUrl, data.pageTitle),
+            link(data.targetApp.url, data.targetApp.name),
             sectionSeparator(),
 
-            sectionHeader('Element path'),
+            sectionHeader('Element'),
             sectionHeaderSeparator(),
-            data.ruleResult.selector,
+            data.element.identifier,
             sectionSeparator(),
 
-            sectionHeader('Snippet'),
-            sectionHeaderSeparator(),
-            snippet(result.snippet),
-            sectionSeparator(),
+            ...snippetSection,
 
             sectionHeader('How to fix'),
             sectionHeaderSeparator(),
-            howToFixSection(result.failureSummary),
+            howToFixSection(data.howToFixSummary),
             sectionSeparator(),
 
             sectionHeader('Environment'),

--- a/src/issue-filing/common/issue-filing-url-string-utils.ts
+++ b/src/issue-filing/common/issue-filing-url-string-utils.ts
@@ -15,9 +15,7 @@ const getTitle = (data: CreateIssueDetailsTextData): string => {
         prefix = prefix + ': ';
     }
 
-    const selectorLastPart = getSelectorLastPart(data.ruleResult.selector);
-
-    return `${prefix}${data.ruleResult.help} (${selectorLastPart})`;
+    return `${prefix}${data.rule.description} (${data.element.conciseName})`;
 };
 
 const getSelectorLastPart = (selector: string): string => {
@@ -34,9 +32,9 @@ const getSelectorLastPart = (selector: string): string => {
 };
 
 const standardizeTags = (data: CreateIssueDetailsTextData): string[] => {
-    const guidanceLinkTextTags = data.ruleResult.guidanceLinks.map(link => link.text.toUpperCase());
+    const guidanceLinkTextTags = data.rule.guidance.map(link => link.text.toUpperCase());
     const tagsFromGuidanceLinkTags = [];
-    data.ruleResult.guidanceLinks.map(link => (link.tags ? link.tags.map(tag => tagsFromGuidanceLinkTags.push(tag.displayText)) : []));
+    data.rule.guidance.map(link => (link.tags ? link.tags.map(tag => tagsFromGuidanceLinkTags.push(tag.displayText)) : []));
     return guidanceLinkTextTags.concat(tagsFromGuidanceLinkTags);
 };
 

--- a/src/issue-filing/rule-result-to-issue-filing-data.ts
+++ b/src/issue-filing/rule-result-to-issue-filing-data.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DecoratedAxeNodeResult } from '../injected/scanner-utils';
 import { CreateIssueDetailsTextData } from '../common/types/create-issue-details-text-data';
+import { DecoratedAxeNodeResult } from '../injected/scanner-utils';
 
 export class AxeResultToIssueFilingDataConverter {
     constructor(private readonly shortenSelector: (selector: string) => string) {}

--- a/src/issue-filing/rule-result-to-issue-filing-data.ts
+++ b/src/issue-filing/rule-result-to-issue-filing-data.ts
@@ -19,7 +19,7 @@ export class AxeResultToIssueFilingDataConverter {
                 url: pageUrl,
             },
             element: {
-                identifier: result.id,
+                identifier: result.selector,
                 conciseName: this.shortenSelector(result.selector),
             },
             howToFixSummary: result.failureSummary,

--- a/src/issue-filing/rule-result-to-issue-filing-data.ts
+++ b/src/issue-filing/rule-result-to-issue-filing-data.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DecoratedAxeNodeResult } from '../injected/scanner-utils';
+import { CreateIssueDetailsTextData } from '../common/types/create-issue-details-text-data';
+
+export class AxeResultToIssueFilingDataConverter {
+    constructor(private readonly shortenSelector: (selector: string) => string) {}
+
+    public convert(result: DecoratedAxeNodeResult, pageTitle: string, pageUrl: string): CreateIssueDetailsTextData {
+        return {
+            rule: {
+                description: result.help,
+                id: result.ruleId,
+                url: result.helpUrl,
+                guidance: result.guidanceLinks,
+            },
+            targetApp: {
+                name: pageTitle,
+                url: pageUrl,
+            },
+            element: {
+                identifier: result.id,
+                conciseName: this.shortenSelector(result.selector),
+            },
+            howToFixSummary: result.failureSummary,
+            snippet: result.snippet,
+        };
+    }
+}

--- a/src/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.ts
+++ b/src/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.ts
@@ -11,7 +11,7 @@ import { HTMLFormatter } from '../../common/markup/html-formatter';
 import { AzureBoardsIssueFilingSettings, AzureBoardsWorkItemType } from './azure-boards-issue-filing-settings';
 
 const buildTags = (createIssueData: CreateIssueDetailsTextData, standardTags: string[]): string => {
-    const tags = ['Accessibility', title, `rule: ${createIssueData.ruleResult.ruleId}`, ...standardTags];
+    const tags = ['Accessibility', title, `rule: ${createIssueData.rule.id}`, ...standardTags];
     return tags.join('; ');
 };
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-details-pane.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-details-pane.test.tsx.snap
@@ -15,6 +15,13 @@ exports[`IssuesDetailsPaneTest render with single selection, issue filing button
       "windowUtils": null,
     }
   }
+  issueDetailsData={
+    Object {
+      "targetApp": Object {
+        "name": "name",
+      },
+    }
+  }
   needsSettingsContentRenderer={[Function]}
   userConfigurationStoreData={Object {}}
 />
@@ -26,8 +33,8 @@ exports[`IssuesDetailsPaneTest render with single selection, test copy to clipbo
     <h2>
       Failure details
     </h2>
-    <CopyIssueDetailsButton deps={{...}} issueDetailsData={[undefined]} onClick={[Function: copyIssueDetailsClicked]} />
-    <IssueFilingButton deps={{...}} issueDetailsData={[undefined]} userConfigurationStoreData={{...}} needsSettingsContentRenderer={[function]} />
+    <CopyIssueDetailsButton deps={{...}} issueDetailsData={{...}} onClick={[Function: copyIssueDetailsClicked]} />
+    <IssueFilingButton deps={{...}} issueDetailsData={{...}} userConfigurationStoreData={{...}} needsSettingsContentRenderer={[function]} />
     <table className=\\"issue-detail-table\\">
       <tbody>
         <tr>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-details-pane.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-details-pane.test.tsx.snap
@@ -4,61 +4,15 @@ exports[`IssuesDetailsPaneTest render with single selection, issue filing button
 <IssueFilingButton
   deps={
     Object {
+      "axeResultToIssueFilingDataConverter": Object {
+        "convert": [Function],
+      },
       "detailsViewActionMessageCreator": Object {
         "copyIssueDetailsClicked": [Function],
       },
       "issueDetailsTextGenerator": null,
       "issueFilingActionMessageCreator": null,
       "windowUtils": null,
-    }
-  }
-  issueDetailsData={
-    Object {
-      "pageTitle": "pageTitle",
-      "pageUrl": "pageUrl",
-      "ruleResult": Object {
-        "all": Array [
-          Object {
-            "data": "check-result-data",
-            "id": "check-result-id",
-            "message": "check-result-message",
-          },
-        ],
-        "any": Array [
-          Object {
-            "data": "check-result-data",
-            "id": "check-result-id",
-            "message": "check-result-message",
-          },
-        ],
-        "failureSummary": null,
-        "fingerprint": "id1",
-        "guidanceLinks": Array [
-          Object {
-            "href": "aka.ms/guidance-url-X.1.1",
-            "text": "guidance X.1.1",
-          },
-          Object {
-            "href": "aka.ms/guidance-url-X.2.2",
-            "text": "guidance X.2.2",
-          },
-        ],
-        "help": "rule-help",
-        "helpUrl": "http://help-url/",
-        "html": null,
-        "id": "id1",
-        "none": Array [
-          Object {
-            "data": "check-result-data",
-            "id": "check-result-id",
-            "message": "check-result-message",
-          },
-        ],
-        "ruleId": "rule-id",
-        "selector": null,
-        "snippet": null,
-        "status": false,
-      },
     }
   }
   needsSettingsContentRenderer={[Function]}
@@ -72,8 +26,8 @@ exports[`IssuesDetailsPaneTest render with single selection, test copy to clipbo
     <h2>
       Failure details
     </h2>
-    <CopyIssueDetailsButton deps={{...}} issueDetailsData={{...}} onClick={[Function: copyIssueDetailsClicked]} />
-    <IssueFilingButton deps={{...}} issueDetailsData={{...}} userConfigurationStoreData={{...}} needsSettingsContentRenderer={[function]} />
+    <CopyIssueDetailsButton deps={{...}} issueDetailsData={[undefined]} onClick={[Function: copyIssueDetailsClicked]} />
+    <IssueFilingButton deps={{...}} issueDetailsData={[undefined]} userConfigurationStoreData={{...}} needsSettingsContentRenderer={[function]} />
     <table className=\\"issue-detail-table\\">
       <tbody>
         <tr>

--- a/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
@@ -57,7 +57,9 @@ describe('IssueFilingDialog', () => {
         envInfoProviderMock.setup(p => p.getEnvironmentInfo()).returns(() => envInfo);
 
         selectedIssueDataStub = {
-            pageTitle: 'some pageTitle',
+            targetApp: {
+                name: 'some pageTitle',
+            },
         } as CreateIssueDetailsTextData;
         selectedServiceData = {
             someServiceData: null,

--- a/src/tests/unit/tests/DetailsView/components/issues-details-pane.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-details-pane.test.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 
 import { HyperlinkDefinition } from 'views/content/content-page';
 import { IssueFilingButton } from '../../../../../common/components/issue-filing-button';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import {
@@ -111,9 +112,14 @@ describe('IssuesDetailsPaneTest', () => {
             };
         }
 
+        const fakeIssueData = {
+            targetApp: {
+                name: 'name',
+            },
+        } as CreateIssueDetailsTextData;
         const deps: IssuesDetailsPaneDeps = {
             axeResultToIssueFilingDataConverter: {
-                convert: (res, title, url) => {},
+                convert: (res, title, url) => fakeIssueData,
             } as AxeResultToIssueFilingDataConverter,
             issueDetailsTextGenerator: null,
             detailsViewActionMessageCreator: {

--- a/src/tests/unit/tests/DetailsView/components/issues-details-pane.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-details-pane.test.tsx
@@ -14,8 +14,8 @@ import {
 } from '../../../../../DetailsView/components/Issues-details-pane';
 import { FixInstructionPanel } from '../../../../../injected/components/fix-instruction-panel';
 import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
-import { DictionaryStringTo } from '../../../../../types/common-types';
 import { AxeResultToIssueFilingDataConverter } from '../../../../../issue-filing/rule-result-to-issue-filing-data';
+import { DictionaryStringTo } from '../../../../../types/common-types';
 
 describe('IssuesDetailsPaneTest', () => {
     const samplePageTitle = 'pageTitle';

--- a/src/tests/unit/tests/DetailsView/components/issues-details-pane.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-details-pane.test.tsx
@@ -15,6 +15,7 @@ import {
 import { FixInstructionPanel } from '../../../../../injected/components/fix-instruction-panel';
 import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
 import { DictionaryStringTo } from '../../../../../types/common-types';
+import { AxeResultToIssueFilingDataConverter } from '../../../../../issue-filing/rule-result-to-issue-filing-data';
 
 describe('IssuesDetailsPaneTest', () => {
     const samplePageTitle = 'pageTitle';
@@ -111,6 +112,9 @@ describe('IssuesDetailsPaneTest', () => {
         }
 
         const deps: IssuesDetailsPaneDeps = {
+            axeResultToIssueFilingDataConverter: {
+                convert: (res, title, url) => {},
+            } as AxeResultToIssueFilingDataConverter,
             issueDetailsTextGenerator: null,
             detailsViewActionMessageCreator: {
                 copyIssueDetailsClicked: _ => {},

--- a/src/tests/unit/tests/background/issue-details-text-generator.test.ts
+++ b/src/tests/unit/tests/background/issue-details-text-generator.test.ts
@@ -20,19 +20,23 @@ describe('Issue details text builder', () => {
 
     beforeEach(() => {
         sampleIssueDetailsData = {
-            pageTitle: 'pageTitle<x>',
-            pageUrl: 'pageUrl',
-            ruleResult: {
-                failureSummary: 'RR-failureSummary',
-                guidanceLinks: [{ text: wcagTags[0] }, { text: wcagTags[1] }],
-                help: 'RR-help',
-                html: 'RR-html',
-                ruleId: 'RR-rule-id',
-                helpUrl: 'RR-help-url',
-                selector,
-                snippet: 'RR-snippet   space',
-            } as any,
-        };
+            rule: {
+                description: 'RR-help',
+                id: 'RR-rule-id',
+                url: 'RR-help-url',
+                guidance: [{ text: wcagTags[0] }, { text: wcagTags[1] }],
+            },
+            targetApp: {
+                name: 'pageTitle<x>',
+                url: 'pageUrl',
+            },
+            element: {
+                identifier: selector,
+                conciseName: selector,
+            },
+            howToFixSummary: 'RR-failureSummary',
+            snippet: 'RR-snippet   space',
+        } as any;
 
         issueUrlCreationUtilsMock = Mock.ofType<IssueUrlCreationUtils>(undefined, MockBehavior.Strict);
         issueUrlCreationUtilsMock.setup(utils => utils.getSelectorLastPart(selector)).returns(() => selector);

--- a/src/tests/unit/tests/common/components/copy-issue-details-button.test.tsx
+++ b/src/tests/unit/tests/common/components/copy-issue-details-button.test.tsx
@@ -21,11 +21,7 @@ describe('CopyIssueDetailsButtonTest', () => {
                     buildText: _ => 'sample text',
                 } as IssueDetailsTextGenerator,
             },
-            issueDetailsData: {
-                pageTitle: 'title',
-                pageUrl: 'url',
-                ruleResult: {},
-            } as CreateIssueDetailsTextData,
+            issueDetailsData: {} as CreateIssueDetailsTextData,
             onClick: onClickMock.object,
         };
     });

--- a/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
+++ b/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
@@ -14,6 +14,7 @@ import { UserConfigurationStoreData } from '../../../../../common/types/store-da
 import { IssueFilingServiceProvider } from '../../../../../issue-filing/issue-filing-service-provider';
 import { IssueFilingService } from '../../../../../issue-filing/types/issue-filing-service';
 import { EventStubFactory } from '../../../common/event-stub-factory';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 
 describe('IssueFilingButtonTest', () => {
     const testKey: string = 'test';
@@ -71,11 +72,7 @@ describe('IssueFilingButtonTest', () => {
                 environmentInfoProvider: environmentInfoProviderMock.object,
                 issueFilingServiceProvider: issueFilingServiceProviderMock.object,
             } as IssueFilingButtonDeps,
-            issueDetailsData: {
-                pageTitle: 'pageTitle',
-                pageUrl: 'http://pageUrl',
-                ruleResult: null,
-            },
+            issueDetailsData: {} as CreateIssueDetailsTextData,
             userConfigurationStoreData: userConfigurationStoreData,
             needsSettingsContentRenderer,
         };
@@ -92,11 +89,7 @@ describe('IssueFilingButtonTest', () => {
                 environmentInfoProvider: environmentInfoProviderMock.object,
                 issueFilingServiceProvider: issueFilingServiceProviderMock.object,
             } as IssueFilingButtonDeps,
-            issueDetailsData: {
-                pageTitle: 'pageTitle',
-                pageUrl: 'http://pageUrl',
-                ruleResult: null,
-            },
+            issueDetailsData: {} as CreateIssueDetailsTextData,
             userConfigurationStoreData: userConfigurationStoreData,
             needsSettingsContentRenderer,
         };
@@ -123,11 +116,7 @@ describe('IssueFilingButtonTest', () => {
                 environmentInfoProvider: environmentInfoProviderMock.object,
                 issueFilingServiceProvider: issueFilingServiceProviderMock.object,
             } as IssueFilingButtonDeps,
-            issueDetailsData: {
-                pageTitle: 'pageTitle',
-                pageUrl: 'http://pageUrl',
-                ruleResult: null,
-            },
+            issueDetailsData: {} as CreateIssueDetailsTextData,
             userConfigurationStoreData: userConfigurationStoreData,
             needsSettingsContentRenderer,
         };

--- a/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
+++ b/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
@@ -9,12 +9,12 @@ import { IssueFilingButton, IssueFilingButtonDeps, IssueFilingButtonProps } from
 import { EnvironmentInfoProvider } from '../../../../../common/environment-info-provider';
 import { IssueFilingActionMessageCreator } from '../../../../../common/message-creators/issue-filing-action-message-creator';
 import { NamedFC } from '../../../../../common/react/named-fc';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 import { IssueFilingNeedsSettingsContentRenderer } from '../../../../../common/types/issue-filing-needs-setting-content';
 import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 import { IssueFilingServiceProvider } from '../../../../../issue-filing/issue-filing-service-provider';
 import { IssueFilingService } from '../../../../../issue-filing/types/issue-filing-service';
 import { EventStubFactory } from '../../../common/event-stub-factory';
-import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 
 describe('IssueFilingButtonTest', () => {
     const testKey: string = 'test';

--- a/src/tests/unit/tests/common/message-creators/issue-filing-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/issue-filing-action-message-creator.test.ts
@@ -77,36 +77,23 @@ describe('IssueFilingActionMessageCreator', () => {
         const telemetry = { ...telemetryStub, service: testService };
 
         telemetryFactoryMock.setup(factory => factory.forFileIssueClick(eventStub, source, testService)).returns(() => telemetry);
-        const issueDetailsData: CreateIssueDetailsTextData = {
-            pageTitle: 'pageTitle<x>',
-            pageUrl: 'pageUrl',
-            ruleResult: {
-                failureSummary: 'RR-failureSummary',
-                guidanceLinks: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
-                help: 'RR-help',
-                html: 'RR-html',
-                ruleId: 'RR-rule-id',
-                helpUrl: 'RR-help-url',
-                selector: 'RR-selector<x>',
-                snippet: 'RR-snippet   space',
-            } as DecoratedAxeNodeResult,
-        };
-
-        dispatcherMock.setup(dispatcher =>
-            dispatcher.dispatchMessage(
-                It.isValue({
-                    messageType: Messages.IssueFiling.FileIssue,
-                    payload: {
-                        service: testService,
-                        issueData: issueDetailsData,
-                        telemetry,
-                    },
-                }),
-            ),
-        );
+        const issueDetailsData: CreateIssueDetailsTextData = {} as any;
 
         testSubject.fileIssue(eventStub, testService, issueDetailsData);
 
-        dispatcherMock.verifyAll();
+        dispatcherMock.verify(
+            dispatcher =>
+                dispatcher.dispatchMessage(
+                    It.isValue({
+                        messageType: Messages.IssueFiling.FileIssue,
+                        payload: {
+                            service: testService,
+                            issueData: issueDetailsData,
+                            telemetry,
+                        },
+                    }),
+                ),
+            Times.once(),
+        );
     });
 });

--- a/src/tests/unit/tests/common/message-creators/issue-filing-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/issue-filing-action-message-creator.test.ts
@@ -14,7 +14,6 @@ import { IssueFilingActionMessageCreator } from '../../../../../common/message-c
 import { Messages } from '../../../../../common/messages';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
-import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
 import { EventStubFactory } from '../../../common/event-stub-factory';
 
 describe('IssueFilingActionMessageCreator', () => {

--- a/src/tests/unit/tests/injected/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/command-bar.test.tsx.snap
@@ -16,76 +16,26 @@ exports[`CommandBar renders renders, shows inspect button message: false 1`] = `
   </CustomizedDefaultButton>
   <React.Fragment>
     <CopyIssueDetailsButton
-      deps={Object {}}
-      issueDetailsData={
+      deps={
         Object {
-          "pageTitle": "",
-          "pageUrl": "http://localhost/",
-          "ruleResult": Object {
-            "failureSummary": "RR-failureSummary",
-            "guidanceLinks": Array [
-              Object {
-                "tags": Array [
-                  Object {
-                    "displayText": "some displayText",
-                    "id": "some-id",
-                  },
-                  Object {
-                    "displayText": "some other displayText",
-                    "id": "some-other-id",
-                  },
-                ],
-                "text": "WCAG-1.4.1",
-              },
-              Object {
-                "text": "wcag-2.8.2",
-              },
-            ],
-            "help": "RR-help",
-            "helpUrl": "RR-help-url",
-            "html": "RR-html",
-            "ruleId": "RR-rule-id",
-            "selector": "RR-selector<x>",
-            "snippet": "RR-snippet   space",
+          "axeResultToIssueFilingDataConverter": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "shortenSelector": undefined,
           },
         }
       }
+      issueDetailsData={Object {}}
     />
     <IssueFilingButton
-      deps={Object {}}
-      issueDetailsData={
+      deps={
         Object {
-          "pageTitle": "",
-          "pageUrl": "http://localhost/",
-          "ruleResult": Object {
-            "failureSummary": "RR-failureSummary",
-            "guidanceLinks": Array [
-              Object {
-                "tags": Array [
-                  Object {
-                    "displayText": "some displayText",
-                    "id": "some-id",
-                  },
-                  Object {
-                    "displayText": "some other displayText",
-                    "id": "some-other-id",
-                  },
-                ],
-                "text": "WCAG-1.4.1",
-              },
-              Object {
-                "text": "wcag-2.8.2",
-              },
-            ],
-            "help": "RR-help",
-            "helpUrl": "RR-help-url",
-            "html": "RR-html",
-            "ruleId": "RR-rule-id",
-            "selector": "RR-selector<x>",
-            "snippet": "RR-snippet   space",
+          "axeResultToIssueFilingDataConverter": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "shortenSelector": undefined,
           },
         }
       }
+      issueDetailsData={Object {}}
       needsSettingsContentRenderer={[Function]}
       userConfigurationStoreData={
         Object {
@@ -114,76 +64,26 @@ exports[`CommandBar renders renders, shows inspect button message: true 1`] = `
   </CustomizedDefaultButton>
   <React.Fragment>
     <CopyIssueDetailsButton
-      deps={Object {}}
-      issueDetailsData={
+      deps={
         Object {
-          "pageTitle": "",
-          "pageUrl": "http://localhost/",
-          "ruleResult": Object {
-            "failureSummary": "RR-failureSummary",
-            "guidanceLinks": Array [
-              Object {
-                "tags": Array [
-                  Object {
-                    "displayText": "some displayText",
-                    "id": "some-id",
-                  },
-                  Object {
-                    "displayText": "some other displayText",
-                    "id": "some-other-id",
-                  },
-                ],
-                "text": "WCAG-1.4.1",
-              },
-              Object {
-                "text": "wcag-2.8.2",
-              },
-            ],
-            "help": "RR-help",
-            "helpUrl": "RR-help-url",
-            "html": "RR-html",
-            "ruleId": "RR-rule-id",
-            "selector": "RR-selector<x>",
-            "snippet": "RR-snippet   space",
+          "axeResultToIssueFilingDataConverter": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "shortenSelector": undefined,
           },
         }
       }
+      issueDetailsData={Object {}}
     />
     <IssueFilingButton
-      deps={Object {}}
-      issueDetailsData={
+      deps={
         Object {
-          "pageTitle": "",
-          "pageUrl": "http://localhost/",
-          "ruleResult": Object {
-            "failureSummary": "RR-failureSummary",
-            "guidanceLinks": Array [
-              Object {
-                "tags": Array [
-                  Object {
-                    "displayText": "some displayText",
-                    "id": "some-id",
-                  },
-                  Object {
-                    "displayText": "some other displayText",
-                    "id": "some-other-id",
-                  },
-                ],
-                "text": "WCAG-1.4.1",
-              },
-              Object {
-                "text": "wcag-2.8.2",
-              },
-            ],
-            "help": "RR-help",
-            "helpUrl": "RR-help-url",
-            "html": "RR-html",
-            "ruleId": "RR-rule-id",
-            "selector": "RR-selector<x>",
-            "snippet": "RR-snippet   space",
+          "axeResultToIssueFilingDataConverter": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "shortenSelector": undefined,
           },
         }
       }
+      issueDetailsData={Object {}}
       needsSettingsContentRenderer={[Function]}
       userConfigurationStoreData={
         Object {

--- a/src/tests/unit/tests/injected/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/injected/components/command-bar.test.tsx
@@ -47,15 +47,17 @@ describe('CommandBar', () => {
         },
     };
 
+    beforeAll(() => {
+        axeConverterMock
+            .setup(m => m.convert(ruleResult, It.isAnyString(), It.isAnyString()))
+            .returns(_ => issueData)
+            .verifiable(Times.atLeastOnce());
+    });
+
     describe('renders', () => {
         const showInspectButtonMessage = [true, false];
 
         it.each(showInspectButtonMessage)('renders, shows inspect button message: %s', show => {
-            axeConverterMock
-                .setup(m => m.convert(ruleResult, It.isAnyString(), It.isAnyString()))
-                .returns(_ => issueData)
-                .verifiable(Times.atLeastOnce());
-
             const props = {
                 ...defaultCommandBarProps,
 
@@ -89,6 +91,7 @@ describe('CommandBar', () => {
             button.simulate('click', eventStub);
 
             onClickMock.verify(onClick => onClick(eventStub), Times.once());
+            axeConverterMock.verifyAll();
         });
 
         test('for copy issue details button', () => {
@@ -106,6 +109,7 @@ describe('CommandBar', () => {
             button.prop('onClick')(eventStub);
 
             onClickMock.verify(onClick => onClick(eventStub), Times.once());
+            axeConverterMock.verifyAll();
         });
     });
 });

--- a/src/tests/unit/tests/injected/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/injected/components/command-bar.test.tsx
@@ -2,16 +2,16 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Mock, Times, It } from 'typemoq';
+import { It, Mock, Times } from 'typemoq';
 
 import { BaseButton, Button } from '../../../../../../node_modules/office-ui-fabric-react';
 import { CopyIssueDetailsButton } from '../../../../../common/components/copy-issue-details-button';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
 import { CommandBar, CommandBarDeps, CommandBarProps } from '../../../../../injected/components/command-bar';
 import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
-import { EventStubFactory } from '../../../common/event-stub-factory';
-import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 import { AxeResultToIssueFilingDataConverter } from '../../../../../issue-filing/rule-result-to-issue-filing-data';
+import { EventStubFactory } from '../../../common/event-stub-factory';
 
 describe('CommandBar', () => {
     const ruleResult = {

--- a/src/tests/unit/tests/injected/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/injected/components/command-bar.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Mock, Times } from 'typemoq';
+import { Mock, Times, It } from 'typemoq';
 
 import { BaseButton, Button } from '../../../../../../node_modules/office-ui-fabric-react';
 import { CopyIssueDetailsButton } from '../../../../../common/components/copy-issue-details-button';
@@ -10,10 +10,32 @@ import { UserConfigurationStoreData } from '../../../../../common/types/store-da
 import { CommandBar, CommandBarDeps, CommandBarProps } from '../../../../../injected/components/command-bar';
 import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
 import { EventStubFactory } from '../../../common/event-stub-factory';
+import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
+import { AxeResultToIssueFilingDataConverter } from '../../../../../issue-filing/rule-result-to-issue-filing-data';
 
 describe('CommandBar', () => {
+    const ruleResult = {
+        failureSummary: 'RR-failureSummary',
+        guidanceLinks: [
+            {
+                text: 'WCAG-1.4.1',
+                tags: [{ id: 'some-id', displayText: 'some displayText' }, { id: 'some-other-id', displayText: 'some other displayText' }],
+            },
+            { text: 'wcag-2.8.2' },
+        ],
+        help: 'RR-help',
+        html: 'RR-html',
+        ruleId: 'RR-rule-id',
+        helpUrl: 'RR-help-url',
+        selector: 'RR-selector<x>',
+        snippet: 'RR-snippet   space',
+    } as DecoratedAxeNodeResult;
+    const axeConverterMock = Mock.ofType(AxeResultToIssueFilingDataConverter);
+    const issueData = {} as CreateIssueDetailsTextData;
     const defaultCommandBarProps: CommandBarProps = {
-        deps: {} as CommandBarDeps,
+        deps: {
+            axeResultToIssueFilingDataConverter: axeConverterMock.object,
+        } as CommandBarDeps,
         onClickInspectButton: undefined,
         onClickCopyIssueDetailsButton: undefined,
         shouldShowInspectButtonMessage: () => false,
@@ -21,25 +43,7 @@ describe('CommandBar', () => {
         devToolsShortcut: 'dev-tools-shortcut',
         currentRuleIndex: 0,
         failedRules: {
-            'RR-rule-id': {
-                failureSummary: 'RR-failureSummary',
-                guidanceLinks: [
-                    {
-                        text: 'WCAG-1.4.1',
-                        tags: [
-                            { id: 'some-id', displayText: 'some displayText' },
-                            { id: 'some-other-id', displayText: 'some other displayText' },
-                        ],
-                    },
-                    { text: 'wcag-2.8.2' },
-                ],
-                help: 'RR-help',
-                html: 'RR-html',
-                ruleId: 'RR-rule-id',
-                helpUrl: 'RR-help-url',
-                selector: 'RR-selector<x>',
-                snippet: 'RR-snippet   space',
-            } as DecoratedAxeNodeResult,
+            'RR-rule-id': ruleResult,
         },
     };
 
@@ -47,14 +51,21 @@ describe('CommandBar', () => {
         const showInspectButtonMessage = [true, false];
 
         it.each(showInspectButtonMessage)('renders, shows inspect button message: %s', show => {
+            axeConverterMock
+                .setup(m => m.convert(ruleResult, It.isAnyString(), It.isAnyString()))
+                .returns(_ => issueData)
+                .verifiable(Times.atLeastOnce());
+
             const props = {
                 ...defaultCommandBarProps,
+
                 shouldShowInspectButtonMessage: () => show,
             };
 
             const wrapper = shallow(<CommandBar {...props} />);
 
             expect(wrapper.getElement()).toMatchSnapshot();
+            axeConverterMock.verifyAll();
         });
     });
 

--- a/src/tests/unit/tests/issue-filing/common/__snapshots__/issue-details-builder.test.ts.snap
+++ b/src/tests/unit/tests/issue-filing/common/__snapshots__/issue-details-builder.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Name of the group build issue details 1`] = `
 "h-Issue-h--s-h-s--s-RR-help-s (l-RR-help-url-RR-rule-id-l)
 h-Target application-h--s-h-s--l-pageUrl-pageTitle<x>-l
-h-Element path-h--s-h-s--RR-selector<x>
+h-Element-h--s-h-s--RR-selector<x>
 h-Snippet-h--s-h-s--s-RR-snippet   space-s
 h-How to fix-h--s-h-s--h-t--RR-failureSummary--h-t
 h-Environment-h--s-h-s--test spec

--- a/src/tests/unit/tests/issue-filing/common/__snapshots__/issue-details-builder.test.ts.snap
+++ b/src/tests/unit/tests/issue-filing/common/__snapshots__/issue-details-builder.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`Name of the group build issue details 1`] = `
 "h-Issue-h--s-h-s--s-RR-help-s (l-RR-help-url-RR-rule-id-l)
 h-Target application-h--s-h-s--l-pageUrl-pageTitle<x>-l
-h-Element-h--s-h-s--RR-selector<x>
+h-Element path-h--s-h-s--RR-selector<x>
 h-Snippet-h--s-h-s--s-RR-snippet   space-s
 h-How to fix-h--s-h-s--h-t--RR-failureSummary--h-t
 h-Environment-h--s-h-s--test spec

--- a/src/tests/unit/tests/issue-filing/common/create-file-issue-handler.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/create-file-issue-handler.test.ts
@@ -14,19 +14,10 @@ describe('createFileIssueHandler', () => {
     it('properly files an issue', () => {
         const serviceMap: IssueFilingServicePropertiesMap = {};
         const issueData: CreateIssueDetailsTextData = {
-            pageTitle: 'pageTitle<x>',
-            pageUrl: 'pageUrl',
-            ruleResult: {
-                failureSummary: 'RR-failureSummary',
-                guidanceLinks: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
-                help: 'RR-help',
-                html: 'RR-html',
-                ruleId: 'RR-rule-id',
-                helpUrl: 'RR-help-url',
-                selector: 'RR-selector<x>',
-                snippet: 'RR-snippet   space',
-            } as DecoratedAxeNodeResult,
-        };
+            targetApp: {
+                name: 'pageTitle<x>',
+            },
+        } as any;
         const environmentInfoStub: EnvironmentInfo = {
             axeCoreVersion: 'test axe version',
             browserSpec: 'test browser spec',

--- a/src/tests/unit/tests/issue-filing/common/create-file-issue-handler.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/create-file-issue-handler.test.ts
@@ -6,7 +6,6 @@ import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-a
 import { EnvironmentInfo } from '../../../../../common/environment-info-provider';
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 import { IssueFilingServicePropertiesMap } from '../../../../../common/types/store-data/user-configuration-store';
-import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
 import { createFileIssueHandler } from '../../../../../issue-filing/common/create-file-issue-handler';
 import { IssueFilingUrlProvider } from '../../../../../issue-filing/types/issue-filing-service';
 

--- a/src/tests/unit/tests/issue-filing/common/issue-details-builder.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-details-builder.test.ts
@@ -7,18 +7,22 @@ import { MarkupFormatter } from '../../../../../issue-filing/common/markup/marku
 
 describe('Name of the group', () => {
     const sampleIssueDetailsData = {
-        pageTitle: 'pageTitle<x>',
-        pageUrl: 'pageUrl',
-        ruleResult: {
-            failureSummary: 'RR-failureSummary',
-            guidanceLinks: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
-            help: 'RR-help',
-            html: 'RR-html',
-            ruleId: 'RR-rule-id',
-            helpUrl: 'RR-help-url',
-            selector: 'RR-selector<x>',
-            snippet: 'RR-snippet   space',
+        rule: {
+            description: 'RR-help',
+            id: 'RR-rule-id',
+            url: 'RR-help-url',
+            guidance: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
         } as any,
+        targetApp: {
+            name: 'pageTitle<x>',
+            url: 'pageUrl',
+        },
+        element: {
+            identifier: 'RR-selector<x>',
+            conciseName: 'RR-selector<x>',
+        },
+        howToFixSummary: 'RR-failureSummary',
+        snippet: 'RR-snippet   space',
     };
     const environmentInfo: EnvironmentInfo = {
         extensionVersion: '1.1.1',

--- a/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
@@ -18,20 +18,9 @@ import { IssueFilingService } from '../../../../../issue-filing/types/issue-fili
 describe('IssueFilingControllerImpl', () => {
     it('fileUssue', () => {
         const serviceKey = 'test-service';
-        const issueData: CreateIssueDetailsTextData = {
-            pageTitle: 'pageTitle<x>',
-            pageUrl: 'pageUrl',
-            ruleResult: {
-                failureSummary: 'RR-failureSummary',
-                guidanceLinks: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
-                help: 'RR-help',
-                html: 'RR-html',
-                ruleId: 'RR-rule-id',
-                helpUrl: 'RR-help-url',
-                selector: 'RR-selector<x>',
-                snippet: 'RR-snippet   space',
-            } as DecoratedAxeNodeResult,
-        };
+        const issueData = {
+            targetApp: {},
+        } as CreateIssueDetailsTextData;
         const environmentInfoStub: EnvironmentInfo = {
             axeCoreVersion: 'test axe version',
             browserSpec: 'test browser spec',

--- a/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
@@ -10,7 +10,6 @@ import {
     IssueFilingServicePropertiesMap,
     UserConfigurationStoreData,
 } from '../../../../../common/types/store-data/user-configuration-store';
-import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
 import { IssueFilingControllerImpl } from '../../../../../issue-filing/common/issue-filing-controller-impl';
 import { IssueFilingServiceProvider } from '../../../../../issue-filing/issue-filing-service-provider';
 import { IssueFilingService } from '../../../../../issue-filing/types/issue-filing-service';

--- a/src/tests/unit/tests/issue-filing/common/issue-filing-url-string-utils.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-filing-url-string-utils.test.ts
@@ -9,11 +9,11 @@ describe('IssueFilingUrlStringUtilsTest', () => {
 
     beforeEach(() => {
         sampleIssueDetailsData = {
-            pageTitle: 'pageTitle<x>',
-            pageUrl: 'pageUrl',
-            ruleResult: {
-                failureSummary: 'RR-failureSummary',
-                guidanceLinks: [
+            rule: {
+                description: 'RR-help',
+                id: 'RR-rule-id',
+                url: 'RR-help-url',
+                guidance: [
                     {
                         text: 'WCAG-1.4.1',
                         tags: [
@@ -23,13 +23,17 @@ describe('IssueFilingUrlStringUtilsTest', () => {
                     },
                     { text: 'wcag-2.8.2' },
                 ],
-                help: 'RR-help',
-                html: 'RR-html',
-                ruleId: 'RR-rule-id',
-                helpUrl: 'RR-help-url',
-                selector: 'RR-selector<x>',
-                snippet: 'RR-snippet   space',
-            } as DecoratedAxeNodeResult,
+            } as any,
+            targetApp: {
+                name: 'pageTitle<x>',
+                url: 'pageUrl',
+            },
+            element: {
+                identifier: 'RR-selector<x>',
+                conciseName: 'RR-selector<x>',
+            },
+            howToFixSummary: 'RR-failureSummary',
+            snippet: 'RR-snippet   space',
         };
     });
 
@@ -39,7 +43,7 @@ describe('IssueFilingUrlStringUtilsTest', () => {
         });
 
         test('without tags', () => {
-            sampleIssueDetailsData.ruleResult.guidanceLinks = [];
+            sampleIssueDetailsData.rule.guidance = [];
 
             expect(IssueFilingUrlStringUtils.getTitle(sampleIssueDetailsData)).toMatchSnapshot();
         });

--- a/src/tests/unit/tests/issue-filing/common/issue-filing-url-string-utils.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-filing-url-string-utils.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
-import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
 import { IssueFilingUrlStringUtils } from './../../../../../issue-filing/common/issue-filing-url-string-utils';
 
 describe('IssueFilingUrlStringUtilsTest', () => {

--- a/src/tests/unit/tests/issue-filing/rule-result-to-issue-filing-data.test.ts
+++ b/src/tests/unit/tests/issue-filing/rule-result-to-issue-filing-data.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { It, Mock } from 'typemoq';
+import { It, Mock, Times } from 'typemoq';
 import { CreateIssueDetailsTextData } from '../../../../common/types/create-issue-details-text-data';
 import { DecoratedAxeNodeResult } from '../../../../injected/scanner-utils';
 import { AxeResultToIssueFilingDataConverter } from '../../../../issue-filing/rule-result-to-issue-filing-data';
@@ -55,9 +55,13 @@ describe('AxeResultToIssueFilingDataConverter', () => {
         };
 
         const shortenSelector = Mock.ofInstance(str => '');
-        shortenSelector.setup(m => m(It.isAnyString())).returns(_ => 'short');
+        shortenSelector
+            .setup(m => m(It.isAnyString()))
+            .returns(_ => 'short')
+            .verifiable(Times.once());
         const converter = new AxeResultToIssueFilingDataConverter(shortenSelector.object);
         const textData = converter.convert(result, fakePageTitle, fakePageUrl);
         expect(textData).toEqual(expected);
+        shortenSelector.verifyAll();
     });
 });

--- a/src/tests/unit/tests/issue-filing/rule-result-to-issue-filing-data.test.ts
+++ b/src/tests/unit/tests/issue-filing/rule-result-to-issue-filing-data.test.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { It, Mock } from 'typemoq';
+import { CreateIssueDetailsTextData } from '../../../../common/types/create-issue-details-text-data';
+import { DecoratedAxeNodeResult } from '../../../../injected/scanner-utils';
+import { AxeResultToIssueFilingDataConverter } from '../../../../issue-filing/rule-result-to-issue-filing-data';
+
+describe('AxeResultToIssueFilingDataConverter', () => {
+    test('constructor', () => {
+        const shortenSelector = selector => 'short';
+        const converter = new AxeResultToIssueFilingDataConverter(shortenSelector);
+        expect(converter).not.toBeNull();
+    });
+
+    test('convert', () => {
+        const result: DecoratedAxeNodeResult = {
+            failureSummary: 'RR-failureSummary',
+            guidanceLinks: [
+                {
+                    text: 'WCAG-1.4.1',
+                    tags: [
+                        { id: 'some-id', displayText: 'some displayText' },
+                        { id: 'some-other-id', displayText: 'some other displayText' },
+                    ],
+                },
+                { text: 'wcag-2.8.2' },
+            ] as any,
+            help: 'RR-help',
+            html: 'RR-html',
+            ruleId: 'RR-rule-id',
+            helpUrl: 'RR-help-url',
+            selector: 'RR-selector<x>',
+            snippet: 'RR-snippet   space',
+        } as any;
+        const fakePageTitle = 'title';
+        const fakePageUrl = 'url';
+
+        const expected: CreateIssueDetailsTextData = {
+            rule: {
+                description: result.help,
+                id: result.ruleId,
+                url: result.helpUrl,
+                guidance: result.guidanceLinks,
+            },
+            targetApp: {
+                name: fakePageTitle,
+                url: fakePageUrl,
+            },
+            element: {
+                identifier: result.selector,
+                conciseName: 'short',
+            },
+            howToFixSummary: result.failureSummary,
+            snippet: result.snippet,
+        };
+
+        const shortenSelector = Mock.ofInstance(str => '');
+        shortenSelector.setup(m => m(It.isAnyString())).returns(_ => 'short');
+        const converter = new AxeResultToIssueFilingDataConverter(shortenSelector.object);
+        const textData = converter.convert(result, fakePageTitle, fakePageUrl);
+        expect(textData).toEqual(expected);
+    });
+});

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.test.ts
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.test.ts
@@ -4,13 +4,13 @@ import { IMock, Mock } from 'typemoq';
 
 import { title } from 'content/strings/application';
 import { EnvironmentInfo } from '../../../../../../common/environment-info-provider';
+import { CreateIssueDetailsTextData } from '../../../../../../common/types/create-issue-details-text-data';
 import { HTTPQueryBuilder } from '../../../../../../issue-filing/common/http-query-builder';
 import { IssueDetailsBuilder } from '../../../../../../issue-filing/common/issue-details-builder';
 import { IssueUrlCreationUtils } from '../../../../../../issue-filing/common/issue-filing-url-string-utils';
 import { AzureBoardsIssueFilingSettings } from '../../../../../../issue-filing/services/azure-boards/azure-boards-issue-filing-settings';
 import { createAzureBoardsIssueFilingUrlProvider } from '../../../../../../issue-filing/services/azure-boards/create-azure-boards-issue-filing-url';
 import { IssueFilingUrlProvider } from '../../../../../../issue-filing/types/issue-filing-service';
-import { CreateIssueDetailsTextData } from '../../../../../../common/types/create-issue-details-text-data';
 
 describe('createAzureBoardsIssueFilingUrl', () => {
     const testIssueDetails = 'html issue details';

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.test.ts
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.test.ts
@@ -10,13 +10,14 @@ import { IssueUrlCreationUtils } from '../../../../../../issue-filing/common/iss
 import { AzureBoardsIssueFilingSettings } from '../../../../../../issue-filing/services/azure-boards/azure-boards-issue-filing-settings';
 import { createAzureBoardsIssueFilingUrlProvider } from '../../../../../../issue-filing/services/azure-boards/create-azure-boards-issue-filing-url';
 import { IssueFilingUrlProvider } from '../../../../../../issue-filing/types/issue-filing-service';
+import { CreateIssueDetailsTextData } from '../../../../../../common/types/create-issue-details-text-data';
 
 describe('createAzureBoardsIssueFilingUrl', () => {
     const testIssueDetails = 'html issue details';
     let baseTags: string;
 
     let environmentInfo: EnvironmentInfo;
-    let sampleIssueDetailsData;
+    let sampleIssueDetailsData: CreateIssueDetailsTextData;
     let settingsData: AzureBoardsIssueFilingSettings;
     let stringUtilsMock: IMock<IssueUrlCreationUtils>;
     let issueDetailsGetterMock: IMock<IssueDetailsBuilder>;
@@ -31,25 +32,29 @@ describe('createAzureBoardsIssueFilingUrl', () => {
             browserSpec: 'test spec',
         };
         sampleIssueDetailsData = {
-            pageTitle: 'pageTitle<x>',
-            pageUrl: 'pageUrl',
-            ruleResult: {
-                failureSummary: 'RR-failureSummary',
-                guidanceLinks: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
-                help: 'RR-help',
-                html: 'RR-html',
-                ruleId: 'RR-rule-id',
-                helpUrl: 'RR-help-url',
-                selector: 'RR-selector<x>',
-                snippet: 'RR-snippet   space',
+            rule: {
+                description: 'RR-help',
+                id: 'RR-rule-id',
+                url: 'RR-help-url',
+                guidance: [{ text: 'WCAG-1.4.1' }, { text: 'wcag-2.8.2' }],
             } as any,
+            targetApp: {
+                name: 'pageTitle<x>',
+                url: 'pageUrl',
+            },
+            element: {
+                identifier: 'RR-selector<x>',
+                conciseName: 'RR-selector<x>',
+            },
+            howToFixSummary: 'RR-failureSummary',
+            snippet: 'RR-snippet   space',
         };
         settingsData = {
             projectURL: 'https://test-project-url',
             issueDetailsField: 'description',
         };
 
-        baseTags = `Accessibility; ${title}; rule: ${sampleIssueDetailsData.ruleResult.ruleId}`;
+        baseTags = `Accessibility; ${title}; rule: ${sampleIssueDetailsData.rule.id}`;
 
         stringUtilsMock = Mock.ofType<IssueUrlCreationUtils>();
         const testTitle = 'test title';


### PR DESCRIPTION
#### Description of changes

This PR follows up from #1351 . The current issue filing implementation assumes the issue-details type contains axe-core result data. This needs to change if we want to reuse the plumbing for the upcoming platform-agnostic data.
- `CreateIssueDetailsTextData` only holds the fields issue filing needs to create a bug, no more or less
- Each consumer of issue filing will convert their data-type (axe-core data or unified-data) to `CreateIssueDetailsTextData` (the cards UI will soon need to do this with unified-data)


#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS

