### PR TITLE
feat(card-selection) : link CardSelectionMessageCreator with Collapsible component for…

### DIFF
--- a/src/background/actions/card-selection-action-creator.ts
+++ b/src/background/actions/card-selection-action-creator.ts
@@ -7,7 +7,7 @@ import { getStoreStateMessage, Messages } from '../../common/messages';
 import { CardSelectionActions } from '../actions/card-selection-actions';
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
-import { CardSelectionPayload } from './action-payloads';
+import { CardSelectionPayload, RuleExpandCollapsePayload } from './action-payloads';
 
 export class CardSelectionActionCreator {
     constructor(
@@ -18,6 +18,7 @@ export class CardSelectionActionCreator {
 
     public registerCallbacks(): void {
         this.interpreter.registerTypeToPayloadCallback(Messages.CardSelection.CardSelectionToggled, this.onCardSelectionToggle);
+        this.interpreter.registerTypeToPayloadCallback(Messages.CardSelection.RuleExpansionToggled, this.onRuleExpansionToggle);
         this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.CardSelectionStore), this.onGetCurrentState);
     }
 
@@ -28,5 +29,10 @@ export class CardSelectionActionCreator {
     private onCardSelectionToggle = (payload: CardSelectionPayload): void => {
         this.cardSelectionActions.toggleCardSelection.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.CARD_SELECTION_TOGGLED, payload);
+    };
+
+    private onRuleExpansionToggle = (payload: RuleExpandCollapsePayload): void => {
+        this.cardSelectionActions.toggleRuleExpandCollapse.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.RULE_EXPANSION_TOGGLED, payload);
     };
 }

--- a/src/common/components/cards/collapsible-component-cards.tsx
+++ b/src/common/components/cards/collapsible-component-cards.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
@@ -11,6 +12,10 @@ import {
     collapsibleTitle,
 } from './collapsible-component-cards.scss';
 
