### PR TITLE
feat(android-cards-view): disable rescan button while scanning

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -47,7 +47,11 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
             <div className={automatedChecksView}>
                 <TitleBar deps={this.props.deps} windowStateStoreData={this.props.windowStateStoreData}></TitleBar>
                 <div className={mainContentWrapper}>
-                    <CommandBar deps={this.props.deps} deviceStoreData={this.props.deviceStoreData} />
+                    <CommandBar
+                        deps={this.props.deps}
+                        deviceStoreData={this.props.deviceStoreData}
+                        scanStoreData={this.props.scanStoreData}
+                    />
                     <main>
                         <HeaderSection />
                         {this.renderScanning()}

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -3,9 +3,11 @@
 import { NamedFC } from 'common/react/named-fc';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
+import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
+import { ScanStatus } from 'electron/flux/types/scan-status';
 import { commandBar, rescanButton } from './command-bar.scss';
 
 export type CommandBarDeps = {
@@ -15,6 +17,7 @@ export type CommandBarDeps = {
 export interface CommandBarProps {
     deps: CommandBarDeps;
     deviceStoreData: DeviceStoreData;
+    scanStoreData: ScanStoreData;
 }
 
 export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: CommandBarProps) => {
@@ -31,6 +34,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: Command
                 }}
                 onClick={onClick}
                 text="Rescan"
+                disabled={props.scanStoreData.status === ScanStatus.Scanning}
             />
         </div>
     );

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AutomatedChecksView renders results 1`] = `
+exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
 <div
   className="automatedChecksView"
 >
@@ -29,6 +29,11 @@ exports[`AutomatedChecksView renders results 1`] = `
         }
       }
       deviceStoreData={Object {}}
+      scanStoreData={
+        Object {
+          "status": 2,
+        }
+      }
     />
     <main>
       <HeaderSection />
@@ -70,7 +75,7 @@ exports[`AutomatedChecksView renders results 1`] = `
 </div>
 `;
 
-exports[`AutomatedChecksView renders status scan <Failed> 1`] = `
+exports[`AutomatedChecksView renders when status scan <Failed> 1`] = `
 <div
   className="automatedChecksView"
 >
@@ -110,6 +115,11 @@ exports[`AutomatedChecksView renders status scan <Failed> 1`] = `
       deviceStoreData={
         Object {
           "connectedDevice": "TEST DEVICE",
+        }
+      }
+      scanStoreData={
+        Object {
+          "status": 3,
         }
       }
     />
@@ -128,7 +138,7 @@ exports[`AutomatedChecksView renders status scan <Failed> 1`] = `
 </div>
 `;
 
-exports[`AutomatedChecksView renders status scan <Scanning> 1`] = `
+exports[`AutomatedChecksView renders when status scan <Scanning> 1`] = `
 <div
   className="automatedChecksView"
 >
@@ -168,6 +178,11 @@ exports[`AutomatedChecksView renders status scan <Scanning> 1`] = `
       deviceStoreData={
         Object {
           "connectedDevice": "TEST DEVICE",
+        }
+      }
+      scanStoreData={
+        Object {
+          "status": 1,
         }
       }
     />
@@ -181,7 +196,7 @@ exports[`AutomatedChecksView renders status scan <Scanning> 1`] = `
 </div>
 `;
 
-exports[`AutomatedChecksView renders status scan <undefined> 1`] = `
+exports[`AutomatedChecksView renders when status scan <undefined> 1`] = `
 <div
   className="automatedChecksView"
 >
@@ -221,6 +236,11 @@ exports[`AutomatedChecksView renders status scan <undefined> 1`] = `
       deviceStoreData={
         Object {
           "connectedDevice": "TEST DEVICE",
+        }
+      }
+      scanStoreData={
+        Object {
+          "status": undefined,
         }
       }
     />

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -30,9 +30,9 @@ describe('AutomatedChecksView', () => {
             } as AutomatedChecksViewProps;
         });
 
-        const scanStatues = [undefined, ScanStatus[ScanStatus.Scanning], ScanStatus[ScanStatus.Failed]];
+        const scanStatuses = [undefined, ScanStatus[ScanStatus.Scanning], ScanStatus[ScanStatus.Failed]];
 
