### PR TITLE
refactor: rename buildDetailsViewMainContent -> ...Body

### DIFF
--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -467,15 +467,7 @@ describe('DetailsViewContainer', () => {
                     dropdownClickHandler={dropdownClickHandler.object}
                     tabClosed={storeMocks.tabStoreData.isClosed}
                 />
-                {buildDetailsViewBody(
-                    storeMocks,
-                    props,
-                    viewType,
-                    rightContentPanelConfig,
-                    switcherNavConfig,
-                    ruleResults,
-                    targetAppInfo,
-                )}
+                {buildDetailsViewBody(storeMocks, props, viewType, rightContentPanelConfig, switcherNavConfig, ruleResults, targetAppInfo)}
                 {buildOverlay(storeMocks, props)}
             </>
         );

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -268,7 +268,7 @@ describe('DetailsViewContainer', () => {
         return storesHubMock;
     }
 
-    function buildDetailsViewMainContent(
+    function buildDetailsViewBody(
         storeMocks: StoreMocks,
         props: DetailsViewContainerProps,
         selectedDetailsView: VisualizationType,
@@ -467,7 +467,7 @@ describe('DetailsViewContainer', () => {
                     dropdownClickHandler={dropdownClickHandler.object}
                     tabClosed={storeMocks.tabStoreData.isClosed}
                 />
-                {buildDetailsViewMainContent(
+                {buildDetailsViewBody(
                     storeMocks,
                     props,
                     viewType,


### PR DESCRIPTION
#### Description of changes

An earlier refactor PR renamed `DetailsViewMainContent` to `DetailsViewBody`, but missed updating this associated test helper method.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
