### PR TITLE
feat: add scan action creator

### DIFF
--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -173,6 +173,9 @@ export type ValidatePortTelemetryData = {
 export type AndroidScanCompletedTelemetryData = {
     port: number;
     scanDuration: number;
+} & InstanceCount;
+
+export type InstanceCount = {
     PASS: {
         [ruleId: string]: number;
     };

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -170,6 +170,25 @@ export type ValidatePortTelemetryData = {
     port: number;
 };
 
+export type AndroidScanCompletedTelemetryData = {
+    port: number;
+    scanDuration: number;
+    PASS: {
+        [ruleId: string]: number;
+    };
+    FAIL: {
+        [ruleId: string]: number;
+    };
+    INCOMPLETE: {
+        [ruleId: string]: number;
+    };
+};
+
+export type AndroidScanFailedTelemetryData = {
+    port: number;
+    scanDuration: number;
+};
+
 export type TelemetryData =
     | BaseTelemetryData
     | ToggleTelemetryData
@@ -190,4 +209,6 @@ export type TelemetryData =
     | IssuesAnalyzerScanTelemetryData
     | AssessmentRequirementScanTelemetryData
     | RequirementStatusTelemetryData
-    | ValidatePortTelemetryData;
+    | ValidatePortTelemetryData
+    | AndroidScanCompletedTelemetryData
+    | AndroidScanFailedTelemetryData;

--- a/src/common/stores/store-names.ts
+++ b/src/common/stores/store-names.ts
@@ -18,4 +18,5 @@ export enum StoreNames {
     CardSelectionStore,
     DeviceStore,
     WindowStateStore,
+    ScanStore,
 }

--- a/src/electron/common/electron-telemetry-events.ts
+++ b/src/electron/common/electron-telemetry-events.ts
@@ -3,3 +3,6 @@
 
 export const APP_INITIALIZED: string = 'AppInitialized';
 export const VALIDATE_PORT: string = 'ValidatePort';
+export const SCAN_STARTED: string = 'ScanStarted';
+export const SCAN_COMPLETED: string = 'ScanCompleted';
+export const SCAN_FAILED: string = 'ScanFailed';

--- a/src/electron/flux/action-creator/scan-action-creator.ts
+++ b/src/electron/flux/action-creator/scan-action-creator.ts
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { TelemetryEventSource, TriggeredByNotApplicable } from 'common/extension-telemetry-events';
+import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
+import { ScanActions } from 'electron/flux/action/scan-actions';
+import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
+import { ScanResults } from 'electron/platform/android/scan-results';
+
+export class ScanActionCreator {
+    constructor(
+        private readonly scanActions: ScanActions,
+        private readonly fetchScanResults: FetchScanResultsType,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+    ) {}
+
+    public scan(port: number): void {
+        this.telemetryEventHandler.publishTelemetry(SCAN_STARTED, {
+            telemetry: {
+                port,
+                source: TelemetryEventSource.ElectronDeviceConnect,
+            },
+        });
+
+        this.scanActions.scanStarted.invoke(null);
+
+        this.fetchScanResults(port)
+            .then(this.scanCompleted)
+            .catch(this.scanFailed);
+    }
+
+    private scanCompleted = (data: ScanResults) => {
+        this.telemetryEventHandler.publishTelemetry(SCAN_COMPLETED, {
+            telemetry: {
+                triggeredBy: TriggeredByNotApplicable,
+                source: TelemetryEventSource.ElectronDeviceConnect,
+            },
+        });
+
+        this.scanActions.scanCompleted.invoke(null);
+    };
+
+    private scanFailed = () => {
+        this.telemetryEventHandler.publishTelemetry(SCAN_FAILED, {
+            telemetry: {
+                triggeredBy: TriggeredByNotApplicable,
+                source: TelemetryEventSource.ElectronDeviceConnect,
+            },
+        });
+
+        this.scanActions.scanFailed.invoke(null);
+    };
+}

--- a/src/electron/flux/action-creator/scan-action-creator.ts
+++ b/src/electron/flux/action-creator/scan-action-creator.ts
@@ -2,18 +2,11 @@
 // Licensed under the MIT License.
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
-import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
+import { SCAN_STARTED } from 'electron/common/electron-telemetry-events';
 import { ScanActions } from 'electron/flux/action/scan-actions';
-import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
-import { ScanResults } from 'electron/platform/android/scan-results';
 
 export class ScanActionCreator {
-    constructor(
-        private readonly scanActions: ScanActions,
-        private readonly fetchScanResults: FetchScanResultsType,
-        private readonly telemetryEventHandler: TelemetryEventHandler,
-        private readonly getCurrentDate: () => Date,
-    ) {}
+    constructor(private readonly scanActions: ScanActions, private readonly telemetryEventHandler: TelemetryEventHandler) {}
 
     public scan(port: number): void {
         this.telemetryEventHandler.publishTelemetry(SCAN_STARTED, {
@@ -23,57 +16,6 @@ export class ScanActionCreator {
             },
         });
 
-        this.scanActions.scanStarted.invoke(null);
-
-        const scanStartedTime = this.getCurrentDate().getTime();
-
-        this.fetchScanResults(port)
-            .then(this.scanCompleted.bind(this, scanStartedTime, port))
-            .catch(this.scanFailed.bind(this, scanStartedTime, port));
-    }
-
-    private scanCompleted(scanStartedTime: number, port: number, data: ScanResults): void {
-        const scanCompletedTime = this.getCurrentDate().getTime();
-
-        const scanDuration = scanCompletedTime - scanStartedTime;
-
-        const instanceCount = data.ruleResults.reduce((acc, cur) => {
-            if (acc[cur.status] == null) {
-                acc[cur.status] = {};
-            }
-
-            if (acc[cur.status][cur.ruleId] == null) {
-                acc[cur.status][cur.ruleId] = 1;
-            } else {
-                acc[cur.status][cur.ruleId]++;
-            }
-
-            return acc;
-        }, {});
-
-        this.telemetryEventHandler.publishTelemetry(SCAN_COMPLETED, {
-            telemetry: {
-                port,
-                scanDuration,
-                ...instanceCount,
-            },
-        });
-
-        this.scanActions.scanCompleted.invoke(null);
-    }
-
-    private scanFailed(scanStartedTime: number, port: number): void {
-        const scanCompletedTime = this.getCurrentDate().getTime();
-
-        const scanDuration = scanCompletedTime - scanStartedTime;
-
-        this.telemetryEventHandler.publishTelemetry(SCAN_FAILED, {
-            telemetry: {
-                port,
-                scanDuration,
-            },
-        });
-
-        this.scanActions.scanFailed.invoke(null);
+        this.scanActions.scanStarted.invoke({ port });
     }
 }

--- a/src/electron/flux/action-creator/scan-action-creator.ts
+++ b/src/electron/flux/action-creator/scan-action-creator.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { TelemetryEventSource, TriggeredByNotApplicable } from 'common/extension-telemetry-events';
+import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
 import { ScanActions } from 'electron/flux/action/scan-actions';
 import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
@@ -12,6 +12,7 @@ export class ScanActionCreator {
         private readonly scanActions: ScanActions,
         private readonly fetchScanResults: FetchScanResultsType,
         private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly getCurrentDate: () => Date,
     ) {}
 
     public scan(port: number): void {
@@ -24,30 +25,55 @@ export class ScanActionCreator {
 
         this.scanActions.scanStarted.invoke(null);
 
+        const scanStartedTime = this.getCurrentDate().getTime();
+
         this.fetchScanResults(port)
-            .then(this.scanCompleted)
-            .catch(this.scanFailed);
+            .then(this.scanCompleted.bind(this, scanStartedTime, port))
+            .catch(this.scanFailed.bind(this, scanStartedTime, port));
     }
 
-    private scanCompleted = (data: ScanResults) => {
+    private scanCompleted(scanStartedTime: number, port: number, data: ScanResults): void {
+        const scanCompletedTime = this.getCurrentDate().getTime();
+
+        const scanDuration = scanCompletedTime - scanStartedTime;
+
+        const instanceCount = data.ruleResults.reduce((acc, cur) => {
+            if (acc[cur.status] == null) {
+                acc[cur.status] = {};
+            }
+
+            if (acc[cur.status][cur.ruleId] == null) {
+                acc[cur.status][cur.ruleId] = 1;
+            } else {
+                acc[cur.status][cur.ruleId]++;
+            }
+
+            return acc;
+        }, {});
+
         this.telemetryEventHandler.publishTelemetry(SCAN_COMPLETED, {
             telemetry: {
-                triggeredBy: TriggeredByNotApplicable,
-                source: TelemetryEventSource.ElectronDeviceConnect,
+                port,
+                scanDuration,
+                ...instanceCount,
             },
         });
 
         this.scanActions.scanCompleted.invoke(null);
-    };
+    }
 
-    private scanFailed = () => {
+    private scanFailed(scanStartedTime: number, port: number): void {
+        const scanCompletedTime = this.getCurrentDate().getTime();
+
+        const scanDuration = scanCompletedTime - scanStartedTime;
+
         this.telemetryEventHandler.publishTelemetry(SCAN_FAILED, {
             telemetry: {
-                triggeredBy: TriggeredByNotApplicable,
-                source: TelemetryEventSource.ElectronDeviceConnect,
+                port,
+                scanDuration,
             },
         });
 
         this.scanActions.scanFailed.invoke(null);
-    };
+    }
 }

--- a/src/electron/flux/action-creator/scan-action-creator.ts
+++ b/src/electron/flux/action-creator/scan-action-creator.ts
@@ -1,21 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { TelemetryEventSource } from 'common/extension-telemetry-events';
-import { SCAN_STARTED } from 'electron/common/electron-telemetry-events';
 import { ScanActions } from 'electron/flux/action/scan-actions';
 
 export class ScanActionCreator {
-    constructor(private readonly scanActions: ScanActions, private readonly telemetryEventHandler: TelemetryEventHandler) {}
+    constructor(private readonly scanActions: ScanActions) {}
 
     public scan(port: number): void {
-        this.telemetryEventHandler.publishTelemetry(SCAN_STARTED, {
-            telemetry: {
-                port,
-                source: TelemetryEventSource.ElectronDeviceConnect,
-            },
-        });
-
         this.scanActions.scanStarted.invoke({ port });
     }
 }

--- a/src/electron/flux/action/device-action-payloads.ts
+++ b/src/electron/flux/action/device-action-payloads.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-export interface ConnectingPayload {
+export interface PortPayload {
     port: number;
 }
 
-export interface ConnectionSucceedPayload {
+export interface ConnectedDevicePayload {
     connectedDevice: string;
 }

--- a/src/electron/flux/action/device-actions.ts
+++ b/src/electron/flux/action/device-actions.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 import { Action } from 'common/flux/action';
 
-import { ConnectingPayload, ConnectionSucceedPayload } from './device-action-payloads';
+import { ConnectedDevicePayload, PortPayload } from './device-action-payloads';
 
 export class DeviceActions {
-    public readonly connectionSucceeded = new Action<ConnectionSucceedPayload>();
+    public readonly connectionSucceeded = new Action<ConnectedDevicePayload>();
     public readonly connectionFailed = new Action<void>();
-    public readonly connecting = new Action<ConnectingPayload>();
+    public readonly connecting = new Action<PortPayload>();
     public readonly resetConnection = new Action<void>();
 }

--- a/src/electron/flux/action/scan-actions.ts
+++ b/src/electron/flux/action/scan-actions.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Action } from 'common/flux/action';
+import { PortPayload } from 'electron/flux/action/device-action-payloads';
 
 export class ScanActions {
-    public readonly scanStarted = new Action<void>();
+    public readonly scanStarted = new Action<PortPayload>();
     public readonly scanCompleted = new Action<void>();
     public readonly scanFailed = new Action<void>();
 }

--- a/src/electron/flux/action/scan-actions.ts
+++ b/src/electron/flux/action/scan-actions.ts
@@ -5,4 +5,5 @@ import { Action } from 'common/flux/action';
 export class ScanActions {
     public readonly scanStarted = new Action<void>();
     public readonly scanCompleted = new Action<void>();
+    public readonly scanFailed = new Action<void>();
 }

--- a/src/electron/flux/action/scan-actions.ts
+++ b/src/electron/flux/action/scan-actions.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Action } from 'common/flux/action';
+
+export class ScanActions {
+    public readonly scanStarted = new Action<void>();
+    public readonly scanCompleted = new Action<void>();
+}

--- a/src/electron/flux/store/device-store.ts
+++ b/src/electron/flux/store/device-store.ts
@@ -4,7 +4,7 @@ import { BaseStoreImpl } from 'background/stores/base-store-impl';
 import { StoreNames } from 'common/stores/store-names';
 
 import { DeviceConnectState } from '../../views/device-connect-view/components/device-connect-state';
-import { ConnectingPayload, ConnectionSucceedPayload } from '../action/device-action-payloads';
+import { ConnectedDevicePayload, PortPayload } from '../action/device-action-payloads';
 import { DeviceActions } from '../action/device-actions';
 import { DeviceStoreData } from '../types/device-store-data';
 
@@ -38,7 +38,7 @@ export class DeviceStore extends BaseStoreImpl<DeviceStoreData> {
         this.emitChanged();
     };
 
-    private onConnecting = (payload: ConnectingPayload) => {
+    private onConnecting = (payload: PortPayload) => {
         if (this.state.deviceConnectState === DeviceConnectState.Connecting && this.state.port === payload.port) {
             return;
         }
@@ -49,7 +49,7 @@ export class DeviceStore extends BaseStoreImpl<DeviceStoreData> {
         this.emitChanged();
     };
 
-    private onConnectionSucceeded = (payload: ConnectionSucceedPayload) => {
+    private onConnectionSucceeded = (payload: ConnectedDevicePayload) => {
         if (this.state.deviceConnectState === DeviceConnectState.Connected) {
             return;
         }

--- a/src/electron/flux/store/scan-store.ts
+++ b/src/electron/flux/store/scan-store.ts
@@ -21,17 +21,29 @@ export class ScanStore extends BaseStoreImpl<ScanStoreData> {
     protected addActionListeners(): void {
         this.scanActions.scanStarted.addListener(this.onScanStarted);
         this.scanActions.scanCompleted.addListener(this.onScanCompleted);
+        this.scanActions.scanFailed.addListener(this.onScanFailed);
     }
 
-    private onScanStarted = () => this.updateToStatus(ScanStatus.Scanning);
-    private onScanCompleted = () => this.updateToStatus(ScanStatus.Completed);
-
-    private updateToStatus(newStatus: ScanStatus): void {
-        if (this.state.status === newStatus) {
+    private onScanStarted = () => {
+        if (this.state.status === ScanStatus.Scanning) {
             return;
         }
 
-        this.state.status = newStatus;
+        this.state.status = ScanStatus.Scanning;
+
+        this.emitChanged();
+    };
+
+    private onScanCompleted = () => this.onScanFinished(ScanStatus.Completed);
+
+    private onScanFailed = () => this.onScanFinished(ScanStatus.Failed);
+
+    private onScanFinished(finalStatus: ScanStatus): void {
+        if (this.state.status !== ScanStatus.Scanning) {
+            return;
+        }
+
+        this.state.status = finalStatus;
 
         this.emitChanged();
     }

--- a/src/electron/flux/store/scan-store.ts
+++ b/src/electron/flux/store/scan-store.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BaseStoreImpl } from 'background/stores/base-store-impl';
+import { StoreNames } from 'common/stores/store-names';
+
+import { ScanStatus } from 'electron/flux/types/scan-status';
+import { ScanActions } from '../action/scan-actions';
+import { ScanStoreData } from '../types/scan-store-data';
+
+export class ScanStore extends BaseStoreImpl<ScanStoreData> {
+    constructor(private readonly scanActions: ScanActions) {
+        super(StoreNames.ScanStore);
+    }
+
+    public getDefaultState(): ScanStoreData {
+        return {
+            status: ScanStatus.Default,
+        };
+    }
+
+    protected addActionListeners(): void {
+        this.scanActions.scanStarted.addListener(this.onScanStarted);
+        this.scanActions.scanCompleted.addListener(this.onScanCompleted);
+    }
+
+    private onScanStarted = () => this.updateToStatus(ScanStatus.Scanning);
+    private onScanCompleted = () => this.updateToStatus(ScanStatus.Completed);
+
+    private updateToStatus(newStatus: ScanStatus): void {
+        if (this.state.status === newStatus) {
+            return;
+        }
+
+        this.state.status = newStatus;
+
+        this.emitChanged();
+    }
+}

--- a/src/electron/flux/types/scan-status.ts
+++ b/src/electron/flux/types/scan-status.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export enum ScanStatus {
+    Default,
+    Scanning,
+    Completed,
+}

--- a/src/electron/flux/types/scan-status.ts
+++ b/src/electron/flux/types/scan-status.ts
@@ -4,4 +4,5 @@ export enum ScanStatus {
     Default,
     Scanning,
     Completed,
+    Failed,
 }

--- a/src/electron/flux/types/scan-store-data.ts
+++ b/src/electron/flux/types/scan-store-data.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ScanStatus } from 'electron/flux/types/scan-status';
+
+export interface ScanStoreData {
+    status: ScanStatus;
+}

--- a/src/electron/platform/android/scan-controller.ts
+++ b/src/electron/platform/android/scan-controller.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { SCAN_COMPLETED, SCAN_FAILED } from 'electron/common/electron-telemetry-events';
+import { PortPayload } from 'electron/flux/action/device-action-payloads';
+import { ScanActions } from 'electron/flux/action/scan-actions';
+import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
+import { ScanResults } from 'electron/platform/android/scan-results';
+
+export class ScanController {
+    constructor(
+        private readonly scanActions: ScanActions,
+        private readonly fetchScanResults: FetchScanResultsType,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly getCurrentDate: () => Date,
+    ) {}
+
+    public initialize(): void {
+        this.scanActions.scanStarted.addListener(this.onScanStarted);
+    }
+
+    private onScanStarted = (payload: PortPayload) => {
+        const port = payload.port;
+
+        const scanStartedTime = this.getCurrentDate().getTime();
+
+        this.fetchScanResults(port)
+            .then(this.scanCompleted.bind(this, scanStartedTime, port))
+            .catch(this.scanFailed.bind(this, scanStartedTime, port));
+    };
+
+    private scanCompleted(scanStartedTime: number, port: number, data: ScanResults): void {
+        const scanCompletedTime = this.getCurrentDate().getTime();
+
+        const scanDuration = scanCompletedTime - scanStartedTime;
+
+        const instanceCount = data.ruleResults.reduce((acc, cur) => {
+            if (acc[cur.status] == null) {
+                acc[cur.status] = {};
+            }
+
+            if (acc[cur.status][cur.ruleId] == null) {
+                acc[cur.status][cur.ruleId] = 1;
+            } else {
+                acc[cur.status][cur.ruleId]++;
+            }
+
+            return acc;
+        }, {});
+
+        this.telemetryEventHandler.publishTelemetry(SCAN_COMPLETED, {
+            telemetry: {
+                port,
+                scanDuration,
+                ...instanceCount,
+            },
+        });
+
+        this.scanActions.scanCompleted.invoke(null);
+    }
+
+    private scanFailed(scanStartedTime: number, port: number): void {
+        const scanCompletedTime = this.getCurrentDate().getTime();
+
+        const scanDuration = scanCompletedTime - scanStartedTime;
+
+        this.telemetryEventHandler.publishTelemetry(SCAN_FAILED, {
+            telemetry: {
+                port,
+                scanDuration,
+            },
+        });
+
+        this.scanActions.scanFailed.invoke(null);
+    }
+}

--- a/src/electron/platform/android/scan-controller.ts
+++ b/src/electron/platform/android/scan-controller.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { InstanceCount, TelemetryEventSource } from 'common/extension-telemetry-events';
+import { createDefaultLogger } from 'common/logging/default-logger';
 import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
 import { PortPayload } from 'electron/flux/action/device-action-payloads';
 import { ScanActions } from 'electron/flux/action/scan-actions';
@@ -14,6 +15,7 @@ export class ScanController {
         private readonly fetchScanResults: FetchScanResultsType,
         private readonly telemetryEventHandler: TelemetryEventHandler,
         private readonly getCurrentDate: () => Date,
+        private readonly logger = createDefaultLogger(),
     ) {}
 
     public initialize(): void {
@@ -70,7 +72,9 @@ export class ScanController {
         );
     }
 
-    private scanFailed(scanStartedTime: number, port: number): void {
+    private scanFailed(scanStartedTime: number, port: number, error: Error): void {
+        this.logger.error('scan failed: ', error);
+
         const scanCompletedTime = this.getCurrentDate().getTime();
 
         const scanDuration = scanCompletedTime - scanStartedTime;

--- a/src/electron/platform/android/scan-controller.ts
+++ b/src/electron/platform/android/scan-controller.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { InstanceCount } from 'common/extension-telemetry-events';
-import { SCAN_COMPLETED, SCAN_FAILED } from 'electron/common/electron-telemetry-events';
+import { InstanceCount, TelemetryEventSource } from 'common/extension-telemetry-events';
+import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
 import { PortPayload } from 'electron/flux/action/device-action-payloads';
 import { ScanActions } from 'electron/flux/action/scan-actions';
 import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
@@ -22,6 +22,13 @@ export class ScanController {
 
     private onScanStarted = (payload: PortPayload) => {
         const port = payload.port;
+
+        this.telemetryEventHandler.publishTelemetry(SCAN_STARTED, {
+            telemetry: {
+                port,
+                source: TelemetryEventSource.ElectronDeviceConnect,
+            },
+        });
 
         const scanStartedTime = this.getCurrentDate().getTime();
 

--- a/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
@@ -5,7 +5,7 @@ import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
 import { VALIDATE_PORT } from 'electron/common/electron-telemetry-events';
 import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
-import { ConnectingPayload, ConnectionSucceedPayload } from 'electron/flux/action/device-action-payloads';
+import { ConnectedDevicePayload, PortPayload } from 'electron/flux/action/device-action-payloads';
 import { DeviceActions } from 'electron/flux/action/device-actions';
 import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
 import { ScanResults } from 'electron/platform/android/scan-results';
@@ -19,14 +19,14 @@ describe('DeviceConnectActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let deviceActionsMock: IMock<DeviceActions>;
     let fetchScanResultsMock: IMock<FetchScanResultsType>;
-    let connectingMock: IMock<Action<ConnectingPayload>>;
+    let connectingMock: IMock<Action<PortPayload>>;
 
     let testSubject: DeviceConnectActionCreator;
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
         deviceActionsMock = Mock.ofType<DeviceActions>();
-        connectingMock = Mock.ofType<Action<ConnectingPayload>>();
+        connectingMock = Mock.ofType<Action<PortPayload>>();
         fetchScanResultsMock = Mock.ofType<FetchScanResultsType>();
 
         deviceActionsMock.setup(actions => actions.connecting).returns(() => connectingMock.object);
@@ -44,7 +44,7 @@ describe('DeviceConnectActionCreator', () => {
 
         fetchScanResultsMock.setup(fetch => fetch(port)).returns(() => Promise.resolve({ deviceName, appIdentifier } as ScanResults));
 
-        const connectionSucceedMock = Mock.ofType<Action<ConnectionSucceedPayload>>();
+        const connectionSucceedMock = Mock.ofType<Action<ConnectedDevicePayload>>();
 
         deviceActionsMock.setup(actions => actions.connectionSucceeded).returns(() => connectionSucceedMock.object);
 

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { TelemetryEventSource, TriggeredByNotApplicable } from 'common/extension-telemetry-events';
+import { Action } from 'common/flux/action';
+import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
+import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { ScanActions } from 'electron/flux/action/scan-actions';
+import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
+import { ScanResults } from 'electron/platform/android/scan-results';
+import { tick } from 'tests/unit/common/tick';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+describe('ScanActionCreator', () => {
+    const port = 1111;
+
+    const expectedScanStartedTelemetry = {
+        telemetry: {
+            port,
+            source: TelemetryEventSource.ElectronDeviceConnect,
+        },
+    };
+
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let scanActionsMock: IMock<ScanActions>;
+    let fetchScanResultsMock: IMock<FetchScanResultsType>;
+    let scanStartedMock: IMock<Action<void>>;
+    let scanCompletedMock: IMock<Action<void>>;
+    let scanFailedMock: IMock<Action<void>>;
+
+    let testSubject: ScanActionCreator;
+
+    beforeEach(() => {
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        fetchScanResultsMock = Mock.ofType<FetchScanResultsType>();
+        scanActionsMock = Mock.ofType<ScanActions>();
+
+        scanStartedMock = Mock.ofType<Action<void>>();
+        scanCompletedMock = Mock.ofType<Action<void>>();
+        scanFailedMock = Mock.ofType<Action<void>>();
+
+        scanActionsMock.setup(actions => actions.scanCompleted).returns(() => scanCompletedMock.object);
+        scanActionsMock.setup(actions => actions.scanStarted).returns(() => scanStartedMock.object);
+        scanActionsMock.setup(actions => actions.scanFailed).returns(() => scanFailedMock.object);
+
+        testSubject = new ScanActionCreator(scanActionsMock.object, fetchScanResultsMock.object, telemetryEventHandlerMock.object);
+    });
+
+    it('scans successfully', async () => {
+        const deviceName = 'test device';
+        const appIdentifier = 'test app';
+
+        fetchScanResultsMock.setup(fetch => fetch(port)).returns(() => Promise.resolve({ deviceName, appIdentifier } as ScanResults));
+
+        testSubject.scan(port);
+
+        await tick();
+
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(SCAN_STARTED, It.isValue(expectedScanStartedTelemetry)),
+            Times.once(),
+        );
+
+        telemetryEventHandlerMock.verify(
+            handler =>
+                handler.publishTelemetry(
+                    SCAN_COMPLETED,
+                    It.isValue({
+                        telemetry: {
+                            triggeredBy: TriggeredByNotApplicable,
+                            source: TelemetryEventSource.ElectronDeviceConnect,
+                        },
+                    }),
+                ),
+            Times.once(),
+        );
+
+        scanStartedMock.verify(scanStarted => scanStarted.invoke(null), Times.once());
+        scanCompletedMock.verify(scanCompleted => scanCompleted.invoke(null), Times.once());
+    });
+
+    it('scans and fail', async () => {
+        fetchScanResultsMock.setup(fetch => fetch(port)).returns(() => Promise.reject());
+
+        testSubject.scan(port);
+
+        await tick();
+
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(SCAN_STARTED, It.isValue(expectedScanStartedTelemetry)),
+            Times.once(),
+        );
+
+        telemetryEventHandlerMock.verify(
+            handler =>
+                handler.publishTelemetry(
+                    SCAN_FAILED,
+                    It.isValue({
+                        telemetry: {
+                            triggeredBy: TriggeredByNotApplicable,
+                            source: TelemetryEventSource.ElectronDeviceConnect,
+                        },
+                    }),
+                ),
+            Times.once(),
+        );
+
+        scanStartedMock.verify(scanStarted => scanStarted.invoke(null), Times.once());
+        scanFailedMock.verify(scanCompleted => scanCompleted.invoke(null), Times.once());
+    });
+});

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -5,6 +5,7 @@ import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
 import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { PortPayload } from 'electron/flux/action/device-action-payloads';
 import { ScanActions } from 'electron/flux/action/scan-actions';
 import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
 import { ScanResults } from 'electron/platform/android/scan-results';
@@ -25,7 +26,7 @@ describe('ScanActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let scanActionsMock: IMock<ScanActions>;
     let fetchScanResultsMock: IMock<FetchScanResultsType>;
-    let scanStartedMock: IMock<Action<void>>;
+    let scanStartedMock: IMock<Action<PortPayload>>;
     let scanCompletedMock: IMock<Action<void>>;
     let scanFailedMock: IMock<Action<void>>;
     let getCurrentDateMock: IMock<() => Date>;
@@ -37,7 +38,7 @@ describe('ScanActionCreator', () => {
         fetchScanResultsMock = Mock.ofType<FetchScanResultsType>();
         scanActionsMock = Mock.ofType<ScanActions>();
 
-        scanStartedMock = Mock.ofType<Action<void>>();
+        scanStartedMock = Mock.ofType<Action<PortPayload>>();
         scanCompletedMock = Mock.ofType<Action<void>>();
         scanFailedMock = Mock.ofType<Action<void>>();
 

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -1,9 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
-import { SCAN_STARTED } from 'electron/common/electron-telemetry-events';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { PortPayload } from 'electron/flux/action/device-action-payloads';
 import { ScanActions } from 'electron/flux/action/scan-actions';
@@ -12,37 +9,24 @@ import { IMock, It, Mock, Times } from 'typemoq';
 describe('ScanActionCreator', () => {
     const port = 1111;
 
-    const expectedScanStartedTelemetry = {
-        telemetry: {
-            port,
-            source: TelemetryEventSource.ElectronDeviceConnect,
-        },
-    };
-
-    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let scanActionsMock: IMock<ScanActions>;
     let scanStartedMock: IMock<Action<PortPayload>>;
 
     let testSubject: ScanActionCreator;
 
     beforeEach(() => {
-        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
         scanActionsMock = Mock.ofType<ScanActions>();
 
         scanStartedMock = Mock.ofType<Action<PortPayload>>();
 
         scanActionsMock.setup(actions => actions.scanStarted).returns(() => scanStartedMock.object);
 
-        testSubject = new ScanActionCreator(scanActionsMock.object, telemetryEventHandlerMock.object);
+        testSubject = new ScanActionCreator(scanActionsMock.object);
     });
 
     it('scans', () => {
         testSubject.scan(port);
 
         scanStartedMock.verify(scanStarted => scanStarted.invoke(It.isValue({ port })), Times.once());
-        telemetryEventHandlerMock.verify(
-            handler => handler.publishTelemetry(SCAN_STARTED, It.isValue(expectedScanStartedTelemetry)),
-            Times.once(),
-        );
     });
 });

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -3,15 +3,11 @@
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
-import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
+import { SCAN_STARTED } from 'electron/common/electron-telemetry-events';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { PortPayload } from 'electron/flux/action/device-action-payloads';
 import { ScanActions } from 'electron/flux/action/scan-actions';
-import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
-import { ScanResults } from 'electron/platform/android/scan-results';
-import { tick } from 'tests/unit/common/tick';
-import { ExpectedCallType, IMock, It, Mock, Times } from 'typemoq';
-import { axeRuleResultExample } from './scan-result-example';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('ScanActionCreator', () => {
     const port = 1111;
@@ -25,107 +21,28 @@ describe('ScanActionCreator', () => {
 
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let scanActionsMock: IMock<ScanActions>;
-    let fetchScanResultsMock: IMock<FetchScanResultsType>;
     let scanStartedMock: IMock<Action<PortPayload>>;
-    let scanCompletedMock: IMock<Action<void>>;
-    let scanFailedMock: IMock<Action<void>>;
-    let getCurrentDateMock: IMock<() => Date>;
 
     let testSubject: ScanActionCreator;
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
-        fetchScanResultsMock = Mock.ofType<FetchScanResultsType>();
         scanActionsMock = Mock.ofType<ScanActions>();
 
         scanStartedMock = Mock.ofType<Action<PortPayload>>();
-        scanCompletedMock = Mock.ofType<Action<void>>();
-        scanFailedMock = Mock.ofType<Action<void>>();
 
-        scanActionsMock.setup(actions => actions.scanCompleted).returns(() => scanCompletedMock.object);
         scanActionsMock.setup(actions => actions.scanStarted).returns(() => scanStartedMock.object);
-        scanActionsMock.setup(actions => actions.scanFailed).returns(() => scanFailedMock.object);
 
-        getCurrentDateMock = Mock.ofType<() => Date>();
-        getCurrentDateMock.setup(getter => getter()).returns(() => new Date(2019, 10, 8, 9, 0, 0));
-        getCurrentDateMock.setup(getter => getter()).returns(() => new Date(2019, 10, 8, 9, 2, 15));
+        testSubject = new ScanActionCreator(scanActionsMock.object, telemetryEventHandlerMock.object);
+    });
 
-        testSubject = new ScanActionCreator(
-            scanActionsMock.object,
-            fetchScanResultsMock.object,
-            telemetryEventHandlerMock.object,
-            getCurrentDateMock.object,
+    it('scans', () => {
+        testSubject.scan(port);
+
+        scanStartedMock.verify(scanStarted => scanStarted.invoke(It.isValue({ port })), Times.once());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(SCAN_STARTED, It.isValue(expectedScanStartedTelemetry)),
+            Times.once(),
         );
-    });
-
-    it('scans successfully', async () => {
-        fetchScanResultsMock.setup(fetch => fetch(port)).returns(() => Promise.resolve(new ScanResults(axeRuleResultExample)));
-
-        telemetryEventHandlerMock
-            .setup(handler => handler.publishTelemetry(SCAN_STARTED, It.isValue(expectedScanStartedTelemetry)))
-            .verifiable(Times.once(), ExpectedCallType.InSequence);
-
-        telemetryEventHandlerMock
-            .setup(handler =>
-                handler.publishTelemetry(
-                    SCAN_COMPLETED,
-                    It.isValue({
-                        telemetry: {
-                            port,
-                            scanDuration: 135000,
-                            PASS: {
-                                ImageViewName: 2,
-                                ColorContrast: 2,
-                                ActiveViewName: 1,
-                                EditTextValue: 1,
-                                DontMoveAccessibilityFocus: 1,
-                            },
-                            FAIL: { TouchSizeWcag: 1, EditTextName: 1, ColorContrast: 1 },
-                            INCOMPLETE: { ColorContrast: 1 },
-                        },
-                    }),
-                ),
-            )
-            .verifiable(Times.once(), ExpectedCallType.InSequence);
-
-        testSubject.scan(port);
-
-        await tick();
-
-        scanStartedMock.verify(scanStarted => scanStarted.invoke(null), Times.once());
-        scanCompletedMock.verify(scanCompleted => scanCompleted.invoke(null), Times.once());
-
-        telemetryEventHandlerMock.verifyAll();
-    });
-
-    it('scans and fail', async () => {
-        fetchScanResultsMock.setup(fetch => fetch(port)).returns(() => Promise.reject());
-
-        telemetryEventHandlerMock
-            .setup(handler => handler.publishTelemetry(SCAN_STARTED, It.isValue(expectedScanStartedTelemetry)))
-            .verifiable(Times.once(), ExpectedCallType.InSequence);
-
-        telemetryEventHandlerMock
-            .setup(handler =>
-                handler.publishTelemetry(
-                    SCAN_FAILED,
-                    It.isValue({
-                        telemetry: {
-                            port,
-                            scanDuration: 135000,
-                        },
-                    }),
-                ),
-            )
-            .verifiable(Times.once(), ExpectedCallType.InSequence);
-
-        testSubject.scan(port);
-
-        await tick();
-
-        scanStartedMock.verify(scanStarted => scanStarted.invoke(null), Times.once());
-        scanFailedMock.verify(scanCompleted => scanCompleted.invoke(null), Times.once());
-
-        telemetryEventHandlerMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-result-example.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-result-example.ts
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export const axeRuleResultExample = {
+    axeRuleResults: [
+        {
+            axeViewId: 1467971545,
+            props: {
+                isImportantForAccessibility: false,
+                contentDescription: null,
+                className: 'android.widget.ImageView',
+            },
+            ruleId: 'ImageViewName',
+            ruleSummary: 'Focusable Informative Views must have Text or a ContentDescription.',
+            status: 'PASS',
+        },
+        {
+            axeViewId: -167704646,
+            props: {
+                isImportantForAccessibility: false,
+                contentDescription: null,
+                className: 'android.widget.ImageView',
+            },
+            ruleId: 'ImageViewName',
+            ruleSummary: 'Focusable Informative Views must have Text or a ContentDescription.',
+            status: 'PASS',
+        },
+        {
+            axeViewId: 2076590804,
+            props: {
+                'Color Contrast Ratio': 15.472099266835668,
+                'Background Color': 'ffffffff',
+                'Visible Text': 'Welcome to OneNote',
+                'Confidence in Color Detection': 'High',
+                className: 'android.widget.TextView',
+                'Foreground Color': 'ff212526',
+            },
+            ruleId: 'ColorContrast',
+            ruleSummary: 'Text adequately contrasts with its background.',
+            status: 'PASS',
+        },
+        {
+            axeViewId: 1100437139,
+            props: {
+                'Color Contrast Ratio': 5.244908611149115,
+                'Background Color': 'ffffffff',
+                'Visible Text': 'Take notes. Get Organized.',
+                'Confidence in Color Detection': 'High',
+                className: 'android.widget.TextView',
+                'Foreground Color': 'ff636e72',
+            },
+            ruleId: 'ColorContrast',
+            ruleSummary: 'Text adequately contrasts with its background.',
+            status: 'PASS',
+        },
+        {
+            axeViewId: 348799259,
+            props: {
+                'Screen Dots Per Inch': 2.625,
+                width: 954,
+                isActive: true,
+                boundsInScreen: {
+                    bottom: 1193,
+                    left: 63,
+                    right: 1017,
+                    top: 1081,
+                },
+                height: 112,
+            },
+            ruleId: 'TouchSizeWcag',
+            ruleSummary: 'Active views adhere to WCAG Touch Target Size requirements.',
+            status: 'FAIL',
+        },
+        {
+            axeViewId: 348799259,
+            props: {
+                labeledBy: null,
+                className: 'android.widget.EditText',
+            },
+            ruleId: 'EditTextName',
+            ruleSummary: 'Views that have modifiable Values should get their name from a nearby Label.',
+            status: 'FAIL',
+        },
+        {
+            axeViewId: 348799259,
+            props: {
+                'Color Contrast Ratio': 2.2691424910346987,
+                'Background Color': 'ffa3aeb2',
+                'Visible Text': 'Enter your email, phone, or Skype name',
+                'Confidence in Color Detection': 'High',
+                className: 'android.widget.EditText',
+                'Foreground Color': 'ffffffff',
+            },
+            ruleId: 'ColorContrast',
+            ruleSummary: 'Text adequately contrasts with its background.',
+            status: 'INCOMPLETE',
+        },
+        {
+            axeViewId: 348799259,
+            props: {
+                'Speakable Text': 'Enter your email, phone, or Skype name ',
+                isActive: true,
+            },
+            ruleId: 'ActiveViewName',
+            ruleSummary: 'Views that users can interact with must have a Name.',
+            status: 'PASS',
+        },
+        {
+            axeViewId: 348799259,
+            props: {
+                contentDescription: null,
+                className: 'android.widget.EditText',
+            },
+            ruleId: 'EditTextValue',
+            ruleSummary: 'Editable Views must not override the Value spoken by TalkBack.',
+            status: 'PASS',
+        },
+        {
+            axeViewId: 818878762,
+            props: {
+                'Color Contrast Ratio': 2.3502802603890585,
+                'Background Color': 'ffa9a9a9',
+                'Visible Text': 'Next',
+                'Confidence in Color Detection': 'High',
+                className: 'android.widget.Button',
+                'Foreground Color': 'ffffffff',
+            },
+            ruleId: 'ColorContrast',
+            ruleSummary: 'Text adequately contrasts with its background.',
+            status: 'FAIL',
+        },
+        {
+            axeViewId: null,
+            props: {
+                'Applicable Event Stream': [],
+            },
+            ruleId: 'DontMoveAccessibilityFocus',
+            ruleSummary: 'Applications should not forcibly move focus around.',
+            status: 'PASS',
+        },
+    ],
+};

--- a/src/tests/unit/tests/electron/flux/store/__snapshots__/scan-store.test.ts.snap
+++ b/src/tests/unit/tests/electron/flux/store/__snapshots__/scan-store.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ScanStore returns default state 1`] = `undefined`;

--- a/src/tests/unit/tests/electron/flux/store/device-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/device-store.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ConnectingPayload, ConnectionSucceedPayload } from 'electron/flux/action/device-action-payloads';
+import { ConnectedDevicePayload, PortPayload } from 'electron/flux/action/device-action-payloads';
 import { DeviceActions } from 'electron/flux/action/device-actions';
 import { DeviceStore } from 'electron/flux/store/device-store';
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
@@ -25,7 +25,7 @@ describe('DeviceStore', () => {
     describe('on connecting', () => {
         const testPort = 10101;
         it('updates the port and status to CONNECTING ', () => {
-            const payload: ConnectingPayload = {
+            const payload: PortPayload = {
                 port: testPort,
             };
 
@@ -44,7 +44,7 @@ describe('DeviceStore', () => {
             initialState.port = testPort;
             initialState.deviceConnectState = DeviceConnectState.Connecting;
 
-            const payload: ConnectingPayload = {
+            const payload: PortPayload = {
                 port: testPort + 1,
             };
 
@@ -62,7 +62,7 @@ describe('DeviceStore', () => {
             initialState.port = testPort;
             initialState.deviceConnectState = DeviceConnectState.Connecting;
 
-            const payload: ConnectingPayload = {
+            const payload: PortPayload = {
                 port: testPort,
             };
 
@@ -79,7 +79,7 @@ describe('DeviceStore', () => {
 
     describe('on connection succeed', () => {
         it('updates connection status and device name', () => {
-            const payload: ConnectionSucceedPayload = {
+            const payload: ConnectedDevicePayload = {
                 connectedDevice: 'test connected device',
             };
             const expectedState: DeviceStoreData = {
@@ -96,7 +96,7 @@ describe('DeviceStore', () => {
         it('does not updates if status is already CONNECTED', () => {
             initialState.deviceConnectState = DeviceConnectState.Connected;
 
-            const payload: ConnectionSucceedPayload = {
+            const payload: ConnectedDevicePayload = {
                 connectedDevice: 'test connected device',
             };
 

--- a/src/tests/unit/tests/electron/flux/store/scan-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/scan-store.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ScanActions } from 'electron/flux/action/scan-actions';
+import { ScanStore } from 'electron/flux/store/scan-store';
+import { ScanStatus } from 'electron/flux/types/scan-status';
+import { ScanStoreData } from 'electron/flux/types/scan-store-data';
+import { createStoreWithNullParams, StoreTester } from 'tests/unit/common/store-tester';
+
+describe('ScanStore', () => {
+    let initialState: ScanStoreData;
+
+    beforeEach(() => {
+        initialState = createStoreWithNullParams(ScanStore).getDefaultState();
+    });
+
+    describe('constructor', () => {
+        it('has no side effects', () => {
+            const testObject = createStoreWithNullParams(ScanStore);
+            expect(testObject).toBeDefined();
+        });
+    });
+
+    it('returns default state', () => {
+        const testObject = createStoreWithNullParams(ScanStore);
+
+        expect(testObject.getState()).toMatchSnapshot();
+    });
+
+    describe('on scan started', () => {
+        describe('updates to scanning', () => {
+            const initialStatuses = [ScanStatus[ScanStatus.Default], ScanStatus[ScanStatus.Completed]];
+
+            it.each(initialStatuses)('from initial state <%s>', initialStatus => {
+                initialState.status = ScanStatus[initialStatus];
+
+                const expectedState: ScanStoreData = {
+                    status: ScanStatus.Scanning,
+                };
+
+                createStoreTesterForScanActions('scanStarted').testListenerToBeCalledOnce(initialState, expectedState);
+            });
+        });
+
+        it('does not update if already scanning', () => {
+            initialState.status = ScanStatus.Scanning;
+
+            const expectedState: ScanStoreData = { ...initialState };
+
+            createStoreTesterForScanActions('scanStarted').testListenerToNeverBeCalled(initialState, expectedState);
+        });
+    });
+
+    describe('on scan completed', () => {
+        describe('updates to completed', () => {
+            const initialStatuses = [ScanStatus[ScanStatus.Default], ScanStatus[ScanStatus.Scanning]];
+
+            it.each(initialStatuses)('from initial state <%s>', initialStatus => {
+                initialState.status = ScanStatus[initialStatus];
+
+                const expectedState: ScanStoreData = {
+                    status: ScanStatus.Completed,
+                };
+
+                createStoreTesterForScanActions('scanCompleted').testListenerToBeCalledOnce(initialState, expectedState);
+            });
+        });
+
+        it('does not updated if already completed', () => {
+            initialState.status = ScanStatus.Completed;
+
+            const expectedState: ScanStoreData = { ...initialState };
+
+            createStoreTesterForScanActions('scanCompleted').testListenerToNeverBeCalled(initialState, expectedState);
+        });
+    });
+
+    function createStoreTesterForScanActions(actionName: keyof ScanActions): StoreTester<ScanStoreData, ScanActions> {
+        const factory = (actions: ScanActions) => new ScanStore(actions);
+
+        return new StoreTester(ScanActions, actionName, factory);
+    }
+});

--- a/src/tests/unit/tests/electron/flux/store/scan-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/scan-store.test.ts
@@ -28,7 +28,7 @@ describe('ScanStore', () => {
 
     describe('on scan started', () => {
         describe('updates to scanning', () => {
-            const initialStatuses = [ScanStatus[ScanStatus.Default], ScanStatus[ScanStatus.Completed]];
+            const initialStatuses = [ScanStatus[ScanStatus.Default], ScanStatus[ScanStatus.Completed], ScanStatus[ScanStatus.Failed]];
 
             it.each(initialStatuses)('from initial state <%s>', initialStatus => {
                 initialState.status = ScanStatus[initialStatus];
@@ -51,26 +51,50 @@ describe('ScanStore', () => {
     });
 
     describe('on scan completed', () => {
-        describe('updates to completed', () => {
-            const initialStatuses = [ScanStatus[ScanStatus.Default], ScanStatus[ScanStatus.Scanning]];
+        it('updates to completed', () => {
+            initialState.status = ScanStatus.Scanning;
 
-            it.each(initialStatuses)('from initial state <%s>', initialStatus => {
-                initialState.status = ScanStatus[initialStatus];
+            const expectedState: ScanStoreData = {
+                status: ScanStatus.Completed,
+            };
 
-                const expectedState: ScanStoreData = {
-                    status: ScanStatus.Completed,
-                };
-
-                createStoreTesterForScanActions('scanCompleted').testListenerToBeCalledOnce(initialState, expectedState);
-            });
+            createStoreTesterForScanActions('scanCompleted').testListenerToBeCalledOnce(initialState, expectedState);
         });
 
-        it('does not updated if already completed', () => {
-            initialState.status = ScanStatus.Completed;
+        describe('does not update if previous state is not scanning', () => {
+            const initialStatuses = [ScanStatus[ScanStatus.Default], ScanStatus[ScanStatus.Failed], ScanStatus[ScanStatus.Completed]];
 
-            const expectedState: ScanStoreData = { ...initialState };
+            it.each(initialStatuses)('with initial status <%s>', initialStatus => {
+                initialState.status = ScanStatus[initialStatus];
 
-            createStoreTesterForScanActions('scanCompleted').testListenerToNeverBeCalled(initialState, expectedState);
+                const expectedState: ScanStoreData = { ...initialState };
+
+                createStoreTesterForScanActions('scanCompleted').testListenerToNeverBeCalled(initialState, expectedState);
+            });
+        });
+    });
+
+    describe('on scan failed', () => {
+        it('updates to failed', () => {
+            initialState.status = ScanStatus.Scanning;
+
+            const expectedState: ScanStoreData = {
+                status: ScanStatus.Failed,
+            };
+
+            createStoreTesterForScanActions('scanFailed').testListenerToBeCalledOnce(initialState, expectedState);
+        });
+
+        describe('does not update if previous state is not scanning', () => {
+            const initialStatuses = [ScanStatus[ScanStatus.Default], ScanStatus[ScanStatus.Failed], ScanStatus[ScanStatus.Completed]];
+
+            it.each(initialStatuses)('with initial status <%s>', initialStatus => {
+                initialState.status = ScanStatus[initialStatus];
+
+                const expectedState: ScanStoreData = { ...initialState };
+
+                createStoreTesterForScanActions('scanFailed').testListenerToNeverBeCalled(initialState, expectedState);
+            });
         });
     });
 

--- a/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
-import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
+import { SCAN_COMPLETED, SCAN_FAILED } from 'electron/common/electron-telemetry-events';
 import { PortPayload } from 'electron/flux/action/device-action-payloads';
 import { ScanActions } from 'electron/flux/action/scan-actions';
 import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';

--- a/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { TelemetryEventSource } from 'common/extension-telemetry-events';
+import { Action } from 'common/flux/action';
+import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
+import { PortPayload } from 'electron/flux/action/device-action-payloads';
+import { ScanActions } from 'electron/flux/action/scan-actions';
+import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
+import { ScanController } from 'electron/platform/android/scan-controller';
+import { ScanResults } from 'electron/platform/android/scan-results';
+import { isFunction } from 'lodash';
+import { tick } from 'tests/unit/common/tick';
+import { axeRuleResultExample } from 'tests/unit/tests/electron/flux/action-creator/scan-result-example';
+import { ExpectedCallType, IMock, It, Mock, Times } from 'typemoq';
+
+describe('ScanController', () => {
+    const port = 1111;
+
+    const payload: PortPayload = {
+        port,
+    };
+
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let scanActionsMock: IMock<ScanActions>;
+    let fetchScanResultsMock: IMock<FetchScanResultsType>;
+    let scanStartedMock: IMock<Action<PortPayload>>;
+    let scanCompletedMock: IMock<Action<void>>;
+    let scanFailedMock: IMock<Action<void>>;
+    let getCurrentDateMock: IMock<() => Date>;
+
+    let testSubject: ScanController;
+
+    beforeEach(() => {
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        fetchScanResultsMock = Mock.ofType<FetchScanResultsType>();
+        scanActionsMock = Mock.ofType<ScanActions>();
+
+        scanStartedMock = Mock.ofType<Action<PortPayload>>();
+        scanStartedMock.setup(scanStarted => scanStarted.addListener(It.is(isFunction))).callback(listener => listener(payload));
+
+        scanCompletedMock = Mock.ofType<Action<void>>();
+        scanFailedMock = Mock.ofType<Action<void>>();
+
+        scanActionsMock.setup(actions => actions.scanCompleted).returns(() => scanCompletedMock.object);
+        scanActionsMock.setup(actions => actions.scanStarted).returns(() => scanStartedMock.object);
+        scanActionsMock.setup(actions => actions.scanFailed).returns(() => scanFailedMock.object);
+
+        getCurrentDateMock = Mock.ofType<() => Date>();
+        getCurrentDateMock.setup(getter => getter()).returns(() => new Date(2019, 10, 8, 9, 0, 0));
+        getCurrentDateMock.setup(getter => getter()).returns(() => new Date(2019, 10, 8, 9, 2, 15));
+
+        testSubject = new ScanController(
+            scanActionsMock.object,
+            fetchScanResultsMock.object,
+            telemetryEventHandlerMock.object,
+            getCurrentDateMock.object,
+        );
+    });
+
+    it('scans and handle successful response', async () => {
+        fetchScanResultsMock.setup(fetch => fetch(port)).returns(() => Promise.resolve(new ScanResults(axeRuleResultExample)));
+
+        telemetryEventHandlerMock
+            .setup(handler =>
+                handler.publishTelemetry(
+                    SCAN_COMPLETED,
+                    It.isValue({
+                        telemetry: {
+                            port,
+                            scanDuration: 135000,
+                            PASS: {
+                                ImageViewName: 2,
+                                ColorContrast: 2,
+                                ActiveViewName: 1,
+                                EditTextValue: 1,
+                                DontMoveAccessibilityFocus: 1,
+                            },
+                            FAIL: { TouchSizeWcag: 1, EditTextName: 1, ColorContrast: 1 },
+                            INCOMPLETE: { ColorContrast: 1 },
+                        },
+                    }),
+                ),
+            )
+            .verifiable(Times.once(), ExpectedCallType.InSequence);
+
+        testSubject.initialize();
+
+        await tick();
+
+        scanCompletedMock.verify(scanCompleted => scanCompleted.invoke(null), Times.once());
+
+        telemetryEventHandlerMock.verifyAll();
+    });
+
+    it('scans and handle error ', async () => {
+        fetchScanResultsMock.setup(fetch => fetch(port)).returns(() => Promise.reject());
+
+        telemetryEventHandlerMock
+            .setup(handler =>
+                handler.publishTelemetry(
+                    SCAN_FAILED,
+                    It.isValue({
+                        telemetry: {
+                            port,
+                            scanDuration: 135000,
+                        },
+                    }),
+                ),
+            )
+            .verifiable(Times.once(), ExpectedCallType.InSequence);
+
+        testSubject.initialize();
+
+        await tick();
+
+        scanFailedMock.verify(scanCompleted => scanCompleted.invoke(null), Times.once());
+
+        telemetryEventHandlerMock.verifyAll();
+    });
+});


### PR DESCRIPTION
#### Description of changes

We need a way to start/re-start a scan. In  this PR:
- add scan actions
- add scan store
- add scan action creator

How of scope for this PR:
- convert and send the results to `UnifiedScanResultStore`
- hook up the new classes.

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1610159
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
