### PR TITLE
refactor: move resource server code

### DIFF
--- a/src/tests/end-to-end/common/test-resources.ts
+++ b/src/tests/end-to-end/common/test-resources.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as testServerConfig from '../setup/test-server-config';
+import { testResourceServerConfig } from 'tests/end-to-end/setup/test-resource-server-config';
 
 export function getTestResourceUrl(path: string): string {
-    return `http://localhost:${testServerConfig.port}/${path}`;
+    return `http://localhost:${testResourceServerConfig.port}/${path}`;
 }

--- a/src/tests/end-to-end/setup/global-setup.ts
+++ b/src/tests/end-to-end/setup/global-setup.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as testResourceServer from './test-resource-server';
+import * as testResourceServer from '../../miscellaneous/test-resource-server/resource-server';
+import { testResourceServerConfig } from './test-resource-server-config';
 
 // tslint:disable-next-line:no-default-export
 export default function(): void {
-    testResourceServer.startServer();
+    testResourceServer.startServer(testResourceServerConfig);
 }

--- a/src/tests/end-to-end/setup/global-teardown.ts
+++ b/src/tests/end-to-end/setup/global-teardown.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as testResourceServer from './test-resource-server';
+import * as testResourceServer from '../../miscellaneous/test-resource-server/resource-server';
 
 // tslint:disable-next-line:no-default-export
 export default function(): void {

--- a/src/tests/end-to-end/setup/test-resource-server-config.ts
+++ b/src/tests/end-to-end/setup/test-resource-server-config.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ResourceServerConfig } from 'tests/miscellaneous/test-resource-server/resource-server-config';
+
+export const testResourceServerConfig: ResourceServerConfig = {
+    port: 9050,
+    path: '../../end-to-end/test-resources',
+};

--- a/src/tests/miscellaneous/test-resource-server/resource-server-config.ts
+++ b/src/tests/miscellaneous/test-resource-server/resource-server-config.ts
@@ -1,4 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
-export const port = 9050;
+export type ResourceServerConfig = {
+    port: number;
+    path: string;
+};

--- a/src/tests/miscellaneous/test-resource-server/resource-server.ts
+++ b/src/tests/miscellaneous/test-resource-server/resource-server.ts
@@ -3,14 +3,17 @@
 import * as express from 'express';
 import * as path from 'path';
 import * as serveStatic from 'serve-static';
-import * as testServerConfig from './test-server-config';
+import { ResourceServerConfig } from 'tests/miscellaneous/test-resource-server/resource-server-config';
 
 let server = null;
 
-export function startServer(): void {
+export function startServer(config: ResourceServerConfig): void {
     const app = express();
-    app.use(serveStatic(path.join(__dirname, '../test-resources')));
-    server = app.listen(testServerConfig.port);
+
+    const dirPath = path.join(__dirname, config.path);
+
+    app.use(serveStatic(dirPath));
+    server = app.listen(config.port);
 }
 
 export function stopServer(): void {


### PR DESCRIPTION
#### Description of changes

In order to write new e2e test for the electron app, specifically, for the automated checks view, we need a way to "mock" axe-android calls and results. We are going to use a similar approach as `yarn with:mock-axe-andoid`, whichs spins up a local static file server to respond with a result file (in the future, we may need to get more sofisticated and have different results file for different scenarios but for now, one file should do).

For this to work properly, we need to generalize how we are spinning that resouces server. Adding a config type seems to fit this nicely as it allows to pack the port and the path we're currently passing ti the resource server under browser extension e2e scenario.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
