### PR TITLE
feat: use outline instead of border for showing selection state in UI

### DIFF
--- a/src/common/components/cards/collapsible-component-cards.scss
+++ b/src/common/components/cards/collapsible-component-cards.scss
@@ -52,6 +52,7 @@
     }
 
     .collapsible-container-content {
+        margin-left: 24px;
         &[aria-hidden='true'] {
             display: none;
         }

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -6,7 +6,7 @@ import { NamedFC } from 'common/react/named-fc';
 import { CardResult } from 'common/types/store-data/card-view-model';
 import { forOwn, isEmpty } from 'lodash';
 import * as React from 'react';
-import { reportInstanceTable } from 'reports/components/instance-details.scss';
+import { instanceDetailsCard, instanceDetailsCardContainer, reportInstanceTable, selected } from 'reports/components/instance-details.scss';
 
 import { CardRowDeps, PropertyConfiguration } from '../../../common/configs/unified-result-property-configurations';
 import { CardSelectionMessageCreator } from '../../../common/message-creators/card-selection-message-creator';
@@ -61,13 +61,18 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
     };
 
     const instanceDetailsCardStyling = classNames({
-        'instance-details-card': true,
-        selected: result.isSelected,
+        [instanceDetailsCard]: true,
+        [selected]: result.isSelected,
+    });
+
+    const instanceDetailsCardContainerStyling = classNames({
+        [instanceDetailsCardContainer]: true,
+        [selected]: result.isSelected,
     });
 
     const kebabMenuAriaLabel = `More Actions for card ${result.identifiers.identifier} in rule ${result.ruleId}`;
     return (
-        <div role="table">
+        <div className={instanceDetailsCardContainerStyling} role="table">
             <div
                 className={instanceDetailsCardStyling}
                 tabIndex={0}

--- a/src/common/components/cards/rule-resources.scss
+++ b/src/common/components/cards/rule-resources.scss
@@ -8,7 +8,6 @@
     display: flex;
     flex-direction: column;
 
-    margin-left: 24px;
     margin-bottom: 16px;
     padding: 14px 20px;
 

--- a/src/reports/components/instance-details.scss
+++ b/src/reports/components/instance-details.scss
@@ -16,14 +16,13 @@
     border-radius: 4px;
     outline-style: 'border-style';
     box-shadow: 0px 0.6px 1.8px $box-shadow-108, 0px 3.2px 7.2px $box-shadow-132;
-    margin-left: 24px;
     margin-bottom: 16px;
     cursor: pointer;
     @include fill-available-width;
 }
 
-.instance-details-card.selected {
-    border: 5px solid $communication-tint-10;
+.instance-details-card-container.selected {
+    outline: 5px solid $communication-tint-10;
 }
 
 .instance-details-card:focus {
@@ -31,22 +30,16 @@
 }
 
 .instance-details-card.selected:focus {
-    border: 5px solid $communication-tint-10;
-    outline: 2px solid $primary-text;
-    outline-offset: 2px;
+    outline-offset: 6px;
 }
 
 .instance-details-card:hover {
     box-shadow: 0px 8px 10px $box-shadow-108, 0px 8px 10px $box-shadow-132;
 }
 
-.instance-details-card.selected:hover {
-    border: 5px solid #2b88d8;
-    box-shadow: 0px 8px 10px $box-shadow-108, 0px 8px 10px $box-shadow-132;
-}
-
 .report-instance-table {
     background: $neutral-0;
+
     display: table;
     table-layout: fixed;
     @include fill-available-width;

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -2,12 +2,13 @@
 
 exports[`InstanceDetails isSelected drives the styling for the card 1`] = `
 <div
+  className="instanceDetailsCardContainer selected"
   role="table"
 >
   <div
     aria-label="test-id card"
     aria-selected={true}
-    className="instance-details-card selected"
+    className="instanceDetailsCard selected"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="row"
@@ -56,12 +57,13 @@ exports[`InstanceDetails isSelected drives the styling for the card 1`] = `
 
 exports[`InstanceDetails isSelected drives the styling for the card 2`] = `
 <div
+  className="instanceDetailsCardContainer"
   role="table"
 >
   <div
     aria-label="test-id card"
     aria-selected={false}
-    className="instance-details-card"
+    className="instanceDetailsCard"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="row"
@@ -110,11 +112,12 @@ exports[`InstanceDetails isSelected drives the styling for the card 2`] = `
 
 exports[`InstanceDetails renders 1`] = `
 <div
+  className="instanceDetailsCardContainer"
   role="table"
 >
   <div
     aria-label="body img card"
-    className="instance-details-card"
+    className="instanceDetailsCard"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="row"
@@ -227,11 +230,12 @@ exports[`InstanceDetails renders 1`] = `
 
 exports[`InstanceDetails renders nothing when there is no card row config for the property / no property 1`] = `
 <div
+  className="instanceDetailsCardContainer"
   role="table"
 >
   <div
     aria-label="test-id card"
-    className="instance-details-card"
+    className="instanceDetailsCard"
     onClick={[Function]}
     onKeyDown={[Function]}
     role="row"

--- a/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
@@ -5,7 +5,9 @@ import { KeyCodeConstants } from 'common/constants/keycode-constants';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { instanceDetailsCard } from 'reports/components/instance-details.scss';
 import { IMock, It, Mock, Times } from 'typemoq';
+
 import {
     AllPropertyTypes,
     CardRowProps,
@@ -28,6 +30,7 @@ describe('InstanceDetails', () => {
         cardSelectionMessageCreatorMock = Mock.ofType(CardSelectionMessageCreator);
         resultStub = exampleUnifiedResult;
         indexStub = 22;
+
         deps = {
             getPropertyConfigById: getPropertyConfigByIdMock.object,
             cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
@@ -59,7 +62,7 @@ describe('InstanceDetails', () => {
             .verifiable(Times.once());
 
         const wrapper = shallow(<InstanceDetails {...props} />);
-        const divElem = wrapper.find('.instance-details-card');
+        const divElem = wrapper.find(`.${instanceDetailsCard}`);
         expect(divElem.length).toBe(1);
 
         divElem.simulate('click');
@@ -77,7 +80,7 @@ describe('InstanceDetails', () => {
             .verifiable(Times.once());
 
         const wrapper = shallow(<InstanceDetails {...props} />);
-        const divElem = wrapper.find('.instance-details-card');
+        const divElem = wrapper.find(`.${instanceDetailsCard}`);
         expect(divElem.length).toBe(1);
 
         divElem.simulate('keydown', { keyCode: keyCode, preventDefault: preventDefaultMock });


### PR DESCRIPTION
#### Description of changes

Adds a class for the table container for instance details card and uses outline instead of border.

![cardselectionoutline](https://user-images.githubusercontent.com/32555133/67439605-8c165f80-f5ab-11e9-8c49-bf16b472754c.gif)


#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
