### PR TITLE
fix: prevent injected dialog buttons wrapping from new Toast layout

### DIFF
--- a/src/common/components/toast.scss
+++ b/src/common/components/toast.scss
@@ -5,7 +5,11 @@
 $toast-width: 316px;
 $toast-padding: 20px;
 
-.toast {
+.toast-container {
+    display: inline-block;
+}
+
+.toast-content {
     background: $neutral-70;
     border-radius: 4px;
     color: $neutral-0;

--- a/src/common/components/toast.tsx
+++ b/src/common/components/toast.tsx
@@ -3,6 +3,7 @@
 import { css } from '@uifabric/utilities';
 import * as React from 'react';
 import { WindowUtils } from '../window-utils';
+import { toastContainer, toastContent } from './toast.scss';
 
 export type ToastDeps = {
     windowUtils: WindowUtils;
@@ -46,8 +47,8 @@ export class Toast extends React.Component<ToastProps, ToastState> {
 
     public render(): JSX.Element {
         return (
-            <div aria-live="polite">
-                {this.state.toastVisible ? <div className={css('ms-fadeIn100', 'toast')}>{this.state.content}</div> : null}
+            <div className={toastContainer} aria-live="polite">
+                {this.state.toastVisible ? <div className={css('ms-fadeIn100', toastContent)}>{this.state.content}</div> : null}
             </div>
         );
     }

--- a/src/tests/unit/tests/common/components/__snapshots__/toast.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/toast.test.tsx.snap
@@ -3,9 +3,10 @@
 exports[`ToastTest render: render content 1`] = `
 <div
   aria-live="polite"
+  class="toastContainer"
 >
   <div
-    class="ms-fadeIn100 toast"
+    class="ms-fadeIn100 toastContent"
   >
     hello world
   </div>
@@ -15,5 +16,6 @@ exports[`ToastTest render: render content 1`] = `
 exports[`ToastTest render: render nothing before show() is called 1`] = `
 <div
   aria-live="polite"
+  class="toastContainer"
 />
 `;


### PR DESCRIPTION
#### Description of changes

Fixes a regression introduced by our recent toast aria-live changes where its container div causes an undesired layout change in the injected target page dialog.

Before:

![screenshot of dialog before change showing buttons wrapping](https://user-images.githubusercontent.com/376284/66967738-d3926e00-f036-11e9-9dc4-631f5a07d668.png)

After:

![screenshot of dialog after change with normal button layout](https://user-images.githubusercontent.com/376284/66967728-c83f4280-f036-11e9-8649-6b965634300e.png)

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
