### PR TITLE
refactor: extract full interface from user configuration action creator

### DIFF
--- a/src/DetailsView/components/settings-panel/settings/high-contrast/high-contrast-settings.tsx
+++ b/src/DetailsView/components/settings-panel/settings/high-contrast/high-contrast-settings.tsx
@@ -16,7 +16,7 @@ export const HighContrastSettings = NamedFC<SettingsProps>('HighContrastSettings
             id="enable-high-contrast-mode"
             name={enableHighContrastSettingsTitle}
             description={highContrastSettingsDescription}
-            onClick={(id, state) => userConfigMessageCreator.setHighContrastMode(state)}
+            onClick={(id, state) => userConfigMessageCreator.setHighContrastMode({ enableHighContrast: state })}
         />
     );
 });

--- a/src/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.tsx
+++ b/src/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { enableTelemetrySettingsPanelTitle } from 'content/settings/improve-accessibility-insights';
-import * as React from 'react';
 import {
     EnableTelemetrySettingDescription,
     EnableTelemetrySettingDescriptionProps,
-} from '../../../../../common/components/enable-telemetry-setting-description';
-import { NamedFC } from '../../../../../common/react/named-fc';
+} from 'common/components/enable-telemetry-setting-description';
+import { NamedFC } from 'common/react/named-fc';
+import { enableTelemetrySettingsPanelTitle } from 'content/settings/improve-accessibility-insights';
+import * as React from 'react';
 import { GenericToggle } from '../../../generic-toggle';
 import { SettingsProps } from '../settings-props';
 
@@ -22,7 +22,7 @@ export const TelemetrySettings = NamedFC<TelemetrySettingsProps>('TelemetrySetti
             id="enable-telemetry"
             name={enableTelemetrySettingsPanelTitle}
             description={<EnableTelemetrySettingDescription deps={deps} />}
-            onClick={(id, state) => userConfigMessageCreator.setTelemetryState(state)}
+            onClick={(id, state) => userConfigMessageCreator.setTelemetryState({ enableTelemetry: state })}
         />
     );
 });

--- a/src/background/global-action-creators/registrar/register-user-configuration-message-callbacks.ts
+++ b/src/background/global-action-creators/registrar/register-user-configuration-message-callbacks.ts
@@ -1,21 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { getStoreStateMessage, Messages } from '../../../common/messages';
-import { StoreNames } from '../../../common/stores/store-names';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { StoreNames } from 'common/stores/store-names';
+
 import { SetTelemetryStatePayload } from '../../actions/action-payloads';
 import { Interpreter } from '../../interpreter';
-import { UserConfigurationActionCreator } from '../user-configuration-action-creator';
+import { UserConfigurationActionCreatorImpl } from '../user-configuration-action-creator-impl';
 
 export const registerUserConfigurationMessageCallback = (
     interpreter: Interpreter,
-    userConfigurationActionCreator: UserConfigurationActionCreator,
+    userConfigurationActionCreator: UserConfigurationActionCreatorImpl,
 ) => {
     interpreter.registerTypeToPayloadCallback(
         getStoreStateMessage(StoreNames.UserConfigurationStore),
         userConfigurationActionCreator.getUserConfigurationState,
     );
     interpreter.registerTypeToPayloadCallback<SetTelemetryStatePayload>(Messages.UserConfig.SetTelemetryConfig, payload =>
-        userConfigurationActionCreator.setTelemetryState(payload.enableTelemetry),
+        userConfigurationActionCreator.setTelemetryState(payload),
     );
     interpreter.registerTypeToPayloadCallback(
         Messages.UserConfig.SetHighContrastConfig,

--- a/src/background/global-action-creators/types/user-configuration-action-creator.ts
+++ b/src/background/global-action-creators/types/user-configuration-action-creator.ts
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    SaveIssueFilingSettingsPayload,
+    SetHighContrastModePayload,
+    SetIssueFilingServicePayload,
+    SetIssueFilingServicePropertyPayload,
+    SetTelemetryStatePayload,
+} from 'background/actions/action-payloads';
+
+export interface UserConfigurationActionCreator {
+    setTelemetryState(payload: SetTelemetryStatePayload): void;
+
+    setHighContrastMode(payload: SetHighContrastModePayload): void;
+
+    setIssueFilingService(payload: SetIssueFilingServicePayload): void;
+
+    setIssueFilingServiceProperty(payload: SetIssueFilingServicePropertyPayload): void;
+
+    saveIssueFilingSettings(payload: SaveIssueFilingSettingsPayload): void;
+}

--- a/src/background/global-action-creators/user-configuration-action-creator-impl.ts
+++ b/src/background/global-action-creators/user-configuration-action-creator-impl.ts
@@ -1,19 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UserConfigurationActionCreator } from 'background/global-action-creators/types/user-configuration-action-creator';
+
 import {
     SaveIssueFilingSettingsPayload,
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
+    SetTelemetryStatePayload,
 } from '../actions/action-payloads';
 import { UserConfigurationActions } from '../actions/user-configuration-actions';
 
