### PR TITLE
feat(card-buttons): make color of menu item icons match text per mockups

### DIFF
--- a/src/common/components/cards/card-kebab-menu-button.scss
+++ b/src/common/components/cards/card-kebab-menu-button.scss
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../styles/colors.scss';
+
+.kebab-menu {
+    i {
+        color: $primary-text;
+    }
+}
+
+.kebab-menu-button {
+    background: transparent;
+    top: calc(50% - 4px / 2);
+
+    i {
+        font-size: 20px;
+        border: 1.25px;
+        color: $primary-text;
+    }
+}

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -16,7 +16,7 @@ import { IssueFilingServiceProperties, UserConfigurationStoreData } from '../../
 import { WindowUtils } from '../../window-utils';
 import { IssueFilingButtonDeps } from '../issue-filing-button';
 import { Toast } from '../toast';
-import { kebabMenuButton } from './card-footer.scss';
+import { kebabMenu, kebabMenuButton } from './card-kebab-menu-button.scss';
 
 export type CardKebabMenuButtonDeps = {
     windowUtils: WindowUtils;
@@ -82,7 +82,14 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
             return null;
         }
 
-        return <ContextualMenu onDismiss={() => this.dismissDropdown()} target={this.state.target} items={this.getMenuItems()} />;
+        return (
+            <ContextualMenu
+                className={kebabMenu}
+                onDismiss={() => this.dismissDropdown()}
+                target={this.state.target}
+                items={this.getMenuItems()}
+            />
+        );
     }
 
     private getMenuItems(): IContextualMenuItem[] {

--- a/src/common/components/cards/instance-details-footer.scss
+++ b/src/common/components/cards/instance-details-footer.scss
@@ -31,15 +31,4 @@
             margin: 14px 0px;
         }
     }
-
-    .kebab-menu-button {
-        background: transparent;
-        top: calc(50% - 4px / 2);
-
-        i {
-            font-size: 20px;
-            border: 1.25px;
-            color: $primary-text;
-        }
-    }
 }

--- a/src/common/components/cards/instance-details-footer.tsx
+++ b/src/common/components/cards/instance-details-footer.tsx
@@ -9,9 +9,9 @@ import { TargetAppData, UnifiedResult, UnifiedRule } from '../../../common/types
 import { UnifiedResultToIssueFilingDataConverter } from '../../../issue-filing/unified-result-to-issue-filing-data';
 import { CreateIssueDetailsTextData } from '../../types/create-issue-details-text-data';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
-import { foot, highlightDiv } from './card-footer.scss';
 import { CardInteractionSupport } from './card-interaction-support';
 import { CardKebabMenuButton, CardKebabMenuButtonDeps } from './card-kebab-menu-button';
+import { foot, highlightDiv } from './instance-details-footer.scss';
 
 export type HighlightState = 'visible' | 'hidden' | 'unavailable';
 

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`CardKebabMenuButtonTest render 1`] = `
 exports[`CardKebabMenuButtonTest render ContextualMenu 1`] = `
 "<div className=\\"kebabMenuButton\\">
   <CustomizedActionButton iconProps={{...}} onClick={[Function]} />
-  <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"Card View\\" items={{...}} />
+  <StyledWithResponsiveMode className=\\"kebabMenu\\" onDismiss={[Function: onDismiss]} target=\\"Card View\\" items={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
 </div>"
 `;


### PR DESCRIPTION
#### Description of changes

* Refactors `card-footer.scss` into separate `instance-details-footer.scss` and `card-kebab-menu-button.scss` to match the separation of the corresponding tsx files
* Adds a distinguishing className to the kebab menu
* Uses that to style the icons it contains as $primary-text per the feature mockup

![screenshot of updated menu with black icons](https://user-images.githubusercontent.com/376284/66443009-58a3d480-e9f2-11e9-81a6-a52afb62f5ec.png)

#### Pull request checklist

- [x] Addresses an existing issue: 1612319
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
