### PR TITLE
Root Container views drag and no-drag implementation

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.scss
+++ b/src/electron/views/automated-checks/automated-checks-view.scss
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 .automated-checks-view {
+    -webkit-app-region: no-drag;
+
     main {
         margin-top: 16px;
         margin-bottom: 16px;

--- a/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
@@ -9,6 +9,7 @@ import * as React from 'react';
 import { NamedFC } from 'common/react/named-fc';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { DeviceStoreData } from '../../../flux/types/device-store-data';
+import { deviceConnectView } from '../device-connect-view.scss';
 import { DeviceConnectBody, DeviceConnectBodyDeps } from './device-connect-body';
 import { WindowTitle, WindowTitleDeps } from './window-title';
 
@@ -24,16 +25,18 @@ export type DeviceConnectViewContainerProps = {
 export const DeviceConnectViewContainer = NamedFC<DeviceConnectViewContainerProps>('DeviceConnectViewContainer', props => {
     return (
         <>
-            <WindowTitle title={brand} deps={props.deps} windowStateStoreData={props.windowStateStoreData}>
-                <BrandBlue />
-            </WindowTitle>
-            <DeviceConnectBody
-                deps={props.deps}
-                viewState={{
-                    deviceConnectState: props.deviceStoreData.deviceConnectState,
-                    connectedDevice: props.deviceStoreData.connectedDevice,
-                }}
-            />
+            <div className={deviceConnectView}>
+                <WindowTitle title={brand} deps={props.deps} windowStateStoreData={props.windowStateStoreData}>
+                    <BrandBlue />
+                </WindowTitle>
+                <DeviceConnectBody
+                    deps={props.deps}
+                    viewState={{
+                        deviceConnectState: props.deviceStoreData.deviceConnectState,
+                        connectedDevice: props.deviceStoreData.connectedDevice,
+                    }}
+                />
+            </div>
             <TelemetryPermissionDialog deps={props.deps} isFirstTime={props.userConfigurationStoreData.isFirstTime} />
         </>
     );

--- a/src/electron/views/device-connect-view/device-connect-view.scss
+++ b/src/electron/views/device-connect-view/device-connect-view.scss
@@ -3,10 +3,14 @@
 @import './components/telemetry-permission-dialog.scss';
 
 body {
-    -webkit-app-region: drag;
     margin: 0px;
 }
 
+.device-connect-view {
+    -webkit-app-region: drag;
+    height: 100%;
+    width: 100%;
+}
 button {
     -webkit-app-region: no-drag;
 }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
@@ -2,27 +2,31 @@
 
 exports[`DeviceConnectViewContainer renders 1`] = `
 <React.Fragment>
-  <WindowTitle
-    deps={Object {}}
-    title="Accessibility Insights"
-    windowStateStoreData={
-      Object {
-        "currentWindowState": "customSize",
-        "routeId": "deviceConnectView",
-      }
-    }
+  <div
+    className="deviceConnectView"
   >
-    <BrandBlue />
-  </WindowTitle>
-  <DeviceConnectBody
-    deps={Object {}}
-    viewState={
-      Object {
-        "connectedDevice": undefined,
-        "deviceConnectState": 0,
+    <WindowTitle
+      deps={Object {}}
+      title="Accessibility Insights"
+      windowStateStoreData={
+        Object {
+          "currentWindowState": "customSize",
+          "routeId": "deviceConnectView",
+        }
       }
-    }
-  />
+    >
+      <BrandBlue />
+    </WindowTitle>
+    <DeviceConnectBody
+      deps={Object {}}
+      viewState={
+        Object {
+          "connectedDevice": undefined,
+          "deviceConnectState": 0,
+        }
+      }
+    />
+  </div>
   <TelemetryPermissionDialog
     deps={Object {}}
     isFirstTime={true}


### PR DESCRIPTION
#### Description of changes

- Maintained the drag functionality of device-connect-view (e.g. user cannot select the text but can drag the window around the screen)
- Added "-webkit-app-region: no-drag" to the automatedChecks view so that users can select text and items within the container

#### Pull request checklist

- [N/A] Addresses an existing issue: Fixes #0000
- [N/A] Added relevant unit test for your changes. (`yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] Ran precheckin (`yarn precheckin`)
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [N/A] (UI changes only) Verified usability with NVDA/JAWS
