### PR TITLE
feat(and-screenshot): create a ScreenshotViewModelProvider

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -16,6 +16,7 @@ import { WindowStateStoreData } from 'electron/flux/types/window-state-store-dat
 import { TitleBar, TitleBarDeps } from 'electron/views/automated-checks/components/title-bar';
 import { mainContentWrapper } from 'electron/views/device-connect-view/device-connect-view.scss';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
+import { ScreenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
 import * as React from 'react';
 
 import { automatedChecksView } from './automated-checks-view.scss';
@@ -29,6 +30,7 @@ export type AutomatedChecksViewDeps = CommandBarDeps &
         windowStateActionCreator: WindowStateActionCreator;
         getUnifiedRuleResultsDelegate: GetUnifiedRuleResultsDelegate;
         getCardSelectionViewData: GetCardSelectionViewData;
+        screenshotViewModelProvider: ScreenshotViewModelProvider;
     };
 
 export type AutomatedChecksViewProps = {

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -62,6 +62,7 @@ import { DeviceStore } from '../flux/store/device-store';
 import { ElectronLink } from './device-connect-view/components/electron-link';
 import { sendAppInitializedTelemetryEvent } from './device-connect-view/send-app-initialized-telemetry';
 import { RootContainerRenderer } from './root-container/root-container-renderer';
+import { screenshotViewModelProvider } from './screenshot/screenshot-view-model-provider';
 
 initializeFabricIcons();
 
@@ -202,6 +203,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
             platformInfo: new PlatformInfo(process),
             getUnifiedRuleResultsDelegate: getUnifiedRuleResults,
             getCardSelectionViewData: getCardSelectionViewData,
+            screenshotViewModelProvider,
             ...cardsViewDeps,
         },
     };

--- a/src/electron/views/screenshot/screenshot-view-model-provider.ts
+++ b/src/electron/views/screenshot/screenshot-view-model-provider.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UnifiedResult, UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import { BoundingRectangle } from 'electron/platform/android/scan-results';
+import { ScreenshotViewModel } from './screenshot-view-model';
+
+export type ScreenshotViewModelProvider = typeof screenshotViewModelProvider;
+
+export function screenshotViewModelProvider(
+    unifiedScanResultStoreData: UnifiedScanResultStoreData,
+    highlightedResultUids: string[],
+): ScreenshotViewModel {
+    const screenshotData = unifiedScanResultStoreData.screenshotData;
+
+    const highlightBoxRectangles =
+        screenshotData == null ? [] : getHighlightBoxRectangles(unifiedScanResultStoreData.results, highlightedResultUids);
+
+    return {
+        screenshotData,
+        highlightBoxRectangles,
+        deviceName: null, // Future work will want to pipe this in via unifiedScanResultStore.platformInfo
+    };
+}
+
+function getHighlightBoxRectangles(results: UnifiedResult[], highlightedUids: string[]): BoundingRectangle[] {
+    const highlightedResults = results.filter(result => highlightedUids.includes(result.uid));
+
+    return highlightedResults.map(result => result.descriptors.boundingRectangle).filter(maybeRect => maybeRect != null);
+}

--- a/src/electron/views/screenshot/screenshot-view-model.ts
+++ b/src/electron/views/screenshot/screenshot-view-model.ts
@@ -4,7 +4,9 @@ import { ScreenshotData } from 'common/types/store-data/unified-data-interface';
 import { BoundingRectangle } from 'electron/platform/android/scan-results';
 
 export type ScreenshotViewModel = {
-    screenshotData: ScreenshotData;
+    // "screenshotData == null" means that the view should show a "screenshot unavailable" message
+    screenshotData?: ScreenshotData;
     highlightBoxRectangles: BoundingRectangle[];
-    deviceName: string;
+    // "deviceName == null" means that the view should omit the "device name" subtitle
+    deviceName?: string;
 };

