### PR TITLE
feat(android-cards-view): convert scan results and invoke unified scan complete action

### DIFF
--- a/src/content/strings/application.ts
+++ b/src/content/strings/application.ts
@@ -1,11 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
-export const title = 'Accessibility Insights for Web';
-
 export const brand = 'Accessibility Insights';
+export const title = `${brand} for Web`;
 export const productName = title;
 export const toolName = title;
-
-export const windowsProductName = 'Accessibility Insights for Windows';
-export const telemetryAppTitle = 'Accessibility Insights for Mobile';
+export const windowsProductName = `${brand} for Windows`;
+export const androidAppTitle = `${brand} for Android`;

--- a/src/electron/common/application-properties-provider.ts
+++ b/src/electron/common/application-properties-provider.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AppDataAdapter } from 'common/browser-adapters/app-data-adapter';
+import { ApplicationProperties } from 'common/types/store-data/unified-data-interface';
+import { androidAppTitle } from 'content/strings/application';
+export type ApplicationPropertiesDelegate = () => ApplicationProperties;
+
+export const createGetApplicationProperties = (appDataAdapter: AppDataAdapter): ApplicationPropertiesDelegate => {
+    return () => {
+        return {
+            name: androidAppTitle,
+            version: appDataAdapter.getVersion(),
+        };
+    };
+};

--- a/src/electron/common/application-properties-provider.ts
+++ b/src/electron/common/application-properties-provider.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AppDataAdapter } from 'common/browser-adapters/app-data-adapter';
-import { ApplicationProperties } from 'common/types/store-data/unified-data-interface';
+import { ApplicationProperties, ToolData } from 'common/types/store-data/unified-data-interface';
 import { androidAppTitle } from 'content/strings/application';
+import { ScanResults } from 'electron/platform/android/scan-results';
 export type ApplicationPropertiesDelegate = () => ApplicationProperties;
 
 export const createGetApplicationProperties = (appDataAdapter: AppDataAdapter): ApplicationPropertiesDelegate => {
@@ -10,6 +11,23 @@ export const createGetApplicationProperties = (appDataAdapter: AppDataAdapter): 
         return {
             name: androidAppTitle,
             version: appDataAdapter.getVersion(),
+        };
+    };
+};
+
+export type ToolDataDelegate = (scanResults: ScanResults) => ToolData;
+
+export const createGetToolDataDelegate = (appDataAdapter: AppDataAdapter): ToolDataDelegate => {
+    return scanResults => {
+        return {
+            scanEngineProperties: {
+                name: 'axe-android',
+                version: scanResults.axeVersion,
+            },
+            applicationProperties: {
+                name: androidAppTitle,
+                version: appDataAdapter.getVersion(),
+            },
         };
     };
 };

--- a/src/electron/common/application-properties-provider.ts
+++ b/src/electron/common/application-properties-provider.ts
@@ -1,19 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AppDataAdapter } from 'common/browser-adapters/app-data-adapter';
-import { ApplicationProperties, ToolData } from 'common/types/store-data/unified-data-interface';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { androidAppTitle } from 'content/strings/application';
 import { ScanResults } from 'electron/platform/android/scan-results';
-export type ApplicationPropertiesDelegate = () => ApplicationProperties;
-
-export const createGetApplicationProperties = (appDataAdapter: AppDataAdapter): ApplicationPropertiesDelegate => {
-    return () => {
-        return {
-            name: androidAppTitle,
-            version: appDataAdapter.getVersion(),
-        };
-    };
-};
 
 export type ToolDataDelegate = (scanResults: ScanResults) => ToolData;
 

--- a/src/electron/platform/android/scan-controller.ts
+++ b/src/electron/platform/android/scan-controller.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { InstanceCount, TelemetryEventSource } from 'common/extension-telemetry-events';
 import { createDefaultLogger } from 'common/logging/default-logger';
@@ -8,11 +9,14 @@ import { PortPayload } from 'electron/flux/action/device-action-payloads';
 import { ScanActions } from 'electron/flux/action/scan-actions';
 import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
 import { RuleResultsData, ScanResults } from 'electron/platform/android/scan-results';
