### PR TITLE
Manage Window State changes

### DIFF
--- a/src/electron/flux/action-creator/window-frame-action-creator.ts
+++ b/src/electron/flux/action-creator/window-frame-action-creator.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
+import { SetSizePayload } from 'electron/flux/action/window-frame-actions-payloads';
+
+export class WindowFrameActionCreator {
+    constructor(private readonly windowFrameActions: WindowFrameActions) {}
+
+    public setWindowSize(size: SetSizePayload): void {
+        this.windowFrameActions.setWindowSize.invoke(size);
+    }
+
+    public maximize(): void {
+        this.windowFrameActions.maximize.invoke();
+    }
+
+    public minimize(): void {
+        this.windowFrameActions.minimize.invoke();
+    }
+    public restore(): void {
+        this.windowFrameActions.restore.invoke();
+    }
+
+    public close(): void {
+        this.windowFrameActions.close.invoke();
+    }
+}

--- a/src/electron/flux/action-creator/window-state-action-creator.ts
+++ b/src/electron/flux/action-creator/window-state-action-creator.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { RoutePayload } from '../action/route-payloads';
 import { WindowStateActions } from '../action/window-state-actions';
+import { WindowStatePayload } from '../action/window-state-payload';
+import { WindowFrameActionCreator } from './window-frame-action-creator';
 
 export class WindowStateActionCreator {
     constructor(
@@ -17,5 +18,9 @@ export class WindowStateActionCreator {
         if (payload.routeId === 'deviceConnectView') {
             this.windowFrameActionCreator.setWindowSize({ width: 600, height: 391 });
         }
+    }
+
+    public setWindowState(payload: WindowStatePayload): void {
+        this.windowStateActions.setWindowState.invoke(payload);
     }
 }

--- a/src/electron/flux/action-creator/window-state-action-creator.ts
+++ b/src/electron/flux/action-creator/window-state-action-creator.ts
@@ -1,18 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { WindowStatePayload } from 'electron/flux/action/window-state-payload';
+import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { RoutePayload } from '../action/route-payloads';
 import { WindowStateActions } from '../action/window-state-actions';
 
 export class WindowStateActionCreator {
-    constructor(private readonly windowStateActions: WindowStateActions) {}
+    constructor(
+        private readonly windowStateActions: WindowStateActions,
+        private readonly windowFrameActionCreator: WindowFrameActionCreator,
+    ) {}
 
     public setRoute(payload: RoutePayload): void {
         this.windowStateActions.setRoute.invoke(payload);
-    }
 
-    public setWindowState(payload: WindowStatePayload): void {
-        this.windowStateActions.setWindowState.invoke(payload);
+        if (payload.routeId === 'deviceConnectView') {
+            this.windowFrameActionCreator.setWindowSize({ width: 600, height: 391 });
+        }
     }
 }

--- a/src/electron/flux/action/window-frame-actions-payloads.ts
+++ b/src/electron/flux/action/window-frame-actions-payloads.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export interface SetSizePayload {
+    width: number;
+    height: number;
+}

--- a/src/electron/flux/action/window-frame-actions.ts
+++ b/src/electron/flux/action/window-frame-actions.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Action } from 'common/flux/action';
+import { SetSizePayload } from 'electron/flux/action/window-frame-actions-payloads';
+
+export class WindowFrameActions {
+    public readonly maximize = new Action<void>();
+    public readonly minimize = new Action<void>();
+    public readonly restore = new Action<void>();
+    public readonly close = new Action<void>();
+    public readonly setWindowSize = new Action<SetSizePayload>();
+}

