### PR TITLE
feat(android-cards-view): update styles for automated checks view

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.scss
+++ b/src/electron/views/automated-checks/automated-checks-view.scss
@@ -2,6 +2,9 @@
 // Licensed under the MIT License.
 .automated-checks-view {
     main {
-        margin: 16px 24px;
+        margin-top: 16px;
+        margin-bottom: 16px;
+        margin-left: 24px;
+        margin-right: 24px;
     }
 }

--- a/src/electron/views/automated-checks/automated-checks-view.scss
+++ b/src/electron/views/automated-checks/automated-checks-view.scss
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.automated-checks-view {
+    main {
+        margin: 16px 24px;
+    }
+}

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -11,6 +11,7 @@ import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { ScanningSpinner } from 'electron/views/automated-checks/components/scanning-spinner';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
+import { automatedChecksView } from './automated-checks-view.scss';
 import { CommandBar, CommandBarDeps } from './components/command-bar';
 import { HeaderSection } from './components/header-section';
 
@@ -34,13 +35,15 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
 
     public render(): JSX.Element {
         return (
-            <>
+            <div className={automatedChecksView}>
                 <TitleBar deps={this.props.deps} windowStateStoreData={this.props.windowStateStoreData}></TitleBar>
                 <CommandBar deps={this.props.deps} />
-                <HeaderSection />
-                {this.renderScanning()}
-                {this.renderDeviceDisconnected()}
-            </>
+                <main>
+                    <HeaderSection />
+                    {this.renderScanning()}
+                    {this.renderDeviceDisconnected()}
+                </main>
+            </div>
         );
     }
 

--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -3,7 +3,6 @@
 @import '../../../../common/styles/colors.scss';
 
 .command-bar {
-    width: 100%;
     display: flex;
     justify-content: space-between;
     min-height: fit-content;
@@ -12,12 +11,12 @@
     font-size: 14px;
     font-weight: normal;
     border-bottom: 1px solid $neutral-alpha-8;
-    padding: 0px 16px;
 
-    #rescan-button {
-        i {
-            color: $primary-text;
-            line-height: 16px;
-        }
+    padding-left: 16px;
+    padding-right: 16px;
+
+    .rescan-button {
+        color: $primary-text;
+        line-height: 16px;
     }
 }

--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -12,4 +12,12 @@
     font-size: 14px;
     font-weight: normal;
     border-bottom: 1px solid $neutral-alpha-8;
+    padding: 0px 16px;
+
+    #rescan-button {
+        i {
+            color: $primary-text;
+            line-height: 16px;
+        }
+    }
 }

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -20,8 +20,8 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: Command
     return (
         <div className={commandBar}>
             <ActionButton
-                id={rescanButton}
                 iconProps={{
+                    className: rescanButton,
                     iconName: 'Refresh',
                 }}
                 onClick={onClick}

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -5,7 +5,7 @@ import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
-import { commandBar } from './command-bar.scss';
+import { commandBar, rescanButton } from './command-bar.scss';
 
 export type CommandBarDeps = {
     deviceConnectActionCreator: DeviceConnectActionCreator;
@@ -20,6 +20,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: Command
     return (
         <div className={commandBar}>
             <ActionButton
+                id={rescanButton}
                 iconProps={{
                     iconName: 'Refresh',
                 }}

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AutomatedChecksView renders device disconnected 1`] = `
-<React.Fragment>
+<div
+  className="automatedChecksView"
+>
   <TitleBar
     deps={
       Object {
@@ -22,20 +24,24 @@ exports[`AutomatedChecksView renders device disconnected 1`] = `
       }
     }
   />
-  <HeaderSection />
-  <ScanningSpinner
-    isScanning={false}
-  />
-  <DeviceDisconnectedPopup
-    deviceName="TEST DEVICE"
-    onConnectNewDevice={[Function]}
-    onRescanDevice={[Function]}
-  />
-</React.Fragment>
+  <main>
+    <HeaderSection />
+    <ScanningSpinner
+      isScanning={false}
+    />
+    <DeviceDisconnectedPopup
+      deviceName="TEST DEVICE"
+      onConnectNewDevice={[Function]}
+      onRescanDevice={[Function]}
+    />
+  </main>
+</div>
 `;
 
 exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
-<React.Fragment>
+<div
+  className="automatedChecksView"
+>
   <TitleBar
     deps={
       Object {
@@ -77,15 +83,19 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
       }
     }
   />
-  <HeaderSection />
-  <ScanningSpinner
-    isScanning={false}
-  />
-</React.Fragment>
+  <main>
+    <HeaderSection />
+    <ScanningSpinner
+      isScanning={false}
+    />
+  </main>
+</div>
 `;
 
 exports[`AutomatedChecksView renders scanning spinner 1`] = `
-<React.Fragment>
+<div
+  className="automatedChecksView"
+>
   <TitleBar
     deps={
       Object {
@@ -127,9 +137,11 @@ exports[`AutomatedChecksView renders scanning spinner 1`] = `
       }
     }
   />
-  <HeaderSection />
-  <ScanningSpinner
-    isScanning={true}
-  />
-</React.Fragment>
+  <main>
+    <HeaderSection />
+    <ScanningSpinner
+      isScanning={true}
+    />
+  </main>
+</div>
 `;

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -7,10 +7,10 @@ exports[`CommandBar render 1`] = `
   <CustomizedActionButton
     iconProps={
       Object {
+        "className": "rescanButton",
         "iconName": "Refresh",
       }
     }
-    id="rescanButton"
     onClick={[Function]}
     text="Rescan"
   />

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`CommandBar render 1`] = `
         "iconName": "Refresh",
       }
     }
+    id="rescanButton"
     onClick={[Function]}
     text="Rescan"
   />


### PR DESCRIPTION
#### Description of changes

Mostly, add margins/paddings values on the automated checks view main content and the command bar.

![image](https://user-images.githubusercontent.com/2837582/66870131-9c985b80-ef55-11e9-91b2-961318318d08.png)

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1606846
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - not affected
