### PR TITLE
refactor: simplify and improve names around `DetailsViewMainContent`

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -382,7 +382,7 @@ div.insights-file-issue-details-dialog-container {
             font-size: 18px;
         }
     }
-    .details-view-main-content {
+    .details-view-body-nav-content-layout {
         padding-left: 0px;
         padding-right: 0px;
         display: grid;
@@ -746,7 +746,9 @@ div.insights-file-issue-details-dialog-container {
                 text-align: left;
             }
         }
-        .details-content {
+        .details-view-body-content-pane {
+            display: flex;
+            flex-direction: column;
             width: 100%;
             padding-bottom: 1px;
             overflow: auto;

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -26,10 +26,10 @@ import { TabInfo } from './components/tab-info';
 import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-table-handler';
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
 
-export type DetailsViewMainContentDeps = DetailsViewContentDeps & DetailsViewLeftNavDeps & DetailsViewCommandBarDeps;
+export type DetailsViewBodyDeps = DetailsViewContentDeps & DetailsViewLeftNavDeps & DetailsViewCommandBarDeps;
 
-export interface DetailsViewMainContentProps {
-    deps: DetailsViewMainContentDeps;
+export interface DetailsViewBodyProps {
+    deps: DetailsViewBodyDeps;
     tabStoreData: TabStoreData;
     assessmentStoreData: AssessmentStoreData;
     pathSnippetStoreData: PathSnippetStoreData;
@@ -52,21 +52,21 @@ export interface DetailsViewMainContentProps {
     targetAppInfo: TargetAppData;
 }
 
-export class DetailsViewMainContent extends React.Component<DetailsViewMainContentProps> {
+export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
     public render(): JSX.Element {
         return (
-            <>
+            <div className="details-view-body">
                 {this.renderCommandBar()}
-                <div className="table row-layout details-view-main-content">
+                <div className="details-view-body-nav-content-layout">
                     {this.renderNavBar()}
-                    <div className="details-content table column-layout">
+                    <div className="details-view-body-content-pane">
                         {this.getTabInfo(this.props.tabStoreData.isClosed)}
-                        <div className="view" role="main">
+                        <main>
                             <this.props.rightPanelConfiguration.RightPanel {...this.props} />
-                        </div>
+                        </main>
                     </div>
                 </div>
-            </>
+            </div>
         );
     }
 

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -61,9 +61,9 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
                     {this.renderNavBar()}
                     <div className="details-view-body-content-pane">
                         {this.getTabInfo(this.props.tabStoreData.isClosed)}
-                        <main>
+                        <div className="view" role="main">
                             <this.props.rightPanelConfiguration.RightPanel {...this.props} />
-                        </main>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -32,7 +32,7 @@ import { Header, HeaderDeps } from './components/header';
 import { IssuesTableHandler } from './components/issues-table-handler';
 import { TargetChangeDialogDeps } from './components/target-change-dialog';
 import { TargetPageClosedView } from './components/target-page-closed-view';
-import { DetailsViewMainContent, DetailsViewMainContentDeps } from './details-view-main-content';
+import { DetailsViewBody, DetailsViewBodyDeps } from './details-view-body';
 import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-table-handler';
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
 import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-handler';
@@ -41,7 +41,7 @@ export type DetailsViewContainerDeps = {
     getDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration;
     getDetailsSwitcherNavConfiguration: GetDetailsSwitcherNavConfiguration;
     getUnifiedRuleResults: GetUnifiedRuleResultsDelegate;
-} & DetailsViewMainContentDeps &
+} & DetailsViewBodyDeps &
     DetailsViewOverlayDeps &
     DetailsViewCommandBarDeps &
     HeaderDeps &
@@ -128,7 +128,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
         return (
             <div className="table column-layout main-wrapper">
                 {this.renderHeader()}
-                <div className="table column-layout details-view-body">{this.renderDetailsView()}</div>
+                {this.renderDetailsView()}
                 {this.renderOverlay()}
             </div>
         );
@@ -182,7 +182,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
         );
 
         return (
-            <DetailsViewMainContent
+            <DetailsViewBody
                 deps={deps}
                 tabStoreData={storeState.tabStoreData}
                 assessmentStoreData={storeState.assessmentStoreData}

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -111,48 +111,23 @@ describe('DetailsViewBody', () => {
             } as DetailsViewBodyProps;
         });
 
-        test('tab is closed', () => {
-            const tabStoreData: TabStoreData = {
-                isClosed: true,
-            } as TabStoreData;
-
-            props.tabStoreData = tabStoreData;
-
-            const expected = (
-                <>
-                    {buildCommandBar(props)}
-                    <div className="details-view-body-nav-content-layout">
-                        {null}
-                        <div className="details-view-body-content-pane">
-                            <div className="view" role="main">
-                                <rightPanelConfig.RightPanel {...props} />
-                            </div>
-                        </div>
-                    </div>
-                </>
-            );
-
-            const testSubject = new DetailsViewBody(props);
-            expect(testSubject.render()).toEqual(expected);
-        });
-
         test('a non-assessment or non-issues view', () => {
             setupClickHandlerFactoryMock(clickHandlerFactoryMock, selectedTest, !scanDataStub.enabled);
             setupConfigFactoryMock(configFactoryMock, getStoreDataMock, configStub, scanDataStub, props);
 
             const expected = (
-                <>
+                <div className="details-view-body">
                     {buildCommandBar(props)}
-                    <div className="table row-layout details-view-body">
+                    <div className="details-view-body-nav-content-layout">
                         {buildLeftNav(props)}
-                        <div className="details-content table column-layout">
+                        <div className="details-view-body-content-pane">
                             {buildTabInfo(props)}
                             <div className="view" role="main">
                                 <rightPanelConfig.RightPanel {...props} />
                             </div>
                         </div>
                     </div>
-                </>
+                </div>
             );
 
             const testSubject = new DetailsViewBody(props);

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -22,14 +22,14 @@ import { DetailsRightPanelConfiguration } from '../../../../DetailsView/componen
 import { DetailsViewSwitcherNavConfiguration } from '../../../../DetailsView/components/details-view-switcher-nav';
 import { DetailsViewLeftNav } from '../../../../DetailsView/components/left-nav/details-view-left-nav';
 import { TabInfo } from '../../../../DetailsView/components/tab-info';
-import { DetailsViewMainContent, DetailsViewMainContentProps } from '../../../../DetailsView/details-view-main-content';
+import { DetailsViewBody, DetailsViewBodyProps } from '../../../../DetailsView/details-view-body';
 import { DetailsViewToggleClickHandlerFactory } from '../../../../DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { TabStoreDataBuilder } from '../../common/tab-store-data-builder';
 import { VisualizationScanResultStoreDataBuilder } from '../../common/visualization-scan-result-store-data-builder';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 import { exampleUnifiedStatusResults } from '../common/components/cards/sample-view-model-data';
 
-describe('DetailsViewMainContentTest', () => {
+describe('DetailsViewBody', () => {
     let selectedTest: VisualizationType;
     let configFactoryMock: IMock<VisualizationConfigurationFactory>;
     let clickHandlerFactoryMock: IMock<DetailsViewToggleClickHandlerFactory>;
@@ -37,25 +37,16 @@ describe('DetailsViewMainContentTest', () => {
     let getStoreDataMock: IMock<(data: TestsEnabledState) => ScanData>;
     let configStub: VisualizationConfiguration;
     let scanDataStub: ScanData;
-    let props: DetailsViewMainContentProps;
+    let props: DetailsViewBodyProps;
     let rightPanelConfig: DetailsRightPanelConfiguration;
     let switcherNavConfig: DetailsViewSwitcherNavConfiguration;
 
     describe('render', () => {
         beforeEach(() => {
             selectedTest = -1;
-            const RightPanelStub: Readonly<ReactFCWithDisplayName<DetailsViewMainContentProps>> = NamedFC<DetailsViewMainContentProps>(
-                'test',
-                _ => null,
-            );
-            const CommandBarStub: Readonly<ReactFCWithDisplayName<DetailsViewMainContentProps>> = NamedFC<DetailsViewMainContentProps>(
-                'test',
-                _ => null,
-            );
-            const LeftNavStub: Readonly<ReactFCWithDisplayName<DetailsViewMainContentProps>> = NamedFC<DetailsViewMainContentProps>(
-                'test',
-                _ => null,
-            );
+            const RightPanelStub: Readonly<ReactFCWithDisplayName<DetailsViewBodyProps>> = NamedFC<DetailsViewBodyProps>('test', _ => null);
+            const CommandBarStub: Readonly<ReactFCWithDisplayName<DetailsViewBodyProps>> = NamedFC<DetailsViewBodyProps>('test', _ => null);
+            const LeftNavStub: Readonly<ReactFCWithDisplayName<DetailsViewBodyProps>> = NamedFC<DetailsViewBodyProps>('test', _ => null);
             rightPanelConfig = {
                 RightPanel: RightPanelStub,
             } as DetailsRightPanelConfiguration;
@@ -117,7 +108,7 @@ describe('DetailsViewMainContentTest', () => {
                 rightPanelConfiguration: rightPanelConfig,
                 switcherNavConfiguration: switcherNavConfig,
                 ruleResultsByStatus: exampleUnifiedStatusResults,
-            } as DetailsViewMainContentProps;
+            } as DetailsViewBodyProps;
         });
 
         test('tab is closed', () => {
@@ -130,19 +121,18 @@ describe('DetailsViewMainContentTest', () => {
             const expected = (
                 <>
                     {buildCommandBar(props)}
-                    <div className="table row-layout details-view-main-content">
+                    <div className="details-view-body-nav-content-layout">
                         {null}
-                        <div className="details-content table column-layout">
-                            {null}
-                            <div className="view" role="main">
+                        <div className="details-view-body-content-pane">
+                            <main>
                                 <rightPanelConfig.RightPanel {...props} />
-                            </div>
+                            </main>
                         </div>
                     </div>
                 </>
             );
 
-            const testSubject = new DetailsViewMainContent(props);
+            const testSubject = new DetailsViewBody(props);
             expect(testSubject.render()).toEqual(expected);
         });
 
@@ -153,7 +143,7 @@ describe('DetailsViewMainContentTest', () => {
             const expected = (
                 <>
                     {buildCommandBar(props)}
-                    <div className="table row-layout details-view-main-content">
+                    <div className="table row-layout details-view-body">
                         {buildLeftNav(props)}
                         <div className="details-content table column-layout">
                             {buildTabInfo(props)}
@@ -165,7 +155,7 @@ describe('DetailsViewMainContentTest', () => {
                 </>
             );
 
-            const testSubject = new DetailsViewMainContent(props);
+            const testSubject = new DetailsViewBody(props);
             expect(testSubject.render()).toEqual(expected);
         });
     });
@@ -175,7 +165,7 @@ describe('DetailsViewMainContentTest', () => {
         givenGetStoreDataMock: IMock<(data: TestsEnabledState) => ScanData>,
         config: VisualizationConfiguration,
         scanData: ScanData,
-        givenProps: DetailsViewMainContentProps,
+        givenProps: DetailsViewBodyProps,
     ): void {
         factoryMock.setup(cfm => cfm.getConfiguration(givenProps.selectedTest)).returns(() => config);
 
@@ -190,11 +180,11 @@ describe('DetailsViewMainContentTest', () => {
         factoryMock.setup(chfm => chfm.createClickHandler(setupType, setupNewValue)).returns(() => clickHandlerStub);
     }
 
-    function buildLeftNav(givenProps: DetailsViewMainContentProps): JSX.Element {
+    function buildLeftNav(givenProps: DetailsViewBodyProps): JSX.Element {
         return <DetailsViewLeftNav {...givenProps} />;
     }
 
-    function buildTabInfo(givenProps: DetailsViewMainContentProps): JSX.Element {
+    function buildTabInfo(givenProps: DetailsViewBodyProps): JSX.Element {
         return (
             <TabInfo
                 isTargetPageHidden={givenProps.tabStoreData.isPageHidden}
@@ -207,7 +197,7 @@ describe('DetailsViewMainContentTest', () => {
         );
     }
 
-    function buildCommandBar(givenProps: DetailsViewMainContentProps): JSX.Element {
+    function buildCommandBar(givenProps: DetailsViewBodyProps): JSX.Element {
         return <switcherNavConfig.CommandBar actionMessageCreator={props.deps.detailsViewActionMessageCreator} {...props} />;
     }
 });

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -14,7 +14,6 @@ import {
     AssessmentStoreData,
     PersistedTabInfo,
 } from '../../../../common/types/store-data/assessment-result-data';
-import { TabStoreData } from '../../../../common/types/store-data/tab-store-data';
 import { ScanData, TestsEnabledState } from '../../../../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../../../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../../../../DetailsView/actions/details-view-action-message-creator';

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -124,9 +124,9 @@ describe('DetailsViewBody', () => {
                     <div className="details-view-body-nav-content-layout">
                         {null}
                         <div className="details-view-body-content-pane">
-                            <main>
+                            <div className="view" role="main">
                                 <rightPanelConfig.RightPanel {...props} />
-                            </main>
+                            </div>
                         </div>
                     </div>
                 </>

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -36,13 +36,13 @@ import {
 import { Header } from '../../../../DetailsView/components/header';
 import { DetailsViewRightContentPanelType } from '../../../../DetailsView/components/left-nav/details-view-right-content-panel-type';
 import { GetSelectedDetailsViewProps } from '../../../../DetailsView/components/left-nav/get-selected-details-view';
+import { DetailsViewBody } from '../../../../DetailsView/details-view-body';
 import {
     DetailsViewContainer,
     DetailsViewContainerDeps,
     DetailsViewContainerProps,
     DetailsViewContainerState,
 } from '../../../../DetailsView/details-view-container';
-import { DetailsViewMainContent } from '../../../../DetailsView/details-view-main-content';
 import { DetailsViewToggleClickHandlerFactory } from '../../../../DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { PreviewFeatureFlagsHandler } from '../../../../DetailsView/handlers/preview-feature-flags-handler';
 import { DetailsViewStoreDataBuilder } from '../../common/details-view-store-data-builder';
@@ -278,7 +278,7 @@ describe('DetailsViewContainer', () => {
         targetApp: TargetAppData,
     ): JSX.Element {
         return (
-            <DetailsViewMainContent
+            <DetailsViewBody
                 deps={deps}
                 tabStoreData={storeMocks.tabStoreData}
                 assessmentStoreData={storeMocks.assessmentStoreData}

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -467,17 +467,15 @@ describe('DetailsViewContainer', () => {
                     dropdownClickHandler={dropdownClickHandler.object}
                     tabClosed={storeMocks.tabStoreData.isClosed}
                 />
-                <div className="table column-layout details-view-body">
-                    {buildDetailsViewMainContent(
-                        storeMocks,
-                        props,
-                        viewType,
-                        rightContentPanelConfig,
-                        switcherNavConfig,
-                        ruleResults,
-                        targetAppInfo,
-                    )}
-                </div>
+                {buildDetailsViewMainContent(
+                    storeMocks,
+                    props,
+                    viewType,
+                    rightContentPanelConfig,
+                    switcherNavConfig,
+                    ruleResults,
+                    targetAppInfo,
+                )}
                 {buildOverlay(storeMocks, props)}
             </div>
         );


### PR DESCRIPTION
#### Description of changes

`DetailsViewMainContent` was named misleadingly; it actually contained several elements besides the main landmark. This PR renames it and its surrounding styles/etc to `DetailsViewBody`, gives it responsibility for its own wrapper div (moved from the parent `DetailsViewContainer`), and moves its layout styles to be controlled by CSS rather than essentially being inlined (via `.table` and similar).

There are no visual changes as part of this PR.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a, no visual change] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