--- a/src/electron/flux/store/window-state-store.ts
+++ b/src/electron/flux/store/window-state-store.ts
@@ -15,7 +15,7 @@ export class WindowStateStore extends BaseStoreImpl<WindowStateStoreData> {
     public getDefaultState(): WindowStateStoreData {
         return {
             routeId: 'deviceConnectView',
-            currentWindowState: 'restoredOrMaximized',
+            currentWindowState: 'customSize',
         };
     }
 
@@ -33,6 +33,10 @@ export class WindowStateStore extends BaseStoreImpl<WindowStateStoreData> {
     };
 
     private onSetWindowState = (payload: WindowStatePayload) => {
+        if (payload.currentWindowState === this.state.currentWindowState) {
+            return;
+        }
+
         this.state.currentWindowState = payload.currentWindowState;
         this.emitChanged();
     };

--- a/src/electron/flux/types/window-state-store-data.ts
+++ b/src/electron/flux/types/window-state-store-data.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type ViewRoutes = 'deviceConnectView' | 'resultsView';
-export type WindowStates = 'restoredOrMaximized' | 'minimized';
+export type WindowStates = 'customSize' | 'maximized' | 'minimized';
 
 export interface WindowStateStoreData {
     routeId: ViewRoutes;

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -8,6 +8,7 @@ import { WindowStateActionCreator } from 'electron/flux/action-creator/window-st
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
+import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { ScanningSpinner } from 'electron/views/automated-checks/components/scanning-spinner';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
 import { CommandBar, CommandBarDeps } from './components/command-bar';
@@ -23,6 +24,7 @@ export type AutomatedChecksViewProps = {
     deps: AutomatedChecksViewDeps;
     scanStoreData: ScanStoreData;
     deviceStoreData: DeviceStoreData;
+    windowStateStoreData: WindowStateStoreData;
 };
 
 export class AutomatedChecksView extends React.Component<AutomatedChecksViewProps> {
@@ -33,7 +35,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
     public render(): JSX.Element {
         return (
             <>
-                <TitleBar deps={this.props.deps}></TitleBar>
+                <TitleBar deps={this.props.deps} windowStateStoreData={this.props.windowStateStoreData}></TitleBar>
                 <CommandBar deps={this.props.deps} />
                 <HeaderSection />
                 {this.renderScanning()}

--- a/src/electron/views/automated-checks/components/title-bar.tsx
+++ b/src/electron/views/automated-checks/components/title-bar.tsx
@@ -8,6 +8,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { brand } from 'content/strings/application';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
+import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { WindowTitle } from 'electron/views/device-connect-view/components/window-title';
 import { BrandWhite } from 'icons/brand/white/brand-white';
 import { titleBar } from './title-bar.scss';
@@ -19,11 +20,16 @@ export type TitleBarDeps = {
 
 export interface TitleBarProps {
     deps: TitleBarDeps;
+    windowStateStoreData: WindowStateStoreData;
 }
 
 export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps) => {
     const minimize = () => props.deps.windowFrameActionCreator.minimize();
-    const maximizeOrRestore = () => props.deps.windowFrameActionCreator.maximize();
+    const maximizeOrRestore = () =>
+        props.windowStateStoreData.currentWindowState === 'maximized'
+            ? props.deps.windowFrameActionCreator.restore()
+            : props.deps.windowFrameActionCreator.maximize();
+
     const close = () => props.deps.windowFrameActionCreator.close();
 
     const icons = [

--- a/src/electron/views/automated-checks/components/title-bar.tsx
+++ b/src/electron/views/automated-checks/components/title-bar.tsx
@@ -7,7 +7,6 @@ import * as React from 'react';
 import { NamedFC } from 'common/react/named-fc';
 import { brand } from 'content/strings/application';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
-import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { WindowTitle } from 'electron/views/device-connect-view/components/window-title';
 import { BrandWhite } from 'icons/brand/white/brand-white';

--- a/src/electron/views/automated-checks/components/title-bar.tsx
+++ b/src/electron/views/automated-checks/components/title-bar.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 
 import { NamedFC } from 'common/react/named-fc';
 import { brand } from 'content/strings/application';
+import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { WindowTitle } from 'electron/views/device-connect-view/components/window-title';
 import { BrandWhite } from 'icons/brand/white/brand-white';
@@ -13,7 +14,7 @@ import { titleBar } from './title-bar.scss';
 
 export type TitleBarDeps = {
     currentWindow: BrowserWindow;
-    windowStateActionCreator: WindowStateActionCreator;
+    windowFrameActionCreator: WindowFrameActionCreator;
 };
 
 export interface TitleBarProps {
@@ -21,9 +22,9 @@ export interface TitleBarProps {
 }
 
 export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps) => {
-    const minimize = () => props.deps.windowStateActionCreator.setWindowState({ currentWindowState: 'minimized' });
-    const maximize = () => props.deps.windowStateActionCreator.setWindowState({ currentWindowState: 'restoredOrMaximized' });
-    const close = () => props.deps.currentWindow.close();
+    const minimize = () => props.deps.windowFrameActionCreator.minimize();
+    const maximizeOrRestore = () => props.deps.windowFrameActionCreator.maximize();
+    const close = () => props.deps.windowFrameActionCreator.close();
 
     const icons = [
         <ActionButton
@@ -42,7 +43,7 @@ export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps
                 iconName: 'Stop',
             }}
             id="maximize-button"
-            onClick={maximize}
+            onClick={maximizeOrRestore}
             tabIndex={-1}
             key="maximize"
         />,

--- a/src/electron/views/device-connect-view/components/device-connect-footer.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-footer.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
@@ -8,6 +9,7 @@ import { deviceConnectFooter, footerButtonCancel, footerButtonStart } from './de
 
 export interface DeviceConnectFooterDeps {
     windowStateActionCreator: WindowStateActionCreator;
+    windowFrameActionCreator: WindowFrameActionCreator;
 }
 
 export interface DeviceConnectFooterProps {
@@ -25,6 +27,7 @@ export const DeviceConnectFooter = NamedFC<DeviceConnectFooterProps>('DeviceConn
                 className={footerButtonStart}
                 onClick={() => {
                     props.deps.windowStateActionCreator.setRoute({ routeId: 'resultsView' });
+                    props.deps.windowFrameActionCreator.maximize();
                 }}
                 disabled={!props.canStartTesting}
                 text="Start testing"

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -19,6 +19,8 @@ import { RootContainerProps, RootContainerState } from 'electron/views/root-cont
 import { WindowFrameUpdater } from 'electron/window-frame-updater';
 import * as ReactDOM from 'react-dom';
 
+import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
+import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
 import { ScanStore } from 'electron/flux/store/scan-store';
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
@@ -51,6 +53,7 @@ const indexedDBInstance: IndexedDBAPI = new IndexedDBUtil(getIndexedDBStore());
 
 const userConfigActions = new UserConfigurationActions();
 const deviceActions = new DeviceActions();
+const windowFrameActions = new WindowFrameActions();
 const windowStateActions = new WindowStateActions();
 const scanActions = new ScanActions();
 const unifiedScanResultActions = new UnifiedScanResultActions();
@@ -93,7 +96,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
     scanStore.initialize();
 
     const currentWindow = remote.getCurrentWindow();
-    const windowFrameUpdater = new WindowFrameUpdater(windowStateStore, currentWindow);
+    const windowFrameUpdater = new WindowFrameUpdater(windowFrameActions, currentWindow);
     windowFrameUpdater.initialize();
 
     const storeHub = new BaseClientStoresHub<RootContainerState>([userConfigurationStore, deviceStore, windowStateStore, scanStore]);
@@ -106,7 +109,8 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
     const userConfigMessageCreator = new UserConfigurationActionCreator(userConfigActions);
 
     const deviceConnectActionCreator = new DeviceConnectActionCreator(deviceActions, fetchScanResults, telemetryEventHandler);
-    const windowStateActionCreator = new WindowStateActionCreator(windowStateActions);
+    const windowFrameActionCreator = new WindowFrameActionCreator(windowFrameActions);
+    const windowStateActionCreator = new WindowStateActionCreator(windowStateActions, windowFrameActionCreator);
     const scanActionCreator = new ScanActionCreator(scanActions);
 
     const getToolData = createGetToolDataDelegate(appDataAdapter);
@@ -134,6 +138,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
             deviceConnectActionCreator,
             storeHub,
             scanActionCreator,
+            windowFrameActionCreator,
         },
     };
 

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -22,6 +22,7 @@ import * as ReactDOM from 'react-dom';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
 import { ScanStore } from 'electron/flux/store/scan-store';
+import { WindowFrameListener } from 'electron/window-frame-listener';
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
 import { UserConfigurationActionCreator } from '../../background/global-action-creators/user-configuration-action-creator';
@@ -46,7 +47,6 @@ import { DeviceStore } from '../flux/store/device-store';
 import { ElectronLink } from './device-connect-view/components/electron-link';
 import { sendAppInitializedTelemetryEvent } from './device-connect-view/send-app-initialized-telemetry';
 import { RootContainerRenderer } from './root-container/root-container-renderer';
-import { WindowFrameListener } from 'electron/window-frame-listener';
 
 initializeFabricIcons();
 

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -46,6 +46,7 @@ import { DeviceStore } from '../flux/store/device-store';
 import { ElectronLink } from './device-connect-view/components/electron-link';
 import { sendAppInitializedTelemetryEvent } from './device-connect-view/send-app-initialized-telemetry';
 import { RootContainerRenderer } from './root-container/root-container-renderer';
+import { WindowFrameListener } from 'electron/window-frame-listener';
 
 initializeFabricIcons();
 
@@ -112,6 +113,9 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
     const windowFrameActionCreator = new WindowFrameActionCreator(windowFrameActions);
     const windowStateActionCreator = new WindowStateActionCreator(windowStateActions, windowFrameActionCreator);
     const scanActionCreator = new ScanActionCreator(scanActions);
+
+    const windowFrameListener = new WindowFrameListener(windowStateActionCreator, currentWindow);
+    windowFrameListener.initialize();
 
     const getToolData = createGetToolDataDelegate(appDataAdapter);
     const unifiedResultsBuilder = createDefaultBuilder(getToolData);

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -41,6 +41,7 @@ export class RootContainer extends React.Component<RootContainerProps, RootConta
                 <AutomatedChecksView
                     deviceStoreData={this.state.deviceStoreData}
                     scanStoreData={this.state.scanStoreData}
+                    windowStateStoreData={this.state.windowStateStoreData}
                     {...this.props}
                 />
             );
@@ -51,6 +52,7 @@ export class RootContainer extends React.Component<RootContainerProps, RootConta
                 {...{
                     userConfigurationStoreData: this.state.userConfigurationStoreData,
                     deviceStoreData: this.state.deviceStoreData,
+                    windowStateStoreData: this.state.windowStateStoreData,
                     ...this.props,
                 }}
             />

--- a/src/electron/views/root-container/root-container-renderer.tsx
+++ b/src/electron/views/root-container/root-container-renderer.tsx
@@ -12,6 +12,8 @@ export class RootContainerRenderer {
     ) {}
 
     public render(): void {
+        this.props.deps.windowStateActionCreator.setRoute({ routeId: 'deviceConnectView' });
+
         const rootContainer = this.dom.querySelector('#root-container');
         this.renderer(<RootContainer {...this.props} />, rootContainer);
     }

--- a/src/electron/window-frame-listener.ts
+++ b/src/electron/window-frame-listener.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BrowserWindow } from 'electron';
+import { WindowStateActionCreator } from './flux/action-creator/window-state-action-creator';
+
+export class WindowFrameListener {
+    constructor(private readonly windowStateActionsCreator: WindowStateActionCreator, private readonly browserWindow: BrowserWindow) {}
+
+    public initialize(): void {
+        this.browserWindow.on('minimize', this.onWindowStateChange);
+        this.browserWindow.on('maximize', this.onWindowStateChange);
+        this.browserWindow.on('unmaximize', this.onWindowStateChange);
+    }
+
+    private onWindowStateChange = (): void => {
+        if (this.browserWindow.isMinimized()) {
+            this.windowStateActionsCreator.setWindowState({ currentWindowState: 'minimized' });
+        } else if (this.browserWindow.isMaximized()) {
+            this.windowStateActionsCreator.setWindowState({ currentWindowState: 'maximized' });
+        } else {
+            this.windowStateActionsCreator.setWindowState({ currentWindowState: 'customSize' });
+        }
+    };
+}

--- a/src/electron/window-frame-updater.ts
+++ b/src/electron/window-frame-updater.ts
@@ -1,37 +1,38 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserWindow } from 'electron';
-import { WindowStateStore } from './flux/store/window-state-store';
+import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
+import { SetSizePayload } from 'electron/flux/action/window-frame-actions-payloads';
 
 export class WindowFrameUpdater {
-    constructor(private readonly windowStateStore: WindowStateStore, private readonly browserWindow: BrowserWindow) {}
+    constructor(private readonly windowFrameActions: WindowFrameActions, private readonly browserWindow: BrowserWindow) {}
 
     public initialize(): void {
-        this.onWindowStateChange();
-        this.windowStateStore.addChangedListener(this.onWindowStateChange);
+        this.windowFrameActions.maximize.addListener(this.onMaximize);
+        this.windowFrameActions.minimize.addListener(this.onMinimize);
+        this.windowFrameActions.restore.addListener(this.onRestore);
+        this.windowFrameActions.close.addListener(this.onClose);
+        this.windowFrameActions.setWindowSize.addListener(this.onSetSize);
     }
 
-    private onWindowStateChange = () => {
-        if (this.windowStateStore.getState().routeId === 'deviceConnectView') {
-            this.browserWindow.setSize(600, 391);
-            this.browserWindow.center();
-        } else {
-            switch (this.windowStateStore.getState().currentWindowState) {
-                case 'restoredOrMaximized':
-                    if (this.browserWindow.isMaximized()) {
-                        this.browserWindow.restore();
-                    } else {
-                        this.browserWindow.maximize();
-                    }
-                    break;
-                case 'minimized':
-                    if (!this.browserWindow.isMinimized()) {
-                        this.browserWindow.minimize();
-                    }
-                    break;
-                default:
-                    break;
-            }
-        }
+    private onMaximize = (): void => {
+        this.browserWindow.maximize();
+    };
+
+    private onMinimize = (): void => {
+        this.browserWindow.minimize();
+    };
+
+    private onRestore = (): void => {
+        this.browserWindow.restore();
+    };
+
+    private onClose = (): void => {
+        this.browserWindow.close();
+    };
+
+    private onSetSize = (sizePayload: SetSizePayload): void => {
+        this.browserWindow.setSize(sizePayload.width, sizePayload.height);
+        this.browserWindow.center();
     };
 }

--- a/src/tests/electron/window-frame-listener.test.ts
+++ b/src/tests/electron/window-frame-listener.test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { BrowserWindow } from 'electron';
+import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
+import { WindowFrameListener } from 'electron/window-frame-listener';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
+describe(WindowFrameListener, () => {
+    let windowStateActionsCreatorMock: IMock<WindowStateActionCreator>;
+    let testSubject: WindowFrameListener;
+    let browserWindowMock: IMock<BrowserWindow>;
+
+    beforeEach(() => {
+        windowStateActionsCreatorMock = Mock.ofType(WindowStateActionCreator);
+        browserWindowMock = Mock.ofType(BrowserWindow, MockBehavior.Strict);
+
+        testSubject = new WindowFrameListener(windowStateActionsCreatorMock.object, browserWindowMock.object);
+    });
+
+    afterEach(() => {
+        browserWindowMock.verifyAll();
+    });
+
+    it('do nothing on action invocation before initialize', () => {
+        browserWindowMock.setup(b => b.on(It.isAny(), It.isAny())).verifiable(Times.never());
+    });
+
+    describe('initialize', () => {
+        it('registers to required window events', () => {
+            const eventCallbacks: Function[] = [];
+
+            const eventsToListen = ['minimize', 'maximize', 'unmaximize'];
+            eventsToListen.forEach(eventName => {
+                browserWindowMock
+                    .setup(b => b.on(eventName as any, It.isAny()))
+                    .callback((event, cb) => {
+                        eventCallbacks.push(cb);
+                    })
+                    .verifiable(Times.once());
+            });
+
+            testSubject.initialize();
+
+            expect(eventCallbacks.length).toBe(eventsToListen.length);
+            expect(new Set(eventCallbacks).size).toBe(1);
+        });
+    });
+
+    describe('verify action listeners', () => {
+        let eventCallback: Function = null;
+
+        beforeEach(() => {
+            const eventsToListen = ['minimize', 'maximize', 'unmaximize'];
+            eventsToListen.forEach(eventName => {
+                browserWindowMock
+                    .setup(b => b.on(eventName as any, It.isAny()))
+                    .callback((event, cb) => {
+                        eventCallback = cb;
+                    });
+            });
+
+            testSubject.initialize();
+        });
+
+        it('invokes maximize', () => {
+            browserWindowMock.setup(b => b.isMinimized()).returns(() => false);
+
+            browserWindowMock.setup(b => b.isMaximized()).returns(() => true);
+
+            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'maximized' })).verifiable(Times.once());
+
+            eventCallback();
+        });
+
+        it('invokes minimize', () => {
+            browserWindowMock.setup(b => b.isMinimized()).returns(() => true);
+
+            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'minimized' })).verifiable(Times.once());
+
+            eventCallback();
+        });
+
+        it('invokes customSize', () => {
+            browserWindowMock.setup(b => b.isMinimized()).returns(() => false);
+
+            browserWindowMock.setup(b => b.isMaximized()).returns(() => false);
+
+            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'customSize' })).verifiable(Times.once());
+
+            eventCallback();
+        });
+    });
+});

