### PR TITLE
Add strongly typed properties in Unified Result

### DIFF
--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -60,13 +60,26 @@ export interface InstancePropertyBag {
 
 export type StoredInstancePropertyBag = InstancePropertyBag;
 
+export type UnifiedIdentifiers = {
+    identifier?: string;
+    conciseName?: string;
+} & InstancePropertyBag;
+
+export type UnifiedDescriptors = {
+    snippet?: string;
+} & InstancePropertyBag;
+
+export type UnifiedResolution = {
+    howToFixSummary?: string;
+} & InstancePropertyBag;
+
 export interface UnifiedResult {
     uid: string;
     status: InstanceResultStatus;
     ruleId: string;
-    identifiers: StoredInstancePropertyBag;
-    descriptors: StoredInstancePropertyBag;
-    resolution: StoredInstancePropertyBag;
+    identifiers: UnifiedIdentifiers;
+    descriptors: UnifiedDescriptors;
+    resolution: UnifiedResolution;
 }
 
 export type InstanceResultStatus = 'pass' | 'fail' | 'unknown';

--- a/src/injected/adapters/scan-results-to-unified-results.ts
+++ b/src/injected/adapters/scan-results-to-unified-results.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { flatMap } from 'lodash';
+
 import { InstanceResultStatus, UnifiedResult } from '../../common/types/store-data/unified-data-interface';
 import { UUIDGeneratorType } from '../../common/uid-generator';
 import { AxeNodeResult, RuleResult, ScanResults } from '../../scanner/iruleresults';
+import { IssueFilingUrlStringUtils } from './../../issue-filing/common/issue-filing-url-string-utils';
 
 export type ConvertScanResultsToUnifiedResultsDelegate = (scanResults: ScanResults, uuidGenerator: UUIDGeneratorType) => UnifiedResult[];
 
@@ -14,6 +16,7 @@ interface RuleResultData {
 
 interface CreationData extends RuleResultData {
     cssSelector: string;
+    failureSummary: string;
     snippet: string;
     howToFix: {
         oneOf: string[];
@@ -78,6 +81,7 @@ const createUnifiedResultFromNode = (
                 none: nodeResult.none.map(checkResult => checkResult.message),
                 all: nodeResult.all.map(checkResult => checkResult.message),
             },
+            failureSummary: nodeResult.failureSummary,
         },
         uuidGenerator,
     );
@@ -89,12 +93,15 @@ const createUnifiedResult = (data: CreationData, uuidGenerator: UUIDGeneratorTyp
         status: data.status,
         ruleId: data.ruleID,
         identifiers: {
+            identifier: data.cssSelector,
+            conciseName: IssueFilingUrlStringUtils.getSelectorLastPart(data.cssSelector),
             'css-selector': data.cssSelector,
         },
         descriptors: {
             snippet: data.snippet,
         },
         resolution: {
+            howToFixSummary: data.failureSummary,
             'how-to-fix-web': {
                 any: data.howToFix.oneOf,
                 none: data.howToFix.none,

--- a/src/issue-filing/unified-result-to-issue-filing-data.ts
+++ b/src/issue-filing/unified-result-to-issue-filing-data.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TargetAppData, UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
+
+import { CreateIssueDetailsTextData } from '../common/types/create-issue-details-text-data';
+
+export class UnifiedResultToIssueFilingDataConverter {
+    public convert(result: UnifiedResult, rule: UnifiedRule, targetApp: TargetAppData): CreateIssueDetailsTextData {
+        return {
+            rule: {
+                description: rule.description,
+                id: rule.id,
+                url: rule.url,
+                guidance: rule.guidance,
+            },
+            targetApp: {
+                name: targetApp.name,
+                url: targetApp.url,
+            },
+            element: {
+                identifier: result.identifiers.identifier,
+                conciseName: result.identifiers.conciseName,
+            },
+            howToFixSummary: result.resolution.howToFixSummary,
+            snippet: result.descriptors.snippet,
+        };
+    }
+}

--- a/src/tests/unit/tests/injected/adapters/__snapshots__/scan-results-to-unified-results.test.ts.snap
+++ b/src/tests/unit/tests/injected/adapters/__snapshots__/scan-results-to-unified-results.test.ts.snap
@@ -9,7 +9,9 @@ Array [
       "snippet": "html1",
     },
     "identifiers": Object {
+      "conciseName": "id1",
       "css-selector": "target1;id1",
+      "identifier": "target1;id1",
     },
     "resolution": Object {
       "how-to-fix-web": Object {
@@ -19,6 +21,7 @@ Array [
         ],
         "none": Array [],
       },
+      "howToFixSummary": "how to fix 1",
     },
     "ruleId": "id1",
     "status": "fail",
@@ -29,7 +32,9 @@ Array [
       "snippet": "html2",
     },
     "identifiers": Object {
+      "conciseName": "id2",
       "css-selector": "target2;id2",
+      "identifier": "target2;id2",
     },
     "resolution": Object {
       "how-to-fix-web": Object {
@@ -39,6 +44,7 @@ Array [
           "none-test-message",
         ],
       },
+      "howToFixSummary": "how to fix 2",
     },
     "ruleId": "id1",
     "status": "fail",
@@ -49,7 +55,9 @@ Array [
       "snippet": "html3",
     },
     "identifiers": Object {
+      "conciseName": "id3",
       "css-selector": "target3;id3",
+      "identifier": "target3;id3",
     },
     "resolution": Object {
       "how-to-fix-web": Object {
@@ -59,6 +67,7 @@ Array [
         "any": Array [],
         "none": Array [],
       },
+      "howToFixSummary": "how to fix 3",
     },
     "ruleId": "id2",
     "status": "fail",
@@ -69,7 +78,9 @@ Array [
       "snippet": "html-pass",
     },
     "identifiers": Object {
+      "conciseName": "passTarget2",
       "css-selector": "passTarget1;passTarget2",
+      "identifier": "passTarget1;passTarget2",
     },
     "resolution": Object {
       "how-to-fix-web": Object {
@@ -77,6 +88,7 @@ Array [
         "any": Array [],
         "none": Array [],
       },
+      "howToFixSummary": undefined,
     },
     "ruleId": "test",
     "status": "pass",

--- a/src/tests/unit/tests/injected/adapters/scan-results-to-unified-results.test.ts
+++ b/src/tests/unit/tests/injected/adapters/scan-results-to-unified-results.test.ts
@@ -56,6 +56,7 @@ describe('ScanResults to Unified Results Test', () => {
         instanceId: 'id1',
         html: 'html1',
         target: ['target1', 'id1'],
+        failureSummary: 'how to fix 1',
     };
 
     const node2: AxeNodeResult = {
@@ -71,6 +72,7 @@ describe('ScanResults to Unified Results Test', () => {
         instanceId: 'id2',
         snippet: 'html2',
         target: ['target2', 'id2'],
+        failureSummary: 'how to fix 2',
     } as AxeNodeResult;
 
     const node3: AxeNodeResult = {
@@ -86,6 +88,7 @@ describe('ScanResults to Unified Results Test', () => {
         instanceId: 'id3',
         html: 'html3',
         target: ['target3', 'id3'],
+        failureSummary: 'how to fix 3',
     };
 
     const passingNode: AxeNodeResult = {

--- a/src/tests/unit/tests/issue-filing/unified-result-to-issue-filing-data.test.ts
+++ b/src/tests/unit/tests/issue-filing/unified-result-to-issue-filing-data.test.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UnifiedResult, TargetAppData, UnifiedRule } from 'common/types/store-data/unified-data-interface';
-import { It, Mock, Times } from 'typemoq';
+import { TargetAppData, UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
 
 import { CreateIssueDetailsTextData } from '../../../../common/types/create-issue-details-text-data';
 import { UnifiedResultToIssueFilingDataConverter } from '../../../../issue-filing/unified-result-to-issue-filing-data';

--- a/src/tests/unit/tests/issue-filing/unified-result-to-issue-filing-data.test.ts
+++ b/src/tests/unit/tests/issue-filing/unified-result-to-issue-filing-data.test.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UnifiedResult, TargetAppData, UnifiedRule } from 'common/types/store-data/unified-data-interface';
+import { It, Mock, Times } from 'typemoq';
+
+import { CreateIssueDetailsTextData } from '../../../../common/types/create-issue-details-text-data';
+import { UnifiedResultToIssueFilingDataConverter } from '../../../../issue-filing/unified-result-to-issue-filing-data';
+
+describe(UnifiedResultToIssueFilingDataConverter, () => {
+    test('constructor', () => {
+        const converter = new UnifiedResultToIssueFilingDataConverter();
+        expect(converter).not.toBeNull();
+    });
+
+    test('convert', () => {
+        const result: UnifiedResult = {
+            uid: 'abcd-1234-KYHF',
+            status: 'pass',
+            ruleId: 'rule-id',
+            identifiers: {
+                identifier: 'selector',
+                conciseName: 'selector last part',
+                'css-selector': 'selector',
+            },
+            descriptors: {
+                snippet: 'snippet',
+            },
+            resolution: {
+                howToFixSummary: 'failureSummary',
+                'how-to-fix-web': {
+                    any: [],
+                    none: [],
+                    all: [],
+                },
+            },
+        } as UnifiedResult;
+        const targetApp: TargetAppData = {
+            name: 'app name',
+            url: 'app url',
+        };
+        const rule: UnifiedRule = {
+            description: 'desc',
+            id: 'rule-id',
+            url: 'url',
+            guidance: [],
+        };
+        const expected: CreateIssueDetailsTextData = {
+            rule,
+            targetApp,
+            element: {
+                identifier: 'selector',
+                conciseName: 'selector last part',
+            },
+            howToFixSummary: 'failureSummary',
+            snippet: 'snippet',
+        };
+
+        const converter = new UnifiedResultToIssueFilingDataConverter();
+        const textData = converter.convert(result, rule, targetApp);
+        expect(textData).toEqual(expected);
+    });
+});


### PR DESCRIPTION
#### Description of changes

- Modified ``UnifiedResult`` data type to have strongly typed properties, currently they are optional since we need to change the data converter in Android as well. Eventually they will all be required properties.
- Add converter to convert unified data to issue filing text create data.
- Add unit tests.
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
