### PR TITLE
contextual menu - high contrast mode

### DIFF
--- a/src/common/components/cards/card-kebab-menu-button.scss
+++ b/src/common/components/cards/card-kebab-menu-button.scss
@@ -2,17 +2,18 @@
 // Licensed under the MIT License.
 @import '../../styles/colors.scss';
 
-.kebab-menu-callout {
-    box-shadow: 0px 6.4px 14.4px $box-shadow-132, 0px 1.2px 3.6px $box-shadow-108 !important;
+div.kebab-menu-callout {
+    box-shadow: 0px 6.4px 14.4px $box-shadow-132, 0px 1.2px 3.6px $box-shadow-108;
     border-radius: 4px;
-    border-width: 0px !important;
-    div.ms-Callout-main {
+    border-width: 0px;
+    > div {
         border-radius: 4px;
     }
 }
 
 .kebab-menu {
     background: $acrylic-light;
+    border: 1px solid $menu-border;
     i {
         color: $primary-text;
     }
@@ -20,12 +21,12 @@
         background-color: $acrylic-light;
     }
 
-    button.ms-ContextualMenu-link {
+    button {
         &:hover {
-            background-color: $neutral-alpha-4;
+            background-color: $hover-background;
         }
         &:active {
-            background-color: $neutral-alpha-8;
+            background-color: $active-background;
         }
     }
 }
@@ -38,13 +39,17 @@ button.kebab-menu-button {
     border-radius: 2px;
     background: transparent;
 
+    svg > circle {
+        stroke: $neutral-100;
+    }
+
     &:hover {
-        background-color: $neutral-alpha-4;
+        background-color: $hover-background;
     }
 
     &:active,
     &[aria-expanded='true'] {
-        background-color: $neutral-alpha-8;
+        background-color: $active-background;
     }
 
     div.ms-Button-flexContainer {

--- a/src/common/components/cards/card-kebab-menu-button.scss
+++ b/src/common/components/cards/card-kebab-menu-button.scss
@@ -12,21 +12,24 @@ div.kebab-menu-callout {
 }
 
 .kebab-menu {
-    background: $acrylic-light;
+    background: $menu-background;
     border: 1px solid $menu-border;
-    i {
-        color: $primary-text;
-    }
     li {
-        background-color: $acrylic-light;
+        background-color: $menu-background;
     }
-
     button {
+        i {
+            color: $primary-text;
+        }
         &:hover {
-            background-color: $hover-background;
+            background-color: $menu-item-background-hover;
         }
         &:active {
-            background-color: $active-background;
+            background-color: $menu-item-background-active;
+            color: $always-black;
+            i {
+                color: $always-black;
+            }
         }
     }
 }
@@ -44,12 +47,16 @@ button.kebab-menu-button {
     }
 
     &:hover {
-        background-color: $hover-background;
+        background-color: $menu-item-background-hover;
     }
 
     &:active,
     &[aria-expanded='true'] {
-        background-color: $active-background;
+        background-color: $menu-item-background-active;
+        color: $always-black;
+        svg > circle {
+            stroke: $always-black;
+        }
     }
 
     div.ms-Button-flexContainer {

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -75,6 +75,8 @@
     --row-selected-background: var(--communication-tint-40);
     --group-selected-background: var(--communication-tint-40);
     --row-hover-background: var(--neutral-4);
+    --hover-background: var(--neutral-alpha-4);
+    --active-background: var(--neutral-alpha-8);
     --link: var(--communication-primary);
     --link-hover: var(--communication-shade-20);
     --switcher-border: var(--ada-brand-variant);
@@ -85,6 +87,7 @@
     --pill: var(--primary-text);
     --pill-background: var(--neutral-alpha-8);
     --spinner-text: var(--communication-primary);
+    --menu-border: --acrylic-light;
 
     // Landmark colors
     --landmark-contentinfo: #00a88c;
@@ -147,6 +150,10 @@
         --pill: var(--black);
         --pill-background: var(--white);
         --spinner-text: var(--communication-tint-40);
+        --hover-background: var(--grey);
+        --active-background: var(--communication-tint-40);
+        --acrylic-light: var(--light-black);
+        --menu-border: var(--grey);
     }
 }
 
@@ -236,6 +243,9 @@ $highlighted-text: var(--highlighted-text);
 $pill: var(--pill);
 $pill-background: var(--pill-background);
 $spinner-text: var(--spinner-text);
+$hover-background: var(--hover-background);
+$active-background: var(--active-background);
+$menu-border: var(--menu-border);
 
 // consistent colors
 $always-white: #ffffff;

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -75,8 +75,8 @@
     --row-selected-background: var(--communication-tint-40);
     --group-selected-background: var(--communication-tint-40);
     --row-hover-background: var(--neutral-4);
-    --hover-background: var(--neutral-alpha-4);
-    --active-background: var(--neutral-alpha-8);
+    --menu-item-background-hover: var(--neutral-alpha-4);
+    --menu-item-background-active: var(--neutral-alpha-8);
     --link: var(--communication-primary);
     --link-hover: var(--communication-shade-20);
     --switcher-border: var(--ada-brand-variant);
@@ -87,7 +87,8 @@
     --pill: var(--primary-text);
     --pill-background: var(--neutral-alpha-8);
     --spinner-text: var(--communication-primary);
-    --menu-border: --acrylic-light;
+    --menu-background: --acrylic-light;
+    --menu-border: --menu-background;
 
     // Landmark colors
     --landmark-contentinfo: #00a88c;
@@ -150,9 +151,9 @@
         --pill: var(--black);
         --pill-background: var(--white);
         --spinner-text: var(--communication-tint-40);
-        --hover-background: var(--grey);
-        --active-background: var(--communication-tint-40);
-        --acrylic-light: var(--light-black);
+        --menu-item-background-hover: var(--grey);
+        --menu-item-background-active: var(--communication-tint-40);
+        --menu-background: var(--light-black);
         --menu-border: var(--grey);
     }
 }
@@ -243,9 +244,10 @@ $highlighted-text: var(--highlighted-text);
 $pill: var(--pill);
 $pill-background: var(--pill-background);
 $spinner-text: var(--spinner-text);
-$hover-background: var(--hover-background);
-$active-background: var(--active-background);
+$menu-item-background-hover: var(--menu-item-background-hover);
+$menu-item-background-active: var(--menu-item-background-active);
 $menu-border: var(--menu-border);
+$menu-background: var(--menu-background);
 
 // consistent colors
 $always-white: #ffffff;


### PR DESCRIPTION
#### Description of changes
Have run the UX flow with Fer and confirmed this is what we want. 
This PR only includes the contextual menu control.



normal:
![image](https://user-images.githubusercontent.com/15974344/66690066-95fea100-ec42-11e9-9316-bdd333e8fd31.png)
hover:
![image](https://user-images.githubusercontent.com/15974344/66690070-9bf48200-ec42-11e9-9cf1-03e517c5ec4c.png)
expand:
![image](https://user-images.githubusercontent.com/15974344/66690386-7bc5c280-ec44-11e9-9b74-fa538f06c3ea.png)

select a menu item:
![image](https://user-images.githubusercontent.com/15974344/66690389-81bba380-ec44-11e9-9b35-c60842da562d.png)



When color contrast is off, nothing changes:
![image](https://user-images.githubusercontent.com/15974344/66690137-fd1c5580-ec42-11e9-91a0-ba3ea798bacd.png)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
