### PR TITLE
fix(target-dialog): fix misalignments in dialog nav footer (and simplify footer layout/css)

### DIFF
--- a/src/injected/components/issue-details-navigation-controls.tsx
+++ b/src/injected/components/issue-details-navigation-controls.tsx
@@ -50,14 +50,10 @@ export const IssueDetailsNavigationControls = NamedFC<IssueDetailsNavigationCont
         );
 
     return (
-        <div className="ms-Grid insights-dialog-next-and-back-container">
-            <div className="ms-Grid-row">
-                <div className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-left">{renderBackButton()}</div>
-                <div className="ms-Grid-col ms-sm6 ms-md6 ms-lg6 insights-dialog-footer">
-                    <div>{props.dialogHandler.getFailureInfo(props.container)}</div>
-                </div>
-                <div className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-right">{renderNextButton()}</div>
-            </div>
+        <div className="insights-dialog-next-and-back-container">
+            <div>{renderBackButton()}</div>
+            <div>{props.dialogHandler.getFailureInfo(props.container)}</div>
+            <div>{renderNextButton()}</div>
         </div>
     );
 });

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -142,28 +142,6 @@
         }
     }
 
-    .insights-dialog-main-override .insights-dialog-button-left {
-        float: left !important;
-    }
-
-    .insights-dialog-main-override .insights-dialog-button-right {
-        float: right !important;
-        text-align: right !important;
-    }
-
-    .insights-dialog-main-override .insights-dialog-footer {
-        text-align: center !important;
-        margin-top: 5px !important;
-    }
-
-    .insights-dialog-main-override-shadow .insights-dialog-footer {
-        text-align: center !important;
-        float: left !important;
-        margin-top: 5px !important;
-        width: 50%;
-        font-size: 14px;
-    }
-
     .insights-dialog-main-override ul,
     .insights-dialog-main-override-shadow ul {
         margin-top: 3px !important;
@@ -251,17 +229,6 @@
             background-color: $neutral-4;
             color: $neutral-30;
             pointer-events: none;
-        }
-
-        .ms-Grid-col.insights-dialog-button-left {
-            padding-left: 0px;
-            float: left;
-        }
-
-        .ms-Grid-col.insights-dialog-button-right {
-            padding-right: 0px;
-            float: right;
-            text-align: right;
         }
     }
 
@@ -404,6 +371,21 @@
 
         .insights-dialog-next-and-back-container {
             margin-top: 16px !important;
+            display: grid !important;
+            color: $primary-text !important;
+            font-size: $fontSizeM !important;
+            align-items: center !important;
+
+            grid-template-columns: 100px 1fr 100px !important;
+            :nth-child(1) {
+                text-align: left !important;
+            }
+            :nth-child(2) {
+                text-align: center !important;
+            }
+            :nth-child(3) {
+                text-align: right !important;
+            }
         }
     }
 

