### PR TITLE
test: add e2e test for automated checks view

### DIFF
--- a/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
@@ -3,4 +3,11 @@
 export const AutomatedChecksViewSelectors = {
     mainContainer: '.automated-checks-view',
     resultSectionContainer: '.result-section',
+    collapsibleRuleDetailsGroup: 'div.collapsible-rule-details-group',
+    collapsibleContainerContent: '.collapsible-container-content',
+    getRuleDetailsIdSelector: (position: number) =>
+        `${AutomatedChecksViewSelectors.collapsibleRuleDetailsGroup}:nth-of-type(${position}) .rule-details-id`,
+    getLiFailuresSelector: (position: number) => `${AutomatedChecksViewSelectors.collapsibleRuleDetailsGroup}:nth-of-type(${position}) li`,
+    getCollapseExpandButtonByGroupPosition: (position: number) =>
+        `${AutomatedChecksViewSelectors.collapsibleRuleDetailsGroup}:nth-of-type(${position}) button`,
 };

--- a/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export const AutomatedChecksViewSelectors = {
+    mainContainer: '.automated-checks-view',
+    resultSectionContainer: '.result-section',
+};

--- a/src/tests/electron/jest.config.js
+++ b/src/tests/electron/jest.config.js
@@ -8,6 +8,8 @@ const currentDir = '<rootDir>/src/tests/electron';
 module.exports = {
     ...common,
     displayName: 'electron tests',
+    globalSetup: `${currentDir}/setup/global-setup.ts`,
+    globalTeardown: `${currentDir}/setup/global-teardown.ts`,
     moduleFileExtensions: ['ts', 'js'],
     rootDir: rootDir,
     roots: [currentDir],

--- a/src/tests/electron/setup/global-setup.ts
+++ b/src/tests/electron/setup/global-setup.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as testResourceServer from '../../miscellaneous/test-resource-server/resource-server';
+import { testResourceServerConfig } from './test-resource-server-config';
+
+// tslint:disable-next-line:no-default-export
+export default function(): void {
+    testResourceServer.startServer(testResourceServerConfig);
+}

--- a/src/tests/electron/setup/global-teardown.ts
+++ b/src/tests/electron/setup/global-teardown.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as testResourceServer from '../../miscellaneous/test-resource-server/resource-server';
+
+// tslint:disable-next-line:no-default-export
+export default function(): void {
+    testResourceServer.stopServer();
+}

--- a/src/tests/electron/setup/test-resource-server-config.ts
+++ b/src/tests/electron/setup/test-resource-server-config.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ResourceServerConfig } from 'tests/miscellaneous/test-resource-server/resource-server-config';
+
+export const testResourceServerConfig: ResourceServerConfig = {
+    port: 9052,
+    path: '../../miscellaneous/mock-axe-android',
+    extensions: ['json'],
+};

--- a/src/tests/electron/setup/timeouts.ts
+++ b/src/tests/electron/setup/timeouts.ts
@@ -2,4 +2,7 @@
 // Licensed under the MIT License.
 
 // How long to allow an entire test to execute
-export const DEFAULT_ELECTRON_TEST_TIMEOUT_MS: number = 20000;
+export const DEFAULT_ELECTRON_TEST_TIMEOUT_MS = 20000;
+
+// How long to wait for an element to be visible
+export const DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS = 5000;

