### PR TITLE
feat(card-selection): pass card selection store to details view initializer

### DIFF
--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import * as React from 'react';
+
 import { ThemeDeps } from '../common/components/theme';
 import { withStoreSubscription, WithStoreSubscriptionDeps } from '../common/components/with-store-subscription';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -76,6 +78,7 @@ export interface DetailsViewContainerState {
     userConfigurationStoreData: UserConfigurationStoreData;
     selectedDetailsView: VisualizationType;
     selectedDetailsRightPanelConfiguration: DetailsRightPanelConfiguration;
+    cardSelectionStoreData: CardSelectionStoreData;
 }
 
 export class DetailsViewContainer extends React.Component<DetailsViewContainerProps> {
@@ -201,6 +204,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
                 userConfigurationStoreData={storeState.userConfigurationStoreData}
                 ruleResultsByStatus={ruleResults}
                 targetAppInfo={storeState.unifiedScanResultStoreData.targetAppInfo}
+                cardSelectionStoreData={storeState.cardSelectionStoreData}
             />
         );
     }

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -4,8 +4,8 @@ import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-defaul
 import { Assessments } from 'assessments/assessments';
 import { assessmentsProviderWithFeaturesEnabled } from 'assessments/assessments-feature-flag-filter';
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
-import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { loadTheme } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
 import { AssessmentReportHtmlGenerator } from 'reports/assessment-report-html-generator';
@@ -140,7 +140,7 @@ if (isNaN(tabId) === false) {
                 StoreNames[StoreNames.UserConfigurationStore],
                 browserAdapter,
             );
