### PR TITLE
fix: broken command-bar test

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -20,7 +20,9 @@ export interface CommandBarProps {
 export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: CommandBarProps) => {
     const { deps, deviceStoreData } = props;
 
-    const onClick = () => deps.deviceConnectActionCreator.validatePort(deviceStoreData.port);
+    const onClick = () => {
+        deps.deviceConnectActionCreator.validatePort(deviceStoreData.port);
+    };
 
     return (
         <div className={commandBar}>


### PR DESCRIPTION
#### Description of changes

Getting this error by running test from master:

![image](https://user-images.githubusercontent.com/2837582/66963378-6b3c9000-f028-11e9-8233-bb91e844900f.png)
(image showing: MockExcetion Function.resetConnection)

Not sure what's going on here. `CommandBar` used to call `resetConnection` but it was refactored to call a different function. Still, I can see this error on master

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
