### PR TITLE
feat(android-cards-view): wire up device disconnected popup

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -4,26 +4,30 @@ import { TitleBar, TitleBarDeps } from 'electron/views/automated-checks/componen
 import * as React from 'react';
 
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
+import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { ScanningSpinner } from 'electron/views/automated-checks/components/scanning-spinner';
+import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
 import { CommandBar, CommandBarDeps } from './components/command-bar';
 import { HeaderSection } from './components/header-section';
 
 export type AutomatedChecksViewDeps = CommandBarDeps &
     TitleBarDeps & {
         scanActionCreator: ScanActionCreator;
+        windowStateActionCreator: WindowStateActionCreator;
     };
 
 export type AutomatedChecksViewProps = {
     deps: AutomatedChecksViewDeps;
-    devicePort: number;
     scanStoreData: ScanStoreData;
+    deviceStoreData: DeviceStoreData;
 };
 
 export class AutomatedChecksView extends React.Component<AutomatedChecksViewProps> {
     public componentDidMount(): void {
-        this.props.deps.scanActionCreator.scan(this.props.devicePort);
+        this.props.deps.scanActionCreator.scan(this.props.deviceStoreData.port);
     }
 
     public render(): JSX.Element {
@@ -33,7 +37,22 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                 <CommandBar deps={this.props.deps} />
                 <HeaderSection />
                 {this.renderScanning()}
+                {this.renderDeviceDisconnected()}
             </>
+        );
+    }
+
+    private renderDeviceDisconnected(): JSX.Element {
+        if (this.props.scanStoreData.status !== ScanStatus.Failed) {
+            return null;
+        }
+
+        return (
+            <DeviceDisconnectedPopup
+                deviceName={this.props.deviceStoreData.connectedDevice}
+                onConnectNewDevice={() => this.props.deps.windowStateActionCreator.setRoute({ routeId: 'deviceConnectView' })}
+                onRescanDevice={() => this.props.deps.scanActionCreator.scan(this.props.deviceStoreData.port)}
+            />
         );
     }
 

--- a/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
@@ -39,7 +39,10 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
                 minWidth={416}
             >
                 <div>