--- a/src/tests/electron/window-frame-updater.test.ts
+++ b/src/tests/electron/window-frame-updater.test.ts
@@ -5,7 +5,7 @@ import { BrowserWindow } from 'electron';
 import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
 import { SetSizePayload } from 'electron/flux/action/window-frame-actions-payloads';
 import { WindowFrameUpdater } from 'electron/window-frame-updater';
-import { IMock, Mock, MockBehavior, Times, ExpectedCallType } from 'typemoq';
+import { ExpectedCallType, IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe(WindowFrameUpdater, () => {
     let windowFrameActions: WindowFrameActions;

--- a/src/tests/electron/window-frame-updater.test.ts
+++ b/src/tests/electron/window-frame-updater.test.ts
@@ -2,144 +2,74 @@
 // Licensed under the MIT License.
 
 import { BrowserWindow } from 'electron';
+import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
+import { SetSizePayload } from 'electron/flux/action/window-frame-actions-payloads';
 import { WindowFrameUpdater } from 'electron/window-frame-updater';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { WindowStateStore } from '../../electron/flux/store/window-state-store';
-import { WindowStateStoreData } from '../../electron/flux/types/window-state-store-data';
+import { IMock, Mock, MockBehavior, Times, ExpectedCallType } from 'typemoq';
 
 describe(WindowFrameUpdater, () => {
-    let windowStateStoreMock: IMock<WindowStateStore>;
+    let windowFrameActions: WindowFrameActions;
     let testSubject: WindowFrameUpdater;
     let browserWindowMock: IMock<BrowserWindow>;
-    let changeListener: () => void;
-    let windowStoreStateData: WindowStateStoreData;
 
     beforeEach(() => {
-        windowStateStoreMock = Mock.ofType(WindowStateStore);
+        windowFrameActions = new WindowFrameActions();
         browserWindowMock = Mock.ofType(BrowserWindow, MockBehavior.Strict);
-        windowStoreStateData = {
-            currentWindowState: undefined,
-            routeId: 'deviceConnectView',
-        };
 
-        windowStateStoreMock
-            .setup(w => w.addChangedListener(It.isAny()))
-            .callback(cb => {
-                changeListener = cb;
-            });
-
-        windowStateStoreMock.setup(w => w.getState()).returns(() => windowStoreStateData);
-
-        testSubject = new WindowFrameUpdater(windowStateStoreMock.object, browserWindowMock.object);
+        testSubject = new WindowFrameUpdater(windowFrameActions, browserWindowMock.object);
     });
 
-    describe('initialize', () => {
-        it('updates window based on initial state - deviceConnectView', () => {
-            setupVerifiableCallsForDeviceConnectRoute();
-            windowStoreStateData.routeId = 'deviceConnectView';
-
-            testSubject.initialize();
-
-            windowStateStoreMock.verifyAll();
-            browserWindowMock.verifyAll();
-        });
-
-        it('updates window based on initial state - resultsView', () => {
-            windowStoreStateData = {
-                currentWindowState: 'restoredOrMaximized',
-                routeId: 'resultsView',
-            };
-            setupVerifiableMaximizeWindowCall();
-
-            testSubject.initialize();
-
-            windowStateStoreMock.verifyAll();
-            browserWindowMock.verifyAll();
-        });
+    afterEach(() => {
+        browserWindowMock.verifyAll();
     });
 
-    describe('verify change listener', () => {
+    it(' do nothing on action invocation before initialize', () => {
+        windowFrameActions.maximize.invoke();
+
+        browserWindowMock.setup(b => b.maximize()).verifiable(Times.never());
+    });
+
+    describe('verify action listeners', () => {
         beforeEach(() => {
-            windowStoreStateData = {
-                routeId: 'deviceConnectView',
-                currentWindowState: 'restoredOrMaximized',
-            };
-
-            setupVerifiableCallsForDeviceConnectRoute();
-
             testSubject.initialize();
-            browserWindowMock.reset();
         });
 
-        it('sets window state to deviceConnectView', () => {
-            setupVerifiableCallsForDeviceConnectRoute();
+        it('invokes maximize', () => {
+            browserWindowMock.setup(b => b.maximize()).verifiable(Times.once());
 
-            changeListener();
-
-            browserWindowMock.verifyAll();
+            windowFrameActions.maximize.invoke();
         });
 
-        it('sets window state to results view', () => {
-            windowStoreStateData = {
-                routeId: 'resultsView',
-                currentWindowState: 'restoredOrMaximized',
+        it('invokes minimize', () => {
+            browserWindowMock.setup(b => b.minimize()).verifiable(Times.once());
+
+            windowFrameActions.minimize.invoke();
+        });
+
+        it('invokes restore', () => {
+            browserWindowMock.setup(b => b.restore()).verifiable(Times.once());
+
+            windowFrameActions.restore.invoke();
+        });
+
+        it('invokes close', () => {
+            browserWindowMock.setup(b => b.close()).verifiable(Times.once());
+
+            windowFrameActions.close.invoke();
+        });
+
+        it('invokes setSize', () => {
+            const sizePayload: SetSizePayload = {
+                width: 12,
+                height: 34,
             };
 
-            setupVerifiableMaximizeWindowCall();
-            changeListener();
+            browserWindowMock
+                .setup(b => b.setSize(sizePayload.width, sizePayload.height))
+                .verifiable(Times.once(), ExpectedCallType.InSequence);
+            browserWindowMock.setup(b => b.center()).verifiable(Times.once(), ExpectedCallType.InSequence);
 
-            browserWindowMock.verifyAll();
-        });
-
-        it('minimizes the window under results view', () => {
-            windowStoreStateData.routeId = 'resultsView';
-            windowStoreStateData.currentWindowState = 'minimized';
-
-            setupVerifiableMinimizeWindowCall();
-
-            changeListener();
-
-            browserWindowMock.verifyAll();
-        });
-
-        it('restores the window under results view', () => {
-            windowStoreStateData.routeId = 'resultsView';
-            windowStoreStateData.currentWindowState = 'restoredOrMaximized';
-
-            setupVerifiableRestoreWindowCall();
-
-            changeListener();
-
-            browserWindowMock.verifyAll();
+            windowFrameActions.setWindowSize.invoke(sizePayload);
         });
     });
-
-    function setupVerifiableCallsForDeviceConnectRoute(): void {
-        browserWindowMock.setup(b => b.setSize(600, 391)).verifiable(Times.once());
-        browserWindowMock.setup(b => b.center()).verifiable(Times.once());
-    }
-
-    function setupVerifiableMaximizeWindowCall(): void {
-        browserWindowMock
-            .setup(b => b.isMaximized())
-            .returns(() => false)
-            .verifiable(Times.once());
-        browserWindowMock.setup(b => b.maximize()).verifiable(Times.once());
-    }
-
-    function setupVerifiableRestoreWindowCall(): void {
-        browserWindowMock
-            .setup(b => b.isMaximized())
-            .returns(() => true)
-            .verifiable(Times.once());
-        browserWindowMock.setup(b => b.restore()).verifiable(Times.once());
-    }
-
-    function setupVerifiableMinimizeWindowCall(): void {
-        browserWindowMock
-            .setup(b => b.isMinimized())
-            .returns(() => false)
-            .verifiable(Times.once());
-        browserWindowMock.setup(b => b.minimize()).verifiable(Times.once());
-    }
 });

--- a/src/tests/unit/tests/electron/flux/action-creator/window-frame-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/window-frame-action-creator.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Action } from 'common/flux/action';
+import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
+import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
+import { SetSizePayload } from 'electron/flux/action/window-frame-actions-payloads';
+import { IMock, Mock, Times } from 'typemoq';
+
+describe(WindowFrameActionCreator, () => {
+    let windowFrameActionsMock: IMock<WindowFrameActions>;
+    let testSubject: WindowFrameActionCreator;
+
+    beforeEach(() => {
+        windowFrameActionsMock = Mock.ofType<WindowFrameActions>();
+        testSubject = new WindowFrameActionCreator(windowFrameActionsMock.object);
+    });
+
+    it('calling setWindowSize invokes setWindowSize action with given payload', () => {
+        const setRouteActionMock = Mock.ofType<Action<SetSizePayload>>();
+        const testPayload: SetSizePayload = {
+            height: 1,
+            width: 2,
+        };
+        windowFrameActionsMock.setup(actions => actions.setWindowSize).returns(() => setRouteActionMock.object);
+        setRouteActionMock.setup(s => s.invoke(testPayload)).verifiable(Times.once());
+
+        testSubject.setWindowSize(testPayload);
+
+        setRouteActionMock.verifyAll();
+    });
+
+    it('calling maximize invokes maximize action', () => {
+        const maximizeActionMock = Mock.ofType<Action<void>>();
+
+        windowFrameActionsMock.setup(actions => actions.maximize).returns(() => maximizeActionMock.object);
+        maximizeActionMock.setup(s => s.invoke()).verifiable(Times.once());
+
+        testSubject.maximize();
+
+        maximizeActionMock.verifyAll();
+    });
+
+    it('calling minimize invokes minimize action', () => {
+        const minimizeActionMock = Mock.ofType<Action<void>>();
+
+        windowFrameActionsMock.setup(actions => actions.minimize).returns(() => minimizeActionMock.object);
+        minimizeActionMock.setup(s => s.invoke()).verifiable(Times.once());
+
+        testSubject.minimize();
+
+        minimizeActionMock.verifyAll();
+    });
+
+    it('calling maximize invokes restore action', () => {
+        const restoreActionMock = Mock.ofType<Action<void>>();
+
+        windowFrameActionsMock.setup(actions => actions.restore).returns(() => restoreActionMock.object);
+        restoreActionMock.setup(s => s.invoke()).verifiable(Times.once());
+
+        testSubject.restore();
+
+        restoreActionMock.verifyAll();
+    });
+
+    it('calling close invokes close action', () => {
+        const closeActionMock = Mock.ofType<Action<void>>();
+
+        windowFrameActionsMock.setup(actions => actions.close).returns(() => closeActionMock.object);
+        closeActionMock.setup(s => s.invoke()).verifiable(Times.once());
+
+        testSubject.close();
+
+        closeActionMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
@@ -2,19 +2,22 @@
 // Licensed under the MIT License.
 
 import { Action } from 'common/flux/action';
+import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { RoutePayload } from 'electron/flux/action/route-payloads';
 import { WindowStateActions } from 'electron/flux/action/window-state-actions';
-import { WindowStatePayload } from 'electron/flux/action/window-state-payload';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe(WindowStateActionCreator, () => {
     let windowStateActionsMock: IMock<WindowStateActions>;
+    let windowFrameActionCreatorMock: IMock<WindowFrameActionCreator>;
     let testSubject: WindowStateActionCreator;
 
     beforeEach(() => {
         windowStateActionsMock = Mock.ofType<WindowStateActions>();
-        testSubject = new WindowStateActionCreator(windowStateActionsMock.object);
+        windowFrameActionCreatorMock = Mock.ofType<WindowFrameActionCreator>(WindowFrameActionCreator, MockBehavior.Strict);
+
+        testSubject = new WindowStateActionCreator(windowStateActionsMock.object, windowFrameActionCreatorMock.object);
     });
 
     it('calling setRoute invokes setRoute action with given payload', () => {
@@ -30,16 +33,20 @@ describe(WindowStateActionCreator, () => {
         setRouteActionMock.verifyAll();
     });
 
-    it('calling setWindowState invokes setWindowState action with given payload', () => {
-        const setWindowStateActionMock = Mock.ofType<Action<WindowStatePayload>>();
-        const testPayload: WindowStatePayload = {
-            currentWindowState: 'minimized',
+    it('calling setRoute with deviceConnectView, invokes setWindowSize', () => {
+        const setRouteActionMock = Mock.ofType<Action<RoutePayload>>();
+        const testPayload: RoutePayload = {
+            routeId: 'deviceConnectView',
         };
-        windowStateActionsMock.setup(actions => actions.setWindowState).returns(() => setWindowStateActionMock.object);
-        setWindowStateActionMock.setup(s => s.invoke(testPayload)).verifiable(Times.once());
 
-        testSubject.setWindowState(testPayload);
+        windowFrameActionCreatorMock.setup(w => w.setWindowSize({ width: 600, height: 391 })).verifiable(Times.once());
 
-        setWindowStateActionMock.verifyAll();
+        windowStateActionsMock.setup(actions => actions.setRoute).returns(() => setRouteActionMock.object);
+        setRouteActionMock.setup(s => s.invoke(testPayload)).verifiable(Times.once());
+
+        testSubject.setRoute(testPayload);
+
+        setRouteActionMock.verifyAll();
+        windowFrameActionCreatorMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
@@ -6,8 +6,8 @@ import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-fr
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { RoutePayload } from 'electron/flux/action/route-payloads';
 import { WindowStateActions } from 'electron/flux/action/window-state-actions';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import { WindowStatePayload } from 'electron/flux/action/window-state-payload';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe(WindowStateActionCreator, () => {
     let windowStateActionsMock: IMock<WindowStateActions>;

--- a/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
@@ -7,6 +7,7 @@ import { WindowStateActionCreator } from 'electron/flux/action-creator/window-st
 import { RoutePayload } from 'electron/flux/action/route-payloads';
 import { WindowStateActions } from 'electron/flux/action/window-state-actions';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { WindowStatePayload } from 'electron/flux/action/window-state-payload';
 
 describe(WindowStateActionCreator, () => {
     let windowStateActionsMock: IMock<WindowStateActions>;
@@ -47,6 +48,21 @@ describe(WindowStateActionCreator, () => {
         testSubject.setRoute(testPayload);
 
         setRouteActionMock.verifyAll();
+        windowFrameActionCreatorMock.verifyAll();
+    });
+
+    it('calling setWindowState invokes setWindowState action', () => {
+        const setWindowStatePayload = Mock.ofType<Action<WindowStatePayload>>();
+        const testPayload: WindowStatePayload = {
+            currentWindowState: 'maximized',
+        };
+
+        windowStateActionsMock.setup(actions => actions.setWindowState).returns(() => setWindowStatePayload.object);
+        setWindowStatePayload.setup(s => s.invoke(testPayload)).verifiable(Times.once());
+
+        testSubject.setWindowState(testPayload);
+
+        setWindowStatePayload.verifyAll();
         windowFrameActionCreatorMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/flux/store/__snapshots__/window-state-store.test.ts.snap
+++ b/src/tests/unit/tests/electron/flux/store/__snapshots__/window-state-store.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`WindowStateStore returns device connect as the default state 1`] = `
 Object {
-  "currentWindowState": "restoredOrMaximized",
+  "currentWindowState": "customSize",
   "routeId": "deviceConnectView",
 }
 `;

--- a/src/tests/unit/tests/electron/flux/store/window-state-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/window-state-store.test.ts
@@ -28,7 +28,7 @@ describe('WindowStateStore', () => {
         };
         const expectedState: WindowStateStoreData = {
             routeId: payload.routeId,
-            currentWindowState: 'restoredOrMaximized',
+            currentWindowState: 'customSize',
         };
 
         const initialState = createStoreWithNullParams(WindowStateStore).getDefaultState();
@@ -44,12 +44,28 @@ describe('WindowStateStore', () => {
         };
         const expectedState: WindowStateStoreData = {
             routeId: payload.routeId,
-            currentWindowState: 'restoredOrMaximized',
+            currentWindowState: 'customSize',
         };
 
         const initialState = createStoreWithNullParams(WindowStateStore).getDefaultState();
 
         createStoreTesterForWindowStateActions('setRoute')
+            .withActionParam(payload)
+            .testListenerToNeverBeCalled(initialState, expectedState);
+    });
+
+    it('does not emit a change when the window state is not changing', () => {
+        const payload: WindowStatePayload = {
+            currentWindowState: 'customSize',
+        };
+        const expectedState: WindowStateStoreData = {
+            routeId: 'deviceConnectView',
+            currentWindowState: 'customSize',
+        };
+
+        const initialState = createStoreWithNullParams(WindowStateStore).getDefaultState();
+
+        createStoreTesterForWindowStateActions('setWindowState')
             .withActionParam(payload)
             .testListenerToNeverBeCalled(initialState, expectedState);
     });

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -34,14 +34,25 @@ exports[`AutomatedChecksView renders device disconnected 1`] = `
 </React.Fragment>
 `;
 
-exports[`AutomatedChecksView renders scanning spinner 1`] = `
+exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
 <React.Fragment>
   <TitleBar
     deps={
       Object {
+        "currentWindow": null,
+        "deviceConnectActionCreator": null,
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
+        },
+        "windowFrameActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActions": undefined,
+        },
+        "windowStateActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActionCreator": undefined,
+          "windowStateActions": undefined,
         },
       }
     }
@@ -49,38 +60,20 @@ exports[`AutomatedChecksView renders scanning spinner 1`] = `
   <CommandBar
     deps={
       Object {
+        "currentWindow": null,
+        "deviceConnectActionCreator": null,
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
         },
-      }
-    }
-  />
-  <HeaderSection />
-  <ScanningSpinner
-    isScanning={true}
-  />
-</React.Fragment>
-`;
-
-exports[`AutomatedChecksView renders the automated checks view 1`] = `
-<React.Fragment>
-  <TitleBar
-    deps={
-      Object {
-        "scanActionCreator": proxy {
+        "windowFrameActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "scanActions": undefined,
+          "windowFrameActions": undefined,
         },
-      }
-    }
-  />
-  <CommandBar
-    deps={
-      Object {
-        "scanActionCreator": proxy {
+        "windowStateActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "scanActions": undefined,
+          "windowFrameActionCreator": undefined,
+          "windowStateActions": undefined,
         },
       }
     }
@@ -88,6 +81,57 @@ exports[`AutomatedChecksView renders the automated checks view 1`] = `
   <HeaderSection />
   <ScanningSpinner
     isScanning={false}
+  />
+</React.Fragment>
+`;
+
+exports[`AutomatedChecksView renders scanning spinner 1`] = `
+<React.Fragment>
+  <TitleBar
+    deps={
+      Object {
+        "currentWindow": null,
+        "deviceConnectActionCreator": null,
+        "scanActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "scanActions": undefined,
+        },
+        "windowFrameActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActions": undefined,
+        },
+        "windowStateActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActionCreator": undefined,
+          "windowStateActions": undefined,
+        },
+      }
+    }
+  />
+  <CommandBar
+    deps={
+      Object {
+        "currentWindow": null,
+        "deviceConnectActionCreator": null,
+        "scanActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "scanActions": undefined,
+        },
+        "windowFrameActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActions": undefined,
+        },
+        "windowStateActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActionCreator": undefined,
+          "windowStateActions": undefined,
+        },
+      }
+    }
+  />
+  <HeaderSection />
+  <ScanningSpinner
+    isScanning={true}
   />
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -56,6 +56,7 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
         },
       }
     }
+    windowStateStoreData="window state store data"
   />
   <CommandBar
     deps={
@@ -107,6 +108,7 @@ exports[`AutomatedChecksView renders scanning spinner 1`] = `
         },
       }
     }
+    windowStateStoreData="window state store data"
   />
   <CommandBar
     deps={

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -23,6 +23,7 @@ describe('AutomatedChecksView', () => {
                 },
                 scanStoreData: {},
                 deviceStoreData: {},
+                windowStateStoreData: 'window state store data' as any,
             } as AutomatedChecksViewProps;
 
             const wrapped = shallow(<AutomatedChecksView {...props} />);
@@ -42,7 +43,8 @@ describe('AutomatedChecksView', () => {
                 scanStoreData: {
                     status: ScanStatus.Scanning,
                 },
-                deviceStoreData: {},
+                deviceStoreData: {} as any,
+                windowStateStoreData: 'window state store data' as any,
             } as AutomatedChecksViewProps;
 
             const wrapped = shallow(<AutomatedChecksView {...props} />);

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { AutomatedChecksView, AutomatedChecksViewProps } from 'electron/views/automated-checks/automated-checks-view';
@@ -11,10 +12,14 @@ import { It, Mock, Times } from 'typemoq';
 
 describe('AutomatedChecksView', () => {
     describe('renders', () => {
-        it('the automated checks view', () => {
+        it('renders the automated checks view', () => {
             const props: AutomatedChecksViewProps = {
                 deps: {
+                    deviceConnectActionCreator: null,
+                    currentWindow: null,
+                    windowStateActionCreator: Mock.ofType(WindowStateActionCreator).object,
                     scanActionCreator: Mock.ofType(ScanActionCreator).object,
+                    windowFrameActionCreator: Mock.ofType(WindowFrameActionCreator).object,
                 },
                 scanStoreData: {},
                 deviceStoreData: {},
@@ -28,7 +33,11 @@ describe('AutomatedChecksView', () => {
         it('scanning spinner', () => {
             const props: AutomatedChecksViewProps = {
                 deps: {
+                    deviceConnectActionCreator: null,
+                    currentWindow: null,
+                    windowStateActionCreator: Mock.ofType(WindowStateActionCreator).object,
                     scanActionCreator: Mock.ofType(ScanActionCreator).object,
+                    windowFrameActionCreator: Mock.ofType(WindowFrameActionCreator).object,
                 },
                 scanStoreData: {
                     status: ScanStatus.Scanning,

--- a/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
@@ -10,17 +10,20 @@ import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-fr
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { TitleBar, TitleBarProps } from 'electron/views/automated-checks/components/title-bar';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
+import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 
 describe('TitleBar', () => {
     const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
     let browserWindowMock: IMock<BrowserWindow>;
     let windowStateActionCreator: IMock<WindowStateActionCreator>;
     let windowFrameActionCreator: IMock<WindowFrameActionCreator>;
+    let windowStateStoreData: WindowStateStoreData;
 
     beforeEach(() => {
         browserWindowMock = Mock.ofType<BrowserWindow>(undefined, MockBehavior.Strict);
         windowStateActionCreator = Mock.ofType<WindowStateActionCreator>(undefined, MockBehavior.Strict);
         windowFrameActionCreator = Mock.ofType<WindowFrameActionCreator>(undefined, MockBehavior.Strict);
+        windowStateStoreData = { routeId: 'resultsView', currentWindowState: 'maximized' };
     });
 
     it('renders', () => {
@@ -30,6 +33,7 @@ describe('TitleBar', () => {
                 windowStateActionCreator: Mock.ofType(WindowStateActionCreator).object,
                 windowFrameActionCreator: Mock.ofType(WindowFrameActionCreator).object,
             },
+            windowStateStoreData,
         } as TitleBarProps;
 
         const wrapper = shallow(<TitleBar {...props} />);
@@ -38,7 +42,14 @@ describe('TitleBar', () => {
     });
 
     const setupVerifiableWindowMaximizeAction = () => {
+        windowStateStoreData.currentWindowState = 'customSize';
+
         windowFrameActionCreator.setup(creator => creator.maximize()).verifiable(Times.once());
+    };
+
+    const setupVerifiableWindowRestoreAction = () => {
+        windowStateStoreData.currentWindowState = 'maximized';
+        windowFrameActionCreator.setup(creator => creator.restore()).verifiable(Times.once());
     };
 
     const setupVerifiableWindowMinimizeCall = () => {
@@ -50,7 +61,8 @@ describe('TitleBar', () => {
     };
 
     const buttonsAndSetups = [
-        { id: '#maximize-button', setupMock: setupVerifiableWindowMaximizeAction },
+        { id: '#maximize-button', setupMock: setupVerifiableWindowMaximizeAction }, // maximize validation
+        { id: '#maximize-button', setupMock: setupVerifiableWindowRestoreAction }, // restore validation
         { id: '#minimize-button', setupMock: setupVerifiableWindowMinimizeCall },
         { id: '#close-button', setupMock: setupVerifiableWindowCloseActionCall },
     ];
@@ -63,6 +75,7 @@ describe('TitleBar', () => {
                 windowStateActionCreator: windowStateActionCreator.object,
                 windowFrameActionCreator: windowFrameActionCreator.object,
             },
+            windowStateStoreData,
         } as TitleBarProps;
 
         const rendered = shallow(<TitleBar {...props} />);

--- a/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
@@ -8,9 +8,9 @@ import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
+import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { TitleBar, TitleBarProps } from 'electron/views/automated-checks/components/title-bar';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
-import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 
 describe('TitleBar', () => {
     const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-footer.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-footer.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import {
     DeviceConnectFooter,
@@ -13,7 +14,6 @@ import { Button } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, Times } from 'typemoq';
-import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 
 describe('DeviceConnectFooterTest', () => {
     let windowStateActionCreatorMock: IMock<WindowStateActionCreator>;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-footer.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-footer.test.tsx
@@ -13,9 +13,11 @@ import { Button } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, Times } from 'typemoq';
+import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 
 describe('DeviceConnectFooterTest', () => {
     let windowStateActionCreatorMock: IMock<WindowStateActionCreator>;
+    let windowFrameActionCreatorMock: IMock<WindowFrameActionCreator>;
     let deps: DeviceConnectFooterDeps;
 
     const onClickMock = Mock.ofInstance(() => {});
@@ -23,7 +25,11 @@ describe('DeviceConnectFooterTest', () => {
 
     beforeEach(() => {
         windowStateActionCreatorMock = Mock.ofType(WindowStateActionCreator);
-        deps = { windowStateActionCreator: windowStateActionCreatorMock.object };
+        windowFrameActionCreatorMock = Mock.ofType(WindowFrameActionCreator);
+        deps = {
+            windowStateActionCreator: windowStateActionCreatorMock.object,
+            windowFrameActionCreator: windowFrameActionCreatorMock.object,
+        };
     });
 
     test('render', () => {
@@ -53,18 +59,20 @@ describe('DeviceConnectFooterTest', () => {
         onClickMock.verify(onClick => onClick(), Times.once());
     });
 
-    test('start testing changes route', () => {
+    test('start testing changes route & maximizes window', () => {
         windowStateActionCreatorMock.setup(w => w.setRoute({ routeId: 'resultsView' })).verifiable(Times.once());
-
+        windowFrameActionCreatorMock.setup(w => w.maximize()).verifiable(Times.once());
         const props: DeviceConnectFooterProps = {
             cancelClick: onClickMock.object,
             canStartTesting: true,
             deps,
         };
-
         const rendered = shallow(<DeviceConnectFooter {...props} />);
         const button = rendered.find(`.${footerButtonStart}`);
+
         button.simulate('click', eventStub);
+
         windowStateActionCreatorMock.verifyAll();
+        windowFrameActionCreatorMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
@@ -20,6 +20,12 @@ exports[`RootContainer renders device connect view container when route is devic
       "isFirstTime": true,
     }
   }
+  windowStateStoreData={
+    Object {
+      "currentWindowState": "customSize",
+      "routeId": "deviceConnectView",
+    }
+  }
 />
 `;
 
@@ -44,6 +50,12 @@ exports[`RootContainer renders results view container when route is resultsView 
       "status": 0,
     }
   }
+  windowStateStoreData={
+    Object {
+      "currentWindowState": "customSize",
+      "routeId": "resultsView",
+    }
+  }
 />
 `;
 
@@ -56,7 +68,7 @@ Object {
     "isFirstTime": true,
   },
   "windowStateStoreData": Object {
-    "currentWindowState": "restoredOrMaximized",
+    "currentWindowState": "customSize",
     "routeId": "deviceConnectView",
   },
 }
@@ -71,7 +83,7 @@ Object {
     "isFirstTime": true,
   },
   "windowStateStoreData": Object {
-    "currentWindowState": "restoredOrMaximized",
+    "currentWindowState": "customSize",
     "routeId": "resultsView",
   },
 }

--- a/src/tests/unit/tests/electron/views/root-container/components/root-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/components/root-container.test.tsx
@@ -35,7 +35,7 @@ describe(RootContainer, () => {
                 .setup(hub => hub.getAllStoreData())
                 .returns(() => {
                     return {
-                        windowStateStoreData: { routeId: 'deviceConnectView', currentWindowState: 'restoredOrMaximized' },
+                        windowStateStoreData: { routeId: 'deviceConnectView', currentWindowState: 'customSize' },
                         userConfigurationStoreData: { isFirstTime: true },
                         deviceStoreData: { deviceConnectState: DeviceConnectState.Connected },
                     } as RootContainerState;
@@ -51,7 +51,7 @@ describe(RootContainer, () => {
                 .setup(hub => hub.getAllStoreData())
                 .returns(() => {
                     return {
-                        windowStateStoreData: { routeId: 'resultsView', currentWindowState: 'restoredOrMaximized' },
+                        windowStateStoreData: { routeId: 'resultsView', currentWindowState: 'customSize' },
                         userConfigurationStoreData: { isFirstTime: true },
                         deviceStoreData: { deviceConnectState: DeviceConnectState.Connected, port: 11111 },
                         scanStoreData: { status: ScanStatus.Default },
@@ -70,7 +70,7 @@ describe(RootContainer, () => {
                 .setup(hub => hub.getAllStoreData())
                 .returns(() => {
                     return {
-                        windowStateStoreData: { routeId: 'deviceConnectView', currentWindowState: 'restoredOrMaximized' },
+                        windowStateStoreData: { routeId: 'deviceConnectView', currentWindowState: 'customSize' },
                         userConfigurationStoreData: { isFirstTime: true },
                         deviceStoreData: { deviceConnectState: DeviceConnectState.Connected },
                     } as RootContainerState;
@@ -79,7 +79,7 @@ describe(RootContainer, () => {
                 .setup(hub => hub.getAllStoreData())
                 .returns(() => {
                     return {
-                        windowStateStoreData: { routeId: 'resultsView', currentWindowState: 'restoredOrMaximized' },
+                        windowStateStoreData: { routeId: 'resultsView', currentWindowState: 'customSize' },
                         userConfigurationStoreData: { isFirstTime: true },
                         deviceStoreData: { deviceConnectState: DeviceConnectState.Connected },
                     } as RootContainerState;

--- a/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserWindow } from 'electron';
+import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { RootContainer, RootContainerProps } from 'electron/views/root-container/components/root-container';
 import { RootContainerRenderer } from 'electron/views/root-container/root-container-renderer';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { IMock, It, Mock } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('RootContainerRendererTest', () => {
     test('render', () => {
         const dom = document.createElement('div');
         const containerDiv = document.createElement('div');
         const renderMock: IMock<typeof ReactDOM.render> = Mock.ofInstance(() => null);
-
+        const windowStateActionCreatorMock = Mock.ofType(WindowStateActionCreator);
         const browserWindow: BrowserWindow = {
             close: () => {
                 return;
@@ -27,15 +28,16 @@ describe('RootContainerRendererTest', () => {
                 currentWindow: browserWindow,
             },
         } as RootContainerProps;
-
         const expectedComponent = <RootContainer {...props} />;
 
         renderMock.setup(r => r(It.isValue(expectedComponent), containerDiv)).verifiable();
+        windowStateActionCreatorMock.setup(w => w.setRoute({ routeId: 'deviceConnectView' })).verifiable(Times.once());
 
         const renderer = new RootContainerRenderer(renderMock.object, dom, props);
 
         renderer.render();
 
         renderMock.verifyAll();
+        windowStateActionCreatorMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
@@ -26,6 +26,7 @@ describe('RootContainerRendererTest', () => {
         const props = {
             deps: {
                 currentWindow: browserWindow,
+                windowStateActionCreator: windowStateActionCreatorMock.object,
             },
         } as RootContainerProps;
         const expectedComponent = <RootContainer {...props} />;


### PR DESCRIPTION

#### Description of changes

WindowFrameUpdater => responsible for performing window operations via actions.
WindowFrameListener => listens to window state & updates store via action

Main changes are in WindowFrameUpdater, WindowFrameListener, TitleBar & RootContainerRenderer, WindowStateStore
(Other files were modified due to this refactoring + delegating action creators)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
