### PR TITLE
Root container renderer

### DIFF
--- a/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
@@ -6,6 +6,7 @@ import { brand } from 'content/strings/application';
 import { BrandBlue } from 'icons/brand/blue/brand-blue';
 import * as React from 'react';
 
+import { NamedFC } from 'common/react/named-fc';
 import { DeviceStoreData } from '../../../flux/types/device-store-data';
 import { DeviceConnectBody, DeviceConnectBodyDeps } from './device-connect-body';
 import { WindowTitle } from './window-title';
@@ -18,22 +19,20 @@ export type DeviceConnectViewContainerProps = {
     deviceStoreData: DeviceStoreData;
 };
 
-export class DeviceConnectViewContainer extends React.Component<DeviceConnectViewContainerProps> {
-    public render(): JSX.Element {
-        return (
-            <>
-                <WindowTitle title={brand}>
-                    <BrandBlue />
-                </WindowTitle>
-                <DeviceConnectBody
-                    deps={this.props.deps}
-                    viewState={{
-                        deviceConnectState: this.props.deviceStoreData.deviceConnectState,
-                        connectedDevice: this.props.deviceStoreData.connectedDevice,
-                    }}
-                />
-                <TelemetryPermissionDialog deps={this.props.deps} isFirstTime={this.props.userConfigurationStoreData.isFirstTime} />
-            </>
-        );
-    }
-}
+export const DeviceConnectViewContainer = NamedFC<DeviceConnectViewContainerProps>('DeviceConnectViewContainer', props => {
+    return (
+        <>
+            <WindowTitle title={brand}>
+                <BrandBlue />
+            </WindowTitle>
+            <DeviceConnectBody
+                deps={props.deps}
+                viewState={{
+                    deviceConnectState: props.deviceStoreData.deviceConnectState,
+                    connectedDevice: props.deviceStoreData.connectedDevice,
+                }}
+            />
+            <TelemetryPermissionDialog deps={props.deps} isFirstTime={props.userConfigurationStoreData.isFirstTime} />
+        </>
+    );
+});

--- a/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TelemetryPermissionDialog, TelemetryPermissionDialogDeps } from 'common/components/telemetry-permission-dialog';
-import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { brand } from 'content/strings/application';
 import { BrandBlue } from 'icons/brand/blue/brand-blue';

--- a/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
@@ -11,26 +11,15 @@ import { DeviceStoreData } from '../../../flux/types/device-store-data';
 import { DeviceConnectBody, DeviceConnectBodyDeps } from './device-connect-body';
 import { WindowTitle } from './window-title';
 
-export type DeviceConnectViewContainerDeps = TelemetryPermissionDialogDeps &
-    DeviceConnectBodyDeps & {
-        storeHub: ClientStoresHub<DeviceConnectViewContainerState>;
-    };
+export type DeviceConnectViewContainerDeps = TelemetryPermissionDialogDeps & DeviceConnectBodyDeps;
 
 export type DeviceConnectViewContainerProps = {
     deps: DeviceConnectViewContainerDeps;
-};
-
-export type DeviceConnectViewContainerState = {
     userConfigurationStoreData: UserConfigurationStoreData;
     deviceStoreData: DeviceStoreData;
 };
 
