### PR TITLE
refactored to create a common window title & added title for electron

### DIFF
--- a/src/electron/views/automated-checks/components/title-bar.scss
+++ b/src/electron/views/automated-checks/components/title-bar.scss
@@ -3,23 +3,18 @@
 @import '../../../../common/styles/colors.scss';
 
 .title-bar {
-    width: 100%;
     background: $ada-brand-color;
-    height: 32px;
 
-    :global(.header-icon) {
-        float: left;
-        height: 20px;
-        margin: 6px;
+    :global(.header-text) {
+        color: $always-white;
     }
 
     button {
-        float: right;
         margin: 10px;
         height: 12px;
 
         i {
-            color: white;
+            color: $always-white;
             font-size: 10px;
         }
     }

--- a/src/electron/views/automated-checks/components/title-bar.scss
+++ b/src/electron/views/automated-checks/components/title-bar.scss
@@ -8,14 +8,4 @@
     :global(.header-text) {
         color: $always-white;
     }
-
-    button {
-        margin: 10px;
-        height: 12px;
-
-        i {
-            color: $always-white;
-            font-size: 10px;
-        }
-    }
 }

--- a/src/electron/views/automated-checks/components/title-bar.tsx
+++ b/src/electron/views/automated-checks/components/title-bar.tsx
@@ -5,7 +5,9 @@ import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
 import { NamedFC } from 'common/react/named-fc';
+import { brand } from 'content/strings/application';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
+import { WindowTitle } from 'electron/views/device-connect-view/components/window-title';
 import { BrandWhite } from 'icons/brand/white/brand-white';
 import { titleBar } from './title-bar.scss';
 
@@ -23,36 +25,42 @@ export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps
     const maximize = () => props.deps.windowStateActionCreator.setWindowState({ currentWindowState: 'restoredOrMaximized' });
     const close = () => props.deps.currentWindow.close();
 
+    const icons = [
+        <ActionButton
+            ariaHidden={true}
+            iconProps={{
+                iconName: 'ChromeMinimize',
+            }}
+            id="minimize-button"
+            onClick={minimize}
+            tabIndex={-1}
+            key="minimize"
+        />,
+        <ActionButton
+            ariaHidden={true}
+            iconProps={{
+                iconName: 'Stop',
+            }}
+            id="maximize-button"
+            onClick={maximize}
+            tabIndex={-1}
+            key="maximize"
+        />,
+        <ActionButton
+            ariaHidden={true}
+            iconProps={{
+                iconName: 'Cancel',
+            }}
+            id="close-button"
+            onClick={close}
+            tabIndex={-1}
+            key="close"
+        />,
+    ];
+
     return (
-        <div className={titleBar}>
+        <WindowTitle title={brand} actionableIcons={icons} className={titleBar}>
             <BrandWhite />
-            <ActionButton
-                ariaHidden={true}
-                iconProps={{
-                    iconName: 'Cancel',
-                }}
-                id="close-button"
-                onClick={close}
-                tabIndex={-1}
-            />
-            <ActionButton
-                ariaHidden={true}
-                iconProps={{
-                    iconName: 'Stop',
-                }}
-                id="maximize-button"
-                onClick={maximize}
-                tabIndex={-1}
-            />
-            <ActionButton
-                ariaHidden={true}
-                iconProps={{
-                    iconName: 'ChromeMinimize',
-                }}
-                id="minimize-button"
-                onClick={minimize}
-                tabIndex={-1}
-            />
-        </div>
+        </WindowTitle>
     );
 });

--- a/src/electron/views/device-connect-view/components/window-title.scss
+++ b/src/electron/views/device-connect-view/components/window-title.scss
@@ -8,17 +8,20 @@
     height: 32px;
     display: flex;
     align-items: center;
+    -webkit-app-region: drag;
 
     .title-container {
-        padding: 6px 9px;
+        padding: 6px 10px;
         display: flex;
     }
 
     .actionable-icons-container {
         margin-left: auto;
         display: flex;
-        > {
-            padding: 6px 9px;
+        -webkit-app-region: no-drag;
+
+        > * {
+            padding: 6px 10px;
         }
     }
 
@@ -35,5 +38,14 @@
         float: left;
         padding: 0px 3px;
         height: 17px;
+    }
+
+    button {
+        padding: 10px;
+
+        i {
+            color: $always-white;
+            font-size: 12px;
+        }
     }
 }

