### PR TITLE
feat(android-cards-view): fix rescan button onClick

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
+import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
-import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 import { commandBar, rescanButton } from './command-bar.scss';
 
 export type CommandBarDeps = {
-    deviceConnectActionCreator: DeviceConnectActionCreator;
+    scanActionCreator: ScanActionCreator;
 };
 
 export interface CommandBarProps {
@@ -20,7 +20,7 @@ export interface CommandBarProps {
 export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: CommandBarProps) => {
     const { deps, deviceStoreData } = props;
 
-    const onClick = () => deps.deviceConnectActionCreator.validatePort(deviceStoreData.port);
+    const onClick = () => deps.scanActionCreator.scan(deviceStoreData.port);
 
     return (
         <div className={commandBar}>

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -77,12 +77,6 @@ exports[`AutomatedChecksView renders status scan <Failed> 1`] = `
   <TitleBar
     deps={
       Object {
-        "deviceConnectActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceActions": undefined,
-          "fetchScanResults": undefined,
-          "telemetryEventHandler": undefined,
-        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
@@ -102,12 +96,6 @@ exports[`AutomatedChecksView renders status scan <Failed> 1`] = `
     <CommandBar
       deps={
         Object {
-          "deviceConnectActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "deviceActions": undefined,
-            "fetchScanResults": undefined,
-            "telemetryEventHandler": undefined,
-          },
           "scanActionCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "scanActions": undefined,
@@ -147,12 +135,6 @@ exports[`AutomatedChecksView renders status scan <Scanning> 1`] = `
   <TitleBar
     deps={
       Object {
-        "deviceConnectActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceActions": undefined,
-          "fetchScanResults": undefined,
-          "telemetryEventHandler": undefined,
-        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
@@ -172,12 +154,6 @@ exports[`AutomatedChecksView renders status scan <Scanning> 1`] = `
     <CommandBar
       deps={
         Object {
-          "deviceConnectActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "deviceActions": undefined,
-            "fetchScanResults": undefined,
-            "telemetryEventHandler": undefined,
-          },
           "scanActionCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "scanActions": undefined,
@@ -212,12 +188,6 @@ exports[`AutomatedChecksView renders status scan <undefined> 1`] = `
   <TitleBar
     deps={
       Object {
-        "deviceConnectActionCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "deviceActions": undefined,
-          "fetchScanResults": undefined,
-          "telemetryEventHandler": undefined,
-        },
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
@@ -237,12 +207,6 @@ exports[`AutomatedChecksView renders status scan <undefined> 1`] = `
     <CommandBar
       deps={
         Object {
-          "deviceConnectActionCreator": proxy {
-            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-            "deviceActions": undefined,
-            "fetchScanResults": undefined,
-            "telemetryEventHandler": undefined,
-          },
           "scanActionCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "scanActions": undefined,

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -3,7 +3,6 @@
 import { getUnifiedRuleResults } from 'common/rule-based-view-model-provider';
 import { CardRuleResult, CardRuleResultsByStatus } from 'common/types/store-data/card-view-model';
 import { UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
-import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
@@ -20,7 +19,6 @@ describe('AutomatedChecksView', () => {
         beforeEach(() => {
             bareMinimumProps = {
                 deps: {
-                    deviceConnectActionCreator: Mock.ofType(DeviceConnectActionCreator).object,
                     windowStateActionCreator: Mock.ofType(WindowStateActionCreator).object,
                     scanActionCreator: Mock.ofType(ScanActionCreator).object,
                 },

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -1,17 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { CommandBar, CommandBarProps } from 'electron/views/automated-checks/components/command-bar';
 import { shallow } from 'enzyme';
 import { Button } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
-import { Mock, MockBehavior, Times } from 'typemoq';
-
-import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
-import { CommandBar, CommandBarProps } from 'electron/views/automated-checks/components/command-bar';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
+import { Mock, MockBehavior, Times } from 'typemoq';
 
 describe('CommandBar', () => {
     test('render', () => {
-        const props = { deps: { deviceConnectActionCreator: null } } as CommandBarProps;
+        const props = { deps: { scanActionCreator: null } } as CommandBarProps;
 
         const rendered = shallow(<CommandBar {...props} />);
 
@@ -23,12 +22,12 @@ describe('CommandBar', () => {
 
         const port = 111;
 
-        const deviceConnectActionCreatorMock = Mock.ofType<DeviceConnectActionCreator>(undefined, MockBehavior.Strict);
-        deviceConnectActionCreatorMock.setup(creator => creator.validatePort(port)).verifiable(Times.once());
+        const scanActionCreatorMock = Mock.ofType<ScanActionCreator>(undefined, MockBehavior.Strict);
+        scanActionCreatorMock.setup(creator => creator.scan(port)).verifiable(Times.once());
 
         const props = {
             deps: {
-                deviceConnectActionCreator: deviceConnectActionCreatorMock.object,
+                scanActionCreator: scanActionCreatorMock.object,
             },
             deviceStoreData: {
                 port,
@@ -40,6 +39,6 @@ describe('CommandBar', () => {
 
         button.simulate('click', eventStub);
 
-        deviceConnectActionCreatorMock.verifyAll();
+        scanActionCreatorMock.verifyAll();
     });
 });


### PR DESCRIPTION
#### Description of changes

Fixing the `onClick` for the "Rescan" button on the automated checks view's command bar.

![13 - rescan button](https://user-images.githubusercontent.com/2837582/67028739-b5715000-f0c0-11e9-8478-4c3668c2fbd5.gif)

#### Pull request checklist

- [ ] Addresses an existing issue: part of WI # 1610159
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [] (UI changes only) Verified usability with NVDA/JAWS