### PR TITLE
Handle copy failure

### DIFF
--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -170,6 +170,6 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
     }
 
     private showToastWithFailureMessage(): void {
-        this.setState({ showingCopyToast: true, toastText: 'Failed to copy Failure details. Please try again.' });
+        this.setState({ showingCopyToast: true, toastText: 'Failed to copy failure details. Please try again.' });
     }
 }

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IPoint } from '@uifabric/utilities';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { DirectionalHint, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import * as React from 'react';
 
 import { IssueDetailsTextGenerator } from '../../../background/issue-details-text-generator';
@@ -26,10 +25,9 @@ export type CardKebabMenuButtonDeps = {
 } & IssueFilingButtonDeps;
 
 export interface CardKebabMenuButtonState {
-    isContextMenuVisible: boolean;
     showNeedsSettingsContent: boolean;
-    target?: HTMLElement | string | MouseEvent | IPoint | null;
     showingCopyToast: boolean;
+    toastText: string;
 }
 
 export interface CardKebabMenuButtonProps {
@@ -43,9 +41,9 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
         super(props);
 
         this.state = {
-            isContextMenuVisible: false,
             showNeedsSettingsContent: false,
             showingCopyToast: false,
+            toastText: '',
         };
     }
 
@@ -53,12 +51,15 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
         return (
             <div className={kebabMenuButton}>
                 <ActionButton
-                    iconProps={{
+                    menuIconProps={{
                         iconName: 'moreVertical',
                     }}
-                    onClick={this.openDropdown}
+                    menuProps={{
+                        directionalHint: DirectionalHint.bottomRightEdge,
+                        shouldFocusOnMount: true,
+                        items: this.getMenuItems(),
+                    }}
                 />
-                {this.renderContextMenu()}
                 {this.renderIssueFilingSettingContent()}
                 {this.renderToast()}
             </div>
@@ -69,20 +70,12 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
         return (
             <>
                 {this.state.showingCopyToast ? (
-                    <Toast onTimeout={() => this.setState({ showingCopyToast: false })} deps={this.props.deps}>
-                        Failure details copied.
+                    <Toast onTimeout={() => this.hideToast()} deps={this.props.deps}>
+                        {this.state.toastText}
                     </Toast>
                 ) : null}
             </>
         );
-    }
-
-    private renderContextMenu(): JSX.Element {
-        if (!this.state.isContextMenuVisible) {
-            return null;
-        }
-
-        return <ContextualMenu onDismiss={() => this.dismissDropdown()} target={this.state.target} items={this.getMenuItems()} />;
     }
 
     private getMenuItems(): IContextualMenuItem[] {
@@ -130,9 +123,14 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
         const text = this.props.deps.issueDetailsTextGenerator.buildText(this.props.issueDetailsData);
         this.props.deps.detailsViewActionMessageCreator.copyIssueDetailsClicked(event);
 
-        await this.props.deps.navigatorUtils.copyToClipboard(text);
+        try {
+            await this.props.deps.navigatorUtils.copyToClipboard(text);
+        } catch (error) {
+            this.showToastWithFailureMessage();
+            return;
+        }
 
-        this.setState({ showingCopyToast: true });
+        this.showToastWithSuccessMessage();
     };
 
     public renderIssueFilingSettingContent(): JSX.Element {
@@ -163,11 +161,15 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
         this.setState({ showNeedsSettingsContent: true });
     }
 
-    private openDropdown = (event): void => {
-        this.setState({ target: event.currentTarget, isContextMenuVisible: true });
-    };
+    private showToastWithSuccessMessage(): void {
+        this.setState({ showingCopyToast: true, toastText: 'Failure details copied.' });
+    }
 
-    private dismissDropdown(): void {
-        this.setState({ target: null, isContextMenuVisible: false });
+    private hideToast(): void {
+        this.setState({ showingCopyToast: false, toastText: '' });
+    }
+
+    private showToastWithFailureMessage(): void {
+        this.setState({ showingCopyToast: true, toastText: 'Failed to copy Failure details. Please try again.' });
     }
 }

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
@@ -1,23 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CardKebabMenuButtonTest render 1`] = `
+exports[`CardKebabMenuButtonTest copies failure details and show the toast 1`] = `
 "<div className=\\"kebabMenuButton\\">
-  <CustomizedActionButton iconProps={{...}} onClick={[Function]} />
-  <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
-</div>"
-`;
-
-exports[`CardKebabMenuButtonTest render ContextualMenu 1`] = `
-"<div className=\\"kebabMenuButton\\">
-  <CustomizedActionButton iconProps={{...}} onClick={[Function]} />
-  <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"Card View\\" items={{...}} />
-  <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
-</div>"
-`;
-
-exports[`CardKebabMenuButtonTest should click copy failure details and show the toast 1`] = `
-"<div className=\\"kebabMenuButton\\">
-  <CustomizedActionButton iconProps={{...}} onClick={[Function]} />
+  <CustomizedActionButton menuIconProps={{...}} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
   <Toast onTimeout={[Function: onTimeout]} deps={{...}} timeoutLength={1000}>
     Failure details copied.
@@ -25,16 +10,33 @@ exports[`CardKebabMenuButtonTest should click copy failure details and show the 
 </div>"
 `;
 
+exports[`CardKebabMenuButtonTest render 1`] = `
+"<div className=\\"kebabMenuButton\\">
+  <CustomizedActionButton menuIconProps={{...}} menuProps={{...}} />
+  <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
+</div>"
+`;
+
 exports[`CardKebabMenuButtonTest should click file issue, invalid settings 1`] = `
 "<div className=\\"kebabMenuButton\\">
-  <CustomizedActionButton iconProps={{...}} onClick={[Function]} />
+  <CustomizedActionButton menuIconProps={{...}} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={true} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
 </div>"
 `;
 
-exports[`CardKebabMenuButtonTest should click file issue, valid settings 1`] = `
+exports[`CardKebabMenuButtonTest should file issue, valid settings 1`] = `
 "<div className=\\"kebabMenuButton\\">
-  <CustomizedActionButton iconProps={{...}} onClick={[Function]} />
+  <CustomizedActionButton menuIconProps={{...}} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
+</div>"
+`;
+
+exports[`CardKebabMenuButtonTest shows failure message if copy failed 1`] = `
+"<div className=\\"kebabMenuButton\\">
+  <CustomizedActionButton menuIconProps={{...}} menuProps={{...}} />
+  <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
+  <Toast onTimeout={[Function: onTimeout]} deps={{...}} timeoutLength={1000}>
+    Failed to copy Failure details. Please try again.
+  </Toast>
 </div>"
 `;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`CardKebabMenuButtonTest shows failure message if copy failed 1`] = `
   <CustomizedActionButton menuIconProps={{...}} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
   <Toast onTimeout={[Function: onTimeout]} deps={{...}} timeoutLength={1000}>
-    Failed to copy Failure details. Please try again.
+    Failed to copy failure details. Please try again.
   </Toast>
 </div>"
 `;

--- a/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
@@ -7,7 +7,7 @@ import { guidanceTags } from 'content/guidance-tags';
 import { shallow, ShallowWrapper } from 'enzyme';
 import { IssueFilingServiceProvider } from 'issue-filing/issue-filing-service-provider';
 import { IssueFilingService } from 'issue-filing/types/issue-filing-service';
-import { ActionButton, ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react';
+import { ActionButton, IContextualMenuItem } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
@@ -166,7 +166,7 @@ describe('CardKebabMenuButtonTest', () => {
 
         expect(rendered.debug()).toMatchSnapshot();
         expect(rendered.state().showingCopyToast).toBe(true);
-        expect(rendered.state().toastText).toBe('Failed to copy Failure details. Please try again.');
+        expect(rendered.state().toastText).toBe('Failed to copy failure details. Please try again.');
     });
 
     it('should file issue, valid settings', async () => {


### PR DESCRIPTION
#### Description of changes
- When copy failed, show toast with text: Failed to copy Failure details. Please try again.
- Removed Contextual Menu and used menu props on action button component as a part of this PR, so that we do not have to handle the state of the contextual menu.
- Updated snapshots and unit tests.

![image](https://user-images.githubusercontent.com/15974344/66444209-32346800-e9f7-11e9-8794-6ec26a007d5a.png)



#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
