### PR TITLE
feat(and-screenshot): add ScreenshotViewModel type

### DIFF
--- a/src/electron/views/screenshot/screenshot-view-model.ts
+++ b/src/electron/views/screenshot/screenshot-view-model.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ScreenshotData } from 'common/types/store-data/unified-data-interface';
+import { BoundingRectangle } from 'electron/platform/android/scan-results';
+
+export type ScreenshotViewModel = {
+    screenshotData: ScreenshotData;
+    highlightBoxRectangles: BoundingRectangle[];
+    deviceName: string;
+};


### PR DESCRIPTION
#### Description of changes

Small PR introducing the ViewModel type for the android screenshot component. Specific info is subject to change later, this is the minimum data that I think would be necessary given the current feature mockups.

Discussed offline with @waabid / @smoralesd about what the best folder layout might be for the view/viewmodel/viewmodelprovider; we agreed that it made the most sense to co-locate them all under `/electron/views/screenshot/` because they're so coupled to one another, regardless of the provider not technically being a view.

#### Pull request checklist

- [x] Addresses an existing issue: 1628911
- [n/a, bag of data only] Added relevant unit test for your changes. (`yarn test`)
- [n/a, bag of data only] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
