### PR TITLE
feat(android-cards-view): className, contentDescription, text card row components

### DIFF
--- a/src/common/components/cards/class-name-card-row.ts
+++ b/src/common/components/cards/class-name-card-row.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { GetLabelledStringPropertyCardRow } from 'common/components/cards/get-labelled-string-property-card-row';
+export const ClassNameCardRow = GetLabelledStringPropertyCardRow('Class name');

--- a/src/common/components/cards/content-description-card-row.ts
+++ b/src/common/components/cards/content-description-card-row.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { GetLabelledStringPropertyCardRow } from 'common/components/cards/get-labelled-string-property-card-row';
+export const ContentDescriptionCardRow = GetLabelledStringPropertyCardRow('Content description');

--- a/src/common/components/cards/text-card-row.ts
+++ b/src/common/components/cards/text-card-row.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { GetLabelledStringPropertyCardRow } from 'common/components/cards/get-labelled-string-property-card-row';
+export const TextCardRow = GetLabelledStringPropertyCardRow('Text');

--- a/src/common/configs/unified-result-property-configurations.tsx
+++ b/src/common/configs/unified-result-property-configurations.tsx
@@ -1,13 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ClassNameCardRow } from 'common/components/cards/class-name-card-row';
+import { ContentDescriptionCardRow } from 'common/components/cards/content-description-card-row';
+
+import { TextCardRow } from 'common/components/cards/text-card-row';
 import { FixInstructionProcessor } from '../../injected/fix-instruction-processor';
 import { HowToFixWebCardRow } from '../components/cards/how-to-fix-card-row';
 import { PathCardRow } from '../components/cards/path-card-row';
 import { SnippetCardRow } from '../components/cards/snippet-card-row';
 import { ReactFCWithDisplayName } from '../react/named-fc';
 
-export type PropertyType = 'css-selector' | 'how-to-fix-web' | 'snippet';
-export const AllPropertyTypes: PropertyType[] = ['css-selector', 'how-to-fix-web', 'snippet'];
+export type PropertyType = 'css-selector' | 'how-to-fix-web' | 'snippet' | 'className' | 'contentDescription' | 'text';
+export const AllPropertyTypes: PropertyType[] = ['css-selector', 'how-to-fix-web', 'snippet', 'className', 'contentDescription', 'text'];
 
 export interface CardRowDeps {
     fixInstructionProcessor: FixInstructionProcessor;
@@ -35,13 +39,28 @@ export const snippetConfiguration: PropertyConfiguration = {
     cardRow: SnippetCardRow,
 };
 
-type PropertyIdToConfigurationMap = {
+export const classNameConfiguration: PropertyConfiguration = {
+    cardRow: ClassNameCardRow,
+};
+
+export const contentDescriptionConfiguration: PropertyConfiguration = {
+    cardRow: ContentDescriptionCardRow,
+};
+
+export const textConfiguration: PropertyConfiguration = {
+    cardRow: TextCardRow,
+};
+
+export type PropertyIdToConfigurationMap = {
     [key in PropertyType]: PropertyConfiguration;
 };
 const propertyIdToConfigurationMap: PropertyIdToConfigurationMap = {
     'css-selector': cssSelectorConfiguration,
     'how-to-fix-web': howToFixConfiguration,
     snippet: snippetConfiguration,
+    className: classNameConfiguration,
+    contentDescription: contentDescriptionConfiguration,
+    text: textConfiguration,
 };
 
 export function getPropertyConfiguration(id: string): Readonly<PropertyConfiguration> {

--- a/src/electron/views/device-connect-view/device-connect-view.scss
+++ b/src/electron/views/device-connect-view/device-connect-view.scss
@@ -18,3 +18,7 @@ button {
 input {
     -webkit-app-region: no-drag;
 }
+
+.report-instance-table .label {
+    width: 127px;
+}

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/class-name-card-row.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/class-name-card-row.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClassNameCardRow renders 1`] = `
+<SimpleCardRow
+  content="test class name"
+  label="Class name"
+  rowKey="Class name--1"
+/>
+`;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/content-description-card-row.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/content-description-card-row.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ContentDescriptionCardRow renders 1`] = `
+<SimpleCardRow
+  content="test content description"
+  label="Content description"
+  rowKey="Content description--1"
+/>
+`;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/text-card-row.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/text-card-row.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextCardRow renders 1`] = `
+<SimpleCardRow
+  content="test text"
+  label="Text"
+  rowKey="Text--1"
+/>
+`;

--- a/src/tests/unit/tests/common/components/cards/class-name-card-row.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/class-name-card-row.test.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ClassNameCardRow } from 'common/components/cards/class-name-card-row';
+import { StringPropertyCardRowProps } from 'common/components/cards/get-labelled-string-property-card-row';
+import { CardRowDeps } from 'common/configs/unified-result-property-configurations';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('ClassNameCardRow', () => {
+    it('renders', () => {
+        const props: StringPropertyCardRowProps = {
+            propertyData: 'test class name',
+            deps: {} as CardRowDeps,
+            index: -1,
+        };
+
+        const wrapped = shallow(<ClassNameCardRow {...props} />);
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/common/components/cards/content-description-card-row.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/content-description-card-row.test.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ContentDescriptionCardRow } from 'common/components/cards/content-description-card-row';
+import { StringPropertyCardRowProps } from 'common/components/cards/get-labelled-string-property-card-row';
+import { CardRowDeps } from 'common/configs/unified-result-property-configurations';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('ContentDescriptionCardRow', () => {
+    it('renders', () => {
+        const props: StringPropertyCardRowProps = {
+            propertyData: 'test content description',
+            deps: {} as CardRowDeps,
+            index: -1,
+        };
+
+        const wrapped = shallow(<ContentDescriptionCardRow {...props} />);
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/common/components/cards/text-card-row.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/text-card-row.test.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { StringPropertyCardRowProps } from 'common/components/cards/get-labelled-string-property-card-row';
+import { TextCardRow } from 'common/components/cards/text-card-row';
+import { CardRowDeps } from 'common/configs/unified-result-property-configurations';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('TextCardRow', () => {
+    it('renders', () => {
+        const props: StringPropertyCardRowProps = {
+            propertyData: 'test text',
+            deps: {} as CardRowDeps,
+            index: -1,
+        };
+
+        const wrapped = shallow(<TextCardRow {...props} />);
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Add card row components for:
- className
- contentDescription
- text

This are all axe-android specific and text only properties we need to render on the `CardView`.

Update the card row configuration file to include this new card row componets too.

**Out of scope for this PR**
- We need to handle `contentDescription` and `text` being null by not rendering that row on the `CardView`. I'll work on that on a different PR.
- I think we should refactor this to separate browser extension specific from android specific card rows configuration but I'll left that to be done after a proper discussion with the team

**"normal" size screen**
![image](https://user-images.githubusercontent.com/2837582/66953970-57872e80-f014-11e9-8392-aadb14c8dea7.png)

**small screens**
![image](https://user-images.githubusercontent.com/2837582/66954005-653cb400-f014-11e9-952b-2cc2fbd4a94d.png)


#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1606846
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
