### PR TITLE
feat(android-cards-view): Add per-result filtering for ColorContrast rule

### DIFF
--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -15,11 +15,13 @@ export class RuleInformationProvider {
                 'ColorContrast',
                 'Text elements must have sufficient contrast against the background.',
                 this.getColorContrastUnifiedResolution,
+                this.includeColorContrastResult,
             ),
             TouchSizeWcag: new RuleInformation(
                 'TouchSizeWcag',
                 'Touch inputs must have a sufficient target size.',
                 this.getTouchSizeUnifiedResolution,
+                this.includeAllResults,
             ),
             ActiveViewName: new RuleInformation(
                 'ActiveViewName',
@@ -29,12 +31,17 @@ export class RuleInformationProvider {
                         'The view is active but has no name available to assistive technologies. Provide a name for the view using its contentDescription, hint, labelFor, or text attribute (depending on the view type)',
                         ['contentDescription', 'hint', 'labelFor', 'text'],
                     ),
+                this.includeAllResults,
             ),
-            ImageViewName: new RuleInformation('ImageViewName', 'Meaningful images must have alternate text.', () =>
-                this.buildUnifiedResolution(
-                    'The image has no alternate text and is not identified as decorative. If the image conveys meaningful content, provide alternate text using the contentDescription attribute. If the image is decorative, give it an empty contentDescription, or set its isImportantForAccessibility attribute to false.',
-                    ['contentDescription', 'isImportantForAccessibility'],
-                ),
+            ImageViewName: new RuleInformation(
+                'ImageViewName',
+                'Meaningful images must have alternate text.',
+                () =>
+                    this.buildUnifiedResolution(
+                        'The image has no alternate text and is not identified as decorative. If the image conveys meaningful content, provide alternate text using the contentDescription attribute. If the image is decorative, give it an empty contentDescription, or set its isImportantForAccessibility attribute to false.',
+                        ['contentDescription', 'isImportantForAccessibility'],
+                    ),
+                this.includeAllResults,
             ),
             EditTextValue: new RuleInformation(
                 'EditTextValue',
@@ -44,6 +51,7 @@ export class RuleInformationProvider {
                         "The element's contentDescription overrides the text value required by assistive technologies. Remove the element’s contentDescription attribute.",
                         ['contentDescription'],
                     ),
+                this.includeAllResults,
             ),
         };
     }
