### PR TITLE
feat: tab controller only fires tab update actions when URL has changed

### DIFF
--- a/src/background/tab-controller.ts
+++ b/src/background/tab-controller.ts
@@ -49,7 +49,7 @@ export class TabController {
         this.browserAdapter.addListenerToTabsOnRemoved(this.onTargetTabRemoved);
         this.browserAdapter.addListenerOnWindowsFocusChanged(this.onWindowFocusChanged);
         this.browserAdapter.addListenerToTabsOnActivated(this.onTabActivated);
-        this.browserAdapter.addListenerToTabsOnUpdated(this.handleTabUpdate);
+        this.browserAdapter.addListenerToTabsOnUpdated(this.handleTabUpdateOnUrlHasChanged);
 
         this.detailsViewController.setupDetailsViewTabRemovedHandler(this.onDetailsViewTabRemoved);
     }
@@ -104,6 +104,12 @@ export class TabController {
         } else {
             this.addTabContext(tabId);
             this.sendTabUpdateAction(tabId);
+        }
+    };
+
+    private handleTabUpdateOnUrlHasChanged = (tabId: number, changeInfo: chrome.tabs.TabChangeInfo): void => {
+        if (changeInfo.url) {
+            this.handleTabUpdate(tabId);
         }
     };
 

--- a/src/background/tab-controller.ts
+++ b/src/background/tab-controller.ts
@@ -36,7 +36,7 @@ export class TabController {
         this.browserAdapter.tabsQuery({}, (tabs: chrome.tabs.Tab[]) => {
             if (tabs) {
                 tabs.forEach(tab => {
-                    this.handleTabUpdate(tab.id);
+                    this.postTabUpdate(tab.id);
                 });
             }
         });
@@ -49,14 +49,14 @@ export class TabController {
         this.browserAdapter.addListenerToTabsOnRemoved(this.onTargetTabRemoved);
         this.browserAdapter.addListenerOnWindowsFocusChanged(this.onWindowFocusChanged);
         this.browserAdapter.addListenerToTabsOnActivated(this.onTabActivated);
-        this.browserAdapter.addListenerToTabsOnUpdated(this.handleTabUpdateOnUrlHasChanged);
+        this.browserAdapter.addListenerToTabsOnUpdated(this.handleTabUpdate);
 
         this.detailsViewController.setupDetailsViewTabRemovedHandler(this.onDetailsViewTabRemoved);
     }
 
     private onTabNavigated = (details: chrome.webNavigation.WebNavigationFramedCallbackDetails): void => {
         if (details.frameId === 0) {
-            this.handleTabUpdate(details.tabId);
+            this.postTabUpdate(details.tabId);
         }
     };
 
@@ -98,7 +98,7 @@ export class TabController {
         );
     };
 
-    private handleTabUpdate = (tabId: number): void => {
+    private postTabUpdate = (tabId: number): void => {
         if (this.hasTabContext(tabId)) {
             this.sendTabChangedAction(tabId);
         } else {
@@ -107,9 +107,9 @@ export class TabController {
         }
     };
 
-    private handleTabUpdateOnUrlHasChanged = (tabId: number, changeInfo: chrome.tabs.TabChangeInfo): void => {
+    private handleTabUpdate = (tabId: number, changeInfo: chrome.tabs.TabChangeInfo): void => {
         if (changeInfo.url) {
-            this.handleTabUpdate(tabId);
+            this.postTabUpdate(tabId);
         }
     };
 


### PR DESCRIPTION
#### Description of changes

We don't really care for all tab changes; only ones that affect the URL (although I can see us caring for title at some point as well). As a result, we shouldn't fire tab update actions until we see this.

The result is we do not throw data away after scroll events cause tab update events (for loading, for example).

#### Pull request checklist

- [n/a] Addresses an existing issue: Fixes #0000
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