+export type CollapsibleComponentCardsDeps = {
+    cardSelectionMessageCreator: CardSelectionMessageCreator;
+};
+
 export interface CollapsibleComponentCardsProps {
     header: JSX.Element;
     content: JSX.Element;
@@ -19,6 +24,7 @@ export interface CollapsibleComponentCardsProps {
     containerClassName?: string;
     buttonAriaLabel?: string;
     id?: string;
+    deps: CollapsibleComponentCardsDeps;
 }
 
 interface CollapsibleComponentCardsState {
@@ -34,6 +40,7 @@ class CollapsibleComponentCards extends React.Component<CollapsibleComponentCard
     private onClick = (): void => {
         const newState = !this.state.showContent;
         this.setState({ showContent: newState });
+        this.props.deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(this.props.id);
     };
 
     public render(): JSX.Element {

--- a/src/common/components/cards/collapsible-component-cards.tsx
+++ b/src/common/components/cards/collapsible-component-cards.tsx
@@ -5,6 +5,7 @@ import { CardSelectionMessageCreator } from 'common/message-creators/card-select
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
+import { NamedFC } from 'common/react/named-fc';
 import {
     collapsibleContainer,
     collapsibleContainerContent,
@@ -25,52 +26,40 @@ export interface CollapsibleComponentCardsProps {
     buttonAriaLabel?: string;
     id?: string;
     deps: CollapsibleComponentCardsDeps;
+    isExpanded?: boolean;
 }
 
-interface CollapsibleComponentCardsState {
-    showContent: boolean;
-}
+const CollapsibleComponentCards = NamedFC<CollapsibleComponentCardsProps>(
+    'CollapsibleComponentCards',
+    (props: CollapsibleComponentCardsProps) => {
+        const { headingLevel, contentClassName, content, isExpanded, deps, buttonAriaLabel, containerClassName, header, id } = props;
 
-class CollapsibleComponentCards extends React.Component<CollapsibleComponentCardsProps, CollapsibleComponentCardsState> {
-    constructor(props: CollapsibleComponentCardsProps) {
-        super(props);
-        this.state = { showContent: true };
-    }
-
-    private onClick = (): void => {
-        const newState = !this.state.showContent;
-        this.setState({ showContent: newState });
-        this.props.deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(this.props.id);
-    };
-
-    public render(): JSX.Element {
-        const showContent = this.state.showContent;
-        const containerProps = { role: 'heading', 'aria-level': this.props.headingLevel };
+        const containerProps = { role: 'heading', 'aria-level': headingLevel };
         let contentWrapper = null;
         let collapsedCSSClassName = 'collapsed';
 
+        const showContent = isExpanded || false;
+
         if (showContent) {
-            contentWrapper = <div className={css(this.props.contentClassName, collapsibleContainerContent)}>{this.props.content}</div>;
+            contentWrapper = <div className={css(contentClassName, collapsibleContainerContent)}>{content}</div>;
             collapsedCSSClassName = null;
         }
 
+        const onClick = () => {
+            deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(id);
+        };
         return (
-            <div className={css(this.props.containerClassName, collapsibleContainer, collapsedCSSClassName)}>
+            <div className={css(containerClassName, collapsibleContainer, collapsedCSSClassName)}>
                 <div {...containerProps}>
-                    <ActionButton
-                        className={collapsibleControl}
-                        onClick={this.onClick}
-                        aria-expanded={showContent}
-                        ariaLabel={this.props.buttonAriaLabel}
-                    >
-                        <span className={collapsibleTitle}>{this.props.header}</span>
+                    <ActionButton className={collapsibleControl} onClick={onClick} aria-expanded={showContent} ariaLabel={buttonAriaLabel}>
+                        <span className={collapsibleTitle}>{header}</span>
                     </ActionButton>
                 </div>
                 {contentWrapper}
             </div>
         );
-    }
-}
+    },
+);
 
 export const CardsCollapsibleControl = (collapsibleControlProps: CollapsibleComponentCardsProps) => (
     <CollapsibleComponentCards {...collapsibleControlProps} />

--- a/src/common/components/cards/collapsible-component-cards.tsx
+++ b/src/common/components/cards/collapsible-component-cards.tsx
@@ -45,9 +45,8 @@ const CollapsibleComponentCards = NamedFC<CollapsibleComponentCardsProps>(
             collapsedCSSClassName = null;
         }
 
-        const onClick = () => {
-            deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(id);
-        };
+        const onClick = () => deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(id);
+
         return (
             <div className={css(containerClassName, collapsibleContainer, collapsedCSSClassName)}>
                 <div {...containerProps}>

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -50,6 +50,7 @@ export const RulesWithInstances = NamedFC<RulesWithInstancesProps>(
                 buttonAriaLabel: buttonAriaLabel,
                 headingLevel: 3,
                 deps: deps,
+                isExpanded: rule.isExpanded,
             };
         };
 

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -49,6 +49,7 @@ export const RulesWithInstances = NamedFC<RulesWithInstancesProps>(
                 containerClassName: css(collapsibleRuleDetailsGroup),
                 buttonAriaLabel: buttonAriaLabel,
                 headingLevel: 3,
+                deps: deps,
             };
         };
 

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -55,6 +55,7 @@ export const CONTENT_PANEL_CLOSED: string = 'contentPanelClosed';
 export const CONTENT_PAGE_OPENED: string = 'contentPageOpened';
 export const CONTENT_HYPERLINK_OPENED: string = 'contentHyperLinkOpened';
 export const CARD_SELECTION_TOGGLED: string = 'cardSelectionToggled';
+export const RULE_EXPANSION_TOGGLED: string = 'ruleExpansionToggled';
 
 export const TriggeredByNotApplicable: TriggeredBy = 'N/A';
 export type TriggeredBy = 'mouseclick' | 'keypress' | 'shortcut' | 'N/A';

--- a/src/common/message-creators/card-selection-message-creator.ts
+++ b/src/common/message-creators/card-selection-message-creator.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CardSelectionPayload } from 'background/actions/action-payloads';
+import { CardSelectionPayload, RuleExpandCollapsePayload } from 'background/actions/action-payloads';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { Messages } from 'common/messages';
 
@@ -15,6 +15,17 @@ export class CardSelectionMessageCreator {
 
         this.dispatcher.dispatchMessage({
             messageType: Messages.CardSelection.CardSelectionToggled,
+            payload,
+        });
+    }
+
+    public toggleRuleExpandCollapse(ruleId: string): void {
+        const payload: RuleExpandCollapsePayload = {
+            ruleId,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.CardSelection.RuleExpansionToggled,
             payload,
         });
     }

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -191,5 +191,6 @@ export class Messages {
 
     public static readonly CardSelection = {
         CardSelectionToggled: `${messagePrefix}/cardSelection/cardSelectionToggled`,
+        RuleExpansionToggled: `${messagePrefix}/cardSelection/ruleExpansionToggled`,
     };
 }

--- a/src/reports/components/report-sections/collapsible-result-section.tsx
+++ b/src/reports/components/report-sections/collapsible-result-section.tsx
@@ -25,6 +25,7 @@ export const CollapsibleResultSection = NamedFC<CollapsibleResultSectionProps>('
         header: <ResultSectionTitle {...props} />,
         content: <RulesOnly {...props} />,
         headingLevel: 2,
+        deps: null,
     });
 
     return <div className={containerClassName}>{CollapsibleContent}</div>;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/collapsible-component-cards.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/collapsible-component-cards.test.tsx.snap
@@ -225,31 +225,6 @@ exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: collap
 </div>
 `;
 
-exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: collapsed 2`] = `
-<div
-  className="collapsibleContainer collapsed"
->
-  <div
-    aria-level={5}
-    role="heading"
-  >
-    <CustomizedActionButton
-      aria-expanded={false}
-      className="collapsibleControl"
-      onClick={[Function]}
-    >
-      <span
-        className="collapsibleTitle"
-      >
-        <div>
-          Some header
-        </div>
-      </span>
-    </CustomizedActionButton>
-  </div>
-</div>
-`;
-
 exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: expanded 1`] = `
 <div
   className="collapsibleContainer"