-            const cardSelectionStore = new StoreProxy<CardSelectionStore>(StoreNames[StoreNames.CardSelectionStore], browserAdapter);
+            const cardSelectionStore = new StoreProxy<CardSelectionStoreData>(StoreNames[StoreNames.CardSelectionStore], browserAdapter);
 
             const storesHub = new BaseClientStoresHub<DetailsViewContainerState>([
                 detailsViewStore,

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -4,6 +4,7 @@ import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-defaul
 import { Assessments } from 'assessments/assessments';
 import { assessmentsProviderWithFeaturesEnabled } from 'assessments/assessments-feature-flag-filter';
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
+import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { loadTheme } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
@@ -139,6 +140,8 @@ if (isNaN(tabId) === false) {
                 StoreNames[StoreNames.UserConfigurationStore],
                 browserAdapter,
             );
+            const cardSelectionStore = new StoreProxy<CardSelectionStore>(StoreNames[StoreNames.CardSelectionStore], browserAdapter);
+
             const storesHub = new BaseClientStoresHub<DetailsViewContainerState>([
                 detailsViewStore,
                 featureFlagStore,
@@ -150,6 +153,7 @@ if (isNaN(tabId) === false) {
                 pathSnippetStore,
                 scopingStore,
                 userConfigStore,
+                cardSelectionStore,
             ]);
 
             const actionMessageDispatcher = new ActionMessageDispatcher(browserAdapter.sendMessageToFrames, tab.id);

--- a/src/background/actions/card-selection-action-creator.ts
+++ b/src/background/actions/card-selection-action-creator.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as TelemetryEvents from '../../common/extension-telemetry-events';
+import { StoreNames } from 'common/stores/store-names';
 
-import { Messages } from '../../common/messages';
+import * as TelemetryEvents from '../../common/extension-telemetry-events';
+import { getStoreStateMessage, Messages } from '../../common/messages';
 import { CardSelectionActions } from '../actions/card-selection-actions';
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
@@ -17,7 +18,12 @@ export class CardSelectionActionCreator {
 
     public registerCallbacks(): void {
         this.interpreter.registerTypeToPayloadCallback(Messages.CardSelection.CardSelectionToggled, this.onCardSelectionToggle);
+        this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.CardSelectionStore), this.onGetCurrentState);
     }
+
+    private onGetCurrentState = (): void => {
+        this.cardSelectionActions.getCurrentState.invoke(null);
+    };
 
     private onCardSelectionToggle = (payload: CardSelectionPayload): void => {
         this.cardSelectionActions.toggleCardSelection.invoke(payload);

--- a/src/background/actions/card-selection-actions.ts
+++ b/src/background/actions/card-selection-actions.ts
@@ -4,6 +4,7 @@ import { Action } from '../../common/flux/action';
 import { CardSelectionPayload, RuleExpandCollapsePayload } from './action-payloads';
 
 export class CardSelectionActions {
+    public readonly getCurrentState = new Action();
     public readonly toggleRuleExpandCollapse = new Action<RuleExpandCollapsePayload>();
     public readonly toggleCardSelection = new Action<CardSelectionPayload>();
     public readonly collapseAllRules = new Action();

--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -20,6 +20,7 @@ export class CardSelectionStore extends BaseStoreImpl<CardSelectionStoreData> {
         this.cardSelectionActions.toggleRuleExpandCollapse.addListener(this.toggleRuleExpandCollapse);
         this.cardSelectionActions.toggleCardSelection.addListener(this.toggleCardSelection);
         this.cardSelectionActions.collapseAllRules.addListener(this.collapseAllRules);
+        this.cardSelectionActions.getCurrentState.addListener(this.onGetCurrentState);
         this.unifiedScanResultActions.scanCompleted.addListener(this.onScanCompleted);
     }
 

--- a/src/common/rule-based-view-model-provider.ts
+++ b/src/common/rule-based-view-model-provider.ts
@@ -5,10 +5,10 @@ import { UnifiedResult, UnifiedRule } from './types/store-data/unified-data-inte
 
 export type GetUnifiedRuleResultsDelegate = (rules: UnifiedRule[], results: UnifiedResult[]) => CardRuleResultsByStatus;
 
-export const getUnifiedRuleResults: GetUnifiedRuleResultsDelegate = function(
+export const getUnifiedRuleResults: GetUnifiedRuleResultsDelegate = (
     rules: UnifiedRule[],
     results: UnifiedResult[],
-): CardRuleResultsByStatus {
+): CardRuleResultsByStatus => {
     if (results == null || rules == null) {
         return null;
     }
@@ -41,7 +41,7 @@ export const getUnifiedRuleResults: GetUnifiedRuleResultsDelegate = function(
     return statusResults;
 };
 
-function getEmptyStatusResults(): CardRuleResultsByStatus {
+const getEmptyStatusResults = (): CardRuleResultsByStatus => {
     const statusResults = {};
 
     AllRuleResultStatuses.forEach(status => {
@@ -49,34 +49,27 @@ function getEmptyStatusResults(): CardRuleResultsByStatus {
     });
 
     return statusResults as CardRuleResultsByStatus;
-}
+};
 
-function createUnifiedRuleResult(result: UnifiedResult, rule: UnifiedRule): CardRuleResult {
-    return {
-        id: rule.id,
-        status: result.status,
-        nodes: [result],
-        description: rule.description,
-        url: rule.url,
-        guidance: rule.guidance,
-    };
-}
+const createUnifiedRuleResult = (result: UnifiedResult, rule: UnifiedRule): CardRuleResult => ({
+    id: rule.id,
+    status: result.status,
+    nodes: [result],
+    description: rule.description,
+    url: rule.url,
+    guidance: rule.guidance,
+});
 
-function createRuleResultWithoutNodes(status: CardRuleResultStatus, rule: UnifiedRule): CardRuleResult {
-    return {
-        id: rule.id,
-        status: status,
-        nodes: [],
-        description: rule.description,
-        url: rule.url,
-        guidance: rule.guidance,
-    };
-}
+const createRuleResultWithoutNodes = (status: CardRuleResultStatus, rule: UnifiedRule): CardRuleResult => ({
+    id: rule.id,
+    status: status,
+    nodes: [],
+    description: rule.description,
+    url: rule.url,
+    guidance: rule.guidance,
+});
 
-function getUnifiedRule(id: string, rules: UnifiedRule[]): UnifiedRule {
-    return rules.find(rule => rule.id === id);
-}
+const getUnifiedRule = (id: string, rules: UnifiedRule[]): UnifiedRule => rules.find(rule => rule.id === id);
 
-function getRuleResultIndex(result: UnifiedResult, ruleResults: CardRuleResult[]): number {
-    return ruleResults.findIndex(ruleResult => ruleResult.id === result.ruleId);
-}
+const getRuleResultIndex = (result: UnifiedResult, ruleResults: CardRuleResult[]): number =>
+    ruleResults.findIndex(ruleResult => ruleResult.id === result.ruleId);

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -261,6 +261,7 @@ describe('DetailsViewContainer', () => {
                         scopingPanelStateStoreData: storeMocks.scopingStoreData,
                         userConfigurationStoreData: storeMocks.userConfigurationStoreData,
                         unifiedScanResultStoreData: storeMocks.unifiedScanResultStoreData,
+                        cardSelectionStoreData: storeMocks.cardSelectionStoreData,
                     }
                 );
             });
@@ -299,6 +300,7 @@ describe('DetailsViewContainer', () => {
                 userConfigurationStoreData={storeMocks.userConfigurationStoreData}
                 ruleResultsByStatus={ruleResults}
                 targetAppInfo={targetApp}
+                cardSelectionStoreData={storeMocks.cardSelectionStoreData}
             />
         );
     }
@@ -367,6 +369,7 @@ describe('DetailsViewContainer', () => {
             unifiedScanResultStoreData: storeMocks.unifiedScanResultStoreData,
             selectedDetailsView: viewType,
             selectedDetailsRightPanelConfiguration: rightPanel,
+            cardSelectionStoreData: storeMocks.cardSelectionStoreData,
         };
     }
 

--- a/src/tests/unit/tests/DetailsView/store-mocks.ts
+++ b/src/tests/unit/tests/DetailsView/store-mocks.ts
@@ -4,6 +4,7 @@ import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
 import { AssessmentDataConverter } from 'background/assessment-data-converter';
 import { ScopingInputTypes } from 'background/scoping-input-types';
 import { AssessmentStore } from 'background/stores/assessment-store';
+import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { DetailsViewStore } from 'background/stores/details-view-store';
 import { CommandStore } from 'background/stores/global/command-store';
 import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
@@ -15,7 +16,9 @@ import { PathSnippetStore } from 'background/stores/path-snippet-store';
 import { TabStore } from 'background/stores/tab-store';
 import { VisualizationScanResultStore } from 'background/stores/visualization-scan-result-store';
 import { VisualizationStore } from 'background/stores/visualization-store';
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { It, Mock, MockBehavior } from 'typemoq';
+
 import { UnifiedScanResultStore } from '../../../../background/stores/unified-scan-result-store';
 import { FeatureFlags } from '../../../../common/feature-flags';
 import { AssessmentStoreData } from '../../../../common/types/store-data/assessment-result-data';
@@ -72,6 +75,8 @@ export class StoreMocks {
         [FeatureFlags[FeatureFlags.logTelemetryToConsole]]: false,
     };
     public assessmentStoreData: AssessmentStoreData;
+
+    public cardSelectionStoreData = new CardSelectionStore(null, null).getDefaultState();
 
     constructor() {
         this.assessmentsProviderMock.setup(ap => ap.all()).returns(() => []);
@@ -134,6 +139,11 @@ export class StoreMocks {
 
     public setUserConfigurationStoreData(data: UserConfigurationStoreData): StoreMocks {
         this.userConfigurationStoreData = data;
+        return this;
+    }
+
+    public setCardSelectionStoreData(data: CardSelectionStoreData): StoreMocks {
+        this.cardSelectionStoreData = data;
         return this;
     }
 


### PR DESCRIPTION
#### Description of changes

Link details-view-initializer with card selection store.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
