### PR TITLE
feat(android-cards-view): starting scan on automated checks first render

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -4,8 +4,8 @@ import * as React from 'react';
 
 import { NamedFC } from 'common/react/named-fc';
 import { TitleBar, TitleBarProps } from 'electron/views/automated-checks/components/title-bar';
-import { CommandBar, CommandBarProps } from './command-bar';
-import { HeaderSection } from './header-section';
+import { CommandBar, CommandBarProps } from './components/command-bar';
+import { HeaderSection } from './components/header-section';
 
 export type AutomatedChecksViewProps = CommandBarProps & TitleBarProps;
 

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -3,15 +3,25 @@
 import { TitleBar, TitleBarDeps } from 'electron/views/automated-checks/components/title-bar';
 import * as React from 'react';
 
+import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { CommandBar, CommandBarDeps } from './components/command-bar';
 import { HeaderSection } from './components/header-section';
 
-export type AutomatedChecksViewDeps = CommandBarDeps & TitleBarDeps;
+export type AutomatedChecksViewDeps = CommandBarDeps &
+    TitleBarDeps & {
+        scanActionCreator: ScanActionCreator;
+    };
+
 export type AutomatedChecksViewProps = {
     deps: AutomatedChecksViewDeps;
+    devicePort: number;
 };
 
 export class AutomatedChecksView extends React.Component<AutomatedChecksViewProps> {
+    public componentDidMount(): void {
+        this.props.deps.scanActionCreator.scan(this.props.devicePort);
+    }
+
     public render(): JSX.Element {
         return (
             <>

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -1,20 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TitleBar, TitleBarDeps } from 'electron/views/automated-checks/components/title-bar';
 import * as React from 'react';
 
-import { NamedFC } from 'common/react/named-fc';
-import { TitleBar, TitleBarProps } from 'electron/views/automated-checks/components/title-bar';
-import { CommandBar, CommandBarProps } from './components/command-bar';
+import { CommandBar, CommandBarDeps } from './components/command-bar';
 import { HeaderSection } from './components/header-section';
 
-export type AutomatedChecksViewProps = CommandBarProps & TitleBarProps;
+export type AutomatedChecksViewDeps = CommandBarDeps & TitleBarDeps;
+export type AutomatedChecksViewProps = {
+    deps: AutomatedChecksViewDeps;
+};
 
-export const AutomatedChecksView = NamedFC<AutomatedChecksViewProps>('AutomatedChecksView', props => {
-    return (
-        <>
-            <TitleBar deps={props.deps}></TitleBar>
-            <CommandBar {...props} />
-            <HeaderSection />
-        </>
-    );
-});
+export class AutomatedChecksView extends React.Component<AutomatedChecksViewProps> {
+    public render(): JSX.Element {
+        return (
+            <>
+                <TitleBar deps={this.props.deps}></TitleBar>
+                <CommandBar deps={this.props.deps} />
+                <HeaderSection />
+            </>
+        );
+    }
+}

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -11,6 +11,8 @@ import { RootContainerProps, RootContainerState } from 'electron/views/root-cont
 import { WindowFrameUpdater } from 'electron/window-frame-updater';
 import * as ReactDOM from 'react-dom';
 
+import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { ScanActions } from 'electron/flux/action/scan-actions';
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
 import { UserConfigurationActionCreator } from '../../background/global-action-creators/user-configuration-action-creator';
@@ -39,9 +41,12 @@ import { RootContainerRenderer } from './root-container/root-container-renderer'
 initializeFabricIcons();
 
 const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(getIndexedDBStore());
+
 const userConfigActions = new UserConfigurationActions();
 const deviceActions = new DeviceActions();
 const windowStateActions = new WindowStateActions();
+const scanActions = new ScanActions();
+
 const storageAdapter = new ElectronStorageAdapter(indexedDBInstance);
 const appDataAdapter = new ElectronAppDataAdapter();
 
@@ -88,6 +93,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
 
     const deviceConnectActionCreator = new DeviceConnectActionCreator(deviceActions, fetchScanResults, telemetryEventHandler);
     const windowStateActionCreator = new WindowStateActionCreator(windowStateActions);
+    const scanActionCreator = new ScanActionCreator(scanActions);
 
     const props: RootContainerProps = {
         deps: {
@@ -100,6 +106,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
             fetchScanResults,
             deviceConnectActionCreator,
             storeHub,
+            scanActionCreator,
         },
     };
 

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -4,7 +4,7 @@ import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
-import { AutomatedChecksView } from 'electron/views/automated-checks/components/automated-checks-view';
+import { AutomatedChecksView } from 'electron/views/automated-checks/automated-checks-view';
 import {
     DeviceConnectViewContainer,
     DeviceConnectViewContainerDeps,

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -4,16 +4,17 @@ import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
-import { AutomatedChecksView } from 'electron/views/automated-checks/automated-checks-view';
+import { AutomatedChecksView, AutomatedChecksViewDeps } from 'electron/views/automated-checks/automated-checks-view';
 import {
     DeviceConnectViewContainer,
     DeviceConnectViewContainerDeps,
 } from 'electron/views/device-connect-view/components/device-connect-view-container';
 import * as React from 'react';
 
-export type RootContainerDeps = DeviceConnectViewContainerDeps & {
-    storeHub: ClientStoresHub<RootContainerState>;
-};
+export type RootContainerDeps = DeviceConnectViewContainerDeps &
+    AutomatedChecksViewDeps & {
+        storeHub: ClientStoresHub<RootContainerState>;
+    };
 
 export type RootContainerProps = {
     deps: RootContainerDeps;
@@ -34,8 +35,11 @@ export class RootContainer extends React.Component<RootContainerProps, RootConta
 
     public render(): JSX.Element {
         if (this.state.windowStateStoreData.routeId === 'resultsView') {
-            return <AutomatedChecksView {...this.props}></AutomatedChecksView>;
+            const devicePort = this.state.deviceStoreData.port;
+
+            return <AutomatedChecksView devicePort={devicePort} {...this.props} />;
         }
+
         return (
             <DeviceConnectViewContainer
                 {...{
@@ -43,7 +47,7 @@ export class RootContainer extends React.Component<RootContainerProps, RootConta
                     deviceStoreData: this.state.deviceStoreData,
                     ...this.props,
                 }}
-            ></DeviceConnectViewContainer>
+            />
         );
     }
 
@@ -52,6 +56,6 @@ export class RootContainer extends React.Component<RootContainerProps, RootConta
     }
 
     private onStoresChange = () => {
-        this.setState(() => (this.props.deps.storeHub as ClientStoresHub<RootContainerState>).getAllStoreData());
+        this.setState(() => this.props.deps.storeHub.getAllStoreData());
     };
 }

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -7,6 +7,10 @@ exports[`AutomatedChecksView renders the automated checks view: automated checks
       Object {
         "currentWindow": null,
         "deviceConnectActionCreator": null,
+        "scanActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "scanActions": undefined,
+        },
         "windowStateActionCreator": null,
       }
     }
@@ -16,6 +20,10 @@ exports[`AutomatedChecksView renders the automated checks view: automated checks
       Object {
         "currentWindow": null,
         "deviceConnectActionCreator": null,
+        "scanActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "scanActions": undefined,
+        },
         "windowStateActionCreator": null,
       }
     }

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { AutomatedChecksView, AutomatedChecksViewProps } from 'electron/views/automated-checks/automated-checks-view';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { Mock, Times } from 'typemoq';
 
 describe('AutomatedChecksView', () => {
     it('renders the automated checks view', () => {
@@ -11,11 +13,30 @@ describe('AutomatedChecksView', () => {
                 deviceConnectActionCreator: null,
                 currentWindow: null,
                 windowStateActionCreator: null,
+                scanActionCreator: Mock.ofType(ScanActionCreator).object,
             },
-        };
+        } as AutomatedChecksViewProps;
 
         const wrapped = shallow(<AutomatedChecksView {...props} />);
 
         expect(wrapped.getElement()).toMatchSnapshot('automated checks view');
+    });
+
+    it('triggers scan when first mounted', () => {
+        const devicePort = 11111;
+
+        const scanActionCreatorMock = Mock.ofType(ScanActionCreator);
+        scanActionCreatorMock.setup(creator => creator.scan(devicePort)).verifiable(Times.once());
+
+        const props: AutomatedChecksViewProps = {
+            deps: {
+                scanActionCreator: scanActionCreatorMock.object,
+            },
+            devicePort,
+        } as AutomatedChecksViewProps;
+
+        const wrapped = shallow(<AutomatedChecksView {...props} />);
+
+        scanActionCreatorMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -35,7 +35,7 @@ describe('AutomatedChecksView', () => {
             devicePort,
         } as AutomatedChecksViewProps;
 
-        const wrapped = shallow(<AutomatedChecksView {...props} />);
+        shallow(<AutomatedChecksView {...props} />);
 
         scanActionCreatorMock.verifyAll();
     });

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AutomatedChecksView, AutomatedChecksViewProps } from 'electron/views/automated-checks/components/automated-checks-view';
+import { AutomatedChecksView, AutomatedChecksViewProps } from 'electron/views/automated-checks/automated-checks-view';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 

--- a/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`RootContainer renders results view container when route is resultsView 
       },
     }
   }
+  devicePort={11111}
 />
 `;
 

--- a/src/tests/unit/tests/electron/views/root-container/components/root-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/components/root-container.test.tsx
@@ -28,6 +28,8 @@ describe(RootContainer, () => {
         } as RootContainerProps;
     });
 
+    //
+
     describe('renders', () => {
         it('device connect view container when route is deviceConnectView', () => {
             storeHubMock
@@ -52,7 +54,7 @@ describe(RootContainer, () => {
                     return {
                         windowStateStoreData: { routeId: 'resultsView', currentWindowState: 'restoredOrMaximized' },
                         userConfigurationStoreData: { isFirstTime: true },
-                        deviceStoreData: { deviceConnectState: DeviceConnectState.Connected },
+                        deviceStoreData: { deviceConnectState: DeviceConnectState.Connected, port: 11111 },
                     } as RootContainerState;
                 });
 


### PR DESCRIPTION
#### Description of changes

This PR hooks up the use of the `ScanActionCreator` to start scanning when we render `AutomatedChecksView`

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1610159
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
