### PR TITLE
refactor: remove unnecessary details view div/styles

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -252,6 +252,9 @@ div.insights-file-issue-details-dialog-container {
 }
 
 #details-container {
+    display: flex;
+    flex-direction: column;
+
     .details-view-body {
         margin-top: $detailsViewHeaderBarHeight;
     }
@@ -1315,18 +1318,4 @@ div.insights-file-issue-details-dialog-container {
             }
         }
     }
-}
-
-.table {
-    display: -webkit-flex;
-    display: flex;
-    flex: 7;
-}
-
-.table.row-layout {
-    flex-direction: row;
-}
-
-.table.column-layout {
-    flex-direction: column;
 }

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -87,10 +87,10 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
     public render(): JSX.Element {
         if (this.isTargetPageClosed()) {
             return (
-                <div className="table column-layout main-wrapper">
+                <>
                     {this.renderHeader()}
                     <TargetPageClosedView />
-                </div>
+                </>
             );
         }
 
@@ -118,11 +118,11 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
 
     private renderContent(): JSX.Element {
         return (
-            <div className="table column-layout main-wrapper">
+            <>
                 {this.renderHeader()}
                 {this.renderDetailsView()}
                 {this.renderOverlay()}
-            </div>
+            </>
         );
     }
 

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
@@ -9,15 +9,15 @@ exports[`DetailsViewContainer render renders spinner when stores not ready 1`] =
 `;
 
 exports[`DetailsViewContainer renderContent renders TargetPageClosedView when target page closed 1`] = `
-"<div className=\\"table column-layout main-wrapper\\">
+"<Fragment>
   <Header deps={{...}} selectedPivot={{...}} featureFlagStoreData={{...}} dropdownClickHandler={[undefined]} tabClosed={true} />
   <TargetPageClosedView />
-</div>"
+</Fragment>"
 `;
 
 exports[`DetailsViewContainer renderContent shows target tab was closed when stores are not loaded 1`] = `
-"<div className=\\"table column-layout main-wrapper\\">
+"<Fragment>
   <Header deps={{...}} selectedPivot={0} featureFlagStoreData={{...}} dropdownClickHandler={[undefined]} tabClosed={true} />
   <TargetPageClosedView />
-</div>"
+</Fragment>"
 `;

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -459,7 +459,7 @@ describe('DetailsViewContainer', () => {
             .returns(() => ruleResults);
 
         const expected: JSX.Element = (
-            <div className="table column-layout main-wrapper">
+            <>
                 <Header
                     deps={props.deps}
                     selectedPivot={DetailsViewPivotType.fastPass}
@@ -477,7 +477,7 @@ describe('DetailsViewContainer', () => {
                     targetAppInfo,
                 )}
                 {buildOverlay(storeMocks, props)}
-            </div>
+            </>
         );
 
         expect(testObject.render()).toEqual(expected);


### PR DESCRIPTION
#### Description of changes

The details view container currently adds a `<div className="table column-layout main-wrapper">` div near the root level. `main-wrapper` is never used in our css, and `table column-layout` is better represented as applying styles to a more logically-named class (so the CSS can have layout responsibility, rather than essentially using inline styles here).

This removes the unnecessary layer of div as well as the `.table` classes from `detailsview.scss` (this was the last spot they were used - there is a separate `.table` style in `content.scss` that is a little more reasonble, which I haven't modified in this PR.

Verified that there are no visual changes as a result of this change. In particular, verified the following details view scenarios:

* FastPass (both left nav tabs)
* Assessement (overview, manual, assisted requirements)
* Settings panel
* Issues filing dialog
* "No content available" page

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
