### PR TITLE
added text field validation via Enter key

### DIFF
--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -4,6 +4,7 @@ import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button'
 import { MaskedTextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 
+import { KeyCodeConstants } from 'common/constants/keycode-constants';
 import { DeviceConnectActionCreator } from '../../../flux/action-creator/device-connect-action-creator';
 import { deviceConnectPortEntry, portNumberField } from './device-connect-port-entry.scss';
 import { DeviceConnectState } from './device-connect-state';
@@ -42,6 +43,7 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
                     className={portNumberField}
                     maskChar=""
                     mask="99999"
+                    onKeyDown={this.onEnterKey}
                 />
                 {this.renderValidationPortButton()}
             </div>
@@ -71,8 +73,14 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
         this.setState({ port: newValue });
     };
 
-    private onValidateClick = (event: React.MouseEvent<HTMLButtonElement>): void => {
+    private onValidateClick = (): void => {
         const port = parseInt(this.state.port, 10);
         this.props.deps.deviceConnectActionCreator.validatePort(port);
+    };
+
+    private onEnterKey = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+        if (event.keyCode === KeyCodeConstants.ENTER) {
+            this.onValidateClick();
+        }
     };
 }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" 1`] = `
       }
     }
     onChange={[Function]}
+    onKeyDown={[Function]}
     placeholder="12345"
   />
   <CustomizedDefaultButton
@@ -52,6 +53,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" and some text in th
       }
     }
     onChange={[Function]}
+    onKeyDown={[Function]}
     placeholder="12345"
   />
   <CustomizedDefaultButton
@@ -84,6 +86,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" 1`] = `
       }
     }
     onChange={[Function]}
+    onKeyDown={[Function]}
     placeholder="12345"
   />
   <CustomizedPrimaryButton
@@ -116,6 +119,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" and some text in t
       }
     }
     onChange={[Function]}
+    onKeyDown={[Function]}
     placeholder="12345"
   />
   <CustomizedPrimaryButton
@@ -148,6 +152,7 @@ exports[`DeviceConnectPortEntryTest renders with "Default" 1`] = `
       }
     }
     onChange={[Function]}
+    onKeyDown={[Function]}
     placeholder="12345"
   />
   <CustomizedPrimaryButton
@@ -180,6 +185,7 @@ exports[`DeviceConnectPortEntryTest renders with "Default" and some text in the 
       }
     }
     onChange={[Function]}
+    onKeyDown={[Function]}
     placeholder="12345"
   />
   <CustomizedPrimaryButton
@@ -212,6 +218,7 @@ exports[`DeviceConnectPortEntryTest renders with "Error" 1`] = `
       }
     }
     onChange={[Function]}
+    onKeyDown={[Function]}
     placeholder="12345"
   />
   <CustomizedPrimaryButton
@@ -244,6 +251,7 @@ exports[`DeviceConnectPortEntryTest renders with "Error" and some text in the po
       }
     }
     onChange={[Function]}
+    onKeyDown={[Function]}
     placeholder="12345"
   />
   <CustomizedPrimaryButton

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -9,15 +9,18 @@ import { shallow } from 'enzyme';
 import { Button } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
+import { KeyCodeConstants } from 'common/constants/keycode-constants';
 import { EnumHelper } from 'common/enum-helper';
 import { portNumberField } from 'electron/views/device-connect-view/components/device-connect-port-entry.scss';
 import { DeviceConnectState } from 'electron/views/device-connect-view/components/device-connect-state';
+import { MaskedTextField } from 'office-ui-fabric-react/lib/TextField';
 
 describe('DeviceConnectPortEntryTest', () => {
     const testPortNumber = 111;
     const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
+    const enterEventStub = new EventStubFactory().createKeypressEvent() as React.KeyboardEvent<HTMLInputElement>;
 
     let deviceConnectActionCreatorMock: IMock<DeviceConnectActionCreator>;
 
@@ -99,6 +102,26 @@ describe('DeviceConnectPortEntryTest', () => {
             const button = rendered.find('.button-validate-port');
 
             button.simulate('click', eventStub);
+
+            deviceConnectActionCreatorMock.verifyAll();
+        });
+
+        it('validates port through enter key', () => {
+            deviceConnectActionCreatorMock.setup(creator => creator.validatePort(testPortNumber)).verifiable(Times.once());
+
+            const props = {
+                deps: {
+                    deviceConnectActionCreator: deviceConnectActionCreatorMock.object,
+                },
+                viewState: {
+                    deviceConnectState: DeviceConnectState.Default,
+                },
+            } as DeviceConnectPortEntryProps;
+            const rendered = shallow(<DeviceConnectPortEntry {...props} />);
+            rendered.setState({ port: testPortNumber });
+            const textField = rendered.find(MaskedTextField);
+
+            textField.simulate('keydown', { keyCode: KeyCodeConstants.ENTER }, enterEventStub);
 
             deviceConnectActionCreatorMock.verifyAll();
         });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -19,7 +19,6 @@ import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 describe('DeviceConnectPortEntryTest', () => {
     const testPortNumber = 111;
     const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
-    const enterEventStub = new EventStubFactory().createKeypressEvent() as React.KeyboardEvent<HTMLInputElement>;
 
     let deviceConnectActionCreatorMock: IMock<DeviceConnectActionCreator>;
 
@@ -120,7 +119,7 @@ describe('DeviceConnectPortEntryTest', () => {
             rendered.setState({ port: testPortNumber });
             const textField = rendered.find(MaskedTextField);
 
-            textField.simulate('keydown', { keyCode: KeyCodeConstants.ENTER }, enterEventStub);
+            textField.simulate('keydown', { keyCode: KeyCodeConstants.ENTER });
 
             deviceConnectActionCreatorMock.verifyAll();
         });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -1,21 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { KeyCodeConstants } from 'common/constants/keycode-constants';
+import { EnumHelper } from 'common/enum-helper';
 import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
 import {
     DeviceConnectPortEntry,
     DeviceConnectPortEntryProps,
 } from 'electron/views/device-connect-view/components/device-connect-port-entry';
-import { shallow } from 'enzyme';
-import { Button } from 'office-ui-fabric-react/lib/Button';
-import * as React from 'react';
-import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
-import { KeyCodeConstants } from 'common/constants/keycode-constants';
-import { EnumHelper } from 'common/enum-helper';
 import { portNumberField } from 'electron/views/device-connect-view/components/device-connect-port-entry.scss';
 import { DeviceConnectState } from 'electron/views/device-connect-view/components/device-connect-state';
+import { shallow } from 'enzyme';
+import { Button } from 'office-ui-fabric-react/lib/Button';
 import { MaskedTextField } from 'office-ui-fabric-react/lib/TextField';
+import * as React from 'react';
+import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('DeviceConnectPortEntryTest', () => {
     const testPortNumber = 111;


### PR DESCRIPTION
#### Description of changes

users can now hit the "Enter" key and validate the port number. This PR also updated device connect port entry test and snapshots

#### Pull request checklist

- [N/A] Addresses an existing issue: Fixes #0000
- [X] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [N/A] (UI changes only) Verified usability with NVDA/JAWS
