### PR TITLE
feat(android-cards-view): wire up CardsView

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { TitleBar, TitleBarDeps } from 'electron/views/automated-checks/components/title-bar';
-import * as React from 'react';
-
+import { GetUnifiedRuleResultsDelegate } from 'common/rule-based-view-model-provider';
+import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { CardsView, CardsViewDeps } from 'DetailsView/components/cards-view';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
@@ -10,16 +11,21 @@ import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { ScanningSpinner } from 'electron/views/automated-checks/components/scanning-spinner';
+import { TitleBar, TitleBarDeps } from 'electron/views/automated-checks/components/title-bar';
 import { mainContentWrapper } from 'electron/views/device-connect-view/device-connect-view.scss';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
+import * as React from 'react';
+
 import { automatedChecksView } from './automated-checks-view.scss';
 import { CommandBar, CommandBarDeps } from './components/command-bar';
 import { HeaderSection } from './components/header-section';
 
 export type AutomatedChecksViewDeps = CommandBarDeps &
-    TitleBarDeps & {
+    TitleBarDeps &
+    CardsViewDeps & {
         scanActionCreator: ScanActionCreator;
         windowStateActionCreator: WindowStateActionCreator;
+        getUnifiedRuleResultsDelegate: GetUnifiedRuleResultsDelegate;
     };
 
 export type AutomatedChecksViewProps = {
@@ -27,6 +33,8 @@ export type AutomatedChecksViewProps = {
     scanStoreData: ScanStoreData;
     deviceStoreData: DeviceStoreData;
     windowStateStoreData: WindowStateStoreData;
+    userConfigurationStoreData: UserConfigurationStoreData;
+    unifiedScanResultStoreData: UnifiedScanResultStoreData;
 };
 
 export class AutomatedChecksView extends React.Component<AutomatedChecksViewProps> {
@@ -44,6 +52,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                         <HeaderSection />
                         {this.renderScanning()}
                         {this.renderDeviceDisconnected()}
+                        {this.renderResults()}
                     </main>
                 </div>
             </div>
@@ -66,5 +75,23 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
 
     private renderScanning(): JSX.Element {
         return <ScanningSpinner isScanning={this.props.scanStoreData.status === ScanStatus.Scanning} />;
+    }
+
+    private renderResults(): JSX.Element {
+        if (this.props.scanStoreData.status !== ScanStatus.Completed) {
+            return null;
+        }
+
+        const { rules, results } = this.props.unifiedScanResultStoreData;
+        const ruleResultsByStatus = this.props.deps.getUnifiedRuleResultsDelegate(rules, results);
+
+        return (
+            <CardsView
+                deps={this.props.deps}
+                targetAppInfo={this.props.unifiedScanResultStoreData.targetAppInfo}
+                ruleResultsByStatus={ruleResultsByStatus}
+                userConfigurationStoreData={this.props.userConfigurationStoreData}
+            />
+        );
     }
 }

--- a/src/electron/views/device-connect-view/device-connect-view.scss
+++ b/src/electron/views/device-connect-view/device-connect-view.scss
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import './components/telemetry-permission-dialog.scss';
+@import '../../../reports/components/outcome.scss';
 
 body {
     margin: 0px;

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -3,10 +3,16 @@
 import { AppInsights } from 'applicationinsights-js';
 import axios from 'axios';
 import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
+import { registerUserConfigurationMessageCallback } from 'background/global-action-creators/registrar/register-user-configuration-message-callbacks';
+import { UserConfigurationActionCreator } from 'background/global-action-creators/user-configuration-action-creator';
 import { Interpreter } from 'background/interpreter';
 import { UnifiedScanResultStore } from 'background/stores/unified-scan-result-store';
+import { noCardInteractionsSupported } from 'common/components/cards/card-interaction-support';
+import { CardsCollapsibleControl } from 'common/components/cards/collapsible-component-cards';
 import { DateProvider } from 'common/date-provider';
+import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { UserConfigMessageCreator } from 'common/message-creators/user-config-message-creator';
+import { CardsViewDeps } from 'DetailsView/components/cards-view';
 import { remote } from 'electron';
 import { DirectActionMessageDispatcher } from 'electron/adapters/direct-action-message-dispatcher';
 import { createGetToolDataDelegate } from 'electron/common/application-properties-provider';
@@ -25,10 +31,11 @@ import { createDefaultBuilder } from 'electron/platform/android/unified-result-b
 import { RootContainerProps, RootContainerState } from 'electron/views/root-container/components/root-container';
 import { WindowFrameListener } from 'electron/window-frame-listener';
 import { WindowFrameUpdater } from 'electron/window-frame-updater';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as ReactDOM from 'react-dom';
 
-import { registerUserConfigurationMessageCallback } from 'background/global-action-creators/registrar/register-user-configuration-message-callbacks';
-import { UserConfigurationActionCreator } from 'background/global-action-creators/user-configuration-action-creator';
+import { getPropertyConfiguration } from 'common/configs/unified-result-property-configurations';
+import { getUnifiedRuleResults } from 'common/rule-based-view-model-provider';
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
 import { IndexedDBDataKeys } from '../../background/IndexedDBDataKeys';
@@ -95,8 +102,8 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
     const windowStateStore = new WindowStateStore(windowStateActions);
     windowStateStore.initialize();
 
-    const unifiedStore = new UnifiedScanResultStore(unifiedScanResultActions);
-    unifiedStore.initialize();
+    const unifiedScanResultStore = new UnifiedScanResultStore(unifiedScanResultActions);
+    unifiedScanResultStore.initialize();
 
     const scanStore = new ScanStore(scanActions);
     scanStore.initialize();
@@ -105,7 +112,13 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
     const windowFrameUpdater = new WindowFrameUpdater(windowFrameActions, currentWindow);
     windowFrameUpdater.initialize();
 
-    const storeHub = new BaseClientStoresHub<RootContainerState>([userConfigurationStore, deviceStore, windowStateStore, scanStore]);
+    const storeHub = new BaseClientStoresHub<RootContainerState>([
+        userConfigurationStore,
+        deviceStore,
+        windowStateStore,
+        scanStore,
+        unifiedScanResultStore,
+    ]);
 
     const telemetryStateListener = new TelemetryStateListener(userConfigurationStore, telemetryEventHandler);
     telemetryStateListener.initialize();
@@ -140,6 +153,31 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
 
     scanController.initialize();
 
+    const fixInstructionProcessor = new FixInstructionProcessor();
+
+    const cardsViewDeps: CardsViewDeps = {
+        LinkComponent: ElectronLink,
+
+        cardInteractionSupport: noCardInteractionsSupported, // we are supposed to have 'copy issue details' support
+        collapsibleControl: CardsCollapsibleControl,
+        fixInstructionProcessor,
+        getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks, // I don't think we have guidance links for axe-android
+
+        userConfigMessageCreator: userConfigMessageCreator,
+        cardSelectionMessageCreator: null,
+        detailsViewActionMessageCreator: null,
+        issueFilingActionMessageCreator: null, // we don't support issue filing right now
+
+        environmentInfoProvider: null,
+        getPropertyConfigById: getPropertyConfiguration, // this seems to be axe-core specific
+
+        issueDetailsTextGenerator: null,
+        issueFilingServiceProvider: null, // we don't support issue filing right now
+        navigatorUtils: null,
+        unifiedResultToIssueFilingDataConverter: null, // we don't support issue filing right now
+        windowUtils: null,
+    };
+
     const props: RootContainerProps = {
         deps: {
             currentWindow,
@@ -154,6 +192,8 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
             scanActionCreator,
             windowFrameActionCreator,
             platformInfo: new PlatformInfo(process),
+            getUnifiedRuleResultsDelegate: getUnifiedRuleResults,
+            ...cardsViewDeps,
         },
     };
 

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ClientStoresHub } from 'common/stores/client-stores-hub';
+import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
@@ -26,6 +27,7 @@ export type RootContainerState = {
     userConfigurationStoreData: UserConfigurationStoreData;
     deviceStoreData: DeviceStoreData;
     scanStoreData: ScanStoreData;
+    unifiedScanResultStoreData: UnifiedScanResultStoreData;
 };
 
 export class RootContainer extends React.Component<RootContainerProps, RootContainerState> {
@@ -42,6 +44,8 @@ export class RootContainer extends React.Component<RootContainerProps, RootConta
                     deviceStoreData={this.state.deviceStoreData}
                     scanStoreData={this.state.scanStoreData}
                     windowStateStoreData={this.state.windowStateStoreData}
+                    unifiedScanResultStoreData={this.state.unifiedScanResultStoreData}
+                    userConfigurationStoreData={this.state.userConfigurationStoreData}
                     {...this.props}
                 />
             );

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -1,5 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`AutomatedChecksView renders results 1`] = `
+<div
+  className="automatedChecksView"
+>
+  <TitleBar
+    deps={
+      Object {
+        "getUnifiedRuleResultsDelegate": [Function],
+        "scanActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "scanActions": undefined,
+        },
+      }
+    }
+  />
+  <div
+    className="mainContentWrapper"
+  >
+    <CommandBar
+      deps={
+        Object {
+          "getUnifiedRuleResultsDelegate": [Function],
+          "scanActionCreator": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "scanActions": undefined,
+          },
+        }
+      }
+      deviceStoreData={Object {}}
+    />
+    <main>
+      <HeaderSection />
+      <ScanningSpinner
+        isScanning={false}
+      />
+      <CardsView
+        deps={
+          Object {
+            "getUnifiedRuleResultsDelegate": [Function],
+            "scanActionCreator": proxy {
+              "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "scanActions": undefined,
+            },
+          }
+        }
+        ruleResultsByStatus={
+          Object {
+            "fail": Array [
+              Object {
+                "id": "test-fail-id",
+              },
+            ],
+          }
+        }
+        targetAppInfo={
+          Object {
+            "name": "test-target-app-name",
+          }
+        }
+        userConfigurationStoreData={
+          Object {
+            "isFirstTime": false,
+          }
+        }
+      />
+    </main>
+  </div>
+</div>
+`;
+
 exports[`AutomatedChecksView renders status scan <Failed> 1`] = `
 <div
   className="automatedChecksView"
@@ -16,10 +86,6 @@ exports[`AutomatedChecksView renders status scan <Failed> 1`] = `
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
-        },
-        "windowFrameActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "windowFrameActions": undefined,
         },
         "windowStateActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -45,10 +111,6 @@ exports[`AutomatedChecksView renders status scan <Failed> 1`] = `
           "scanActionCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "scanActions": undefined,
