### PR TITLE
fix: ensure the collapsible component doesn't break for scenarios where highlighting is not supported

### DIFF
--- a/src/common/components/cards/collapsible-component-cards.tsx
+++ b/src/common/components/cards/collapsible-component-cards.tsx
@@ -61,7 +61,7 @@ class CollapsibleComponentCards extends React.Component<CollapsibleComponentCard
 
     public render(): JSX.Element {
         const { showContent } = this.state;
-        const { headingLevel, contentClassName, content, isExpanded, deps, buttonAriaLabel, containerClassName, header, id } = this.props;
+        const { headingLevel, contentClassName, content, buttonAriaLabel, containerClassName, header } = this.props;
 
         const containerProps = { role: 'heading', 'aria-level': headingLevel };
         let contentWrapper = null;

--- a/src/common/components/cards/collapsible-component-cards.tsx
+++ b/src/common/components/cards/collapsible-component-cards.tsx
@@ -40,23 +40,16 @@ class CollapsibleComponentCards extends React.Component<CollapsibleComponentCard
         this.state = { showContent: props.isExpanded };
     }
 
-    public componentWillReceiveProps(newProps, currentProps): void {
-        if (newProps.isExpanded !== currentProps.isExpanded) {
-            this.setState({ showContent: newProps.isExpanded });
-        }
-    }
-
     private onClick = (): void => {
         const { deps, id } = this.props;
         const isHighlightingInteractionSupported = deps.cardInteractionSupport.supportsHighlighting;
 
         if (isHighlightingInteractionSupported) {
-            console.log('here');
             deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(id);
-        } else {
-            const newState = !this.state.showContent;
-            this.setState({ showContent: newState });
         }
+
+        const newState = !this.state.showContent;
+        this.setState({ showContent: newState });
     };
 
     public render(): JSX.Element {

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -11,13 +11,14 @@ import { outcomeTypeSemantics } from '../../../reports/components/outcome-type';
 import { MinimalRuleHeader } from '../../../reports/components/report-sections/minimal-rule-header';
 import { CardRuleResult } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
-import { CollapsibleComponentCardsProps } from './collapsible-component-cards';
+import { CollapsibleComponentCardsDeps, CollapsibleComponentCardsProps } from './collapsible-component-cards';
 import { RuleContent, RuleContentDeps } from './rule-content';
 import { collapsibleRuleDetailsGroup, ruleDetailsGroup } from './rules-with-instances.scss';
 
-export type RulesWithInstancesDeps = RuleContentDeps & {
-    collapsibleControl: (props: CollapsibleComponentCardsProps) => JSX.Element;
-};
+export type RulesWithInstancesDeps = RuleContentDeps &
+    CollapsibleComponentCardsDeps & {
+        collapsibleControl: (props: CollapsibleComponentCardsProps) => JSX.Element;
+    };
 
 export type RulesWithInstancesProps = {
     deps: RulesWithInstancesDeps;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/collapsible-component-cards.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/collapsible-component-cards.test.tsx.snap
@@ -193,6 +193,63 @@ exports[`CollapsibleComponentCardsTest render with contentClassName set to: unde
 </div>
 `;
 
+exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed but not call the action since no highlighting interaction is supported: collapsed 1`] = `
+<div
+  className="collapsibleContainer collapsed"
+>
+  <div
+    aria-level={5}
+    role="heading"
+  >
+    <CustomizedActionButton
+      aria-expanded={false}
+      className="collapsibleControl"
+      onClick={[Function]}
+    >
+      <span
+        className="collapsibleTitle"
+      >
+        <div>
+          Some header
+        </div>
+      </span>
+    </CustomizedActionButton>
+  </div>
+</div>
+`;
+
+exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed but not call the action since no highlighting interaction is supported: expanded 1`] = `
+<div
+  className="collapsibleContainer"
+>
+  <div
+    aria-level={5}
+    role="heading"
+  >
+    <CustomizedActionButton
+      aria-expanded={true}
+      className="collapsibleControl"
+      onClick={[Function]}
+    >
+      <span
+        className="collapsibleTitle"
+      >
+        <div>
+          Some header
+        </div>
+      </span>
+    </CustomizedActionButton>
+  </div>
+  <div
+    className="collapsibleContainerContent"
+  >
+    <div>
+      Some content
+    </div>
+  </div>
+</div>
+`;
+
 exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: collapsed 1`] = `
 <div
   className="collapsibleContainer"

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/collapsible-component-cards.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/collapsible-component-cards.test.tsx.snap
@@ -252,14 +252,14 @@ exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed but not
 
 exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: collapsed 1`] = `
 <div
-  className="collapsibleContainer"
+  className="collapsibleContainer collapsed"
 >
   <div
     aria-level={5}
     role="heading"
   >
     <CustomizedActionButton
-      aria-expanded={true}
+      aria-expanded={false}
       className="collapsibleControl"
       onClick={[Function]}
     >
@@ -271,13 +271,6 @@ exports[`CollapsibleComponentCardsTest toggle from expanded to collapsed: collap
         </div>
       </span>
     </CustomizedActionButton>
-  </div>
-  <div
-    className="collapsibleContainerContent"
-  >
-    <div>
-      Some content
-    </div>
   </div>
 </div>
 `;

--- a/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
@@ -68,4 +68,30 @@ describe('CollapsibleComponentCardsTest', () => {
 
         cardSelectionMessageCreatorMock.verifyAll();
     });
+
+    test('toggle from expanded to collapsed but not call the action since no highlighting interaction is supported', () => {
+        cardSelectionMessageCreatorMock.setup(mock => mock.toggleRuleExpandCollapse(It.isAnyString())).verifiable(Times.never());
+
+        const props: CollapsibleComponentCardsProps = {
+            header: <div>Some header</div>,
+            content: <div>Some content</div>,
+            headingLevel: 5,
+            deps: {
+                cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
+                cardInteractionSupport: noCardInteractionsSupported,
+            },
+            isExpanded: true,
+            id: 'test-id',
+        };
+        const control = CardsCollapsibleControl(props);
+        const result = shallow(control);
+        expect(result.getElement()).toMatchSnapshot('expanded');
+
+        const button = result.find('CustomizedActionButton');
+        button.simulate('click');
+
+        expect(result.getElement()).toMatchSnapshot('collapsed');
+        expect(result.state()).toEqual({ showContent: false });
+        cardSelectionMessageCreatorMock.verifyAll();
+    });
 });

--- a/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { allCardInteractionsSupported, noCardInteractionsSupported } from 'common/components/cards/card-interaction-support';
 import { CardsCollapsibleControl, CollapsibleComponentCardsProps } from 'common/components/cards/collapsible-component-cards';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { shallow } from 'enzyme';
@@ -29,7 +30,10 @@ describe('CollapsibleComponentCardsTest', () => {
                     content: <div>Some content</div>,
                     headingLevel: 5,
                     [propertyName]: value,
-                    deps: { cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object },
+                    deps: {
+                        cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
+                        cardInteractionSupport: noCardInteractionsSupported,
+                    },
                     isExpanded: true,
                 };
                 const control = CardsCollapsibleControl(props);
@@ -49,6 +53,7 @@ describe('CollapsibleComponentCardsTest', () => {
             headingLevel: 5,
             deps: {
                 cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
+                cardInteractionSupport: allCardInteractionsSupported,
             },
             isExpanded: true,
             id: 'test-id',


### PR DESCRIPTION
#### Description of changes

Makes sure that collapsible component is not broken in its primary behavior that it expands/collapses if `cardInteractionSupport` doesn't have `noHightlightSupported`.



#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
