### PR TITLE
refactor: remove unused updateVisibility workflow

### DIFF
--- a/src/ad-hoc-visualizations/color/visualization.tsx
+++ b/src/ad-hoc-visualizations/color/visualization.tsx
@@ -48,6 +48,5 @@ export const ColorAdHocVisualization: VisualizationConfiguration = {
     getDrawer: provider => provider.createSingleTargetDrawer('insights-grey-scale-container'),
     getSwitchToTargetTabOnScan: () => false,
     getInstanceIdentiferGenerator: () => generateUID,
-    getUpdateVisibility: () => false,
     guidance,
 };

--- a/src/ad-hoc-visualizations/headings/visualization.tsx
+++ b/src/ad-hoc-visualizations/headings/visualization.tsx
@@ -49,6 +49,5 @@ export const HeadingsAdHocVisualization: VisualizationConfiguration = {
     getDrawer: provider => provider.createHeadingsDrawer(),
     getSwitchToTargetTabOnScan: () => false,
     getInstanceIdentiferGenerator: () => generateUID,
-    getUpdateVisibility: () => false,
     guidance,
 };

--- a/src/ad-hoc-visualizations/issues/visualization.tsx
+++ b/src/ad-hoc-visualizations/issues/visualization.tsx
@@ -55,5 +55,4 @@ export const IssuesAdHocVisualization: VisualizationConfiguration = {
     getDrawer: provider => provider.createIssuesDrawer(),
     getSwitchToTargetTabOnScan: () => false,
     getInstanceIdentiferGenerator: () => generateUID,
-    getUpdateVisibility: () => false,
 };

--- a/src/ad-hoc-visualizations/landmarks/visualization.tsx
+++ b/src/ad-hoc-visualizations/landmarks/visualization.tsx
@@ -49,6 +49,5 @@ export const LandmarksAdHocVisualization: VisualizationConfiguration = {
     getDrawer: provider => provider.createLandmarksDrawer(),
     getSwitchToTargetTabOnScan: () => false,
     getInstanceIdentiferGenerator: () => generateUID,
-    getUpdateVisibility: () => false,
     guidance,
 };

--- a/src/ad-hoc-visualizations/tab-stops/visualization.tsx
+++ b/src/ad-hoc-visualizations/tab-stops/visualization.tsx
@@ -47,6 +47,5 @@ export const TabStopsAdHocVisualization: VisualizationConfiguration = {
     getNotificationMessage: selectorMap => 'Start pressing Tab to start visualizing tab stops.',
     getSwitchToTargetTabOnScan: () => true,
     getInstanceIdentiferGenerator: () => generateUID,
-    getUpdateVisibility: () => false,
     guidance,
 };

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -151,7 +151,6 @@ export class AssessmentBuilder {
             getNotificationMessage: getNotificationMessage,
             getSwitchToTargetTabOnScan: this.getSwitchToTargetTabOnScan(requirements),
             getInstanceIdentiferGenerator: this.getInstanceIdentifier(requirements),
-            getUpdateVisibility: this.getUpdateVisibility(requirements),
         };
 
         this.buildRequirementReportDescription(requirements);
@@ -230,7 +229,6 @@ export class AssessmentBuilder {
             getNotificationMessage: getNotificationMessage,
             getSwitchToTargetTabOnScan: AssessmentBuilder.getSwitchToTargetTabOnScan(requirements),
             getInstanceIdentiferGenerator: AssessmentBuilder.getInstanceIdentifier(requirements),
-            getUpdateVisibility: AssessmentBuilder.getUpdateVisibility(requirements),
         } as AssesssmentVisualizationConfiguration;
 
         AssessmentBuilder.buildRequirementReportDescription(requirements);
@@ -301,16 +299,6 @@ export class AssessmentBuilder {
         }
 
         return children;
