### PR TITLE
Set strongly typed 'identifiers' properties in UnifiedResult as required

### DIFF
--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -61,8 +61,8 @@ export interface InstancePropertyBag {
 export type StoredInstancePropertyBag = InstancePropertyBag;
 
 export type UnifiedIdentifiers = {
-    identifier?: string;
-    conciseName?: string;
+    identifier: string;
+    conciseName: string;
 } & InstancePropertyBag;
 
 export type UnifiedDescriptors = {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/cards-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/cards-view.test.tsx.snap
@@ -17,7 +17,9 @@ exports[`CardsView should return cards view 1`] = `
                   "snippet": "this is a sample snippet",
                 },
                 "identifiers": Object {
+                  "conciseName": "body img",
                   "css-selector": "body img",
+                  "identifier": "body img",
                 },
                 "resolution": Object {
                   "how-to-fix-web": Object {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-list-issues-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-list-issues-view.test.tsx.snap
@@ -23,7 +23,9 @@ exports[`DetailsListIssuesView should return  issues table with violations to nu
                 "snippet": "this is a sample snippet",
               },
               "identifiers": Object {
+                "conciseName": "body img",
                 "css-selector": "body img",
+                "identifier": "body img",
               },
               "resolution": Object {
                 "how-to-fix-web": Object {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
@@ -248,7 +248,9 @@ exports[`IssuesTableTest table with 0 issues 1`] = `
                         "snippet": "this is a sample snippet",
                       },
                       "identifiers": Object {
+                        "conciseName": "body img",
                         "css-selector": "body img",
+                        "identifier": "body img",
                       },
                       "resolution": Object {
                         "how-to-fix-web": Object {
@@ -470,7 +472,9 @@ exports[`IssuesTableTest table with 1 issues 1`] = `
                         "snippet": "this is a sample snippet",
                       },
                       "identifiers": Object {
+                        "conciseName": "body img",
                         "css-selector": "body img",
+                        "identifier": "body img",
                       },
                       "resolution": Object {
                         "how-to-fix-web": Object {
@@ -701,7 +705,9 @@ exports[`IssuesTableTest table with 2 issues 1`] = `
                         "snippet": "this is a sample snippet",
                       },
                       "identifiers": Object {
+                        "conciseName": "body img",
                         "css-selector": "body img",
+                        "identifier": "body img",
                       },
                       "resolution": Object {
                         "how-to-fix-web": Object {

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/failed-instances-section.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/failed-instances-section.test.tsx.snap
@@ -18,7 +18,9 @@ exports[`FailedInstancesSection renders 1`] = `
               "snippet": "this is a sample snippet",
             },
             "identifiers": Object {
+              "conciseName": "body img",
               "css-selector": "body img",
+              "identifier": "body img",
             },
             "resolution": Object {
               "how-to-fix-web": Object {
@@ -49,7 +51,9 @@ exports[`FailedInstancesSection renders 1`] = `
               "snippet": "this is a sample snippet",
             },
             "identifiers": Object {
+              "conciseName": "body img",
               "css-selector": "body img",
+              "identifier": "body img",
             },
             "resolution": Object {
               "how-to-fix-web": Object {

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details-group.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details-group.test.tsx.snap
@@ -16,7 +16,9 @@ exports[`InstanceDetailsGroup renders 1`] = `
             "snippet": "this is a sample snippet",
           },
           "identifiers": Object {
+            "conciseName": "body img",
             "css-selector": "body img",
+            "identifier": "body img",
           },
           "resolution": Object {
             "how-to-fix-web": Object {

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -81,7 +81,9 @@ exports[`InstanceDetails renders 1`] = `
           "snippet": "this is a sample snippet",
         },
         "identifiers": Object {
+          "conciseName": "body img",
           "css-selector": "body img",
+          "identifier": "body img",
         },
         "resolution": Object {
           "how-to-fix-web": Object {
@@ -131,6 +133,8 @@ exports[`InstanceDetails renders nothing when there is no card row config for th
       Object {
         "descriptors": Object {},
         "identifiers": Object {
+          "conciseName": "test-concise-name",
+          "identifier": "test-id",
           "this-property-does-not-have-config": "some value",
         },
         "resolution": Object {},

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/result-section-content.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/result-section-content.test.tsx.snap
@@ -18,7 +18,9 @@ exports[`ResultSectionContent renders, with some rules 1`] = `
               "snippet": "this is a sample snippet",
             },
             "identifiers": Object {
+              "conciseName": "body img",
               "css-selector": "body img",
+              "identifier": "body img",
             },
             "resolution": Object {
               "how-to-fix-web": Object {

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
@@ -36,7 +36,9 @@ exports[`RulesWithInstances renders 1`] = `
                   "snippet": "this is a sample snippet",
                 },
                 "identifiers": Object {
+                  "conciseName": "body img",
                   "css-selector": "body img",
+                  "identifier": "body img",
                 },
                 "resolution": Object {
                   "how-to-fix-web": Object {
@@ -75,7 +77,9 @@ exports[`RulesWithInstances renders 1`] = `
                   "snippet": "this is a sample snippet",
                 },
                 "identifiers": Object {
+                  "conciseName": "body img",
                   "css-selector": "body img",
+                  "identifier": "body img",
                 },
                 "resolution": Object {
                   "how-to-fix-web": Object {

--- a/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
@@ -5,7 +5,6 @@ import { CardSelectionMessageCreator } from 'common/message-creators/card-select
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
-
 import {
     AllPropertyTypes,
     CardRowProps,
@@ -63,7 +62,11 @@ describe('InstanceDetails', () => {
     });
 
     it('renders nothing when there is no card row config for the property / no property', () => {
-        props.result.identifiers = { 'this-property-does-not-have-config': 'some value' };
+        props.result.identifiers = {
+            identifier: 'test-id',
+            conciseName: 'test-concise-name',
+            'this-property-does-not-have-config': 'some value',
+        };
         props.result.descriptors = {};
         props.result.resolution = {} as UnifiedResolution;
 

--- a/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
+++ b/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
@@ -9,6 +9,8 @@ export const exampleUnifiedResult: UnifiedResult = {
     status: 'fail',
     ruleId: 'image-alt',
     identifiers: {
+        identifier: 'body img',
+        conciseName: 'body img',
         'css-selector': 'body img',
     },
     descriptors: {

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
@@ -40,7 +40,9 @@ exports[`ReportBody renders 1`] = `
                   "snippet": "this is a sample snippet",
                 },
                 "identifiers": Object {
+                  "conciseName": "body img",
                   "css-selector": "body img",
+                  "identifier": "body img",
                 },
                 "resolution": Object {
                   "how-to-fix-web": Object {
@@ -122,7 +124,9 @@ exports[`ReportBody renders 1`] = `
                     "snippet": "this is a sample snippet",
                   },
                   "identifiers": Object {
+                    "conciseName": "body img",
                     "css-selector": "body img",
+                    "identifier": "body img",
                   },
                   "resolution": Object {
                     "how-to-fix-web": Object {
@@ -202,7 +206,9 @@ exports[`ReportBody renders 1`] = `
                     "snippet": "this is a sample snippet",
                   },
                   "identifiers": Object {
+                    "conciseName": "body img",
                     "css-selector": "body img",
+                    "identifier": "body img",
                   },
                   "resolution": Object {
                     "how-to-fix-web": Object {
@@ -282,7 +288,9 @@ exports[`ReportBody renders 1`] = `
                     "snippet": "this is a sample snippet",
                   },
                   "identifiers": Object {
+                    "conciseName": "body img",
                     "css-selector": "body img",
+                    "identifier": "body img",
                   },
                   "resolution": Object {
                     "how-to-fix-web": Object {
@@ -362,7 +370,9 @@ exports[`ReportBody renders 1`] = `
                       "snippet": "this is a sample snippet",
                     },
                     "identifiers": Object {
+                      "conciseName": "body img",
                       "css-selector": "body img",
+                      "identifier": "body img",
                     },
                     "resolution": Object {
                       "how-to-fix-web": Object {
@@ -442,7 +452,9 @@ exports[`ReportBody renders 1`] = `
                       "snippet": "this is a sample snippet",
                     },
                     "identifiers": Object {
+                      "conciseName": "body img",
                       "css-selector": "body img",
+                      "identifier": "body img",
                     },
                     "resolution": Object {
                       "how-to-fix-web": Object {
@@ -522,7 +534,9 @@ exports[`ReportBody renders 1`] = `
                       "snippet": "this is a sample snippet",
                     },
                     "identifiers": Object {
+                      "conciseName": "body img",
                       "css-selector": "body img",
+                      "identifier": "body img",
                     },
                     "resolution": Object {
                       "how-to-fix-web": Object {
@@ -604,7 +618,9 @@ exports[`ReportBody renders 1`] = `
                   "snippet": "this is a sample snippet",
                 },
                 "identifiers": Object {
+                  "conciseName": "body img",
                   "css-selector": "body img",
+                  "identifier": "body img",
                 },
                 "resolution": Object {
                   "how-to-fix-web": Object {


### PR DESCRIPTION
#### Description of changes

Updated the strongly-typed properties in `identifiers` of UnifiedResult (added in #1377) from optional to required. 

#### Pull request checklist

- [x] Addresses an existing feature: WI # 1584979
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
