### PR TITLE
fix: make "copy failure details" button in target page dialog work again

### DIFF
--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { MoreActionsMenuIcon } from 'common/icons/more-actions-menu-icon';
-import { createDefaultLogger } from 'common/logging/default-logger';
-import { Logger } from 'common/logging/logger';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { DirectionalHint, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import * as React from 'react';

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -142,6 +142,7 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
         try {
             await this.props.deps.navigatorUtils.copyToClipboard(text);
         } catch (error) {
+            console.error(`Failed to copy failure details: ${error}`);
             this.toastRef.current.show('Failed to copy failure details. Please try again.');
             return;
         }

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { MoreActionsMenuIcon } from 'common/icons/more-actions-menu-icon';
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { DirectionalHint, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import * as React from 'react';
-
-import { MoreActionsMenuIcon } from 'common/icons/more-actions-menu-icon';
 import { IssueDetailsTextGenerator } from '../../../background/issue-details-text-generator';
 import { DetailsViewActionMessageCreator } from '../../../DetailsView/actions/details-view-action-message-creator';
 import { IssueFilingDialog } from '../../../DetailsView/components/issue-filing-dialog';
@@ -142,7 +143,6 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
         try {
             await this.props.deps.navigatorUtils.copyToClipboard(text);
         } catch (error) {
-            console.error(`Failed to copy failure details: ${error}`);
             this.toastRef.current.show('Failed to copy failure details. Please try again.');
             return;
         }

--- a/src/common/components/copy-issue-details-button.tsx
+++ b/src/common/components/copy-issue-details-button.tsx
@@ -40,6 +40,7 @@ export class CopyIssueDetailsButton extends React.Component<CopyIssueDetailsButt
         try {
             await this.props.deps.navigatorUtils.copyToClipboard(this.getIssueDetailsText(this.props.issueDetailsData));
         } catch (error) {
+            console.error(`Failed to copy failure details: ${error}`);
             this.toastRef.current.show('Failed to copy failure details. Please try again.');
             return;
         }

--- a/src/common/components/copy-issue-details-button.tsx
+++ b/src/common/components/copy-issue-details-button.tsx
@@ -40,7 +40,6 @@ export class CopyIssueDetailsButton extends React.Component<CopyIssueDetailsButt
         try {
             await this.props.deps.navigatorUtils.copyToClipboard(this.getIssueDetailsText(this.props.issueDetailsData));
         } catch (error) {
-            console.error(`Failed to copy failure details: ${error}`);
             this.toastRef.current.show('Failed to copy failure details. Please try again.');
             return;
         }

--- a/src/common/navigator-utils.ts
+++ b/src/common/navigator-utils.ts
@@ -31,12 +31,10 @@ export class NavigatorUtils {
         return userAgent.substring(versionOffset + versionPrefix.length + 1).split(' ')[0];
     }
 
-    public async copyToClipboard(data: string): Promise<void> {
-        try {
-            await this.navigatorInfo.clipboard.writeText(data);
-        } catch (error) {
+    public copyToClipboard(data: string): Promise<void> {
+        return this.navigatorInfo.clipboard.writeText(data).catch(error => {
             this.logger.error(`Error during copyToClipboard: ${error}`);
             throw error;
-        }
+        });
     }
 }

--- a/src/common/navigator-utils.ts
+++ b/src/common/navigator-utils.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
+
 export class NavigatorUtils {
-    private navigatorInfo: Navigator;
-    constructor(navigatorInfo: Navigator) {
-        this.navigatorInfo = navigatorInfo;
-    }
+    constructor(private navigatorInfo: Navigator, private logger: Logger = createDefaultLogger()) {}
 
     public getBrowserSpec(): string {
         const userAgent = this.navigatorInfo.userAgent;
@@ -31,7 +31,12 @@ export class NavigatorUtils {
         return userAgent.substring(versionOffset + versionPrefix.length + 1).split(' ')[0];
     }
 
-    public copyToClipboard(data: string): Promise<void> {
-        return this.navigatorInfo.clipboard.writeText(data);
+    public async copyToClipboard(data: string): Promise<void> {
+        try {
+            await this.navigatorInfo.clipboard.writeText(data);
+        } catch (error) {
+            this.logger.error(`Error during copyToClipboard: ${error}`);
+            throw error;
+        }
     }
 }

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -79,7 +79,7 @@ export class DialogRenderer {
                 IssueFilingUrlStringUtils.getSelectorLastPart,
             );
 
-            const deps = {
+            const deps: LayeredDetailsDialogDeps = {
                 axeResultToIssueFilingDataConverter,
                 fixInstructionProcessor,
                 issueDetailsTextGenerator,

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -93,7 +93,7 @@ export class DialogRenderer {
                 issueFilingServiceProvider: mainWindowContext.getIssueFilingServiceProvider(),
                 userConfigMessageCreator: mainWindowContext.getUserConfigMessageCreator(),
                 LinkComponent: NewTabLink,
-            } as LayeredDetailsDialogDeps;
+            };
 
             this.renderer(
                 <LayeredDetailsDialogComponent

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { getRTL } from '@uifabric/utilities';
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
+import { NavigatorUtils } from 'common/navigator-utils';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
@@ -43,6 +44,7 @@ export class DialogRenderer {
         private readonly frameCommunicator: FrameCommunicator,
         private readonly htmlElementUtils: HTMLElementUtils,
         private readonly windowUtils: WindowUtils,
+        private readonly navigatorUtils: NavigatorUtils,
         private readonly shadowUtils: ShadowUtils,
         private readonly browserAdapter: BrowserAdapter,
         private readonly getRTLFunc: typeof getRTL,
@@ -82,6 +84,7 @@ export class DialogRenderer {
                 fixInstructionProcessor,
                 issueDetailsTextGenerator,
                 windowUtils: this.windowUtils,
+                navigatorUtils: this.navigatorUtils,
                 targetPageActionMessageCreator: mainWindowContext.getTargetPageActionMessageCreator(),
                 issueFilingActionMessageCreator: mainWindowContext.getIssueFilingActionMessageCreator(),
                 browserAdapter: this.browserAdapter,

--- a/src/injected/visualization/drawer-provider.ts
+++ b/src/injected/visualization/drawer-provider.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { getRTL } from '@uifabric/utilities';
 
+import { NavigatorUtils } from 'common/navigator-utils';
 import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
 import { HTMLElementUtils } from '../../common/html-element-utils';
 import { TabbableElementsHelper } from '../../common/tabbable-elements-helper';
@@ -37,6 +38,7 @@ export class DrawerProvider {
     constructor(
         private readonly htmlElementUtils: HTMLElementUtils,
         private readonly windowUtils: WindowUtils,
+        private readonly navigatorUtils: NavigatorUtils,
         private readonly shadowUtils: ShadowUtils,
         private readonly drawerUtils: DrawerUtils,
         private readonly clientUtils: ClientUtils,
@@ -97,6 +99,7 @@ export class DrawerProvider {
             this.frameCommunicator,
             this.htmlElementUtils,
             this.windowUtils,
+            this.navigatorUtils,
             this.shadowUtils,
             this.browserAdapter,
             this.getRTLFunc,

--- a/src/injected/visualization/issues-formatter.ts
+++ b/src/injected/visualization/issues-formatter.ts
@@ -3,6 +3,7 @@
 import { getRTL } from '@uifabric/utilities';
 import * as ReactDOM from 'react-dom';
 
+import { NavigatorUtils } from 'common/navigator-utils';
 import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
 import { HTMLElementUtils } from '../../common/html-element-utils';
 import { WindowUtils } from '../../common/window-utils';
@@ -21,6 +22,7 @@ export class IssuesFormatter implements Formatter {
         frameCommunicator: FrameCommunicator,
         htmlElementUtils: HTMLElementUtils,
         windowUtils: WindowUtils,
+        navigatorUtils: NavigatorUtils,
         shadowUtils: ShadowUtils,
         browserAdapter: BrowserAdapter,
         getRTLFunc: typeof getRTL,
@@ -32,6 +34,7 @@ export class IssuesFormatter implements Formatter {
             frameCommunicator,
             htmlElementUtils,
             windowUtils,
+            navigatorUtils,
             shadowUtils,
             browserAdapter,
             getRTLFunc,

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -3,6 +3,7 @@
 import { getRTL } from '@uifabric/utilities';
 import * as Q from 'q';
 
+import { NavigatorUtils } from 'common/navigator-utils';
 import { AppDataAdapter } from '../common/browser-adapters/app-data-adapter';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { ChromeAdapter } from '../common/browser-adapters/chrome-adapter';
@@ -78,6 +79,7 @@ export class WindowInitializer {
         const drawerProvider = new DrawerProvider(
             htmlElementUtils,
             this.windowUtils,
+            new NavigatorUtils(window.navigator),
             new ShadowUtils(new HTMLElementUtils()),
             new DrawerUtils(document),
             this.clientUtils,

--- a/src/tests/unit/tests/common/navigator-utils.test.ts
+++ b/src/tests/unit/tests/common/navigator-utils.test.ts
@@ -1,34 +1,80 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { NavigatorUtils } from '../../../../common/navigator-utils';
+import { Logger } from 'common/logging/logger';
+import { NavigatorUtils } from 'common/navigator-utils';
+import { It, Mock, Times } from 'typemoq';
 
-describe('NavigatorUtilsTest', () => {
-    test('getEnvironmentInfo: chrome', () => {
-        validateBrowserSpecReturnedWithUserAgent(
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36',
-            'Chrome version 65.0.3325.181',
-        );
+describe('NavigatorUtils', () => {
+    describe('getEnvironmentInfo', () => {
+        it('understands Chrome user agents', () => {
+            validateBrowserSpecReturnedWithUserAgent(
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.181 Safari/537.36',
+                'Chrome version 65.0.3325.181',
+            );
+        });
+
+        it('understands Edge user agents', () => {
+            validateBrowserSpecReturnedWithUserAgent(
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3763.0 Safari/537.36 Edg/75.0.131.0',
+                'Microsoft Edge version 75.0.131.0',
+            );
+        });
+
+        it("uses treats non-chromium user agents' original user agent strings as browser specs", () => {
+            const userAgent =
+                'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1';
+            validateBrowserSpecReturnedWithUserAgent(userAgent, userAgent);
+        });
+
+        function validateBrowserSpecReturnedWithUserAgent(userAgent: string, expected: string): void {
+            const navigatorInfo = {
+                userAgent: userAgent,
+            };
+            const testSubject = new NavigatorUtils(navigatorInfo as Navigator);
+            const actual = testSubject.getBrowserSpec();
+            expect(actual).toEqual(expected);
+        }
     });
 
-    test('getEnvironmentInfo: edge', () => {
-        validateBrowserSpecReturnedWithUserAgent(
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3763.0 Safari/537.36 Edg/75.0.131.0',
-            'Microsoft Edge version 75.0.131.0',
-        );
-    });
+    describe('copyToClipboard', () => {
+        it('logs an error and rethrows on underlying exception', async () => {
+            const loggerMock = Mock.ofType<Logger>();
+            const clipboardMock = Mock.ofType<Clipboard>();
+            const mockNavigatorInfo = {
+                clipboard: clipboardMock.object,
+            } as Navigator;
+            const testSubject = new NavigatorUtils(mockNavigatorInfo, loggerMock.object);
 
-    test('getEnvironmentInfo: non-chrome environment', () => {
-        const userAgent =
-            'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1';
-        validateBrowserSpecReturnedWithUserAgent(userAgent, userAgent);
-    });
+            const testError = new Error('test text');
+            clipboardMock
+                .setup(m => m.writeText(It.isAny()))
+                .returns(() => Promise.reject(testError))
+                .verifiable(Times.once());
 
-    function validateBrowserSpecReturnedWithUserAgent(userAgent: string, expected: string): void {
-        const navigatorInfo = {
-            userAgent: userAgent,
-        };
-        const testSubject = new NavigatorUtils(navigatorInfo as Navigator);
-        const actual = testSubject.getBrowserSpec();
-        expect(actual).toEqual(expected);
-    }
+            loggerMock.setup(l => l.error('Error during copyToClipboard: Error: test text')).verifiable(Times.once());
+
+            await expect(testSubject.copyToClipboard('irrelevant')).rejects.toBe(testError);
+
+            clipboardMock.verifyAll();
+            loggerMock.verifyAll();
+        });
+
+        it('passes through to the underlying Clipboard in the happy path', async () => {
+            const clipboardMock = Mock.ofType<Clipboard>();
+            const mockNavigatorInfo = {
+                clipboard: clipboardMock.object,
+            } as Navigator;
+            const testSubject = new NavigatorUtils(mockNavigatorInfo);
+
+            const testText = 'test text';
+            clipboardMock
+                .setup(m => m.writeText(testText))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+
+            await testSubject.copyToClipboard(testText);
+
+            clipboardMock.verifyAll();
+        });
+    });
 });

--- a/src/tests/unit/tests/injected/dialog-renderer.test.tsx
+++ b/src/tests/unit/tests/injected/dialog-renderer.test.tsx
@@ -6,6 +6,7 @@ import { GlobalMock, GlobalScope, IGlobalMock, IMock, It, Mock, MockBehavior, Ti
 
 import { DevToolStore } from 'background/stores/dev-tools-store';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
+import { NavigatorUtils } from 'common/navigator-utils';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { EnvironmentInfoProvider } from '../../../../common/environment-info-provider';
 import { FeatureFlags, getDefaultFeatureFlagValues } from '../../../../common/feature-flags';
@@ -32,6 +33,7 @@ import { DictionaryStringTo } from '../../../../types/common-types';
 describe('DialogRendererTests', () => {
     let htmlElementUtilsMock: IMock<HTMLElementUtils>;
     let windowUtilsMock: IMock<WindowUtils>;
+    let navigatorUtilsMock: IMock<NavigatorUtils>;
     let frameCommunicator: IMock<FrameCommunicator>;
     let mainWindowContext: MainWindowContext;
     let shadowUtilMock: IMock<ShadowUtils>;
@@ -54,6 +56,7 @@ describe('DialogRendererTests', () => {
     beforeEach(() => {
         htmlElementUtilsMock = Mock.ofType(HTMLElementUtils);
         windowUtilsMock = Mock.ofType(WindowUtils);
+        navigatorUtilsMock = Mock.ofType(NavigatorUtils);
         shadowUtilMock = Mock.ofType(ShadowUtils);
         browserAdapter = Mock.ofType<BrowserAdapter>();
         detailsDialogHandlerMock = Mock.ofType<DetailsDialogHandler>();
@@ -533,6 +536,7 @@ describe('DialogRendererTests', () => {
             frameCommunicator.object,
             htmlElementUtilsMock.object,
             windowUtilsMock.object,
+            navigatorUtilsMock.object,
             shadowUtilMock.object,
             browserAdapter.object,
             getRTLMock.object,

--- a/src/tests/unit/tests/injected/visualization/drawer-provider.test.ts
+++ b/src/tests/unit/tests/injected/visualization/drawer-provider.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NavigatorUtils } from 'common/navigator-utils';
 import { IMock, Mock } from 'typemoq';
 import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
 import { HTMLElementUtils } from '../../../../../common/html-element-utils';
@@ -19,6 +20,7 @@ describe('DrawerProviderTests', () => {
     let testObject: DrawerProvider;
     let htmlElementUtils: IMock<HTMLElementUtils>;
     let windowUtils: IMock<WindowUtils>;
+    let navigatorUtils: IMock<NavigatorUtils>;
     let shadowUtils: IMock<ShadowUtils>;
     let drawerUtils: IMock<DrawerUtils>;
     let clientUtils: IMock<ClientUtils>;
@@ -30,6 +32,7 @@ describe('DrawerProviderTests', () => {
     beforeEach(() => {
         htmlElementUtils = Mock.ofType(HTMLElementUtils);
         windowUtils = Mock.ofType(WindowUtils);
+        navigatorUtils = Mock.ofType(NavigatorUtils);
         shadowUtils = Mock.ofType(ShadowUtils);
         drawerUtils = Mock.ofType(DrawerUtils);
         clientUtils = Mock.ofType(ClientUtils);
@@ -41,6 +44,7 @@ describe('DrawerProviderTests', () => {
         testObject = new DrawerProvider(
             htmlElementUtils.object,
             windowUtils.object,
+            navigatorUtils.object,
             shadowUtils.object,
             drawerUtils.object,
             clientUtils.object,

--- a/src/tests/unit/tests/injected/visualization/issues-formatter.test.ts
+++ b/src/tests/unit/tests/injected/visualization/issues-formatter.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { IMock, Mock } from 'typemoq';
 
+import { NavigatorUtils } from 'common/navigator-utils';
 import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
 import { HTMLElementUtils } from '../../../../../common/html-element-utils';
 import { WindowUtils } from '../../../../../common/window-utils';
@@ -22,6 +23,7 @@ describe('IssuesFormatterTests', () => {
         const frameCommunicator: IMock<FrameCommunicator> = Mock.ofType(FrameCommunicator);
         htmlElementUtilsMock = Mock.ofType(HTMLElementUtils);
         const windowUtils: IMock<WindowUtils> = Mock.ofType(WindowUtils);
+        const navigatorUtils: IMock<NavigatorUtils> = Mock.ofType(NavigatorUtils);
         const shadowUtils: IMock<ShadowUtils> = Mock.ofType(ShadowUtils);
         const browserAdapter = Mock.ofType<BrowserAdapter>();
         const getRTLMock = Mock.ofInstance(() => null);
@@ -30,6 +32,7 @@ describe('IssuesFormatterTests', () => {
             frameCommunicator.object,
             htmlElementUtilsMock.object,
             windowUtils.object,
+            navigatorUtils.object,
             shadowUtils.object,
             browserAdapter.object,
             getRTLMock.object,


### PR DESCRIPTION
#### Description of changes

* Adds `console.error` logging with the full error message on copy failure, for diagnosability
* Wires up `NavigatorUtils` in the target page to the dialog renderer (it was missing before)

![screenshot of copying working in target page](https://user-images.githubusercontent.com/376284/67038024-7bf61000-f0d3-11e9-8914-3d8bd9a4896f.png)

(give an overview. Add technical description describing your changes)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1501 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
