### PR TITLE
adding title bar support for mac

### DIFF
--- a/src/electron/flux/types/window-state-store-data.ts
+++ b/src/electron/flux/types/window-state-store-data.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 export type ViewRoutes = 'deviceConnectView' | 'resultsView';
-export type WindowStates = 'customSize' | 'maximized' | 'minimized';
+export type WindowStates = 'customSize' | 'maximized' | 'fullScreen';
 
 export interface WindowStateStoreData {
     routeId: ViewRoutes;

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -32,11 +32,11 @@ const createWindow = () => {
 };
 
 const enableDevMode = (window: BrowserWindow) => {
-    // if (process.env.DEV_MODE === 'true') {
-    window.webContents.openDevTools({
-        mode: 'detach',
-    });
-    // }
+    if (process.env.DEV_MODE === 'true') {
+        window.webContents.openDevTools({
+            mode: 'detach',
+        });
+    }
 };
 
 app.on('ready', createWindow);

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -2,17 +2,22 @@
 // Licensed under the MIT License.
 import { app, BrowserWindow } from 'electron';
 import * as path from 'path';
+import { PlatformInfo, OSType } from 'electron/platform-info';
 
 let mainWindow: BrowserWindow;
-
+let platformInfo = new PlatformInfo(process);
 const createWindow = () => {
+    const os = platformInfo.getOs();
     mainWindow = new BrowserWindow({
         show: false,
         webPreferences: { nodeIntegration: true },
-        frame: false,
+        titleBarStyle: 'hidden',
         width: 600,
         height: 391,
+        frame: os == OSType.Mac ? true : false,
     });
+    mainWindow.setMenuBarVisibility(false);
+    mainWindow.setSheetOffset(22);
 
     mainWindow
         .loadFile(path.resolve(__dirname, '../electron/views/index.html'))
@@ -27,11 +32,11 @@ const createWindow = () => {
 };
 
 const enableDevMode = (window: BrowserWindow) => {
-    if (process.env.DEV_MODE === 'true') {
-        window.webContents.openDevTools({
-            mode: 'detach',
-        });
-    }
+    // if (process.env.DEV_MODE === 'true') {
+    window.webContents.openDevTools({
+        mode: 'detach',
+    });
+    // }
 };
 
 app.on('ready', createWindow);

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { app, BrowserWindow } from 'electron';
+import { OSType, PlatformInfo } from 'electron/platform-info';
 import * as path from 'path';
-import { PlatformInfo, OSType } from 'electron/platform-info';
 
 let mainWindow: BrowserWindow;
-let platformInfo = new PlatformInfo(process);
+const platformInfo = new PlatformInfo(process);
 const createWindow = () => {
     const os = platformInfo.getOs();
     mainWindow = new BrowserWindow({
@@ -14,7 +14,7 @@ const createWindow = () => {
         titleBarStyle: 'hidden',
         width: 600,
         height: 391,
-        frame: os == OSType.Mac ? true : false,
+        frame: os === OSType.Mac ? true : false,
     });
     mainWindow.setMenuBarVisibility(false);
     mainWindow.setSheetOffset(22);

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -16,8 +16,10 @@ const createWindow = () => {
         height: 391,
         frame: os === OSType.Mac ? true : false,
     });
-    mainWindow.setMenuBarVisibility(false);
-    mainWindow.setSheetOffset(22);
+    if (platformInfo.isMac()) {
+        // We need this so that if there are any system dialog, they will not be placed on top of the title bar.
+        mainWindow.setSheetOffset(22);
+    }
 
     mainWindow
         .loadFile(path.resolve(__dirname, '../electron/views/index.html'))

--- a/src/electron/platform-info.ts
+++ b/src/electron/platform-info.ts
@@ -1,19 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 export enum OSType {
     Windows,
     Linux,
-    Mac
+    Mac,
 }
 export class PlatformInfo {
-    constructor(private readonly currentProcess: NodeJS.Process) { }
+    constructor(private readonly currentProcess: NodeJS.Process) {}
 
     public getOs(): OSType {
-        if (this.currentProcess.platform === "win32") {
-            return OSType.Windows
-        }
-        else if (this.currentProcess.platform === "linux") {
+        if (this.currentProcess.platform === 'win32') {
+            return OSType.Windows;
+        } else if (this.currentProcess.platform === 'linux') {
             return OSType.Linux;
-        }
-        else if (this.currentProcess.platform === "darwin") {
+        } else if (this.currentProcess.platform === 'darwin') {
             return OSType.Mac;
         }
 

--- a/src/electron/platform-info.ts
+++ b/src/electron/platform-info.ts
@@ -1,0 +1,26 @@
+export enum OSType {
+    Windows,
+    Linux,
+    Mac
+}
+export class PlatformInfo {
+    constructor(private readonly currentProcess: NodeJS.Process) { }
+
+    public getOs(): OSType {
+        if (this.currentProcess.platform === "win32") {
+            return OSType.Windows
+        }
+        else if (this.currentProcess.platform === "linux") {
+            return OSType.Linux;
+        }
+        else if (this.currentProcess.platform === "darwin") {
+            return OSType.Mac;
+        }
+
+        return null;
+    }
+
+    public isMac(): boolean {
+        return this.getOs() === OSType.Mac;
+    }
+}

--- a/src/electron/views/automated-checks/components/title-bar.tsx
+++ b/src/electron/views/automated-checks/components/title-bar.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserWindow } from 'electron';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
@@ -24,8 +23,7 @@ export interface TitleBarProps {
 export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps) => {
     const minimize = () => props.deps.windowFrameActionCreator.minimize();
     const maximizeOrRestore = () =>
-        props.windowStateStoreData.currentWindowState === 'maximized' ||
-            props.windowStateStoreData.currentWindowState === "fullScreen"
+        props.windowStateStoreData.currentWindowState === 'maximized' || props.windowStateStoreData.currentWindowState === 'fullScreen'
             ? props.deps.windowFrameActionCreator.restore()
             : props.deps.windowFrameActionCreator.maximize();
 
@@ -65,7 +63,13 @@ export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps
     ];
 
     return (
-        <WindowTitle title={brand} actionableIcons={icons} windowStateStoreData={props.windowStateStoreData} deps={props.deps} className={titleBar}>
+        <WindowTitle
+            title={brand}
+            actionableIcons={icons}
+            windowStateStoreData={props.windowStateStoreData}
+            deps={props.deps}
+            className={titleBar}
+        >
             <BrandWhite />
         </WindowTitle>
     );

--- a/src/electron/views/automated-checks/components/title-bar.tsx
+++ b/src/electron/views/automated-checks/components/title-bar.tsx
@@ -8,14 +8,13 @@ import { NamedFC } from 'common/react/named-fc';
 import { brand } from 'content/strings/application';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
-import { WindowTitle } from 'electron/views/device-connect-view/components/window-title';
+import { WindowTitle, WindowTitleDeps } from 'electron/views/device-connect-view/components/window-title';
 import { BrandWhite } from 'icons/brand/white/brand-white';
 import { titleBar } from './title-bar.scss';
 
 export type TitleBarDeps = {
-    currentWindow: BrowserWindow;
     windowFrameActionCreator: WindowFrameActionCreator;
-};
+} & WindowTitleDeps;
 
 export interface TitleBarProps {
     deps: TitleBarDeps;
@@ -25,7 +24,8 @@ export interface TitleBarProps {
 export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps) => {
     const minimize = () => props.deps.windowFrameActionCreator.minimize();
     const maximizeOrRestore = () =>
-        props.windowStateStoreData.currentWindowState === 'maximized'
+        props.windowStateStoreData.currentWindowState === 'maximized' ||
+            props.windowStateStoreData.currentWindowState === "fullScreen"
             ? props.deps.windowFrameActionCreator.restore()
             : props.deps.windowFrameActionCreator.maximize();
 
@@ -65,7 +65,7 @@ export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps
     ];
 
     return (
-        <WindowTitle title={brand} actionableIcons={icons} className={titleBar}>
+        <WindowTitle title={brand} actionableIcons={icons} windowStateStoreData={props.windowStateStoreData} deps={props.deps} className={titleBar}>
             <BrandWhite />
         </WindowTitle>
     );

--- a/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
@@ -9,20 +9,22 @@ import * as React from 'react';
 import { NamedFC } from 'common/react/named-fc';
 import { DeviceStoreData } from '../../../flux/types/device-store-data';
 import { DeviceConnectBody, DeviceConnectBodyDeps } from './device-connect-body';
-import { WindowTitle } from './window-title';
+import { WindowTitle, WindowTitleDeps } from './window-title';
+import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 
-export type DeviceConnectViewContainerDeps = TelemetryPermissionDialogDeps & DeviceConnectBodyDeps;
+export type DeviceConnectViewContainerDeps = TelemetryPermissionDialogDeps & DeviceConnectBodyDeps & WindowTitleDeps;
 
 export type DeviceConnectViewContainerProps = {
     deps: DeviceConnectViewContainerDeps;
     userConfigurationStoreData: UserConfigurationStoreData;
     deviceStoreData: DeviceStoreData;
+    windowStateStoreData: WindowStateStoreData;
 };
 
 export const DeviceConnectViewContainer = NamedFC<DeviceConnectViewContainerProps>('DeviceConnectViewContainer', props => {
     return (
         <>
-            <WindowTitle title={brand}>
+            <WindowTitle title={brand} deps={props.deps} windowStateStoreData={props.windowStateStoreData}>
                 <BrandBlue />
             </WindowTitle>
             <DeviceConnectBody

--- a/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
@@ -7,10 +7,10 @@ import { BrandBlue } from 'icons/brand/blue/brand-blue';
 import * as React from 'react';
 
 import { NamedFC } from 'common/react/named-fc';
+import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { DeviceStoreData } from '../../../flux/types/device-store-data';
 import { DeviceConnectBody, DeviceConnectBodyDeps } from './device-connect-body';
 import { WindowTitle, WindowTitleDeps } from './window-title';
-import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 
 export type DeviceConnectViewContainerDeps = TelemetryPermissionDialogDeps & DeviceConnectBodyDeps & WindowTitleDeps;
 

--- a/src/electron/views/device-connect-view/components/window-title.scss
+++ b/src/electron/views/device-connect-view/components/window-title.scss
@@ -14,13 +14,13 @@
     .title-container {
         display: flex;
         align-items: center;
-        
+
         > * {
             padding-left: 10px;
         }
     }
 
-    &.mac-window-title{
+    &.mac-window-title {
         height: 22px;
 
         .title-container {

--- a/src/electron/views/device-connect-view/components/window-title.scss
+++ b/src/electron/views/device-connect-view/components/window-title.scss
@@ -9,12 +9,31 @@
     display: flex;
     align-items: center;
     -webkit-app-region: drag;
+    -webkit-user-select: none;
 
     .title-container {
         display: flex;
-
+        align-items: center;
+        
         > * {
             padding-left: 10px;
+        }
+    }
+
+    &.mac-window-title{
+        height: 22px;
+
+        .title-container {
+            padding-left: 60px;
+        }
+
+        .header-text {
+            line-height: 18px;
+            font-size: 12px;
+        }
+
+        .header-icon {
+            height: 12px;
         }
     }
 

--- a/src/electron/views/device-connect-view/components/window-title.tsx
+++ b/src/electron/views/device-connect-view/components/window-title.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { css } from '@uifabric/utilities';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { PlatformInfo } from 'electron/platform-info';
 import { isEmpty } from 'lodash';
@@ -24,13 +25,13 @@ export const WindowTitle = NamedFC<WindowTitleProps>('WindowTitle', (props: Wind
         return null;
     }
 
-    const windowtitleClassNames = [windowTitle, props.className].filter(c => c != null);
+    const windowTitleClassNames = [windowTitle, props.className];
 
     if (props.deps.platformInfo.isMac()) {
-        windowtitleClassNames.push(macWindowTitle);
+        windowTitleClassNames.push(macWindowTitle);
     }
     return (
-        <header className={windowtitleClassNames.join(' ')}>
+        <header className={css(...windowTitleClassNames)}>
             <div className={titleContainer}>
                 {props.children}
                 <h1 className={headerText}>{props.title}</h1>

--- a/src/electron/views/device-connect-view/components/window-title.tsx
+++ b/src/electron/views/device-connect-view/components/window-title.tsx
@@ -3,30 +3,46 @@
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 import { NamedFC } from '../../../../common/react/named-fc';
-import { actionableIconsContainer, headerText, titleContainer, windowTitle } from './window-title.scss';
+import { actionableIconsContainer, headerText, titleContainer, windowTitle, macWindowTitle } from './window-title.scss';
+import { PlatformInfo } from 'electron/platform-info';
+import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 
+export interface WindowTitleDeps {
+    platformInfo: PlatformInfo;
+}
 export interface WindowTitleProps {
+    deps: WindowTitleDeps,
     title: string;
     children?: JSX.Element;
     actionableIcons?: JSX.Element[];
     className?: string;
+    windowStateStoreData: WindowStateStoreData
 }
 
 export const WindowTitle = NamedFC<WindowTitleProps>('WindowTitle', (props: WindowTitleProps) => {
+    if (props.windowStateStoreData.currentWindowState == "fullScreen") {
+        return null;
+    }
+
+    const windowtitleClassNames = [windowTitle, props.className].filter(c => c != null);
+
+    if (props.deps.platformInfo.isMac()) {
+        windowtitleClassNames.push(macWindowTitle);
+    }
     return (
-        <header className={[windowTitle, props.className].filter(c => c != null).join(' ')}>
+        <header className={windowtitleClassNames.join(' ')}>
             <div className={titleContainer}>
                 {props.children}
                 <h1 className={headerText}>{props.title}</h1>
             </div>
-            {getIconsContainer(props.actionableIcons)}
+            {getIconsContainer(props)}
         </header>
     );
 });
 
-function getIconsContainer(icons?: JSX.Element[]): JSX.Element {
-    if (!isEmpty(icons)) {
-        return <div className={actionableIconsContainer}>{icons}</div>;
+function getIconsContainer(props: WindowTitleProps): JSX.Element {
+    if (!props.deps.platformInfo.isMac() && !isEmpty(props.actionableIcons)) {
+        return <div className={actionableIconsContainer}>{props.actionableIcons}</div>;
     }
 
     return null;

--- a/src/electron/views/device-connect-view/components/window-title.tsx
+++ b/src/electron/views/device-connect-view/components/window-title.tsx
@@ -1,26 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
+import { PlatformInfo } from 'electron/platform-info';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 import { NamedFC } from '../../../../common/react/named-fc';
-import { actionableIconsContainer, headerText, titleContainer, windowTitle, macWindowTitle } from './window-title.scss';
-import { PlatformInfo } from 'electron/platform-info';
-import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
+import { actionableIconsContainer, headerText, macWindowTitle, titleContainer, windowTitle } from './window-title.scss';
 
 export interface WindowTitleDeps {
     platformInfo: PlatformInfo;
 }
 export interface WindowTitleProps {
-    deps: WindowTitleDeps,
+    deps: WindowTitleDeps;
     title: string;
     children?: JSX.Element;
     actionableIcons?: JSX.Element[];
     className?: string;
-    windowStateStoreData: WindowStateStoreData
+    windowStateStoreData: WindowStateStoreData;
 }
 
 export const WindowTitle = NamedFC<WindowTitleProps>('WindowTitle', (props: WindowTitleProps) => {
-    if (props.windowStateStoreData.currentWindowState == "fullScreen") {
+    if (props.windowStateStoreData.currentWindowState === 'fullScreen') {
         return null;
     }
 

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -47,6 +47,7 @@ import { DeviceStore } from '../flux/store/device-store';
 import { ElectronLink } from './device-connect-view/components/electron-link';
 import { sendAppInitializedTelemetryEvent } from './device-connect-view/send-app-initialized-telemetry';
 import { RootContainerRenderer } from './root-container/root-container-renderer';
+import { PlatformInfo } from 'electron/platform-info';
 
 initializeFabricIcons();
 
@@ -143,6 +144,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
             storeHub,
             scanActionCreator,
             windowFrameActionCreator,
+            platformInfo: new PlatformInfo(process)
         },
     };
 

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -22,6 +22,7 @@ import * as ReactDOM from 'react-dom';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
 import { ScanStore } from 'electron/flux/store/scan-store';
+import { PlatformInfo } from 'electron/platform-info';
 import { WindowFrameListener } from 'electron/window-frame-listener';
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
@@ -47,7 +48,6 @@ import { DeviceStore } from '../flux/store/device-store';
 import { ElectronLink } from './device-connect-view/components/electron-link';
 import { sendAppInitializedTelemetryEvent } from './device-connect-view/send-app-initialized-telemetry';
 import { RootContainerRenderer } from './root-container/root-container-renderer';
-import { PlatformInfo } from 'electron/platform-info';
 
 initializeFabricIcons();
 
@@ -144,7 +144,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
             storeHub,
             scanActionCreator,
             windowFrameActionCreator,
-            platformInfo: new PlatformInfo(process)
+            platformInfo: new PlatformInfo(process),
         },
     };
 

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -11,12 +11,11 @@ import {
     DeviceConnectViewContainerDeps,
 } from 'electron/views/device-connect-view/components/device-connect-view-container';
 import * as React from 'react';
-import { Helmet } from 'react-helmet';
 
 export type RootContainerDeps = DeviceConnectViewContainerDeps &
     AutomatedChecksViewDeps & {
-    storeHub: ClientStoresHub<RootContainerState>;
-};
+        storeHub: ClientStoresHub<RootContainerState>;
+    };
 
 export type RootContainerProps = {
     deps: RootContainerDeps;

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -11,11 +11,12 @@ import {
     DeviceConnectViewContainerDeps,
 } from 'electron/views/device-connect-view/components/device-connect-view-container';
 import * as React from 'react';
+import { Helmet } from 'react-helmet';
 
 export type RootContainerDeps = DeviceConnectViewContainerDeps &
     AutomatedChecksViewDeps & {
-        storeHub: ClientStoresHub<RootContainerState>;
-    };
+    storeHub: ClientStoresHub<RootContainerState>;
+};
 
 export type RootContainerProps = {
     deps: RootContainerDeps;
@@ -46,7 +47,6 @@ export class RootContainer extends React.Component<RootContainerProps, RootConta
                 />
             );
         }
-
         return (
             <DeviceConnectViewContainer
                 {...{

--- a/src/electron/window-frame-listener.ts
+++ b/src/electron/window-frame-listener.ts
@@ -4,7 +4,7 @@ import { BrowserWindow } from 'electron';
 import { WindowStateActionCreator } from './flux/action-creator/window-state-action-creator';
 
 export class WindowFrameListener {
-    constructor(private readonly windowStateActionsCreator: WindowStateActionCreator, private readonly browserWindow: BrowserWindow) { }
+    constructor(private readonly windowStateActionsCreator: WindowStateActionCreator, private readonly browserWindow: BrowserWindow) {}
 
     public initialize(): void {
         this.browserWindow.on('maximize', this.onMaximize);
@@ -14,21 +14,19 @@ export class WindowFrameListener {
     }
     private onMaximize = (): void => {
         this.windowStateActionsCreator.setWindowState({ currentWindowState: 'maximized' });
-    }
+    };
 
     private onEnterFullScreen = (): void => {
         this.windowStateActionsCreator.setWindowState({ currentWindowState: 'fullScreen' });
-    }
+    };
     private onLeaveFullScreen = (): void => {
         if (this.browserWindow.isMaximized()) {
             this.onMaximize();
-        }
-        else {
+        } else {
             this.onUnMaximize();
         }
-
-    }
+    };
     private onUnMaximize = (): void => {
         this.windowStateActionsCreator.setWindowState({ currentWindowState: 'customSize' });
-    }
+    };
 }

--- a/src/electron/window-frame-listener.ts
+++ b/src/electron/window-frame-listener.ts
@@ -4,21 +4,31 @@ import { BrowserWindow } from 'electron';
 import { WindowStateActionCreator } from './flux/action-creator/window-state-action-creator';
 
 export class WindowFrameListener {
-    constructor(private readonly windowStateActionsCreator: WindowStateActionCreator, private readonly browserWindow: BrowserWindow) {}
+    constructor(private readonly windowStateActionsCreator: WindowStateActionCreator, private readonly browserWindow: BrowserWindow) { }
 
     public initialize(): void {
-        this.browserWindow.on('minimize', this.onWindowStateChange);
-        this.browserWindow.on('maximize', this.onWindowStateChange);
-        this.browserWindow.on('unmaximize', this.onWindowStateChange);
+        this.browserWindow.on('maximize', this.onMaximize);
+        this.browserWindow.on('unmaximize', this.onUnMaximize);
+        this.browserWindow.on('enter-full-screen', this.onEnterFullScreen);
+        this.browserWindow.on('leave-full-screen', this.onLeaveFullScreen);
+    }
+    private onMaximize = (): void => {
+        this.windowStateActionsCreator.setWindowState({ currentWindowState: 'maximized' });
     }
 
-    private onWindowStateChange = (): void => {
-        if (this.browserWindow.isMinimized()) {
-            this.windowStateActionsCreator.setWindowState({ currentWindowState: 'minimized' });
-        } else if (this.browserWindow.isMaximized()) {
-            this.windowStateActionsCreator.setWindowState({ currentWindowState: 'maximized' });
-        } else {
-            this.windowStateActionsCreator.setWindowState({ currentWindowState: 'customSize' });
+    private onEnterFullScreen = (): void => {
+        this.windowStateActionsCreator.setWindowState({ currentWindowState: 'fullScreen' });
+    }
+    private onLeaveFullScreen = (): void => {
+        if (this.browserWindow.isMaximized()) {
+            this.onMaximize();
         }
-    };
+        else {
+            this.onUnMaximize();
+        }
+
+    }
+    private onUnMaximize = (): void => {
+        this.windowStateActionsCreator.setWindowState({ currentWindowState: 'customSize' });
+    }
 }

--- a/src/electron/window-frame-updater.ts
+++ b/src/electron/window-frame-updater.ts
@@ -5,7 +5,7 @@ import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
 import { SetSizePayload } from 'electron/flux/action/window-frame-actions-payloads';
 
 export class WindowFrameUpdater {
-    constructor(private readonly windowFrameActions: WindowFrameActions, private readonly browserWindow: BrowserWindow) {}
+    constructor(private readonly windowFrameActions: WindowFrameActions, private readonly browserWindow: BrowserWindow) { }
 
     public initialize(): void {
         this.windowFrameActions.maximize.addListener(this.onMaximize);
@@ -24,7 +24,12 @@ export class WindowFrameUpdater {
     };
 
     private onRestore = (): void => {
-        this.browserWindow.restore();
+        if (this.browserWindow.isFullScreen()) {
+            this.browserWindow.setFullScreen(false);
+        }
+        else {
+            this.browserWindow.unmaximize();
+        }
     };
 
     private onClose = (): void => {

--- a/src/electron/window-frame-updater.ts
+++ b/src/electron/window-frame-updater.ts
@@ -5,7 +5,7 @@ import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
 import { SetSizePayload } from 'electron/flux/action/window-frame-actions-payloads';
 
 export class WindowFrameUpdater {
-    constructor(private readonly windowFrameActions: WindowFrameActions, private readonly browserWindow: BrowserWindow) { }
+    constructor(private readonly windowFrameActions: WindowFrameActions, private readonly browserWindow: BrowserWindow) {}
 
     public initialize(): void {
         this.windowFrameActions.maximize.addListener(this.onMaximize);
@@ -26,8 +26,7 @@ export class WindowFrameUpdater {
     private onRestore = (): void => {
         if (this.browserWindow.isFullScreen()) {
             this.browserWindow.setFullScreen(false);
-        }
-        else {
+        } else {
             this.browserWindow.unmaximize();
         }
     };

--- a/src/tests/electron/window-frame-listener.test.ts
+++ b/src/tests/electron/window-frame-listener.test.ts
@@ -34,10 +34,10 @@ describe(WindowFrameListener, () => {
         let leaveFullScreenCallback: Function;
 
         beforeEach(() => {
-            setupVerifiableWindowEventCallback('maximize', (cb) => maximizeCallback = cb);
-            setupVerifiableWindowEventCallback('unmaximize', (cb) => unmaximizeCallback = cb);
-            setupVerifiableWindowEventCallback('enter-full-screen', (cb) => enterFullScreenCallback = cb);
-            setupVerifiableWindowEventCallback('leave-full-screen', (cb) => leaveFullScreenCallback = cb);
+            setupVerifiableWindowEventCallback('maximize', cb => (maximizeCallback = cb));
+            setupVerifiableWindowEventCallback('unmaximize', cb => (unmaximizeCallback = cb));
+            setupVerifiableWindowEventCallback('enter-full-screen', cb => (enterFullScreenCallback = cb));
+            setupVerifiableWindowEventCallback('leave-full-screen', cb => (leaveFullScreenCallback = cb));
 
             testSubject.initialize();
         });
@@ -74,14 +74,13 @@ describe(WindowFrameListener, () => {
             leaveFullScreenCallback();
         });
 
-
-        function setupVerifiableWindowEventCallback(eventName: string, callback: (eventCallback: Function) => void) {
+        function setupVerifiableWindowEventCallback(eventName: string, callback: (eventCallback: Function) => void): void {
             browserWindowMock
                 .setup(b => b.on(eventName as any, It.isAny()))
                 .callback((event, cb) => {
                     callback(cb);
-                }).verifiable(Times.once());
-
+                })
+                .verifiable(Times.once());
         }
     });
 });

--- a/src/tests/electron/window-frame-listener.test.ts
+++ b/src/tests/electron/window-frame-listener.test.ts
@@ -20,75 +20,68 @@ describe(WindowFrameListener, () => {
 
     afterEach(() => {
         browserWindowMock.verifyAll();
+        windowStateActionsCreatorMock.verifyAll();
     });
 
     it('do nothing on action invocation before initialize', () => {
         browserWindowMock.setup(b => b.on(It.isAny(), It.isAny())).verifiable(Times.never());
     });
 
-    describe('initialize', () => {
-        it('registers to required window events', () => {
-            const eventCallbacks: Function[] = [];
-
-            const eventsToListen = ['minimize', 'maximize', 'unmaximize'];
-            eventsToListen.forEach(eventName => {
-                browserWindowMock
-                    .setup(b => b.on(eventName as any, It.isAny()))
-                    .callback((event, cb) => {
-                        eventCallbacks.push(cb);
-                    })
-                    .verifiable(Times.once());
-            });
-
-            testSubject.initialize();
-
-            expect(eventCallbacks.length).toBe(eventsToListen.length);
-            expect(new Set(eventCallbacks).size).toBe(1);
-        });
-    });
-
-    describe('verify action listeners', () => {
-        let eventCallback: Function = null;
+    describe('validate window listeners', () => {
+        let maximizeCallback: Function;
+        let unmaximizeCallback: Function;
+        let enterFullScreenCallback: Function;
+        let leaveFullScreenCallback: Function;
 
         beforeEach(() => {
-            const eventsToListen = ['minimize', 'maximize', 'unmaximize'];
-            eventsToListen.forEach(eventName => {
-                browserWindowMock
-                    .setup(b => b.on(eventName as any, It.isAny()))
-                    .callback((event, cb) => {
-                        eventCallback = cb;
-                    });
-            });
+            setupVerifiableWindowEventCallback('maximize', (cb) => maximizeCallback = cb);
+            setupVerifiableWindowEventCallback('unmaximize', (cb) => unmaximizeCallback = cb);
+            setupVerifiableWindowEventCallback('enter-full-screen', (cb) => enterFullScreenCallback = cb);
+            setupVerifiableWindowEventCallback('leave-full-screen', (cb) => leaveFullScreenCallback = cb);
 
             testSubject.initialize();
         });
 
-        it('invokes maximize', () => {
-            browserWindowMock.setup(b => b.isMinimized()).returns(() => false);
-
-            browserWindowMock.setup(b => b.isMaximized()).returns(() => true);
-
+        it('validate window state on maximize', () => {
             windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'maximized' })).verifiable(Times.once());
 
-            eventCallback();
+            maximizeCallback();
         });
 
-        it('invokes minimize', () => {
-            browserWindowMock.setup(b => b.isMinimized()).returns(() => true);
-
-            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'minimized' })).verifiable(Times.once());
-
-            eventCallback();
-        });
-
-        it('invokes customSize', () => {
-            browserWindowMock.setup(b => b.isMinimized()).returns(() => false);
-
-            browserWindowMock.setup(b => b.isMaximized()).returns(() => false);
-
+        it('validate window state on unmaximize', () => {
             windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'customSize' })).verifiable(Times.once());
 
-            eventCallback();
+            unmaximizeCallback();
         });
+
+        it('validate window state on fullscreen', () => {
+            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'fullScreen' })).verifiable(Times.once());
+
+            enterFullScreenCallback();
+        });
+
+        it('validate window state on leaving full screen to maximized state', () => {
+            browserWindowMock.setup(b => b.isMaximized()).returns(() => true);
+            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'maximized' })).verifiable(Times.once());
+
+            leaveFullScreenCallback();
+        });
+
+        it('validate window state on leaving full screen to custom size', () => {
+            browserWindowMock.setup(b => b.isMaximized()).returns(() => false);
+            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'customSize' })).verifiable(Times.once());
+
+            leaveFullScreenCallback();
+        });
+
+
+        function setupVerifiableWindowEventCallback(eventName: string, callback: (eventCallback: Function) => void) {
+            browserWindowMock
+                .setup(b => b.on(eventName as any, It.isAny()))
+                .callback((event, cb) => {
+                    callback(cb);
+                }).verifiable(Times.once());
+
+        }
     });
 });

--- a/src/tests/electron/window-frame-updater.test.ts
+++ b/src/tests/electron/window-frame-updater.test.ts
@@ -47,14 +47,20 @@ describe(WindowFrameUpdater, () => {
         });
 
         it('handles restore when in full screen', () => {
-            browserWindowMock.setup(b => b.isFullScreen()).returns(() => true).verifiable(Times.once());
+            browserWindowMock
+                .setup(b => b.isFullScreen())
+                .returns(() => true)
+                .verifiable(Times.once());
             browserWindowMock.setup(b => b.setFullScreen(false)).verifiable(Times.once());
 
             windowFrameActions.restore.invoke(null);
         });
 
         it('handles restore when not in full screen', () => {
-            browserWindowMock.setup(b => b.isFullScreen()).returns(() => false).verifiable(Times.once());
+            browserWindowMock
+                .setup(b => b.isFullScreen())
+                .returns(() => false)
+                .verifiable(Times.once());
             browserWindowMock.setup(b => b.unmaximize()).verifiable(Times.once());
 
             windowFrameActions.restore.invoke(null);

--- a/src/tests/electron/window-frame-updater.test.ts
+++ b/src/tests/electron/window-frame-updater.test.ts
@@ -24,7 +24,7 @@ describe(WindowFrameUpdater, () => {
     });
 
     it(' do nothing on action invocation before initialize', () => {
-        windowFrameActions.maximize.invoke();
+        windowFrameActions.maximize.invoke(null);
 
         browserWindowMock.setup(b => b.maximize()).verifiable(Times.never());
     });
@@ -37,25 +37,33 @@ describe(WindowFrameUpdater, () => {
         it('invokes maximize', () => {
             browserWindowMock.setup(b => b.maximize()).verifiable(Times.once());
 
-            windowFrameActions.maximize.invoke();
+            windowFrameActions.maximize.invoke(null);
         });
 
         it('invokes minimize', () => {
             browserWindowMock.setup(b => b.minimize()).verifiable(Times.once());
 
-            windowFrameActions.minimize.invoke();
+            windowFrameActions.minimize.invoke(null);
         });
 
-        it('invokes restore', () => {
-            browserWindowMock.setup(b => b.restore()).verifiable(Times.once());
+        it('handles restore when in full screen', () => {
+            browserWindowMock.setup(b => b.isFullScreen()).returns(() => true).verifiable(Times.once());
+            browserWindowMock.setup(b => b.setFullScreen(false)).verifiable(Times.once());
 
-            windowFrameActions.restore.invoke();
+            windowFrameActions.restore.invoke(null);
+        });
+
+        it('handles restore when not in full screen', () => {
+            browserWindowMock.setup(b => b.isFullScreen()).returns(() => false).verifiable(Times.once());
+            browserWindowMock.setup(b => b.unmaximize()).verifiable(Times.once());
+
+            windowFrameActions.restore.invoke(null);
         });
 
         it('invokes close', () => {
             browserWindowMock.setup(b => b.close()).verifiable(Times.once());
 
-            windowFrameActions.close.invoke();
+            windowFrameActions.close.invoke(null);
         });
 
         it('invokes setSize', () => {

--- a/src/tests/unit/tests/electron/flux/store/window-state-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/window-state-store.test.ts
@@ -70,9 +70,9 @@ describe('WindowStateStore', () => {
             .testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    it('changes currentWindowState from default to minimized', () => {
+    it('changes currentWindowState from default to maximized', () => {
         const payload: WindowStatePayload = {
-            currentWindowState: 'minimized',
+            currentWindowState: 'maximized',
         };
         const expectedState: WindowStateStoreData = {
             routeId: 'deviceConnectView',

--- a/src/tests/unit/tests/electron/platform-info.test.ts
+++ b/src/tests/unit/tests/electron/platform-info.test.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { PlatformInfo, OSType } from "electron/platform-info";
+import { IMock, Mock } from "typemoq";
+
+describe(PlatformInfo, () => {
+    let testSubject: PlatformInfo;
+    let processMock: IMock<NodeJS.Process>;
+
+    beforeEach(() => {
+        processMock = Mock.ofType<NodeJS.Process>();
+
+        testSubject = new PlatformInfo(processMock.object);
+    })
+
+    describe('getOS', () => {
+        type GetOsTestCase = { platformName: typeof process.platform, osType: OSType };
+
+        test.each([
+            { platformName: 'linux', osType: OSType.Linux },
+            { platformName: 'darwin', osType: OSType.Mac },
+            { platformName: 'win32', osType: OSType.Windows },
+        ] as GetOsTestCase[])
+            ("validate getOs %o", (testCase: GetOsTestCase) => {
+                processMock.setup(p => p.platform).returns(() => testCase.platformName);
+
+                expect(testSubject.getOs()).toBe(testCase.osType);
+            });
+    });
+
+    it('isMac', () => {
+        processMock.setup(p => p.platform).returns(() => "darwin");
+
+        expect(testSubject.isMac()).toBe(true);
+    })
+})

--- a/src/tests/unit/tests/electron/platform-info.test.ts
+++ b/src/tests/unit/tests/electron/platform-info.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { PlatformInfo, OSType } from "electron/platform-info";
-import { IMock, Mock } from "typemoq";
+import { OSType, PlatformInfo } from 'electron/platform-info';
+import { IMock, Mock } from 'typemoq';
 
 describe(PlatformInfo, () => {
     let testSubject: PlatformInfo;
@@ -12,26 +12,25 @@ describe(PlatformInfo, () => {
         processMock = Mock.ofType<NodeJS.Process>();
 
         testSubject = new PlatformInfo(processMock.object);
-    })
+    });
 
     describe('getOS', () => {
-        type GetOsTestCase = { platformName: typeof process.platform, osType: OSType };
+        type GetOsTestCase = { platformName: typeof process.platform; osType: OSType };
 
         test.each([
             { platformName: 'linux', osType: OSType.Linux },
             { platformName: 'darwin', osType: OSType.Mac },
             { platformName: 'win32', osType: OSType.Windows },
-        ] as GetOsTestCase[])
-            ("validate getOs %o", (testCase: GetOsTestCase) => {
-                processMock.setup(p => p.platform).returns(() => testCase.platformName);
+        ] as GetOsTestCase[])('validate getOs %o', (testCase: GetOsTestCase) => {
+            processMock.setup(p => p.platform).returns(() => testCase.platformName);
 
-                expect(testSubject.getOs()).toBe(testCase.osType);
-            });
+            expect(testSubject.getOs()).toBe(testCase.osType);
+        });
     });
 
     it('isMac', () => {
-        processMock.setup(p => p.platform).returns(() => "darwin");
+        processMock.setup(p => p.platform).returns(() => 'darwin');
 
         expect(testSubject.isMac()).toBe(true);
-    })
-})
+    });
+});

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -39,8 +39,11 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
   <TitleBar
     deps={
       Object {
-        "currentWindow": null,
         "deviceConnectActionCreator": null,
+        "platformInfo": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "currentProcess": undefined,
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
@@ -48,11 +51,6 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
         "windowFrameActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "windowFrameActions": undefined,
-        },
-        "windowStateActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "windowFrameActionCreator": undefined,
-          "windowStateActions": undefined,
         },
       }
     }
@@ -61,8 +59,11 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
   <CommandBar
     deps={
       Object {
-        "currentWindow": null,
         "deviceConnectActionCreator": null,
+        "platformInfo": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "currentProcess": undefined,
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
@@ -70,11 +71,6 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
         "windowFrameActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "windowFrameActions": undefined,
-        },
-        "windowStateActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "windowFrameActionCreator": undefined,
-          "windowStateActions": undefined,
         },
       }
     }

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -40,10 +40,6 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
     deps={
       Object {
         "deviceConnectActionCreator": null,
-        "platformInfo": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "currentProcess": undefined,
-        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
@@ -51,6 +47,11 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
         "windowFrameActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "windowFrameActions": undefined,
+        },
+        "windowStateActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActionCreator": undefined,
+          "windowStateActions": undefined,
         },
       }
     }
@@ -60,10 +61,6 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
     deps={
       Object {
         "deviceConnectActionCreator": null,
-        "platformInfo": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "currentProcess": undefined,
-        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
@@ -71,6 +68,11 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
         "windowFrameActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "windowFrameActions": undefined,
+        },
+        "windowStateActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActionCreator": undefined,
+          "windowStateActions": undefined,
         },
       }
     }
@@ -87,7 +89,6 @@ exports[`AutomatedChecksView renders scanning spinner 1`] = `
   <TitleBar
     deps={
       Object {
-        "currentWindow": null,
         "deviceConnectActionCreator": null,
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -109,7 +110,6 @@ exports[`AutomatedChecksView renders scanning spinner 1`] = `
   <CommandBar
     deps={
       Object {
-        "currentWindow": null,
         "deviceConnectActionCreator": null,
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -16,7 +16,6 @@ describe('AutomatedChecksView', () => {
             const props: AutomatedChecksViewProps = {
                 deps: {
                     deviceConnectActionCreator: null,
-                    currentWindow: null,
                     windowStateActionCreator: Mock.ofType(WindowStateActionCreator).object,
                     scanActionCreator: Mock.ofType(ScanActionCreator).object,
                     windowFrameActionCreator: Mock.ofType(WindowFrameActionCreator).object,
@@ -35,7 +34,6 @@ describe('AutomatedChecksView', () => {
             const props: AutomatedChecksViewProps = {
                 deps: {
                     deviceConnectActionCreator: null,
-                    currentWindow: null,
                     windowStateActionCreator: Mock.ofType(WindowStateActionCreator).object,
                     scanActionCreator: Mock.ofType(ScanActionCreator).object,
                     windowFrameActionCreator: Mock.ofType(WindowFrameActionCreator).object,

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/title-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/title-bar.test.tsx.snap
@@ -40,7 +40,25 @@ exports[`TitleBar renders 1`] = `
     ]
   }
   className="titleBar"
+  deps={
+    Object {
+      "platformInfo": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "currentProcess": undefined,
+      },
+      "windowFrameActionCreator": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "windowFrameActions": undefined,
+      },
+    }
+  }
   title="Accessibility Insights"
+  windowStateStoreData={
+    Object {
+      "currentWindowState": "maximized",
+      "routeId": "resultsView",
+    }
+  }
 >
   <BrandWhite />
 </WindowTitle>

--- a/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
@@ -1,17 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserWindow } from 'electron';
+
+import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
+import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
+import { PlatformInfo } from 'electron/platform-info';
+import { TitleBar, TitleBarProps } from 'electron/views/automated-checks/components/title-bar';
 import { shallow } from 'enzyme';
 import { Button } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-
-import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
-import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
-import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
-import { TitleBar, TitleBarProps } from 'electron/views/automated-checks/components/title-bar';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
-import { PlatformInfo } from 'electron/platform-info';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('TitleBar', () => {
     const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
@@ -28,7 +26,7 @@ describe('TitleBar', () => {
                 platformInfo: Mock.ofType(PlatformInfo).object,
             },
             windowStateStoreData,
-        }
+        };
     });
 
     it('renders', () => {
@@ -71,7 +69,7 @@ describe('TitleBar', () => {
         { id: '#close-button', setupMock: setupVerifiableWindowCloseActionCall },
     ];
 
-    buttonsAndSetups.forEach((testCase) => {
+    buttonsAndSetups.forEach(testCase => {
         it(`test button - ${testCase.id}`, () => {
             testCase.setupMock();
 

--- a/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
@@ -11,34 +11,32 @@ import { WindowStateActionCreator } from 'electron/flux/action-creator/window-st
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { TitleBar, TitleBarProps } from 'electron/views/automated-checks/components/title-bar';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
+import { PlatformInfo } from 'electron/platform-info';
 
 describe('TitleBar', () => {
     const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
-    let browserWindowMock: IMock<BrowserWindow>;
-    let windowStateActionCreator: IMock<WindowStateActionCreator>;
     let windowFrameActionCreator: IMock<WindowFrameActionCreator>;
     let windowStateStoreData: WindowStateStoreData;
+    let props: TitleBarProps;
 
     beforeEach(() => {
-        browserWindowMock = Mock.ofType<BrowserWindow>(undefined, MockBehavior.Strict);
-        windowStateActionCreator = Mock.ofType<WindowStateActionCreator>(undefined, MockBehavior.Strict);
         windowFrameActionCreator = Mock.ofType<WindowFrameActionCreator>(undefined, MockBehavior.Strict);
         windowStateStoreData = { routeId: 'resultsView', currentWindowState: 'maximized' };
+        props = {
+            deps: {
+                windowFrameActionCreator: windowFrameActionCreator.object,
+                platformInfo: Mock.ofType(PlatformInfo).object,
+            },
+            windowStateStoreData,
+        }
     });
 
     it('renders', () => {
-        const props = {
-            deps: {
-                currentWindow: Mock.ofType(BrowserWindow).object,
-                windowStateActionCreator: Mock.ofType(WindowStateActionCreator).object,
-                windowFrameActionCreator: Mock.ofType(WindowFrameActionCreator).object,
-            },
-            windowStateStoreData,
-        } as TitleBarProps;
-
+        props.deps.windowFrameActionCreator = Mock.ofType(WindowFrameActionCreator).object;
         const wrapper = shallow(<TitleBar {...props} />);
 
-        expect(wrapper.getElement()).toMatchSnapshot();
+        const element = wrapper.getElement();
+        expect(element).toMatchSnapshot();
     });
 
     const setupVerifiableWindowMaximizeAction = () => {
@@ -47,8 +45,13 @@ describe('TitleBar', () => {
         windowFrameActionCreator.setup(creator => creator.maximize()).verifiable(Times.once());
     };
 
-    const setupVerifiableWindowRestoreAction = () => {
+    const setupVerifiableWindowRestoreActionFromMaximized = () => {
         windowStateStoreData.currentWindowState = 'maximized';
+        windowFrameActionCreator.setup(creator => creator.restore()).verifiable(Times.once());
+    };
+
+    const setupVerifiableWindowRestoreActionFromFullScreen = () => {
+        windowStateStoreData.currentWindowState = 'fullScreen';
         windowFrameActionCreator.setup(creator => creator.restore()).verifiable(Times.once());
     };
 
@@ -62,31 +65,25 @@ describe('TitleBar', () => {
 
     const buttonsAndSetups = [
         { id: '#maximize-button', setupMock: setupVerifiableWindowMaximizeAction }, // maximize validation
-        { id: '#maximize-button', setupMock: setupVerifiableWindowRestoreAction }, // restore validation
+        { id: '#maximize-button', setupMock: setupVerifiableWindowRestoreActionFromFullScreen }, // restore validation from full screen
+        { id: '#maximize-button', setupMock: setupVerifiableWindowRestoreActionFromMaximized }, // restore validation from maximized state
         { id: '#minimize-button', setupMock: setupVerifiableWindowMinimizeCall },
         { id: '#close-button', setupMock: setupVerifiableWindowCloseActionCall },
     ];
 
-    test.each(buttonsAndSetups)('test button %s', args => {
-        args.setupMock();
-        const props = {
-            deps: {
-                currentWindow: browserWindowMock.object,
-                windowStateActionCreator: windowStateActionCreator.object,
-                windowFrameActionCreator: windowFrameActionCreator.object,
-            },
-            windowStateStoreData,
-        } as TitleBarProps;
+    buttonsAndSetups.forEach((testCase) => {
+        it(`test button - ${testCase.id}`, () => {
+            testCase.setupMock();
 
-        const rendered = shallow(<TitleBar {...props} />);
-        const renderedElement = rendered.getElement();
-        const renderedIcons = shallow(<div>{renderedElement.props.actionableIcons}</div>);
+            const rendered = shallow(<TitleBar {...props} />);
+            const renderedElement = rendered.getElement();
+            const renderedIcons = shallow(<div>{renderedElement.props.actionableIcons}</div>);
 
-        const button = renderedIcons.find(args.id);
+            const button = renderedIcons.find(testCase.id);
 
-        button.simulate('click', eventStub);
+            button.simulate('click', eventStub);
 
-        browserWindowMock.verifyAll();
-        windowStateActionCreator.verifyAll();
+            windowFrameActionCreator.verifyAll();
+        });
     });
 });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
@@ -3,18 +3,19 @@
 exports[`DeviceConnectViewContainer renders 1`] = `
 <React.Fragment>
   <WindowTitle
+    deps={Object {}}
     title="Accessibility Insights"
+    windowStateStoreData={
+      Object {
+        "currentWindowState": "customSize",
+        "routeId": "deviceConnectView",
+      }
+    }
   >
     <BrandBlue />
   </WindowTitle>
   <DeviceConnectBody
-    deps={
-      Object {
-        "currentWindow": Object {
-          "close": [Function],
-        },
-      }
-    }
+    deps={Object {}}
     viewState={
       Object {
         "connectedDevice": undefined,
@@ -23,13 +24,7 @@ exports[`DeviceConnectViewContainer renders 1`] = `
     }
   />
   <TelemetryPermissionDialog
-    deps={
-      Object {
-        "currentWindow": Object {
-          "close": [Function],
-        },
-      }
-    }
+    deps={Object {}}
     isFirstTime={true}
   />
 </React.Fragment>

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/window-title.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/window-title.test.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`WindowTitleTest renders nothing if fullscreen 1`] = `null`;
+
 exports[`WindowTitleTest renders with actionable icons 1`] = `
 <header
   className="windowTitle"
@@ -36,6 +38,38 @@ exports[`WindowTitleTest renders with custom class name 1`] = `
   <div
     className="titleContainer"
   >
+    <span>
+      logo
+    </span>
+    <h1
+      className="headerText"
+    >
+      title 1
+    </h1>
+  </div>
+  <div
+    className="actionableIconsContainer"
+  >
+    <div>
+      icon1
+    </div>
+    <div>
+      icon2
+    </div>
+  </div>
+</header>
+`;
+
+exports[`WindowTitleTest renders without actionable buttons for mac 1`] = `
+<header
+  className="windowTitle macWindowTitle"
+>
+  <div
+    className="titleContainer"
+  >
+    <span>
+      logo
+    </span>
     <h1
       className="headerText"
     >

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-view-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-view-container.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserWindow } from 'electron';
+
 import { DeviceConnectState } from 'electron/views/device-connect-view/components/device-connect-state';
 import {
     DeviceConnectViewContainer,
@@ -11,10 +11,8 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('DeviceConnectViewContainer', () => {
-
     it('renders', () => {
-        const deps: DeviceConnectViewContainerDeps = {
-        } as DeviceConnectViewContainerDeps;
+        const deps: DeviceConnectViewContainerDeps = {} as DeviceConnectViewContainerDeps;
 
         const props: DeviceConnectViewContainerProps = {
             deps,
@@ -27,7 +25,7 @@ describe('DeviceConnectViewContainer', () => {
             windowStateStoreData: {
                 currentWindowState: 'customSize',
                 routeId: 'deviceConnectView',
-            }
+            },
         } as DeviceConnectViewContainerProps;
 
         const wrapped = shallow(<DeviceConnectViewContainer {...props} />);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-view-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-view-container.test.tsx
@@ -11,15 +11,9 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('DeviceConnectViewContainer', () => {
-    const currentWindowStub = {
-        close: () => {
-            return;
-        },
-    } as BrowserWindow;
 
     it('renders', () => {
         const deps: DeviceConnectViewContainerDeps = {
-            currentWindow: currentWindowStub,
         } as DeviceConnectViewContainerDeps;
 
         const props: DeviceConnectViewContainerProps = {
@@ -30,6 +24,10 @@ describe('DeviceConnectViewContainer', () => {
             deviceStoreData: {
                 deviceConnectState: DeviceConnectState.Default,
             },
+            windowStateStoreData: {
+                currentWindowState: 'customSize',
+                routeId: 'deviceConnectView',
+            }
         } as DeviceConnectViewContainerProps;
 
         const wrapped = shallow(<DeviceConnectViewContainer {...props} />);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/window-title.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/window-title.test.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
+import { PlatformInfo } from 'electron/platform-info';
 import { WindowTitle, WindowTitleProps } from 'electron/views/device-connect-view/components/window-title';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock } from 'typemoq';
-import { PlatformInfo } from 'electron/platform-info';
-import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 
 describe('WindowTitleTest', () => {
     let platformInfoMock: IMock<PlatformInfo>;
@@ -21,8 +22,8 @@ describe('WindowTitleTest', () => {
             deps: { platformInfo: platformInfoMock.object },
             children: <span>logo</span>,
             actionableIcons: [<div key="key1">icon1</div>, <div key="key2">icon2</div>],
-            windowStateStoreData
-        }
+            windowStateStoreData,
+        };
     });
 
     it('renders without actionable icons', () => {
@@ -35,13 +36,12 @@ describe('WindowTitleTest', () => {
     });
 
     it('renders nothing if fullscreen', () => {
-        windowStateStoreData.currentWindowState = "fullScreen";
+        windowStateStoreData.currentWindowState = 'fullScreen';
 
         const rendered = shallow(<WindowTitle {...props} />);
 
         expect(rendered.getElement()).toMatchSnapshot();
-    })
-
+    });
 
     it('renders with actionable icons', () => {
         const rendered = shallow(<WindowTitle {...props} />);
@@ -67,7 +67,7 @@ describe('WindowTitleTest', () => {
     });
 
     it('renders with custom class name', () => {
-        props.className = "custom-class-name";
+        props.className = 'custom-class-name';
 
         const rendered = shallow(<WindowTitle {...props} />);
 

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/window-title.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/window-title.test.tsx
@@ -3,25 +3,54 @@
 import { WindowTitle, WindowTitleProps } from 'electron/views/device-connect-view/components/window-title';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { IMock, Mock } from 'typemoq';
+import { PlatformInfo } from 'electron/platform-info';
+import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 
 describe('WindowTitleTest', () => {
-    it('renders without actionable icons', () => {
-        const props: WindowTitleProps = {
+    let platformInfoMock: IMock<PlatformInfo>;
+    let windowStateStoreData: WindowStateStoreData;
+    let props: WindowTitleProps;
+
+    beforeEach(() => {
+        platformInfoMock = Mock.ofType(PlatformInfo);
+        windowStateStoreData = { currentWindowState: 'maximized', routeId: 'deviceConnectView' };
+
+        props = {
             title: 'title 1',
+            deps: { platformInfo: platformInfoMock.object },
             children: <span>logo</span>,
-        };
+            actionableIcons: [<div key="key1">icon1</div>, <div key="key2">icon2</div>],
+            windowStateStoreData
+        }
+    });
+
+    it('renders without actionable icons', () => {
+        props.children = <span>logo</span>;
+        props.actionableIcons = undefined;
 
         const rendered = shallow(<WindowTitle {...props} />);
 
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
+    it('renders nothing if fullscreen', () => {
+        windowStateStoreData.currentWindowState = "fullScreen";
+
+        const rendered = shallow(<WindowTitle {...props} />);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    })
+
+
     it('renders with actionable icons', () => {
-        const props: WindowTitleProps = {
-            title: 'title 1',
-            children: <span>logo</span>,
-            actionableIcons: [<div key="key1">icon1</div>, <div key="key2">icon2</div>],
-        };
+        const rendered = shallow(<WindowTitle {...props} />);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('renders without actionable buttons for mac', () => {
+        platformInfoMock.setup(p => p.isMac()).returns(() => true);
 
         const rendered = shallow(<WindowTitle {...props} />);
 
@@ -29,9 +58,8 @@ describe('WindowTitleTest', () => {
     });
 
     it('renders without children & actionable icon', () => {
-        const props: WindowTitleProps = {
-            title: 'title 1',
-        };
+        props.children = undefined;
+        props.actionableIcons = undefined;
 
         const rendered = shallow(<WindowTitle {...props} />);
 
@@ -39,10 +67,7 @@ describe('WindowTitleTest', () => {
     });
 
     it('renders with custom class name', () => {
-        const props: WindowTitleProps = {
-            title: 'title 1',
-            className: 'custom-class-name',
-        };
+        props.className = "custom-class-name";
 
         const rendered = shallow(<WindowTitle {...props} />);
 


### PR DESCRIPTION
#### Description of changes

- As part of this PR, we handle mac os separately. If mac, we use window frame with titlebar style set to hidden. This adds 3 icons to top left corner of window. So, we need to add some padding to the title bar to cover this icons. Also, we remove the title bar if the window is in full screen mode.

- For windows & mac, we show the minimize, close & maximize icons on the right side.

- As part of this change, we have also made changes to only listen to maximize, unmaximize, enter-full-screen & leave-full-screen. We don't have to listen to minimize action, since we don't change state based on whether the window is minimized or not.

**Device connect view:**
![image](https://user-images.githubusercontent.com/29855291/66780480-c08c6c00-ee85-11e9-9ca8-19fa860920d0.png)

**Results view in maximized mode:**
![image](https://user-images.githubusercontent.com/29855291/66780532-e4e84880-ee85-11e9-8447-7b910c62a363.png)

**Results view in full screen view**
![image](https://user-images.githubusercontent.com/29855291/66782609-ee27e400-ee8a-11e9-843b-7a80d6724580.png)



#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
