### PR TITLE
fix: disable windows electron publish step temporarily

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -65,14 +65,15 @@ jobs:
             displayName: publish drop
 
     # CI build only
-    - job: 'publish_electron_windows_linux'
-      condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
-      pool:
-          vmImage: 'windows-latest'
-      steps:
-          - template: pipeline/electron/distribute-electron.yaml
-            parameters:
-                platforms: -w # linux disabled until https://github.com/electron-userland/electron-builder/issues/4318 resolved
+    # disabled until https://github.com/electron-userland/electron-builder/issues/4318
+    # - job: 'publish_electron_windows_linux'
+    #   condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+    #   pool:
+    #       vmImage: 'windows-latest'
+    #   steps:
+    #       - template: pipeline/electron/distribute-electron.yaml
+    #         parameters:
+    #             platforms: -w
 
     # CI build only
     - job: 'publish_electron_mac'
@@ -86,7 +87,7 @@ jobs:
 
     - job: 'e2e_mac_web_electron'
       pool:
-          vmImage: macOS-10.14
+          vmImage: 'macOS-10.14'
       steps:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/e2e-test-from-agent.yaml
@@ -96,7 +97,7 @@ jobs:
 
     - job: 'e2e_linux_electron'
       pool:
-          vmImage: ubuntu-16.04
+          vmImage: 'ubuntu-16.04'
       steps:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/electron/electron-e2e-test-linux.yaml


### PR DESCRIPTION
#### Description of changes

Temp fix: disable windows electron publish step temporarily from CI builds.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
