### PR TITLE
refactor: move UnifiedStatusResults and UnifiedRuleResult interfaces to another file

### DIFF
--- a/src/DetailsView/components/cards-view.tsx
+++ b/src/DetailsView/components/cards-view.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FailedInstancesSection, FailedInstancesSectionDeps, UnifiedStatusResults } from 'common/components/cards/failed-instances-section';
+import { FailedInstancesSection, FailedInstancesSectionDeps } from 'common/components/cards/failed-instances-section';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { TargetAppData } from '../../common/types/store-data/unified-data-interface';
+import { TargetAppData, UnifiedStatusResults } from '../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 
 export type CardsViewDeps = FailedInstancesSectionDeps;

--- a/src/DetailsView/components/details-list-issues-view.tsx
+++ b/src/DetailsView/components/details-list-issues-view.tsx
@@ -3,13 +3,12 @@
 import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 
-import { UnifiedStatusResults } from '../../common/components/cards/failed-instances-section';
 import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { NamedFC } from '../../common/react/named-fc';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
-import { TargetAppData } from '../../common/types/store-data/unified-data-interface';
+import { TargetAppData, UnifiedStatusResults } from '../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { VisualizationScanResultData } from '../../common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from '../../common/types/store-data/visualization-store-data';

--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -6,14 +6,13 @@ import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 
-import { UnifiedStatusResults } from '../../common/components/cards/failed-instances-section';
 import { FlaggedComponent } from '../../common/components/flagged-component';
 import { VisualizationToggle } from '../../common/components/visualization-toggle';
 import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { FeatureFlags } from '../../common/feature-flags';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { TargetAppData } from '../../common/types/store-data/unified-data-interface';
+import { TargetAppData, UnifiedStatusResults } from '../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { DecoratedAxeNodeResult } from '../../injected/scanner-utils';

--- a/src/DetailsView/components/test-view-container.tsx
+++ b/src/DetailsView/components/test-view-container.tsx
@@ -2,14 +2,13 @@
 // Licensed under the MIT License.
 import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
 
-import { UnifiedStatusResults } from '../../common/components/cards/failed-instances-section';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { NamedFC } from '../../common/react/named-fc';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { PathSnippetStoreData } from '../../common/types/store-data/path-snippet-store-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
-import { TargetAppData } from '../../common/types/store-data/unified-data-interface';
+import { TargetAppData, UnifiedStatusResults } from '../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { VisualizationScanResultData } from '../../common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from '../../common/types/store-data/visualization-store-data';

--- a/src/DetailsView/details-view-main-content.tsx
+++ b/src/DetailsView/details-view-main-content.tsx
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { TargetAppData } from 'common/types/store-data/unified-data-interface';
+import { TargetAppData, UnifiedStatusResults } from 'common/types/store-data/unified-data-interface';
 import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 
-import { UnifiedStatusResults } from '../common/components/cards/failed-instances-section';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { DropdownClickHandler } from '../common/dropdown-click-handler';
 import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';

--- a/src/common/components/cards/failed-instances-section.tsx
+++ b/src/common/components/cards/failed-instances-section.tsx
@@ -3,8 +3,7 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { TargetAppData, UnifiedResult, UnifiedRuleResultStatus } from '../../../common/types/store-data/unified-data-interface';
-import { GuidanceLink } from '../../../scanner/rule-to-links-mappings';
+import { TargetAppData, UnifiedStatusResults } from '../../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { ResultSection, ResultSectionDeps } from './result-section';
 
