### PR TITLE
chore: update typescript sdk path in vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -36,5 +36,5 @@
     "prettier.requireConfig": true,
     "editor.formatOnSave": true,
     "editor.rulers": [140],
-    "typescript.tsdk": "node_modules\\typescript\\lib"
+    "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
#### Description of changes

Update typescript sdk path in vscode settings because the way its currently mentioned; it doesn't find that path on MacOS.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
