### PR TITLE
fix: prevent weird scrollbars in "No content available" page

### DIFF
--- a/src/DetailsView/components/target-page-closed-view.scss
+++ b/src/DetailsView/components/target-page-closed-view.scss
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 .target-page-closed {
-    padding: 24px;
+    margin-top: 40px;
+    margin-left: 24px;
+    margin-right: 24px;
 }

--- a/src/DetailsView/components/target-page-closed-view.tsx
+++ b/src/DetailsView/components/target-page-closed-view.tsx
@@ -7,10 +7,10 @@ import { targetPageClosed } from './target-page-closed-view.scss';
 export class TargetPageClosedView extends React.Component {
     public render(): JSX.Element {
         return (
-            <div className={targetPageClosed}>
+            <main className={targetPageClosed}>
                 <h1>No content available</h1>
                 <p>The target page was closed. You can close this tab or reuse it for something else.</p>
-            </div>
+            </main>
         );
     }
 }

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -86,15 +86,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
             return (
                 <div className="table column-layout main-wrapper">
                     {this.renderHeader()}
-                    <div className="table column-layout details-view-body">
-                        <div className="table row-layout details-view-main-content">
-                            <div className="details-content table column-layout">
-                                <div className="view" role="main">
-                                    <TargetPageClosedView />
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                    <TargetPageClosedView />
                 </div>
             );
         }

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
@@ -11,29 +11,13 @@ exports[`DetailsViewContainer render renders spinner when stores not ready 1`] =
 exports[`DetailsViewContainer renderContent renders TargetPageClosedView when target page closed 1`] = `
 "<div className=\\"table column-layout main-wrapper\\">
   <Header deps={{...}} selectedPivot={{...}} featureFlagStoreData={{...}} dropdownClickHandler={[undefined]} tabClosed={true} />
-  <div className=\\"table column-layout details-view-body\\">
-    <div className=\\"table row-layout details-view-main-content\\">
-      <div className=\\"details-content table column-layout\\">
-        <div className=\\"view\\" role=\\"main\\">
-          <TargetPageClosedView />
-        </div>
-      </div>
-    </div>
-  </div>
+  <TargetPageClosedView />
 </div>"
 `;
 
 exports[`DetailsViewContainer renderContent shows target tab was closed when stores are not loaded 1`] = `
 "<div className=\\"table column-layout main-wrapper\\">
   <Header deps={{...}} selectedPivot={0} featureFlagStoreData={{...}} dropdownClickHandler={[undefined]} tabClosed={true} />
-  <div className=\\"table column-layout details-view-body\\">
-    <div className=\\"table row-layout details-view-main-content\\">
-      <div className=\\"details-content table column-layout\\">
-        <div className=\\"view\\" role=\\"main\\">
-          <TargetPageClosedView />
-        </div>
-      </div>
-    </div>
-  </div>
+  <TargetPageClosedView />
 </div>"
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-closed-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-closed-view.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StaleView render stale view for default 1`] = `
-<div
+<main
   className="targetPageClosed"
 >
   <h1>
@@ -10,5 +10,5 @@ exports[`StaleView render stale view for default 1`] = `
   <p>
     The target page was closed. You can close this tab or reuse it for something else.
   </p>
-</div>
+</main>
 `;


### PR DESCRIPTION
#### Description of changes

Fixes weird scrollbar behavior in "No content available" screen by removing a bunch of unnecessary code in that path.

![screenshot of fixed page](https://user-images.githubusercontent.com/376284/66790705-bda17380-eea5-11e9-8a43-70e9d86ce66b.png)

Verified how the whole page reads in JAWS

#### Pull request checklist

- [x] Addresses an existing issue: Addresses #1397
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
