### PR TITLE
fix(card-buttons): improve accessibility of toast notifications (greater timeout, live region)

### DIFF
--- a/src/common/components/toast.tsx
+++ b/src/common/components/toast.tsx
@@ -19,7 +19,7 @@ export class Toast extends React.Component<ToastProps> {
     private hidden: boolean;
 
     public static defaultProps = {
-        timeoutLength: 1000,
+        timeoutLength: 6000,
     };
 
     public componentWillUnmount(): void {
@@ -40,6 +40,10 @@ export class Toast extends React.Component<ToastProps> {
     }
 
     public render(): JSX.Element {
-        return this.hidden ? null : <div className={css('ms-fadeIn100', 'toast')}>{this.props.children}</div>;
+        return this.hidden ? null : (
+            <div role="alert" aria-live="polite" className={css('ms-fadeIn100', 'toast')}>
+                {this.props.children}
+            </div>
+        );
     }
 }

--- a/src/tests/unit/tests/common/components/__snapshots__/copy-issue-details-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/copy-issue-details-button.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`CopyIssueDetailsButtonTest render after click shows toast 1`] = `
       }
     }
     onTimeout={[Function]}
-    timeoutLength={1000}
+    timeoutLength={6000}
   >
     Failure details copied.
   </Toast>

--- a/src/tests/unit/tests/common/components/__snapshots__/toast.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/toast.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`ToastTest render 1`] = `
 <div
+  aria-live="polite"
   className="ms-fadeIn100 toast"
+  role="alert"
 >
   Hello
 </div>

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`CardKebabMenuButtonTest copies failure details and show the toast 1`] =
 "<Fragment>
   <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
-  <Toast onTimeout={[Function: onTimeout]} deps={{...}} timeoutLength={1000}>
+  <Toast onTimeout={[Function: onTimeout]} deps={{...}} timeoutLength={6000}>
     Failure details copied.
   </Toast>
 </Fragment>"
@@ -85,7 +85,7 @@ exports[`CardKebabMenuButtonTest shows failure message if copy failed 1`] = `
 "<Fragment>
   <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
-  <Toast onTimeout={[Function: onTimeout]} deps={{...}} timeoutLength={1000}>
+  <Toast onTimeout={[Function: onTimeout]} deps={{...}} timeoutLength={6000}>
     Failed to copy failure details. Please try again.
   </Toast>
 </Fragment>"


### PR DESCRIPTION
#### Description of changes

This PR ensures that the toast notification our copy failure details button/menu item uses is announced as a live region and stays on the screen for a reasonably readable amount of time (6s instead of 1s).

We're still discussing whether this is actually enough of a change (in particular, if/how [WCAG SC 2.2.1: Timing Adjustable](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html) applies), but this is a pretty clear improvement over the old behavior so putting it in while we discuss further.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a (no visible change)] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