+import { UnifiedScanCompletedPayloadBuilder } from 'electron/platform/android/unified-result-builder';
 
 export class ScanController {
     constructor(
         private readonly scanActions: ScanActions,
+        private readonly unifiedScanResultAction: UnifiedScanResultActions,
         private readonly fetchScanResults: FetchScanResultsType,
+        private readonly unifiedResultsBuilder: UnifiedScanCompletedPayloadBuilder,
         private readonly telemetryEventHandler: TelemetryEventHandler,
         private readonly getCurrentDate: () => Date,
         private readonly logger = createDefaultLogger(),
@@ -54,6 +58,9 @@ export class ScanController {
             },
         });
 
+        const payload = this.unifiedResultsBuilder(data);
+
+        this.unifiedScanResultAction.scanCompleted.invoke(payload);
         this.scanActions.scanCompleted.invoke(null);
     }
 

--- a/src/electron/platform/android/scan-results.ts
+++ b/src/electron/platform/android/scan-results.ts
@@ -57,4 +57,12 @@ export class ScanResults {
             return [];
         }
     }
+
+    public get axeVersion(): string {
+        try {
+            return this.rawData.axeContext.axeMetaData.axeVersion;
+        } catch {
+            return 'no-version';
+        }
+    }
 }

--- a/src/electron/platform/android/unified-result-builder.ts
+++ b/src/electron/platform/android/unified-result-builder.ts
@@ -13,6 +13,8 @@ import {
     ConvertScanResultsToUnifiedRulesDelegate,
 } from 'electron/platform/android/scan-results-to-unified-rules';
 