@@ -14,18 +13,6 @@ export type FailedInstancesSectionProps = {
     ruleResultsByStatus: UnifiedStatusResults;
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
-};
-
-export interface UnifiedRuleResult {
-    id: string;
-    nodes: UnifiedResult[];
-    description: string;
-    url: string;
-    guidance: GuidanceLink[];
-}
-
-export type UnifiedStatusResults = {
-    [key in UnifiedRuleResultStatus]: UnifiedRuleResult[];
 };
 
 export const FailedInstancesSection = NamedFC<FailedInstancesSectionProps>(

--- a/src/common/components/cards/instance-details-group.tsx
+++ b/src/common/components/cards/instance-details-group.tsx
@@ -5,9 +5,8 @@ import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
 import { getPropertyConfiguration } from '../../../common/configs/unified-result-property-configurations';
-import { TargetAppData, UnifiedRule } from '../../../common/types/store-data/unified-data-interface';
+import { TargetAppData, UnifiedRule, UnifiedRuleResult } from '../../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
-import { UnifiedRuleResult } from './failed-instances-section';
 import { InstanceDetails, InstanceDetailsDeps } from './instance-details';
 import { instanceDetailsList } from './instance-details-group.scss';
 

--- a/src/common/components/cards/result-section-content.tsx
+++ b/src/common/components/cards/result-section-content.tsx
@@ -4,11 +4,10 @@ import { NamedFC } from 'common/react/named-fc';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 
-import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';
+import { TargetAppData, UnifiedRuleResult } from '../../../common/types/store-data/unified-data-interface';
 import { InstanceOutcomeType } from '../../../reports/components/instance-outcome-type';
 import { NoFailedInstancesCongrats } from '../../../reports/components/report-sections/no-failed-instances-congrats';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
-import { UnifiedRuleResult } from './failed-instances-section';
 import { RulesWithInstances, RulesWithInstancesDeps } from './rules-with-instances';
 
 export type ResultSectionContentDeps = RulesWithInstancesDeps;

--- a/src/common/components/cards/rule-content.tsx
+++ b/src/common/components/cards/rule-content.tsx
@@ -3,9 +3,8 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';
+import { TargetAppData, UnifiedRuleResult } from '../../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
-import { UnifiedRuleResult } from './failed-instances-section';
 import { InstanceDetailsGroup, InstanceDetailsGroupDeps } from './instance-details-group';
 import { RuleResources, RuleResourcesDeps } from './rule-resources';
 

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -5,13 +5,12 @@ import { NamedFC } from 'common/react/named-fc';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 
-import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';
+import { TargetAppData, UnifiedRuleResult } from '../../../common/types/store-data/unified-data-interface';
 import { InstanceOutcomeType } from '../../../reports/components/instance-outcome-type';
 import { outcomeTypeSemantics } from '../../../reports/components/outcome-type';
 import { MinimalRuleHeader } from '../../../reports/components/report-sections/minimal-rule-header';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { CollapsibleComponentCardsProps } from './collapsible-component-cards';
-import { UnifiedRuleResult } from './failed-instances-section';
 import { RuleContent, RuleContentDeps } from './rule-content';
 import { collapsibleRuleDetailsGroup, ruleDetailsGroup } from './rules-with-instances.scss';
 

--- a/src/common/rule-based-view-model-provider.ts
+++ b/src/common/rule-based-view-model-provider.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UnifiedRuleResult, UnifiedStatusResults } from './components/cards/failed-instances-section';
-import { AllRuleResultStatuses, UnifiedResult, UnifiedRule, UnifiedRuleResultStatus } from './types/store-data/unified-data-interface';
+import {
+    AllRuleResultStatuses,
+    UnifiedResult,
+    UnifiedRule,
+    UnifiedRuleResult,
+    UnifiedRuleResultStatus,
+    UnifiedStatusResults,
+} from './types/store-data/unified-data-interface';
 
 export type GetUnifiedRuleResultsDelegate = (rules: UnifiedRule[], results: UnifiedResult[]) => UnifiedStatusResults;
 

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -86,4 +86,16 @@ export type InstanceResultStatus = 'pass' | 'fail' | 'unknown';
 
 export type UnifiedRuleResultStatus = InstanceResultStatus | 'inapplicable';
 
+export interface UnifiedRuleResult {
+    id: string;
+    nodes: UnifiedResult[];
+    description: string;
+    url: string;
+    guidance: GuidanceLink[];
+}
+
+export type UnifiedStatusResults = {
+    [key in UnifiedRuleResultStatus]: UnifiedRuleResult[];
+};
+
 export const AllRuleResultStatuses: UnifiedRuleResultStatus[] = ['pass', 'fail', 'unknown', 'inapplicable'];

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FailedInstancesSectionDeps, UnifiedStatusResults } from 'common/components/cards/failed-instances-section';
+import { FailedInstancesSectionDeps } from 'common/components/cards/failed-instances-section';
 import { EnvironmentInfo } from 'common/environment-info-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { ReactFCWithDisplayName } from 'common/react/named-fc';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import { ScanResults } from 'scanner/iruleresults';
 