-                    <p>Uh-oh! It seems the {deviceName} device has disconnected before the snapshot completed its analysis.</p>
+                    <p>
+                        Uh-oh! It seems the <strong>{deviceName}</strong> device has disconnected before the snapshot completed its
+                        analysis.
+                    </p>
                     <p>Make sure your device is properly connected, and try rescanning or connecting a different device.</p>
                 </div>
                 <DialogFooter>

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -37,9 +37,13 @@ export class RootContainer extends React.Component<RootContainerProps, RootConta
 
     public render(): JSX.Element {
         if (this.state.windowStateStoreData.routeId === 'resultsView') {
-            const devicePort = this.state.deviceStoreData.port;
-
-            return <AutomatedChecksView devicePort={devicePort} scanStoreData={this.state.scanStoreData} {...this.props} />;
+            return (
+                <AutomatedChecksView
+                    deviceStoreData={this.state.deviceStoreData}
+                    scanStoreData={this.state.scanStoreData}
+                    {...this.props}
+                />
+            );
         }
 
         return (

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -1,6 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AutomatedChecksView renders scanning spinner: automated checks view 1`] = `
+exports[`AutomatedChecksView renders device disconnected 1`] = `
+<React.Fragment>
+  <TitleBar
+    deps={
+      Object {
+        "scanActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "scanActions": undefined,
+        },
+      }
+    }
+  />
+  <CommandBar
+    deps={
+      Object {
+        "scanActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "scanActions": undefined,
+        },
+      }
+    }
+  />
+  <HeaderSection />
+  <ScanningSpinner
+    isScanning={false}
+  />
+  <DeviceDisconnectedPopup
+    deviceName="TEST DEVICE"
+    onConnectNewDevice={[Function]}
+    onRescanDevice={[Function]}
+  />
+</React.Fragment>
+`;
+
+exports[`AutomatedChecksView renders scanning spinner 1`] = `
 <React.Fragment>
   <TitleBar
     deps={
@@ -29,7 +63,7 @@ exports[`AutomatedChecksView renders scanning spinner: automated checks view 1`]
 </React.Fragment>
 `;
 
-exports[`AutomatedChecksView renders the automated checks view: automated checks view 1`] = `
+exports[`AutomatedChecksView renders the automated checks view 1`] = `
 <React.Fragment>
   <TitleBar
     deps={

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { AutomatedChecksView, AutomatedChecksViewProps } from 'electron/views/automated-checks/automated-checks-view';
+import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Mock, Times } from 'typemoq';
+import { It, Mock, Times } from 'typemoq';
 
 describe('AutomatedChecksView', () => {
     describe('renders', () => {
@@ -15,11 +17,12 @@ describe('AutomatedChecksView', () => {
                     scanActionCreator: Mock.ofType(ScanActionCreator).object,
                 },
                 scanStoreData: {},
+                deviceStoreData: {},
             } as AutomatedChecksViewProps;
 
             const wrapped = shallow(<AutomatedChecksView {...props} />);
 
-            expect(wrapped.getElement()).toMatchSnapshot('automated checks view');
+            expect(wrapped.getElement()).toMatchSnapshot();
         });
 
         it('scanning spinner', () => {
@@ -30,30 +33,99 @@ describe('AutomatedChecksView', () => {
                 scanStoreData: {
                     status: ScanStatus.Scanning,
                 },
+                deviceStoreData: {},
             } as AutomatedChecksViewProps;
 
             const wrapped = shallow(<AutomatedChecksView {...props} />);
 
-            expect(wrapped.getElement()).toMatchSnapshot('automated checks view');
+            expect(wrapped.getElement()).toMatchSnapshot();
+        });
+
+        it('device disconnected', () => {
+            const props: AutomatedChecksViewProps = {
+                deps: {
+                    scanActionCreator: Mock.ofType(ScanActionCreator).object,
+                },
+                scanStoreData: {
+                    status: ScanStatus.Failed,
+                },
+                deviceStoreData: {
+                    connectedDevice: 'TEST DEVICE',
+                },
+            } as AutomatedChecksViewProps;
+
+            const wrapped = shallow(<AutomatedChecksView {...props} />);
+
+            expect(wrapped.getElement()).toMatchSnapshot();
         });
     });
 
     it('triggers scan when first mounted', () => {
-        const devicePort = 11111;
+        const port = 11111;
 
         const scanActionCreatorMock = Mock.ofType(ScanActionCreator);
-        scanActionCreatorMock.setup(creator => creator.scan(devicePort)).verifiable(Times.once());
+        scanActionCreatorMock.setup(creator => creator.scan(port)).verifiable(Times.once());
 
         const props: AutomatedChecksViewProps = {
             deps: {
                 scanActionCreator: scanActionCreatorMock.object,
             },
-            devicePort,
             scanStoreData: {},
+            deviceStoreData: {
+                port,
+            },
         } as AutomatedChecksViewProps;
 
         shallow(<AutomatedChecksView {...props} />);
 
         scanActionCreatorMock.verifyAll();
+    });
+
+    describe('DeviceDisconnectedPopup event handlers', () => {
+        it('onRescanDevice', () => {
+            const port = 11111;
+
+            const scanActionCreatorMock = Mock.ofType(ScanActionCreator);
+
+            const props: AutomatedChecksViewProps = {
+                deps: {
+                    scanActionCreator: scanActionCreatorMock.object,
+                },
+                scanStoreData: {
+                    status: ScanStatus.Failed,
+                },
+                deviceStoreData: {
+                    port,
+                },
+            } as AutomatedChecksViewProps;
+
+            const wrapped = shallow(<AutomatedChecksView {...props} />);
+
+            wrapped.find(DeviceDisconnectedPopup).prop('onRescanDevice')();
+
+            scanActionCreatorMock.verify(creator => creator.scan(port), Times.exactly(2));
+        });
+
+        it('onConnectNewDevice', () => {
+            const scanActionCreatorMock = Mock.ofType(ScanActionCreator);
+            const windowStateActionCreatorMock = Mock.ofType(WindowStateActionCreator);
+
+            const props: AutomatedChecksViewProps = {
+                deps: {
+                    scanActionCreator: scanActionCreatorMock.object,
+                    windowStateActionCreator: windowStateActionCreatorMock.object,
+                },
+                scanStoreData: {
+                    status: ScanStatus.Failed,
+                },
+                deviceStoreData: {},
+            } as AutomatedChecksViewProps;
+
+            const wrapped = shallow(<AutomatedChecksView {...props} />);
+
+            wrapped.find(DeviceDisconnectedPopup).prop('onConnectNewDevice')();
+
+            windowStateActionCreatorMock.verify(creator => creator.setRoute(It.isValue({ routeId: 'deviceConnectView' })), Times.once());
+        });
     });
 });

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -101,9 +101,11 @@ describe('AutomatedChecksView', () => {
 
             const wrapped = shallow(<AutomatedChecksView {...props} />);
 
+            scanActionCreatorMock.reset(); // this mock is used on componentDidMount, which is not in the scope of this unit test
+
             wrapped.find(DeviceDisconnectedPopup).prop('onRescanDevice')();
 
-            scanActionCreatorMock.verify(creator => creator.scan(port), Times.exactly(2));
+            scanActionCreatorMock.verify(creator => creator.scan(port), Times.once());
         });
 
         it('onConnectNewDevice', () => {

--- a/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-disconnected-popup/__snapshots__/device-disconnected-popup.test.tsx.snap
@@ -30,7 +30,9 @@ exports[`DeviceDisconnectedPopup renders 1`] = `
   <div>
     <p>
       Uh-oh! It seems the 
-      test device name
+      <strong>
+        test device name
+      </strong>
        device has disconnected before the snapshot completed its analysis.
     </p>
     <p>

--- a/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
@@ -33,7 +33,12 @@ exports[`RootContainer renders results view container when route is resultsView 
       },
     }
   }
-  devicePort={11111}
+  deviceStoreData={
+    Object {
+      "deviceConnectState": 2,
+      "port": 11111,
+    }
+  }
   scanStoreData={
     Object {
       "status": 0,


### PR DESCRIPTION
#### Description of changes

Wiring up the "Device disconnected" popup. When the user reaches the "Automated checks" view, we should the "scanning" spinner, if the scan failes, we'll be showing this popup that let's the user rescan the same device or navigate back to input a different port number.

![image](https://user-images.githubusercontent.com/2837582/66689271-f8ee3900-ec3e-11e9-8bce-67e40058e534.png)

**Notes for the reviews**
- This is only a wiring up PR, the dialog was already there
- The only exception to the previous point is: I made the device name a bold text to make it easier to catch
- There is a flickering on the window when navigating back to the port entry view. I had left that out of the scope of this PR as it touches a different piece of code and technically speaking, that bug was already there.

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1606846
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [] (UI changes only) Added screenshots/GIFs to description above
- [] (UI changes only) Verified usability with NVDA/JAWS
