### PR TITLE
feat(card-selection): add accessibility announcements for cards selection 

### DIFF
--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -34,6 +34,7 @@ export interface CardKebabMenuButtonProps {
     deps: CardKebabMenuButtonDeps;
     userConfigurationStoreData: UserConfigurationStoreData;
     issueDetailsData: CreateIssueDetailsTextData;
+    kebabMenuAriaLabel?: string;
 }
 
 export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProps, CardKebabMenuButtonState> {
@@ -63,7 +64,7 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
             <div onKeyDown={handleKeyDown}>
                 <ActionButton
                     className={kebabMenuButton}
-                    ariaLabel="More actions"
+                    ariaLabel={this.props.kebabMenuAriaLabel || 'More actions'}
                     onRenderMenuIcon={MoreActionsMenuIcon}
                     menuProps={{
                         className: kebabMenu,

--- a/src/common/components/cards/instance-details-footer.tsx
+++ b/src/common/components/cards/instance-details-footer.tsx
@@ -28,10 +28,11 @@ export type InstanceDetailsFooterProps = {
     userConfigurationStoreData: UserConfigurationStoreData;
     targetAppInfo: TargetAppData;
     rule: UnifiedRule;
+    kebabMenuAriaLabel?: string;
 };
 
 export const InstanceDetailsFooter = NamedFC<InstanceDetailsFooterProps>('InstanceDetailsFooter', props => {
-    const { highlightState, deps, userConfigurationStoreData, result, rule, targetAppInfo } = props;
+    const { highlightState, deps, userConfigurationStoreData, result, rule, targetAppInfo, kebabMenuAriaLabel } = props;
     const { cardInteractionSupport } = deps;
 
     const anyInteractionSupport = some(values(cardInteractionSupport));
@@ -43,7 +44,12 @@ export const InstanceDetailsFooter = NamedFC<InstanceDetailsFooterProps>('Instan
 
     const renderKebabMenu = () => {
         return (
-            <CardKebabMenuButton deps={deps} userConfigurationStoreData={userConfigurationStoreData} issueDetailsData={issueDetailsData} />
+            <CardKebabMenuButton
+                deps={deps}
+                userConfigurationStoreData={userConfigurationStoreData}
+                issueDetailsData={issueDetailsData}
+                kebabMenuAriaLabel={kebabMenuAriaLabel}
+            />
         );
     };
 

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -67,31 +67,33 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
 
     const kebabMenuAriaLabel = `More Actions ${result.identifiers.identifier} ${result.ruleId}`;
     return (
-        <div
-            className={instanceDetailsCardStyling}
-            tabIndex={0}
-            onClick={cardClickHandler}
-            onKeyDown={cardKeyPressHandler}
-            aria-selected={result.isSelected}
-            aria-label={`${result.identifiers.identifier} card`}
-            role="row"
-        >
-            <table className={reportInstanceTable}>
-                <tbody>
-                    {renderCardRowsForPropertyBag(result.identifiers)}
-                    {renderCardRowsForPropertyBag(result.descriptors)}
-                    {renderCardRowsForPropertyBag(result.resolution)}
-                </tbody>
-            </table>
-            <InstanceDetailsFooter
-                deps={deps}
-                result={result}
-                highlightState={highlightState}
-                userConfigurationStoreData={userConfigurationStoreData}
-                rule={rule}
-                targetAppInfo={targetAppInfo}
-                kebabMenuAriaLabel={kebabMenuAriaLabel}
-            />
+        <div role="table">
+            <div
+                className={instanceDetailsCardStyling}
+                tabIndex={0}
+                onClick={cardClickHandler}
+                onKeyDown={cardKeyPressHandler}
+                aria-selected={result.isSelected}
+                aria-label={`${result.identifiers.identifier} card`}
+                role="row"
+            >
+                <table className={reportInstanceTable}>
+                    <tbody>
+                        {renderCardRowsForPropertyBag(result.identifiers)}
+                        {renderCardRowsForPropertyBag(result.descriptors)}
+                        {renderCardRowsForPropertyBag(result.resolution)}
+                    </tbody>
+                </table>
+                <InstanceDetailsFooter
+                    deps={deps}
+                    result={result}
+                    highlightState={highlightState}
+                    userConfigurationStoreData={userConfigurationStoreData}
+                    rule={rule}
+                    targetAppInfo={targetAppInfo}
+                    kebabMenuAriaLabel={kebabMenuAriaLabel}
+                />
+            </div>
         </div>
     );
 });

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -65,7 +65,7 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
         selected: result.isSelected,
     });
 
-    const kebabMenuAriaLabel = `More Actions ${result.ruleId} ${result.identifiers.identifier}`;
+    const kebabMenuAriaLabel = `More Actions ${result.identifiers.identifier} ${result.ruleId}`;
     return (
         <div
             className={instanceDetailsCardStyling}

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -65,8 +65,17 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
         selected: result.isSelected,
     });
 
+    console.log({ result });
     return (
-        <div className={instanceDetailsCardStyling} tabIndex={0} onClick={cardClickHandler} onKeyDown={cardKeyPressHandler}>
+        <div
+            className={instanceDetailsCardStyling}
+            tabIndex={0}
+            onClick={cardClickHandler}
+            onKeyDown={cardKeyPressHandler}
+            aria-selected={result.isSelected}
+            aria-label={`${result.identifiers.identifier} card`}
+            role="row"
+        >
             <table className={reportInstanceTable}>
                 <tbody>
                     {renderCardRowsForPropertyBag(result.identifiers)}

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -65,7 +65,7 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
         selected: result.isSelected,
     });
 
