### PR TITLE
remove redundant 'how to fix' from android converter

### DIFF
--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { InstancePropertyBag } from 'common/types/store-data/unified-data-interface';
+import { UnifiedResolution } from 'common/types/store-data/unified-data-interface';
 import { DictionaryStringTo } from '../../../types/common-types';
 import { RuleInformation } from './rule-information';
 import { RuleResultsData } from './scan-results';
@@ -14,24 +14,24 @@ export class RuleInformationProvider {
             ColorContrast: new RuleInformation(
                 'ColorContrast',
                 'Text elements must have sufficient contrast against the background.',
-                this.getColorContrastHowToFix,
+                this.getColorContrastUnifiedResolution,
             ),
             TouchSizeWcag: new RuleInformation(
                 'TouchSizeWcag',
                 'Touch inputs must have a sufficient target size.',
-                this.getTouchSizeHowToFix,
+                this.getTouchSizeUnifiedResolution,
             ),
             ActiveViewName: new RuleInformation(
                 'ActiveViewName',
                 "Active views must have a name that's available to assistive technologies.",
                 () =>
-                    this.buildHowtoFixPropertyBag(
+                    this.buildUnifiedResolution(
                         'The view is active but has no name available to assistive technologies. Provide a name for the view using its contentDescription, hint, labelFor, or text attribute (depending on the view type)',
                         ['contentDescription', 'hint', 'labelFor', 'text'],
                     ),
             ),
             ImageViewName: new RuleInformation('ImageViewName', 'Meaningful images must have alternate text.', () =>
-                this.buildHowtoFixPropertyBag(
+                this.buildUnifiedResolution(
                     'The image has no alternate text and is not identified as decorative. If the image conveys meaningful content, provide alternate text using the contentDescription attribute. If the image is decorative, give it an empty contentDescription, or set its isImportantForAccessibility attribute to false.',
                     ['contentDescription', 'isImportantForAccessibility'],
                 ),
@@ -40,7 +40,7 @@ export class RuleInformationProvider {
                 'EditTextValue',
                 'EditText elements must expose their entered text value to assistive technologies',
                 () =>
-                    this.buildHowtoFixPropertyBag(
+                    this.buildUnifiedResolution(
                         "The element's contentDescription overrides the text value required by assistive technologies. Remove the element’s contentDescription attribute.",
                         ['contentDescription'],
                     ),
@@ -48,31 +48,31 @@ export class RuleInformationProvider {
         };
     }
 
-    private getColorContrastHowToFix = (ruleResultsData: RuleResultsData): InstancePropertyBag => {
+    private getColorContrastUnifiedResolution = (ruleResultsData: RuleResultsData): UnifiedResolution => {
         const ratio = ruleResultsData.props['Color Contrast Ratio'] as string;
         const foreground = (ruleResultsData.props['Foreground Color'] as string).substring(2);
         const background = (ruleResultsData.props['Background Color'] as string).substring(2);
 
-        return this.buildHowtoFixPropertyBag(
+        return this.buildUnifiedResolution(
             `The text element has insufficient contrast of ${ratio}. Foreground color: #${foreground}, background color: #${background}). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).`,
         );
     };
 
-    private getTouchSizeHowToFix = (ruleResultsData: RuleResultsData): InstancePropertyBag => {
+    private getTouchSizeUnifiedResolution = (ruleResultsData: RuleResultsData): UnifiedResolution => {
         const dpi = ruleResultsData.props['Screen Dots Per Inch'] as number;
         const physicalWidth = ruleResultsData.props['width'] as number;
         const physicalHeight = ruleResultsData.props['height'] as number;
         const logicalWidth = physicalWidth / dpi;
         const logicalHeight = physicalHeight / dpi;
 
-        return this.buildHowtoFixPropertyBag(
+        return this.buildUnifiedResolution(
             `The element has an insufficient target size (width: ${logicalWidth}dp, height: ${logicalHeight}dp). Set the element's minWidth and minHeight attributes to at least 48dp.`,
             ['minWidth', 'minHeight'],
         );
     };
 
-    private buildHowtoFixPropertyBag(unformattedText: string, codeStrings: string[] = null): InstancePropertyBag {
-        return { unformattedText: unformattedText, formatAsCode: codeStrings };
+    private buildUnifiedResolution(unformattedText: string, codeStrings: string[] = null): UnifiedResolution {
+        return { howToFixSummary: unformattedText, formatAsCode: codeStrings };
     }
 
     public getRuleInformation(ruleId: string): RuleInformation {

--- a/src/electron/platform/android/rule-information.ts
+++ b/src/electron/platform/android/rule-information.ts
@@ -1,19 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { InstancePropertyBag } from 'common/types/store-data/unified-data-interface';
+import { UnifiedResolution } from 'common/types/store-data/unified-data-interface';
 import { RuleResultsData } from './scan-results';
 
-export type HowToFixDelegate = (ruleResultsData: RuleResultsData) => InstancePropertyBag;
+export type GetUnifiedResolutionDelegate = (ruleResultsData: RuleResultsData) => UnifiedResolution;
 
 export class RuleInformation {
-    constructor(readonly ruleId: string, readonly ruleDescription: string, readonly howToFixDelegate: HowToFixDelegate) {}
+    constructor(
+        readonly ruleId: string,
+        readonly ruleDescription: string,
+        readonly getUnifiedResolutionDelegate: GetUnifiedResolutionDelegate,
+    ) {}
 
-    public howToFix(ruleResultsData: RuleResultsData): InstancePropertyBag {
-        return this.howToFixDelegate(ruleResultsData);
-    }
-
-    public howToFixString(ruleResultsData: RuleResultsData): string {
-        return this.howToFixDelegate(ruleResultsData).unformattedText;
+    public getUnifiedResolution(ruleResultsData: RuleResultsData): UnifiedResolution {
+        return this.getUnifiedResolutionDelegate(ruleResultsData);
     }
 }

--- a/src/electron/platform/android/scan-results-to-unified-results.ts
+++ b/src/electron/platform/android/scan-results-to-unified-results.ts
@@ -65,10 +65,7 @@ function createUnifiedResult(
         status: getStatus(ruleResult.status),
         descriptors: getDescriptors(viewElementLookup[ruleResult.axeViewId]),
         identifiers: null,
-        resolution: {
-            howToFixSummary: ruleInformation.howToFixString(ruleResult),
-            'how-to-fix': ruleInformation.howToFix(ruleResult),
-        },
+        resolution: ruleInformation.getUnifiedResolution(ruleResult),
     };
 }
 

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/rule-information-provider.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/rule-information-provider.test.ts.snap
@@ -8,14 +8,14 @@ Object {
     "labelFor",
     "text",
   ],
-  "unformattedText": "The view is active but has no name available to assistive technologies. Provide a name for the view using its contentDescription, hint, labelFor, or text attribute (depending on the view type)",
+  "howToFixSummary": "The view is active but has no name available to assistive technologies. Provide a name for the view using its contentDescription, hint, labelFor, or text attribute (depending on the view type)",
 }
 `;
 
 exports[`RuleInformationProvider getRuleInformation returns correct data for ColorContrast rule 1`] = `
 Object {
   "formatAsCode": null,
-  "unformattedText": "The text element has insufficient contrast of 2.798498811425733. Foreground color: #979797, background color: #fafafa). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
+  "howToFixSummary": "The text element has insufficient contrast of 2.798498811425733. Foreground color: #979797, background color: #fafafa). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
 }
 `;
 
@@ -24,7 +24,7 @@ Object {
   "formatAsCode": Array [
     "contentDescription",
   ],
-  "unformattedText": "The element's contentDescription overrides the text value required by assistive technologies. Remove the element’s contentDescription attribute.",
+  "howToFixSummary": "The element's contentDescription overrides the text value required by assistive technologies. Remove the element’s contentDescription attribute.",
 }
 `;
 
@@ -34,7 +34,7 @@ Object {
     "contentDescription",
     "isImportantForAccessibility",
   ],
-  "unformattedText": "The image has no alternate text and is not identified as decorative. If the image conveys meaningful content, provide alternate text using the contentDescription attribute. If the image is decorative, give it an empty contentDescription, or set its isImportantForAccessibility attribute to false.",
+  "howToFixSummary": "The image has no alternate text and is not identified as decorative. If the image conveys meaningful content, provide alternate text using the contentDescription attribute. If the image is decorative, give it an empty contentDescription, or set its isImportantForAccessibility attribute to false.",
 }
 `;
 
@@ -44,6 +44,6 @@ Object {
     "minWidth",
     "minHeight",
   ],
-  "unformattedText": "The element has an insufficient target size (width: 42.22222222222222dp, height: 38.22222222222222dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
+  "howToFixSummary": "The element has an insufficient target size (width: 42.22222222222222dp, height: 38.22222222222222dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
 }
 `;

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-results.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-results.test.ts.snap
@@ -20,10 +20,7 @@ Array [
     },
     "identifiers": null,
     "resolution": Object {
-      "how-to-fix": Object {
-        "formatAsCode": null,
-        "unformattedText": "The text element has insufficient contrast of 1. Foreground color: #ffffff, background color: #ffffff). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
-      },
+      "formatAsCode": null,
       "howToFixSummary": "The text element has insufficient contrast of 1. Foreground color: #ffffff, background color: #ffffff). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
     },
     "ruleId": "ColorContrast",
@@ -39,13 +36,10 @@ Array [
     },
     "identifiers": null,
     "resolution": Object {
-      "how-to-fix": Object {
-        "formatAsCode": Array [
-          "minWidth",
-          "minHeight",
-        ],
-        "unformattedText": "The element has an insufficient target size (width: 32dp, height: 32dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
-      },
+      "formatAsCode": Array [
+        "minWidth",
+        "minHeight",
+      ],
       "howToFixSummary": "The element has an insufficient target size (width: 32dp, height: 32dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
     },
     "ruleId": "TouchSizeWcag",
@@ -66,13 +60,10 @@ Array [
     },
     "identifiers": null,
     "resolution": Object {
-      "how-to-fix": Object {
-        "formatAsCode": Array [
-          "minWidth",
-          "minHeight",
-        ],
-        "unformattedText": "The element has an insufficient target size (width: 48dp, height: 48dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
-      },
+      "formatAsCode": Array [
+        "minWidth",
+        "minHeight",
+      ],
       "howToFixSummary": "The element has an insufficient target size (width: 48dp, height: 48dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
     },
     "ruleId": "TouchSizeWcag",
@@ -93,10 +84,7 @@ Array [
     },
     "identifiers": null,
     "resolution": Object {
-      "how-to-fix": Object {
-        "formatAsCode": null,
-        "unformattedText": "The text element has insufficient contrast of 21. Foreground color: #ffffff, background color: #000000). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
-      },
+      "formatAsCode": null,
       "howToFixSummary": "The text element has insufficient contrast of 21. Foreground color: #ffffff, background color: #000000). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
     },
     "ruleId": "ColorContrast",
@@ -107,13 +95,10 @@ Array [
     "descriptors": null,
     "identifiers": null,
     "resolution": Object {
-      "how-to-fix": Object {
-        "formatAsCode": Array [
-          "minWidth",
-          "minHeight",
-        ],
-        "unformattedText": "The element has an insufficient target size (width: 0dp, height: 0dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
-      },
+      "formatAsCode": Array [
+        "minWidth",
+        "minHeight",
+      ],
       "howToFixSummary": "The element has an insufficient target size (width: 0dp, height: 0dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
     },
     "ruleId": "TouchSizeWcag",

--- a/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { InstancePropertyBag } from 'common/types/store-data/unified-data-interface';
+import { UnifiedResolution } from 'common/types/store-data/unified-data-interface';
 import { RuleInformation } from 'electron/platform/android/rule-information';
 import { RuleInformationProvider } from 'electron/platform/android/rule-information-provider';
 import { RuleResultsData } from 'electron/platform/android/scan-results';
@@ -18,43 +18,43 @@ describe('RuleInformationProvider', () => {
         expect(provider.getRuleInformation('unknown rule')).toBeNull();
     });
 
-    function validateHowToFix(ruleId: string, ruleResult: RuleResultsData): InstancePropertyBag {
+    function validateUnifiedResolution(ruleId: string, ruleResult: RuleResultsData): UnifiedResolution {
         const ruleInformation: RuleInformation = provider.getRuleInformation(ruleId);
-        const howToFix = ruleInformation.howToFix(ruleResult);
+        const unifiedResolution = ruleInformation.getUnifiedResolution(ruleResult);
 
         expect(ruleInformation).toBeTruthy();
         expect(ruleInformation.ruleId).toEqual(ruleId);
         expect(ruleInformation.ruleDescription.length).toBeGreaterThan(0);
 
-        return howToFix;
+        return unifiedResolution;
     }
 
     test('getRuleInformation returns correct data for ColorContrast rule', () => {
         const testRuleId: string = 'ColorContrast';
         const ruleResult: RuleResultsData = buildColorContrastRuleResultObject('FAIL', 2.798498811425733, 'ff979797', 'fffafafa');
-        const howToFix: InstancePropertyBag = validateHowToFix(testRuleId, ruleResult);
-        expect(howToFix).toMatchSnapshot();
+        const unifiedResolution: UnifiedResolution = validateUnifiedResolution(testRuleId, ruleResult);
+        expect(unifiedResolution).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for TouchSizeWcag rule', () => {
         const testRuleId: string = 'TouchSizeWcag';
         const ruleResult: RuleResultsData = buildTouchSizeWcagRuleResultObject('FAIL', 2.25, 86, 95);
-        const howToFix: InstancePropertyBag = validateHowToFix(testRuleId, ruleResult);
-        expect(howToFix).toMatchSnapshot();
+        const unifiedResolution: UnifiedResolution = validateUnifiedResolution(testRuleId, ruleResult);
+        expect(unifiedResolution).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for ActiveViewName rule', () => {
-        const howToFix: InstancePropertyBag = validateHowToFix('ActiveViewName', null);
-        expect(howToFix).toMatchSnapshot();
+        const unifiedResolution: UnifiedResolution = validateUnifiedResolution('ActiveViewName', null);
+        expect(unifiedResolution).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for EditTextValue rule', () => {
-        const howToFix: InstancePropertyBag = validateHowToFix('EditTextValue', null);
-        expect(howToFix).toMatchSnapshot();
+        const unifiedResolution: UnifiedResolution = validateUnifiedResolution('EditTextValue', null);
+        expect(unifiedResolution).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for ImageViewName rule', () => {
-        const howToFix: InstancePropertyBag = validateHowToFix('ImageViewName', null);
-        expect(howToFix).toMatchSnapshot();
+        const unifiedResolution: UnifiedResolution = validateUnifiedResolution('ImageViewName', null);
+        expect(unifiedResolution).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { Mock } from 'typemoq';
-
-import { HowToFixDelegate, RuleInformation } from 'electron/platform/android/rule-information';
+import { UnifiedResolution } from 'common/types/store-data/unified-data-interface';
+import { GetUnifiedResolutionDelegate, RuleInformation } from 'electron/platform/android/rule-information';
 import { RuleResultsData } from 'electron/platform/android/scan-results';
+import { Mock } from 'typemoq';
 
 describe('RuleInformation', () => {
     const testInputs = ['abc', 'xyz', 'this should work'];
@@ -23,7 +23,7 @@ describe('RuleInformation', () => {
         }
     });
 
-    test('HowToFix works correctly', () => {
+    test('GetUnifiedResolution works correctly', () => {
         const testData: RuleResultsData = {
             axeViewId: 'test',
             ruleId: 'some rule',
@@ -32,12 +32,16 @@ describe('RuleInformation', () => {
         };
 
         for (const howToFixString of testInputs) {
-            const expectedPropertyBag = { someLabel: howToFixString };
-            const howToFixDelegateMock = Mock.ofType<HowToFixDelegate>();
-            howToFixDelegateMock.setup(func => func(testData)).returns(() => expectedPropertyBag);
-            const ruleInformation = new RuleInformation(null, null, howToFixDelegateMock.object);
-            const actualPropertyBag = ruleInformation.howToFix(testData);
-            expect(actualPropertyBag).toBe(expectedPropertyBag);
+            const expectedUnifiedResolution: UnifiedResolution = { howToFixSummary: howToFixString };
+
+            const getUnifiedResolutionDelegateMock = Mock.ofType<GetUnifiedResolutionDelegate>();
+            getUnifiedResolutionDelegateMock.setup(func => func(testData)).returns(() => expectedUnifiedResolution);
+
+            const ruleInformation = new RuleInformation(null, null, getUnifiedResolutionDelegateMock.object);
+
+            const actualUnifiedResolution = ruleInformation.getUnifiedResolution(testData);
+
+            expect(actualUnifiedResolution).toBe(expectedUnifiedResolution);
         }
     });
 });


### PR DESCRIPTION
#### Description of changes

Updated the android results to unified results converter to populate UnifiedResolution with getUnifiedResolution, instead of saving two versions of the how to fix text (in 'how-to-fix' unformattedText and in howToFixSummary). 

Main changes are that the howToFixString function has been removed, as it is not needed, and unformattedText in the InstancePropertyBag is now called howToFixSummary to match the UnifiedResolution type.

#### Pull request checklist

- [x] Addresses an existing WI: # 1611808
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
