### PR TITLE
refactor: renamed and moved view model to separate files for cards

### DIFF
--- a/src/DetailsView/components/cards-view.tsx
+++ b/src/DetailsView/components/cards-view.tsx
@@ -4,14 +4,15 @@ import { FailedInstancesSection, FailedInstancesSectionDeps } from 'common/compo
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { TargetAppData, UnifiedStatusResults } from '../../common/types/store-data/unified-data-interface';
+import { CardRuleResultsByStatus } from '../../common/types/store-data/card-view-model';
+import { TargetAppData } from '../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 
 export type CardsViewDeps = FailedInstancesSectionDeps;
 
 export interface CardsViewProps {
     deps: CardsViewDeps;
-    ruleResultsByStatus: UnifiedStatusResults;
+    ruleResultsByStatus: CardRuleResultsByStatus;
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
 }

--- a/src/DetailsView/components/details-list-issues-view.tsx
+++ b/src/DetailsView/components/details-list-issues-view.tsx
@@ -6,9 +6,10 @@ import * as React from 'react';
 import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { NamedFC } from '../../common/react/named-fc';
+import { CardRuleResultsByStatus } from '../../common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
-import { TargetAppData, UnifiedStatusResults } from '../../common/types/store-data/unified-data-interface';
+import { TargetAppData } from '../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { VisualizationScanResultData } from '../../common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from '../../common/types/store-data/visualization-store-data';
@@ -32,7 +33,7 @@ export interface DetailsListIssuesViewProps {
     issuesTableHandler: IssuesTableHandler;
     configuration: VisualizationConfiguration;
     userConfigurationStoreData: UserConfigurationStoreData;
-    ruleResultsByStatus: UnifiedStatusResults;
+    ruleResultsByStatus: CardRuleResultsByStatus;
     targetAppInfo: TargetAppData;
 }
 

--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -11,8 +11,9 @@ import { VisualizationToggle } from '../../common/components/visualization-toggl
 import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { FeatureFlags } from '../../common/feature-flags';
+import { CardRuleResultsByStatus } from '../../common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { TargetAppData, UnifiedStatusResults } from '../../common/types/store-data/unified-data-interface';
+import { TargetAppData } from '../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { DecoratedAxeNodeResult } from '../../injected/scanner-utils';
@@ -49,7 +50,7 @@ export interface IssuesTableProps {
     featureFlags: FeatureFlagStoreData;
     scanResult: ScanResults;
     userConfigurationStoreData: UserConfigurationStoreData;
-    ruleResultsByStatus: UnifiedStatusResults;
+    ruleResultsByStatus: CardRuleResultsByStatus;
     targetAppInfo: TargetAppData;
 }
 

--- a/src/DetailsView/components/test-view-container.tsx
+++ b/src/DetailsView/components/test-view-container.tsx
@@ -5,10 +5,11 @@ import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { NamedFC } from '../../common/react/named-fc';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
+import { CardRuleResultsByStatus } from '../../common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { PathSnippetStoreData } from '../../common/types/store-data/path-snippet-store-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
-import { TargetAppData, UnifiedStatusResults } from '../../common/types/store-data/unified-data-interface';
+import { TargetAppData } from '../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { VisualizationScanResultData } from '../../common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from '../../common/types/store-data/visualization-store-data';
@@ -40,7 +41,7 @@ export interface TestViewContainerProps {
     issuesSelection: ISelection;
     issuesTableHandler: IssuesTableHandler;
     userConfigurationStoreData: UserConfigurationStoreData;
-    ruleResultsByStatus: UnifiedStatusResults;
+    ruleResultsByStatus: CardRuleResultsByStatus;
     targetAppInfo: TargetAppData;
 }
 

--- a/src/DetailsView/details-view-main-content.tsx
+++ b/src/DetailsView/details-view-main-content.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { TargetAppData, UnifiedStatusResults } from 'common/types/store-data/unified-data-interface';
+import { CardRuleResultsByStatus } from 'common/types/store-data/card-view-model';
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
 
@@ -47,7 +48,7 @@ export interface DetailsViewMainContentProps {
     rightPanelConfiguration: DetailsRightPanelConfiguration;
     switcherNavConfiguration: DetailsViewSwitcherNavConfiguration;
     userConfigurationStoreData: UserConfigurationStoreData;
-    ruleResultsByStatus: UnifiedStatusResults;
+    ruleResultsByStatus: CardRuleResultsByStatus;
     targetAppInfo: TargetAppData;
 }
 

