### PR TITLE
fix: avoid console.warning about deprecated use of Dialog className prop

### DIFF
--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -65,7 +65,6 @@ export class IssueFilingDialog extends React.Component<IssueFilingDialogProps, I
 
         return (
             <Dialog
-                className={'issue-filing-dialog'}
                 hidden={!isOpen}
                 dialogContentProps={{
                     type: DialogType.normal,
@@ -76,6 +75,7 @@ export class IssueFilingDialog extends React.Component<IssueFilingDialogProps, I
                 modalProps={{
                     isBlocking: false,
                     containerClassName: 'insights-dialog-main-override',
+                    className: 'issue-filing-dialog',
                 }}
                 onDismiss={onClose}
             >

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issue-filing-dialog.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have changed 1`] = `
 <StyledWithResponsiveMode
-  className="issue-filing-dialog"
   dialogContentProps={
     Object {
       "showCloseButton": false,
@@ -14,6 +13,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have ch
   hidden={true}
   modalProps={
     Object {
+      "className": "issue-filing-dialog",
       "containerClassName": "insights-dialog-main-override",
       "isBlocking": false,
     }
@@ -77,7 +77,6 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have ch
 
 exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have not changed 1`] = `
 <StyledWithResponsiveMode
-  className="issue-filing-dialog"
   dialogContentProps={
     Object {
       "showCloseButton": false,
@@ -89,6 +88,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have no
   hidden={true}
   modalProps={
     Object {
+      "className": "issue-filing-dialog",
       "containerClassName": "insights-dialog-main-override",
       "isBlocking": false,
     }
@@ -152,7 +152,6 @@ exports[`IssueFilingDialog componentDidUpdate dialog is not open & props have no
 
 exports[`IssueFilingDialog componentDidUpdate dialog is open & props have changed 1`] = `
 <StyledWithResponsiveMode
-  className="issue-filing-dialog"
   dialogContentProps={
     Object {
       "showCloseButton": false,
@@ -164,6 +163,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have change
   hidden={false}
   modalProps={
     Object {
+      "className": "issue-filing-dialog",
       "containerClassName": "insights-dialog-main-override",
       "isBlocking": false,
     }
@@ -227,7 +227,6 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have change
 
 exports[`IssueFilingDialog componentDidUpdate dialog is open & props have not changed 1`] = `
 <StyledWithResponsiveMode
-  className="issue-filing-dialog"
   dialogContentProps={
     Object {
       "showCloseButton": false,
@@ -239,6 +238,7 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have not ch
   hidden={false}
   modalProps={
     Object {
+      "className": "issue-filing-dialog",
       "containerClassName": "insights-dialog-main-override",
       "isBlocking": false,
     }
@@ -302,7 +302,6 @@ exports[`IssueFilingDialog componentDidUpdate dialog is open & props have not ch
 
 exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
 <StyledWithResponsiveMode
-  className="issue-filing-dialog"
   dialogContentProps={
     Object {
       "showCloseButton": false,
@@ -314,6 +313,7 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
   hidden={false}
   modalProps={
     Object {
+      "className": "issue-filing-dialog",
       "containerClassName": "insights-dialog-main-override",
       "isBlocking": false,
     }
@@ -377,7 +377,6 @@ exports[`IssueFilingDialog render with isSettingsValid: false 1`] = `
 
 exports[`IssueFilingDialog render with isSettingsValid: true 1`] = `
 <StyledWithResponsiveMode
-  className="issue-filing-dialog"
   dialogContentProps={
     Object {
       "showCloseButton": false,
@@ -389,6 +388,7 @@ exports[`IssueFilingDialog render with isSettingsValid: true 1`] = `
   hidden={false}
   modalProps={
     Object {
+      "className": "issue-filing-dialog",
       "containerClassName": "insights-dialog-main-override",
       "isBlocking": false,
     }
@@ -452,7 +452,6 @@ exports[`IssueFilingDialog render with isSettingsValid: true 1`] = `
 
 exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) sent to settings container when service settings are not null 1`] = `
 <StyledWithResponsiveMode
-  className="issue-filing-dialog"
   dialogContentProps={
     Object {
       "showCloseButton": false,
@@ -464,6 +463,7 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
   hidden={false}
   modalProps={
     Object {
+      "className": "issue-filing-dialog",
       "containerClassName": "insights-dialog-main-override",
       "isBlocking": false,
     }
@@ -528,7 +528,6 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
 
 exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) sent to settings container when service settings are null 1`] = `
 <StyledWithResponsiveMode
-  className="issue-filing-dialog"
   dialogContentProps={
     Object {
       "showCloseButton": false,
@@ -540,6 +539,7 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
   hidden={false}
   modalProps={
     Object {
+      "className": "issue-filing-dialog",
       "containerClassName": "insights-dialog-main-override",
       "isBlocking": false,
     }
@@ -603,7 +603,6 @@ exports[`IssueFilingDialog render: validate callback (onPropertyUpdateCallback) 
 
 exports[`IssueFilingDialog render: validate callback (onSelectedServiceChange) sent to settings container 1`] = `
 <StyledWithResponsiveMode
-  className="issue-filing-dialog"
   dialogContentProps={
     Object {
       "showCloseButton": false,
@@ -615,6 +614,7 @@ exports[`IssueFilingDialog render: validate callback (onSelectedServiceChange) s
   hidden={false}
   modalProps={
     Object {
+      "className": "issue-filing-dialog",
       "containerClassName": "insights-dialog-main-override",
       "isBlocking": false,
     }


### PR DESCRIPTION
#### Description of changes

The dev console in the details view currently spews a few warning about use of the deprecated className prop of the Dialog component (it's been replaced with `modalProps.className`). This fixes the warnings.

Verified that this has no impact on the final rendered dialog.

#### Pull request checklist

- [no] Addresses an existing issue: 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
