### PR TITLE
chore: remove unused prop in details-view

### DIFF
--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -189,7 +189,6 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
                 detailsViewStoreData={storeState.detailsViewStoreData}
                 visualizationStoreData={storeState.visualizationStoreData}
                 visualizationScanResultData={storeState.visualizationScanResultStoreData}
-                unifiedResults={ruleResults}
                 visualizationConfigurationFactory={this.props.visualizationConfigurationFactory}
                 assessmentsProvider={this.props.assessmentsProvider}
                 dropdownClickHandler={this.props.dropdownClickHandler}

--- a/src/DetailsView/details-view-main-content.tsx
+++ b/src/DetailsView/details-view-main-content.tsx
@@ -38,7 +38,6 @@ export interface DetailsViewMainContentProps {
     selectedTest: VisualizationType;
     visualizationStoreData: VisualizationStoreData;
     visualizationScanResultData: VisualizationScanResultData;
-    unifiedResults: UnifiedStatusResults;
     visualizationConfigurationFactory: VisualizationConfigurationFactory;
     assessmentsProvider: AssessmentsProvider;
     dropdownClickHandler: DropdownClickHandler;

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -287,7 +287,6 @@ describe('DetailsViewContainer', () => {
                 detailsViewStoreData={storeMocks.detailsViewStoreData}
                 visualizationStoreData={storeMocks.visualizationStoreData}
                 visualizationScanResultData={storeMocks.visualizationScanResultsStoreData}
-                unifiedResults={ruleResults}
                 visualizationConfigurationFactory={props.visualizationConfigurationFactory}
                 assessmentsProvider={props.assessmentsProvider}
                 dropdownClickHandler={props.dropdownClickHandler}


### PR DESCRIPTION
#### Description of changes

This PR removes an unused `unifiedResults` prop. The prop being used instead is `ruleResultsByStatus`.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
