### PR TITLE
fix(card-buttons): avoid misalignment of more actions button in release builds

### DIFF
--- a/src/common/components/cards/card-kebab-menu-button.scss
+++ b/src/common/components/cards/card-kebab-menu-button.scss
@@ -59,7 +59,7 @@ button.kebab-menu-button {
         }
     }
 
-    div.ms-Button-flexContainer {
+    > div {
         justify-content: center;
     }
 }


### PR DESCRIPTION
#### Description of changes

This fixes a release-build-specific css issue (#1509) caused by the use of an office fabric style selector which was not qualified with `:global()`. This PR fixes the issue by avoiding the use of the fabric classname entirely.

![screenshot of updated button](https://user-images.githubusercontent.com/376284/67126276-926f9a80-f1ab-11e9-895f-ee5d9b9c6039.png)

#### Pull request checklist

- [x] Addresses an existing issue: Addresses #1509
- [n/a] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