-    console.log({ result });
+    const kebabMenuAriaLabel = `More Actions ${result.ruleId} ${result.identifiers.identifier}`;
     return (
         <div
             className={instanceDetailsCardStyling}
@@ -90,6 +90,7 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
                 userConfigurationStoreData={userConfigurationStoreData}
                 rule={rule}
                 targetAppInfo={targetAppInfo}
+                kebabMenuAriaLabel={kebabMenuAriaLabel}
             />
         </div>
     );

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSu
 </div>"
 `;
 
-exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and test-kebabmenuarialabel aria label passed as prop 2`] = `
+exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and test-kebabmenuarialabel aria label passed as prop: test-kebabmenuarialabel 1`] = `
 Object {
   "calloutProps": Object {
     "className": "kebabMenuCallout",

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
@@ -37,6 +37,80 @@ Object {
 }
 `;
 
+exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and test-kebabmenuarialabel aria label passed as prop 1`] = `
+"<div onKeyDown={[Function: handleKeyDown]}>
+  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"test-kebabmenuarialabel\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
+  <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
+  <Toast deps={{...}} timeoutLength={6000} />
+</div>"
+`;
+
+exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and test-kebabmenuarialabel aria label passed as prop 2`] = `
+Object {
+  "calloutProps": Object {
+    "className": "kebabMenuCallout",
+  },
+  "className": "kebabMenu",
+  "directionalHint": 6,
+  "items": Array [
+    Object {
+      "iconProps": Object {
+        "iconName": "ladybugSolid",
+      },
+      "key": "fileissue",
+      "name": "File issue",
+      "onClick": [Function],
+    },
+    Object {
+      "iconProps": Object {
+        "iconName": "copy",
+      },
+      "key": "copyfailuredetails",
+      "name": "Copy failure details",
+      "onClick": [Function],
+    },
+  ],
+  "shouldFocusOnMount": true,
+}
+`;
+
+exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and undefined aria label passed as prop 1`] = `
+"<div onKeyDown={[Function: handleKeyDown]}>
+  <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
+  <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
+  <Toast deps={{...}} timeoutLength={6000} />
+</div>"
+`;
+
+exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and undefined aria label passed as prop 2`] = `
+Object {
+  "calloutProps": Object {
+    "className": "kebabMenuCallout",
+  },
+  "className": "kebabMenu",
+  "directionalHint": 6,
+  "items": Array [
+    Object {
+      "iconProps": Object {
+        "iconName": "ladybugSolid",
+      },
+      "key": "fileissue",
+      "name": "File issue",
+      "onClick": [Function],
+    },
+    Object {
+      "iconProps": Object {
+        "iconName": "copy",
+      },
+      "key": "copyfailuredetails",
+      "name": "Copy failure details",
+      "onClick": [Function],
+    },
+  ],
+  "shouldFocusOnMount": true,
+}
+`;
+
 exports[`CardKebabMenuButtonTest renders per snapshot with onlyUserConfigAgnosticCardInteractionsSupported 1`] = `
 "<div onKeyDown={[Function: handleKeyDown]}>
   <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/card-kebab-menu-button.test.tsx.snap
@@ -37,7 +37,7 @@ Object {
 }
 `;
 
-exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and test-kebabmenuarialabel aria label passed as prop 1`] = `
+exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and test-kebabmenuarialabel aria label passed as prop: with aria-label passed as prop 1`] = `
 "<div onKeyDown={[Function: handleKeyDown]}>
   <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"test-kebabmenuarialabel\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
@@ -45,7 +45,7 @@ exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSu
 </div>"
 `;
 
-exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and test-kebabmenuarialabel aria label passed as prop: test-kebabmenuarialabel 1`] = `
+exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and test-kebabmenuarialabel aria label passed as prop: with aria-label passed as prop 2`] = `
 Object {
   "calloutProps": Object {
     "className": "kebabMenuCallout",
@@ -74,7 +74,7 @@ Object {
 }
 `;
 
-exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and undefined aria label passed as prop 1`] = `
+exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and undefined aria label passed as prop: without aria-label 1`] = `
 "<div onKeyDown={[Function: handleKeyDown]}>
   <CustomizedActionButton className=\\"kebabMenuButton\\" ariaLabel=\\"More actions\\" onRenderMenuIcon={[Function]} menuProps={{...}} />
   <IssueFilingDialog deps={{...}} isOpen={false} selectedIssueFilingService={{...}} selectedIssueData={{...}} selectedIssueFilingServiceData={{...}} onClose={[Function]} issueFilingServicePropertiesMap={{...}} />
@@ -82,7 +82,7 @@ exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSu
 </div>"
 `;
 
-exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and undefined aria label passed as prop 2`] = `
+exports[`CardKebabMenuButtonTest renders per snapshot with allCardInteractionsSupported and undefined aria label passed as prop: without aria-label 2`] = `
 Object {
   "calloutProps": Object {
     "className": "kebabMenuCallout",

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`InstanceDetails isSelected drives the styling for the card 1`] = `
       }
     }
     highlightState="unavailable"
-    kebabMenuAriaLabel="More Actions image-alt test-id"
+    kebabMenuAriaLabel="More Actions test-id image-alt"
     result={
       Object {
         "descriptors": Object {},
@@ -80,7 +80,7 @@ exports[`InstanceDetails isSelected drives the styling for the card 2`] = `
       }
     }
     highlightState="unavailable"
-    kebabMenuAriaLabel="More Actions image-alt test-id"
+    kebabMenuAriaLabel="More Actions test-id image-alt"
     result={
       Object {
         "descriptors": Object {},
@@ -181,7 +181,7 @@ exports[`InstanceDetails renders 1`] = `
       }
     }
     highlightState="unavailable"
-    kebabMenuAriaLabel="More Actions image-alt body img"
+    kebabMenuAriaLabel="More Actions body img image-alt"
     result={
       Object {
         "descriptors": Object {
@@ -242,7 +242,7 @@ exports[`InstanceDetails renders nothing when there is no card row config for th
       }
     }
     highlightState="unavailable"
-    kebabMenuAriaLabel="More Actions image-alt test-id"
+    kebabMenuAriaLabel="More Actions test-id image-alt"
     result={
       Object {
         "descriptors": Object {},

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`InstanceDetails isSelected drives the styling for the card 1`] = `
       }
     }
     highlightState="unavailable"
+    kebabMenuAriaLabel="More Actions image-alt test-id"
     result={
       Object {
         "descriptors": Object {},
@@ -79,6 +80,7 @@ exports[`InstanceDetails isSelected drives the styling for the card 2`] = `
       }
     }
     highlightState="unavailable"
