### PR TITLE
fix: update aria label for kebab menu action button

### DIFF
--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -65,7 +65,7 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
         selected: result.isSelected,
     });
 
-    const kebabMenuAriaLabel = `More Actions for card ${result.identifiers.identifier} in ${result.ruleId}`;
+    const kebabMenuAriaLabel = `More Actions for card ${result.identifiers.identifier} in rule ${result.ruleId}`;
     return (
         <div role="table">
             <div

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -65,7 +65,7 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
         selected: result.isSelected,
     });
 
-    const kebabMenuAriaLabel = `More Actions ${result.identifiers.identifier} ${result.ruleId}`;
+    const kebabMenuAriaLabel = `More Actions for card ${result.identifiers.identifier} in ${result.ruleId}`;
     return (
         <div role="table">
             <div

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`InstanceDetails isSelected drives the styling for the card 1`] = `
         }
       }
       highlightState="unavailable"
-      kebabMenuAriaLabel="More Actions test-id image-alt"
+      kebabMenuAriaLabel="More Actions for card test-id in image-alt"
       result={
         Object {
           "descriptors": Object {},
@@ -87,7 +87,7 @@ exports[`InstanceDetails isSelected drives the styling for the card 2`] = `
         }
       }
       highlightState="unavailable"
-      kebabMenuAriaLabel="More Actions test-id image-alt"
+      kebabMenuAriaLabel="More Actions for card test-id in image-alt"
       result={
         Object {
           "descriptors": Object {},
@@ -192,7 +192,7 @@ exports[`InstanceDetails renders 1`] = `
         }
       }
       highlightState="unavailable"
-      kebabMenuAriaLabel="More Actions body img image-alt"
+      kebabMenuAriaLabel="More Actions for card body img in image-alt"
       result={
         Object {
           "descriptors": Object {
@@ -257,7 +257,7 @@ exports[`InstanceDetails renders nothing when there is no card row config for th
         }
       }
       highlightState="unavailable"
-      kebabMenuAriaLabel="More Actions test-id image-alt"
+      kebabMenuAriaLabel="More Actions for card test-id in image-alt"
       result={
         Object {
           "descriptors": Object {},

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`InstanceDetails isSelected drives the styling for the card 1`] = `
         }
       }
       highlightState="unavailable"
-      kebabMenuAriaLabel="More Actions for card test-id in image-alt"
+      kebabMenuAriaLabel="More Actions for card test-id in rule image-alt"
       result={
         Object {
           "descriptors": Object {},
@@ -87,7 +87,7 @@ exports[`InstanceDetails isSelected drives the styling for the card 2`] = `
         }
       }
       highlightState="unavailable"
-      kebabMenuAriaLabel="More Actions for card test-id in image-alt"
+      kebabMenuAriaLabel="More Actions for card test-id in rule image-alt"
       result={
         Object {
           "descriptors": Object {},
@@ -192,7 +192,7 @@ exports[`InstanceDetails renders 1`] = `
         }
       }
       highlightState="unavailable"
-      kebabMenuAriaLabel="More Actions for card body img in image-alt"
+      kebabMenuAriaLabel="More Actions for card body img in rule image-alt"
       result={
         Object {
           "descriptors": Object {
@@ -257,7 +257,7 @@ exports[`InstanceDetails renders nothing when there is no card row config for th
         }
       }
       highlightState="unavailable"
-      kebabMenuAriaLabel="More Actions for card test-id in image-alt"
+      kebabMenuAriaLabel="More Actions for card test-id in rule image-alt"
       result={
         Object {
           "descriptors": Object {},


### PR DESCRIPTION
#### Description of changes

After offline discussion with @RobGallo . Fixed the menu action button aria label to be something like 
`More Actions for card .bnp_hfly_collapse_close in rule image-alt button menu`.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
