### PR TITLE
feat(android-cards-view): update command bar

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -3,18 +3,6 @@
 @import '../../../../common/styles/colors.scss';
 
 .command-bar {
-    display: flex;
-    justify-content: space-between;
-    min-height: fit-content;
-    align-items: center;
-    background-color: $neutral-0;
-    font-size: 14px;
-    font-weight: normal;
-    border-bottom: 1px solid $neutral-alpha-8;
-
-    padding-left: 16px;
-    padding-right: 16px;
-
     .rescan-button {
         color: $primary-text;
         line-height: 16px;

--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -3,7 +3,17 @@
 @import '../../../../common/styles/colors.scss';
 
 .command-bar {
-    .rescan-button {
+    border-bottom: 1px solid $neutral-alpha-8;
+
+    div[role='menubar'] {
+        background-color: $neutral-0;
+    }
+
+    .menu-item-button {
+        background-color: $neutral-0;
+    }
+
+    .button-icon {
         color: $primary-text;
         line-height: 16px;
     }

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -3,11 +3,10 @@
 import { NamedFC } from 'common/react/named-fc';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
-import { ScanStoreData } from 'electron/flux/types/scan-store-data';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import * as React from 'react';
-
 import { ScanStatus } from 'electron/flux/types/scan-status';
+import { ScanStoreData } from 'electron/flux/types/scan-store-data';
+import { CommandBar as UICommandBar, ICommandBarItemProps } from 'office-ui-fabric-react/lib/CommandBar';
+import * as React from 'react';
 import { commandBar, rescanButton } from './command-bar.scss';
 
 export type CommandBarDeps = {
@@ -23,19 +22,21 @@ export interface CommandBarProps {
 export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: CommandBarProps) => {
     const { deps, deviceStoreData } = props;
 
-    const onClick = () => deps.scanActionCreator.scan(deviceStoreData.port);
+    const onRescanClick = () => deps.scanActionCreator.scan(deviceStoreData.port);
 
-    return (
-        <div className={commandBar}>
-            <ActionButton
-                iconProps={{
-                    className: rescanButton,
-                    iconName: 'Refresh',
-                }}
-                onClick={onClick}
-                text="Rescan"
-                disabled={props.scanStoreData.status === ScanStatus.Scanning}
-            />
-        </div>
-    );
+    const farItems: ICommandBarItemProps[] = [
+        {
+            key: 'rescan',
+            name: 'Rescan',
+            iconProps: {
+                className: rescanButton,
+                iconName: 'Refresh',
+            },
+            onClick: onRescanClick,
+            disabled: props.scanStoreData.status === ScanStatus.Scanning,
+        },
+    ];
+
+    const items: ICommandBarItemProps[] = []; // UICommandBar expects items to not be null (it does not check)
+    return <UICommandBar items={items} farItems={farItems} className={commandBar} />;
 });

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -7,7 +7,8 @@ import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { CommandBar as UICommandBar, ICommandBarItemProps } from 'office-ui-fabric-react/lib/CommandBar';
 import * as React from 'react';
-import { commandBar, rescanButton } from './command-bar.scss';
+
+import { buttonIcon, commandBar, menuItemButton } from './command-bar.scss';
 
 export type CommandBarDeps = {
     scanActionCreator: ScanActionCreator;
@@ -29,9 +30,10 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: Command
             key: 'rescan',
             name: 'Rescan',
             iconProps: {
-                className: rescanButton,
+                className: buttonIcon,
                 iconName: 'Refresh',
             },
+            className: menuItemButton,
             onClick: onRescanClick,
             disabled: props.scanStoreData.status === ScanStatus.Scanning,
         },

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -1,73 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CommandBar renders while status is <Completed> 1`] = `
-<div
+<StyledCommandBarBase
   className="commandBar"
->
-  <CustomizedActionButton
-    disabled={false}
-    iconProps={
+  farItems={
+    Array [
       Object {
-        "className": "rescanButton",
-        "iconName": "Refresh",
-      }
-    }
-    onClick={[Function]}
-    text="Rescan"
-  />
-</div>
+        "disabled": false,
+        "iconProps": Object {
+          "className": "rescanButton",
+          "iconName": "Refresh",
+        },
+        "key": "rescan",
+        "name": "Rescan",
+        "onClick": [Function],
+      },
+    ]
+  }
+  items={Array []}
+/>
 `;
 
 exports[`CommandBar renders while status is <Default> 1`] = `
-<div
+<StyledCommandBarBase
   className="commandBar"
->
-  <CustomizedActionButton
-    disabled={false}
-    iconProps={
+  farItems={
+    Array [
       Object {
-        "className": "rescanButton",
-        "iconName": "Refresh",
-      }
-    }
-    onClick={[Function]}
-    text="Rescan"
-  />
-</div>
+        "disabled": false,
+        "iconProps": Object {
+          "className": "rescanButton",
+          "iconName": "Refresh",
+        },
+        "key": "rescan",
+        "name": "Rescan",
+        "onClick": [Function],
+      },
+    ]
+  }
+  items={Array []}
+/>
 `;
 
 exports[`CommandBar renders while status is <Failed> 1`] = `
-<div
+<StyledCommandBarBase
   className="commandBar"
->
-  <CustomizedActionButton
-    disabled={false}
-    iconProps={
+  farItems={
+    Array [
       Object {
-        "className": "rescanButton",
-        "iconName": "Refresh",
-      }
-    }
-    onClick={[Function]}
-    text="Rescan"
-  />
-</div>
+        "disabled": false,
+        "iconProps": Object {
+          "className": "rescanButton",
+          "iconName": "Refresh",
+        },
+        "key": "rescan",
+        "name": "Rescan",
+        "onClick": [Function],
+      },
+    ]
+  }
+  items={Array []}
+/>
 `;
 
 exports[`CommandBar renders while status is <Scanning> 1`] = `
-<div
+<StyledCommandBarBase
   className="commandBar"
->
-  <CustomizedActionButton
-    disabled={true}
-    iconProps={
+  farItems={
+    Array [
       Object {
-        "className": "rescanButton",
-        "iconName": "Refresh",
-      }
-    }
-    onClick={[Function]}
-    text="Rescan"
-  />
-</div>
+        "disabled": true,
+        "iconProps": Object {
+          "className": "rescanButton",
+          "iconName": "Refresh",
+        },
+        "key": "rescan",
+        "name": "Rescan",
+        "onClick": [Function],
+      },
+    ]
+  }
+  items={Array []}
+/>
 `;

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -6,9 +6,10 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
   farItems={
     Array [
       Object {
+        "className": "menuItemButton",
         "disabled": false,
         "iconProps": Object {
-          "className": "rescanButton",
+          "className": "buttonIcon",
           "iconName": "Refresh",
         },
         "key": "rescan",
@@ -27,9 +28,10 @@ exports[`CommandBar renders while status is <Default> 1`] = `
   farItems={
     Array [
       Object {
+        "className": "menuItemButton",
         "disabled": false,
         "iconProps": Object {
-          "className": "rescanButton",
+          "className": "buttonIcon",
           "iconName": "Refresh",
         },
         "key": "rescan",
@@ -48,9 +50,10 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
   farItems={
     Array [
       Object {
+        "className": "menuItemButton",
         "disabled": false,
         "iconProps": Object {
-          "className": "rescanButton",
+          "className": "buttonIcon",
           "iconName": "Refresh",
         },
         "key": "rescan",
@@ -69,9 +72,10 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
   farItems={
     Array [
       Object {
+        "className": "menuItemButton",
         "disabled": true,
         "iconProps": Object {
-          "className": "rescanButton",
+          "className": "buttonIcon",
           "iconName": "Refresh",
         },
         "key": "rescan",

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -4,7 +4,7 @@ import { EnumHelper } from 'common/enum-helper';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { CommandBar, CommandBarProps } from 'electron/views/automated-checks/components/command-bar';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { Button } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
@@ -63,8 +63,8 @@ describe('CommandBar', () => {
             },
         } as CommandBarProps;
 
-        const rendered = shallow(<CommandBar {...props} />);
-        const button = rendered.find('[text="Rescan"]');
+        const rendered = mount(<CommandBar {...props} />);
+        const button = rendered.find('button[name="Rescan"]');
 
         button.simulate('click', eventStub);
 


### PR DESCRIPTION
#### Description of changes

We need to have the rescan button push to the right side of the "command bar" (on LTR mode).
In the near future, we'll have buttons close to the left and others close to the right (when we add "undock screenshot" button).

Additionally, our current command bar is a custom component which doesn't handle this behavior.

In this PR:
- Using office ui fabric's CommandBar to implement our custom command bar
- Put the Rescan button on the "farItems" prop so it shows up on the right side of the command bar (on LTR mode)
- Update styles of the command bar so it matches our figma mocks

**default state**
![01 - default state](https://user-images.githubusercontent.com/2837582/67125743-512abb00-f1aa-11e9-8c25-4c4a5c93df11.png)

**hover over state**
![02 - hover over state](https://user-images.githubusercontent.com/2837582/67125760-56880580-f1aa-11e9-8381-4e540a87f9d3.png)

**mouse down state**
![03 - mouse down state](https://user-images.githubusercontent.com/2837582/67125771-5daf1380-f1aa-11e9-9390-52cfc737be55.png)

**focused state**
![04 - focused state](https://user-images.githubusercontent.com/2837582/67125786-6273c780-f1aa-11e9-8a84-005064318d6d.png)

**disabled state**
![05 - disabled state](https://user-images.githubusercontent.com/2837582/67125798-669fe500-f1aa-11e9-830a-452f0210be39.png)

**NOTES**

- I check the command bar accessibility with both JAWS and NVDA, it works properly altough the are differences on the SC behaviors, most notably, navigation between the command buttons in JAWS is done by using left/right arrows while NVDA does this with up/down arrows. This specific test was run by using the "Export to CodePen" option on CommandBar's Office UI Fabric [webpage](https://developer.microsoft.com/en-us/fabric#/controls/web/commandbar), since our command bar only have one button.
- We only update the backround color of the command bar as well as added the box-shadow on the bottom. All the other styles (specially the ones highlighted on the screenshots) come directly from office fabric as we don't want to change that too much. The only expection is the color of the button icon which was override with some shade of gray.

#### Pull request checklist

- [x] Addresses an existing issue: completes WI # 1606847
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
