### PR TITLE
exclude webdriverio v5 from dependabot updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -17,3 +17,12 @@ update_configs:
           # dependabot auto-update them like other deps.
           dependency_name: "office-ui-fabric-react"
           version_requirement: ">=7.0.0"
+      - match:
+          # We use webdriverio only indirectly via spectron; our direct
+          # dependency on the package is only for the sake of typings, so
+          # we stick to the major version of webdriverio used by spectron.
+          #
+          # The spectron issue tracking their update to v5 is
+          # https://github.com/electron-userland/spectron/issues/349
+          dependency_name: "webdriverio"
+          version_requirement: ">=5.0.0"


### PR DESCRIPTION
#### Description of changes

We only use the webdriverio package for the sake of getting typings to use with Spectron, so we want to keep its major version pinned to the major version spectron uses (v4) until spectron updates (see https://github.com/electron-userland/spectron/issues/349 )

Verified that the updated file passes the [dependabot config file validator](https://dependabot.com/docs/config-file/validator/).

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
