### PR TITLE
refactor: move/extract android e2e test resusable helpers

### DIFF
--- a/src/tests/electron/common/create-application.ts
+++ b/src/tests/electron/common/create-application.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as Electron from 'electron';
+import { Application } from 'spectron';
+
+export function createApplication(): Promise<Application> {
+    const electronPath = `${(global as any).rootDir}/drop/electron/extension/bundle/main.bundle.js`;
+    const app = new Application({
+        path: Electron as any,
+        args: [electronPath],
+    });
+
+    return app.start();
+}

--- a/src/tests/electron/common/dismiss-telemetry-opt-in-dialog.ts
+++ b/src/tests/electron/common/dismiss-telemetry-opt-in-dialog.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Application } from 'spectron';
+import { DEFAULT_ELECTRON_TEST_TIMEOUT_MS } from 'tests/electron/setup/timeouts';
+import { popupPageElementIdentifiers } from 'tests/end-to-end/common/element-identifiers/popup-page-element-identifiers';
+import { Client } from 'webdriverio';
+
+export async function dismissTelemetryOptInDialog(app: Application): Promise<void> {
+    const webDriverClient: Client<void> = app.client;
+
+    await webDriverClient.waitForVisible(popupPageElementIdentifiers.telemetryDialog, DEFAULT_ELECTRON_TEST_TIMEOUT_MS);
+    await webDriverClient.click(popupPageElementIdentifiers.startUsingProductButton);
+}

--- a/src/tests/electron/tests/main.test.ts
+++ b/src/tests/electron/tests/main.test.ts
@@ -3,9 +3,9 @@
 import * as Electron from 'electron';
 import { Application } from 'spectron';
 import * as WebdriverIO from 'webdriverio';
-import { popupPageElementIdentifiers } from '../end-to-end/common/element-identifiers/popup-page-element-identifiers';
-import { CommonSelectors } from './common/element-identifiers/common-selectors';
-import { DEFAULT_ELECTRON_TEST_TIMEOUT_MS } from './setup/timeouts';
+import { popupPageElementIdentifiers } from '../../end-to-end/common/element-identifiers/popup-page-element-identifiers';
+import { CommonSelectors } from '../common/element-identifiers/common-selectors';
+import { DEFAULT_ELECTRON_TEST_TIMEOUT_MS } from '../setup/timeouts';
 
 describe('Electron E2E', () => {
     let app: Application;

--- a/src/tests/electron/tests/main.test.ts
+++ b/src/tests/electron/tests/main.test.ts
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 import * as Electron from 'electron';
 import { Application } from 'spectron';
+import { dismissTelemetryOptInDialog } from 'tests/electron/common/dismiss-telemetry-opt-in-dialog';
 import * as WebdriverIO from 'webdriverio';
-import { popupPageElementIdentifiers } from '../../end-to-end/common/element-identifiers/popup-page-element-identifiers';
+
 import { CommonSelectors } from '../common/element-identifiers/common-selectors';
 import { DEFAULT_ELECTRON_TEST_TIMEOUT_MS } from '../setup/timeouts';
 
@@ -24,12 +25,6 @@ describe('Electron E2E', () => {
     // so tslint thinks some of the methods do not return promises.
     // tslint:disable: await-promise
 
-    async function dismissTelemetryOptInDialog(): Promise<void> {
-        const webDriverClient: WebdriverIO.Client<void> = app.client;
-        await webDriverClient.waitForVisible(popupPageElementIdentifiers.telemetryDialog, DEFAULT_ELECTRON_TEST_TIMEOUT_MS);
-        await webDriverClient.click(popupPageElementIdentifiers.startUsingProductButton);
-    }
-
     async function ensureAppIsInDeviceConnectionDialog(): Promise<void> {
         const webDriverClient: WebdriverIO.Client<void> = app.client;
         await webDriverClient.waitForVisible(CommonSelectors.rootContainer, DEFAULT_ELECTRON_TEST_TIMEOUT_MS);
@@ -37,7 +32,7 @@ describe('Electron E2E', () => {
     }
 
     beforeEach(async () => {
-        await dismissTelemetryOptInDialog();
+        await dismissTelemetryOptInDialog(app);
     });
 
     afterEach(async () => {

--- a/src/tests/electron/tests/main.test.ts
+++ b/src/tests/electron/tests/main.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as Electron from 'electron';
 import { Application } from 'spectron';
+import { createApplication } from 'tests/electron/common/create-application';
 import { dismissTelemetryOptInDialog } from 'tests/electron/common/dismiss-telemetry-opt-in-dialog';
 import * as WebdriverIO from 'webdriverio';
 
@@ -11,14 +11,8 @@ import { DEFAULT_ELECTRON_TEST_TIMEOUT_MS } from '../setup/timeouts';
 describe('Electron E2E', () => {
     let app: Application;
 
-    beforeEach(() => {
-        const electronPath = `${(global as any).rootDir}/drop/electron/extension/bundle/main.bundle.js`;
-        app = new Application({
-            path: Electron as any,
-            args: [electronPath],
-        });
-
-        return app.start();
+    beforeEach(async () => {
+        app = await createApplication();
     });
 
     // spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,


### PR DESCRIPTION
#### Description of changes

In order to reuse some of the current helper code for our AI-Android e2e test, I'm moving this function to their own files.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