--- a/src/electron/views/device-connect-view/components/window-title.scss
+++ b/src/electron/views/device-connect-view/components/window-title.scss
@@ -4,7 +4,23 @@
 @import '../../../../common/styles/fonts.scss';
 
 .window-title {
-    padding: 6px 9px;
+    width: 100%;
+    height: 32px;
+    display: flex;
+    align-items: center;
+
+    .title-container {
+        padding: 6px 9px;
+        display: flex;
+    }
+
+    .actionable-icons-container {
+        margin-left: auto;
+        display: flex;
+        > {
+            padding: 6px 9px;
+        }
+    }
 
     .header-text {
         color: $ada-brand-color;

--- a/src/electron/views/device-connect-view/components/window-title.scss
+++ b/src/electron/views/device-connect-view/components/window-title.scss
@@ -11,8 +11,11 @@
     -webkit-app-region: drag;
 
     .title-container {
-        padding: 6px 10px;
         display: flex;
+
+        > * {
+            padding-left: 10px;
+        }
     }
 
     .actionable-icons-container {
@@ -35,8 +38,6 @@
     }
 
     :global(.header-icon) {
-        float: left;
-        padding: 0px 3px;
         height: 17px;
     }
 

--- a/src/electron/views/device-connect-view/components/window-title.tsx
+++ b/src/electron/views/device-connect-view/components/window-title.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { isEmpty } from 'lodash';
 import * as React from 'react';
 import { NamedFC } from '../../../../common/react/named-fc';
 import { actionableIconsContainer, headerText, titleContainer, windowTitle } from './window-title.scss';
@@ -24,7 +25,7 @@ export const WindowTitle = NamedFC<WindowTitleProps>('WindowTitle', (props: Wind
 });
 
 function getIconsContainer(icons?: JSX.Element[]): JSX.Element {
-    if (icons != null && icons.length > 0) {
+    if (!isEmpty(icons)) {
         return <div className={actionableIconsContainer}>{icons}</div>;
     }
 

--- a/src/electron/views/device-connect-view/components/window-title.tsx
+++ b/src/electron/views/device-connect-view/components/window-title.tsx
@@ -2,20 +2,31 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 import { NamedFC } from '../../../../common/react/named-fc';
-import { headerText, windowTitle } from './window-title.scss';
+import { actionableIconsContainer, headerText, titleContainer, windowTitle } from './window-title.scss';
 
 export interface WindowTitleProps {
     title: string;
     children?: JSX.Element;
+    actionableIcons?: JSX.Element[];
+    className?: string;
 }
 
 export const WindowTitle = NamedFC<WindowTitleProps>('WindowTitle', (props: WindowTitleProps) => {
     return (
-        <header className={windowTitle}>
-            <div>
+        <header className={[windowTitle, props.className].filter(c => c != null).join(' ')}>
+            <div className={titleContainer}>
                 {props.children}
                 <h1 className={headerText}>{props.title}</h1>
             </div>
+            {getIconsContainer(props.actionableIcons)}
         </header>
     );
 });
+
+function getIconsContainer(icons?: JSX.Element[]): JSX.Element {
+    if (icons != null && icons.length > 0) {
+        return <div className={actionableIconsContainer}>{icons}</div>;
+    }
+
+    return null;
+}

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/title-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/title-bar.test.tsx.snap
@@ -1,42 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TitleBar renders 1`] = `
-<div
+<WindowTitle
+  actionableIcons={
+    Array [
+      <CustomizedActionButton
+        ariaHidden={true}
+        iconProps={
+          Object {
+            "iconName": "ChromeMinimize",
+          }
+        }
+        id="minimize-button"
+        onClick={[Function]}
+        tabIndex={-1}
+      />,
+      <CustomizedActionButton
+        ariaHidden={true}
+        iconProps={
+          Object {
+            "iconName": "Stop",
+          }
+        }
+        id="maximize-button"
+        onClick={[Function]}
+        tabIndex={-1}
+      />,
+      <CustomizedActionButton
+        ariaHidden={true}
+        iconProps={
+          Object {
+            "iconName": "Cancel",
+          }
+        }
+        id="close-button"
+        onClick={[Function]}
+        tabIndex={-1}
+      />,
+    ]
+  }
   className="titleBar"
+  title="Accessibility Insights"
 >
   <BrandWhite />
-  <CustomizedActionButton
-    ariaHidden={true}
-    iconProps={
-      Object {
-        "iconName": "Cancel",
-      }
-    }
-    id="close-button"
-    onClick={[Function]}
-    tabIndex={-1}
-  />
-  <CustomizedActionButton
-    ariaHidden={true}
-    iconProps={
-      Object {
-        "iconName": "Stop",
-      }
-    }
-    id="maximize-button"
-    onClick={[Function]}
-    tabIndex={-1}
-  />
-  <CustomizedActionButton
-    ariaHidden={true}
-    iconProps={
-      Object {
-        "iconName": "ChromeMinimize",
-      }
-    }
-    id="minimize-button"
-    onClick={[Function]}
-    tabIndex={-1}
-  />
-</div>
+</WindowTitle>
 `;

--- a/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
@@ -63,7 +63,10 @@ describe('TitleBar', () => {
         } as TitleBarProps;
 
         const rendered = shallow(<TitleBar {...props} />);
-        const button = rendered.find(args.id);
+        const renderedElement = rendered.getElement();
+        const renderedIcons = shallow(<div>{renderedElement.props.actionableIcons}</div>);
+
+        const button = renderedIcons.find(args.id);
 
         button.simulate('click', eventStub);
 

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/window-title.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/window-title.test.tsx.snap
@@ -29,6 +29,22 @@ exports[`WindowTitleTest renders with actionable icons 1`] = `
 </header>
 `;
 
+exports[`WindowTitleTest renders with custom class name 1`] = `
+<header
+  className="windowTitle custom-class-name"
+>
+  <div
+    className="titleContainer"
+  >
+    <h1
+      className="headerText"
+    >
+      title 1
+    </h1>
+  </div>
+</header>
+`;
+
 exports[`WindowTitleTest renders without actionable icons 1`] = `
 <header
   className="windowTitle"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/window-title.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/window-title.test.tsx.snap
@@ -1,17 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`WindowTitleTest render 1`] = `
+exports[`WindowTitleTest renders with actionable icons 1`] = `
 <header
   className="windowTitle"
 >
-  <div>
+  <div
+    className="titleContainer"
+  >
     <span>
-      test
+      logo
     </span>
     <h1
       className="headerText"
     >
-      Test
+      title 1
+    </h1>
+  </div>
+  <div
+    className="actionableIconsContainer"
+  >
+    <div>
+      icon1
+    </div>
+    <div>
+      icon2
+    </div>
+  </div>
+</header>
+`;
+
+exports[`WindowTitleTest renders without actionable icons 1`] = `
+<header
+  className="windowTitle"
+>
+  <div
+    className="titleContainer"
+  >
+    <span>
+      logo
+    </span>
+    <h1
+      className="headerText"
+    >
+      title 1
+    </h1>
+  </div>
+</header>
+`;
+
+exports[`WindowTitleTest renders without children & actionable icon 1`] = `
+<header
+  className="windowTitle"
+>
+  <div
+    className="titleContainer"
+  >
+    <h1
+      className="headerText"
+    >
+      title 1
     </h1>
   </div>
 </header>

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/window-title.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/window-title.test.tsx
@@ -37,4 +37,15 @@ describe('WindowTitleTest', () => {
 
         expect(rendered.getElement()).toMatchSnapshot();
     });
+
+    it('renders with custom class name', () => {
+        const props: WindowTitleProps = {
+            title: 'title 1',
+            className: 'custom-class-name',
+        };
+
+        const rendered = shallow(<WindowTitle {...props} />);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
 });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/window-title.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/window-title.test.tsx
@@ -5,10 +5,32 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('WindowTitleTest', () => {
-    test('render', () => {
+    it('renders without actionable icons', () => {
         const props: WindowTitleProps = {
-            title: 'Test',
-            children: <span>test</span>,
+            title: 'title 1',
+            children: <span>logo</span>,
+        };
+
+        const rendered = shallow(<WindowTitle {...props} />);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('renders with actionable icons', () => {
+        const props: WindowTitleProps = {
+            title: 'title 1',
+            children: <span>logo</span>,
+            actionableIcons: [<div key="key1">icon1</div>, <div key="key2">icon2</div>],
+        };
+
+        const rendered = shallow(<WindowTitle {...props} />);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('renders without children & actionable icon', () => {
+        const props: WindowTitleProps = {
+            title: 'title 1',
         };
 
         const rendered = shallow(<WindowTitle {...props} />);


### PR DESCRIPTION
#### Description of changes

This PR refactors WindowTitle to support adding actionable icons.
Also, adds title to automated check view title bar.
Using flex to simplify styling
moved padding inside rather than on container. This way, the icons will have more hover space

Moving Window-title outside device-connect-view will be in a later pr

![image](https://user-images.githubusercontent.com/29855291/66612923-7b5ff580-eb78-11e9-8b2b-55c398da03fe.png)


![image](https://user-images.githubusercontent.com/29855291/66612899-62efdb00-eb78-11e9-859d-76675cd94377.png)



#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
