### PR TITLE
chore: css modules will always use the hash value for generating class names

### DIFF
--- a/src/DetailsView/components/overview-content/overview-heading.tsx
+++ b/src/DetailsView/components/overview-content/overview-heading.tsx
@@ -6,10 +6,12 @@ import * as React from 'react';
 import { NamedFC } from '../../../common/react/named-fc';
 import { overviewHeading, overviewHeadingContent } from './overview-heading.scss';
 
+export const overviewHeadingAutomationId = 'overview-heading';
+
 export const OverviewHeading = NamedFC('OverviewHeading', () => {
     return (
         <>
-            <div className={overviewHeading}>
+            <div className={overviewHeading} data-automation-id={overviewHeadingAutomationId}>
                 <h1>Overview</h1>
                 <div className={overviewHeadingContent}>
                     This page contains a summary that indicates the progress of your assessment. An assessment is a manual experience in

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -1,10 +1,10 @@
+import { overviewHeadingAutomationId } from 'DetailsView/components/overview-content/overview-heading';
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 export const detailsViewSelectors = {
     previewFeaturesPanel: '.preview-features-panel',
-    previewFeaturesPanelToggleList: '.preview-feature-toggle-list',
 
-    testNavArea: 'nav',
     testNavLink: (testName: string): string => `nav [name=${testName}] a`,
 
     mainContent: '[role=main]',
@@ -19,5 +19,5 @@ export const detailsViewSelectors = {
 
 export const overviewSelectors = {
     overview: '.overview',
-    overviewHeading: '.overview-heading',
+    overviewHeading: `[data-automation-id=${overviewHeadingAutomationId}]`,
 };

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
@@ -71,7 +71,7 @@ exports[`Preview Features Panel Normal mode should match content in snapshot 1`]
             class="ms-Panel-content content-000"
           >
             <div
-              class="no-preview-feature-message"
+              class="no-preview-feature-message116bs"
               id="no-displayable-feature-flag-message"
             >
               No preview features are currently available to manage. Follow this page for future cool features.

--- a/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-heading.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/__snapshots__/overview-heading.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`OverviewHeading match snapshot 1`] = `
 <React.Fragment>
   <div
     className="overviewHeading"
+    data-automation-id="overview-heading"
   >
     <h1>
       Overview

--- a/src/tests/unit/tests/DetailsView/components/overview-content/overview-heading.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/overview-content/overview-heading.test.tsx
@@ -8,6 +8,7 @@ import { OverviewHeading } from '../../../../../../DetailsView/components/overvi
 describe('OverviewHeading', () => {
     test('match snapshot', () => {
         const wrapper = shallow(<OverviewHeading />);
+
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,7 @@ const TerserWebpackPlugin = require('terser-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 
-const getCSSModulesLoadersConfig = isDevMode => {
+const getCSSModulesLoadersConfig = () => {
     return {
         test: /\.scss$/,
         use: [
@@ -16,7 +16,7 @@ const getCSSModulesLoadersConfig = isDevMode => {
                 loader: 'css-loader',
                 options: {
                     modules: {
-                        localIdentName: isDevMode ? '[local]' : '[local][hash:base64:5]',
+                        localIdentName: '[local][hash:base64:5]',
                     },
                     localsConvention: 'camelCaseOnly',
                 },
@@ -95,11 +95,11 @@ const commonConfig = {
 };
 
 const devModules = {
-    rules: [...commonConfig.module.rules, getCSSModulesLoadersConfig(true)],
+    rules: [...commonConfig.module.rules, getCSSModulesLoadersConfig()],
 };
 
 const prodModules = {
-    rules: [...commonConfig.module.rules, getCSSModulesLoadersConfig(false)],
+    rules: [...commonConfig.module.rules, getCSSModulesLoadersConfig()],
 };
 
 const electronConfig = {


### PR DESCRIPTION
#### Description of changes

We've had a few issues recently where the css loads fine locally but then we run into issues in prod/insider. This is occurring due to how css-modules work. A bit of context:

The way to use css-modules is to import classNames in our code (ts/tsx files) straight from our css files. This is beneficial for us in the sense that our code/components will be directly linked to our styles rather than softly coupling our code by explicitly referencing class names in two separate places (both ts and css files).

Additionally, css-modules has a feature to uniquely generate classNames on compile time, ensuring that if a className, such as "header" is used in separate components, their css will not class because at compile time they may be generated as "headerX" and "headerY" (where X and Y are unique hashes; in our implementation, these are based off filenames). Previously, we did not do this for local builds and our e2e tests. As a result, if there was a component with some class name that was relying on css-modules but that class name was also referenced in our non-bundled css file (i.e. details-view.css), there would be a style collision **locally** but not in production/insider (since the class name here would be hashed). As such, you'd get this odd behavior where css would look one way locally but another way in insider/production, increasing the chances for bugs.

This PR ensures we use the hashed css names locally as well. The benefit of using the non-hashed names was that we would not into issues if we wanted to query for selectors in our e2e tests and makes css otherwise a bit easier to understand when working locally. The former can be dealt with by using data-* attributes (in this case, I went with data-automation-id) and the latter while a nice to have is not as important as ensuring we see these css issues locally.

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