@@ -87,6 +95,14 @@ export class RuleInformationProvider {
     private buildUnifiedResolution(unformattedText: string, codeStrings: string[] = null): UnifiedResolution {
         return { howToFixSummary: unformattedText, formatAsCode: codeStrings };
     }
+
+    private includeColorContrastResult = (ruleResultsData: RuleResultsData): boolean => {
+        return ruleResultsData.props['Confidence in Color Detection'] === 'High';
+    };
+
+    private includeAllResults = (ruleResultsData: RuleResultsData): boolean => {
+        return true;
+    };
 
     public getRuleInformation(ruleId: string): RuleInformation {
         const ruleInfo = this.supportedRules[ruleId];

--- a/src/electron/platform/android/rule-information.ts
+++ b/src/electron/platform/android/rule-information.ts
@@ -6,14 +6,21 @@ import { RuleResultsData } from './scan-results';
 
 export type GetUnifiedResolutionDelegate = (ruleResultsData: RuleResultsData) => UnifiedResolution;
 
+export type IncludeThisResultDelegate = (ruleResultsData: RuleResultsData) => boolean;
+
 export class RuleInformation {
     constructor(
         readonly ruleId: string,
         readonly ruleDescription: string,
         readonly getUnifiedResolutionDelegate: GetUnifiedResolutionDelegate,
+        readonly includeThisResultDelegate: IncludeThisResultDelegate,
     ) {}
 
     public getUnifiedResolution(ruleResultsData: RuleResultsData): UnifiedResolution {
         return this.getUnifiedResolutionDelegate(ruleResultsData);
+    }
+
+    public includeThisResult(ruleResultsData: RuleResultsData): boolean {
+        return this.includeThisResultDelegate(ruleResultsData);
     }
 }

--- a/src/electron/platform/android/scan-results-to-unified-results.ts
+++ b/src/electron/platform/android/scan-results-to-unified-results.ts
@@ -37,7 +37,7 @@ function createUnifiedResultsFromScanResults(
     for (const ruleResult of scanResults.ruleResults) {
         const ruleInformation: RuleInformation = ruleInformationProvider.getRuleInformation(ruleResult.ruleId);
 
-        if (ruleInformation) {
+        if (ruleInformation && ruleInformation.includeThisResult(ruleResult)) {
             unifiedResults.push(createUnifiedResult(ruleInformation, ruleResult, viewElementLookup, uuidGenerator));
         }
     }

--- a/src/electron/platform/android/scan-results-to-unified-rules.ts
+++ b/src/electron/platform/android/scan-results-to-unified-rules.ts
@@ -30,7 +30,7 @@ export function convertScanResultsToUnifiedRules(
         if (!ruleIds.has(ruleId)) {
             const ruleInformation = ruleInformationProvider.getRuleInformation(ruleId);
 
-            if (ruleInformation) {
+            if (ruleInformation && ruleInformation.includeThisResult(result)) {
                 unifiedRules.push(createUnifiedRuleFromRuleResult(ruleInformation, uuidGenerator));
                 ruleIds.add(ruleId);
             }

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/rule-information-provider.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/rule-information-provider.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`RuleInformationProvider getRuleInformation handles no foreground/background color values 1`] = `
 Object {
   "formatAsCode": null,
-  "howToFixSummary": "The text element has insufficient contrast of 2.798498811425733. Foreground color: NO VALUE AVAILABLE, background color: NO VALUE AVAILABLE). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
+  "howToFixSummary": "The text element has insufficient contrast of undefined. Foreground color: NO VALUE AVAILABLE, background color: NO VALUE AVAILABLE). Modify the text foreground and/or background colors to provide a contrast ratio of at least 4.5:1 for regular text, or 3:1 for large text (at least 18pt, or 14pt+bold).",
 }
 `;
 

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-rules.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-rules.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ScanResultsToUnifiedResults Null ScanResults input returns empty output 1`] = `Array []`;
+exports[`ScanResultsToUnifiedRules Null ScanResults input returns empty output 1`] = `Array []`;
 
-exports[`ScanResultsToUnifiedResults ScanResults with 1 supported rule 1`] = `
+exports[`ScanResultsToUnifiedRules ScanResults with 1 supported rule 1`] = `
 Array [
   Object {
     "description": "This describes Rule #1",
@@ -14,7 +14,7 @@ Array [
 ]
 `;
 
-exports[`ScanResultsToUnifiedResults ScanResults with 1 supported rule that repeats 1`] = `
+exports[`ScanResultsToUnifiedRules ScanResults with 1 supported rule that repeats 1`] = `
 Array [
   Object {
     "description": "This describes Rule #1",
@@ -26,7 +26,7 @@ Array [
 ]
 `;
 
-exports[`ScanResultsToUnifiedResults ScanResults with a mix of supported and unsupported rules 1`] = `
+exports[`ScanResultsToUnifiedRules ScanResults with a mix of supported rules, unsupported rules, and excluded results 1`] = `
 Array [
   Object {
     "description": "This describes Rule #3",
@@ -52,6 +52,6 @@ Array [
 ]
 `;
 
-exports[`ScanResultsToUnifiedResults ScanResults with no RuleResults returns empty output 1`] = `Array []`;
+exports[`ScanResultsToUnifiedRules ScanResults with no RuleResults returns empty output 1`] = `Array []`;
 
-exports[`ScanResultsToUnifiedResults ScanResults with only unsupported rules 1`] = `Array []`;
+exports[`ScanResultsToUnifiedRules ScanResults with only unsupported rules 1`] = `Array []`;

--- a/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
@@ -107,7 +107,7 @@ describe('RuleInformationProvider', () => {
     });
 
     test('ColorContrast includeThisResult returns false when confidence is not defined', () => {
-        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject('FAIL', 2.798498811425733, 'ff979797', 'fffafafa', null);
+        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject('PASS', null, null, null, null);
         const ruleInformation: RuleInformation = provider.getRuleInformation(ruleResult.ruleId);
         expect(ruleInformation.includeThisResult(ruleResult)).toBe(false);
     });
@@ -119,20 +119,17 @@ describe('RuleInformationProvider', () => {
     });
 
     test('ActiveViewName includeThisResult returns true', () => {
-        const ruleResult: RuleResultsData = buildRuleResultObject('ActiveViewName', 'FAIL');
-        const ruleInformation: RuleInformation = provider.getRuleInformation(ruleResult.ruleId);
+        const ruleInformation: RuleInformation = provider.getRuleInformation('ActiveViewName');
         expect(ruleInformation.includeThisResult(null)).toBe(true);
     });
 
     test('EditTextValue includeThisResult returns true', () => {
-        const ruleResult: RuleResultsData = buildRuleResultObject('EditTextValue', 'FAIL');
-        const ruleInformation: RuleInformation = provider.getRuleInformation(ruleResult.ruleId);
+        const ruleInformation: RuleInformation = provider.getRuleInformation('EditTextValue');
         expect(ruleInformation.includeThisResult(null)).toBe(true);
     });
 
-    test('EditTextValue includeThisResult returns true', () => {
-        const ruleResult: RuleResultsData = buildRuleResultObject('EditTextValue', 'FAIL');
-        const ruleInformation: RuleInformation = provider.getRuleInformation(ruleResult.ruleId);
+    test('ImageViewName includeThisResult returns true', () => {
+        const ruleInformation: RuleInformation = provider.getRuleInformation('ImageViewName');
         expect(ruleInformation.includeThisResult(null)).toBe(true);
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
@@ -89,17 +89,24 @@ export function buildViewElement(
     return viewElement as ViewElementData;
 }
 
-export function buildRuleInformation(ruleId: string): RuleInformation {
+export function buildRuleInformation(ruleId: string, includeResults: boolean = true): RuleInformation {
     return {
         ruleId: ruleId,
         ruleDescription: 'This describes ' + ruleId,
         getUnifiedResolutionDelegate: r => {
-            expect('abc').toBe('This line should never execute');
+            expect('getUnifiedResolution').toBe('This code should never execute');
             return null;
         },
         getUnifiedResolution: r => {
             const summary: string = 'How to fix ' + ruleId;
             return ({ howtoFixSummary: summary } as unknown) as UnifiedResolution;
+        },
+        includeThisResultDelegate: r => {
+            expect('includeThisResultDelegate').toBe('This code should never execute');
+            return null;
+        },
+        includeThisResult: r => {
+            return includeResults;
         },
     } as RuleInformation;
 }

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
@@ -18,6 +18,7 @@ describe('ScanResultsToUnifiedResults', () => {
     const ruleId1: string = 'My Rule #1';
     const ruleId2: string = 'My Rule #2';
     const ruleId3: string = 'My Rule #3';
+    const ruleId4: string = 'My Rule #4';
 
     beforeEach(() => {
         const guidStub = 'gguid-mock-stub';
@@ -27,38 +28,42 @@ describe('ScanResultsToUnifiedResults', () => {
         const ruleInformation1: RuleInformation = buildRuleInformation(ruleId1);
         const ruleInformation2: RuleInformation = buildRuleInformation(ruleId2);
         const ruleInformation3: RuleInformation = buildRuleInformation(ruleId3);
+        const ruleInformation4: RuleInformation = buildRuleInformation(ruleId4, false);
 
         ruleInformationProviderMock = Mock.ofType<RuleInformationProviderType>();
         ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId1)).returns(() => ruleInformation1);
         ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId2)).returns(() => ruleInformation2);
         ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId3)).returns(() => ruleInformation3);
+        ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId4)).returns(() => ruleInformation4);
     });
 
     function verifyMockCounts(
         expectedRule1Count: number,
         expectedRule2Count: number,
         expectedRule3Count: number,
+        expectedRule4Count: number,
         expectedOtherCount: number,
     ): void {
-        const totalCalls: number = expectedRule1Count + expectedRule2Count + expectedRule3Count + expectedOtherCount;
+        const totalCalls: number = expectedRule1Count + expectedRule2Count + expectedRule3Count + expectedRule4Count + expectedOtherCount;
 
         ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId1), Times.exactly(expectedRule1Count));
         ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId2), Times.exactly(expectedRule2Count));
         ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId3), Times.exactly(expectedRule3Count));
+        ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId4), Times.exactly(expectedRule4Count));
         ruleInformationProviderMock.verify(x => x.getRuleInformation(It.isAnyString()), Times.exactly(totalCalls));
     }
 
     test('Null ScanResults input returns empty output', () => {
         const results: UnifiedResult[] = convertScanResultsToUnifiedResults(null, ruleInformationProviderMock.object, null);
         expect(results).toMatchSnapshot();
-        verifyMockCounts(0, 0, 0, 0);
+        verifyMockCounts(0, 0, 0, 0, 0);
     });
 
     test('ScanResults with no RuleResults returns empty output', () => {
         const scanResults: ScanResults = buildScanResultsObject();
         const results: UnifiedResult[] = convertScanResultsToUnifiedResults(scanResults, ruleInformationProviderMock.object, null);
         expect(results).toMatchSnapshot();
-        verifyMockCounts(0, 0, 0, 0);
+        verifyMockCounts(0, 0, 0, 0, 0);
     });
 
     test('ScanResults with passes, failures, view IDs, and excluded results', () => {
@@ -72,6 +77,7 @@ describe('ScanResultsToUnifiedResults', () => {
             buildRuleResultObject(ruleId2, 'FAIL', id3),
             buildRuleResultObject(ruleId2, 'PASS', id4),
             buildRuleResultObject('unsupprted Rule #2', 'FAIL', id1),
+            buildRuleResultObject(ruleId4, 'PASS', id2),
             buildRuleResultObject(ruleId3, 'PASS', id2),
             buildRuleResultObject(ruleId2, 'UNKNOWN', 'does not exist'), // Force "unknown" cases
         ];
@@ -97,6 +103,6 @@ describe('ScanResultsToUnifiedResults', () => {
             generateGuidMock.object,
         );
         expect(results).toMatchSnapshot();
-        verifyMockCounts(1, 3, 1, 2);
+        verifyMockCounts(1, 3, 1, 1, 2);
     });
 });

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-rules.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-rules.test.ts
@@ -11,7 +11,7 @@ import { RuleResultsData, ScanResults } from 'electron/platform/android/scan-res
 import { convertScanResultsToUnifiedRules } from 'electron/platform/android/scan-results-to-unified-rules';
 import { buildRuleInformation, buildRuleResultObject, buildScanResultsObject } from './scan-results-helpers';
 
-describe('ScanResultsToUnifiedResults', () => {
+describe('ScanResultsToUnifiedRules', () => {
     let ruleInformationProviderMock: IMock<RuleInformationProviderType>;
 
     let generateGuidMock: IMock<() => string>;
@@ -22,19 +22,22 @@ describe('ScanResultsToUnifiedResults', () => {
         expectedRule1Count: number,
         expectedRule2Count: number,
         expectedRule3Count: number,
+        expectedRule4Count: number,
         expectedOtherCount: number,
     ): void {
-        const totalCalls: number = expectedRule1Count + expectedRule2Count + expectedRule3Count + expectedOtherCount;
+        const totalCalls: number = expectedRule1Count + expectedRule2Count + expectedRule3Count + expectedRule4Count + expectedOtherCount;
 
         ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId1), Times.exactly(expectedRule1Count));
         ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId2), Times.exactly(expectedRule2Count));
         ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId3), Times.exactly(expectedRule3Count));
+        ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId4), Times.exactly(expectedRule4Count));
         ruleInformationProviderMock.verify(x => x.getRuleInformation(It.isAnyString()), Times.exactly(totalCalls));
     }
 
     const ruleId1: string = 'Rule #1';
     const ruleId2: string = 'Rule #2';
     const ruleId3: string = 'Rule #3';
