### PR TITLE
feat(android-cards-view): LabelledStringPropertyCardRow null handling

### DIFF
--- a/src/common/components/cards/get-labelled-string-property-card-row.tsx
+++ b/src/common/components/cards/get-labelled-string-property-card-row.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { isEmpty } from 'lodash';
 import * as React from 'react';
 import { CardRowProps } from '../../../common/configs/unified-result-property-configurations';
 import { NamedFC } from '../../../common/react/named-fc';
@@ -11,6 +12,10 @@ export interface StringPropertyCardRowProps extends CardRowProps {
 
 export const GetLabelledStringPropertyCardRow = (label: string, contentClassName?: string) => {
     return NamedFC<StringPropertyCardRowProps>('StringPropertyCardRowProps', props => {
+        if (isEmpty(props.propertyData)) {
+            return null;
+        }
+
         return (
             <SimpleCardRow
                 label={label}

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/get-labelled-string-property-card-row.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/get-labelled-string-property-card-row.test.tsx.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GetLabelledStringPropertyCardRow renders null when property data is <> 1`] = `null`;
+
+exports[`GetLabelledStringPropertyCardRow renders null when property data is <null> 1`] = `null`;
+
+exports[`GetLabelledStringPropertyCardRow renders null when property data is <undefined> 1`] = `null`;
+
 exports[`GetLabelledStringPropertyCardRow renders with appropriate label/propertyData and contentClassName 1`] = `
 <SimpleCardRow
   content="some string as propertyData"

--- a/src/tests/unit/tests/common/components/cards/get-labelled-string-property-card-row.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/get-labelled-string-property-card-row.test.tsx
@@ -28,4 +28,17 @@ describe('GetLabelledStringPropertyCardRow', () => {
         const wrapper = shallow(<TestSubject {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
     });
+
+    const falsyPropertyData = [undefined, null, ''];
+
+    it.each(falsyPropertyData)('renders null when property data is <%s>', propertyData => {
+        const TestSubject = GetLabelledStringPropertyCardRow('some label', 'test class name');
+        const props: CardRowProps = {
+            deps: {} as CardRowDeps,
+            propertyData,
+            index: 22,
+        };
+        const wrapper = shallow(<TestSubject {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Description of changes

For AI-Android, if a result instance have empty `text` or empty `contentDescription` we need to not render that card row on the UI.

In order to do so, I'm updating `GetLabelledStringPropertyCardRow` to handle this case.

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1610159
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