-export class DeviceConnectViewContainer extends React.Component<DeviceConnectViewContainerProps, DeviceConnectViewContainerState> {
-    constructor(props: DeviceConnectViewContainerProps) {
-        super(props);
-        this.state = props.deps.storeHub.getAllStoreData();
-    }
-
+export class DeviceConnectViewContainer extends React.Component<DeviceConnectViewContainerProps> {
     public render(): JSX.Element {
         return (
             <>
@@ -40,20 +29,12 @@ export class DeviceConnectViewContainer extends React.Component<DeviceConnectVie
                 <DeviceConnectBody
                     deps={this.props.deps}
                     viewState={{
-                        deviceConnectState: this.state.deviceStoreData.deviceConnectState,
-                        connectedDevice: this.state.deviceStoreData.connectedDevice,
+                        deviceConnectState: this.props.deviceStoreData.deviceConnectState,
+                        connectedDevice: this.props.deviceStoreData.connectedDevice,
                     }}
                 />
-                <TelemetryPermissionDialog deps={this.props.deps} isFirstTime={this.state.userConfigurationStoreData.isFirstTime} />
+                <TelemetryPermissionDialog deps={this.props.deps} isFirstTime={this.props.userConfigurationStoreData.isFirstTime} />
             </>
         );
     }
-
-    public componentDidMount(): void {
-        this.props.deps.storeHub.addChangedListenerToAllStores(this.onStoresChange);
-    }
-
-    private onStoresChange = () => {
-        this.setState(() => this.props.deps.storeHub.getAllStoreData());
-    };
 }

--- a/src/electron/views/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/views/device-connect-view/device-connect-view-initializer.ts
@@ -4,6 +4,7 @@ import { AppInsights } from 'applicationinsights-js';
 import axios from 'axios';
 import { remote } from 'electron';
 import { createFetchScanResults } from 'electron/platform/android/fetch-scan-results';
+import { RootContainerState } from 'electron/views/root-container/components/root-container';
 import * as ReactDOM from 'react-dom';
 import { UserConfigurationActions } from '../../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../../background/get-persisted-data';
@@ -26,9 +27,8 @@ import { RiggedFeatureFlagChecker } from '../../common/rigged-feature-flag-check
 import { DeviceConnectActionCreator } from '../../flux/action-creator/device-connect-action-creator';
 import { DeviceActions } from '../../flux/action/device-actions';
 import { DeviceStore } from '../../flux/store/device-store';
-import { DeviceConnectViewContainerState } from './components/device-connect-view-container';
 import { ElectronLink } from './components/electron-link';
-import { DeviceConnectViewRenderer } from './device-connect-view-renderer';
+import { RootContainerRenderer } from './device-connect-view-renderer';
 import { sendAppInitializedTelemetryEvent } from './send-app-initialized-telemetry';
 
 initializeFabricIcons();
@@ -64,7 +64,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
     const deviceStore = new DeviceStore(deviceActions);
     deviceStore.initialize();
 
-    const storeHub = new BaseClientStoresHub<DeviceConnectViewContainerState>([userConfigurationStore, deviceStore]);
+    const storeHub = new BaseClientStoresHub<RootContainerState>([userConfigurationStore, deviceStore]);
 
     const telemetryStateListener = new TelemetryStateListener(userConfigurationStore, telemetryEventHandler);
     telemetryStateListener.initialize();
@@ -88,7 +88,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
         },
     };
 
-    const renderer = new DeviceConnectViewRenderer(ReactDOM.render, document, props);
+    const renderer = new RootContainerRenderer(ReactDOM.render, document, props);
     renderer.render();
 
     sendAppInitializedTelemetryEvent(telemetryEventHandler);

--- a/src/electron/views/device-connect-view/device-connect-view-initializer.ts
+++ b/src/electron/views/device-connect-view/device-connect-view-initializer.ts
@@ -3,6 +3,8 @@
 import { AppInsights } from 'applicationinsights-js';
 import axios from 'axios';
 import { remote } from 'electron';
+import { WindowStateActions } from 'electron/flux/action/window-state-actions';
+import { WindowStateStore } from 'electron/flux/store/window-state-store';
 import { createFetchScanResults } from 'electron/platform/android/fetch-scan-results';
 import { RootContainerState } from 'electron/views/root-container/components/root-container';
 import * as ReactDOM from 'react-dom';
@@ -36,6 +38,7 @@ initializeFabricIcons();
 const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(getIndexedDBStore());
 const userConfigActions = new UserConfigurationActions();
 const deviceActions = new DeviceActions();
+const windowStateActions = new WindowStateActions();
 const storageAdapter = new ElectronStorageAdapter(indexedDBInstance);
 const appDataAdapter = new ElectronAppDataAdapter();
 
@@ -64,7 +67,10 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
     const deviceStore = new DeviceStore(deviceActions);
     deviceStore.initialize();
 
-    const storeHub = new BaseClientStoresHub<RootContainerState>([userConfigurationStore, deviceStore]);
+    const windowStateStore = new WindowStateStore(windowStateActions);
+    windowStateStore.initialize();
+
+    const storeHub = new BaseClientStoresHub<RootContainerState>([userConfigurationStore, deviceStore, windowStateStore]);
 
     const telemetryStateListener = new TelemetryStateListener(userConfigurationStore, telemetryEventHandler);
     telemetryStateListener.initialize();

--- a/src/electron/views/device-connect-view/device-connect-view-renderer.tsx
+++ b/src/electron/views/device-connect-view/device-connect-view-renderer.tsx
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { RootContainer, RootContainerProps } from 'electron/views/root-container/components/root-container';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { DeviceConnectViewContainer, DeviceConnectViewContainerProps } from './components/device-connect-view-container';
 
