### PR TITLE
Extract dimensions from bounding rectangle

### DIFF
--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -81,8 +81,9 @@ export class RuleInformationProvider {
 
     private getTouchSizeUnifiedFormattableResolution = (ruleResultsData: RuleResultsData): UnifiedFormattableResolution => {
         const dpi = ruleResultsData.props['Screen Dots Per Inch'] as number;
-        const physicalWidth = ruleResultsData.props['width'] as number;
-        const physicalHeight = ruleResultsData.props['height'] as number;
+        const boundingRect = ruleResultsData.props['boundsInScreen'];
+        const physicalWidth = (boundingRect['right'] as number) - (boundingRect['left'] as number);
+        const physicalHeight = (boundingRect['bottom'] as number) - (boundingRect['top'] as number);
         const logicalWidth = physicalWidth / dpi;
         const logicalHeight = physicalHeight / dpi;
 

--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -82,6 +82,7 @@ export class RuleInformationProvider {
         const dpi = ruleResultsData.props['Screen Dots Per Inch'] as number;
         const boundingRect = ruleResultsData.props['boundsInScreen'];
         const physicalWidth = (boundingRect['right'] as number) - (boundingRect['left'] as number);
+        const physicalHeight = (boundingRect['bottom'] as number) - (boundingRect['top'] as number);
         const logicalWidth = this.floorTo3Decimal(physicalWidth / dpi);
         const logicalHeight = this.floorTo3Decimal(physicalHeight / dpi);
 

--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -79,10 +79,10 @@ export class RuleInformationProvider {
     }
 
     private getTouchSizeUnifiedFormattableResolution = (ruleResultsData: RuleResultsData): UnifiedFormattableResolution => {
-        const dpi = ruleResultsData.props['Screen Dots Per Inch'] as number;
+        const dpi: number = ruleResultsData.props['Screen Dots Per Inch'];
         const boundingRect = ruleResultsData.props['boundsInScreen'];
-        const physicalWidth = (boundingRect['right'] as number) - (boundingRect['left'] as number);
-        const physicalHeight = (boundingRect['bottom'] as number) - (boundingRect['top'] as number);
+        const physicalWidth: number = boundingRect['right'] - boundingRect['left'];
+        const physicalHeight: number = boundingRect['bottom'] - boundingRect['top'];
         const logicalWidth = this.floorTo3Decimal(physicalWidth / dpi);
         const logicalHeight = this.floorTo3Decimal(physicalHeight / dpi);
 

--- a/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
@@ -19,8 +19,8 @@ describe('RuleInformationProvider', () => {
         // This is based on the output of the Android service.
         props['Screen Dots Per Inch'] = dpi;
 
-        const left = 123 as number;
-        const top = 345 as number;
+        const left: number = 123;
+        const top: number = 345;
         const right = left + width;
         const bottom = top + height;
 

--- a/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
@@ -16,10 +16,20 @@ describe('RuleInformationProvider', () => {
 
     function buildTouchSizeWcagRuleResultObject(status: string, dpi: number, height: number, width: number): RuleResultsData {
         const props = {};
-        // This is based on the output of the Android service
+        // This is based on the output of the Android service.
         props['Screen Dots Per Inch'] = dpi;
-        props['height'] = height;
-        props['width'] = width;
+
+        const left = 123 as number;
+        const top = 345 as number;
+        const right = left + width;
+        const bottom = top + height;
+
+        props['boundsInScreen'] = {
+            top: top,
+            left: left,
+            bottom: bottom,
+            right: right,
+        };
 
         return buildRuleResultObject('TouchSizeWcag', status, null, props);
     }


### PR DESCRIPTION
#### Description of changes

We discovered that the Axe service has changed the format of the data in the TouchSizeWcag rule result. The new format looks wrong, so we're extracting the dimensions directly from the bounding rectangle. This should work in both old and new versions of the service.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