@@ -278,31 +253,6 @@ exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: expand
     <div>
       Some content
     </div>
-  </div>
-</div>
-`;
-
-exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: expanded 2`] = `
-<div
-  className="collapsibleContainer collapsed"
->
-  <div
-    aria-level={5}
-    role="heading"
-  >
-    <CustomizedActionButton
-      aria-expanded={false}
-      className="collapsibleControl"
-      onClick={[Function]}
-    >
-      <span
-        className="collapsibleTitle"
-      >
-        <div>
-          Some header
-        </div>
-      </span>
-    </CustomizedActionButton>
   </div>
 </div>
 `;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/collapsible-component-cards.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/collapsible-component-cards.test.tsx.snap
@@ -195,14 +195,14 @@ exports[`CollapsibleComponentCardsTest render with contentClassName set to: unde
 
 exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: collapsed 1`] = `
 <div
-  className="collapsibleContainer collapsed"
+  className="collapsibleContainer"
 >
   <div
     aria-level={5}
     role="heading"
   >
     <CustomizedActionButton
-      aria-expanded={false}
+      aria-expanded={true}
       className="collapsibleControl"
       onClick={[Function]}
     >
@@ -214,6 +214,13 @@ exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: collap
         </div>
       </span>
     </CustomizedActionButton>
+  </div>
+  <div
+    className="collapsibleContainerContent"
+  >
+    <div>
+      Some content
+    </div>
   </div>
 </div>
 `;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/collapsible-component-cards.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/collapsible-component-cards.test.tsx.snap
@@ -225,6 +225,31 @@ exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: collap
 </div>
 `;
 
+exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: collapsed 2`] = `
+<div
+  className="collapsibleContainer collapsed"
+>
+  <div
+    aria-level={5}
+    role="heading"
+  >
+    <CustomizedActionButton
+      aria-expanded={false}
+      className="collapsibleControl"
+      onClick={[Function]}
+    >
+      <span
+        className="collapsibleTitle"
+      >
+        <div>
+          Some header
+        </div>
+      </span>
+    </CustomizedActionButton>
+  </div>
+</div>
+`;
+
 exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: expanded 1`] = `
 <div
   className="collapsibleContainer"
