### PR TITLE
fix: announcing device connection status

### DIFF
--- a/src/electron/views/device-connect-view/components/device-connect-connected-device.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-connected-device.tsx
@@ -53,7 +53,9 @@ export const DeviceConnectConnectedDevice = NamedFC<DeviceConnectConnectedDevice
         return (
             <div className={deviceConnectConnectedDevice}>
                 <h3>Connected device</h3>
-                {renderContents()}
+                <div role="alert" aria-live="assertive">
+                    {renderContents()}
+                </div>
             </div>
         );
     },

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-connected-device.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-connected-device.test.tsx.snap
@@ -7,18 +7,23 @@ exports[`DeviceConnectConnectedDeviceTest render connection failure: connection 
   <h3>
     Connected device
   </h3>
-  <React.Fragment>
-    <StyledIconBase
-      ariaLabel="Connection failed"
-      className="connectionErrorIcon"
-      iconName="statusErrorFull"
-    />
-    <span
-      className="scannedText"
-    >
-      No active applications were found at the provided local host.
-    </span>
-  </React.Fragment>
+  <div
+    aria-live="assertive"
+    role="alert"
+  >
+    <React.Fragment>
+      <StyledIconBase
+        ariaLabel="Connection failed"
+        className="connectionErrorIcon"
+        iconName="statusErrorFull"
+      />
+      <span
+        className="scannedText"
+      >
+        No active applications were found at the provided local host.
+      </span>
+    </React.Fragment>
+  </div>
 </div>
 `;
 
@@ -29,11 +34,16 @@ exports[`DeviceConnectConnectedDeviceTest render connection success: connection 
   <h3>
     Connected device
   </h3>
-  <span
-    className="scannedText"
+  <div
+    aria-live="assertive"
+    role="alert"
   >
-    A Test Device!
-  </span>
+    <span
+      className="scannedText"
+    >
+      A Test Device!
+    </span>
+  </div>
 </div>
 `;
 
@@ -44,6 +54,10 @@ exports[`DeviceConnectConnectedDeviceTest render no content: no content 1`] = `
   <h3>
     Connected device
   </h3>
+  <div
+    aria-live="assertive"
+    role="alert"
+  />
 </div>
 `;
 
@@ -54,12 +68,17 @@ exports[`DeviceConnectConnectedDeviceTest render scanning spinner: scanning spin
   <h3>
     Connected device
   </h3>
-  <StyledSpinnerBase
-    className="deviceConnectSpinner"
-    label="Connecting to mobile device"
-    labelPosition="right"
-    size={0}
-  />
+  <div
+    aria-live="assertive"
+    role="alert"
+  >
+    <StyledSpinnerBase
+      className="deviceConnectSpinner"
+      label="Connecting to mobile device"
+      labelPosition="right"
+      size={0}
+    />
+  </div>
 </div>
 `;
 
@@ -70,5 +89,9 @@ exports[`DeviceConnectConnectedDeviceTest render user change the port number: us
   <h3>
     Connected device
   </h3>
+  <div
+    aria-live="assertive"
+    role="alert"
+  />
 </div>
 `;


### PR DESCRIPTION
#### Description of changes

By using `role` and `aria-live` we can make the screen reader announce the device connection status.

#### Pull request checklist

- [x] Addresses an existing issue: there is no issue filed for this
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
