### PR TITLE
refactor: clean up window-utils usages

### DIFF
--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -4,6 +4,7 @@ import { MoreActionsMenuIcon } from 'common/icons/more-actions-menu-icon';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
 import { DirectionalHint, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import * as React from 'react';
+
 import { IssueDetailsTextGenerator } from '../../../background/issue-details-text-generator';
 import { DetailsViewActionMessageCreator } from '../../../DetailsView/actions/details-view-action-message-creator';
 import { IssueFilingDialog } from '../../../DetailsView/components/issue-filing-dialog';
@@ -12,19 +13,18 @@ import { NavigatorUtils } from '../../navigator-utils';
 import { CreateIssueDetailsTextData } from '../../types/create-issue-details-text-data';
 import { IssueFilingNeedsSettingsContentProps } from '../../types/issue-filing-needs-setting-content';
 import { IssueFilingServiceProperties, UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
-import { WindowUtils } from '../../window-utils';
 import { IssueFilingButtonDeps } from '../issue-filing-button';
-import { Toast } from '../toast';
+import { Toast, ToastDeps } from '../toast';
 import { CardInteractionSupport } from './card-interaction-support';
 import { kebabMenu, kebabMenuButton, kebabMenuCallout } from './card-kebab-menu-button.scss';
 
 export type CardKebabMenuButtonDeps = {
-    windowUtils: WindowUtils;
     issueDetailsTextGenerator: IssueDetailsTextGenerator;
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
     navigatorUtils: NavigatorUtils;
     cardInteractionSupport: CardInteractionSupport;
-} & IssueFilingButtonDeps;
+} & IssueFilingButtonDeps &
+    ToastDeps;
 
 export interface CardKebabMenuButtonState {
     showNeedsSettingsContent: boolean;

--- a/src/common/components/copy-issue-details-button.tsx
+++ b/src/common/components/copy-issue-details-button.tsx
@@ -4,13 +4,12 @@ import { IssueDetailsTextGenerator } from 'background/issue-details-text-generat
 import { NavigatorUtils } from 'common/navigator-utils';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
+
 import { CopyIcon } from '../../common/icons/copy-icon';
 import { CreateIssueDetailsTextData } from '../types/create-issue-details-text-data';
-import { WindowUtils } from '../window-utils';
-import { Toast } from './toast';
+import { Toast, ToastDeps } from './toast';
 
-export type CopyIssueDetailsButtonDeps = {
-    windowUtils: WindowUtils;
+export type CopyIssueDetailsButtonDeps = ToastDeps & {
     navigatorUtils: NavigatorUtils;
     issueDetailsTextGenerator: IssueDetailsTextGenerator;
 };

--- a/src/injected/frameCommunicators/frame-communicator.ts
+++ b/src/injected/frameCommunicators/frame-communicator.ts
@@ -5,7 +5,6 @@ import * as Q from 'q';
 import { HTMLElementUtils } from '../../common/html-element-utils';
 import { createDefaultLogger } from '../../common/logging/default-logger';
 import { Logger } from '../../common/logging/logger';
-import { WindowUtils } from '../../common/window-utils';
 import { ErrorMessageContent } from './error-message-content';
 import { FrameMessageResponseCallback, WindowMessageHandler } from './window-message-handler';
 
@@ -29,7 +28,6 @@ export class FrameCommunicator {
     constructor(
         protected windowMessageHandler: WindowMessageHandler,
         protected htmlElementUtils: HTMLElementUtils,
-        protected windowUtils: WindowUtils,
         private q: typeof Q,
         private logger: Logger = createDefaultLogger(),
     ) {

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -74,7 +74,7 @@ export class WindowInitializer {
             this.windowUtils,
             new WindowMessageMarshaller(this.browserAdapter, generateUID),
         );
-        this.frameCommunicator = new FrameCommunicator(windowMessageHandler, htmlElementUtils, this.windowUtils, Q);
+        this.frameCommunicator = new FrameCommunicator(windowMessageHandler, htmlElementUtils, Q);
         this.tabStopsListener = new TabStopsListener(this.frameCommunicator, this.windowUtils, htmlElementUtils, this.scannerUtils);
         const drawerProvider = new DrawerProvider(
             htmlElementUtils,

--- a/src/tests/unit/tests/injected/frameCommunicators/frame-communicator.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/frame-communicator.test.ts
@@ -5,7 +5,6 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { HTMLElementUtils } from '../../../../../common/html-element-utils';
 import { Logger } from '../../../../../common/logging/logger';
-import { WindowUtils } from '../../../../../common/window-utils';
 import { FrameCommunicator, MessageRequest } from '../../../../../injected/frameCommunicators/frame-communicator';
 import { FrameMessageResponseCallback, WindowMessageHandler } from '../../../../../injected/frameCommunicators/window-message-handler';
 import { HTMLCollectionOfBuilder } from '../../../common/html-collection-of-builder';
@@ -29,14 +28,12 @@ describe('FrameCommunicatorTests', () => {
     let childFrameWithoutWindowInfo: FrameInfo;
 
     let mockHtmlElementUtils: IMock<HTMLElementUtils>;
-    let mockWindowUtils: IMock<WindowUtils>;
     let mockWindowMessageHandler: IMock<WindowMessageHandler>;
 
     let mockQ: IMock<typeof Q>;
 
     beforeEach(() => {
         mockWindowMessageHandler = Mock.ofType(WindowMessageHandler);
-        mockWindowUtils = Mock.ofType(WindowUtils, MockBehavior.Strict);
         mockHtmlElementUtils = Mock.ofType(HTMLElementUtils);
 
         childFrame1Info = createFrameInfo(true);
@@ -45,13 +42,7 @@ describe('FrameCommunicatorTests', () => {
         mockQ = Mock.ofType(QStub) as any;
         const loggerMock = Mock.ofType<Logger>();
 
-        testSubject = new FrameCommunicator(
-            mockWindowMessageHandler.object,
-            mockHtmlElementUtils.object,
-            mockWindowUtils.object,
-            mockQ.object,
-            loggerMock.object,
-        );
+        testSubject = new FrameCommunicator(mockWindowMessageHandler.object, mockHtmlElementUtils.object, mockQ.object, loggerMock.object);
 
         mockHtmlElementUtils
             .setup(x => x.getAllElementsByTagName('iframe'))
@@ -106,7 +97,6 @@ describe('FrameCommunicatorTests', () => {
         testSubject.dispose().then(data => {
             expect(framesCompletedData).toMatchObject(data);
 
-            mockWindowUtils.verifyAll();
             mockHtmlElementUtils.verifyAll();
             mockWindowMessageHandler.verifyAll();
             done();
@@ -166,7 +156,6 @@ describe('FrameCommunicatorTests', () => {
         testSubject.initialize();
         disposeCallback();
         mockWindowMessageHandler.setup(x => x.dispose()).verifiable(Times.once());
-        mockWindowUtils.verifyAll();
         mockHtmlElementUtils.verifyAll();
 
         mockWindowMessageHandler.setup(x => x.dispose()).verifiable(Times.never());
@@ -254,7 +243,6 @@ describe('FrameCommunicatorTests', () => {
 
         mockQ.verifyAll();
         sendMessageToFrameStrictMock.verifyAll();
-        mockWindowUtils.verifyAll();
     });
 
     test('SendMessageToFrame should not throw if window does not exist for frame', async done => {


### PR DESCRIPTION
#### Description of changes

Found some `Deps` types not following our deps pattern and declaring `windowUtils: WindowUtils` prop when not directly using it.
Found a class that receives an instance of `WindowUtils` but never using it.

Clean those two cases on this PR.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