--- a/src/tests/unit/tests/injected/components/__snapshots__/issue-details-navigation-controls.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/issue-details-navigation-controls.test.tsx.snap
@@ -2,113 +2,65 @@
 
 exports[`IssueDetailsNavigationControls render handles button states: {"backButtonDisabled": false, "nextButtonDisabled": false} 1`] = `
 <div
-  className="ms-Grid insights-dialog-next-and-back-container"
+  className="insights-dialog-next-and-back-container"
 >
-  <div
-    className="ms-Grid-row"
-  >
-    <div
-      className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-left"
-    >
-      <CustomizedDefaultButton
-        data-automation-id="back"
-        onClick={[Function]}
-        text="< Back"
-      />
-    </div>
-    <div
-      className="ms-Grid-col ms-sm6 ms-md6 ms-lg6 insights-dialog-footer"
-    >
-      <div />
-    </div>
-    <div
-      className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-right"
-    >
-      <CustomizedDefaultButton
-        data-automation-id="next"
-        onClick={[Function]}
-        text="Next >"
-      />
-    </div>
+  <div>
+    <CustomizedDefaultButton
+      data-automation-id="back"
+      onClick={[Function]}
+      text="< Back"
+    />
+  </div>
+  <div />
+  <div>
+    <CustomizedDefaultButton
+      data-automation-id="next"
+      onClick={[Function]}
+      text="Next >"
+    />
   </div>
 </div>
 `;
 
 exports[`IssueDetailsNavigationControls render handles button states: {"backButtonDisabled": false, "nextButtonDisabled": true} 1`] = `
 <div
-  className="ms-Grid insights-dialog-next-and-back-container"
+  className="insights-dialog-next-and-back-container"
 >
-  <div
-    className="ms-Grid-row"
-  >
-    <div
-      className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-left"
-    >
-      <CustomizedDefaultButton
-        data-automation-id="back"
-        onClick={[Function]}
-        text="< Back"
-      />
-    </div>
-    <div
-      className="ms-Grid-col ms-sm6 ms-md6 ms-lg6 insights-dialog-footer"
-    >
-      <div />
-    </div>
-    <div
-      className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-right"
+  <div>
+    <CustomizedDefaultButton
+      data-automation-id="back"
+      onClick={[Function]}
+      text="< Back"
     />
   </div>
+  <div />
+  <div />
 </div>
 `;
 
 exports[`IssueDetailsNavigationControls render handles button states: {"backButtonDisabled": true, "nextButtonDisabled": false} 1`] = `
 <div
-  className="ms-Grid insights-dialog-next-and-back-container"
+  className="insights-dialog-next-and-back-container"
 >
-  <div
-    className="ms-Grid-row"
-  >
-    <div
-      className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-left"
+  <div />
+  <div />
+  <div>
+    <CustomizedDefaultButton
+      data-automation-id="next"
+      onClick={[Function]}
+      text="Next >"
     />
-    <div
-      className="ms-Grid-col ms-sm6 ms-md6 ms-lg6 insights-dialog-footer"
-    >
-      <div />
-    </div>
-    <div
-      className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-right"
-    >
-      <CustomizedDefaultButton
-        data-automation-id="next"
-        onClick={[Function]}
-        text="Next >"
-      />
-    </div>
   </div>
 </div>
 `;
 
 exports[`IssueDetailsNavigationControls render handles button states: {"backButtonDisabled": true, "nextButtonDisabled": true} 1`] = `
 <div
-  className="ms-Grid insights-dialog-next-and-back-container"
+  className="insights-dialog-next-and-back-container"
 >
-  <div
-    className="ms-Grid-row"
-  >
-    <div
-      className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-left"
-    />
-    <div
-      className="ms-Grid-col ms-sm6 ms-md6 ms-lg6 insights-dialog-footer"
-    >
-      <div />
-    </div>
-    <div
-      className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-right"
-    />
-  </div>
+  <div />
+  <div />
+  <div />
 </div>
 `;
 
@@ -118,34 +70,22 @@ exports[`IssueDetailsNavigationControls render handles failures count 1 failure 
 
 exports[`IssueDetailsNavigationControls render handles failures count multiple failures 1`] = `
 <div
-  className="ms-Grid insights-dialog-next-and-back-container"
+  className="insights-dialog-next-and-back-container"
 >
-  <div
-    className="ms-Grid-row"
-  >
-    <div
-      className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-left"
-    >
-      <CustomizedDefaultButton
-        data-automation-id="back"
-        onClick={[Function]}
-        text="< Back"
-      />
-    </div>
-    <div
-      className="ms-Grid-col ms-sm6 ms-md6 ms-lg6 insights-dialog-footer"
-    >
-      <div />
-    </div>
-    <div
-      className="ms-Grid-col ms-sm3 ms-md3 ms-lg3 insights-dialog-button-right"
-    >
-      <CustomizedDefaultButton
-        data-automation-id="next"
-        onClick={[Function]}
-        text="Next >"
-      />
-    </div>
+  <div>
+    <CustomizedDefaultButton
+      data-automation-id="back"
+      onClick={[Function]}
+      text="< Back"
+    />
+  </div>
+  <div />
+  <div>
+    <CustomizedDefaultButton
+      data-automation-id="next"
+      onClick={[Function]}
+      text="Next >"
+    />
   </div>
 </div>
 `;


### PR DESCRIPTION
#### Description of changes

Fixes the misalignment issues in the target dialog nav footer by simplifying the footer layout and avoiding the use of fabric implementation details (which happened to change from under us unnoticed in a past fabric update).

Before:

![gif showing different states of the nav footer before changes](https://user-images.githubusercontent.com/376284/67130405-09aa2c00-f1b6-11e9-89ec-67cd1bef23dc.gif)

After:

(Note: ignore the appearance of the button backgrounds before hover being white; this is a licecap issue, they show as the expected gray in that state in reality...)

![gif showing different states of the nav footer after changes](https://user-images.githubusercontent.com/376284/67130317-d10a5280-f1b5-11e9-9f08-94a16643b4b5.gif)


#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1500 
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
