### PR TITLE
fix: Use DEV_MODE env variable to enable dev mode

### DIFF
--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -27,9 +27,11 @@ const createWindow = () => {
 };
 
 const enableDevMode = (window: BrowserWindow) => {
-    window.webContents.openDevTools({
-        mode: 'detach',
-    });
+    if (process.env.DEV_MODE === 'true') {
+        window.webContents.openDevTools({
+            mode: 'detach',
+        });
+    }
 };
 
 app.on('ready', createWindow);


### PR DESCRIPTION
#### Description of changes

Adding proper handling of DEV_MODE enviroment variable on the electron app

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