@@ -253,6 +278,31 @@ exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: expand
     <div>
       Some content
     </div>
+  </div>
+</div>
+`;
+
+exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: expanded 2`] = `
+<div
+  className="collapsibleContainer collapsed"
+>
+  <div
+    aria-level={5}
+    role="heading"
+  >
+    <CustomizedActionButton
+      aria-expanded={false}
+      className="collapsibleControl"
+      onClick={[Function]}
+    >
+      <span
+        className="collapsibleTitle"
+      >
+        <div>
+          Some header
+        </div>
+      </span>
+    </CustomizedActionButton>
   </div>
 </div>
 `;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
@@ -73,6 +73,11 @@ exports[`RulesWithInstances renders 1`] = `
         userConfigurationStoreData={null}
       />
     }
+    deps={
+      Object {
+        "collapsibleControl": [Function],
+      }
+    }
     header={
       <MinimalRuleHeader
         outcomeType="pass"

--- a/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
@@ -1,25 +1,37 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CardsCollapsibleControl, CollapsibleComponentCardsProps } from 'common/components/cards/collapsible-component-cards';
+import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { shallow } from 'enzyme';
 import { forOwn } from 'lodash';
 import * as React from 'react';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('CollapsibleComponentCardsTest', () => {
+    let cardSelectionMessageCreatorMock: IMock<CardSelectionMessageCreator>;
     const optionalPropertiesObject = {
         contentClassName: [undefined, 'content-class-name-a'],
         containerClassName: [undefined, 'a-container'],
         buttonAriaLabel: [undefined, 'some button label'],
     };
 
+    beforeEach(() => {
+        cardSelectionMessageCreatorMock = Mock.ofType(CardSelectionMessageCreator);
+    });
+
     forOwn(optionalPropertiesObject, (propertyValues, propertyName) => {
         propertyValues.forEach(value => {
             test(`render with ${propertyName} set to: ${value}`, () => {
+                cardSelectionMessageCreatorMock
+                    .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString()))
+                    .verifiable(Times.never());
+
                 const props: CollapsibleComponentCardsProps = {
                     header: <div>Some header</div>,
                     content: <div>Some content</div>,
                     headingLevel: 5,
                     [propertyName]: value,
+                    deps: { cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object },
                 };
                 const control = CardsCollapsibleControl(props);
                 const result = shallow(control);
@@ -29,10 +41,17 @@ describe('CollapsibleComponentCardsTest', () => {
     });
 
     test('toggle from expanded to collapsed', () => {
+        cardSelectionMessageCreatorMock
+            .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString()))
+            .verifiable(Times.never());
+
         const props: CollapsibleComponentCardsProps = {
             header: <div>Some header</div>,
             content: <div>Some content</div>,
             headingLevel: 5,
+            deps: {
+                cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
+            },
         };
         const control = CardsCollapsibleControl(props);
         const result = shallow(control);
@@ -40,5 +59,6 @@ describe('CollapsibleComponentCardsTest', () => {
         const button = result.find('CustomizedActionButton');
         button.simulate('click');
         expect(result.getElement()).toMatchSnapshot('collapsed');
+        cardSelectionMessageCreatorMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
@@ -41,7 +41,8 @@ describe('CollapsibleComponentCardsTest', () => {
         });
     });
 
-    test('toggle from expanded to collapsed', () => {
+    const isExpandedParams = [true, false];
+    test.each(isExpandedParams)('toggle from expanded to collapsed', isExpanded => {
         cardSelectionMessageCreatorMock
             .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString()))
             .verifiable(Times.never());
@@ -53,7 +54,7 @@ describe('CollapsibleComponentCardsTest', () => {
             deps: {
                 cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
             },
-            isExpanded: true,
+            isExpanded,
         };
         const control = CardsCollapsibleControl(props);
         const result = shallow(control);
@@ -61,6 +62,7 @@ describe('CollapsibleComponentCardsTest', () => {
         const button = result.find('CustomizedActionButton');
         button.simulate('click');
         expect(result.getElement()).toMatchSnapshot('collapsed');
+
         cardSelectionMessageCreatorMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
@@ -22,9 +22,7 @@ describe('CollapsibleComponentCardsTest', () => {
     forOwn(optionalPropertiesObject, (propertyValues, propertyName) => {
         propertyValues.forEach(value => {
             test(`render with ${propertyName} set to: ${value}`, () => {
-                cardSelectionMessageCreatorMock
-                    .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString()))
-                    .verifiable(Times.never());
+                cardSelectionMessageCreatorMock.setup(mock => mock.toggleRuleExpandCollapse(It.isAnyString())).verifiable(Times.never());
 
                 const props: CollapsibleComponentCardsProps = {
                     header: <div>Some header</div>,
@@ -37,15 +35,13 @@ describe('CollapsibleComponentCardsTest', () => {
                 const control = CardsCollapsibleControl(props);
                 const result = shallow(control);
                 expect(result.getElement()).toMatchSnapshot();
+                cardSelectionMessageCreatorMock.verifyAll();
             });
         });
     });
 
-    const isExpandedParams = [true, false];
-    test.each(isExpandedParams)('toggle from expanded to collapsed', isExpanded => {
-        cardSelectionMessageCreatorMock
-            .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString()))
-            .verifiable(Times.never());
+    test('toggle from expanded to collapsed', () => {
+        cardSelectionMessageCreatorMock.setup(mock => mock.toggleRuleExpandCollapse(It.isAnyString())).verifiable(Times.once());
 
         const props: CollapsibleComponentCardsProps = {
             header: <div>Some header</div>,
@@ -54,11 +50,13 @@ describe('CollapsibleComponentCardsTest', () => {
             deps: {
                 cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
             },
-            isExpanded,
+            isExpanded: true,
+            id: 'test-id',
         };
         const control = CardsCollapsibleControl(props);
         const result = shallow(control);
         expect(result.getElement()).toMatchSnapshot('expanded');
+
         const button = result.find('CustomizedActionButton');
         button.simulate('click');
         expect(result.getElement()).toMatchSnapshot('collapsed');

--- a/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
@@ -32,6 +32,7 @@ describe('CollapsibleComponentCardsTest', () => {
                     headingLevel: 5,
                     [propertyName]: value,
                     deps: { cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object },
+                    isExpanded: true,
                 };
                 const control = CardsCollapsibleControl(props);
                 const result = shallow(control);
@@ -52,6 +53,7 @@ describe('CollapsibleComponentCardsTest', () => {
             deps: {
                 cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
             },
+            isExpanded: true,
         };
         const control = CardsCollapsibleControl(props);
         const result = shallow(control);

--- a/src/tests/unit/tests/reports/components/report-sections/report-collapsible-container.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/report-collapsible-container.test.tsx
@@ -23,6 +23,7 @@ describe('ReportCollapsibleContainerControl', () => {
                     content: <div>Some content</div>,
                     headingLevel: 5,
                     [propertyName]: value,
+                    deps: null,
                 };
                 const control = ReportCollapsibleContainerControl(props);
                 const result = shallow(control);

--- a/src/tests/unit/tests/reports/components/report-sections/report-collapsible-container.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/report-collapsible-container.test.tsx
@@ -24,6 +24,7 @@ describe('ReportCollapsibleContainerControl', () => {
                     headingLevel: 5,
                     [propertyName]: value,
                     deps: null,
+                    isExpanded: false,
                 };
                 const control = ReportCollapsibleContainerControl(props);
                 const result = shallow(control);


### PR DESCRIPTION
#### Description of changes

This PR achieves following things:

- links Card-Selection-Message-creator with the `collapsible-container-cards` to invoke that action whenever we expand/collapse card view
- also links the isExpanded from view model to drive the isExpanded behavior.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes AD #1584983
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
