### PR TITLE
Add encoding setting on the Assessment Report and set DOCTYPE

### DIFF
--- a/src/reports/assessment-report-html-generator.tsx
+++ b/src/reports/assessment-report-html-generator.tsx
@@ -50,6 +50,7 @@ export class AssessmentReportHtmlGenerator {
         const reportElement = (
             <React.Fragment>
                 <head>
+                    <meta charSet="UTF-8" />
                     <title>Assessment report</title>
                     <style dangerouslySetInnerHTML={{ __html: reportStyles.styleSheet }} />
                     <style dangerouslySetInnerHTML={{ __html: bundledStyles.styleSheet }} />
@@ -69,6 +70,6 @@ export class AssessmentReportHtmlGenerator {
 
         const reportBody = this.renderer.renderToStaticMarkup(reportElement);
 
-        return `<html lang="en">${reportBody}</html>`;
+        return `<!DOCTYPE html><html lang="en">${reportBody}</html>`;
     }
 }

--- a/src/reports/components/report-head.tsx
+++ b/src/reports/components/report-head.tsx
@@ -10,7 +10,7 @@ import * as reportStyles from '../automated-checks-report.styles';
 export const ReportHead = NamedFC('ReportHead', () => {
     return (
         <head>
-            <meta httpEquiv="Content-Type" content="text/html;charset=utf-8" />
+            <meta charSet="UTF-8" />
             <title>{title} automated checks result</title>
             <style dangerouslySetInnerHTML={{ __html: reportStyles.styleSheet }} />
             <style dangerouslySetInnerHTML={{ __html: bundledStyles.styleSheet }} />

--- a/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
@@ -41,6 +41,7 @@ describe('AssessmentReportHtmlGenerator', () => {
         const expectedComponent = (
             <React.Fragment>
                 <head>
+                    <meta charSet="UTF-8" />
                     <title>Assessment report</title>
                     <style dangerouslySetInnerHTML={{ __html: reportStyles.styleSheet }} />
                     <style dangerouslySetInnerHTML={{ __html: detailsViewBundledCSS.styleSheet }} />
@@ -58,7 +59,7 @@ describe('AssessmentReportHtmlGenerator', () => {
             </React.Fragment>
         );
         const expectedBody: string = '<head>styles</head><body>report-body</body>';
-        const expectedHtml = `<html lang="en">${expectedBody}</html>`;
+        const expectedHtml = `<!DOCTYPE html><html lang="en">${expectedBody}</html>`;
 
         const testDate = new Date(2018, 9, 19, 11, 25);
         const assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator = new AssessmentDefaultMessageGenerator();

--- a/src/tests/unit/tests/reports/components/__snapshots__/report-head.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/report-head.test.tsx.snap
@@ -3,8 +3,7 @@
 exports[`ReportHead renders 1`] = `
 <head>
   <meta
-    content="text/html;charset=utf-8"
-    httpEquiv="Content-Type"
+    charSet="UTF-8"
   />
   <title>
     Accessibility Insights for Web


### PR DESCRIPTION
#### Description of changes

2-byte characters are garbled on the Assessment Report.
This PR adds encoding settings and set a DOCTYPE to the report.

#### Pull request checklist

- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
