### PR TITLE
fix(report-cards): prevent clicks on card content from collapsing rule groups

### DIFF
--- a/src/reports/components/report-sections/collapsible-script-provider.tsx
+++ b/src/reports/components/report-sections/collapsible-script-provider.tsx
@@ -4,9 +4,9 @@ export const addEventListenerForCollapsibleSection = (doc: Document) => {
     const collapsibles = doc.getElementsByClassName('collapsible-container');
 
     for (let index = 0; index < collapsibles.length; index++) {
-        const self = collapsibles.item(index);
-        self.addEventListener('click', () => {
-            const button = self.querySelector('.collapsible-control');
+        const container = collapsibles.item(index);
+        const button = container.querySelector('.collapsible-control');
+        button.addEventListener('click', () => {
             const content = button.parentElement.nextElementSibling as HTMLElement;
             const wasExpandedBefore = button.getAttribute('aria-expanded') === 'false' ? false : true;
             const isExpandedAfter = !wasExpandedBefore;
@@ -15,9 +15,9 @@ export const addEventListenerForCollapsibleSection = (doc: Document) => {
             content.setAttribute('aria-hidden', !isExpandedAfter + '');
 
             if (isExpandedAfter) {
-                self.classList.remove('collapsed');
+                container.classList.remove('collapsed');
             } else {
-                self.classList.add('collapsed');
+                container.classList.add('collapsed');
             }
         });
     }

--- a/src/tests/unit/tests/reports/components/report-sections/collapsible-script-provider.test.ts
+++ b/src/tests/unit/tests/reports/components/report-sections/collapsible-script-provider.test.ts
@@ -30,17 +30,19 @@ describe('CollapsibleScriptProvider', () => {
         collapsibleParentMock.setup(parent => parent.nextElementSibling).returns(() => collapsibleNextSiblingMock.object);
 
         const collapsibleContainerMock = Mock.ofType<Element>();
-        const collapsibleElementMock = Mock.ofType<Element>();
+        const collapsibleButtonMock = Mock.ofType<Element>();
 
-        collapsibleElementMock.setup(collapsible => collapsible.parentElement).returns(() => collapsibleParentMock.object);
-
-        collapsibleElementMock.setup(collapsible => collapsible.getAttribute('aria-expanded')).returns(() => isExpandedString);
-
-        collapsibleContainerMock.setup(ccm => ccm.addEventListener('click', It.is(isFunction))).callback((event, listener) => listener());
+        let registeredButtonClickHandler: Function = null;
+        collapsibleButtonMock
+            .setup(ccm => ccm.addEventListener('click', It.is(isFunction)))
+            .callback((event, listener) => {
+                registeredButtonClickHandler = listener;
+            });
+        collapsibleButtonMock.setup(collapsible => collapsible.parentElement).returns(() => collapsibleParentMock.object);
+        collapsibleButtonMock.setup(collapsible => collapsible.getAttribute('aria-expanded')).returns(() => isExpandedString);
 
         collapsibleContainerMock.setup(ccm => ccm.classList).returns(() => classListMock.object);
-
-        collapsibleContainerMock.setup(ccm => ccm.querySelector('.collapsible-control')).returns(() => collapsibleElementMock.object);
+        collapsibleContainerMock.setup(ccm => ccm.querySelector('.collapsible-control')).returns(() => collapsibleButtonMock.object);
 
         const docMock = Mock.ofType<Document>(undefined, MockBehavior.Strict);
         docMock
@@ -49,8 +51,12 @@ describe('CollapsibleScriptProvider', () => {
 
         addEventListenerForCollapsibleSection(docMock.object);
 
-        collapsibleElementMock.verify(collapsible => collapsible.setAttribute('aria-expanded', isHiddenString), Times.once());
+        collapsibleButtonMock.verify(ccm => ccm.addEventListener('click', It.is(isFunction)), Times.once());
+        collapsibleContainerMock.verify(ccm => ccm.addEventListener('click', It.is(isFunction)), Times.never());
 
+        registeredButtonClickHandler();
+
+        collapsibleButtonMock.verify(collapsible => collapsible.setAttribute('aria-expanded', isHiddenString), Times.once());
         collapsibleNextSiblingMock.verify(sibling => sibling.setAttribute('aria-hidden', isExpandedString), Times.once());
 
         if (isExpanded) {


### PR DESCRIPTION
#### Description of changes

Previously, in the generated reports using the new cards UI, the rule groups were incorrectly collapsing if any content underneath them was clicked, rather than only collapsing when the headers were clicked. This fixes the location of the onClick handler to prevent this behavior.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1444 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
