### PR TITLE
Bug fix: handle when property config for a prop does not exist

### DIFF
--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -6,6 +6,7 @@ import { StoredInstancePropertyBag, UnifiedResult } from 'common/types/store-dat
 import { forOwn, isEmpty } from 'lodash';
 import * as React from 'react';
 import { reportInstanceTable } from 'reports/components/instance-details.scss';
+
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { HighlightState, InstanceDetailsFooter, InstanceDetailsFooterDeps } from './instance-details-footer';
 
@@ -32,12 +33,11 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
         const cardRows = [];
         forOwn(propertyBag, (propertyData, propertyName) => {
             const propertyConfig = deps.getPropertyConfigById(propertyName);
-            if (isEmpty(propertyConfig)) {
-                return;
+            if (!isEmpty(propertyConfig)) {
+                const CardRow = propertyConfig.cardRow;
+                ++propertyIndex;
+                cardRows.push(<CardRow deps={deps} propertyData={propertyData} index={index} key={`${propertyName}-${propertyIndex}`} />);
             }
-            const CardRow = propertyConfig.cardRow;
-            ++propertyIndex;
-            cardRows.push(<CardRow deps={deps} propertyData={propertyData} index={index} key={`${propertyName}-${propertyIndex}`} />);
         });
         return <>{cardRows}</>;
     };

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -3,7 +3,7 @@
 import { CardRowDeps, PropertyConfiguration } from 'common/configs/unified-result-property-configurations';
 import { NamedFC } from 'common/react/named-fc';
 import { StoredInstancePropertyBag, UnifiedResult } from 'common/types/store-data/unified-data-interface';
-import { forOwn } from 'lodash';
+import { forOwn, isEmpty } from 'lodash';
 import * as React from 'react';
 import { reportInstanceTable } from 'reports/components/instance-details.scss';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
@@ -31,7 +31,11 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
         let propertyIndex = 0;
         const cardRows = [];
         forOwn(propertyBag, (propertyData, propertyName) => {
-            const CardRow = deps.getPropertyConfigById(propertyName).cardRow;
+            const propertyConfig = deps.getPropertyConfigById(propertyName);
+            if (isEmpty(propertyConfig)) {
+                return;
+            }
+            const CardRow = propertyConfig.cardRow;
             ++propertyIndex;
             cardRows.push(<CardRow deps={deps} propertyData={propertyData} index={index} key={`${propertyName}-${propertyIndex}`} />);
         });

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -85,3 +85,37 @@ exports[`InstanceDetails renders 1`] = `
   />
 </React.Fragment>
 `;
+
+exports[`InstanceDetails renders nothing when there is no card row config for the property / no property 1`] = `
+<React.Fragment>
+  <table
+    className="reportInstanceTable"
+  >
+    <tbody>
+      <React.Fragment />
+      <React.Fragment />
+      <React.Fragment />
+    </tbody>
+  </table>
+  <InstanceDetailsFooter
+    deps={
+      Object {
+        "getPropertyConfigById": [Function],
+      }
+    }
+    highlightState="unavailable"
+    result={
+      Object {
+        "descriptors": Object {},
+        "identifiers": Object {
+          "this-property-does-not-have-config": "some value",
+        },
+        "resolution": Object {},
+        "ruleId": "image-alt",
+        "status": "fail",
+        "uid": "some-guid-here",
+      }
+    }
+  />
+</React.Fragment>
+`;

--- a/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
@@ -50,4 +50,19 @@ describe('InstanceDetails', () => {
     function getCardRowStub(name: string): ReactFCWithDisplayName<CardRowProps> {
         return NamedFC<CardRowProps>(name, _ => null);
     }
+
+    it('renders nothing when there is no card row config for the property / no property', () => {
+        props.result.identifiers = { 'this-property-does-not-have-config': 'some value' };
+        props.result.descriptors = {};
+        props.result.resolution = {};
+        AllPropertyTypes.forEach(propertyType => {
+            const propertyConfigurationStub: PropertyConfiguration = {
+                cardRow: getCardRowStub(propertyType),
+            };
+            getPropertyConfigByIdMock.setup(mock => mock(propertyType)).returns(() => propertyConfigurationStub);
+        });
+
+        const testSubject = shallow(<InstanceDetails {...props} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Description of changes

Bug fix: handle when property config for a prop does not exist

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