+    const ruleId4: string = 'Rule #4';
 
     beforeEach(() => {
         const guidStub = 'gguid-mock-stub';
@@ -44,24 +47,26 @@ describe('ScanResultsToUnifiedResults', () => {
         const ruleInformation1: RuleInformation = buildRuleInformation(ruleId1);
         const ruleInformation2: RuleInformation = buildRuleInformation(ruleId2);
         const ruleInformation3: RuleInformation = buildRuleInformation(ruleId3);
+        const ruleInformation4: RuleInformation = buildRuleInformation(ruleId4, false);
 
         ruleInformationProviderMock = Mock.ofType<RuleInformationProviderType>();
         ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId1)).returns(() => ruleInformation1);
         ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId2)).returns(() => ruleInformation2);
         ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId3)).returns(() => ruleInformation3);
+        ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId4)).returns(() => ruleInformation4);
     });
 
     test('Null ScanResults input returns empty output', () => {
         const results: UnifiedRule[] = convertScanResultsToUnifiedRules(null, ruleInformationProviderMock.object, null);
         expect(results).toMatchSnapshot();
-        verifyMockCounts(0, 0, 0, 0);
+        verifyMockCounts(0, 0, 0, 0, 0);
     });
 
     test('ScanResults with no RuleResults returns empty output', () => {
         const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier);
         const results: UnifiedRule[] = convertScanResultsToUnifiedRules(scanResults, ruleInformationProviderMock.object, null);
         expect(results).toMatchSnapshot();
-        verifyMockCounts(0, 0, 0, 0);
+        verifyMockCounts(0, 0, 0, 0, 0);
     });
 
     test('ScanResults with only unsupported rules', () => {
@@ -78,7 +83,7 @@ describe('ScanResultsToUnifiedResults', () => {
             generateGuidMock.object,
         );
         expect(results).toMatchSnapshot();
-        verifyMockCounts(0, 0, 0, 3);
+        verifyMockCounts(0, 0, 0, 0, 3);
     });
 
     test('ScanResults with 1 supported rule', () => {
@@ -91,7 +96,7 @@ describe('ScanResultsToUnifiedResults', () => {
             generateGuidMock.object,
         );
         expect(results).toMatchSnapshot();
-        verifyMockCounts(1, 0, 0, 0);
+        verifyMockCounts(1, 0, 0, 0, 0);
     });
 
     test('ScanResults with 1 supported rule that repeats', () => {
@@ -108,10 +113,10 @@ describe('ScanResultsToUnifiedResults', () => {
             generateGuidMock.object,
         );
         expect(results).toMatchSnapshot();
-        verifyMockCounts(1, 0, 0, 0);
+        verifyMockCounts(1, 0, 0, 0, 0);
     });
 
-    test('ScanResults with a mix of supported and unsupported rules', () => {
+    test('ScanResults with a mix of supported rules, unsupported rules, and excluded results', () => {
         const ruleResults: RuleResultsData[] = [
             buildRuleResultObject(ruleId3, 'FAIL'),
             buildRuleResultObject('not supported', 'PASS'),
@@ -121,6 +126,7 @@ describe('ScanResultsToUnifiedResults', () => {
             buildRuleResultObject(ruleId1, 'FAIL'),
             buildRuleResultObject('sorry', 'FAIL'),
             buildRuleResultObject(ruleId2, 'PASS'),
+            buildRuleResultObject(ruleId4, 'PASS'),
             buildRuleResultObject(ruleId1, 'PASS'),
             buildRuleResultObject(ruleId3, 'FAIL'),
             buildRuleResultObject('thanks for playing', 'FAIL'),
@@ -133,6 +139,6 @@ describe('ScanResultsToUnifiedResults', () => {
             generateGuidMock.object,
         );
         expect(results).toMatchSnapshot();
-        verifyMockCounts(1, 1, 1, 3);
+        verifyMockCounts(1, 1, 1, 1, 3);
     });
 });


### PR DESCRIPTION
#### Description of changes

We want to exclude ColorContrast results where the confidence is anything but **High**. To enable this, we're adding a filter method on the RuleInformation class, then calling it on each result to determine if that result should be filtered out. Adding filters to other rules will only require changing the RuleInformationProvider.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