-    }
-
-    private static getUpdateVisibility(requirements: Requirement[]): (requirement: string) => boolean {
-        return (requirementKey: string): boolean => {
-            const requirementConfig = AssessmentBuilder.getRequirementConfig(requirements, requirementKey);
-            if (requirementConfig == null || requirementConfig.updateVisibility == null) {
-                return true;
-            }
-            return requirementConfig.updateVisibility;
-        };
     }
 
     private static nullScanPolicy(scan, data): void {}

--- a/src/assessments/color/test-steps/auditory-cues.tsx
+++ b/src/assessments/color/test-steps/auditory-cues.tsx
@@ -37,5 +37,4 @@ export const AuditoryCues: Requirement = {
     isManual: true,
     ...content,
     guidanceLinks: [link.WCAG_1_3_3],
-    updateVisibility: false,
 };

--- a/src/assessments/color/test-steps/flashing.tsx
+++ b/src/assessments/color/test-steps/flashing.tsx
@@ -53,5 +53,4 @@ export const Flashing: Requirement = {
     isManual: true,
     ...content,
     guidanceLinks: [link.WCAG_2_3_1],
-    updateVisibility: false,
 };

--- a/src/assessments/color/test-steps/sensory-characteristics.tsx
+++ b/src/assessments/color/test-steps/sensory-characteristics.tsx
@@ -43,5 +43,4 @@ export const SensoryCharacteristics: Requirement = {
     isManual: true,
     ...content,
     guidanceLinks: [link.WCAG_1_3_3],
-    updateVisibility: false,
 };

--- a/src/assessments/color/test-steps/use-of-color.tsx
+++ b/src/assessments/color/test-steps/use-of-color.tsx
@@ -54,7 +54,6 @@ export const UseOfColor: Requirement = {
                 testType: VisualizationType.ColorSensoryAssessment,
             }),
         ),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
     getDrawer: provider => provider.createSingleTargetDrawer('insights-grey-scale-container'),
 };

--- a/src/assessments/contrast/test-steps/state-changes.tsx
+++ b/src/assessments/contrast/test-steps/state-changes.tsx
@@ -98,6 +98,5 @@ export const StateChanges: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createNonTextComponentDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/contrast/test-steps/ui-components.tsx
+++ b/src/assessments/contrast/test-steps/ui-components.tsx
@@ -89,6 +89,5 @@ export const UIComponents: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createNonTextComponentDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/custom-widgets/test-steps/cues.tsx
+++ b/src/assessments/custom-widgets/test-steps/cues.tsx
@@ -110,6 +110,5 @@ export const Cues: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/custom-widgets/test-steps/design-pattern.tsx
+++ b/src/assessments/custom-widgets/test-steps/design-pattern.tsx
@@ -91,6 +91,5 @@ export const DesignPattern: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createCustomWidgetsDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/custom-widgets/test-steps/expected-input.tsx
+++ b/src/assessments/custom-widgets/test-steps/expected-input.tsx
@@ -88,6 +88,5 @@ export const ExpectedInput: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/custom-widgets/test-steps/instructions.tsx
+++ b/src/assessments/custom-widgets/test-steps/instructions.tsx
@@ -92,6 +92,5 @@ export const Instructions: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
+++ b/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
@@ -83,6 +83,5 @@ export const KeyboardInteraction: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/custom-widgets/test-steps/role-state-property.tsx
+++ b/src/assessments/custom-widgets/test-steps/role-state-property.tsx
@@ -100,6 +100,5 @@ export const RoleStateProperty: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/keyboard-interaction/test-steps/keyboard-navigation.tsx
+++ b/src/assessments/keyboard-interaction/test-steps/keyboard-navigation.tsx
@@ -87,6 +87,6 @@ export const KeyboardNavigation: Requirement = {
         }),
     getNotificationMessage: selectorMap => 'Start pressing Tab to start visualizing tab stops.',
     switchToTargetTabOnScan: true,
-    updateVisibility: false,
+
     generateInstanceIdentifier: generateUID,
 };