+    kebabMenuAriaLabel="More Actions image-alt test-id"
     result={
       Object {
         "descriptors": Object {},
@@ -179,6 +181,7 @@ exports[`InstanceDetails renders 1`] = `
       }
     }
     highlightState="unavailable"
+    kebabMenuAriaLabel="More Actions image-alt body img"
     result={
       Object {
         "descriptors": Object {
@@ -239,6 +242,7 @@ exports[`InstanceDetails renders nothing when there is no card row config for th
       }
     }
     highlightState="unavailable"
+    kebabMenuAriaLabel="More Actions image-alt test-id"
     result={
       Object {
         "descriptors": Object {},

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -2,161 +2,209 @@
 
 exports[`InstanceDetails isSelected drives the styling for the card 1`] = `
 <div
-  aria-label="test-id card"
-  aria-selected={true}
-  className="instance-details-card selected"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  role="row"
-  tabIndex={0}
+  role="table"
 >
-  <table
-    className="reportInstanceTable"
+  <div
+    aria-label="test-id card"
+    aria-selected={true}
+    className="instance-details-card selected"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="row"
+    tabIndex={0}
   >
-    <tbody>
-      <React.Fragment />
-      <React.Fragment />
-      <React.Fragment />
-    </tbody>
-  </table>
-  <InstanceDetailsFooter
-    deps={
-      Object {
-        "cardSelectionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-        },
-        "getPropertyConfigById": [Function],
+    <table
+      className="reportInstanceTable"
+    >
+      <tbody>
+        <React.Fragment />
+        <React.Fragment />
+        <React.Fragment />
+      </tbody>
+    </table>
+    <InstanceDetailsFooter
+      deps={
+        Object {
+          "cardSelectionMessageCreator": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "dispatcher": undefined,
+          },
+          "getPropertyConfigById": [Function],
+        }
       }
-    }
-    highlightState="unavailable"
-    kebabMenuAriaLabel="More Actions test-id image-alt"
-    result={
-      Object {
-        "descriptors": Object {},
-        "identifiers": Object {
-          "conciseName": "test-concise-name",
-          "identifier": "test-id",
-          "this-property-does-not-have-config": "some value",
-        },
-        "isSelected": true,
-        "resolution": Object {},
-        "ruleId": "image-alt",
-        "status": "fail",
-        "uid": "some-guid-here",
+      highlightState="unavailable"
+      kebabMenuAriaLabel="More Actions test-id image-alt"
+      result={
+        Object {
+          "descriptors": Object {},
+          "identifiers": Object {
+            "conciseName": "test-concise-name",
+            "identifier": "test-id",
+            "this-property-does-not-have-config": "some value",
+          },
+          "isSelected": true,
+          "resolution": Object {},
+          "ruleId": "image-alt",
+          "status": "fail",
+          "uid": "some-guid-here",
+        }
       }
-    }
-  />
+    />
+  </div>
 </div>
 `;
 
 exports[`InstanceDetails isSelected drives the styling for the card 2`] = `
 <div
-  aria-label="test-id card"
-  aria-selected={false}
-  className="instance-details-card"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  role="row"
-  tabIndex={0}
+  role="table"
 >
-  <table
-    className="reportInstanceTable"
+  <div
+    aria-label="test-id card"
+    aria-selected={false}
+    className="instance-details-card"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="row"
+    tabIndex={0}
   >
-    <tbody>
-      <React.Fragment />
-      <React.Fragment />
-      <React.Fragment />
-    </tbody>
-  </table>
-  <InstanceDetailsFooter
-    deps={
-      Object {
-        "cardSelectionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-        },
-        "getPropertyConfigById": [Function],
+    <table
+      className="reportInstanceTable"
+    >
+      <tbody>
+        <React.Fragment />
+        <React.Fragment />
+        <React.Fragment />
+      </tbody>
+    </table>
+    <InstanceDetailsFooter
+      deps={
+        Object {
+          "cardSelectionMessageCreator": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "dispatcher": undefined,
+          },
+          "getPropertyConfigById": [Function],
+        }
       }
-    }
-    highlightState="unavailable"
-    kebabMenuAriaLabel="More Actions test-id image-alt"
-    result={
-      Object {
-        "descriptors": Object {},
-        "identifiers": Object {
-          "conciseName": "test-concise-name",
-          "identifier": "test-id",
-          "this-property-does-not-have-config": "some value",
-        },
-        "isSelected": false,
-        "resolution": Object {},
-        "ruleId": "image-alt",
-        "status": "fail",
-        "uid": "some-guid-here",
+      highlightState="unavailable"
+      kebabMenuAriaLabel="More Actions test-id image-alt"
+      result={
+        Object {
+          "descriptors": Object {},
+          "identifiers": Object {
+            "conciseName": "test-concise-name",
+            "identifier": "test-id",
+            "this-property-does-not-have-config": "some value",
+          },
+          "isSelected": false,
+          "resolution": Object {},
+          "ruleId": "image-alt",
+          "status": "fail",
+          "uid": "some-guid-here",
+        }
       }
-    }
-  />
+    />
+  </div>
 </div>
 `;
 
 exports[`InstanceDetails renders 1`] = `
 <div
-  aria-label="body img card"
-  className="instance-details-card"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  role="row"
-  tabIndex={0}
+  role="table"
 >
-  <table
-    className="reportInstanceTable"
+  <div
+    aria-label="body img card"
+    className="instance-details-card"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="row"
+    tabIndex={0}
   >
-    <tbody>
-      <React.Fragment>
-        <css-selector
-          deps={
-            Object {
-              "cardSelectionMessageCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "dispatcher": undefined,
-              },
-              "getPropertyConfigById": [Function],
+    <table
+      className="reportInstanceTable"
+    >
+      <tbody>
+        <React.Fragment>
+          <css-selector
+            deps={
+              Object {
+                "cardSelectionMessageCreator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "dispatcher": undefined,
+                },
+                "getPropertyConfigById": [Function],
+              }
             }
-          }
-          index={22}
-          propertyData="body img"
-        />
-      </React.Fragment>
-      <React.Fragment>
-        <snippet
-          deps={
-            Object {
-              "cardSelectionMessageCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "dispatcher": undefined,
-              },
-              "getPropertyConfigById": [Function],
+            index={22}
+            propertyData="body img"
+          />
+        </React.Fragment>
+        <React.Fragment>
+          <snippet
+            deps={
+              Object {
+                "cardSelectionMessageCreator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "dispatcher": undefined,
+                },
+                "getPropertyConfigById": [Function],
+              }
             }
-          }
-          index={22}
-          propertyData="this is a sample snippet"
-        />
-      </React.Fragment>
-      <React.Fragment>
-        <how-to-fix-web
-          deps={
-            Object {
-              "cardSelectionMessageCreator": proxy {
-                "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-                "dispatcher": undefined,
-              },
-              "getPropertyConfigById": [Function],
+            index={22}
+            propertyData="this is a sample snippet"
+          />
+        </React.Fragment>
+        <React.Fragment>
+          <how-to-fix-web
+            deps={
+              Object {
+                "cardSelectionMessageCreator": proxy {
+                  "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                  "dispatcher": undefined,
+                },
+                "getPropertyConfigById": [Function],
+              }
             }
-          }
-          index={22}
-          propertyData={
-            Object {
+            index={22}
+            propertyData={
+              Object {
+                "all": Array [],
+                "any": Array [
+                  "Element does not have an alt attribute",
+                  "aria-label attribute does not exist or is empty",
+                  "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty",
+                ],
+                "none": Array [],
+              }
+            }
+          />
+        </React.Fragment>
+      </tbody>
+    </table>
+    <InstanceDetailsFooter
+      deps={
+        Object {
+          "cardSelectionMessageCreator": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "dispatcher": undefined,
+          },
+          "getPropertyConfigById": [Function],
+        }
+      }
+      highlightState="unavailable"
+      kebabMenuAriaLabel="More Actions body img image-alt"
+      result={
+        Object {
+          "descriptors": Object {
+            "snippet": "this is a sample snippet",
+          },
+          "identifiers": Object {
+            "conciseName": "body img",
+            "css-selector": "body img",
+            "identifier": "body img",
+          },
+          "resolution": Object {
+            "how-to-fix-web": Object {
               "all": Array [],
               "any": Array [
                 "Element does not have an alt attribute",
@@ -164,99 +212,67 @@ exports[`InstanceDetails renders 1`] = `
                 "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty",
               ],
               "none": Array [],
-            }
-          }
-        />
-      </React.Fragment>
-    </tbody>
-  </table>
-  <InstanceDetailsFooter
-    deps={
-      Object {
-        "cardSelectionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-        },
-        "getPropertyConfigById": [Function],
-      }
-    }
-    highlightState="unavailable"
-    kebabMenuAriaLabel="More Actions body img image-alt"
-    result={
-      Object {
-        "descriptors": Object {
-          "snippet": "this is a sample snippet",
-        },
-        "identifiers": Object {
-          "conciseName": "body img",
-          "css-selector": "body img",
-          "identifier": "body img",
-        },
-        "resolution": Object {
-          "how-to-fix-web": Object {
-            "all": Array [],
-            "any": Array [
-              "Element does not have an alt attribute",
-              "aria-label attribute does not exist or is empty",
-              "aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty",
-            ],
-            "none": Array [],
+            },
+            "howToFixSummary": "sample how to fix summary",
           },
-          "howToFixSummary": "sample how to fix summary",
-        },
-        "ruleId": "image-alt",
-        "status": "fail",
-        "uid": "some-guid-here",
+          "ruleId": "image-alt",
+          "status": "fail",
+          "uid": "some-guid-here",
+        }
       }