--- a/src/common/components/cards/failed-instances-section.tsx
+++ b/src/common/components/cards/failed-instances-section.tsx
@@ -3,14 +3,15 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { TargetAppData, UnifiedStatusResults } from '../../../common/types/store-data/unified-data-interface';
+import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';
+import { CardRuleResultsByStatus } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { ResultSection, ResultSectionDeps } from './result-section';
 
 export type FailedInstancesSectionDeps = ResultSectionDeps;
 export type FailedInstancesSectionProps = {
     deps: FailedInstancesSectionDeps;
-    ruleResultsByStatus: UnifiedStatusResults;
+    ruleResultsByStatus: CardRuleResultsByStatus;
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
 };

--- a/src/common/components/cards/instance-details-group.tsx
+++ b/src/common/components/cards/instance-details-group.tsx
@@ -5,7 +5,8 @@ import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
 import { getPropertyConfiguration } from '../../../common/configs/unified-result-property-configurations';
-import { TargetAppData, UnifiedRule, UnifiedRuleResult } from '../../../common/types/store-data/unified-data-interface';
+import { TargetAppData, UnifiedRule } from '../../../common/types/store-data/unified-data-interface';
+import { CardRuleResult } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { InstanceDetails, InstanceDetailsDeps } from './instance-details';
 import { instanceDetailsList } from './instance-details-group.scss';
