### PR TITLE
Disable linux electron build

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -72,7 +72,7 @@ jobs:
       steps:
           - template: pipeline/electron/distribute-electron.yaml
             parameters:
-                platforms: -wl
+                platforms: -w # linux disabled until https://github.com/electron-userland/electron-builder/issues/4318 resolved
 
     # CI build only
     - job: 'publish_electron_mac'


### PR DESCRIPTION
#### Description of changes

The linux electron-distributable step in CI is failing because of https://github.com/electron-userland/electron-builder/issues/4318. This PR temporarily disables the Linux build.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
