### PR TITLE
refactor: remove unused detailsview.scss classes

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -114,10 +114,6 @@ div.insights-file-issue-details-dialog-container {
     font-family: $codeFontFamily;
 }
 
-.path-list {
-    padding-left: 13px !important;
-}
-
 .column-header span:first-of-type {
     padding-left: 5px !important;
 }
@@ -224,22 +220,6 @@ div.insights-file-issue-details-dialog-container {
 .preview-features-panel {
     .preview-feature-toggle-list {
         margin-top: 2vh;
-        .preview-feature-toggle-container {
-            .pf-name-toggle {
-                margin-bottom: 1vh;
-                .pf-name {
-                    display: inline-block;
-                    font-size: 16px;
-                    font-weight: bold;
-                }
-                .pf-toggle {
-                    float: right;
-                }
-            }
-        }
-        .preview-feature-toggle-container + .preview-feature-toggle-container {
-            margin-top: 4vh;
-        }
     }
     .no-preview-feature-message {
         font-size: 20px;
@@ -896,13 +876,8 @@ div.insights-file-issue-details-dialog-container {
                 b {
                     font-weight: 600;
                 }
-                .why-vis,
-                .about-vis {
+                .why-vis {
                     padding-top: 4px;
-                }
-                .why-vis,
-                .about-vis,
-                .more-info {
                     font-size: 14px;
                     .ms-Link {
                         color: $communication-primary;
@@ -911,12 +886,6 @@ div.insights-file-issue-details-dialog-container {
                 .tab-stops-accessibility-problems-list {
                     background: $neutral-6;
                     list-style-type: disc;
-                }
-                .landmarks-legend-description {
-                    padding-left: 12px;
-                    font-size: 14px;
-                    display: table-cell;
-                    vertical-align: middle;
                 }
                 .landmarks-legend {
                     color: $neutral-100;


### PR DESCRIPTION
#### Description of changes

I looked through `popup.scss`, `injected.scss`, `detailsview.scss`, and `content.scss` for class names that had styles but were never used in the application. I did this by starting from the results of the following powershell function (uses [ripgrep](https://github.com/BurntSushi/ripgrep)):

```powershell
function findUnusedStyles($file) {
    $styleNames = type $file | `
        sls '\.([a-zA-Z\-_][\w\d\-_]*)[ {]' | `
        % { $_.Matches[0].Groups[1].Value } | `
        select -unique | `
        sort;
    $unusedStyles = $styleNames | `
        where { $_ -notmatch 'ms-' } | `
        where { 0 -eq @(rg -g '!$file' $_).Count };
    return $unusedStyles;
}
```

...and then additionally double checking with vs code's find-all for every class I removed.

There weren't any results except for in `detailsview.scss`.

Did a sanity check over the app that no UI seemed different (with particular attention to the preview features panel).

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