-          },
-          "windowFrameActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "windowFrameActions": undefined,
           },
           "windowStateActionCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -95,10 +157,6 @@ exports[`AutomatedChecksView renders status scan <Scanning> 1`] = `
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
         },
-        "windowFrameActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "windowFrameActions": undefined,
-        },
         "windowStateActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "windowFrameActionCreator": undefined,
@@ -123,10 +181,6 @@ exports[`AutomatedChecksView renders status scan <Scanning> 1`] = `
           "scanActionCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "scanActions": undefined,
-          },
-          "windowFrameActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "windowFrameActions": undefined,
           },
           "windowStateActionCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
@@ -168,10 +222,6 @@ exports[`AutomatedChecksView renders status scan <undefined> 1`] = `
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
         },
-        "windowFrameActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "windowFrameActions": undefined,
-        },
         "windowStateActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "windowFrameActionCreator": undefined,
@@ -196,10 +246,6 @@ exports[`AutomatedChecksView renders status scan <undefined> 1`] = `
           "scanActionCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "scanActions": undefined,
-          },
-          "windowFrameActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "windowFrameActions": undefined,
           },
           "windowStateActionCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { getUnifiedRuleResults } from 'common/rule-based-view-model-provider';
+import { CardRuleResult, CardRuleResultsByStatus } from 'common/types/store-data/card-view-model';
+import { UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
 import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
-import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { AutomatedChecksView, AutomatedChecksViewProps } from 'electron/views/automated-checks/automated-checks-view';
@@ -11,6 +13,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { It, Mock, Times } from 'typemoq';
 
+//
 describe('AutomatedChecksView', () => {
     describe('renders', () => {
         let bareMinimumProps: AutomatedChecksViewProps;
@@ -21,7 +24,6 @@ describe('AutomatedChecksView', () => {
                     deviceConnectActionCreator: Mock.ofType(DeviceConnectActionCreator).object,
                     windowStateActionCreator: Mock.ofType(WindowStateActionCreator).object,
                     scanActionCreator: Mock.ofType(ScanActionCreator).object,
-                    windowFrameActionCreator: Mock.ofType(WindowFrameActionCreator).object,
                 },
                 scanStoreData: {},
                 deviceStoreData: {
@@ -37,6 +39,44 @@ describe('AutomatedChecksView', () => {
             bareMinimumProps.scanStoreData.status = ScanStatus[scanStatusName];
 
             const wrapped = shallow(<AutomatedChecksView {...bareMinimumProps} />);
+
+            expect(wrapped.getElement()).toMatchSnapshot();
+        });
+
+        it('results', () => {
+            const rulesStub = [{ description: 'test-rule-description' } as UnifiedRule];
+            const resultsStub = [{ uid: 'test-uid' } as UnifiedResult];
+
+            const getUnifiedRuleResultsMock = Mock.ofInstance(getUnifiedRuleResults);
+
+            const ruleResultsByStatusStub = {
+                fail: [{ id: 'test-fail-id' } as CardRuleResult],
+            } as CardRuleResultsByStatus;
+
+            getUnifiedRuleResultsMock.setup(getter => getter(rulesStub, resultsStub)).returns(() => ruleResultsByStatusStub);
+
+            const props: AutomatedChecksViewProps = {
+                deps: {
+                    scanActionCreator: Mock.ofType(ScanActionCreator).object,
+                    getUnifiedRuleResultsDelegate: getUnifiedRuleResultsMock.object,
+                },
+                deviceStoreData: {},
+                scanStoreData: {
+                    status: ScanStatus.Completed,
+                },
+                userConfigurationStoreData: {
+                    isFirstTime: false,
+                },
+                unifiedScanResultStoreData: {
+                    targetAppInfo: {
+                        name: 'test-target-app-name',
+                    },
+                    rules: rulesStub,
+                    results: resultsStub,
+                },
+            } as AutomatedChecksViewProps;
+
+            const wrapped = shallow(<AutomatedChecksView {...props} />);
 
             expect(wrapped.getElement()).toMatchSnapshot();
         });

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -13,7 +13,6 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { It, Mock, Times } from 'typemoq';
 
-//
 describe('AutomatedChecksView', () => {
     describe('renders', () => {
         let bareMinimumProps: AutomatedChecksViewProps;

--- a/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
@@ -50,6 +50,11 @@ exports[`RootContainer renders results view container when route is resultsView 
       "status": 0,
     }
   }