-export class UserConfigurationActionCreator {
+export class UserConfigurationActionCreatorImpl implements UserConfigurationActionCreator {
     constructor(private readonly userConfigActions: UserConfigurationActions) {}
 
     public getUserConfigurationState = () => this.userConfigActions.getCurrentState.invoke(null);
 
-    public setTelemetryState = (enableTelemetry: boolean) => this.userConfigActions.setTelemetryState.invoke(enableTelemetry);
+    public setTelemetryState = (payload: SetTelemetryStatePayload) =>
+        this.userConfigActions.setTelemetryState.invoke(payload.enableTelemetry);
 
     public setHighContrastMode = (payload: SetHighContrastModePayload) => this.userConfigActions.setHighContrastMode.invoke(payload);
 

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -20,7 +20,7 @@ import { GlobalActionCreator } from './global-action-creators/global-action-crea
 import { IssueFilingActionCreator } from './global-action-creators/issue-filing-action-creator';
 import { registerUserConfigurationMessageCallback } from './global-action-creators/registrar/register-user-configuration-message-callbacks';
 import { ScopingActionCreator } from './global-action-creators/scoping-action-creator';
-import { UserConfigurationActionCreator } from './global-action-creators/user-configuration-action-creator';
+import { UserConfigurationActionCreatorImpl } from './global-action-creators/user-configuration-action-creator-impl';
 import { GlobalContext } from './global-context';
 import { Interpreter } from './interpreter';
 import { LocalStorageData } from './storage-data';
@@ -70,7 +70,7 @@ export class GlobalContextFactory {
         const issueFilingActionCreator = new IssueFilingActionCreator(interpreter, telemetryEventHandler, issueFilingController);
         const actionCreator = new GlobalActionCreator(globalActionsHub, interpreter, commandsAdapter, telemetryEventHandler);
         const assessmentActionCreator = new AssessmentActionCreator(interpreter, globalActionsHub.assessmentActions, telemetryEventHandler);
-        const userConfigurationActionCreator = new UserConfigurationActionCreator(globalActionsHub.userConfigurationActions);
+        const userConfigurationActionCreator = new UserConfigurationActionCreatorImpl(globalActionsHub.userConfigurationActions);
         const featureFlagsActionCreator = new FeatureFlagsActionCreator(
             interpreter,
             globalActionsHub.featureFlagActions,

--- a/src/common/components/telemetry-permission-dialog.tsx
+++ b/src/common/components/telemetry-permission-dialog.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UserConfigurationActionCreator } from 'background/global-action-creators/types/user-configuration-action-creator';
 import { telemetryPopupCheckboxTitle, telemetryPopupTitle } from 'content/settings/improve-accessibility-insights';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
@@ -17,12 +18,8 @@ export interface TelemetryPermissionDialogProps {
     isFirstTime: boolean;
 }
 
-export type SetTelemetryStateMessageCreator = {
-    setTelemetryState: (enableTelemetry: boolean) => void;
-};
-
 export type TelemetryPermissionDialogDeps = {
-    userConfigMessageCreator: SetTelemetryStateMessageCreator;
+    userConfigMessageCreator: UserConfigurationActionCreator;
 } & TelemetryNoticeDeps &
     PrivacyStatementTextDeps;
 
@@ -68,7 +65,11 @@ export class TelemetryPermissionDialog extends React.Component<TelemetryPermissi
                     <PrimaryButton
                         className="start-using-product-button"
                         text={`OK`}
-                        onClick={() => this.props.deps.userConfigMessageCreator.setTelemetryState(this.state.isEnableTelemetryChecked)}
+                        onClick={() =>
+                            this.props.deps.userConfigMessageCreator.setTelemetryState({
+                                enableTelemetry: this.state.isEnableTelemetryChecked,
+                            })
+                        }
                     />
                 </DialogFooter>
             </Dialog>

--- a/src/common/message-creators/user-config-message-creator.ts
+++ b/src/common/message-creators/user-config-message-creator.ts
@@ -7,27 +7,22 @@ import {
     SetIssueFilingServicePropertyPayload,
     SetTelemetryStatePayload,
 } from 'background/actions/action-payloads';
+import { UserConfigurationActionCreator } from 'background/global-action-creators/types/user-configuration-action-creator';
+
 import { Messages } from '../messages';
 import { ActionMessageDispatcher } from './action-message-dispatcher';
 
-export class UserConfigMessageCreator {
+export class UserConfigMessageCreator implements UserConfigurationActionCreator {
     constructor(private readonly dispatcher: ActionMessageDispatcher) {}
-    public setTelemetryState(enableTelemetry: boolean): void {
-        const payload: SetTelemetryStatePayload = {
-            enableTelemetry,
-        };
 
+    public setTelemetryState(payload: SetTelemetryStatePayload): void {
         this.dispatcher.dispatchMessage({
             messageType: Messages.UserConfig.SetTelemetryConfig,
             payload,
         });
     }
 
-    public setHighContrastMode(enableHighContrast: boolean): void {
-        const payload: SetHighContrastModePayload = {
-            enableHighContrast,
-        };
-
+    public setHighContrastMode(payload: SetHighContrastModePayload): void {
         this.dispatcher.dispatchMessage({
             messageType: Messages.UserConfig.SetHighContrastConfig,
             payload,

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -8,25 +8,25 @@ import { DateProvider } from 'common/date-provider';
 import { remote } from 'electron';
 import { createGetToolDataDelegate } from 'electron/common/application-properties-provider';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { ScanActions } from 'electron/flux/action/scan-actions';
+import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
 import { WindowStateActions } from 'electron/flux/action/window-state-actions';
+import { ScanStore } from 'electron/flux/store/scan-store';
 import { WindowStateStore } from 'electron/flux/store/window-state-store';
+import { PlatformInfo } from 'electron/platform-info';
 import { createFetchScanResults } from 'electron/platform/android/fetch-scan-results';
 import { ScanController } from 'electron/platform/android/scan-controller';
 import { createDefaultBuilder } from 'electron/platform/android/unified-result-builder';
 import { RootContainerProps, RootContainerState } from 'electron/views/root-container/components/root-container';
+import { WindowFrameListener } from 'electron/window-frame-listener';
 import { WindowFrameUpdater } from 'electron/window-frame-updater';
 import * as ReactDOM from 'react-dom';
 
-import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
-import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
-import { ScanStore } from 'electron/flux/store/scan-store';
-import { PlatformInfo } from 'electron/platform-info';
-import { WindowFrameListener } from 'electron/window-frame-listener';
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
-import { UserConfigurationActionCreator } from '../../background/global-action-creators/user-configuration-action-creator';
+import { UserConfigurationActionCreatorImpl } from '../../background/global-action-creators/user-configuration-action-creator-impl';
 import { IndexedDBDataKeys } from '../../background/IndexedDBDataKeys';
 import { InstallationData } from '../../background/installation-data';
 import { UserConfigurationStore } from '../../background/stores/global/user-configuration-store';
@@ -108,7 +108,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
 
     const fetchScanResults = createFetchScanResults(axios.get);
 
-    const userConfigMessageCreator = new UserConfigurationActionCreator(userConfigActions);
+    const userConfigMessageCreator = new UserConfigurationActionCreatorImpl(userConfigActions);
 
     const deviceConnectActionCreator = new DeviceConnectActionCreator(deviceActions, fetchScanResults, telemetryEventHandler);
     const windowFrameActionCreator = new WindowFrameActionCreator(windowFrameActions);

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/settings/high-contrast/high-contrast-settings.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/settings/high-contrast/high-contrast-settings.test.tsx
@@ -45,7 +45,9 @@ describe('HighContrastSettings', () => {
 
             const wrapper = shallow(<HighContrastSettings {...props} />);
 
-            userConfigMessageCreatorMock.setup(creator => creator.setHighContrastMode(!enabled)).verifiable(Times.once());
+            userConfigMessageCreatorMock
+                .setup(creator => creator.setHighContrastMode({ enableHighContrast: !enabled }))
+                .verifiable(Times.once());
 
             wrapper
                 .dive()

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.test.tsx
@@ -56,7 +56,9 @@ describe('TelemetrySettings', () => {
 
             const wrapper = shallow(<TelemetrySettings {...props} />);
 
-            userConfigMessageCreatorMock.setup(creator => creator.setTelemetryState(!enabled)).verifiable(Times.once());
+            userConfigMessageCreatorMock
+                .setup(creator => creator.setTelemetryState({ enableTelemetry: !enabled }))
+                .verifiable(Times.once());
 
             wrapper
                 .dive()

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -7,7 +7,7 @@ import {
     SetIssueFilingServicePropertyPayload,
 } from 'background/actions/action-payloads';
 import { UserConfigurationActions } from 'background/actions/user-configuration-actions';
-import { UserConfigurationActionCreator } from 'background/global-action-creators/user-configuration-action-creator';
+import { UserConfigurationActionCreatorImpl } from 'background/global-action-creators/user-configuration-action-creator-impl';
 import { IMock, Mock } from 'typemoq';
 
 import { createActionMock } from './action-creator-test-helpers';
@@ -17,7 +17,7 @@ describe('UserConfigurationActionCreator', () => {
         const payload = null;
         const getCurrentStateMock = createActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
+        const testSubject = new UserConfigurationActionCreatorImpl(actionsMock.object);
 
         testSubject.getUserConfigurationState();
 
@@ -29,9 +29,9 @@ describe('UserConfigurationActionCreator', () => {
 
         const setTelemetryStateMock = createActionMock(setTelemetryState);
         const actionsMock = createActionsMock('setTelemetryState', setTelemetryStateMock.object);
-        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
+        const testSubject = new UserConfigurationActionCreatorImpl(actionsMock.object);
 
-        testSubject.setTelemetryState(setTelemetryState);
+        testSubject.setTelemetryState({ enableTelemetry: setTelemetryState });
 
         setTelemetryStateMock.verifyAll();
     });
@@ -42,7 +42,7 @@ describe('UserConfigurationActionCreator', () => {
         };
         const setHighContrastConfigMock = createActionMock(payload);
         const actionsMock = createActionsMock('setHighContrastMode', setHighContrastConfigMock.object);
-        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
+        const testSubject = new UserConfigurationActionCreatorImpl(actionsMock.object);
 
         testSubject.setHighContrastMode(payload);
 
@@ -55,7 +55,7 @@ describe('UserConfigurationActionCreator', () => {
         };
         const setBugServiceMock = createActionMock(payload);
         const actionsMock = createActionsMock('setIssueFilingService', setBugServiceMock.object);
-        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
+        const testSubject = new UserConfigurationActionCreatorImpl(actionsMock.object);
 
         testSubject.setIssueFilingService(payload);
 
@@ -70,7 +70,7 @@ describe('UserConfigurationActionCreator', () => {
         };
         const setIssueFilingServicePropertyMock = createActionMock(payload);
         const actionsMock = createActionsMock('setIssueFilingServiceProperty', setIssueFilingServicePropertyMock.object);
-        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
+        const testSubject = new UserConfigurationActionCreatorImpl(actionsMock.object);
 
         testSubject.setIssueFilingServiceProperty(payload);
 
@@ -84,7 +84,7 @@ describe('UserConfigurationActionCreator', () => {
         };
         const setIssueFilingSettings = createActionMock(payload);
         const actionsMock = createActionsMock('saveIssueFilingSettings', setIssueFilingSettings.object);
-        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
+        const testSubject = new UserConfigurationActionCreatorImpl(actionsMock.object);
 
         testSubject.saveIssueFilingSettings(payload);
 

--- a/src/tests/unit/tests/common/components/telemetry-permission-dialog.test.tsx
+++ b/src/tests/unit/tests/common/components/telemetry-permission-dialog.test.tsx
@@ -1,26 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UserConfigurationActionCreator } from 'background/global-action-creators/types/user-configuration-action-creator';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { PrivacyStatementPopupText } from 'common/components/privacy-statement-text';
+import { TelemetryNotice } from 'common/components/telemetry-notice';
+import {
+    TelemetryPermissionDialog,
+    TelemetryPermissionDialogDeps,
+    TelemetryPermissionDialogProps,
+} from 'common/components/telemetry-permission-dialog';
 import * as Enzyme from 'enzyme';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import * as React from 'react';
-import { NewTabLink } from '../../../../../common/components/new-tab-link';
-import { PrivacyStatementPopupText } from '../../../../../common/components/privacy-statement-text';
-import { TelemetryNotice } from '../../../../../common/components/telemetry-notice';
-import {
-    SetTelemetryStateMessageCreator,
-    TelemetryPermissionDialog,
-    TelemetryPermissionDialogDeps,
-    TelemetryPermissionDialogProps,
-} from '../../../../../common/components/telemetry-permission-dialog';
-import { UserConfigMessageCreator } from '../../../../../common/message-creators/user-config-message-creator';
 
 describe('TelemetryPermissionDialogTest', () => {
-    let userConfigMessageCreatorStub: SetTelemetryStateMessageCreator;
+    let userConfigMessageCreatorStub: UserConfigurationActionCreator;
     let setTelemetryStateMock: () => null;
 
     beforeEach(() => {
-        userConfigMessageCreatorStub = {} as UserConfigMessageCreator;
+        userConfigMessageCreatorStub = {} as UserConfigurationActionCreator;
         setTelemetryStateMock = jest.fn();
         userConfigMessageCreatorStub.setTelemetryState = setTelemetryStateMock;
     });

--- a/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
@@ -33,7 +33,7 @@ describe('UserConfigMessageCreator', () => {
             payload,
         };
 
-        testSubject.setTelemetryState(enableTelemetry);
+        testSubject.setTelemetryState(payload);
 
         dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });
@@ -48,7 +48,7 @@ describe('UserConfigMessageCreator', () => {
             payload,
         };
 
-        testSubject.setHighContrastMode(enableHighContrast);
+        testSubject.setHighContrastMode(payload);
 
         dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });


### PR DESCRIPTION
#### Description of changes

`UserConfigMessageCreator` is one of the several indirect dependencies of the `CardsView` component so we need to make the message creator API to match that of the action creator. 
In this PR:
- Extract interface from the `UserConfigurationActionCreator`
- Make both message & action creator API to match the new interface
- Update all usages to match new API
- Use the interface for dependency (instead of depending on the concrete classes)

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1610159
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