--- a/src/assessments/keyboard-interaction/test-steps/keyboard-navigation.tsx
+++ b/src/assessments/keyboard-interaction/test-steps/keyboard-navigation.tsx
@@ -87,6 +87,5 @@ export const KeyboardNavigation: Requirement = {
         }),
     getNotificationMessage: selectorMap => 'Start pressing Tab to start visualizing tab stops.',
     switchToTargetTabOnScan: true,
-
     generateInstanceIdentifier: generateUID,
 };

--- a/src/assessments/landmarks/test-steps/landmark-roles.tsx
+++ b/src/assessments/landmarks/test-steps/landmark-roles.tsx
@@ -98,7 +98,6 @@ export const LandmarkRoles: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createLandmarksDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
     ...content,
 };

--- a/src/assessments/landmarks/test-steps/no-repeating-content.tsx
+++ b/src/assessments/landmarks/test-steps/no-repeating-content.tsx
@@ -44,7 +44,7 @@ export const NoRepeatingContent: Requirement = {
                 testType: VisualizationType.LandmarksAssessment,
             }),
         ),
-    updateVisibility: false,
+
     getDrawer: provider => provider.createLandmarksDrawer(),
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
     ...content,

--- a/src/assessments/landmarks/test-steps/no-repeating-content.tsx
+++ b/src/assessments/landmarks/test-steps/no-repeating-content.tsx
@@ -44,7 +44,6 @@ export const NoRepeatingContent: Requirement = {
                 testType: VisualizationType.LandmarksAssessment,
             }),
         ),
-
     getDrawer: provider => provider.createLandmarksDrawer(),
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
     ...content,

--- a/src/assessments/landmarks/test-steps/primary-content.tsx
+++ b/src/assessments/landmarks/test-steps/primary-content.tsx
@@ -42,7 +42,6 @@ export const PrimaryContent: Requirement = {
                 testType: VisualizationType.LandmarksAssessment,
             }),
         ),
-
     getDrawer: provider => provider.createLandmarksDrawer(),
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
     ...content,

--- a/src/assessments/landmarks/test-steps/primary-content.tsx
+++ b/src/assessments/landmarks/test-steps/primary-content.tsx
@@ -42,7 +42,7 @@ export const PrimaryContent: Requirement = {
                 testType: VisualizationType.LandmarksAssessment,
             }),
         ),
-    updateVisibility: false,
+
     getDrawer: provider => provider.createLandmarksDrawer(),
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
     ...content,

--- a/src/assessments/links/test-steps/link-function.tsx
+++ b/src/assessments/links/test-steps/link-function.tsx
@@ -96,6 +96,5 @@ export const LinkFunction: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/links/test-steps/link-purpose.tsx
+++ b/src/assessments/links/test-steps/link-purpose.tsx
@@ -99,6 +99,5 @@ export const LinkPurpose: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/native-widgets/test-steps/autocomplete.tsx
+++ b/src/assessments/native-widgets/test-steps/autocomplete.tsx
@@ -83,6 +83,5 @@ export const Autocomplete: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: true,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/native-widgets/test-steps/cues.tsx
+++ b/src/assessments/native-widgets/test-steps/cues.tsx
@@ -112,6 +112,5 @@ export const Cues: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/native-widgets/test-steps/expected-input.tsx
+++ b/src/assessments/native-widgets/test-steps/expected-input.tsx
@@ -83,6 +83,5 @@ export const ExpectedInput: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/native-widgets/test-steps/instructions.tsx
+++ b/src/assessments/native-widgets/test-steps/instructions.tsx
@@ -94,6 +94,5 @@ export const Instructions: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/native-widgets/test-steps/widget-function.tsx
+++ b/src/assessments/native-widgets/test-steps/widget-function.tsx
@@ -98,6 +98,5 @@ export const WidgetFunction: Requirement = {
             }),
         ),
     getDrawer: provider => provider.createHighlightBoxDrawer(),
-    updateVisibility: false,
     getVisualHelperToggle: props => <AssessmentVisualizationEnabledToggle {...props} />,
 };