-    }
-  />
+    />
+  </div>
 </div>
 `;
 
 exports[`InstanceDetails renders nothing when there is no card row config for the property / no property 1`] = `
 <div
-  aria-label="test-id card"
-  className="instance-details-card"
-  onClick={[Function]}
-  onKeyDown={[Function]}
-  role="row"
-  tabIndex={0}
+  role="table"
 >
-  <table
-    className="reportInstanceTable"
+  <div
+    aria-label="test-id card"
+    className="instance-details-card"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="row"
+    tabIndex={0}
   >
-    <tbody>
-      <React.Fragment />
-      <React.Fragment />
-      <React.Fragment />
-    </tbody>
-  </table>
-  <InstanceDetailsFooter
-    deps={
-      Object {
-        "cardSelectionMessageCreator": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "dispatcher": undefined,
-        },
-        "getPropertyConfigById": [Function],
+    <table
+      className="reportInstanceTable"
+    >
+      <tbody>
+        <React.Fragment />
+        <React.Fragment />
+        <React.Fragment />
+      </tbody>
+    </table>
+    <InstanceDetailsFooter
+      deps={
+        Object {
+          "cardSelectionMessageCreator": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "dispatcher": undefined,
+          },
+          "getPropertyConfigById": [Function],
+        }
       }
