### PR TITLE
fix(card-buttons): prevent "more actions" button shifting left when file issue dialog is open

### DIFF
--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -57,7 +57,10 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
         }
 
         return (
-            <>
+            // The wrapper has to be a real element, not a <>, because we want the placeholder elements
+            // the dialog/toast involve to be considered as part of the button for the purposes of layout
+            // calculation in this component's parent.
+            <div>
                 <ActionButton
                     className={kebabMenuButton}
                     ariaLabel="More actions"
@@ -71,7 +74,7 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
                 />
                 {this.renderIssueFilingSettingContent()}
                 {this.renderCopyFailureDetailsToast()}
-            </>
+            </div>
         );
     }
 

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
@@ -1,20 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CardKebabMenuButtonTest copies failure details and show the toast 1`] = `
-"<Fragment>
+"<div>
   <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
   <Toast onTimeout={[Function: onTimeout]} deps={{...}} timeoutLength={1000}>
     Failure details copied.
   </Toast>
-</Fragment>"
+</div>"
 `;
 
 exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported 1`] = `
-"<Fragment>
+"<div>
   <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
-</Fragment>"
+</div>"
 `;
 
 exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported 2`] = `
@@ -44,9 +44,9 @@ Object {
 `;
 
 exports[`CardKebabMenuButtonTest renders per snapshot with onlyUserConfigAgnosticCardInteractionsSupported 1`] = `
-"<Fragment>
+"<div>
   <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
-</Fragment>"
+</div>"
 `;
 
 exports[`CardKebabMenuButtonTest renders per snapshot with onlyUserConfigAgnosticCardInteractionsSupported 2`] = `
@@ -68,25 +68,25 @@ Object {
 `;
 
 exports[`CardKebabMenuButtonTest should click file issue, invalid settings 1`] = `
-"<Fragment>
+"<div>
   <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={true} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
-</Fragment>"
+</div>"
 `;
 
 exports[`CardKebabMenuButtonTest should file issue, valid settings 1`] = `
-"<Fragment>
+"<div>
   <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
-</Fragment>"
+</div>"
 `;
 
 exports[`CardKebabMenuButtonTest shows failure message if copy failed 1`] = `
-"<Fragment>
+"<div>
   <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
   <Toast onTimeout={[Function: onTimeout]} deps={{...}} timeoutLength={1000}>
     Failed to copy failure details. Please try again.
   </Toast>
-</Fragment>"
+</div>"
 `;


### PR DESCRIPTION
#### Description of changes

Fixes an issue where the file issue dialog opening would cause the action menu button to shift to the middle of the card.

![screenshot after change](https://user-images.githubusercontent.com/376284/66675160-96367680-ec19-11e9-86ab-f8c42c67bd2a.png)

#### Pull request checklist

- [x] Addresses an existing issue: 1614250
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