-export class DeviceConnectViewRenderer {
+export class RootContainerRenderer {
     constructor(
         private readonly renderer: typeof ReactDOM.render,
         private readonly dom: ParentNode,
-        private readonly props: DeviceConnectViewContainerProps,
+        private readonly props: RootContainerProps,
     ) {}
 
     public render(): void {
         const deviceConnectViewContainer = this.dom.querySelector('#device-connect-view-container');
-        this.renderer(<DeviceConnectViewContainer {...this.props} />, deviceConnectViewContainer);
+        this.renderer(<RootContainer {...this.props} />, deviceConnectViewContainer);
     }
 }

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { AutomatedChecksView } from 'electron/views/automated-checks/components/automated-checks-view';
 import {
     DeviceConnectViewContainer,
     DeviceConnectViewContainerDeps,
-    DeviceConnectViewContainerProps,
 } from 'electron/views/device-connect-view/components/device-connect-view-container';
 import * as React from 'react';
 
@@ -14,12 +15,14 @@ export type RootContainerDeps = DeviceConnectViewContainerDeps & {
     storeHub: ClientStoresHub<RootContainerState>;
 };
 
-export type RootContainerProps = DeviceConnectViewContainerProps & {
+export type RootContainerProps = {
     deps: RootContainerDeps;
 };
 
 export type RootContainerState = {
     windowStateStoreData: WindowStateStoreData;
+    userConfigurationStoreData: UserConfigurationStoreData;
+    deviceStoreData: DeviceStoreData;
 };
 
 export class RootContainer extends React.Component<RootContainerProps, RootContainerState> {
@@ -33,7 +36,15 @@ export class RootContainer extends React.Component<RootContainerProps, RootConta
         if (this.state.windowStateStoreData.routeId === 'resultsView') {
             return <AutomatedChecksView {...this.props}></AutomatedChecksView>;
         }
-        return <DeviceConnectViewContainer {...this.props}></DeviceConnectViewContainer>;
+        return (
+            <DeviceConnectViewContainer
+                {...{
+                    userConfigurationStoreData: this.state.userConfigurationStoreData,
+                    deviceStoreData: this.state.deviceStoreData,
+                    ...this.props,
+                }}
+            ></DeviceConnectViewContainer>
+        );
     }
 
     public componentDidMount(): void {

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -29,7 +29,7 @@ export class RootContainer extends React.Component<RootContainerProps, RootConta
     constructor(props: RootContainerProps) {
         super(props);
 
-        this.state = (props.deps.storeHub as ClientStoresHub<RootContainerState>).getAllStoreData();
+        this.state = props.deps.storeHub.getAllStoreData();
     }
 
     public render(): JSX.Element {

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
@@ -1,29 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DeviceConnectViewContainer listens to store changes through the stores hub: state from constructor 1`] = `
-Object {
-  "deviceStoreData": Object {
-    "deviceConnectState": 0,
-  },
-  "userConfigurationStoreData": Object {
-    "enableTelemetry": false,
-    "isFirstTime": true,
-  },
-}
-`;
-
-exports[`DeviceConnectViewContainer listens to store changes through the stores hub: updated state 1`] = `
-Object {
-  "deviceStoreData": Object {
-    "deviceConnectState": 0,
-  },
-  "userConfigurationStoreData": Object {
-    "enableTelemetry": true,
-    "isFirstTime": false,
-  },
-}
-`;
-
 exports[`DeviceConnectViewContainer renders 1`] = `
 <React.Fragment>
   <WindowTitle
@@ -36,10 +12,6 @@ exports[`DeviceConnectViewContainer renders 1`] = `
       Object {
         "currentWindow": Object {
           "close": [Function],
-        },
-        "storeHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
         },
       }
     }
@@ -55,10 +27,6 @@ exports[`DeviceConnectViewContainer renders 1`] = `
       Object {
         "currentWindow": Object {
           "close": [Function],
-        },
-        "storeHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
         },
       }
     }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-view-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-view-container.test.tsx
@@ -1,19 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
-import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { BrowserWindow } from 'electron';
 import { DeviceConnectState } from 'electron/views/device-connect-view/components/device-connect-state';
 import {
     DeviceConnectViewContainer,
     DeviceConnectViewContainerDeps,
     DeviceConnectViewContainerProps,
-    DeviceConnectViewContainerState,
 } from 'electron/views/device-connect-view/components/device-connect-view-container';
 import { shallow } from 'enzyme';
-import { isFunction } from 'lodash';
 import * as React from 'react';
-import { It, Mock } from 'typemoq';
 
 describe('DeviceConnectViewContainer', () => {
     const currentWindowStub = {
@@ -23,79 +18,22 @@ describe('DeviceConnectViewContainer', () => {
     } as BrowserWindow;
 
     it('renders', () => {
-        const storeHubMock = Mock.ofType<ClientStoresHub<DeviceConnectViewContainerState>>(BaseClientStoresHub);
-        storeHubMock
-            .setup(hub => hub.getAllStoreData())
-            .returns(() => {
-                return {
-                    userConfigurationStoreData: {
-                        isFirstTime: true,
-                    },
-                    deviceStoreData: {
-                        deviceConnectState: DeviceConnectState.Default,
-                    },
-                } as DeviceConnectViewContainerState;
-            });
-
         const deps: DeviceConnectViewContainerDeps = {
             currentWindow: currentWindowStub,
-            storeHub: storeHubMock.object,
         } as DeviceConnectViewContainerDeps;
 
-        const props: DeviceConnectViewContainerProps = { deps };
+        const props: DeviceConnectViewContainerProps = {
+            deps,
+            userConfigurationStoreData: {
+                isFirstTime: true,
+            },
+            deviceStoreData: {
+                deviceConnectState: DeviceConnectState.Default,
+            },
+        } as DeviceConnectViewContainerProps;
 
         const wrapped = shallow(<DeviceConnectViewContainer {...props} />);
 
         expect(wrapped.getElement()).toMatchSnapshot();
-    });
-
-    it('listens to store changes through the stores hub', () => {
-        const storeHubMock = Mock.ofType<ClientStoresHub<DeviceConnectViewContainerState>>(BaseClientStoresHub);
-
-        storeHubMock
-            .setup(hub => hub.getAllStoreData())
-            .returns(() => {
-                return {
-                    userConfigurationStoreData: {
-                        isFirstTime: true,
-                        enableTelemetry: false,
-                    },
-                    deviceStoreData: {
-                        deviceConnectState: DeviceConnectState.Default,
-                    },
-                } as DeviceConnectViewContainerState;
-            });
-
-        storeHubMock
-            .setup(hub => hub.getAllStoreData())
-            .returns(() => {
-                return {
-                    userConfigurationStoreData: {
-                        isFirstTime: false,
-                        enableTelemetry: true,
-                    },
-                    deviceStoreData: {
-                        deviceConnectState: DeviceConnectState.Default,
-                    },
-                } as DeviceConnectViewContainerState;
-            });
-
-        let storeListener: Function;
-
-        storeHubMock.setup(hub => hub.addChangedListenerToAllStores(It.is(isFunction))).callback(listener => (storeListener = listener));
-
-        const deps: DeviceConnectViewContainerDeps = {
-            storeHub: storeHubMock.object,
-        } as DeviceConnectViewContainerDeps;
-
-        const props: DeviceConnectViewContainerProps = { deps };
-
-        const wrapped = shallow(<DeviceConnectViewContainer {...props} />);
-
-        expect(wrapped.instance().state).toMatchSnapshot('state from constructor');
-
-        storeListener();
-
-        expect(wrapped.instance().state).toMatchSnapshot('updated state');
     });
 });

--- a/src/tests/unit/tests/electron/views/device-connect-view/device-connect-view-renderer.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/device-connect-view-renderer.test.tsx
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserWindow } from 'electron';
-import {
-    DeviceConnectViewContainer,
-    DeviceConnectViewContainerProps,
-} from 'electron/views/device-connect-view/components/device-connect-view-container';
-import { DeviceConnectViewRenderer } from 'electron/views/device-connect-view/device-connect-view-renderer';
+import { RootContainerRenderer } from 'electron/views/device-connect-view/device-connect-view-renderer';
+import { RootContainer, RootContainerProps } from 'electron/views/root-container/components/root-container';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { IMock, It, Mock } from 'typemoq';
@@ -29,13 +26,13 @@ describe('DeviceConnectViewRendererTest', () => {
             deps: {
                 currentWindow: browserWindow,
             },
-        } as DeviceConnectViewContainerProps;
+        } as RootContainerProps;
 
-        const expectedComponent = <DeviceConnectViewContainer {...props} />;
+        const expectedComponent = <RootContainer {...props} />;
 
         renderMock.setup(r => r(It.isValue(expectedComponent), containerDiv)).verifiable();
 
-        const renderer = new DeviceConnectViewRenderer(renderMock.object, dom, props);
+        const renderer = new RootContainerRenderer(renderMock.object, dom, props);
 
         renderer.render();
 

--- a/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
@@ -10,6 +10,16 @@ exports[`RootContainer renders device connect view container when route is devic
       },
     }
   }
+  deviceStoreData={
+    Object {
+      "deviceConnectState": 2,
+    }
+  }
+  userConfigurationStoreData={
+    Object {
+      "isFirstTime": true,
+    }
+  }
 />
 `;
 
@@ -28,6 +38,12 @@ exports[`RootContainer renders results view container when route is resultsView 
 
 exports[`RootContainer store listening uses the store to update the state: initial state 1`] = `
 Object {
+  "deviceStoreData": Object {
+    "deviceConnectState": 2,
+  },
+  "userConfigurationStoreData": Object {
+    "isFirstTime": true,
+  },
   "windowStateStoreData": Object {
     "routeId": "deviceConnectView",
   },
@@ -36,6 +52,12 @@ Object {
 
 exports[`RootContainer store listening uses the store to update the state: updated state 1`] = `
 Object {
+  "deviceStoreData": Object {
+    "deviceConnectState": 2,
+  },
+  "userConfigurationStoreData": Object {
+    "isFirstTime": true,
+  },
   "windowStateStoreData": Object {
     "routeId": "resultsView",
   },

--- a/src/tests/unit/tests/electron/views/root-container/components/root-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/components/root-container.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
+import { DeviceConnectState } from 'electron/views/device-connect-view/components/device-connect-state';
 import {
     RootContainer,
     RootContainerDeps,
@@ -16,11 +17,15 @@ import { IMock, It, Mock } from 'typemoq';
 describe(RootContainer, () => {
     let deps: RootContainerDeps;
     let storeHubMock: IMock<ClientStoresHub<RootContainerState>>;
+    let props: RootContainerProps;
 
     beforeEach(() => {
         storeHubMock = Mock.ofType<ClientStoresHub<RootContainerState>>(BaseClientStoresHub);
 
         deps = { storeHub: storeHubMock.object } as RootContainerDeps;
+        props = {
+            deps,
+        } as RootContainerProps;
     });
 
     describe('renders', () => {
@@ -28,10 +33,13 @@ describe(RootContainer, () => {
             storeHubMock
                 .setup(hub => hub.getAllStoreData())
                 .returns(() => {
-                    return { windowStateStoreData: { routeId: 'deviceConnectView' } };
+                    return {
+                        windowStateStoreData: { routeId: 'deviceConnectView' },
+                        userConfigurationStoreData: { isFirstTime: true },
+                        deviceStoreData: { deviceConnectState: DeviceConnectState.Connected },
+                    } as RootContainerState;
                 });
 
-            const props: RootContainerProps = { deps };
             const wrapped = shallow(<RootContainer {...props} />);
 
             expect(wrapped.getElement()).toMatchSnapshot();
@@ -41,10 +49,13 @@ describe(RootContainer, () => {
             storeHubMock
                 .setup(hub => hub.getAllStoreData())
                 .returns(() => {
-                    return { windowStateStoreData: { routeId: 'resultsView' } };
+                    return {
+                        windowStateStoreData: { routeId: 'resultsView' },
+                        userConfigurationStoreData: { isFirstTime: true },
+                        deviceStoreData: { deviceConnectState: DeviceConnectState.Connected },
+                    } as RootContainerState;
                 });
 
-            const props: RootContainerProps = { deps };
             const wrapped = shallow(<RootContainer {...props} />);
 
             expect(wrapped.getElement()).toMatchSnapshot();
@@ -56,12 +67,20 @@ describe(RootContainer, () => {
             storeHubMock
                 .setup(hub => hub.getAllStoreData())
                 .returns(() => {
-                    return { windowStateStoreData: { routeId: 'deviceConnectView' } };
+                    return {
+                        windowStateStoreData: { routeId: 'deviceConnectView' },
+                        userConfigurationStoreData: { isFirstTime: true },
+                        deviceStoreData: { deviceConnectState: DeviceConnectState.Connected },
+                    } as RootContainerState;
                 });
             storeHubMock
                 .setup(hub => hub.getAllStoreData())
                 .returns(() => {
-                    return { windowStateStoreData: { routeId: 'resultsView' } };
+                    return {
+                        windowStateStoreData: { routeId: 'resultsView' },
+                        userConfigurationStoreData: { isFirstTime: true },
+                        deviceStoreData: { deviceConnectState: DeviceConnectState.Connected },
+                    } as RootContainerState;
                 });
             let storeListener: Function;
             storeHubMock
@@ -70,7 +89,6 @@ describe(RootContainer, () => {
                     storeListener = cb;
                 });
 
-            const props: RootContainerProps = { deps };
             const wrapped = shallow(<RootContainer {...props} />);
             expect(wrapped.state()).toMatchSnapshot('initial state');
 


### PR DESCRIPTION
#### Description of changes

Created root container, that will be used to render the proper view based on route id; connected it to the device connect view initializer

#### Pull request checklist

- [N/A] Addresses an existing issue: Fixes #0000
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [N/A] (UI changes only) Verified usability with NVDA/JAWS