-        it.each(scanStatues)('when status scan <%s>', scanStatusName => {
+        it.each(scanStatuses)('when status scan <%s>', scanStatusName => {
             bareMinimumProps.scanStoreData.status = ScanStatus[scanStatusName];
 
             const wrapped = shallow(<AutomatedChecksView {...bareMinimumProps} />);

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -32,7 +32,7 @@ describe('AutomatedChecksView', () => {
 
         const scanStatues = [undefined, ScanStatus[ScanStatus.Scanning], ScanStatus[ScanStatus.Failed]];
 
-        it.each(scanStatues)('status scan <%s>', scanStatusName => {
+        it.each(scanStatues)('when status scan <%s>', scanStatusName => {
             bareMinimumProps.scanStoreData.status = ScanStatus[scanStatusName];
 
             const wrapped = shallow(<AutomatedChecksView {...bareMinimumProps} />);
@@ -40,7 +40,7 @@ describe('AutomatedChecksView', () => {
             expect(wrapped.getElement()).toMatchSnapshot();
         });
 
-        it('results', () => {
+        it('when status scan <Completed>', () => {
             const rulesStub = [{ description: 'test-rule-description' } as UnifiedRule];
             const resultsStub = [{ uid: 'test-uid' } as UnifiedResult];
 

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -1,10 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CommandBar render 1`] = `
+exports[`CommandBar renders while status is <Completed> 1`] = `
 <div
   className="commandBar"
 >
   <CustomizedActionButton
+    disabled={false}
+    iconProps={
+      Object {
+        "className": "rescanButton",
+        "iconName": "Refresh",
+      }
+    }
+    onClick={[Function]}
+    text="Rescan"
+  />
+</div>
+`;
+
+exports[`CommandBar renders while status is <Default> 1`] = `
+<div
+  className="commandBar"
+>
+  <CustomizedActionButton
+    disabled={false}
+    iconProps={
+      Object {
+        "className": "rescanButton",
+        "iconName": "Refresh",
+      }
+    }
+    onClick={[Function]}
+    text="Rescan"
+  />
+</div>
+`;
+
+exports[`CommandBar renders while status is <Failed> 1`] = `
+<div
+  className="commandBar"
+>
+  <CustomizedActionButton
+    disabled={false}
+    iconProps={
+      Object {
+        "className": "rescanButton",
+        "iconName": "Refresh",
+      }
+    }
+    onClick={[Function]}
+    text="Rescan"
+  />
+</div>
+`;
+
+exports[`CommandBar renders while status is <Scanning> 1`] = `
+<div
+  className="commandBar"
+>
+  <CustomizedActionButton
+    disabled={true}
     iconProps={
       Object {
         "className": "rescanButton",

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { EnumHelper } from 'common/enum-helper';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
+import { ScanStatus } from 'electron/flux/types/scan-status';
 import { CommandBar, CommandBarProps } from 'electron/views/automated-checks/components/command-bar';
 import { shallow } from 'enzyme';
 import { Button } from 'office-ui-fabric-react/lib/Button';
@@ -9,12 +11,36 @@ import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { Mock, MockBehavior, Times } from 'typemoq';
 
 describe('CommandBar', () => {
-    test('render', () => {
-        const props = { deps: { scanActionCreator: null } } as CommandBarProps;
+    describe('renders', () => {
+        it('while status is <Scanning>', () => {
+            const props = {
+                deps: { scanActionCreator: null },
+                scanStoreData: {
+                    status: ScanStatus.Scanning,
+                },
+            } as CommandBarProps;
 
-        const rendered = shallow(<CommandBar {...props} />);
+            const rendered = shallow(<CommandBar {...props} />);
 
-        expect(rendered.getElement()).toMatchSnapshot();
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
+
+        const notScanningStatuses = EnumHelper.getNumericValues<ScanStatus>(ScanStatus)
+            .filter(status => status !== ScanStatus.Scanning)
+            .map(status => ScanStatus[status]);
+
+        it.each(notScanningStatuses)('while status is <%s>', status => {
+            const props = {
+                deps: { scanActionCreator: null },
+                scanStoreData: {
+                    status: ScanStatus[status],
+                },
+            } as CommandBarProps;
+
+            const rendered = shallow(<CommandBar {...props} />);
+
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
     });
 
     test('rescan click', () => {
@@ -31,6 +57,9 @@ describe('CommandBar', () => {
             },
             deviceStoreData: {
                 port,
+            },
+            scanStoreData: {
+                status: ScanStatus.Default,
             },
         } as CommandBarProps;
 


### PR DESCRIPTION
#### Description of changes

We don't want to send scan http request to the axe-android service, nor we have an explicit queue for handling this scenario. So, the desired behavior is to disable the "Rescan" button while we're scanning. 

This PR adds such behavior.

![01 - rescan button disabled while scanning](https://user-images.githubusercontent.com/2837582/67051590-5dead880-f0f0-11e9-9023-df84e635257a.gif)

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1606846
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
