### PR TITLE
feat: Optionally show start over and export buttons on command bar

### DIFF
--- a/src/DetailsView/components/command-bars.tsx
+++ b/src/DetailsView/components/command-bars.tsx
@@ -12,10 +12,6 @@ export const CommandBarWithExportAndStartOver = NamedFC<CommandBarProps>('Comman
     return <DetailsViewCommandBar renderExportAndStartOver={true} {...props} />;
 });
 
-export const BasicCommandBar = NamedFC<CommandBarProps>('BasicCommandBar', props => {
-    return <DetailsViewCommandBar renderExportAndStartOver={false} {...props} />;
-});
-
 export const CommandBarWithOptionalExportAndStartOver = NamedFC<CommandBarProps>('CommandBarWithOptionalExportAndStartOver', props => {
     return <DetailsViewCommandBar renderExportAndStartOver={props.featureFlagStoreData[FeatureFlags.universalCardsUI]} {...props} />;
 });

--- a/src/DetailsView/components/command-bars.tsx
+++ b/src/DetailsView/components/command-bars.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
+import { FeatureFlags } from 'common/feature-flags';
 import { NamedFC } from '../../common/react/named-fc';
 import { DetailsViewCommandBar, DetailsViewCommandBarProps } from './details-view-command-bar';
 
