### PR TITLE
feat(card-buttons): set up card action menu to only show the supported items

### DIFF
--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
@@ -10,11 +10,61 @@ exports[`CardKebabMenuButtonTest copies failure details and show the toast 1`] =
 </div>"
 `;
 
-exports[`CardKebabMenuButtonTest render 1`] = `
+exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported 1`] = `
 "<div className=\\"kebabMenuButton\\">
   <CustomizedActionButton menuIconProps={{...}} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
 </div>"
+`;
+
+exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported 2`] = `
+Object {
+  "className": "kebabMenu",
+  "directionalHint": 6,
+  "items": Array [
+    Object {
+      "iconProps": Object {
+        "iconName": "ladybugSolid",
+      },
+      "key": "fileissue",
+      "name": "File issue",
+      "onClick": [Function],
+    },
+    Object {
+      "iconProps": Object {
+        "iconName": "copy",
+      },
+      "key": "copyfailuredetails",
+      "name": "Copy failure details",
+      "onClick": [Function],
+    },
+  ],
+  "shouldFocusOnMount": true,
+}
+`;
+
+exports[`CardKebabMenuButtonTest renders per snapshot with onlyUserConfigAgnosticCardInteractionsSupported 1`] = `
+"<div className=\\"kebabMenuButton\\">
+  <CustomizedActionButton menuIconProps={{...}} menuProps={{...}} />
+</div>"
+`;
+
+exports[`CardKebabMenuButtonTest renders per snapshot with onlyUserConfigAgnosticCardInteractionsSupported 2`] = `
+Object {
+  "className": "kebabMenu",
+  "directionalHint": 6,
+  "items": Array [
+    Object {
+      "iconProps": Object {
+        "iconName": "copy",
+      },
+      "key": "copyfailuredetails",
+      "name": "Copy failure details",
+      "onClick": [Function],
+    },
+  ],
+  "shouldFocusOnMount": true,
+}
 `;
 
 exports[`CardKebabMenuButtonTest should click file issue, invalid settings 1`] = `

--- a/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
@@ -11,14 +11,24 @@ import { ActionButton, IContextualMenuItem } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
+import {
+    allCardInteractionsSupported,
+    noCardInteractionsSupported,
+    onlyUserConfigAgnosticCardInteractionsSupported,
+} from 'common/components/cards/card-interaction-support';
 import { IssueDetailsTextGenerator } from '../../../../../../background/issue-details-text-generator';
-import { CardKebabMenuButton, CardKebabMenuButtonProps } from '../../../../../../common/components/cards/card-kebab-menu-button';
+import {
+    CardKebabMenuButton,
+    CardKebabMenuButtonDeps,
+    CardKebabMenuButtonProps,
+} from '../../../../../../common/components/cards/card-kebab-menu-button';
 import { NavigatorUtils } from '../../../../../../common/navigator-utils';
 import { CreateIssueDetailsTextData } from '../../../../../../common/types/create-issue-details-text-data';
 import { DetailsViewActionMessageCreator } from '../../../../../../DetailsView/actions/details-view-action-message-creator';
 
 describe('CardKebabMenuButtonTest', () => {
     let defaultProps: CardKebabMenuButtonProps;
+    let defaultDeps: CardKebabMenuButtonDeps;
     let actionCreatorMock: IMock<DetailsViewActionMessageCreator>;
     let navigatorUtilsMock: IMock<NavigatorUtils>;
     let userConfigurationStoreData: UserConfigurationStoreData;
@@ -97,23 +107,49 @@ describe('CardKebabMenuButtonTest', () => {
             .returns(() => issueDetailsText)
             .verifiable();
 
+        defaultDeps = {
+            detailsViewActionMessageCreator: actionCreatorMock.object,
+            navigatorUtils: navigatorUtilsMock.object,
+            issueFilingServiceProvider: issueFilingServiceProviderMock.object,
+            issueFilingActionMessageCreator: issueFilingActionMessageCreatorMock.object,
+            issueDetailsTextGenerator: textGeneratorMock.object,
+            cardInteractionSupport: allCardInteractionsSupported,
+        } as CardKebabMenuButtonDeps;
+
         defaultProps = {
-            deps: {
-                detailsViewActionMessageCreator: actionCreatorMock.object,
-                navigatorUtils: navigatorUtilsMock.object,
-                issueFilingServiceProvider: issueFilingServiceProviderMock.object,
-                issueFilingActionMessageCreator: issueFilingActionMessageCreatorMock.object,
-                issueDetailsTextGenerator: textGeneratorMock.object,
-            },
+            deps: defaultDeps,
             userConfigurationStoreData,
             issueDetailsData,
         } as CardKebabMenuButtonProps;
     });
 
-    it('render', () => {
-        const rendered = shallow(<CardKebabMenuButton {...defaultProps} />);
+    it('renders as null with noCardInteractionsSupported', () => {
+        const rendered = shallow(
+            <CardKebabMenuButton {...defaultProps} deps={{ ...defaultDeps, cardInteractionSupport: noCardInteractionsSupported }} />,
+        );
+
+        expect(rendered.getElement()).toBeNull();
+    });
+
+    it('renders per snapshot with allCardInteractionsSupported', () => {
+        const rendered = shallow(
+            <CardKebabMenuButton {...defaultProps} deps={{ ...defaultDeps, cardInteractionSupport: allCardInteractionsSupported }} />,
+        );
 
         expect(rendered.debug()).toMatchSnapshot();
+        expect(rendered.find(ActionButton).prop('menuProps')).toMatchSnapshot();
+    });
+
+    it('renders per snapshot with onlyUserConfigAgnosticCardInteractionsSupported', () => {
+        const rendered = shallow(
+            <CardKebabMenuButton
+                {...defaultProps}
+                deps={{ ...defaultDeps, cardInteractionSupport: onlyUserConfigAgnosticCardInteractionsSupported }}
+            />,
+        );
+
+        expect(rendered.debug()).toMatchSnapshot();
+        expect(rendered.find(ActionButton).prop('menuProps')).toMatchSnapshot();
     });
 
     it('copies failure details and show the toast', async () => {


### PR DESCRIPTION
#### Description of changes

Updates the `card-kebab-menu-button` to respect the same `cardInteractionSupport` dep the card itself is using, in preparation for the android selection feature's requirement to only show the user-config-agnostic menu items for the time being.

Here's what it looks like (with a temporary change to cause details-view-initializer to pass `cardInteractionSupport: onlyUserConfigAgnosticCardInteractionsSupported`, to emulate what electron will be doing):

![screenshot of card action menu with only copy failure details showing](https://user-images.githubusercontent.com/376284/66534627-a7716d00-eacb-11e9-91ba-2fd27ffcef05.png)

#### Pull request checklist

- [n/a] Addresses an existing issue:
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
