### PR TITLE
Contextual menu fit and finish

### DIFF
--- a/src/common/components/cards/card-kebab-menu-button.scss
+++ b/src/common/components/cards/card-kebab-menu-button.scss
@@ -2,9 +2,31 @@
 // Licensed under the MIT License.
 @import '../../styles/colors.scss';
 
+.kebab-menu-callout {
+    box-shadow: 0px 6.4px 14.4px $box-shadow-132, 0px 1.2px 3.6px $box-shadow-108 !important;
+    border-radius: 4px;
+    border-width: 0px !important;
+    div.ms-Callout-main {
+        border-radius: 4px;
+    }
+}
+
 .kebab-menu {
+    background: $acrylic-light;
     i {
         color: $primary-text;
+    }
+    li {
+        background-color: $acrylic-light;
+    }
+
+    button.ms-ContextualMenu-link {
+        &:hover {
+            background-color: $neutral-alpha-4;
+        }
+        &:active {
+            background-color: $neutral-alpha-8;
+        }
     }
 }
 

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -17,7 +17,7 @@ import { WindowUtils } from '../../window-utils';
 import { IssueFilingButtonDeps } from '../issue-filing-button';
 import { Toast } from '../toast';
 import { CardInteractionSupport } from './card-interaction-support';
-import { kebabMenu, kebabMenuButton } from './card-kebab-menu-button.scss';
+import { kebabMenu, kebabMenuButton, kebabMenuCallout } from './card-kebab-menu-button.scss';
 
 export type CardKebabMenuButtonDeps = {
     windowUtils: WindowUtils;
@@ -67,6 +67,9 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
                         directionalHint: DirectionalHint.bottomRightEdge,
                         shouldFocusOnMount: true,
                         items: this.getMenuItems(),
+                        calloutProps: {
+                            className: kebabMenuCallout,
+                        },
                     }}
                 />
                 {this.renderIssueFilingSettingContent()}

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -62,6 +62,9 @@
     --neutral-outcome: var(--neutral-60);
     --incomplete-color: var(--neutral-60);
     // Additional colors
+    --acrylic-light: #f6f6f6;
+    --box-shadow-108: rgba(0, 0, 0, 0.108);
+    --box-shadow-132: rgba(0, 0, 0, 0.132);
     --accent2-dark: rgb(16, 124, 16);
     --communication-alpha-5: rgba(0, 120, 212, 0.05);
     --overview-percent-selected: var(--neutral-55);
@@ -193,6 +196,10 @@ $neutral-alpha-60: var(--neutral-alpha-60);
 $neutral-alpha-70: var(--neutral-alpha-70);
 $neutral-alpha-80: var(--neutral-alpha-80);
 $neutral-alpha-90: var(--neutral-alpha-90);
+$acrylic-light: var(--acrylic-light);
+$box-shadow-132: var(--box-shadow-132);
+$box-shadow-108: var(--box-shadow-108);
+
 // Outcome colors
 $positive-outcome: var(--positive-outcome);
 $negative-outcome: var(--negative-outcome);

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
@@ -19,6 +19,9 @@ exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSu
 
 exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported 2`] = `
 Object {
+  "calloutProps": Object {
+    "className": "kebabMenuCallout",
+  },
   "className": "kebabMenu",
   "directionalHint": 6,
   "items": Array [
@@ -51,6 +54,9 @@ exports[`CardKebabMenuButtonTest renders per snapshot with onlyUserConfigAgnosti
 
 exports[`CardKebabMenuButtonTest renders per snapshot with onlyUserConfigAgnosticCardInteractionsSupported 2`] = `
 Object {
+  "calloutProps": Object {
+    "className": "kebabMenuCallout",
+  },
   "className": "kebabMenu",
   "directionalHint": 6,
   "items": Array [


### PR DESCRIPTION
#### Description of changes
- Update the background color of the contextual menu to match the mock.
- Update the background color of the menu button on hover to match the mock.
- Update the background color of the menu button on pressed to match the mock.
- Give the contextual menu a 4px border radius.
- Update the box shadow of the menu to match the mock.

Figma - hovered and pressed:
![image](https://user-images.githubusercontent.com/15974344/66684295-94c37900-ec2e-11e9-85b4-131c4c6d2e86.png)

Screenshot of the change:
hover:
![image](https://user-images.githubusercontent.com/15974344/66684574-2cc16280-ec2f-11e9-846f-7ef32a854314.png)

pressed:

![image](https://user-images.githubusercontent.com/15974344/66684593-39de5180-ec2f-11e9-9c3c-10051ac9da76.png)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
