### PR TITLE
feat(card-selection): add code to propogate the CardSelectionStoreData to the card view model

### DIFF
--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -6,6 +6,7 @@ import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import * as React from 'react';
 
+import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { ThemeDeps } from '../common/components/theme';
 import { withStoreSubscription, WithStoreSubscriptionDeps } from '../common/components/with-store-subscription';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -171,6 +172,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
         const ruleResults = this.props.deps.getUnifiedRuleResults(
             this.props.storeState.unifiedScanResultStoreData.rules,
             this.props.storeState.unifiedScanResultStoreData.results,
+            getCardSelectionViewData(this.props.storeState.cardSelectionStoreData),
         );
 
         return (

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
 import * as React from 'react';
 
-import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { ThemeDeps } from '../common/components/theme';
 import { withStoreSubscription, WithStoreSubscriptionDeps } from '../common/components/with-store-subscription';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -42,6 +42,7 @@ export type DetailsViewContainerDeps = {
     getDetailsRightPanelConfiguration: GetDetailsRightPanelConfiguration;
     getDetailsSwitcherNavConfiguration: GetDetailsSwitcherNavConfiguration;
     getUnifiedRuleResults: GetUnifiedRuleResultsDelegate;
+    getCardSelectionViewData: GetCardSelectionViewData;
 } & DetailsViewBodyDeps &
     DetailsViewOverlayDeps &
     DetailsViewCommandBarDeps &
@@ -172,7 +173,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
         const ruleResults = this.props.deps.getUnifiedRuleResults(
             this.props.storeState.unifiedScanResultStoreData.rules,
             this.props.storeState.unifiedScanResultStoreData.results,
-            getCardSelectionViewData(this.props.storeState.cardSelectionStoreData),
+            this.props.deps.getCardSelectionViewData(this.props.storeState.cardSelectionStoreData),
         );
 
         return (

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -4,6 +4,7 @@ import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-defaul
 import { Assessments } from 'assessments/assessments';
 import { assessmentsProviderWithFeaturesEnabled } from 'assessments/assessments-feature-flag-filter';
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
+import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { loadTheme } from 'office-ui-fabric-react';
@@ -333,6 +334,7 @@ if (isNaN(tabId) === false) {
                 cardInteractionSupport: allCardInteractionsSupported,
                 navigatorUtils: navigatorUtils,
                 cardSelectionMessageCreator,
+                getCardSelectionViewData: getCardSelectionViewData,
             };
 
             const renderer = new DetailsViewRenderer(

--- a/src/common/get-card-selection-view-data.ts
+++ b/src/common/get-card-selection-view-data.ts
@@ -13,7 +13,9 @@ export interface CardSelectionViewData {
     expandedRuleIds: string[];
 }
 
-export function getCardSelectionViewData(storeData: CardSelectionStoreData): CardSelectionViewData {
+export type GetCardSelectionViewData = (storeData: CardSelectionStoreData) => CardSelectionViewData;
+
+export const getCardSelectionViewData: GetCardSelectionViewData = (storeData: CardSelectionStoreData): CardSelectionViewData => {
     const viewData = getEmptyViewData();
 
     if (!storeData) {
@@ -34,7 +36,7 @@ export function getCardSelectionViewData(storeData: CardSelectionStoreData): Car
         : getAllResultUidsFromRuleIdArray(storeData.rules, viewData.expandedRuleIds);
 
     return viewData;
-}
+};
 
 function getEmptyViewData(): CardSelectionViewData {
     const viewData: CardSelectionViewData = {

--- a/src/common/types/store-data/card-view-model.ts
+++ b/src/common/types/store-data/card-view-model.ts
@@ -9,9 +9,12 @@ export interface CardRuleResult {
     description: string;
     url: string;
     guidance: GuidanceLink[];
+    isExpanded: boolean;
 }
 export type CardRuleResultsByStatus = {
     [key in CardRuleResultStatus]: CardRuleResult[];
 };
-export interface CardResult extends UnifiedResult {}
+export interface CardResult extends UnifiedResult {
+    isSelected: boolean;
+}
 export const AllRuleResultStatuses: CardRuleResultStatus[] = ['pass', 'fail', 'unknown', 'inapplicable'];

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { GetUnifiedRuleResultsDelegate } from 'common/rule-based-view-model-provider';
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { CardsView, CardsViewDeps } from 'DetailsView/components/cards-view';
@@ -26,6 +28,7 @@ export type AutomatedChecksViewDeps = CommandBarDeps &
         scanActionCreator: ScanActionCreator;
         windowStateActionCreator: WindowStateActionCreator;
         getUnifiedRuleResultsDelegate: GetUnifiedRuleResultsDelegate;
+        getCardSelectionViewData: GetCardSelectionViewData;
     };
 
 export type AutomatedChecksViewProps = {
@@ -35,6 +38,7 @@ export type AutomatedChecksViewProps = {
     windowStateStoreData: WindowStateStoreData;
     userConfigurationStoreData: UserConfigurationStoreData;
     unifiedScanResultStoreData: UnifiedScanResultStoreData;
+    cardSelectionStoreData: CardSelectionStoreData;
 };
 
 export class AutomatedChecksView extends React.Component<AutomatedChecksViewProps> {
@@ -83,7 +87,11 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
         }
 
         const { rules, results } = this.props.unifiedScanResultStoreData;
-        const ruleResultsByStatus = this.props.deps.getUnifiedRuleResultsDelegate(rules, results);
+        const ruleResultsByStatus = this.props.deps.getUnifiedRuleResultsDelegate(
+            rules,
+            results,
+            this.props.deps.getCardSelectionViewData(this.props.cardSelectionStoreData),
+        );
 
         return (
             <CardsView

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
@@ -28,6 +29,7 @@ export type RootContainerState = {
     deviceStoreData: DeviceStoreData;
     scanStoreData: ScanStoreData;
     unifiedScanResultStoreData: UnifiedScanResultStoreData;
+    cardSelectionStoreData: CardSelectionStoreData;
 };
 
 export class RootContainer extends React.Component<RootContainerProps, RootContainerState> {
@@ -46,6 +48,7 @@ export class RootContainer extends React.Component<RootContainerProps, RootConta
                     windowStateStoreData={this.state.windowStateStoreData}
                     unifiedScanResultStoreData={this.state.unifiedScanResultStoreData}
                     userConfigurationStoreData={this.state.userConfigurationStoreData}
+                    cardSelectionStoreData={this.state.cardSelectionStoreData}
                     {...this.props}
                 />
             );

--- a/src/tests/unit/common/__snapshots__/rule-based-view-model-provider.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/rule-based-view-model-provider.test.ts.snap
@@ -15,7 +15,10 @@ Object {
       "isExpanded": true,
       "nodes": Array [
         Object {
+          "descriptors": null,
+          "identifiers": null,
           "isSelected": true,
+          "resolution": null,
           "ruleId": "rule1",
           "status": "fail",
           "uid": "stub_uid",
@@ -54,7 +57,10 @@ Object {
       "isExpanded": false,
       "nodes": Array [
         Object {
+          "descriptors": null,
+          "identifiers": null,
           "isSelected": false,
+          "resolution": null,
           "ruleId": "rule1",
           "status": "pass",
           "uid": "stub_uid",
@@ -77,13 +83,19 @@ Object {
       "isExpanded": false,
       "nodes": Array [
         Object {
+          "descriptors": null,
+          "identifiers": null,
           "isSelected": false,
+          "resolution": null,
           "ruleId": "rule2",
           "status": "unknown",
           "uid": "stub_uid",
         },
         Object {
+          "descriptors": null,
+          "identifiers": null,
           "isSelected": false,
+          "resolution": null,
           "ruleId": "rule2",
           "status": "unknown",
           "uid": "stub_uid",

--- a/src/tests/unit/common/__snapshots__/rule-based-view-model-provider.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/rule-based-view-model-provider.test.ts.snap
@@ -1,0 +1,97 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults 1`] = `
+Object {
+  "fail": Array [
+    Object {
+      "description": "stub_description_rule1",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule1",
+          "text": "stub_guidance_text_rule1",
+        },
+      ],
+      "id": "rule1",
+      "isExpanded": true,
+      "nodes": Array [
+        Object {
+          "isSelected": true,
+          "ruleId": "rule1",
+          "status": "fail",
+          "uid": "stub_uid",
+        },
+      ],
+      "status": "fail",
+      "url": "stub_url_rule1",
+    },
+  ],
+  "inapplicable": Array [
+    Object {
+      "description": "stub_description_rule3",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule3",
+          "text": "stub_guidance_text_rule3",
+        },
+      ],
+      "id": "rule3",
+      "isExpanded": false,
+      "nodes": Array [],
+      "status": "inapplicable",
+      "url": "stub_url_rule3",
+    },
+  ],
+  "pass": Array [
+    Object {
+      "description": "stub_description_rule1",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule1",
+          "text": "stub_guidance_text_rule1",
+        },
+      ],
+      "id": "rule1",
+      "isExpanded": false,
+      "nodes": Array [
+        Object {
+          "isSelected": false,
+          "ruleId": "rule1",
+          "status": "pass",
+          "uid": "stub_uid",
+        },
+      ],
+      "status": "pass",
+      "url": "stub_url_rule1",
+    },
+  ],
+  "unknown": Array [
+    Object {
+      "description": "stub_description_rule2",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule2",
+          "text": "stub_guidance_text_rule2",
+        },
+      ],
+      "id": "rule2",
+      "isExpanded": false,
+      "nodes": Array [
+        Object {
+          "isSelected": false,
+          "ruleId": "rule2",
+          "status": "unknown",
+          "uid": "stub_uid",
+        },
+        Object {
+          "isSelected": false,
+          "ruleId": "rule2",
+          "status": "unknown",
+          "uid": "stub_uid",
+        },
+      ],
+      "status": "unknown",
+      "url": "stub_url_rule2",
+    },
+  ],
+}
+`;

--- a/src/tests/unit/common/__snapshots__/rule-based-view-model-provider.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/rule-based-view-model-provider.test.ts.snap
@@ -1,6 +1,222 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults 1`] = `
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isSelected": false} 1`] = `
+Object {
+  "fail": Array [
+    Object {
+      "description": "stub_description_rule1",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule1",
+          "text": "stub_guidance_text_rule1",
+        },
+      ],
+      "id": "rule1",
+      "isExpanded": false,
+      "nodes": Array [
+        Object {
+          "descriptors": null,
+          "identifiers": null,
+          "isSelected": false,
+          "resolution": null,
+          "ruleId": "rule1",
+          "status": "fail",
+          "uid": "stub_uid",
+        },
+      ],
+      "status": "fail",
+      "url": "stub_url_rule1",
+    },
+  ],
+  "inapplicable": Array [
+    Object {
+      "description": "stub_description_rule3",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule3",
+          "text": "stub_guidance_text_rule3",
+        },
+      ],
+      "id": "rule3",
+      "isExpanded": false,
+      "nodes": Array [],
+      "status": "inapplicable",
+      "url": "stub_url_rule3",
+    },
+  ],
+  "pass": Array [
+    Object {
+      "description": "stub_description_rule1",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule1",
+          "text": "stub_guidance_text_rule1",
+        },
+      ],
+      "id": "rule1",
+      "isExpanded": false,
+      "nodes": Array [
+        Object {
+          "descriptors": null,
+          "identifiers": null,
+          "isSelected": false,
+          "resolution": null,
+          "ruleId": "rule1",
+          "status": "pass",
+          "uid": "stub_uid",
+        },
+      ],
+      "status": "pass",
+      "url": "stub_url_rule1",
+    },
+  ],
+  "unknown": Array [
+    Object {
+      "description": "stub_description_rule2",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule2",
+          "text": "stub_guidance_text_rule2",
+        },
+      ],
+      "id": "rule2",
+      "isExpanded": false,
+      "nodes": Array [
+        Object {
+          "descriptors": null,
+          "identifiers": null,
+          "isSelected": false,
+          "resolution": null,
+          "ruleId": "rule2",
+          "status": "unknown",
+          "uid": "stub_uid",
+        },
+        Object {
+          "descriptors": null,
+          "identifiers": null,
+          "isSelected": false,
+          "resolution": null,
+          "ruleId": "rule2",
+          "status": "unknown",
+          "uid": "stub_uid",
+        },
+      ],
+      "status": "unknown",
+      "url": "stub_url_rule2",
+    },
+  ],
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isSelected": false} 1`] = `
+Object {
+  "fail": Array [
+    Object {
+      "description": "stub_description_rule1",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule1",
+          "text": "stub_guidance_text_rule1",
+        },
+      ],
+      "id": "rule1",
+      "isExpanded": true,
+      "nodes": Array [
+        Object {
+          "descriptors": null,
+          "identifiers": null,
+          "isSelected": false,
+          "resolution": null,
+          "ruleId": "rule1",
+          "status": "fail",
+          "uid": "stub_uid",
+        },
+      ],
+      "status": "fail",
+      "url": "stub_url_rule1",
+    },
+  ],
+  "inapplicable": Array [
+    Object {
+      "description": "stub_description_rule3",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule3",
+          "text": "stub_guidance_text_rule3",
+        },
+      ],
+      "id": "rule3",
+      "isExpanded": false,
+      "nodes": Array [],
+      "status": "inapplicable",
+      "url": "stub_url_rule3",
+    },
+  ],
+  "pass": Array [
+    Object {
+      "description": "stub_description_rule1",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule1",
+          "text": "stub_guidance_text_rule1",
+        },
+      ],
+      "id": "rule1",
+      "isExpanded": false,
+      "nodes": Array [
+        Object {
+          "descriptors": null,
+          "identifiers": null,
+          "isSelected": false,
+          "resolution": null,
+          "ruleId": "rule1",
+          "status": "pass",
+          "uid": "stub_uid",
+        },
+      ],
+      "status": "pass",
+      "url": "stub_url_rule1",
+    },
+  ],
+  "unknown": Array [
+    Object {
+      "description": "stub_description_rule2",
+      "guidance": Array [
+        Object {
+          "href": "stub_guidance_href_rule2",
+          "text": "stub_guidance_text_rule2",
+        },
+      ],
+      "id": "rule2",
+      "isExpanded": false,
+      "nodes": Array [
+        Object {
+          "descriptors": null,
+          "identifiers": null,
+          "isSelected": false,
+          "resolution": null,
+          "ruleId": "rule2",
+          "status": "unknown",
+          "uid": "stub_uid",
+        },
+        Object {
+          "descriptors": null,
+          "identifiers": null,
+          "isSelected": false,
+          "resolution": null,
+          "ruleId": "rule2",
+          "status": "unknown",
+          "uid": "stub_uid",
+        },
+      ],
+      "status": "unknown",
+      "url": "stub_url_rule2",
+    },
+  ],
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isSelected": true} 1`] = `
 Object {
   "fail": Array [
     Object {

--- a/src/tests/unit/common/rule-based-view-model-provider.test.ts
+++ b/src/tests/unit/common/rule-based-view-model-provider.test.ts
@@ -48,76 +48,9 @@ describe('RuleBasedViewModelProvider', () => {
             selectedResultUids: ['stub_uid'],
         };
 
-        const expectedResults: CardRuleResultsByStatus = {
-            pass: [
-                {
-                    id: 'rule1',
-                    status: 'pass',
-                    nodes: [resultStub1],
-                    description: 'stub_description_rule1',
-                    url: 'stub_url_rule1',
-                    guidance: [
-                        {
-                            href: 'stub_guidance_href_rule1',
-                            text: 'stub_guidance_text_rule1',
-                        },
-                    ],
-                    isExpanded: false,
-                },
-            ],
-            fail: [
-                {
-                    id: 'rule1',
-                    status: 'fail',
-                    nodes: [resultStub2],
-                    description: 'stub_description_rule1',
-                    url: 'stub_url_rule1',
-                    guidance: [
-                        {
-                            href: 'stub_guidance_href_rule1',
-                            text: 'stub_guidance_text_rule1',
-                        },
-                    ],
-                    isExpanded: true,
-                },
-            ],
-            unknown: [
-                {
-                    id: 'rule2',
-                    status: 'unknown',
-                    nodes: [resultStub3, resultStub4],
-                    description: 'stub_description_rule2',
-                    url: 'stub_url_rule2',
-                    guidance: [
-                        {
-                            href: 'stub_guidance_href_rule2',
-                            text: 'stub_guidance_text_rule2',
-                        },
-                    ],
-                    isExpanded: false,
-                },
-            ],
-            inapplicable: [
-                {
-                    id: 'rule3',
-                    status: 'inapplicable',
-                    nodes: [],
-                    description: 'stub_description_rule3',
-                    url: 'stub_url_rule3',
-                    guidance: [
-                        {
-                            href: 'stub_guidance_href_rule3',
-                            text: 'stub_guidance_text_rule3',
-                        },
-                    ],
-                    isExpanded: false,
-                } as CardRuleResult,
-            ],
-        };
-
         const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults(rules, results, cardSelectionViewData);
 
-        expect(actualResults).toEqual(expectedResults);
+        expect(actualResults).toMatchSnapshot();
     });
 
     function getSampleRules(): UnifiedRule[] {

--- a/src/tests/unit/common/rule-based-view-model-provider.test.ts
+++ b/src/tests/unit/common/rule-based-view-model-provider.test.ts
@@ -33,20 +33,26 @@ describe('RuleBasedViewModelProvider', () => {
         expect(actualResults).toEqual(null);
     });
 
-    test('getUnifiedRuleResults', () => {
+    const testStubCombinations = [
+        { isExpanded: true, isSelected: true },
+        { isExpanded: false, isSelected: false },
+        { isExpanded: true, isSelected: false },
+    ];
+
+    it.each(testStubCombinations)('getUnifiedRuleResults for combination %p', stub => {
         const rules = getSampleRules();
 
         const resultStub1 = createUnifiedResultStub('pass', 'rule1');
-        const resultStub2 = createUnifiedResultStub('fail', 'rule1', true);
+        const resultStub2 = createUnifiedResultStub('fail', 'rule1', stub.isSelected);
         const resultStub3 = createUnifiedResultStub('unknown', 'rule2');
         const resultStub4 = createUnifiedResultStub('unknown', 'rule2');
 
         const results: UnifiedResult[] = [resultStub1, resultStub2, resultStub3, resultStub4];
 
         const cardSelectionViewData: CardSelectionViewData = {
-            expandedRuleIds: ['rule1'],
+            expandedRuleIds: stub.isExpanded ? ['rule1'] : [],
             highlightedResultUids: ['stub_uid'],
-            selectedResultUids: ['stub_uid'],
+            selectedResultUids: stub.isExpanded && stub.isSelected ? ['stub_uid'] : [],
         };
 
         const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults(rules, results, cardSelectionViewData);

--- a/src/tests/unit/common/rule-based-view-model-provider.test.ts
+++ b/src/tests/unit/common/rule-based-view-model-provider.test.ts
@@ -84,6 +84,9 @@ describe('RuleBasedViewModelProvider', () => {
             status: status,
             ruleId: id,
             isSelected,
-        } as CardResult;
+            identifiers: null,
+            descriptors: null,
+            resolution: null,
+        };
     }
 });

--- a/src/tests/unit/common/rule-based-view-model-provider.test.ts
+++ b/src/tests/unit/common/rule-based-view-model-provider.test.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CardSelectionViewData } from 'common/get-card-selection-view-data';
+
 import { getUnifiedRuleResults } from '../../../common/rule-based-view-model-provider';
-import { CardResult, CardRuleResult, CardRuleResultsByStatus } from '../../../common/types/store-data/card-view-model';
+import { CardResult, CardRuleResultsByStatus } from '../../../common/types/store-data/card-view-model';
 import { InstanceResultStatus, UnifiedResult, UnifiedRule } from '../../../common/types/store-data/unified-data-interface';
 
 describe('RuleBasedViewModelProvider', () => {

--- a/src/tests/unit/common/rule-based-view-model-provider.test.ts
+++ b/src/tests/unit/common/rule-based-view-model-provider.test.ts
@@ -1,24 +1,33 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardSelectionViewData } from 'common/get-card-selection-view-data';
 import { getUnifiedRuleResults } from '../../../common/rule-based-view-model-provider';
-import { CardRuleResult, CardRuleResultsByStatus } from '../../../common/types/store-data/card-view-model';
+import { CardResult, CardRuleResult, CardRuleResultsByStatus } from '../../../common/types/store-data/card-view-model';
 import { InstanceResultStatus, UnifiedResult, UnifiedRule } from '../../../common/types/store-data/unified-data-interface';
 
 describe('RuleBasedViewModelProvider', () => {
+    const emptyCardSelectionViewData = {} as CardSelectionViewData;
+
     test('getUnifiedRuleResults with null rules and results', () => {
-        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults(null, null);
+        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults(null, null, null);
 
         expect(actualResults).toEqual(null);
     });
 
     test('getUnifiedRuleResults with null rules', () => {
-        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults(null, []);
+        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults(null, [], emptyCardSelectionViewData);
 
         expect(actualResults).toEqual(null);
     });
 
     test('getUnifiedRuleResults with null results', () => {
-        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults([], null);
+        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults([], null, emptyCardSelectionViewData);
+
+        expect(actualResults).toEqual(null);
+    });
+
+    test('getUnifiedRuleResults with null card selection view data', () => {
+        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults([], [], null);
 
         expect(actualResults).toEqual(null);
     });
@@ -26,12 +35,18 @@ describe('RuleBasedViewModelProvider', () => {
     test('getUnifiedRuleResults', () => {
         const rules = getSampleRules();
 
-        const resultStub1: UnifiedResult = createUnifiedResultStub('pass', 'rule1');
-        const resultStub2: UnifiedResult = createUnifiedResultStub('fail', 'rule1');
-        const resultStub3: UnifiedResult = createUnifiedResultStub('unknown', 'rule2');
-        const resultStub4: UnifiedResult = createUnifiedResultStub('unknown', 'rule2');
+        const resultStub1 = createUnifiedResultStub('pass', 'rule1');
+        const resultStub2 = createUnifiedResultStub('fail', 'rule1', true);
+        const resultStub3 = createUnifiedResultStub('unknown', 'rule2');
+        const resultStub4 = createUnifiedResultStub('unknown', 'rule2');
 
         const results: UnifiedResult[] = [resultStub1, resultStub2, resultStub3, resultStub4];
+
+        const cardSelectionViewData: CardSelectionViewData = {
+            expandedRuleIds: ['rule1'],
+            highlightedResultUids: ['stub_uid'],
+            selectedResultUids: ['stub_uid'],
+        };
 
         const expectedResults: CardRuleResultsByStatus = {
             pass: [
@@ -47,6 +62,7 @@ describe('RuleBasedViewModelProvider', () => {
                             text: 'stub_guidance_text_rule1',
                         },
                     ],
+                    isExpanded: false,
                 },
             ],
             fail: [
@@ -62,6 +78,7 @@ describe('RuleBasedViewModelProvider', () => {
                             text: 'stub_guidance_text_rule1',
                         },
                     ],
+                    isExpanded: true,
                 },
             ],
             unknown: [
@@ -77,6 +94,7 @@ describe('RuleBasedViewModelProvider', () => {
                             text: 'stub_guidance_text_rule2',
                         },
                     ],
+                    isExpanded: false,
                 },
             ],
             inapplicable: [
@@ -92,11 +110,12 @@ describe('RuleBasedViewModelProvider', () => {
                             text: 'stub_guidance_text_rule3',
                         },
                     ],
+                    isExpanded: false,
                 } as CardRuleResult,
             ],
         };
 
-        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults(rules, results);
+        const actualResults: CardRuleResultsByStatus = getUnifiedRuleResults(rules, results, cardSelectionViewData);
 
         expect(actualResults).toEqual(expectedResults);
     });
@@ -125,11 +144,12 @@ describe('RuleBasedViewModelProvider', () => {
         };
     }
 
-    function createUnifiedResultStub(status: InstanceResultStatus, id: string): UnifiedResult {
+    function createUnifiedResultStub(status: InstanceResultStatus, id: string, isSelected: boolean = false): CardResult {
         return {
             uid: 'stub_uid',
             status: status,
             ruleId: id,
-        } as UnifiedResult;
+            isSelected,
+        } as CardResult;
     }
 });

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -197,7 +197,7 @@ describe('DetailsViewContainer', () => {
 
             const ruleResults: CardRuleResultsByStatus = {} as any;
             getUnifiedRuleResultsMock
-                .setup(m => m(state.unifiedScanResultStoreData.rules, state.unifiedScanResultStoreData.results))
+                .setup(m => m(state.unifiedScanResultStoreData.rules, state.unifiedScanResultStoreData.results, null))
                 .returns(() => ruleResults);
 
             testObject.render();
@@ -455,7 +455,7 @@ describe('DetailsViewContainer', () => {
 
         const ruleResults: CardRuleResultsByStatus = {} as any;
         getUnifiedRuleResultsMock
-            .setup(m => m(state.unifiedScanResultStoreData.rules, state.unifiedScanResultStoreData.results))
+            .setup(m => m(state.unifiedScanResultStoreData.rules, state.unifiedScanResultStoreData.results, null))
             .returns(() => ruleResults);
 
         const expected: JSX.Element = (

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardSelectionViewData, GetCardSelectionViewData } from 'common/get-card-selection-view-data';
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { shallow } from 'enzyme';
 import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
 import * as React from 'react';
@@ -58,19 +60,25 @@ describe('DetailsViewContainer', () => {
     let getDetailsRightPanelConfiguration: IMock<GetDetailsRightPanelConfiguration>;
     let getDetailsSwitcherNavConfiguration: IMock<GetDetailsSwitcherNavConfiguration>;
     let getUnifiedRuleResultsMock: IMock<GetUnifiedRuleResultsDelegate>;
+    let getCardSelectionViewDataMock: IMock<GetCardSelectionViewData>;
     let targetAppInfo: TargetAppData;
 
     beforeEach(() => {
         detailsViewActionMessageCreator = Mock.ofType<DetailsViewActionMessageCreator>();
         getDetailsRightPanelConfiguration = Mock.ofInstance((props: GetDetailsRightPanelConfigurationProps) => null, MockBehavior.Strict);
         getDetailsSwitcherNavConfiguration = Mock.ofInstance((props: GetDetailsSwitcherNavConfigurationProps) => null, MockBehavior.Strict);
-        getUnifiedRuleResultsMock = Mock.ofInstance((rules: UnifiedRule[], results: UnifiedResult[]) => null, MockBehavior.Strict);
+        getUnifiedRuleResultsMock = Mock.ofInstance(
+            (rules: UnifiedRule[], results: UnifiedResult[], cardSelectionViewData: CardSelectionViewData) => null,
+            MockBehavior.Strict,
+        );
+        getCardSelectionViewDataMock = Mock.ofInstance((storeData: CardSelectionStoreData) => null, MockBehavior.Strict);
         targetAppInfo = { name: 'app' };
         deps = {
             detailsViewActionMessageCreator: detailsViewActionMessageCreator.object,
             getDetailsRightPanelConfiguration: getDetailsRightPanelConfiguration.object,
             getDetailsSwitcherNavConfiguration: getDetailsSwitcherNavConfiguration.object,
             getUnifiedRuleResults: getUnifiedRuleResultsMock.object,
+            getCardSelectionViewData: getCardSelectionViewDataMock.object,
         } as DetailsViewContainerDeps;
     });
 
@@ -196,8 +204,10 @@ describe('DetailsViewContainer', () => {
                 .returns(() => viewType);
 
             const ruleResults: CardRuleResultsByStatus = {} as any;
+            const cardSelectionViewData: CardSelectionViewData = {} as CardSelectionViewData;
+            getCardSelectionViewDataMock.setup(g => g(state.cardSelectionStoreData)).returns(() => cardSelectionViewData);
             getUnifiedRuleResultsMock
-                .setup(m => m(state.unifiedScanResultStoreData.rules, state.unifiedScanResultStoreData.results, null))
+                .setup(m => m(state.unifiedScanResultStoreData.rules, state.unifiedScanResultStoreData.results, cardSelectionViewData))
                 .returns(() => ruleResults);
 
             testObject.render();
@@ -453,9 +463,15 @@ describe('DetailsViewContainer', () => {
             )
             .returns(() => viewType);
 
+        const cardSelectionViewData: CardSelectionViewData = {} as CardSelectionViewData;
+        getCardSelectionViewDataMock
+            .setup(g => g(state.cardSelectionStoreData))
+            .returns(() => cardSelectionViewData)
+            .verifiable(Times.once());
+
         const ruleResults: CardRuleResultsByStatus = {} as any;
         getUnifiedRuleResultsMock
-            .setup(m => m(state.unifiedScanResultStoreData.rules, state.unifiedScanResultStoreData.results, null))
+            .setup(m => m(state.unifiedScanResultStoreData.rules, state.unifiedScanResultStoreData.results, cardSelectionViewData))
             .returns(() => ruleResults);
 
         const expected: JSX.Element = (
@@ -483,5 +499,6 @@ describe('DetailsViewContainer', () => {
         expect(testObject.render()).toEqual(expected);
 
         clickHandlerFactoryMock.verifyAll();
+        getCardSelectionViewDataMock.verifyAll();
     }
 });

--- a/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
+++ b/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
@@ -35,7 +35,7 @@ export const exampleUnifiedRuleResult: CardRuleResult = {
     description: 'sample-description',
     url: 'sample-url',
     guidance: [{ href: 'sample-guidance-href', text: 'sample-guidance-text' }],
-};
+} as CardRuleResult;
 
 export const exampleUnifiedStatusResults: CardRuleResultsByStatus = {
     pass: [],

--- a/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
+++ b/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
@@ -31,12 +31,11 @@ export const exampleUnifiedResult: UnifiedResult = {
 
 export const exampleUnifiedRuleResult: CardRuleResult = {
     id: 'some-rule',
-    nodes: [{ ...exampleUnifiedResult, isSelected: false }],
+    nodes: [exampleUnifiedResult as UnifiedResult],
     description: 'sample-description',
     url: 'sample-url',
     guidance: [],
-    isExpanded: false,
-};
+} as CardRuleResult;
 
 export const exampleUnifiedStatusResults: CardRuleResultsByStatus = {
     pass: [],

--- a/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
+++ b/src/tests/unit/tests/common/components/cards/sample-view-model-data.ts
@@ -31,10 +31,11 @@ export const exampleUnifiedResult: UnifiedResult = {
 
 export const exampleUnifiedRuleResult: CardRuleResult = {
     id: 'some-rule',
-    nodes: [exampleUnifiedResult],
+    nodes: [{ ...exampleUnifiedResult, isSelected: false }],
     description: 'sample-description',
     url: 'sample-url',
     guidance: [],
+    isExpanded: false,
 };
 
 export const exampleUnifiedStatusResults: CardRuleResultsByStatus = {

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`AutomatedChecksView renders results 1`] = `
   <TitleBar
     deps={
       Object {
+        "getCardSelectionViewData": [Function],
         "getUnifiedRuleResultsDelegate": [Function],
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -21,6 +22,7 @@ exports[`AutomatedChecksView renders results 1`] = `
     <CommandBar
       deps={
         Object {
+          "getCardSelectionViewData": [Function],
           "getUnifiedRuleResultsDelegate": [Function],
           "scanActionCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -38,20 +40,12 @@ exports[`AutomatedChecksView renders results 1`] = `
       <CardsView
         deps={
           Object {
+            "getCardSelectionViewData": [Function],
             "getUnifiedRuleResultsDelegate": [Function],
             "scanActionCreator": proxy {
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
               "scanActions": undefined,
             },
-          }
-        }
-        ruleResultsByStatus={
-          Object {
-            "fail": Array [
-              Object {
-                "id": "test-fail-id",
-              },
-            ],
           }
         }
         targetAppInfo={

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardSelectionViewData, getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { getUnifiedRuleResults } from 'common/rule-based-view-model-provider';
 import { CardRuleResult, CardRuleResultsByStatus } from 'common/types/store-data/card-view-model';
 import { UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
@@ -47,17 +48,22 @@ describe('AutomatedChecksView', () => {
             const resultsStub = [{ uid: 'test-uid' } as UnifiedResult];
 
             const getUnifiedRuleResultsMock = Mock.ofInstance(getUnifiedRuleResults);
-
+            const getCardSelectionViewDataMock = Mock.ofInstance(getCardSelectionViewData);
             const ruleResultsByStatusStub = {
                 fail: [{ id: 'test-fail-id' } as CardRuleResult],
             } as CardRuleResultsByStatus;
 
-            getUnifiedRuleResultsMock.setup(getter => getter(rulesStub, resultsStub)).returns(() => ruleResultsByStatusStub);
+            const cardSelectionViewDataStub = {} as CardSelectionViewData;
+
+            getUnifiedRuleResultsMock
+                .setup(getter => getter(rulesStub, resultsStub, cardSelectionViewDataStub))
+                .returns(() => ruleResultsByStatusStub);
 
             const props: AutomatedChecksViewProps = {
                 deps: {
                     scanActionCreator: Mock.ofType(ScanActionCreator).object,
                     getUnifiedRuleResultsDelegate: getUnifiedRuleResultsMock.object,
+                    getCardSelectionViewData: getCardSelectionViewDataMock.object,
                 },
                 deviceStoreData: {},
                 scanStoreData: {


### PR DESCRIPTION
#### Description of changes

This change adds the data from the CardSelectionStore into the cards view model. The store data is first transformed into data relevant to the view model by a call to getCardSelectionViewData. The CardSelectionViewData is then passed to getUnifiedRuleResults where it is assigned to newly added fields in the view model data. The data can now be consumed by the details view.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