--- a/src/tests/electron/tests/automated-checks.view.test.ts
+++ b/src/tests/electron/tests/automated-checks.view.test.ts
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Application } from 'spectron';
+import { createApplication } from 'tests/electron/common/create-application';
+import { dismissTelemetryOptInDialog } from 'tests/electron/common/dismiss-telemetry-opt-in-dialog';
+import { AutomatedChecksViewSelectors } from 'tests/electron/common/element-identifiers/automated-checks-view-selectors';
+import { CommonSelectors } from 'tests/electron/common/element-identifiers/common-selectors';
+import { testResourceServerConfig } from 'tests/electron/setup/test-resource-server-config';
+import { DEFAULT_ELECTRON_TEST_TIMEOUT_MS } from 'tests/electron/setup/timeouts';
+import * as WebDriverIO from 'webdriverio';
+
+// spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,
+// so tslint thinks some of the methods do not return promises.
+// tslint:disable: await-promise
+
+describe('AutomatedChecksView', () => {
+    let app: Application;
+    let client: WebDriverIO.Client<void>;
+
+    const collapsibleRuleDetailsGroupSelector = '.collapsible-rule-details-group';
+
+    beforeEach(async () => {
+        app = await createApplication();
+        client = app.client;
+    });
+
+    beforeEach(async () => {
+        await dismissTelemetryOptInDialog(app);
+
+        await ensureAppIsInDeviceConnectionDialog();
+
+        // inputs the port, validate and start scanning
+        await client.click(CommonSelectors.portNumber);
+        await client.element(CommonSelectors.portNumber).keys(testResourceServerConfig.port.toString());
+
+        await client.waitForEnabled(CommonSelectors.validateButton);
+        await client.click(CommonSelectors.validateButton);
+
+        await client.waitForEnabled(CommonSelectors.startButton);
+        await client.click(CommonSelectors.startButton);
+
+        // wait for automated checks view to be visible
+        await client.waitForVisible(AutomatedChecksViewSelectors.mainContainer, DEFAULT_ELECTRON_TEST_TIMEOUT_MS);
+    });
+
+    afterEach(async () => {
+        if (app && app.isRunning()) {
+            await app.stop();
+        }
+    });
+
+    it('show automated checks results', async () => {
+        const ruleGroups = await client.$$(`div${collapsibleRuleDetailsGroupSelector}`);
+
+        expect(ruleGroups).toHaveLength(4);
+
+        await assertExpandedRuleGroup(1, 'ImageViewName', 1);
+        await assertExpandedRuleGroup(2, 'ActiveViewName', 2);
+        await assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
+        await assertExpandedRuleGroup(4, 'ColorContrast', 1);
+    });
+
+    it('collapse groups, hiding the failure details', async () => {
+        const ruleGroups = await client.$$(`div${collapsibleRuleDetailsGroupSelector}`);
+
+        expect(ruleGroups).toHaveLength(4);
+
+        const collapseGroup = async (position: number) => {
+            await client.click(`div${collapsibleRuleDetailsGroupSelector}:nth-of-type(${position}) button`);
+        };
+
+        await collapseGroup(1);
+        await collapseGroup(2);
+        await collapseGroup(3);
+        await collapseGroup(4);
+
+        const collapsibleContentElements = await client.$$('.collapsible-container-content');
+
+        expect(collapsibleContentElements).toHaveLength(0);
+    });
+
+    async function assertExpandedRuleGroup(position: number, expectedTitle: string, expectedFailures: number): Promise<void> {
+        const title = await client.$(`div${collapsibleRuleDetailsGroupSelector}:nth-of-type(${position}) .rule-details-id`).getText();
+        expect(title).toEqual(expectedTitle);
+
+        const failures = await client.$$(`div${collapsibleRuleDetailsGroupSelector}:nth-of-type(${position}) li`);
+        expect(failures).toHaveLength(expectedFailures);
+    }
+
+    async function ensureAppIsInDeviceConnectionDialog(): Promise<void> {
+        await client.waitForVisible(CommonSelectors.rootContainer, DEFAULT_ELECTRON_TEST_TIMEOUT_MS);
+        expect(await app.webContents.getTitle()).toBe('Accessibility Insights for Mobile');
+    }
+});

--- a/src/tests/electron/tests/automated-checks.view.test.ts
+++ b/src/tests/electron/tests/automated-checks.view.test.ts
@@ -6,7 +6,7 @@ import { dismissTelemetryOptInDialog } from 'tests/electron/common/dismiss-telem
 import { AutomatedChecksViewSelectors } from 'tests/electron/common/element-identifiers/automated-checks-view-selectors';
 import { CommonSelectors } from 'tests/electron/common/element-identifiers/common-selectors';
 import { testResourceServerConfig } from 'tests/electron/setup/test-resource-server-config';
-import { DEFAULT_ELECTRON_TEST_TIMEOUT_MS } from 'tests/electron/setup/timeouts';
+import { DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS } from 'tests/electron/setup/timeouts';
 import * as WebDriverIO from 'webdriverio';
 
 // spectron wraps calls to electron APIs as promises. Unfortunately, only electron typings are used,