@@ -13,4 +14,8 @@ export const CommandBarWithExportAndStartOver = NamedFC<CommandBarProps>('Comman
 
 export const BasicCommandBar = NamedFC<CommandBarProps>('BasicCommandBar', props => {
     return <DetailsViewCommandBar renderExportAndStartOver={false} {...props} />;
+});
+
+export const CommandBarWithOptionalExportAndStartOver = NamedFC<CommandBarProps>('CommandBarWithOptionalExportAndStartOver', props => {
+    return <DetailsViewCommandBar renderExportAndStartOver={props.featureFlagStoreData[FeatureFlags.universalCardsUI]} {...props} />;
 });

--- a/src/DetailsView/components/details-view-switcher-nav.ts
+++ b/src/DetailsView/components/details-view-switcher-nav.ts
@@ -3,7 +3,7 @@
 import { ReactFCWithDisplayName } from '../../common/react/named-fc';
 import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
 import { VisualizationType } from '../../common/types/visualization-type';
-import { BasicCommandBar, CommandBarProps, CommandBarWithExportAndStartOver } from './command-bars';
+import { CommandBarProps, CommandBarWithExportAndStartOver, CommandBarWithOptionalExportAndStartOver } from './command-bars';
 import { AssessmentLeftNav, AssessmentLeftNavDeps, AssessmentLeftNavProps } from './left-nav/assessment-left-nav';
 import { FastPassLeftNav, FastPassLeftNavDeps, FastPassLeftNavProps } from './left-nav/fast-pass-left-nav';
 import {
@@ -46,7 +46,7 @@ const detailsViewSwitcherNavs: { [key in DetailsViewPivotType]: InternalDetailsV
         getSelectedDetailsView: getAssessmentSelectedDetailsView,
     },
     [DetailsViewPivotType.fastPass]: {
-        CommandBar: BasicCommandBar,
+        CommandBar: CommandBarWithOptionalExportAndStartOver,
         LeftNav: FastPassLeftNav,
         getSelectedDetailsView: getFastPassSelectedDetailsView,
     },
@@ -58,6 +58,7 @@ const detailsViewSwitcherNavs: { [key in DetailsViewPivotType]: InternalDetailsV
 };
 
 export type GetDetailsSwitcherNavConfiguration = (props: GetDetailsSwitcherNavConfigurationProps) => DetailsViewSwitcherNavConfiguration;
+
 export const GetDetailsSwitcherNavConfiguration: GetDetailsSwitcherNavConfiguration = (props: GetDetailsSwitcherNavConfigurationProps) => {
     return detailsViewSwitcherNavs[props.selectedDetailsViewPivot] as DetailsViewSwitcherNavConfiguration;
 };

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bars.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bars.test.tsx.snap
@@ -1,12 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`getBasicCommandBar should return command bar with renderExportAndStartOver as false 1`] = `
-<DetailsViewCommandBar
-  assessmentsProvider={null}
-  renderExportAndStartOver={false}
-/>
-`;
-
 exports[`getCommandBarWithExportAndStartOver should return command bar with renderExportAndStartOver as true 1`] = `
 <DetailsViewCommandBar
   assessmentsProvider={null}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bars.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/command-bars.test.tsx.snap
@@ -13,3 +13,27 @@ exports[`getCommandBarWithExportAndStartOver should return command bar with rend
   renderExportAndStartOver={true}
 />
 `;
+
+exports[`getCommandBarWithOptionalExportAndStartOver universalCardsUI disabled should return command bar with renderExportAndStartOver as false 1`] = `
+<DetailsViewCommandBar
+  assessmentsProvider={null}
+  featureFlagStoreData={
+    Object {
+      "universalCardsUI": false,
+    }
+  }
+  renderExportAndStartOver={false}
+/>
+`;
+
+exports[`getCommandBarWithOptionalExportAndStartOver universalCardsUI enabled should return command bar with renderExportAndStartOver as true 1`] = `
+<DetailsViewCommandBar
+  assessmentsProvider={null}
+  featureFlagStoreData={
+    Object {
+      "universalCardsUI": true,
+    }
+  }
+  renderExportAndStartOver={true}
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/components/command-bars.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bars.test.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 
 import { DictionaryStringTo } from 'types/common-types';
 import {
-    BasicCommandBar,
     CommandBarProps,
     CommandBarWithExportAndStartOver,
     CommandBarWithOptionalExportAndStartOver,
@@ -17,17 +16,6 @@ describe('getCommandBarWithExportAndStartOver', () => {
             assessmentsProvider: null,
         } as CommandBarProps;
         const actual = shallow(<CommandBarWithExportAndStartOver {...props} />);
-
-        expect(actual.getElement()).toMatchSnapshot();
-    });
-});
-
-describe('getBasicCommandBar', () => {
-    it('should return command bar with renderExportAndStartOver as false', () => {
-        const props = {
-            assessmentsProvider: null,
-        } as CommandBarProps;
-        const actual = shallow(<BasicCommandBar {...props} />);
 
         expect(actual.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/DetailsView/components/command-bars.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/command-bars.test.tsx
@@ -3,7 +3,13 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { BasicCommandBar, CommandBarProps, CommandBarWithExportAndStartOver } from '../../../../../DetailsView/components/command-bars';
+import { DictionaryStringTo } from 'types/common-types';
+import {
+    BasicCommandBar,
+    CommandBarProps,
+    CommandBarWithExportAndStartOver,
+    CommandBarWithOptionalExportAndStartOver,
+} from '../../../../../DetailsView/components/command-bars';
 
 describe('getCommandBarWithExportAndStartOver', () => {
     it('should return command bar with renderExportAndStartOver as true', () => {
@@ -22,6 +28,36 @@ describe('getBasicCommandBar', () => {
             assessmentsProvider: null,
         } as CommandBarProps;
         const actual = shallow(<BasicCommandBar {...props} />);
+
+        expect(actual.getElement()).toMatchSnapshot();
+    });
+});
+
+describe('getCommandBarWithOptionalExportAndStartOver universalCardsUI disabled', () => {
+    it('should return command bar with renderExportAndStartOver as false', () => {
+        const featureFlags: DictionaryStringTo<boolean> = {
+            universalCardsUI: false,
+        };
+        const props = {
+            assessmentsProvider: null,
+            featureFlagStoreData: featureFlags,
+        } as CommandBarProps;
+        const actual = shallow(<CommandBarWithOptionalExportAndStartOver {...props} />);
+
+        expect(actual.getElement()).toMatchSnapshot();
+    });
+});
+
+describe('getCommandBarWithOptionalExportAndStartOver universalCardsUI enabled', () => {
+    it('should return command bar with renderExportAndStartOver as true', () => {
+        const featureFlags: DictionaryStringTo<boolean> = {
+            universalCardsUI: true,
+        };
+        const props = {
+            assessmentsProvider: null,
+            featureFlagStoreData: featureFlags,
+        } as CommandBarProps;
+        const actual = shallow(<CommandBarWithOptionalExportAndStartOver {...props} />);
 
         expect(actual.getElement()).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

This is the first step towards having a consistent header in all views. The next step will be to update the implementation of the buttons to match the new context (there are separate user stories for this work). This removes the BasicCommandBar construct since it's no longer referenced.

Screenshots (only difference was changing the __universalCardsUI__ flag:

![image](https://user-images.githubusercontent.com/45672944/68042922-52231880-fc91-11e9-8219-bdf82a57d743.png)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
