### PR TITLE
fix: add failures detected AT announcement on CardsView

### DIFF
--- a/src/DetailsView/components/cards-view.tsx
+++ b/src/DetailsView/components/cards-view.tsx
@@ -25,6 +25,7 @@ export const CardsView = NamedFC<CardsViewProps>('CardsView', props => {
                 ruleResultsByStatus={props.ruleResultsByStatus}
                 userConfigurationStoreData={props.userConfigurationStoreData}
                 targetAppInfo={props.targetAppInfo}
+                shouldAlertFailuresCount={true}
             />
         </>
     );

--- a/src/common/components/cards/failed-instances-section.tsx
+++ b/src/common/components/cards/failed-instances-section.tsx
@@ -14,11 +14,12 @@ export type FailedInstancesSectionProps = {
     ruleResultsByStatus: CardRuleResultsByStatus;
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
+    shouldAlertFailuresCount?: boolean;
 };
 
 export const FailedInstancesSection = NamedFC<FailedInstancesSectionProps>(
     'FailedInstancesSection',
-    ({ ruleResultsByStatus, deps, userConfigurationStoreData, targetAppInfo }) => {
+    ({ ruleResultsByStatus, deps, userConfigurationStoreData, targetAppInfo, shouldAlertFailuresCount }) => {
         if (ruleResultsByStatus == null) {
             return null;
         }
@@ -37,6 +38,7 @@ export const FailedInstancesSection = NamedFC<FailedInstancesSectionProps>(
                 badgeCount={count}
                 userConfigurationStoreData={userConfigurationStoreData}
                 targetAppInfo={targetAppInfo}
+                shouldAlertFailuresCount={shouldAlertFailuresCount}
             />
         );
     },

--- a/src/common/components/cards/result-section-title.tsx
+++ b/src/common/components/cards/result-section-title.tsx
@@ -11,13 +11,21 @@ export type ResultSectionTitleProps = {
     title: string;
     badgeCount: number;
     outcomeType: InstanceOutcomeType;
+    shouldAlertFailuresCount?: boolean;
 };
 
 export const ResultSectionTitle = NamedFC<ResultSectionTitleProps>('ResultSectionTitle', props => {
+    const failureTerm = props.badgeCount > 1 ? 'failures were' : 'failure was';
+    const alertingFailuresCount = (
+        <span role="alert">
+            {props.badgeCount} {failureTerm} detected.
+        </span>
+    );
+
     return (
         <span className={resultSectionTitle}>
             <span className="screen-reader-only">
-                {props.title} {props.badgeCount}
+                {props.title} {props.shouldAlertFailuresCount ? alertingFailuresCount : props.badgeCount}
             </span>
             <span className={title} aria-hidden="true">
                 {props.title}

--- a/src/common/components/cards/result-section-title.tsx
+++ b/src/common/components/cards/result-section-title.tsx
@@ -15,7 +15,7 @@ export type ResultSectionTitleProps = {
 };
 
 export const ResultSectionTitle = NamedFC<ResultSectionTitleProps>('ResultSectionTitle', props => {
-    const failureTerm = props.badgeCount > 1 ? 'failures were' : 'failure was';
+    const failureTerm = props.badgeCount !== 1 ? 'failures were' : 'failure was';
     const alertingFailuresCount = (
         <span role="alert">
             {props.badgeCount} {failureTerm} detected.

--- a/src/common/components/cards/result-section.tsx
+++ b/src/common/components/cards/result-section.tsx
@@ -18,6 +18,7 @@ export type ResultSectionProps = ResultSectionContentProps &
         containerClassName: string;
         deps: ResultSectionDeps;
         targetAppInfo: TargetAppData;
+        shouldAlertFailuresCount?: boolean;
     };
 
 export const ResultSection = NamedFC<ResultSectionProps>('ResultSection', props => {

--- a/src/reports/components/report-sections/automated-checks-report-section-factory.tsx
+++ b/src/reports/components/report-sections/automated-checks-report-section-factory.tsx
@@ -22,7 +22,7 @@ export const AutomatedChecksReportSectionFactory: ReportSectionFactory = {
     SummarySection,
     DetailsSection,
     ResultsContainer,
-    FailedInstancesSection: FailedInstancesSection,
+    FailedInstancesSection,
     PassedChecksSection,
     NotApplicableChecksSection,
     FooterSection: ReportFooter,

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -30,6 +30,7 @@ export type SectionProps = {
     ruleResultsByStatus: CardRuleResultsByStatus;
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
+    shouldAlertFailuresCount?: boolean;
 };
 
 export type ReportSectionFactory = {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/cards-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/cards-view.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`CardsView should return cards view 1`] = `
         "unknown": Array [],
       }
     }
+    shouldAlertFailuresCount={true}
   />
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/failed-instances-section.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/failed-instances-section.test.tsx.snap
@@ -1,6 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FailedInstancesSection renders 1`] = `
+exports[`FailedInstancesSection renders null results 1`] = `null`;
+
+exports[`FailedInstancesSection renders with alerting off 1`] = `
+<ResultSection
+  badgeCount={0}
+  containerClassName={null}
+  deps={Object {}}
+  outcomeType="fail"
+  results={Array []}
+  shouldAlertFailuresCount={false}
+  title="Failed instances"
+/>
+`;
+
+exports[`FailedInstancesSection renders with alerting on 1`] = `
+<ResultSection
+  badgeCount={0}
+  containerClassName={null}
+  deps={Object {}}
+  outcomeType="fail"
+  results={Array []}
+  shouldAlertFailuresCount={true}
+  title="Failed instances"
+/>
+`;
+
+exports[`FailedInstancesSection renders with failures 1`] = `
 <ResultSection
   badgeCount={2}
   containerClassName={null}
@@ -89,5 +115,3 @@ exports[`FailedInstancesSection renders 1`] = `
   title="Failed instances"
 />
 `;
-
-exports[`FailedInstancesSection renders null when result is null 1`] = `null`;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/result-section-title.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/result-section-title.test.tsx.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ResultSectionTitle renders with alerting, badgeCount is 0 1`] = `
+<span
+  className="resultSectionTitle"
+>
+  <span
+    className="screen-reader-only"
+  >
+    test title
+     
+    <span
+      role="alert"
+    >
+      0
+       
+      failures were
+       detected.
+    </span>
+  </span>
+  <span
+    aria-hidden="true"
+    className="title"
+  >
+    test title
+  </span>
+  <span
+    aria-hidden="true"
+    className="outcomeChipContainer"
+  >
+    <OutcomeChip
+      count={0}
+      outcomeType="pass"
+    />
+  </span>
+</span>
+`;
+
 exports[`ResultSectionTitle renders with alerting, badgeCount is 1 1`] = `
 <span
   className="resultSectionTitle"

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/result-section-title.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/result-section-title.test.tsx.snap
@@ -1,6 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ResultSectionTitle renders 1`] = `
+exports[`ResultSectionTitle renders with alerting, badgeCount is 1 1`] = `
+<span
+  className="resultSectionTitle"
+>
+  <span
+    className="screen-reader-only"
+  >
+    test title
+     
+    <span
+      role="alert"
+    >
+      1
+       
+      failure was
+       detected.
+    </span>
+  </span>
+  <span
+    aria-hidden="true"
+    className="title"
+  >
+    test title
+  </span>
+  <span
+    aria-hidden="true"
+    className="outcomeChipContainer"
+  >
+    <OutcomeChip
+      count={1}
+      outcomeType="pass"
+    />
+  </span>
+</span>
+`;
+
+exports[`ResultSectionTitle renders with alerting, badgeCount is greater than 1 1`] = `
+<span
+  className="resultSectionTitle"
+>
+  <span
+    className="screen-reader-only"
+  >
+    test title
+     
+    <span
+      role="alert"
+    >
+      2
+       
+      failures were
+       detected.
+    </span>
+  </span>
+  <span
+    aria-hidden="true"
+    className="title"
+  >
+    test title
+  </span>
+  <span
+    aria-hidden="true"
+    className="outcomeChipContainer"
+  >
+    <OutcomeChip
+      count={2}
+      outcomeType="pass"
+    />
+  </span>
+</span>
+`;
+
+exports[`ResultSectionTitle renders with no-alerting 1`] = `
 <span
   className="resultSectionTitle"
 >
@@ -23,6 +95,35 @@ exports[`ResultSectionTitle renders 1`] = `
   >
     <OutcomeChip
       count={10}
+      outcomeType="pass"
+    />
+  </span>
+</span>
+`;
+
+exports[`ResultSectionTitle renders with no-alerting, shouldAlertFailuresCount is undefined 1`] = `
+<span
+  className="resultSectionTitle"
+>
+  <span
+    className="screen-reader-only"
+  >
+    test title
+     
+    15
+  </span>
+  <span
+    aria-hidden="true"
+    className="title"
+  >
+    test title
+  </span>
+  <span
+    aria-hidden="true"
+    className="outcomeChipContainer"
+  >
+    <OutcomeChip
+      count={15}
       outcomeType="pass"
     />
   </span>

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/result-section.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/result-section.test.tsx.snap
@@ -1,6 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ResultSection renders 1`] = `
+exports[`ResultSection renders with shouldAlertFailureCount = <false> 1`] = `
+<div
+  className="result-section-class-name resultSection"
+>
+  <h2>
+    <ResultSectionTitle
+      containerClassName="result-section-class-name"
+      deps={Object {}}
+      shouldAlertFailuresCount={false}
+    />
+  </h2>
+  <ResultSectionContent
+    containerClassName="result-section-class-name"
+    deps={Object {}}
+    shouldAlertFailuresCount={false}
+  />
+</div>
+`;
+
+exports[`ResultSection renders with shouldAlertFailureCount = <true> 1`] = `
+<div
+  className="result-section-class-name resultSection"
+>
+  <h2>
+    <ResultSectionTitle
+      containerClassName="result-section-class-name"
+      deps={Object {}}
+      shouldAlertFailuresCount={true}
+    />
+  </h2>
+  <ResultSectionContent
+    containerClassName="result-section-class-name"
+    deps={Object {}}
+    shouldAlertFailuresCount={true}
+  />
+</div>
+`;
+
+exports[`ResultSection renders with shouldAlertFailureCount = <undefined> 1`] = `
 <div
   className="result-section-class-name resultSection"
 >

--- a/src/tests/unit/tests/common/components/cards/failed-instances-section.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/failed-instances-section.test.tsx
@@ -5,35 +5,38 @@ import {
     FailedInstancesSectionDeps,
     FailedInstancesSectionProps,
 } from 'common/components/cards/failed-instances-section';
+import { CardRuleResultsByStatus } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { exampleUnifiedRuleResult } from './sample-view-model-data';
 
 describe('FailedInstancesSection', () => {
-    it('renders', () => {
-        const props = {
-            deps: {} as FailedInstancesSectionDeps,
-            ruleResultsByStatus: {
-                pass: [],
-                fail: [exampleUnifiedRuleResult, exampleUnifiedRuleResult],
-                inapplicable: [],
-                unknown: [],
-            },
-        } as FailedInstancesSectionProps;
+    const resultsWithFailures: CardRuleResultsByStatus = {
+        fail: [exampleUnifiedRuleResult, exampleUnifiedRuleResult],
+        pass: [],
+        inapplicable: [],
+        unknown: [],
+    };
+    const nonEmptyResults: CardRuleResultsByStatus = { fail: [], pass: [], inapplicable: [], unknown: [] };
 
-        const wrapper = shallow(<FailedInstancesSection {...props} />);
+    describe('renders', () => {
+        it.each`
+            results                | shouldAlertFailuresCount | description
+            ${resultsWithFailures} | ${undefined}             | ${'with failures'}
+            ${null}                | ${undefined}             | ${'null results'}
+            ${nonEmptyResults}     | ${true}                  | ${'with alerting on'}
+            ${nonEmptyResults}     | ${false}                 | ${'with alerting off'}
+        `('$description', ({ results, shouldAlertFailuresCount }) => {
+            const props = {
+                deps: {} as FailedInstancesSectionDeps,
+                ruleResultsByStatus: results,
+                shouldAlertFailuresCount,
+            } as FailedInstancesSectionProps;
 
-        expect(wrapper.getElement()).toMatchSnapshot();
-    });
+            const wrapper = shallow(<FailedInstancesSection {...props} />);
 
-    it('renders null when result is null', () => {
-        const props = {
-            deps: {} as FailedInstancesSectionDeps,
-        } as FailedInstancesSectionProps;
-
-        const wrapper = shallow(<FailedInstancesSection {...props} />);
-
-        expect(wrapper.getElement()).toMatchSnapshot();
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
     });
 });

--- a/src/tests/unit/tests/common/components/cards/result-section-title.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/result-section-title.test.tsx
@@ -5,14 +5,23 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('ResultSectionTitle', () => {
-    it('renders', () => {
-        const props: ResultSectionTitleProps = {
-            title: 'test title',
-            badgeCount: 10,
-            outcomeType: 'pass',
-        };
+    describe('renders', () => {
+        it.each`
+            badgeCount | shouldAlertFailuresCount | description
+            ${10}      | ${false}                 | ${'with no-alerting'}
+            ${15}      | ${undefined}             | ${'with no-alerting, shouldAlertFailuresCount is undefined'}
+            ${1}       | ${true}                  | ${'with alerting, badgeCount is 1'}
+            ${2}       | ${true}                  | ${'with alerting, badgeCount is greater than 1'}
+        `('$description', ({ badgeCount, shouldAlertFailuresCount }) => {
+            const props: ResultSectionTitleProps = {
+                title: 'test title',
+                badgeCount,
+                shouldAlertFailuresCount,
+                outcomeType: 'pass',
+            };
 
-        const wrapped = shallow(<ResultSectionTitle {...props} />);
-        expect(wrapped.getElement()).toMatchSnapshot();
+            const wrapped = shallow(<ResultSectionTitle {...props} />);
+            expect(wrapped.getElement()).toMatchSnapshot();
+        });
     });
 });

--- a/src/tests/unit/tests/common/components/cards/result-section-title.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/result-section-title.test.tsx
@@ -10,6 +10,7 @@ describe('ResultSectionTitle', () => {
             badgeCount | shouldAlertFailuresCount | description
             ${10}      | ${false}                 | ${'with no-alerting'}
             ${15}      | ${undefined}             | ${'with no-alerting, shouldAlertFailuresCount is undefined'}
+            ${0}       | ${true}                  | ${'with alerting, badgeCount is 0'}
             ${1}       | ${true}                  | ${'with alerting, badgeCount is 1'}
             ${2}       | ${true}                  | ${'with alerting, badgeCount is greater than 1'}
         `('$description', ({ badgeCount, shouldAlertFailuresCount }) => {

--- a/src/tests/unit/tests/common/components/cards/result-section.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/result-section.test.tsx
@@ -5,13 +5,18 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('ResultSection', () => {
-    it('renders', () => {
-        const props: ResultSectionProps = {
-            containerClassName: 'result-section-class-name',
-            deps: {} as ResultSectionDeps,
-        } as ResultSectionProps;
+    describe('renders', () => {
+        const shouldAlertValues = [false, true, undefined];
 
-        const wrapper = shallow(<ResultSection {...props} />);
-        expect(wrapper.getElement()).toMatchSnapshot();
+        it.each(shouldAlertValues)('with shouldAlertFailureCount = <%s>', shouldAlertFailuresCount => {
+            const props: ResultSectionProps = {
+                containerClassName: 'result-section-class-name',
+                deps: {} as ResultSectionDeps,
+                shouldAlertFailuresCount,
+            } as ResultSectionProps;
+
+            const wrapper = shallow(<ResultSection {...props} />);
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
     });
 });

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
@@ -86,6 +86,7 @@ exports[`ReportBody renders 1`] = `
         "violations": Array [],
       }
     }
+    shouldAlertFailuresCount={false}
     targetAppInfo={
       Object {
         "name": "app",
@@ -180,6 +181,7 @@ exports[`ReportBody renders 1`] = `
           "violations": Array [],
         }
       }
+      shouldAlertFailuresCount={false}
       targetAppInfo={
         Object {
           "name": "app",
@@ -272,6 +274,7 @@ exports[`ReportBody renders 1`] = `
           "violations": Array [],
         }
       }
+      shouldAlertFailuresCount={false}
       targetAppInfo={
         Object {
           "name": "app",
@@ -364,6 +367,7 @@ exports[`ReportBody renders 1`] = `
           "violations": Array [],
         }
       }
+      shouldAlertFailuresCount={false}
       targetAppInfo={
         Object {
           "name": "app",
@@ -456,6 +460,7 @@ exports[`ReportBody renders 1`] = `
             "violations": Array [],
           }
         }
+        shouldAlertFailuresCount={false}
         targetAppInfo={
           Object {
             "name": "app",
@@ -548,6 +553,7 @@ exports[`ReportBody renders 1`] = `
             "violations": Array [],
           }
         }
+        shouldAlertFailuresCount={false}
         targetAppInfo={
           Object {
             "name": "app",
@@ -640,6 +646,7 @@ exports[`ReportBody renders 1`] = `
             "violations": Array [],
           }
         }
+        shouldAlertFailuresCount={false}
         targetAppInfo={
           Object {
             "name": "app",
@@ -734,6 +741,7 @@ exports[`ReportBody renders 1`] = `
         "violations": Array [],
       }
     }
+    shouldAlertFailuresCount={false}
     targetAppInfo={
       Object {
         "name": "app",

--- a/src/tests/unit/tests/reports/components/report-sections/report-body.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/report-body.test.tsx
@@ -46,6 +46,7 @@ describe('ReportBody', () => {
             ruleResultsByStatus: exampleUnifiedStatusResults,
             userConfigurationStoreData: null,
             targetAppInfo: { name: 'app' },
+            shouldAlertFailuresCount: false,
         };
 
         const props: ReportBodyProps = {


### PR DESCRIPTION
#### Description of changes

Our current failure details list (using Office UI Fabric' DetailsList) includes an AT alert. When the scan is finished and there are failures, AT announce: "X failures detected". Our current `CardsView` does not have this alert.

In this PR:
- Add the alert on the `CardsView`, i.e. on the details view.
- Make sure the automated checks report does not have the alert (as the report is an static document)

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
   - there is no issue filed against GitHub
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [x] (UI changes only) Added screenshots/GIFs to description above
   - not affected
- [x] (UI changes only) Verified usability with NVDA/JAWS
   - NVDA/JAWS under Windows 10, no VoiceOver 
