### PR TITLE
feat: Reduce text size in the "no failures" message in cards UI.

### DIFF
--- a/src/reports/components/report-sections/no-failed-instances-congrats.scss
+++ b/src/reports/components/report-sections/no-failed-instances-congrats.scss
@@ -8,14 +8,14 @@
 }
 
 .report-congrats-head {
-    font-size: 28px;
+    font-size: 16px;
     font-weight: 600;
     color: $primary-text;
     padding: 10px 0 10px 0;
 }
 
 .report-congrats-info {
-    font-size: 20px;
+    font-size: 14px;
     color: $secondary-text;
     padding: 10px 0 10px 0;
 }

--- a/src/reports/components/report-sections/no-failed-instances-congrats.scss
+++ b/src/reports/components/report-sections/no-failed-instances-congrats.scss
@@ -8,14 +8,14 @@
 }
 
 .report-congrats-head {
-    font-size: 48px;
+    font-size: 28px;
     font-weight: 600;
     color: $primary-text;
     padding: 10px 0 10px 0;
 }
 
 .report-congrats-info {
-    font-size: 40px;
+    font-size: 20px;
     color: $secondary-text;
     padding: 10px 0 10px 0;
 }


### PR DESCRIPTION
#### Description of changes

Reduce text size in the "no failures" message in cards UI. Use 16px instead of 48px for the "Congratulations" text, and 14px instead of 40px for the "No failed automation checks were found" message.

Before change:
![image](https://user-images.githubusercontent.com/45672944/67790238-ac726e00-fa32-11e9-9cf1-203f50a05ce6.png)

After change:
![image](https://user-images.githubusercontent.com/45672944/67792306-2b1cda80-fa36-11e9-97b6-1e40ea6aec77.png)


#### Pull request checklist

- [x] Addresses an existing issue: Fixes #1548
- [x] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [ ] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
