### PR TITLE
fix(card-buttons): clean up border/shadow behavior of cards around new footer

### DIFF
--- a/src/common/components/cards/instance-details-footer.scss
+++ b/src/common/components/cards/instance-details-footer.scss
@@ -10,6 +10,8 @@
     height: 48px;
 
     border-top: 0.5px solid $neutral-10;
+    border-bottom-left-radius: inherit;
+    border-bottom-right-radius: inherit;
 
     .highlight-div {
         background: transparent;

--- a/src/common/components/cards/instance-details-footer.scss
+++ b/src/common/components/cards/instance-details-footer.scss
@@ -7,10 +7,9 @@
     justify-content: space-between;
     display: flex;
     background-color: $neutral-2;
-    box-shadow: 0px -1px 0px rgba(0, 0, 0, 0.08);
-    border-radius: 4px;
-    margin: 0px 0px 18px 24px;
     height: 48px;
+
+    border-top: 0.5px solid $neutral-10;
 
     .highlight-div {
         background: transparent;

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -12,7 +12,7 @@ import {
     UnifiedResult,
     UnifiedRule,
 } from '../../../common/types/store-data/unified-data-interface';
-import { reportInstanceTable } from '../../../reports/components/instance-details.scss';
+import { instanceDetailsCard, reportInstanceTable } from '../../../reports/components/instance-details.scss';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { HighlightState, InstanceDetailsFooter, InstanceDetailsFooterDeps } from './instance-details-footer';
 
@@ -53,7 +53,7 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
 
     const cardClickHandler = () => deps.cardSelectionMessageCreator.toggleCardSelection(result.uid);
     return (
-        <>
+        <div className={instanceDetailsCard}>
             <table className={reportInstanceTable} onClick={cardClickHandler}>
                 <tbody>
                     {renderCardRowsForPropertyBag(result.identifiers)}
@@ -69,6 +69,6 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
                 rule={rule}
                 targetAppInfo={targetAppInfo}
             />
-        </>
+        </div>
     );
 });

--- a/src/reports/components/instance-details.scss
+++ b/src/reports/components/instance-details.scss
@@ -26,6 +26,9 @@
     table-layout: fixed;
     @include fill-available-width;
 
+    border-top-left-radius: inherit;
+    border-top-right-radius: inherit;
+
     th {
         padding: 12px 20px;
 

--- a/src/reports/components/instance-details.scss
+++ b/src/reports/components/instance-details.scss
@@ -16,6 +16,7 @@
     border-radius: 4px;
     box-shadow: 0px 0.6px 1.8px rgba(0, 0, 0, 0.108), 0px 3.2px 7.2px rgba(0, 0, 0, 0.132);
     margin-left: 24px;
+    margin-bottom: 16px;
     @include fill-available-width;
 }
 

--- a/src/reports/components/instance-details.scss
+++ b/src/reports/components/instance-details.scss
@@ -26,8 +26,7 @@
     table-layout: fixed;
     @include fill-available-width;
 
-    border-top-left-radius: inherit;
-    border-top-right-radius: inherit;
+    border-radius: inherit;
 
     th {
         padding: 12px 20px;

--- a/src/reports/components/instance-details.scss
+++ b/src/reports/components/instance-details.scss
@@ -4,18 +4,26 @@
 @import '../../common/styles/colors.scss';
 @import '../../common/styles/fonts.scss';
 
-.report-instance-table {
-    background: $neutral-0;
-    border-radius: 4px;
-    box-shadow: 0px 0.6px 1.8px rgba(0, 0, 0, 0.108), 0px 3.2px 7.2px rgba(0, 0, 0, 0.132);
-    display: table;
+@mixin fill-available-width {
     width: -moz-available;
     /* WebKit-based browsers will ignore this. */
     width: -webkit-fill-available;
     /* Mozilla-based browsers will ignore this. */
     width: fill-available;
+}
+
+.instance-details-card {
+    border-radius: 4px;
+    box-shadow: 0px 0.6px 1.8px rgba(0, 0, 0, 0.108), 0px 3.2px 7.2px rgba(0, 0, 0, 0.132);
     margin-left: 24px;
+    @include fill-available-width;
+}
+
+.report-instance-table {
+    background: $neutral-0;
+    display: table;
     table-layout: fixed;
+    @include fill-available-width;
 
     th {
         padding: 12px 20px;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`InstanceDetails renders 1`] = `
-<React.Fragment>
+<div
+  className="instanceDetailsCard"
+>
   <table
     className="reportInstanceTable"
     onClick={[Function]}
@@ -103,11 +105,13 @@ exports[`InstanceDetails renders 1`] = `
       }
     }
   />
-</React.Fragment>
+</div>
 `;
 
 exports[`InstanceDetails renders nothing when there is no card row config for the property / no property 1`] = `
-<React.Fragment>
+<div
+  className="instanceDetailsCard"
+>
   <table
     className="reportInstanceTable"
     onClick={[Function]}
@@ -144,5 +148,5 @@ exports[`InstanceDetails renders nothing when there is no card row config for th
       }
     }
   />
-</React.Fragment>
+</div>
 `;


### PR DESCRIPTION
#### Description of changes

Fixes the border/shadow between the new card footer and the rest of the card to make the whole card have one cohesive border/shadow, per UI mockups.

Did this by adding a wrapping div to contain the card+footer together, moving the border/shadow styling from the table to there, removing the redundant styling in the table+footer, and setting the table+footer to inherit the appropriate border-radius parts from the container.

Verified that the card's shadow looks valid in both report and fastpass.

Before:

<img width="434" alt="screenshot of card before changes" src="https://user-images.githubusercontent.com/376284/66527750-0cb86480-eab2-11e9-890e-b6d6d6efb6fb.png">

After:

<img width="425" alt="screenshot of card after changes" src="https://user-images.githubusercontent.com/376284/66527758-0e822800-eab2-11e9-9fc7-223e3d02f919.png">


#### Pull request checklist

- [x] Addresses an existing issue: 1612323
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