+export type UnifiedScanCompletedPayloadBuilder = (scanResults: ScanResults) => UnifiedScanCompletedPayload;
+
 export const createBuilder = (
     getUnifiedResults: ConvertScanResultsToUnifiedResultsDelegate,
     getUnifiedRules: ConvertScanResultsToUnifiedRulesDelegate,

--- a/src/electron/platform/android/unified-result-builder.ts
+++ b/src/electron/platform/android/unified-result-builder.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
 import { generateUID, UUIDGeneratorType } from 'common/uid-generator';
-import { ApplicationPropertiesDelegate } from 'electron/common/application-properties-provider';
+import { ToolDataDelegate } from 'electron/common/application-properties-provider';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import {
     convertScanResultsToUnifiedResults,
@@ -19,18 +19,12 @@ export const createBuilder = (
     getUnifiedResults: ConvertScanResultsToUnifiedResultsDelegate,
     getUnifiedRules: ConvertScanResultsToUnifiedRulesDelegate,
     uuidGenerator: UUIDGeneratorType,
-    applicationPropertiesDelegate: ApplicationPropertiesDelegate,
+    getToolData: ToolDataDelegate,
 ) => (scanResults: ScanResults): UnifiedScanCompletedPayload => {
     const payload: UnifiedScanCompletedPayload = {
         scanResult: getUnifiedResults(scanResults, uuidGenerator),
         rules: getUnifiedRules(scanResults, uuidGenerator),
-        toolInfo: {
-            scanEngineProperties: {
-                name: 'axe-android',
-                version: scanResults.axeVersion,
-            },
-            applicationProperties: applicationPropertiesDelegate(),
-        },
+        toolInfo: getToolData(scanResults),
         targetAppInfo: {
             name: scanResults.appIdentifier,
         },
@@ -38,6 +32,6 @@ export const createBuilder = (
     return payload;
 };
 
-export const createDefaultBuilder = (applicationPropertiesDelegate: ApplicationPropertiesDelegate) => {
-    return createBuilder(convertScanResultsToUnifiedResults, convertScanResultsToUnifiedRules, generateUID, applicationPropertiesDelegate);
+export const createDefaultBuilder = (getToolData: ToolDataDelegate) => {
+    return createBuilder(convertScanResultsToUnifiedResults, convertScanResultsToUnifiedRules, generateUID, getToolData);
 };

--- a/src/electron/platform/android/unified-result-builder.ts
+++ b/src/electron/platform/android/unified-result-builder.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
 import { generateUID, UUIDGeneratorType } from 'common/uid-generator';
+import { ApplicationPropertiesDelegate } from 'electron/common/application-properties-provider';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import {
     convertScanResultsToUnifiedResults,
@@ -16,6 +17,7 @@ export const createBuilder = (
     getUnifiedResults: ConvertScanResultsToUnifiedResultsDelegate,
     getUnifiedRules: ConvertScanResultsToUnifiedRulesDelegate,
     uuidGenerator: UUIDGeneratorType,
+    applicationPropertiesDelegate: ApplicationPropertiesDelegate,
 ) => (scanResults: ScanResults): UnifiedScanCompletedPayload => {
     const payload: UnifiedScanCompletedPayload = {
         scanResult: getUnifiedResults(scanResults, uuidGenerator),
@@ -25,10 +27,7 @@ export const createBuilder = (
                 name: 'axe-android',
                 version: scanResults.axeVersion,
             },
-            applicationProperties: {
-                name: 'AI-Android',
-                version: '0.0',
-            },
+            applicationProperties: applicationPropertiesDelegate(),
         },
         targetAppInfo: {
             name: scanResults.appIdentifier,
@@ -37,6 +36,6 @@ export const createBuilder = (
     return payload;
 };
 
-export const createDefaultBuilder = () => {
-    return createBuilder(convertScanResultsToUnifiedResults, convertScanResultsToUnifiedRules, generateUID);
+export const createDefaultBuilder = (applicationPropertiesDelegate: ApplicationPropertiesDelegate) => {
+    return createBuilder(convertScanResultsToUnifiedResults, convertScanResultsToUnifiedRules, generateUID, applicationPropertiesDelegate);
 };

--- a/src/electron/platform/android/unified-result-builder.ts
+++ b/src/electron/platform/android/unified-result-builder.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
+import { generateUID, UUIDGeneratorType } from 'common/uid-generator';
+import { ScanResults } from 'electron/platform/android/scan-results';
+import {
+    convertScanResultsToUnifiedResults,
+    ConvertScanResultsToUnifiedResultsDelegate,
+} from 'electron/platform/android/scan-results-to-unified-results';
+import {
+    convertScanResultsToUnifiedRules,
+    ConvertScanResultsToUnifiedRulesDelegate,
+} from 'electron/platform/android/scan-results-to-unified-rules';
+
+export const createBuilder = (
+    getUnifiedResults: ConvertScanResultsToUnifiedResultsDelegate,
+    getUnifiedRules: ConvertScanResultsToUnifiedRulesDelegate,
+    uuidGenerator: UUIDGeneratorType,
+) => (scanResults: ScanResults): UnifiedScanCompletedPayload => {
+    const payload: UnifiedScanCompletedPayload = {
+        scanResult: getUnifiedResults(scanResults, uuidGenerator),
+        rules: getUnifiedRules(scanResults, uuidGenerator),
+        toolInfo: {
+            scanEngineProperties: {
+                name: 'axe-android',
+                version: scanResults.axeVersion,
+            },
+            applicationProperties: {
+                name: 'AI-Android',
+                version: '0.0',
+            },
+        },
+        targetAppInfo: {
+            name: scanResults.appIdentifier,
+        },
+    };
+    return payload;
+};
+
+export const createDefaultBuilder = () => {
+    return createBuilder(convertScanResultsToUnifiedResults, convertScanResultsToUnifiedRules, generateUID);
+};

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -25,7 +25,7 @@ import { initializeFabricIcons } from '../../common/fabric-icons';
 import { getIndexedDBStore } from '../../common/indexedDB/get-indexeddb-store';
 import { IndexedDBAPI, IndexedDBUtil } from '../../common/indexedDB/indexedDB';
 import { BaseClientStoresHub } from '../../common/stores/base-client-stores-hub';
-import { telemetryAppTitle } from '../../content/strings/application';
+import { androidAppTitle } from '../../content/strings/application';
 import { ElectronAppDataAdapter } from '../adapters/electron-app-data-adapter';
 import { ElectronStorageAdapter } from '../adapters/electron-storage-adapter';
 import { RiggedFeatureFlagChecker } from '../common/rigged-feature-flag-checker';
@@ -55,7 +55,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
     telemetryLogger.initialize(new RiggedFeatureFlagChecker());
 
     const telemetryClient = getTelemetryClient(
-        telemetryAppTitle,
+        androidAppTitle,
         installationData,
         appDataAdapter,
         telemetryLogger,

--- a/src/tests/unit/tests/electron/common/application-properties-provider.test.ts
+++ b/src/tests/unit/tests/electron/common/application-properties-provider.test.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AppDataAdapter } from 'common/browser-adapters/app-data-adapter';
+import { createGetApplicationProperties } from 'electron/common/application-properties-provider';
+import { Mock } from 'typemoq';
+
+describe('getApplicationProperties', () => {
+    it('returns proper application properties', () => {
+        const appDataAdapterMock = Mock.ofType<AppDataAdapter>();
+        appDataAdapterMock.setup(adapter => adapter.getVersion()).returns(() => 'test-version');
+
+        const testSubject = createGetApplicationProperties(appDataAdapterMock.object);
+
+        const result = testSubject();
+
+        expect(result).toMatchInlineSnapshot(`
+            Object {
+              "name": "Accessibility Insights for Android",
+              "version": "test-version",
+            }
+        `);
+    });
+});

--- a/src/tests/unit/tests/electron/common/application-properties-provider.test.ts
+++ b/src/tests/unit/tests/electron/common/application-properties-provider.test.ts
@@ -1,27 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AppDataAdapter } from 'common/browser-adapters/app-data-adapter';
-import { createGetApplicationProperties, createGetToolDataDelegate } from 'electron/common/application-properties-provider';
+import { createGetToolDataDelegate } from 'electron/common/application-properties-provider';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import { Mock } from 'typemoq';
-
-describe('getApplicationProperties', () => {
-    it('returns proper application properties', () => {
-        const appDataAdapterMock = Mock.ofType<AppDataAdapter>();
-        appDataAdapterMock.setup(adapter => adapter.getVersion()).returns(() => 'test-version');
-
-        const testSubject = createGetApplicationProperties(appDataAdapterMock.object);
-
-        const result = testSubject();
-
-        expect(result).toMatchInlineSnapshot(`
-            Object {
-              "name": "Accessibility Insights for Android",
-              "version": "test-version",
-            }
-        `);
-    });
-});
 
 describe('ToolDataDelegate', () => {
     it('returns proper tool data', () => {

--- a/src/tests/unit/tests/electron/common/application-properties-provider.test.ts
+++ b/src/tests/unit/tests/electron/common/application-properties-provider.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AppDataAdapter } from 'common/browser-adapters/app-data-adapter';
-import { createGetApplicationProperties } from 'electron/common/application-properties-provider';
+import { createGetApplicationProperties, createGetToolDataDelegate } from 'electron/common/application-properties-provider';
+import { ScanResults } from 'electron/platform/android/scan-results';
 import { Mock } from 'typemoq';
 
 describe('getApplicationProperties', () => {
@@ -17,6 +18,33 @@ describe('getApplicationProperties', () => {
             Object {
               "name": "Accessibility Insights for Android",
               "version": "test-version",
+            }
+        `);
+    });
+});
+
+describe('ToolDataDelegate', () => {
+    it('returns proper tool data', () => {
+        const appDataAdapterMock = Mock.ofType<AppDataAdapter>();
+        appDataAdapterMock.setup(adapter => adapter.getVersion()).returns(() => 'test-version');
+
+        const scanResultsMock = Mock.ofType<ScanResults>();
+        scanResultsMock.setup(results => results.axeVersion).returns(() => 'test-axe-version');
+
+        const testSubject = createGetToolDataDelegate(appDataAdapterMock.object);
+
+        const result = testSubject(scanResultsMock.object);
+
+        expect(result).toMatchInlineSnapshot(`
+            Object {
+              "applicationProperties": Object {
+                "name": "Accessibility Insights for Android",
+                "version": "test-version",
+              },
+              "scanEngineProperties": Object {
+                "name": "axe-android",
+                "version": "test-axe-version",
+              },
             }
         `);
     });

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-result-example.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-result-example.ts
@@ -1,6 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 export const axeRuleResultExample = {
+    axeContext: {
+        axeMetaData: {
+            appIdentifier: 'com.test.scan-result',
+            axeVersion: 'axe-android-test-version',
+        },
+    },
     axeRuleResults: [
         {
             axeViewId: 1467971545,

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/unified-result-builder.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/unified-result-builder.test.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildUnifiedScanCompletedPayload builds the payload 1`] = `
+Object {
+  "rules": Array [
+    Object {
+      "description": "test-rule-description",
+      "guidance": Array [],
+      "id": "test-rule-id",
+      "url": "test-url",
+    },
+  ],
+  "scanResult": Array [
+    Object {
+      "descriptors": null,
+      "identifiers": null,
+      "resolution": null,
+      "ruleId": "test-rule-id",
+      "status": "pass",
+      "uid": "test-result-uid",
+    },
+  ],
+  "targetAppInfo": Object {
+    "name": "com.test.scan-result",
+  },
+  "toolInfo": Object {
+    "applicationProperties": Object {
+      "name": "AI-Android",
+      "version": "0.0",
+    },
+    "scanEngineProperties": Object {
+      "name": "axe-android",
+      "version": "axe-android-test-version",
+    },
+  },
+}
+`;

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/unified-result-builder.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/unified-result-builder.test.ts.snap
@@ -25,8 +25,8 @@ Object {
   },
   "toolInfo": Object {
     "applicationProperties": Object {
-      "name": "AI-Android",
-      "version": "0.0",
+      "name": "test-app",
+      "version": "test-version",
     },
     "scanEngineProperties": Object {
       "name": "axe-android",

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/unified-result-builder.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/unified-result-builder.test.ts.snap
@@ -25,12 +25,12 @@ Object {
   },
   "toolInfo": Object {
     "applicationProperties": Object {
-      "name": "test-app",
+      "name": "test-app-name",
       "version": "test-version",
     },
     "scanEngineProperties": Object {
-      "name": "axe-android",
-      "version": "axe-android-test-version",
+      "name": "test-scan-engine-name",
+      "version": "test-scan-engine-version",
     },
   },
 }

--- a/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
@@ -8,6 +8,7 @@ export function buildScanResultsObject(
     appIdentifier: string = null,
     resultsArray: RuleResultsData[] = null,
     axeView: ViewElementData = null,
+    axeVersion: string = null,
 ): ScanResults {
     const scanResults = {};
     const axeContext = {};
@@ -29,6 +30,15 @@ export function buildScanResultsObject(
 
     if (axeView) {
         axeContext['axeView'] = axeView;
+        addContext = true;
+    }
+
+    if (axeVersion) {
+        if (axeContext['axeMetaData'] == null) {
+            axeContext['axeMetaData'] = {};
+        }
+
+        axeContext['axeMetaData']['axeVersion'] = axeVersion;
         addContext = true;
     }
 

--- a/src/tests/unit/tests/electron/platform/android/scan-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results.test.ts
@@ -6,7 +6,7 @@ import { buildRuleResultObject, buildScanResultsObject, buildViewElement } from 
 describe('ScanResults', () => {
     test('axeVersion is "no-version" if missing from input', () => {
         const scanResults = buildScanResultsObject();
-        expect(scanResults.axeVersion).toBeNull();
+        expect(scanResults.axeVersion).toEqual('no-version');
     });
 
     test('axeVersion is correct if specified in input', () => {

--- a/src/tests/unit/tests/electron/platform/android/scan-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results.test.ts
@@ -4,6 +4,17 @@
 import { buildRuleResultObject, buildScanResultsObject, buildViewElement } from './scan-results-helpers';
 
 describe('ScanResults', () => {
+    test('axeVersion is "no-version" if missing from input', () => {
+        const scanResults = buildScanResultsObject();
+        expect(scanResults.axeVersion).toBeNull();
+    });
+
+    test('axeVersion is correct if specified in input', () => {
+        const axeVersion = 'test-axe-version';
+        const scanResults = buildScanResultsObject(null, null, null, null, axeVersion);
+        expect(scanResults.axeVersion).toEqual(axeVersion);
+    });
+
     test('deviceName is null if missing from input', () => {
         const scanResults = buildScanResultsObject();
         expect(scanResults.deviceName).toBeNull();

--- a/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UUIDGeneratorType } from 'common/uid-generator';
+import { ScanResults } from 'electron/platform/android/scan-results';
+import { ConvertScanResultsToUnifiedResultsDelegate } from 'electron/platform/android/scan-results-to-unified-results';
+import { ConvertScanResultsToUnifiedRulesDelegate } from 'electron/platform/android/scan-results-to-unified-rules';
+import { createBuilder } from 'electron/platform/android/unified-result-builder';
+import { axeRuleResultExample } from 'tests/unit/tests/electron/flux/action-creator/scan-result-example';
+import { Mock, MockBehavior } from 'typemoq';
+
+describe('buildUnifiedScanCompletedPayload', () => {
+    const exampleScanResults = new ScanResults(axeRuleResultExample);
+
+    it('builds the payload', () => {
+        const generateUIDMock = Mock.ofType<UUIDGeneratorType>();
+
+        const getUnifiedResultsMock = Mock.ofType<ConvertScanResultsToUnifiedResultsDelegate>();
+        getUnifiedResultsMock
+            .setup(converter => converter(exampleScanResults, generateUIDMock.object))
+            .returns(() => {
+                return [
+                    {
+                        uid: 'test-result-uid',
+                        status: 'pass',
+                        ruleId: 'test-rule-id',
+                        descriptors: null,
+                        identifiers: null,
+                        resolution: null,
+                    },
+                ];
+            });
+
+        const getUnifiedRulesMock = Mock.ofType<ConvertScanResultsToUnifiedRulesDelegate>(undefined, MockBehavior.Strict);
+        getUnifiedRulesMock
+            .setup(converter => converter(exampleScanResults, generateUIDMock.object))
+            .returns(() => {
+                return [
+                    {
+                        id: 'test-rule-id',
+                        description: 'test-rule-description',
+                        url: 'test-url',
+                        guidance: [],
+                    },
+                ];
+            });
+
+        const testSubject = createBuilder(getUnifiedResultsMock.object, getUnifiedRulesMock.object, generateUIDMock.object);
+        const result = testSubject(exampleScanResults);
+
+        expect(result).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { UUIDGeneratorType } from 'common/uid-generator';
-import { ApplicationPropertiesDelegate } from 'electron/common/application-properties-provider';
+import { ToolDataDelegate } from 'electron/common/application-properties-provider';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import { ConvertScanResultsToUnifiedResultsDelegate } from 'electron/platform/android/scan-results-to-unified-results';
 import { ConvertScanResultsToUnifiedRulesDelegate } from 'electron/platform/android/scan-results-to-unified-rules';
@@ -45,13 +45,19 @@ describe('buildUnifiedScanCompletedPayload', () => {
                 ];
             });
 
-        const applicationPropertiesDelegateMock = Mock.ofType<ApplicationPropertiesDelegate>(undefined, MockBehavior.Strict);
-        applicationPropertiesDelegateMock
-            .setup(delegate => delegate())
+        const getToolDataMock = Mock.ofType<ToolDataDelegate>();
+        getToolDataMock
+            .setup(getter => getter(exampleScanResults))
             .returns(() => {
                 return {
-                    name: 'test-app',
-                    version: 'test-version',
+                    applicationProperties: {
+                        name: 'test-app-name',
+                        version: 'test-version',
+                    },
+                    scanEngineProperties: {
+                        name: 'test-scan-engine-name',
+                        version: 'test-scan-engine-version',
+                    },
                 };
             });
 
@@ -59,7 +65,7 @@ describe('buildUnifiedScanCompletedPayload', () => {
             getUnifiedResultsMock.object,
             getUnifiedRulesMock.object,
             generateUIDMock.object,
-            applicationPropertiesDelegateMock.object,
+            getToolDataMock.object,
         );
         const result = testSubject(exampleScanResults);
 

--- a/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { UUIDGeneratorType } from 'common/uid-generator';
+import { ApplicationPropertiesDelegate } from 'electron/common/application-properties-provider';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import { ConvertScanResultsToUnifiedResultsDelegate } from 'electron/platform/android/scan-results-to-unified-results';
 import { ConvertScanResultsToUnifiedRulesDelegate } from 'electron/platform/android/scan-results-to-unified-rules';
@@ -44,7 +45,22 @@ describe('buildUnifiedScanCompletedPayload', () => {
                 ];
             });
 
-        const testSubject = createBuilder(getUnifiedResultsMock.object, getUnifiedRulesMock.object, generateUIDMock.object);
+        const applicationPropertiesDelegateMock = Mock.ofType<ApplicationPropertiesDelegate>(undefined, MockBehavior.Strict);
+        applicationPropertiesDelegateMock
+            .setup(delegate => delegate())
+            .returns(() => {
+                return {
+                    name: 'test-app',
+                    version: 'test-version',
+                };
+            });
+
+        const testSubject = createBuilder(
+            getUnifiedResultsMock.object,
+            getUnifiedRulesMock.object,
+            generateUIDMock.object,
+            applicationPropertiesDelegateMock.object,
+        );
         const result = testSubject(exampleScanResults);
 
         expect(result).toMatchSnapshot();


### PR DESCRIPTION
#### Description of changes

- expose `axeVersion` from `ScanResults` class to be used on the unified scan completed payload
- introduce UnifiedScanCompletedPayloadBuilder to convert scan results to proper payload
- introduce application properties getter
- on `ScanController`, when the scan succeed, converting the scan results and invoking the unified scan completed action

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1610159
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