--- a/src/tests/unit/tests/electron/views/screenshot/screenshot-view-model-provider.test.ts
+++ b/src/tests/unit/tests/electron/views/screenshot/screenshot-view-model-provider.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { PlatformData, ScreenshotData, UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import { BoundingRectangle } from 'electron/platform/android/scan-results';
+import { screenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
+import { exampleUnifiedResult } from 'tests/unit/tests/common/components/cards/sample-view-model-data';
+
+describe('screenshotViewModelProvider', () => {
+    it('provides a null screenshotData when the UnifiedScanResultStore has no screenshotData', () => {
+        const unifiedScanResultStoreData = {
+            screenshotData: null,
+            results: [],
+        } as UnifiedScanResultStoreData;
+
+        const output = screenshotViewModelProvider(unifiedScanResultStoreData, []);
+
+        expect(output.screenshotData).toBeNull();
+    });
+
+    it('provides no highlight boxes when the UnifiedScanResultStore has no screenshotData', () => {
+        const unifiedScanResultStoreData = {
+            screenshotData: null,
+            results: [exampleUnifiedResult],
+        } as UnifiedScanResultStoreData;
+
+        const output = screenshotViewModelProvider(unifiedScanResultStoreData, [exampleUnifiedResult.uid]);
+
+        expect(output.highlightBoxRectangles).toStrictEqual([]);
+    });
+
+    it("provides the store's screenshotData when the UnifiedScanResultStore has screenshotData", () => {
+        const storeScreenshotData: ScreenshotData = { base64PngData: 'test-data' };
+        const unifiedScanResultStoreData = {
+            screenshotData: storeScreenshotData,
+            results: [],
+        } as UnifiedScanResultStoreData;
+
+        const output = screenshotViewModelProvider(unifiedScanResultStoreData, []);
+
+        expect(output.screenshotData).toBe(storeScreenshotData);
+    });
+
+    const platformInfosWithoutDeviceName: PlatformData[] = [null, {} as PlatformData];
+    it.each(platformInfosWithoutDeviceName)(
+        'provides a null deviceName when the UnifiedScanResultStore has platformInfo %p',
+        (platformInfo?: PlatformData) => {
+            const unifiedScanResultStoreData = {
+                screenshotData: null,
+                results: [],
+                platformInfo,
+            } as UnifiedScanResultStoreData;
+
+            const output = screenshotViewModelProvider(unifiedScanResultStoreData, []);
+
+            expect(output.deviceName).toBeNull();
+        },
+    );
+
+    it('provides highlightBoxRectangles for each result in highlightedResultUids with a boundingRectangle', () => {
+        const expectedBoundingRectangle: BoundingRectangle = {
+            top: 1,
+            left: 2,
+            bottom: 3,
+            right: 4,
+        };
+        const unexpectedBoundingRectangle: BoundingRectangle = {
+            top: 5,
+            left: 6,
+            bottom: 7,
+            right: 8,
+        };
+        const highlightedUids = ['uid-highlighted-1', 'uid-highlighted-2'];
+        const resultCases = {
+            highlightedResultWithBoundingRectangle: {
+                ...exampleUnifiedResult,
+                uid: 'uid-highlighted-1',
+                descriptors: {
+                    boundingRectangle: expectedBoundingRectangle,
+                },
+            },
+            highlightedResultWithoutBoundingRectangle: {
+                ...exampleUnifiedResult,
+                uid: 'uid-highlighted-2',
+                descriptors: {},
+            },
+            nonHighlightedResultWithBoundingRectangle: {
+                ...exampleUnifiedResult,
+                uid: 'uid-non-highlighted-1',
+                descriptors: {
+                    boundingRectangle: unexpectedBoundingRectangle,
+                },
+            },
+            nonHighlightedResultWithoutBoundingRectangle: {
+                ...exampleUnifiedResult,
+                uid: 'uid-non-highlighted-2',
+                descriptors: {},
+            },
+        };
+
+        const unifiedScanResultStoreData = {
+            screenshotData: { base64PngData: 'any-non-null-screenshot-data' },
+            results: Object.values(resultCases),
+        } as UnifiedScanResultStoreData;
+
+        const output = screenshotViewModelProvider(unifiedScanResultStoreData, highlightedUids);
+
+        expect(output.highlightBoxRectangles).toStrictEqual([
+            resultCases.highlightedResultWithBoundingRectangle.descriptors.boundingRectangle,
+        ]);
+    });
+});


### PR DESCRIPTION
#### Description of changes

Implements a `ScreenshotViewModelProvider` to convert from inputs of the form `AutomatedChecksView` already has to inputs in the format we expect `ScreenshotView` and its children to need. Wires it up as a dep to `AutomatedChecksView`, which will be using it to create the `ScreenshotViewModel` that its future child `ScreenshotView` will be accepting as a prop.

Out of scope:
* Wiring up `AutomatedChecksView` to invoke and pass down the provider (1628927)
* Wiring up the `deviceName` input (requires separate changes to UnifiedScanResultStoreData, 1639043)

#### Pull request checklist

- [x] Addresses an existing issue: 1628918
- [x] Added relevant unit test for your changes. (`yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
