### PR TITLE
feat(card-buttons): add real "more actions" icon from mocks

### DIFF
--- a/src/common/components/cards/card-kebab-menu-button.scss
+++ b/src/common/components/cards/card-kebab-menu-button.scss
@@ -28,9 +28,4 @@ button.kebab-menu-button {
     div.ms-Button-flexContainer {
         justify-content: center;
     }
-
-    i {
-        font-size: 20px;
-        color: $primary-text;
-    }
 }

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -4,6 +4,7 @@ import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { DirectionalHint, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import * as React from 'react';
 
+import { MoreActionsMenuIcon } from 'common/icons/more-actions-menu-icon';
 import { IssueDetailsTextGenerator } from '../../../background/issue-details-text-generator';
 import { DetailsViewActionMessageCreator } from '../../../DetailsView/actions/details-view-action-message-creator';
 import { IssueFilingDialog } from '../../../DetailsView/components/issue-filing-dialog';
@@ -60,9 +61,7 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
                 <ActionButton
                     className={kebabMenuButton}
                     ariaLabel="More actions"
-                    menuIconProps={{
-                        iconName: 'moreVertical',
-                    }}
+                    onRenderMenuIcon={MoreActionsMenuIcon}
                     menuProps={{
                         className: kebabMenu,
                         directionalHint: DirectionalHint.bottomRightEdge,

--- a/src/common/fabric-icons.ts
+++ b/src/common/fabric-icons.ts
@@ -48,7 +48,6 @@ export function initializeFabricIcons(): void {
             ladybugSolid: '\uF44A',
             mail: '\uE715',
             medical: '\uEAD4',
-            moreVertical: '\uF2BC',
             play: '\uE768',
             redEye: '\uE7B3',
             refresh: '\uE72C',

--- a/src/common/icons/more-actions-menu-icon.tsx
+++ b/src/common/icons/more-actions-menu-icon.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { NamedFC } from '../react/named-fc';
 
 export const MoreActionsMenuIcon = NamedFC('MoreActionsMenuIcon', () => (
-    <svg width="34" height="32" viewBox="0 0 34 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg width="34" height="32" viewBox="0 0 34 32" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
         <circle cx="17" cy="22" r="1.5" stroke="black" strokeOpacity="0.9" />
         <circle cx="17" cy="16" r="1.5" stroke="black" strokeOpacity="0.9" />
         <circle cx="17" cy="10" r="1.5" stroke="black" strokeOpacity="0.9" />

--- a/src/common/icons/more-actions-menu-icon.tsx
+++ b/src/common/icons/more-actions-menu-icon.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+import { NamedFC } from '../react/named-fc';
+
+export const MoreActionsMenuIcon = NamedFC('MoreActionsMenuIcon', () => (
+    <svg width="34" height="32" viewBox="0 0 34 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="17" cy="22" r="1.5" stroke="black" strokeOpacity="0.9" />
+        <circle cx="17" cy="16" r="1.5" stroke="black" strokeOpacity="0.9" />
+        <circle cx="17" cy="10" r="1.5" stroke="black" strokeOpacity="0.9" />
+    </svg>
+));

--- a/src/common/icons/more-actions-menu-icon.tsx
+++ b/src/common/icons/more-actions-menu-icon.tsx
@@ -5,9 +5,9 @@ import * as React from 'react';
 import { NamedFC } from '../react/named-fc';
 
 export const MoreActionsMenuIcon = NamedFC('MoreActionsMenuIcon', () => (
-    <svg width="34" height="32" viewBox="0 0 34 32" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
-        <circle cx="17" cy="22" r="1.5" stroke="black" strokeOpacity="0.9" />
-        <circle cx="17" cy="16" r="1.5" stroke="black" strokeOpacity="0.9" />
-        <circle cx="17" cy="10" r="1.5" stroke="black" strokeOpacity="0.9" />
+    <svg width="10" height="16" viewBox="0 0 10 16" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true">
+        <circle cx="5" cy="14" r="1.5" stroke="black" strokeOpacity="0.9" />
+        <circle cx="5" cy="8" r="1.5" stroke="black" strokeOpacity="0.9" />
+        <circle cx="5" cy="2" r="1.5" stroke="black" strokeOpacity="0.9" />
     </svg>
 ));

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CardKebabMenuButtonTest copies failure details and show the toast 1`] = `
 "<Fragment>
-  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" menuIconProps={{...}} menuProps={{...}} />
+  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
   <Toast onTimeout={[Function: onTimeout]} deps={{...}} timeoutLength={1000}>
     Failure details copied.
@@ -12,7 +12,7 @@ exports[`CardKebabMenuButtonTest copies failure details and show the toast 1`] =
 
 exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported 1`] = `
 "<Fragment>
-  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" menuIconProps={{...}} menuProps={{...}} />
+  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
 </Fragment>"
 `;
@@ -45,7 +45,7 @@ Object {
 
 exports[`CardKebabMenuButtonTest renders per snapshot with onlyUserConfigAgnosticCardInteractionsSupported 1`] = `
 "<Fragment>
-  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" menuIconProps={{...}} menuProps={{...}} />
+  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
 </Fragment>"
 `;
 
@@ -69,21 +69,21 @@ Object {
 
 exports[`CardKebabMenuButtonTest should click file issue, invalid settings 1`] = `
 "<Fragment>
-  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" menuIconProps={{...}} menuProps={{...}} />
+  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={true} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
 </Fragment>"
 `;
 
 exports[`CardKebabMenuButtonTest should file issue, valid settings 1`] = `
 "<Fragment>
-  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" menuIconProps={{...}} menuProps={{...}} />
+  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
 </Fragment>"
 `;
 
 exports[`CardKebabMenuButtonTest shows failure message if copy failed 1`] = `
 "<Fragment>
-  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" menuIconProps={{...}} menuProps={{...}} />
+  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
   <Toast onTimeout={[Function: onTimeout]} deps={{...}} timeoutLength={1000}>
     Failed to copy failure details. Please try again.


### PR DESCRIPTION
#### Description of changes

Updates the more actions card menu to use the icon from the mocks, rather than office fabric's close-ish one.

Left is as-implemented, right is expectation from the mock
![screenshot of new icon and its mock side by side](https://user-images.githubusercontent.com/376284/66616014-ee229e00-eb83-11e9-8a40-2c6f6c6a4655.png)


#### Pull request checklist

- [x] Addresses an existing issue: 1612317
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
