### PR TITLE
Fix a11y issue on toast and add proper test

### DIFF
--- a/src/common/components/toast.tsx
+++ b/src/common/components/toast.tsx
@@ -45,6 +45,10 @@ export class Toast extends React.Component<ToastProps, ToastState> {
     }
 
     public render(): JSX.Element {
-        return this.state.toastVisible ? <div className={css('ms-fadeIn100', 'toast')}>{this.state.content}</div> : null;
+        return this.state.toastVisible ? (
+            <div role="alert" aria-live="polite" className={css('ms-fadeIn100', 'toast')}>
+                {this.state.content}
+            </div>
+        ) : null;
     }
 }

--- a/src/tests/unit/tests/common/components/__snapshots__/toast.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/toast.test.tsx.snap
@@ -1,3 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ToastTest render 1`] = `null`;
+exports[`ToastTest render: render content 1`] = `
+<div
+  aria-live="polite"
+  class="ms-fadeIn100 toast"
+  role="alert"
+>
+  hello world
+</div>
+`;
+
+exports[`ToastTest render: render nothing before show() is called 1`] = `null`;

--- a/src/tests/unit/tests/common/components/toast.test.tsx
+++ b/src/tests/unit/tests/common/components/toast.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/common/components/toast.test.tsx
+++ b/src/tests/unit/tests/common/components/toast.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
 
@@ -23,8 +23,14 @@ describe('ToastTest', () => {
     });
 
     test('render', () => {
-        const result = shallow(<Toast {...props}></Toast>);
-        expect(result.getElement()).toMatchSnapshot();
+        const toastRef: React.RefObject<Toast> = React.createRef();
+        const result = mount(<Toast ref={toastRef} {...props}></Toast>);
+
+        expect(result.getDOMNode()).toMatchSnapshot('render nothing before show() is called');
+
+        toastRef.current.show('hello world');
+
+        expect(result.getDOMNode()).toMatchSnapshot('render content');
     });
 
     test('show', () => {


### PR DESCRIPTION
#### Description of changes

- Fix a11y issue on toast by adding ``https://github.com/microsoft/accessibility-insights-web/pull/1479`` back.
- add proper snapshot testing.
- verified that the toast message is read out by AT.
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
