### PR TITLE
refactor: user config message creator refactor signatures

### DIFF
--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -4,7 +4,6 @@ import { cloneDeep, isEqual } from 'lodash';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import * as React from 'react';
 
-import { SaveIssueFilingSettingsPayload } from 'background/actions/action-payloads';
 import { EnvironmentInfoProvider } from '../../common/environment-info-provider';
 import { IssueFilingActionMessageCreator } from '../../common/message-creators/issue-filing-action-message-creator';
 import { UserConfigMessageCreator } from '../../common/message-creators/user-config-message-creator';

--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -113,13 +113,14 @@ export class IssueFilingDialog extends React.Component<IssueFilingDialogProps, I
         }));
     };
 
-    private onPropertyUpdateCallback: OnPropertyUpdateCallback = (service, propertyName, propertyValue) => {
+    private onPropertyUpdateCallback: OnPropertyUpdateCallback = payload => {
+        const { issueFilingServiceName, propertyName, propertyValue } = payload;
         const selectedServiceData =
             this.state.selectedIssueFilingService.getSettingsFromStoreData(this.state.issueFilingServicePropertiesMap) || {};
         selectedServiceData[propertyName] = propertyValue;
         const newIssueFilingServicePropertiesMap = {
             ...this.state.issueFilingServicePropertiesMap,
-            [service]: selectedServiceData,
+            [issueFilingServiceName]: selectedServiceData,
         };
         this.setState(() => ({
             issueFilingServicePropertiesMap: newIssueFilingServicePropertiesMap,

--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -109,7 +109,7 @@ export class IssueFilingDialog extends React.Component<IssueFilingDialogProps, I
 
     private onSelectedServiceChange: OnSelectedServiceChange = service => {
         this.setState(() => ({
-            selectedIssueFilingService: this.props.deps.issueFilingServiceProvider.forKey(service),
+            selectedIssueFilingService: this.props.deps.issueFilingServiceProvider.forKey(service.issueFilingServiceName),
         }));
     };
 

--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -4,6 +4,7 @@ import { cloneDeep, isEqual } from 'lodash';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import * as React from 'react';
 
+import { SaveIssueFilingSettingsPayload } from 'background/actions/action-payloads';
 import { EnvironmentInfoProvider } from '../../common/environment-info-provider';
 import { IssueFilingActionMessageCreator } from '../../common/message-creators/issue-filing-action-message-creator';
 import { UserConfigMessageCreator } from '../../common/message-creators/user-config-message-creator';
@@ -102,7 +103,11 @@ export class IssueFilingDialog extends React.Component<IssueFilingDialogProps, I
     private onPrimaryButtonClick = (ev: React.SyntheticEvent<Element, Event>) => {
         const newData = this.state.selectedIssueFilingService.getSettingsFromStoreData(this.state.issueFilingServicePropertiesMap);
         const service = this.state.selectedIssueFilingService.key;
-        this.props.deps.userConfigMessageCreator.saveIssueFilingSettings(service, newData);
+        const payload = {
+            issueFilingServiceName: service,
+            issueFilingSettings: newData,
+        };
+        this.props.deps.userConfigMessageCreator.saveIssueFilingSettings(payload);
         this.props.deps.issueFilingActionMessageCreator.fileIssue(ev, service, this.props.selectedIssueData);
         this.props.onClose(ev);
     };

--- a/src/common/message-creators/user-config-message-creator.ts
+++ b/src/common/message-creators/user-config-message-creator.ts
@@ -46,13 +46,7 @@ export class UserConfigMessageCreator {
         });
     };
 
-    public setIssueFilingServiceProperty = (issueFilingServiceName: string, propertyName: string, propertyValue: string) => {
-        const payload: SetIssueFilingServicePropertyPayload = {
-            issueFilingServiceName,
-            propertyName,
-            propertyValue,
-        };
-
+    public setIssueFilingServiceProperty = (payload: SetIssueFilingServicePropertyPayload) => {
         this.dispatcher.dispatchMessage({
             messageType: Messages.UserConfig.SetIssueFilingServiceProperty,
             payload,

--- a/src/common/message-creators/user-config-message-creator.ts
+++ b/src/common/message-creators/user-config-message-creator.ts
@@ -35,11 +35,7 @@ export class UserConfigMessageCreator {
         });
     }
 
-    public setIssueFilingService = (issueFilingServiceName: string) => {
-        const payload: SetIssueFilingServicePayload = {
-            issueFilingServiceName,
-        };
-
+    public setIssueFilingService = (payload: SetIssueFilingServicePayload) => {
         this.dispatcher.dispatchMessage({
             messageType: Messages.UserConfig.SetIssueFilingService,
             payload,

--- a/src/common/message-creators/user-config-message-creator.ts
+++ b/src/common/message-creators/user-config-message-creator.ts
@@ -8,7 +8,6 @@ import {
     SetTelemetryStatePayload,
 } from 'background/actions/action-payloads';
 import { Messages } from '../messages';
-import { IssueFilingServiceProperties } from '../types/store-data/user-configuration-store';
 import { ActionMessageDispatcher } from './action-message-dispatcher';
 
 export class UserConfigMessageCreator {

--- a/src/common/message-creators/user-config-message-creator.ts
+++ b/src/common/message-creators/user-config-message-creator.ts
@@ -49,12 +49,7 @@ export class UserConfigMessageCreator {
         });
     };
 
-    public saveIssueFilingSettings = (issueFilingServiceName: string, issueFilingSettings: IssueFilingServiceProperties) => {
-        const payload: SaveIssueFilingSettingsPayload = {
-            issueFilingServiceName,
-            issueFilingSettings,
-        };
-
+    public saveIssueFilingSettings = (payload: SaveIssueFilingSettingsPayload) => {
         this.dispatcher.dispatchMessage({
             messageType: Messages.UserConfig.SaveIssueFilingSettings,
             payload,

--- a/src/issue-filing/components/issue-filing-choice-group.tsx
+++ b/src/issue-filing/components/issue-filing-choice-group.tsx
@@ -24,7 +24,10 @@ export const IssueFilingChoiceGroup = NamedFC<IssueFilingChoiceGroupProps>('Issu
     };
 
     const onChange = (ev?: React.FormEvent<HTMLElement | HTMLInputElement>, option?: IChoiceGroupOption) => {
-        props.onSelectedServiceChange(option.key);
+        const payload = {
+            issueFilingServiceName: option.key,
+        };
+        props.onSelectedServiceChange(payload);
     };
 
     return (

--- a/src/issue-filing/components/issue-filing-settings-container.tsx
+++ b/src/issue-filing/components/issue-filing-settings-container.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
+import { SetIssueFilingServicePropertyPayload } from 'background/actions/action-payloads';
 import { NamedFC } from '../../common/react/named-fc';
 import { IssueFilingServiceProperties } from '../../common/types/store-data/user-configuration-store';
 import { SettingsDeps } from '../../DetailsView/components/settings-panel/settings/settings-props';
@@ -9,7 +10,7 @@ import { IssueFilingServiceProvider } from '../issue-filing-service-provider';
 import { IssueFilingService } from '../types/issue-filing-service';
 import { IssueFilingChoiceGroup } from './issue-filing-choice-group';
 
-export type OnPropertyUpdateCallback = (bugService: string, propertyName: string, propertyValue: string) => void;
+export type OnPropertyUpdateCallback = (payload: SetIssueFilingServicePropertyPayload) => void;
 export type OnSelectedServiceChange = (service: string) => void;
 
 export interface IssueFilingSettingsContainerProps {

--- a/src/issue-filing/components/issue-filing-settings-container.tsx
+++ b/src/issue-filing/components/issue-filing-settings-container.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { SetIssueFilingServicePayload, SetIssueFilingServicePropertyPayload } from 'background/actions/action-payloads';
 import * as React from 'react';
 
-import { SetIssueFilingServicePropertyPayload } from 'background/actions/action-payloads';
 import { NamedFC } from '../../common/react/named-fc';
 import { IssueFilingServiceProperties } from '../../common/types/store-data/user-configuration-store';
 import { SettingsDeps } from '../../DetailsView/components/settings-panel/settings/settings-props';
@@ -11,7 +11,7 @@ import { IssueFilingService } from '../types/issue-filing-service';
 import { IssueFilingChoiceGroup } from './issue-filing-choice-group';
 
 export type OnPropertyUpdateCallback = (payload: SetIssueFilingServicePropertyPayload) => void;
-export type OnSelectedServiceChange = (service: string) => void;
+export type OnSelectedServiceChange = (payload: SetIssueFilingServicePayload) => void;
 
 export interface IssueFilingSettingsContainerProps {
     deps: IssueFilingSettingsContainerDeps;

--- a/src/issue-filing/services/azure-boards/azure-boards-settings-form.tsx
+++ b/src/issue-filing/services/azure-boards/azure-boards-settings-form.tsx
@@ -22,12 +22,22 @@ export const AzureBoardsSettingsForm = NamedFC<SettingsFormProps<AzureBoardsIssu
 
     const onProjectURLChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const propertyName: keyof AzureBoardsIssueFilingSettings = 'projectURL';
-        props.onPropertyUpdateCallback(AzureBoardsIssueFilingService.key, propertyName, newValue);
+        const payload = {
+            issueFilingServiceName: AzureBoardsIssueFilingService.key,
+            propertyName,
+            propertyValue: newValue,
+        };
+        props.onPropertyUpdateCallback(payload);
     };
 
     const onIssueDetailLocationChange = (event: React.FormEvent<HTMLElement>, newValue: IDropdownOption) => {
         const propertyName: keyof AzureBoardsIssueFilingSettings = 'issueDetailsField';
-        props.onPropertyUpdateCallback(AzureBoardsIssueFilingService.key, propertyName, newValue.key as AzureBoardsIssueDetailField);
+        const payload = {
+            issueFilingServiceName: AzureBoardsIssueFilingService.key,
+            propertyName,
+            propertyValue: newValue.key as AzureBoardsIssueDetailField,
+        };
+        props.onPropertyUpdateCallback(payload);
     };
 
     return (

--- a/src/issue-filing/services/github/github-issue-filing-service.tsx
+++ b/src/issue-filing/services/github/github-issue-filing-service.tsx
@@ -27,7 +27,12 @@ function isSettingsValid(data: GitHubIssueFilingSettings): boolean {
 const settingsForm = NamedFC<SettingsFormProps<GitHubIssueFilingSettings>>('IssueFilingSettings', props => {
     const onGitHubRepositoryChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
         const propertyName: keyof GitHubIssueFilingSettings = 'repository';
-        props.onPropertyUpdateCallback(GitHubIssueFilingServiceKey, propertyName, newValue);
+        const payload = {
+            issueFilingServiceName: GitHubIssueFilingServiceKey,
+            propertyName,
+            propertyValue: newValue,
+        };
+        props.onPropertyUpdateCallback(payload);
     };
 
     return (

--- a/src/issue-filing/types/settings-form-props.ts
+++ b/src/issue-filing/types/settings-form-props.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SettingsDeps } from './../../DetailsView/components/settings-panel/settings/settings-props';
+import { SetIssueFilingServicePropertyPayload } from 'background/actions/action-payloads';
+import { SettingsDeps } from 'DetailsView/components/settings-panel/settings/settings-props';
 
 export type SettingsFormProps<Settings> = {
     deps: SettingsDeps;
     settings: Settings;
-    onPropertyUpdateCallback: (bugService: string, propertyName: string, propertyValue: string) => void;
+    onPropertyUpdateCallback: (payload: SetIssueFilingServicePropertyPayload) => void;
 };

--- a/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
@@ -4,6 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
+import { SetIssueFilingServicePayload } from 'background/actions/action-payloads';
 import { EnvironmentInfo, EnvironmentInfoProvider } from '../../../../../common/environment-info-provider';
 import { IssueFilingActionMessageCreator } from '../../../../../common/message-creators/issue-filing-action-message-creator';
 import { UserConfigMessageCreator } from '../../../../../common/message-creators/user-config-message-creator';
@@ -204,7 +205,10 @@ describe('IssueFilingDialog', () => {
 
         const testSubject = shallow(<IssueFilingDialog {...props} />);
         const issueFilingSettingsContainer = testSubject.find(IssueFilingSettingsContainer);
-        issueFilingSettingsContainer.props().onSelectedServiceChange(differentServiceKey);
+        const payload = {
+            issueFilingServiceName: differentServiceKey,
+        };
+        issueFilingSettingsContainer.props().onSelectedServiceChange(payload);
 
         expect(testSubject.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
@@ -4,7 +4,6 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
-import { SetIssueFilingServicePayload } from 'background/actions/action-payloads';
 import { EnvironmentInfo, EnvironmentInfoProvider } from '../../../../../common/environment-info-provider';
 import { IssueFilingActionMessageCreator } from '../../../../../common/message-creators/issue-filing-action-message-creator';
 import { UserConfigMessageCreator } from '../../../../../common/message-creators/user-config-message-creator';
@@ -119,7 +118,11 @@ describe('IssueFilingDialog', () => {
     });
 
     it('render: validate correct callbacks to ActionAndCancelButtonsComponent (file issue on click and cancel)', () => {
-        userConfigMessageCreatorMock.setup(ucmcm => ucmcm.saveIssueFilingSettings(serviceKey, selectedServiceData)).verifiable();
+        const payload = {
+            issueFilingServiceName: serviceKey,
+            issueFilingSettings: selectedServiceData,
+        };
+        userConfigMessageCreatorMock.setup(creator => creator.saveIssueFilingSettings(payload)).verifiable();
         issueFilingActionMessageCreatorMock
             .setup(creator => creator.fileIssue(eventStub as any, serviceKey, It.isValue(props.selectedIssueData)))
             .verifiable(Times.once());

--- a/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
@@ -136,14 +136,14 @@ describe('IssueFilingDialog', () => {
 
     it('render: validate callback (onPropertyUpdateCallback) sent to settings container when service settings are null', () => {
         const propertyStub = 'some_property';
-        const propertValueStub = 'some_value';
+        const propertyValueStub = 'some_value';
         const differentServiceKey = 'some_different_key';
 
         const testSubject = shallow(<IssueFilingDialog {...props} />);
         const issueFilingSettingsContainer = testSubject.find(IssueFilingSettingsContainer);
 
         getSettingsFromStoreDataMock.setup(mock => mock(It.isValue(issueFilingServicePropertiesMapStub))).returns(() => null);
-        issueFilingServicePropertiesMapStub[differentServiceKey] = { [propertyStub]: propertValueStub };
+        issueFilingServicePropertiesMapStub[differentServiceKey] = { [propertyStub]: propertyValueStub };
         getSettingsFromStoreDataMock
             .setup(mock => mock(It.isValue(issueFilingServicePropertiesMapStub)))
             .returns(() => issueFilingServicePropertiesMapStub[differentServiceKey]);
@@ -151,24 +151,34 @@ describe('IssueFilingDialog', () => {
             .setup(isSettingsValid => isSettingsValid(issueFilingServicePropertiesMapStub[differentServiceKey]))
             .returns(() => true);
 
-        issueFilingSettingsContainer.props().onPropertyUpdateCallback(differentServiceKey, propertyStub, propertValueStub);
+        const payload = {
+            issueFilingServiceName: differentServiceKey,
+            propertyName: propertyStub,
+            propertyValue: propertyValueStub,
+        };
+        issueFilingSettingsContainer.props().onPropertyUpdateCallback(payload);
 
         expect(testSubject.getElement()).toMatchSnapshot();
     });
 
     it('render: validate callback (onPropertyUpdateCallback) sent to settings container when service settings are not null', () => {
         const propertyStub = 'some_property';
-        const propertValueStub = 'some_value';
+        const propertyValueStub = 'some_value';
         const testSubject = shallow(<IssueFilingDialog {...props} />);
         const issueFilingSettingsContainer = testSubject.find(IssueFilingSettingsContainer);
 
-        issueFilingServicePropertiesMapStub[serviceKey][propertyStub] = propertValueStub;
+        issueFilingServicePropertiesMapStub[serviceKey][propertyStub] = propertyValueStub;
         getSettingsFromStoreDataMock
             .setup(mock => mock(It.isValue(issueFilingServicePropertiesMapStub)))
             .returns(() => issueFilingServicePropertiesMapStub[serviceKey]);
         isSettingsValidMock.setup(isSettingsValid => isSettingsValid(issueFilingServicePropertiesMapStub[serviceKey])).returns(() => true);
 
-        issueFilingSettingsContainer.props().onPropertyUpdateCallback(serviceKey, propertyStub, propertValueStub);
+        const payload = {
+            issueFilingServiceName: serviceKey,
+            propertyName: propertyStub,
+            propertyValue: propertyValueStub,
+        };
+        issueFilingSettingsContainer.props().onPropertyUpdateCallback(payload);
 
         expect(testSubject.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
@@ -96,7 +96,7 @@ describe('UserConfigMessageCreator', () => {
             payload,
         };
 
-        testSubject.saveIssueFilingSettings(issueFilingServiceName, issueFilingSettings);
+        testSubject.saveIssueFilingSettings(payload);
 
         dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });

--- a/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
@@ -63,7 +63,7 @@ describe('UserConfigMessageCreator', () => {
             payload,
         };
 
-        testSubject.setIssueFilingService(issueFilingServiceName);
+        testSubject.setIssueFilingService(payload);
 
         dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });

--- a/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
@@ -79,7 +79,7 @@ describe('UserConfigMessageCreator', () => {
             payload,
         };
 
-        testSubject.setIssueFilingServiceProperty(payload.issueFilingServiceName, payload.propertyName, payload.propertyValue);
+        testSubject.setIssueFilingServiceProperty(payload);
 
         dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });

--- a/src/tests/unit/tests/issue-filing/components/issue-filing-option-choice-group.test.tsx
+++ b/src/tests/unit/tests/issue-filing/components/issue-filing-option-choice-group.test.tsx
@@ -5,6 +5,7 @@ import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/Choi
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
+import { SetIssueFilingServicePayload } from 'background/actions/action-payloads';
 import { IssueFilingChoiceGroup, IssueFilingChoiceGroupProps } from '../../../../../issue-filing/components/issue-filing-choice-group';
 import { OnSelectedServiceChange } from '../../../../../issue-filing/components/issue-filing-settings-container';
 import { IssueFilingService } from '../../../../../issue-filing/types/issue-filing-service';
@@ -45,7 +46,11 @@ describe('IssueFilingChoiceGroupTest', () => {
             onSelectedServiceChange: onServiceChangeMock.object,
         };
 
-        onServiceChangeMock.setup(u => u(testOption.key)).verifiable(Times.once());
+        const payload: SetIssueFilingServicePayload = {
+            issueFilingServiceName: testOption.key,
+        };
+
+        onServiceChangeMock.setup(u => u(payload)).verifiable(Times.once());
 
         const wrapper = shallow(<IssueFilingChoiceGroup {...props} />);
         wrapper

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-settings-form.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-settings-form.test.tsx
@@ -6,7 +6,6 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
-import { SetIssueFilingServicePropertyPayload } from 'background/actions/action-payloads';
 import { SettingsDeps } from '../../../../../../DetailsView/components/settings-panel/settings/settings-props';
 import { OnPropertyUpdateCallback } from '../../../../../../issue-filing/components/issue-filing-settings-container';
 import { AzureBoardsIssueFilingService } from '../../../../../../issue-filing/services/azure-boards/azure-boards-issue-filing-service';

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-settings-form.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-settings-form.test.tsx
@@ -6,6 +6,7 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
+import { SetIssueFilingServicePropertyPayload } from 'background/actions/action-payloads';
 import { SettingsDeps } from '../../../../../../DetailsView/components/settings-panel/settings/settings-props';
 import { OnPropertyUpdateCallback } from '../../../../../../issue-filing/components/issue-filing-settings-container';
 import { AzureBoardsIssueFilingService } from '../../../../../../issue-filing/services/azure-boards/azure-boards-issue-filing-service';
@@ -54,9 +55,12 @@ describe('AzureBoardsSettingsForm', () => {
             const newProjectUrl = 'a different project URL';
 
             const projectUrlProperty: keyof AzureBoardsIssueFilingSettings = 'projectURL';
-            onPropertyUpdateCallbackMock
-                .setup(mock => mock(AzureBoardsIssueFilingService.key, projectUrlProperty, newProjectUrl))
-                .verifiable(Times.once());
+            const payload = {
+                issueFilingServiceName: AzureBoardsIssueFilingService.key,
+                propertyName: projectUrlProperty,
+                propertyValue: newProjectUrl,
+            };
+            onPropertyUpdateCallbackMock.setup(updateCallback => updateCallback(payload)).verifiable(Times.once());
 
             const testSubject = shallow(<AzureBoardsSettingsForm {...props} />);
 
@@ -69,9 +73,12 @@ describe('AzureBoardsSettingsForm', () => {
             const newIssueDetailsFieldKey = 'a-different-field-key';
 
             const issueDetailsFieldProperty: keyof AzureBoardsIssueFilingSettings = 'issueDetailsField';
-            onPropertyUpdateCallbackMock
-                .setup(mock => mock(AzureBoardsIssueFilingService.key, issueDetailsFieldProperty, newIssueDetailsFieldKey))
-                .verifiable(Times.once());
+            const payload = {
+                issueFilingServiceName: AzureBoardsIssueFilingService.key,
+                propertyName: issueDetailsFieldProperty,
+                propertyValue: newIssueDetailsFieldKey,
+            };
+            onPropertyUpdateCallbackMock.setup(updateCallback => updateCallback(payload)).verifiable(Times.once());
 
             const testSubject = shallow(<AzureBoardsSettingsForm {...props} />);
 

--- a/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
@@ -3,8 +3,9 @@
 import { shallow } from 'enzyme';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
+import { SetIssueFilingServicePropertyPayload } from 'background/actions/action-payloads';
 import { IssueFilingServicePropertiesMap } from '../../../../../../common/types/store-data/user-configuration-store';
 import { SettingsDeps } from '../../../../../../DetailsView/components/settings-panel/settings/settings-props';
 import { OnPropertyUpdateCallback } from '../../../../../../issue-filing/components/issue-filing-settings-container';
@@ -89,11 +90,17 @@ describe('GithubIssueFilingServiceTest', () => {
         it('onChange', () => {
             const Component = GitHubIssueFilingService.settingsForm;
             const wrapper = shallow(<Component {...props} />);
-            onPropertyUpdateCallbackMock.setup(mock => mock('gitHub', 'repository', 'new value')).verifiable(Times.once());
+            const newRepositoryValue = 'new repo';
+            const payload = {
+                issueFilingServiceName: GitHubIssueFilingService.key,
+                propertyName: 'repository',
+                propertyValue: newRepositoryValue,
+            };
+            onPropertyUpdateCallbackMock.setup(updateCallback => updateCallback(It.isValue(payload))).verifiable(Times.once());
             wrapper
                 .find(TextField)
                 .props()
-                .onChange(null, 'new value');
+                .onChange(null, newRepositoryValue);
             onPropertyUpdateCallbackMock.verifyAll();
         });
     });

--- a/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
@@ -5,7 +5,6 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
 
-import { SetIssueFilingServicePropertyPayload } from 'background/actions/action-payloads';
 import { IssueFilingServicePropertiesMap } from '../../../../../../common/types/store-data/user-configuration-store';
 import { SettingsDeps } from '../../../../../../DetailsView/components/settings-panel/settings/settings-props';
 import { OnPropertyUpdateCallback } from '../../../../../../issue-filing/components/issue-filing-settings-container';


### PR DESCRIPTION
#### Description of changes

We'll be using `CardsView` component on AI-Android. Deed down the `CardsViewDeps`, we're going to use the `UserConfigMessageCreator` issue filining-related functions so we need the **Message Creator** API to match that of the **Action Creator** so we can use them indistinctly on the UI.

**NOTES**
This are the componets use (directly) by `CardsView` that have the `UserCOnfigMessageCreator` as a dep:
- `IssueFilingDialog` uses `saveIssueFilingSettings`
- `IssueFilingSettingsContainer` uses `setIssueFilingService` and `setIssueFilingServiceProperty`

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1610159
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