@@ -16,8 +16,6 @@ import * as WebDriverIO from 'webdriverio';
 describe('AutomatedChecksView', () => {
     let app: Application;
     let client: WebDriverIO.Client<void>;
-
-    const collapsibleRuleDetailsGroupSelector = '.collapsible-rule-details-group';
 
     beforeEach(async () => {
         app = await createApplication();
@@ -40,7 +38,7 @@ describe('AutomatedChecksView', () => {
         await client.click(CommonSelectors.startButton);
 
         // wait for automated checks view to be visible
-        await client.waitForVisible(AutomatedChecksViewSelectors.mainContainer, DEFAULT_ELECTRON_TEST_TIMEOUT_MS);
+        await client.waitForVisible(AutomatedChecksViewSelectors.mainContainer, DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS);
     });
 
     afterEach(async () => {
@@ -50,7 +48,7 @@ describe('AutomatedChecksView', () => {
     });
 
     it('show automated checks results', async () => {
-        const ruleGroups = await client.$$(`div${collapsibleRuleDetailsGroupSelector}`);
+        const ruleGroups = await client.$$(AutomatedChecksViewSelectors.collapsibleRuleDetailsGroup);
 
         expect(ruleGroups).toHaveLength(4);
 
@@ -61,12 +59,12 @@ describe('AutomatedChecksView', () => {
     });
 
     it('collapse groups, hiding the failure details', async () => {
-        const ruleGroups = await client.$$(`div${collapsibleRuleDetailsGroupSelector}`);
+        const ruleGroups = await client.$$(AutomatedChecksViewSelectors.collapsibleRuleDetailsGroup);
 
         expect(ruleGroups).toHaveLength(4);
 
         const collapseGroup = async (position: number) => {
-            await client.click(`div${collapsibleRuleDetailsGroupSelector}:nth-of-type(${position}) button`);
+            await client.click(AutomatedChecksViewSelectors.getCollapseExpandButtonByGroupPosition(position));
         };
 
         await collapseGroup(1);
@@ -74,21 +72,21 @@ describe('AutomatedChecksView', () => {
         await collapseGroup(3);
         await collapseGroup(4);
 
-        const collapsibleContentElements = await client.$$('.collapsible-container-content');
+        const collapsibleContentElements = await client.$$(AutomatedChecksViewSelectors.collapsibleContainerContent);
 
         expect(collapsibleContentElements).toHaveLength(0);
     });
 
     async function assertExpandedRuleGroup(position: number, expectedTitle: string, expectedFailures: number): Promise<void> {
-        const title = await client.$(`div${collapsibleRuleDetailsGroupSelector}:nth-of-type(${position}) .rule-details-id`).getText();
+        const title = await client.$(AutomatedChecksViewSelectors.getRuleDetailsIdSelector(position)).getText();
         expect(title).toEqual(expectedTitle);
 
-        const failures = await client.$$(`div${collapsibleRuleDetailsGroupSelector}:nth-of-type(${position}) li`);
+        const failures = await client.$$(AutomatedChecksViewSelectors.getLiFailuresSelector(position));
         expect(failures).toHaveLength(expectedFailures);
     }
 
     async function ensureAppIsInDeviceConnectionDialog(): Promise<void> {
-        await client.waitForVisible(CommonSelectors.rootContainer, DEFAULT_ELECTRON_TEST_TIMEOUT_MS);
+        await client.waitForVisible(CommonSelectors.rootContainer, DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS);
         expect(await app.webContents.getTitle()).toBe('Accessibility Insights for Mobile');
     }
 });

--- a/src/tests/miscellaneous/test-resource-server/resource-server-config.ts
+++ b/src/tests/miscellaneous/test-resource-server/resource-server-config.ts
@@ -3,4 +3,5 @@
 export type ResourceServerConfig = {
     port: number;
     path: string;
+    extensions?: string[];
 };

--- a/src/tests/miscellaneous/test-resource-server/resource-server.ts
+++ b/src/tests/miscellaneous/test-resource-server/resource-server.ts
@@ -12,7 +12,11 @@ export function startServer(config: ResourceServerConfig): void {
 
     const dirPath = path.join(__dirname, config.path);
 
-    app.use(serveStatic(dirPath));
+    const serveStaticOptions = {
+        extensions: config.extensions,
+    };
+
+    app.use(serveStatic(dirPath, serveStaticOptions));
     server = app.listen(config.port);
 }
 


### PR DESCRIPTION
#### Description of changes

Adding e2e test for electron app, automated checks view. Since the `CardsView` component is shared between browser extension and the electron app, and we have since some breaking changes between both, it's a good idea to move forward and add this e2e tests even if they are not in it's final form (of considering the comments from #1533)

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