+  userConfigurationStoreData={
+    Object {
+      "isFirstTime": true,
+    }
+  }
   windowStateStoreData={
     Object {
       "currentWindowState": "customSize",

--- a/src/tests/unit/tests/electron/views/root-container/components/root-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/components/root-container.test.tsx
@@ -38,6 +38,8 @@ describe(RootContainer, () => {
                         windowStateStoreData: { routeId: 'deviceConnectView', currentWindowState: 'customSize' },
                         userConfigurationStoreData: { isFirstTime: true },
                         deviceStoreData: { deviceConnectState: DeviceConnectState.Connected },
+                        unifiedScanResultStoreData: { targetAppInfo: { name: 'test-target-app-name' } },
+                        scanStoreData: { status: ScanStatus.Completed },
                     } as RootContainerState;
                 });
 


### PR DESCRIPTION
#### Description of changes

Wiring up `CardsView` on ai-android.

![12 - automated checks view](https://user-images.githubusercontent.com/2837582/66964817-8c9f7b00-f02c-11e9-80f3-e01f50a86507.gif)

**Notes**
I'm purposfully creating the `CardsViewDeps` as a separated object so we know which dependencies are needed from `CardsView` (or child components). I left some comments, on some properties, specially on issue filing related deps. I want the clean up part of the deps to be on a separated PR so we can more thoroughly check what we actually need and what we don't

**Out of Scope**
I only added `CardRow` components for the most simple values, basically of type string. That is: `text`, `className` and `componentDescription`. There is another PR to take care of `howToFix` (#1489)

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1606846 and # 1610159
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