@@ -16,7 +17,7 @@ export type InstanceDetailsGroupDeps = {
 
 export type InstanceDetailsGroupProps = {
     deps: InstanceDetailsGroupDeps;
-    rule: UnifiedRuleResult;
+    rule: CardRuleResult;
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
 };

--- a/src/common/components/cards/result-section-content.tsx
+++ b/src/common/components/cards/result-section-content.tsx
@@ -4,9 +4,10 @@ import { NamedFC } from 'common/react/named-fc';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 
-import { TargetAppData, UnifiedRuleResult } from '../../../common/types/store-data/unified-data-interface';
+import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';
 import { InstanceOutcomeType } from '../../../reports/components/instance-outcome-type';
 import { NoFailedInstancesCongrats } from '../../../reports/components/report-sections/no-failed-instances-congrats';
+import { CardRuleResult } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { RulesWithInstances, RulesWithInstancesDeps } from './rules-with-instances';
 
@@ -14,7 +15,7 @@ export type ResultSectionContentDeps = RulesWithInstancesDeps;
 
 export type ResultSectionContentProps = {
     deps: ResultSectionContentDeps;
-    results: UnifiedRuleResult[];
+    results: CardRuleResult[];
     outcomeType: InstanceOutcomeType;
     fixInstructionProcessor?: FixInstructionProcessor;
     userConfigurationStoreData: UserConfigurationStoreData;

--- a/src/common/components/cards/rule-content.tsx
+++ b/src/common/components/cards/rule-content.tsx
@@ -3,7 +3,8 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { TargetAppData, UnifiedRuleResult } from '../../../common/types/store-data/unified-data-interface';
+import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';
+import { CardRuleResult } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { InstanceDetailsGroup, InstanceDetailsGroupDeps } from './instance-details-group';
 import { RuleResources, RuleResourcesDeps } from './rule-resources';
@@ -12,7 +13,7 @@ export type RuleContentDeps = InstanceDetailsGroupDeps & RuleResourcesDeps;
 
 export type RuleContentProps = {
     deps: RuleContentDeps;
-    rule: UnifiedRuleResult;
+    rule: CardRuleResult;
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
 };

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -5,10 +5,11 @@ import { NamedFC } from 'common/react/named-fc';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 
-import { TargetAppData, UnifiedRuleResult } from '../../../common/types/store-data/unified-data-interface';
+import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';
 import { InstanceOutcomeType } from '../../../reports/components/instance-outcome-type';
 import { outcomeTypeSemantics } from '../../../reports/components/outcome-type';
 import { MinimalRuleHeader } from '../../../reports/components/report-sections/minimal-rule-header';
+import { CardRuleResult } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { CollapsibleComponentCardsProps } from './collapsible-component-cards';
 import { RuleContent, RuleContentDeps } from './rule-content';
@@ -21,7 +22,7 @@ export type RulesWithInstancesDeps = RuleContentDeps & {
 export type RulesWithInstancesProps = {
     deps: RulesWithInstancesDeps;
     fixInstructionProcessor: FixInstructionProcessor;
-    rules: UnifiedRuleResult[];
+    rules: CardRuleResult[];
     outcomeType: InstanceOutcomeType;
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
@@ -30,7 +31,7 @@ export type RulesWithInstancesProps = {
 export const RulesWithInstances = NamedFC<RulesWithInstancesProps>(
     'RulesWithInstances',
     ({ rules, outcomeType, fixInstructionProcessor, deps, userConfigurationStoreData, targetAppInfo }) => {
-        const getCollapsibleComponentProps = (rule: UnifiedRuleResult, idx: number, buttonAriaLabel: string) => {
+        const getCollapsibleComponentProps = (rule: CardRuleResult, idx: number, buttonAriaLabel: string) => {
             return {
                 id: rule.id,
                 key: `summary-details-${idx + 1}`,

--- a/src/common/rule-based-view-model-provider.ts
+++ b/src/common/rule-based-view-model-provider.ts
@@ -1,11 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import {
-    AllRuleResultStatuses,
-    CardRuleResult,
-    CardRuleResultsByStatus,
-    CardRuleResultStatus,
-} from './types/store-data/card-view-model';
+import { AllRuleResultStatuses, CardRuleResult, CardRuleResultsByStatus, CardRuleResultStatus } from './types/store-data/card-view-model';
 import { UnifiedResult, UnifiedRule } from './types/store-data/unified-data-interface';
 
 export type GetUnifiedRuleResultsDelegate = (rules: UnifiedRule[], results: UnifiedResult[]) => CardRuleResultsByStatus;

--- a/src/common/rule-based-view-model-provider.ts
+++ b/src/common/rule-based-view-model-provider.ts
@@ -2,19 +2,18 @@
 // Licensed under the MIT License.
 import {
     AllRuleResultStatuses,
-    UnifiedResult,
-    UnifiedRule,
-    UnifiedRuleResult,
-    UnifiedRuleResultStatus,
-    UnifiedStatusResults,
-} from './types/store-data/unified-data-interface';
+    CardRuleResult,
+    CardRuleResultsByStatus,
+    CardRuleResultStatus,
+} from './types/store-data/card-view-model';
+import { UnifiedResult, UnifiedRule } from './types/store-data/unified-data-interface';
 
-export type GetUnifiedRuleResultsDelegate = (rules: UnifiedRule[], results: UnifiedResult[]) => UnifiedStatusResults;
+export type GetUnifiedRuleResultsDelegate = (rules: UnifiedRule[], results: UnifiedResult[]) => CardRuleResultsByStatus;
 
 export const getUnifiedRuleResults: GetUnifiedRuleResultsDelegate = function(
     rules: UnifiedRule[],
     results: UnifiedResult[],
-): UnifiedStatusResults {
+): CardRuleResultsByStatus {
     if (results == null || rules == null) {
         return null;
     }
@@ -47,17 +46,17 @@ export const getUnifiedRuleResults: GetUnifiedRuleResultsDelegate = function(
     return statusResults;
 };
 
-function getEmptyStatusResults(): UnifiedStatusResults {
+function getEmptyStatusResults(): CardRuleResultsByStatus {
     const statusResults = {};
 
     AllRuleResultStatuses.forEach(status => {
         statusResults[status] = [];
     });
 
-    return statusResults as UnifiedStatusResults;
+    return statusResults as CardRuleResultsByStatus;
 }
 
-function createUnifiedRuleResult(result: UnifiedResult, rule: UnifiedRule): UnifiedRuleResult {
+function createUnifiedRuleResult(result: UnifiedResult, rule: UnifiedRule): CardRuleResult {
     return {
         id: rule.id,
         status: result.status,
@@ -68,7 +67,7 @@ function createUnifiedRuleResult(result: UnifiedResult, rule: UnifiedRule): Unif
     };
 }
 
-function createRuleResultWithoutNodes(status: UnifiedRuleResultStatus, rule: UnifiedRule): UnifiedRuleResult {
+function createRuleResultWithoutNodes(status: CardRuleResultStatus, rule: UnifiedRule): CardRuleResult {
     return {
         id: rule.id,
         status: status,
@@ -83,6 +82,6 @@ function getUnifiedRule(id: string, rules: UnifiedRule[]): UnifiedRule {
     return rules.find(rule => rule.id === id);
 }
 
-function getRuleResultIndex(result: UnifiedResult, ruleResults: UnifiedRuleResult[]): number {
+function getRuleResultIndex(result: UnifiedResult, ruleResults: CardRuleResult[]): number {
     return ruleResults.findIndex(ruleResult => ruleResult.id === result.ruleId);
 }

--- a/src/common/types/store-data/card-view-model.ts
+++ b/src/common/types/store-data/card-view-model.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { GuidanceLink } from '../../../scanner/rule-to-links-mappings';
 import { InstanceResultStatus, UnifiedResult } from './unified-data-interface';
 export type CardRuleResultStatus = InstanceResultStatus | 'inapplicable';

--- a/src/common/types/store-data/card-view-model.ts
+++ b/src/common/types/store-data/card-view-model.ts
@@ -1,0 +1,15 @@
+import { GuidanceLink } from '../../../scanner/rule-to-links-mappings';
+import { InstanceResultStatus, UnifiedResult } from './unified-data-interface';
+export type CardRuleResultStatus = InstanceResultStatus | 'inapplicable';
+export interface CardRuleResult {
+    id: string;
+    nodes: CardResult[];
+    description: string;
+    url: string;
+    guidance: GuidanceLink[];
+}
+export type CardRuleResultsByStatus = {
+    [key in CardRuleResultStatus]: CardRuleResult[];
+};
+export interface CardResult extends UnifiedResult {}
+export const AllRuleResultStatuses: CardRuleResultStatus[] = ['pass', 'fail', 'unknown', 'inapplicable'];

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -83,5 +83,3 @@ export interface UnifiedResult {
 }
 
 export type InstanceResultStatus = 'pass' | 'fail' | 'unknown';
-
-

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -84,18 +84,4 @@ export interface UnifiedResult {
 
 export type InstanceResultStatus = 'pass' | 'fail' | 'unknown';
 
-export type UnifiedRuleResultStatus = InstanceResultStatus | 'inapplicable';
 
-export interface UnifiedRuleResult {
-    id: string;
-    nodes: UnifiedResult[];
-    description: string;
-    url: string;
-    guidance: GuidanceLink[];
-}
-
-export type UnifiedStatusResults = {
-    [key in UnifiedRuleResultStatus]: UnifiedRuleResult[];
-};
-
-export const AllRuleResultStatuses: UnifiedRuleResultStatus[] = ['pass', 'fail', 'unknown', 'inapplicable'];

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -7,7 +7,8 @@ import { ReactFCWithDisplayName } from 'common/react/named-fc';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import { ScanResults } from 'scanner/iruleresults';
 
-import { TargetAppData, UnifiedStatusResults } from '../../../common/types/store-data/unified-data-interface';
+import { CardRuleResultsByStatus } from '../../../common/types/store-data/card-view-model';
+import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../../common/types/store-data/user-configuration-store';
 import { NotApplicableChecksSectionDeps } from './not-applicable-checks-section';
 import { PassedChecksSectionDeps } from './passed-checks-section';
@@ -26,7 +27,7 @@ export type SectionProps = {
     toUtcString: (date: Date) => string;
     getCollapsibleScript: () => string;
     getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks;
-    ruleResultsByStatus: UnifiedStatusResults;
+    ruleResultsByStatus: CardRuleResultsByStatus;
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
 };

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { CardRuleResultsByStatus } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
-import { UnifiedStatusResults } from 'common/types/store-data/unified-data-interface';
 import { ScanResults } from 'scanner/iruleresults';
 
 import { AssessmentReportHtmlGenerator } from './assessment-report-html-generator';
@@ -27,7 +27,7 @@ export class ReportGenerator {
         scanDate: Date,
         pageTitle: string,
         pageUrl: string,
-        ruleResultsByStatus: UnifiedStatusResults,
+        ruleResultsByStatus: CardRuleResultsByStatus,
         description: string,
     ): string {
         return this.reportHtmlGenerator.generateHtml(scanResult, scanDate, pageTitle, pageUrl, description, ruleResultsByStatus);

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -4,7 +4,7 @@ import { noCardInteractionsSupported } from 'common/components/cards/card-intera
 import { PropertyConfiguration } from 'common/configs/unified-result-property-configurations';
 import { EnvironmentInfo } from 'common/environment-info-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
-import { UnifiedStatusResults } from 'common/types/store-data/unified-data-interface';
+import { CardRuleResultsByStatus } from 'common/types/store-data/card-view-model';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 import { ScanResults } from 'scanner/iruleresults';
@@ -33,7 +33,7 @@ export class ReportHtmlGenerator {
         pageTitle: string,
         pageUrl: string,
         description: string,
-        ruleResultsByStatus: UnifiedStatusResults,
+        ruleResultsByStatus: CardRuleResultsByStatus,
     ): string {
         const headElement: JSX.Element = <ReportHead />;
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(headElement);

--- a/src/tests/unit/common/rule-based-view-model-provider.test.ts
+++ b/src/tests/unit/common/rule-based-view-model-provider.test.ts
@@ -1,29 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { getUnifiedRuleResults } from '../../../common/rule-based-view-model-provider';
-import {
-    InstanceResultStatus,
-    UnifiedResult,
-    UnifiedRule,
-    UnifiedRuleResult,
-    UnifiedStatusResults,
-} from '../../../common/types/store-data/unified-data-interface';
+import { CardRuleResult, CardRuleResultsByStatus } from '../../../common/types/store-data/card-view-model';
+import { InstanceResultStatus, UnifiedResult, UnifiedRule } from '../../../common/types/store-data/unified-data-interface';
 
 describe('RuleBasedViewModelProvider', () => {
     test('getUnifiedRuleResults with null rules and results', () => {
-        const actualResults: UnifiedStatusResults = getUnifiedRuleResults(null, null);
+        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults(null, null);
 
         expect(actualResults).toEqual(null);
     });
 
     test('getUnifiedRuleResults with null rules', () => {
-        const actualResults: UnifiedStatusResults = getUnifiedRuleResults(null, []);
+        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults(null, []);
 
         expect(actualResults).toEqual(null);
     });
 
     test('getUnifiedRuleResults with null results', () => {
-        const actualResults: UnifiedStatusResults = getUnifiedRuleResults([], null);
+        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults([], null);
 
         expect(actualResults).toEqual(null);
     });
@@ -38,7 +33,7 @@ describe('RuleBasedViewModelProvider', () => {
 
         const results: UnifiedResult[] = [resultStub1, resultStub2, resultStub3, resultStub4];
 
-        const expectedResults: UnifiedStatusResults = {
+        const expectedResults: CardRuleResultsByStatus = {
             pass: [
                 {
                     id: 'rule1',
@@ -97,11 +92,11 @@ describe('RuleBasedViewModelProvider', () => {
                             text: 'stub_guidance_text_rule3',
                         },
                     ],
-                } as UnifiedRuleResult,
+                } as CardRuleResult,
             ],
         };
 
-        const actualResults: UnifiedStatusResults = getUnifiedRuleResults(rules, results);
+        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults(rules, results);
 
         expect(actualResults).toEqual(expectedResults);
     });

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -11,13 +11,13 @@ import { StoreActionMessageCreatorImpl } from '../../../../common/message-creato
 import { GetUnifiedRuleResultsDelegate } from '../../../../common/rule-based-view-model-provider';
 import { BaseClientStoresHub } from '../../../../common/stores/base-client-stores-hub';
 import { DetailsViewPivotType } from '../../../../common/types/details-view-pivot-type';
+import { CardRuleResultsByStatus } from '../../../../common/types/store-data/card-view-model';
 import { TabStoreData } from '../../../../common/types/store-data/tab-store-data';
 import {
     TargetAppData,
     UnifiedResult,
     UnifiedRule,
     UnifiedScanResultStoreData,
-    UnifiedStatusResults,
 } from '../../../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../../../common/types/store-data/user-configuration-store';
 import { VisualizationType } from '../../../../common/types/visualization-type';
@@ -195,7 +195,7 @@ describe('DetailsViewContainer', () => {
                 )
                 .returns(() => viewType);
 
-            const ruleResults: UnifiedStatusResults = {} as any;
+            const ruleResults: CardRuleResultsByStatus = {} as any;
             getUnifiedRuleResultsMock
                 .setup(m => m(state.unifiedScanResultStoreData.rules, state.unifiedScanResultStoreData.results))
                 .returns(() => ruleResults);
@@ -273,7 +273,7 @@ describe('DetailsViewContainer', () => {
         selectedDetailsView: VisualizationType,
         rightPanelConfiguration: DetailsRightPanelConfiguration,
         switcherNavConfiguration: DetailsViewSwitcherNavConfiguration,
-        ruleResults: UnifiedStatusResults,
+        ruleResults: CardRuleResultsByStatus,
         targetApp: TargetAppData,
     ): JSX.Element {
         return (
@@ -450,7 +450,7 @@ describe('DetailsViewContainer', () => {
             )
             .returns(() => viewType);
 
-        const ruleResults: UnifiedStatusResults = {} as any;
+        const ruleResults: CardRuleResultsByStatus = {} as any;
         getUnifiedRuleResultsMock
             .setup(m => m(state.unifiedScanResultStoreData.rules, state.unifiedScanResultStoreData.results))
             .returns(() => ruleResults);

--- a/src/tests/unit/tests/common/components/cards/instance-details-group.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/instance-details-group.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { InstanceDetailsGroup, InstanceDetailsGroupDeps, InstanceDetailsGroupProps } from 'common/components/cards/instance-details-group';
-import { UnifiedRuleResult } from 'common/types/store-data/unified-data-interface';
+import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
@@ -12,7 +12,7 @@ import { exampleUnifiedRuleResult } from './sample-view-model-data';
 describe('InstanceDetailsGroup', () => {
     it('renders', () => {
         const fixInstructionProcessorMock = Mock.ofType(FixInstructionProcessor);
-        const rule: UnifiedRuleResult = exampleUnifiedRuleResult;
+        const rule: CardRuleResult = exampleUnifiedRuleResult;
         const depsStub: InstanceDetailsGroupDeps = {} as InstanceDetailsGroupDeps;
 
         const props: InstanceDetailsGroupProps = {

--- a/src/tests/unit/tests/common/components/cards/result-section-content.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/result-section-content.test.tsx
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ResultSectionContent, ResultSectionContentDeps, ResultSectionContentProps } from 'common/components/cards/result-section-content';
-import { UnifiedRuleResult } from 'common/types/store-data/unified-data-interface';
+import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { exampleUnifiedRuleResult } from './sample-view-model-data';
 
 describe('ResultSectionContent', () => {
-    const emptyRules: UnifiedRuleResult[] = [];
-    const someRules: UnifiedRuleResult[] = [exampleUnifiedRuleResult];
+    const emptyRules: CardRuleResult[] = [];
+    const someRules: CardRuleResult[] = [exampleUnifiedRuleResult];
     const depsStub = {} as ResultSectionContentDeps;
 
     it('renders, with some rules', () => {

--- a/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
+++ b/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UnifiedResult, UnifiedRuleResult, UnifiedStatusResults } from '../../../../../../common/types/store-data/unified-data-interface';
+import { CardRuleResult, CardRuleResultsByStatus } from '../../../../../../common/types/store-data/card-view-model';
+import { UnifiedResult } from '../../../../../../common/types/store-data/unified-data-interface';
 
 export const exampleUnifiedResult: UnifiedResult = {
     uid: 'some-guid-here',
@@ -28,7 +29,7 @@ export const exampleUnifiedResult: UnifiedResult = {
     },
 };
 
-export const exampleUnifiedRuleResult: UnifiedRuleResult = {
+export const exampleUnifiedRuleResult: CardRuleResult = {
     id: 'some-rule',
     nodes: [exampleUnifiedResult],
     description: 'sample-description',
@@ -36,7 +37,7 @@ export const exampleUnifiedRuleResult: UnifiedRuleResult = {
     guidance: [],
 };
 
-export const exampleUnifiedStatusResults: UnifiedStatusResults = {
+export const exampleUnifiedStatusResults: CardRuleResultsByStatus = {
     pass: [],
     fail: [exampleUnifiedRuleResult],
     inapplicable: [],


### PR DESCRIPTION
#### Description of changes

This moves interfaces/types that are really only for the cards view to a separate place for them specifically.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