--- a/src/assessments/semantics/test-steps/css-content.tsx
+++ b/src/assessments/semantics/test-steps/css-content.tsx
@@ -87,7 +87,6 @@ export const CssContent: Requirement = {
     isManual: true,
     guidanceLinks: [link.WCAG_1_3_1],
     ...content,
-
     getAnalyzer: provider =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({

--- a/src/assessments/semantics/test-steps/css-content.tsx
+++ b/src/assessments/semantics/test-steps/css-content.tsx
@@ -87,7 +87,7 @@ export const CssContent: Requirement = {
     isManual: true,
     guidanceLinks: [link.WCAG_1_3_1],
     ...content,
-    updateVisibility: false,
+
     getAnalyzer: provider =>
         provider.createRuleAnalyzer(
             AnalyzerConfigurationFactory.forScanner({

--- a/src/assessments/semantics/test-steps/data-tables.tsx
+++ b/src/assessments/semantics/test-steps/data-tables.tsx
@@ -53,5 +53,4 @@ export const DataTables: Requirement = {
     isManual: true,
     ...content,
     guidanceLinks: [link.WCAG_1_3_1],
-    updateVisibility: false,
 };

--- a/src/assessments/semantics/test-steps/emphasis.tsx
+++ b/src/assessments/semantics/test-steps/emphasis.tsx
@@ -34,5 +34,4 @@ export const SemanticsEmphasis: Requirement = {
     isManual: true,
     ...content,
     guidanceLinks: [link.WCAG_1_3_1],
-    updateVisibility: false,
 };

--- a/src/assessments/semantics/test-steps/letter-spacing.tsx
+++ b/src/assessments/semantics/test-steps/letter-spacing.tsx
@@ -33,5 +33,4 @@ export const SemanticsLetterSpacing: Requirement = {
     isManual: true,
     ...content,
     guidanceLinks: [link.WCAG_1_3_1],
-    updateVisibility: false,
 };

--- a/src/assessments/semantics/test-steps/lists.tsx
+++ b/src/assessments/semantics/test-steps/lists.tsx
@@ -54,5 +54,4 @@ export const SemanticsLists: Requirement = {
     isManual: true,
     ...content,
     guidanceLinks: [link.WCAG_1_3_1],
-    updateVisibility: false,
 };

--- a/src/assessments/semantics/test-steps/quotes.tsx
+++ b/src/assessments/semantics/test-steps/quotes.tsx
@@ -37,5 +37,4 @@ export const SemanticsQuotes: Requirement = {
     isManual: true,
     ...content,
     guidanceLinks: [link.WCAG_1_3_1],
-    updateVisibility: false,
 };

--- a/src/assessments/types/requirement.ts
+++ b/src/assessments/types/requirement.ts
@@ -36,7 +36,6 @@ export interface Requirement {
     getVisualHelperToggle?: (props: VisualHelperToggleConfig) => JSX.Element;
     visualizationInstanceProcessor?: VisualizationInstanceProcessorCallback<PropertyBags, PropertyBags>;
     getDrawer?: (provider: DrawerProvider, featureFlagStoreData?: FeatureFlagStoreData) => Drawer;
-    updateVisibility?: boolean;
     getNotificationMessage?: (selectorMap: DictionaryStringTo<any>) => string;
     doNotScanByDefault?: boolean;
     switchToTargetTabOnScan?: boolean;

--- a/src/assessments/visible-focus-order/test-steps/focus-order.tsx
+++ b/src/assessments/visible-focus-order/test-steps/focus-order.tsx
@@ -68,7 +68,6 @@ export const FocusOrder: Requirement = {
     getVisualHelperToggle: props => <RestartScanVisualHelperToggle {...props} />,
     getDrawer: provider => provider.createSVGDrawer(),
     visualizationInstanceProcessor: VisualizationInstanceProcessor.addOrder,
-
     getNotificationMessage: selectorMap => 'Start pressing Tab to start visualizing tab stops.',
     doNotScanByDefault: true,
     switchToTargetTabOnScan: true,

--- a/src/assessments/visible-focus-order/test-steps/focus-order.tsx
+++ b/src/assessments/visible-focus-order/test-steps/focus-order.tsx
@@ -68,7 +68,7 @@ export const FocusOrder: Requirement = {
     getVisualHelperToggle: props => <RestartScanVisualHelperToggle {...props} />,
     getDrawer: provider => provider.createSVGDrawer(),
     visualizationInstanceProcessor: VisualizationInstanceProcessor.addOrder,
-    updateVisibility: false,
+
     getNotificationMessage: selectorMap => 'Start pressing Tab to start visualizing tab stops.',
     doNotScanByDefault: true,
     switchToTargetTabOnScan: true,

--- a/src/assessments/visible-focus-order/test-steps/visible-focus.tsx
+++ b/src/assessments/visible-focus-order/test-steps/visible-focus.tsx
@@ -69,6 +69,6 @@ export const VisibleFocus: Requirement = {
         }),
     getNotificationMessage: selectorMap => 'Start pressing Tab to start visualizing tab stops.',
     switchToTargetTabOnScan: true,
-    updateVisibility: false,
+
     generateInstanceIdentifier: generateUID,
 };

--- a/src/assessments/visible-focus-order/test-steps/visible-focus.tsx
+++ b/src/assessments/visible-focus-order/test-steps/visible-focus.tsx
@@ -69,6 +69,5 @@ export const VisibleFocus: Requirement = {
         }),
     getNotificationMessage: selectorMap => 'Start pressing Tab to start visualizing tab stops.',
     switchToTargetTabOnScan: true,
-
     generateInstanceIdentifier: generateUID,
 };

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -21,15 +21,6 @@ export interface SelectRequirementPayload extends BaseActionPayload {
     selectedTest: VisualizationType;
 }
 
-export interface UpdateInstanceVisibilityPayload extends ToggleActionPayload {
-    selector: string;
-    isVisible: boolean;
-}
-
-export interface UpdateVisibilityPayload {
-    payloadBatch: UpdateInstanceVisibilityPayload[];
-}
-
 export interface AssessmentToggleActionPayload extends ToggleActionPayload {
     requirement: string;
 }

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -21,7 +21,6 @@ import {
     RemoveFailureInstancePayload,
     SelectRequirementPayload,
     ToggleActionPayload,
-    UpdateVisibilityPayload,
 } from './action-payloads';
 import { AssessmentActions } from './assessment-actions';
 
@@ -59,7 +58,6 @@ export class AssessmentActionCreator {
         this.interpreter.registerTypeToPayloadCallback(AssessmentMessages.AddResultDescription, this.onAddResultDescription);
         this.interpreter.registerTypeToPayloadCallback(AssessmentMessages.RemoveFailureInstance, this.onRemoveFailureInstance);
         this.interpreter.registerTypeToPayloadCallback(AssessmentMessages.EditFailureInstance, this.onEditFailureInstance);
-        this.interpreter.registerTypeToPayloadCallback(AssessmentMessages.UpdateInstanceVisibility, this.onUpdateInstanceVisibility);
         this.interpreter.registerTypeToPayloadCallback(AssessmentMessages.PassUnmarkedInstances, this.onPassUnmarkedInstances);
         this.interpreter.registerTypeToPayloadCallback(AssessmentMessages.ScanUpdate, this.onScanUpdate);
         this.interpreter.registerTypeToPayloadCallback(AssessmentMessages.TrackingCompleted, this.onTrackingCompleted);
@@ -146,10 +144,6 @@ export class AssessmentActionCreator {
 
     private onStartOverAllAssessments = (payload: ToggleActionPayload, tabId: number): void => {
         this.assessmentActions.resetAllAssessmentsData.invoke(tabId);
-    };
-
-    private onUpdateInstanceVisibility = (payload: UpdateVisibilityPayload): void => {
-        this.assessmentActions.updateInstanceVisibility.invoke(payload);
     };
 
     private onAssessmentScanCompleted = (payload: ScanCompletedPayload<any>, tabId: number): void => {

--- a/src/background/actions/assessment-actions.ts
+++ b/src/background/actions/assessment-actions.ts
@@ -14,7 +14,6 @@ import {
     SelectRequirementPayload,
     ToggleActionPayload,
     UpdateSelectedDetailsViewPayload,
-    UpdateVisibilityPayload,
 } from './action-payloads';
 
 export class AssessmentActions {
@@ -28,7 +27,6 @@ export class AssessmentActions {
     public readonly passUnmarkedInstance = new Action<ToggleActionPayload>();
     public readonly changeAssessmentVisualizationState = new Action<ChangeInstanceSelectionPayload>();
     public readonly changeAssessmentVisualizationStateForAll = new Action<ChangeInstanceSelectionPayload>();
-    public readonly updateInstanceVisibility = new Action<UpdateVisibilityPayload>();
     public readonly undoInstanceStatusChange = new Action<AssessmentActionInstancePayload>();
     public readonly undoRequirementStatusChange = new Action<ChangeRequirementStatusPayload>();
     public readonly getCurrentState = new Action<void>();

--- a/src/common/configs/assesssment-visualization-configuration.ts
+++ b/src/common/configs/assesssment-visualization-configuration.ts
@@ -35,5 +35,4 @@ export interface AssesssmentVisualizationConfiguration {
     getDrawer: (provider: DrawerProvider, testStep?: string) => Drawer;
     getSwitchToTargetTabOnScan: (testStep?: string) => boolean;
     getInstanceIdentiferGenerator: (testStep?: string) => (instance: UniquelyIdentifiableInstances) => string;
-    getUpdateVisibility: (testStep?: string) => boolean;
 }

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -130,7 +130,6 @@ export class Messages {
         EditFailureInstance: `${messagePrefix}/assessment/editFailureInstance`,
         PassUnmarkedInstances: `${messagePrefix}/assessment/passUnmarkedInstances`,
         ChangeVisualizationStateForAll: `${messagePrefix}/assessment/changeVisualizationStateForAll`,
-        UpdateInstanceVisibility: `${messagePrefix}/assessment/updateInstanceVisibility`,
         ScanUpdate: `${messagePrefix}/assessment/scanUpdate`,
         ContinuePreviousAssessment: `${messagePrefix}/assessment/continuePreviousAssessment`,
     };

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -47,13 +47,11 @@ describe('AssessmentBuilderTest', () => {
             guidanceLinks: [],
             name: 'requirement name',
             generateInstanceIdentifier: getInstanceIdentifierMock.object,
-            updateVisibility: false,
         };
 
         const requirement2: Requirement = _.cloneDeep(requirement);
         requirement2.key = 'requirement2';
         requirement2.generateInstanceIdentifier = null;
-        requirement2.updateVisibility = null;
 
         const baseAssessment: ManualAssessment = {
             key: 'manualAssessmentKey',
@@ -169,7 +167,6 @@ describe('AssessmentBuilderTest', () => {
             generateInstanceIdentifier: getInstanceIdentifierMock.object,
             getDrawer: getDrawerMock.object,
             switchToTargetTabOnScan: true,
-            updateVisibility: false,
         };
         const scannerStub = {
             getAllCompletedInstances: {},
@@ -192,7 +189,6 @@ describe('AssessmentBuilderTest', () => {
         requirement5.getDrawer = null;
         requirement5.switchToTargetTabOnScan = null;
         requirement5.generateInstanceIdentifier = null;
-        requirement5.updateVisibility = null;
         requirement5.isManual = false;
         const requirement6: Requirement = _.cloneDeep(requirement1);
         requirement6.key = 'requirement6';

--- a/src/tests/unit/tests/assessments/assessment-builder.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-builder.test.tsx
@@ -119,9 +119,6 @@ describe('AssessmentBuilderTest', () => {
         ).toEqual(requirement2.renderReportDescription());
         expect(config.getInstanceIdentiferGenerator(requirement2.key)).toEqual(InstanceIdentifierGenerator.defaultHtmlSelectorIdentifier);
         expect(config.getInstanceIdentiferGenerator('non existent key')).toEqual(InstanceIdentifierGenerator.defaultHtmlSelectorIdentifier);
-        expect(config.getUpdateVisibility(selectedRequirementKey)).toBe(false);
-        expect(config.getUpdateVisibility(requirement2.key)).toBe(true);
-        expect(config.getUpdateVisibility('non existent key')).toBe(true);
         expect(config.getTestView(testViewPropsStub)).toEqual(expectedTestView);
 
         validateInstanceTableSettings(requirement);
@@ -285,9 +282,6 @@ describe('AssessmentBuilderTest', () => {
         );
         expect(config.getInstanceIdentiferGenerator(requirement5.key)).toEqual(InstanceIdentifierGenerator.defaultHtmlSelectorIdentifier);
         expect(config.getInstanceIdentiferGenerator('non existent key')).toEqual(InstanceIdentifierGenerator.defaultHtmlSelectorIdentifier);
-        expect(config.getUpdateVisibility(selectedRequirementKey)).toBe(false);
-        expect(config.getUpdateVisibility(requirement5.key)).toBe(true);
-        expect(config.getUpdateVisibility('non existent key')).toBe(true);
         expect(config.getTestView(testViewPropsStub)).toEqual(expectedTestView);
 
         validateInstanceTableSettings(requirement1);

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -12,7 +12,6 @@ import {
     RemoveFailureInstancePayload,
     SelectRequirementPayload,
     ToggleActionPayload,
-    UpdateVisibilityPayload,
 } from 'background/actions/action-payloads';
 import { AssessmentActionCreator } from 'background/actions/assessment-action-creator';
 import { AssessmentActions } from 'background/actions/assessment-actions';
@@ -319,20 +318,6 @@ describe('AssessmentActionCreatorTest', () => {
         testSubject.registerCallbacks();
 
         resetDataMock.verifyAll();
-    });
-
-    it('handles UpdateInstanceVisibility message', () => {
-        const payload: UpdateVisibilityPayload = { payloadBatch: [] };
-
-        const updateInstanceVisibilityMock = createActionMock(payload);
-        const actionsMock = createActionsMock('updateInstanceVisibility', updateInstanceVisibilityMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.UpdateInstanceVisibility, payload, testTabId);
-
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
-
-        testSubject.registerCallbacks();
-
-        updateInstanceVisibilityMock.verifyAll();
     });
 
     it('handles StartOverAllAssessments message', () => {


### PR DESCRIPTION
#### Description of changes

In some of our visualizations, we used to check whether elements were still visible in the DOM and update our highlighting to match. We don't do this anymore. For example, microsoft.com has a carousel. Running the headings ad-hoc test will show which headings were visible at a single point in time. The heading box stays there even if the carousel moves and the heading disappears. This is true in production.

Some of the code that enabled the old workflow (dynamically add and remove visualizations based on element visibility) still remains in our codebase but isn't exercised. This PR removes all instances I could find of leftover instance-visibility concepts. Much of the client logic / usages used to be in  `instance-visibility-checker` which does not exist anymore: https://github.com/microsoft/accessibility-insights-web/blob/v2.10.0/src/injected/instance-visibility-checker.ts

The assessment-store in production is not aware of instance-visibility - assuming I'm not missing anything, removing the remaining plumbing (action creator, etc) should have no impact on behavior.

This PR includes many files in order to keep these deletions together semantically - that way in the future it might be easier to remember what happened.

This PR does not include any updates to feature flags. It looks like we have a feature flag for showing instance visibility. A different PR will remove this.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Added relevant unit test for your changes. (`yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] Ran precheckin (`yarn precheckin`)
- [x] Added a suitable semantic tag to PR title (fix, chore, feat., refactor). Check workflow guide at: `<rootDir>/docs/workflow.md` <!-- Please leave it blank if you are unsure -->
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