-    }
-    highlightState="unavailable"
-    kebabMenuAriaLabel="More Actions test-id image-alt"
-    result={
-      Object {
-        "descriptors": Object {},
-        "identifiers": Object {
-          "conciseName": "test-concise-name",
-          "identifier": "test-id",
-          "this-property-does-not-have-config": "some value",
-        },
-        "resolution": Object {},
-        "ruleId": "image-alt",
-        "status": "fail",
-        "uid": "some-guid-here",
+      highlightState="unavailable"
+      kebabMenuAriaLabel="More Actions test-id image-alt"
+      result={
+        Object {
+          "descriptors": Object {},
+          "identifiers": Object {
+            "conciseName": "test-concise-name",
+            "identifier": "test-id",
+            "this-property-does-not-have-config": "some value",
+          },
+          "resolution": Object {},
+          "ruleId": "image-alt",
+          "status": "fail",
+          "uid": "some-guid-here",
+        }
       }
-    }
-  />
+    />
+  </div>
 </div>
 `;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -2,9 +2,12 @@
 
 exports[`InstanceDetails isSelected drives the styling for the card 1`] = `
 <div
+  aria-label="test-id card"
+  aria-selected={true}
   className="instance-details-card selected"
   onClick={[Function]}
   onKeyDown={[Function]}
+  role="row"
   tabIndex={0}
 >
   <table
@@ -48,9 +51,12 @@ exports[`InstanceDetails isSelected drives the styling for the card 1`] = `
 
 exports[`InstanceDetails isSelected drives the styling for the card 2`] = `
 <div
+  aria-label="test-id card"
+  aria-selected={false}
   className="instance-details-card"
   onClick={[Function]}
   onKeyDown={[Function]}
+  role="row"
   tabIndex={0}
 >
   <table
@@ -94,9 +100,11 @@ exports[`InstanceDetails isSelected drives the styling for the card 2`] = `
 
 exports[`InstanceDetails renders 1`] = `
 <div
+  aria-label="body img card"
   className="instance-details-card"
   onClick={[Function]}
   onKeyDown={[Function]}
+  role="row"
   tabIndex={0}
 >
   <table
@@ -204,9 +212,11 @@ exports[`InstanceDetails renders 1`] = `
 
 exports[`InstanceDetails renders nothing when there is no card row config for the property / no property 1`] = `
 <div
+  aria-label="test-id card"
   className="instance-details-card"
   onClick={[Function]}
   onKeyDown={[Function]}
+  role="row"
   tabIndex={0}
 >
   <table

--- a/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
@@ -156,7 +156,7 @@ describe('CardKebabMenuButtonTest', () => {
             );
 
             expect(rendered.debug()).toMatchSnapshot();
-            expect(rendered.find(ActionButton).prop('menuProps')).toMatchSnapshot();
+            expect(rendered.find(ActionButton).prop('menuProps')).toMatchSnapshot(ariaLabel);
         },
     );
 

