### PR TITLE
feat(android-cards-view): fix rescan button

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -37,7 +37,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
         return (
             <div className={automatedChecksView}>
                 <TitleBar deps={this.props.deps} windowStateStoreData={this.props.windowStateStoreData}></TitleBar>
-                <CommandBar deps={this.props.deps} />
+                <CommandBar deps={this.props.deps} deviceStoreData={this.props.deviceStoreData} />
                 <main>
                     <HeaderSection />
                     {this.renderScanning()}

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -5,8 +5,8 @@ import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
-import { commandBar, rescanButton } from './command-bar.scss';
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
+import { commandBar, rescanButton } from './command-bar.scss';
 
 export type CommandBarDeps = {
     deviceConnectActionCreator: DeviceConnectActionCreator;

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -6,6 +6,7 @@ import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
 import { commandBar, rescanButton } from './command-bar.scss';
+import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 
 export type CommandBarDeps = {
     deviceConnectActionCreator: DeviceConnectActionCreator;
@@ -13,10 +14,14 @@ export type CommandBarDeps = {
 
 export interface CommandBarProps {
     deps: CommandBarDeps;
+    deviceStoreData: DeviceStoreData;
 }
 
 export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: CommandBarProps) => {
-    const onClick = () => props.deps.deviceConnectActionCreator.resetConnection();
+    const { deps, deviceStoreData } = props;
+
+    const onClick = () => deps.deviceConnectActionCreator.validatePort(deviceStoreData.port);
+
     return (
         <div className={commandBar}>
             <ActionButton

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -1,26 +1,62 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AutomatedChecksView renders device disconnected 1`] = `
+exports[`AutomatedChecksView renders status scan <Failed> 1`] = `
 <div
   className="automatedChecksView"
 >
   <TitleBar
     deps={
       Object {
+        "deviceConnectActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
+          "fetchScanResults": undefined,
+          "telemetryEventHandler": undefined,
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
         },
+        "windowFrameActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActions": undefined,
+        },
+        "windowStateActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActionCreator": undefined,
+          "windowStateActions": undefined,
+        },
       }
     }
+    windowStateStoreData="window state store data"
   />
   <CommandBar
     deps={
       Object {
+        "deviceConnectActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
+          "fetchScanResults": undefined,
+          "telemetryEventHandler": undefined,
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
         },
+        "windowFrameActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActions": undefined,
+        },
+        "windowStateActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActionCreator": undefined,
+          "windowStateActions": undefined,
+        },
+      }
+    }
+    deviceStoreData={
+      Object {
+        "connectedDevice": "TEST DEVICE",
       }
     }
   />
@@ -38,14 +74,19 @@ exports[`AutomatedChecksView renders device disconnected 1`] = `
 </div>
 `;
 
-exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
+exports[`AutomatedChecksView renders status scan <Scanning> 1`] = `
 <div
   className="automatedChecksView"
 >
   <TitleBar
     deps={
       Object {
-        "deviceConnectActionCreator": null,
+        "deviceConnectActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
+          "fetchScanResults": undefined,
+          "telemetryEventHandler": undefined,
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
@@ -66,7 +107,12 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
   <CommandBar
     deps={
       Object {
-        "deviceConnectActionCreator": null,
+        "deviceConnectActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
+          "fetchScanResults": undefined,
+          "telemetryEventHandler": undefined,
+        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
@@ -82,58 +128,9 @@ exports[`AutomatedChecksView renders renders the automated checks view 1`] = `
         },
       }
     }
-  />
-  <main>
-    <HeaderSection />
-    <ScanningSpinner
-      isScanning={false}
-    />
-  </main>
-</div>
-`;
-
-exports[`AutomatedChecksView renders scanning spinner 1`] = `
-<div
-  className="automatedChecksView"
->
-  <TitleBar
-    deps={
+    deviceStoreData={
       Object {
-        "deviceConnectActionCreator": null,
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "scanActions": undefined,
-        },
-        "windowFrameActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "windowFrameActions": undefined,
-        },
-        "windowStateActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "windowFrameActionCreator": undefined,
-          "windowStateActions": undefined,
-        },
-      }
-    }
-    windowStateStoreData="window state store data"
-  />
-  <CommandBar
-    deps={
-      Object {
-        "deviceConnectActionCreator": null,
-        "scanActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "scanActions": undefined,
-        },
-        "windowFrameActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "windowFrameActions": undefined,
-        },
-        "windowStateActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "windowFrameActionCreator": undefined,
-          "windowStateActions": undefined,
-        },
+        "connectedDevice": "TEST DEVICE",
       }
     }
   />
@@ -141,6 +138,75 @@ exports[`AutomatedChecksView renders scanning spinner 1`] = `
     <HeaderSection />
     <ScanningSpinner
       isScanning={true}
+    />
+  </main>
+</div>
+`;
+
+exports[`AutomatedChecksView renders status scan <undefined> 1`] = `
+<div
+  className="automatedChecksView"
+>
+  <TitleBar
+    deps={
+      Object {
+        "deviceConnectActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
+          "fetchScanResults": undefined,
+          "telemetryEventHandler": undefined,
+        },
+        "scanActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "scanActions": undefined,
+        },
+        "windowFrameActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActions": undefined,
+        },
+        "windowStateActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActionCreator": undefined,
+          "windowStateActions": undefined,
+        },
+      }
+    }
+    windowStateStoreData="window state store data"
+  />
+  <CommandBar
+    deps={
+      Object {
+        "deviceConnectActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
+          "fetchScanResults": undefined,
+          "telemetryEventHandler": undefined,
+        },
+        "scanActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "scanActions": undefined,
+        },
+        "windowFrameActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActions": undefined,
+        },
+        "windowStateActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActionCreator": undefined,
+          "windowStateActions": undefined,
+        },
+      }
+    }
+    deviceStoreData={
+      Object {
+        "connectedDevice": "TEST DEVICE",
+      }
+    }
+  />
+  <main>
+    <HeaderSection />
+    <ScanningSpinner
+      isScanning={false}
     />
   </main>
 </div>

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
@@ -12,58 +13,30 @@ import { It, Mock, Times } from 'typemoq';
 
 describe('AutomatedChecksView', () => {
     describe('renders', () => {
-        it('renders the automated checks view', () => {
-            const props: AutomatedChecksViewProps = {
+        let bareMinimumProps: AutomatedChecksViewProps;
+
+        beforeEach(() => {
+            bareMinimumProps = {
                 deps: {
-                    deviceConnectActionCreator: null,
+                    deviceConnectActionCreator: Mock.ofType(DeviceConnectActionCreator).object,
                     windowStateActionCreator: Mock.ofType(WindowStateActionCreator).object,
                     scanActionCreator: Mock.ofType(ScanActionCreator).object,
                     windowFrameActionCreator: Mock.ofType(WindowFrameActionCreator).object,
                 },
                 scanStoreData: {},
-                deviceStoreData: {},
-                windowStateStoreData: 'window state store data' as any,
-            } as AutomatedChecksViewProps;
-
-            const wrapped = shallow(<AutomatedChecksView {...props} />);
-
-            expect(wrapped.getElement()).toMatchSnapshot();
-        });
-
-        it('scanning spinner', () => {
-            const props: AutomatedChecksViewProps = {
-                deps: {
-                    deviceConnectActionCreator: null,
-                    windowStateActionCreator: Mock.ofType(WindowStateActionCreator).object,
-                    scanActionCreator: Mock.ofType(ScanActionCreator).object,
-                    windowFrameActionCreator: Mock.ofType(WindowFrameActionCreator).object,
-                },
-                scanStoreData: {
-                    status: ScanStatus.Scanning,
-                },
-                deviceStoreData: {} as any,
-                windowStateStoreData: 'window state store data' as any,
-            } as AutomatedChecksViewProps;
-
-            const wrapped = shallow(<AutomatedChecksView {...props} />);
-
-            expect(wrapped.getElement()).toMatchSnapshot();
-        });
-
-        it('device disconnected', () => {
-            const props: AutomatedChecksViewProps = {
-                deps: {
-                    scanActionCreator: Mock.ofType(ScanActionCreator).object,
-                },
-                scanStoreData: {
-                    status: ScanStatus.Failed,
-                },
                 deviceStoreData: {
                     connectedDevice: 'TEST DEVICE',
                 },
+                windowStateStoreData: 'window state store data' as any,
             } as AutomatedChecksViewProps;
+        });
 
-            const wrapped = shallow(<AutomatedChecksView {...props} />);
+        const scanStatues = [undefined, ScanStatus[ScanStatus.Scanning], ScanStatus[ScanStatus.Failed]];
+
+        it.each(scanStatues)('status scan <%s>', scanStatusName => {
+            bareMinimumProps.scanStoreData.status = ScanStatus[scanStatusName];
+
+            const wrapped = shallow(<AutomatedChecksView {...bareMinimumProps} />);
 
             expect(wrapped.getElement()).toMatchSnapshot();
         });

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -11,7 +11,8 @@ import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 
 describe('CommandBar', () => {
     test('render', () => {
-        const props: CommandBarProps = { deps: { deviceConnectActionCreator: null } };
+        const props = { deps: { deviceConnectActionCreator: null } } as CommandBarProps;
+
         const rendered = shallow(<CommandBar {...props} />);
 
         expect(rendered.getElement()).toMatchSnapshot();
@@ -20,14 +21,19 @@ describe('CommandBar', () => {
     test('rescan click', () => {
         const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
 
+        const port = 111;
+
         const deviceConnectActionCreatorMock = Mock.ofType<DeviceConnectActionCreator>(undefined, MockBehavior.Strict);
-        deviceConnectActionCreatorMock.setup(creator => creator.resetConnection()).verifiable(Times.once());
+        deviceConnectActionCreatorMock.setup(creator => creator.validatePort(port)).verifiable(Times.once());
 
         const props = {
             deps: {
                 deviceConnectActionCreator: deviceConnectActionCreatorMock.object,
             },
-        };
+            deviceStoreData: {
+                port,
+            },
+        } as CommandBarProps;
 
         const rendered = shallow(<CommandBar {...props} />);
         const button = rendered.find('[text="Rescan"]');


### PR DESCRIPTION
#### Description of changes

Currently, the rescan button (on the automated checks view) just "reset the connection". This PR fixes the button on click function so the proper action creator's scan function is called. Additionally, there are some improvements on automated checks view tests.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