-import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';
+import { TargetAppData, UnifiedStatusResults } from '../../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../../common/types/store-data/user-configuration-store';
 import { NotApplicableChecksSectionDeps } from './not-applicable-checks-section';
 import { PassedChecksSectionDeps } from './passed-checks-section';

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { UnifiedStatusResults } from 'common/components/cards/failed-instances-section';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { UnifiedStatusResults } from 'common/types/store-data/unified-data-interface';
 import { ScanResults } from 'scanner/iruleresults';
 
 import { AssessmentReportHtmlGenerator } from './assessment-report-html-generator';

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { noCardInteractionsSupported } from 'common/components/cards/card-interaction-support';
-import { UnifiedStatusResults } from 'common/components/cards/failed-instances-section';
 import { PropertyConfiguration } from 'common/configs/unified-result-property-configurations';
 import { EnvironmentInfo } from 'common/environment-info-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { UnifiedStatusResults } from 'common/types/store-data/unified-data-interface';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 import { ScanResults } from 'scanner/iruleresults';
+
 import { ReportHead } from './components/report-head';
 import { ReportBody, ReportBodyProps } from './components/report-sections/report-body';
 import { ReportCollapsibleContainerControl } from './components/report-sections/report-collapsible-container';

--- a/src/tests/unit/common/rule-based-view-model-provider.test.ts
+++ b/src/tests/unit/common/rule-based-view-model-provider.test.ts
@@ -1,8 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UnifiedRuleResult, UnifiedStatusResults } from '../../../common/components/cards/failed-instances-section';
 import { getUnifiedRuleResults } from '../../../common/rule-based-view-model-provider';
-import { InstanceResultStatus, UnifiedResult, UnifiedRule } from '../../../common/types/store-data/unified-data-interface';
+import {
+    InstanceResultStatus,
+    UnifiedResult,
+    UnifiedRule,
+    UnifiedRuleResult,
+    UnifiedStatusResults,
+} from '../../../common/types/store-data/unified-data-interface';
 
 describe('RuleBasedViewModelProvider', () => {
     test('getUnifiedRuleResults with null rules and results', () => {

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -5,7 +5,6 @@ import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
-import { UnifiedStatusResults } from '../../../../common/components/cards/failed-instances-section';
 import { DropdownClickHandler } from '../../../../common/dropdown-click-handler';
 import { StoreActionMessageCreator } from '../../../../common/message-creators/store-action-message-creator';
 import { StoreActionMessageCreatorImpl } from '../../../../common/message-creators/store-action-message-creator-impl';
@@ -18,6 +17,7 @@ import {
     UnifiedResult,
     UnifiedRule,
     UnifiedScanResultStoreData,
+    UnifiedStatusResults,
 } from '../../../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../../../common/types/store-data/user-configuration-store';
 import { VisualizationType } from '../../../../common/types/visualization-type';

--- a/src/tests/unit/tests/common/components/cards/instance-details-group.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/instance-details-group.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UnifiedRuleResult } from 'common/components/cards/failed-instances-section';
 import { InstanceDetailsGroup, InstanceDetailsGroupDeps, InstanceDetailsGroupProps } from 'common/components/cards/instance-details-group';
+import { UnifiedRuleResult } from 'common/types/store-data/unified-data-interface';
 import { shallow } from 'enzyme';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';

--- a/src/tests/unit/tests/common/components/cards/result-section-content.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/result-section-content.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UnifiedRuleResult } from 'common/components/cards/failed-instances-section';
 import { ResultSectionContent, ResultSectionContentDeps, ResultSectionContentProps } from 'common/components/cards/result-section-content';
+import { UnifiedRuleResult } from 'common/types/store-data/unified-data-interface';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 

--- a/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
+++ b/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UnifiedRuleResult, UnifiedStatusResults } from 'common/components/cards/failed-instances-section';
-
-import { UnifiedResult } from '../../../../../../common/types/store-data/unified-data-interface';
+import { UnifiedResult, UnifiedRuleResult, UnifiedStatusResults } from '../../../../../../common/types/store-data/unified-data-interface';
 
 export const exampleUnifiedResult: UnifiedResult = {
     uid: 'some-guid-here',


### PR DESCRIPTION
#### Description of changes

As discussed today offline with Wahaj, `UnifiedStatusResults` and `UnifiedRuleResult` interfaces were placed in `failed-instances-section.tsx`. Moving them over to `unified-data-interface.ts`.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