--- a/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
@@ -155,8 +155,9 @@ describe('CardKebabMenuButtonTest', () => {
                 <CardKebabMenuButton {...newProps} deps={{ ...defaultDeps, cardInteractionSupport: allCardInteractionsSupported }} />,
             );
 
-            expect(rendered.debug()).toMatchSnapshot();
-            expect(rendered.find(ActionButton).prop('menuProps')).toMatchSnapshot(ariaLabel);
+            const snapshotLabel = ariaLabel ? 'with aria-label passed as prop' : 'without aria-label';
+            expect(rendered.debug()).toMatchSnapshot(snapshotLabel);
+            expect(rendered.find(ActionButton).prop('menuProps')).toMatchSnapshot(snapshotLabel);
         },
     );
 

--- a/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
@@ -144,6 +144,22 @@ describe('CardKebabMenuButtonTest', () => {
         expect(rendered.find(ActionButton).prop('menuProps')).toMatchSnapshot();
     });
 
+    it.each(['test-kebabmenuarialabel', undefined])(
+        'renders per snapshot with allCardInteractionsSupported and %s aria label passed as prop',
+        ariaLabel => {
+            const newProps = {
+                ...defaultProps,
+                kebabMenuAriaLabel: ariaLabel,
+            };
+            const rendered = shallow(
+                <CardKebabMenuButton {...newProps} deps={{ ...defaultDeps, cardInteractionSupport: allCardInteractionsSupported }} />,
+            );
+
+            expect(rendered.debug()).toMatchSnapshot();
+            expect(rendered.find(ActionButton).prop('menuProps')).toMatchSnapshot();
+        },
+    );
+
     it('renders per snapshot with onlyUserConfigAgnosticCardInteractionsSupported', () => {
         const rendered = shallow(
             <CardKebabMenuButton


### PR DESCRIPTION
#### Description of changes

After discussion with Rob, Fer & Wahaj, we decided to add some explicit text to be announced on card focus and kebab menu focus.

#### NVDA output:

For card:
`html card  row  not selected` 

For Kebab Menu:

`More Actions html html-has-lang
menu button  collapsed  subMenu`

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
