### PR TITLE
fix: remove doctype from assessment report to fix icon regression

### DIFF
--- a/src/reports/assessment-report-html-generator.tsx
+++ b/src/reports/assessment-report-html-generator.tsx
@@ -70,6 +70,6 @@ export class AssessmentReportHtmlGenerator {
 
         const reportBody = this.renderer.renderToStaticMarkup(reportElement);
 
-        return `<!DOCTYPE html><html lang="en">${reportBody}</html>`;
+        return `<html lang="en">${reportBody}</html>`;
     }
 }

--- a/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
@@ -59,7 +59,7 @@ describe('AssessmentReportHtmlGenerator', () => {
             </React.Fragment>
         );
         const expectedBody: string = '<head>styles</head><body>report-body</body>';
-        const expectedHtml = `<!DOCTYPE html><html lang="en">${expectedBody}</html>`;
+        const expectedHtml = `<html lang="en">${expectedBody}</html>`;
 
         const testDate = new Date(2018, 9, 19, 11, 25);
         const assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator = new AssessmentDefaultMessageGenerator();


### PR DESCRIPTION
#### Description of changes

The change #1450 introduced DOCTYPE in the assessment HTML report. We should have it, but it leads to icon mangling as described in #1470 - this PR reverts the DOCTYPE changes for now so master is unblocked.

#### Pull request checklist

- [x] Addresses an existing issue: addresses #1470 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS

![image](https://user-images.githubusercontent.com/7775527/66868746-c603b800-ef52-11e9-8f75-71411ce047b6.png)

