### PR TITLE
chore: fix invalid job name in sample electron yaml & refactor to avoid duplicate node-prereq

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -70,6 +70,7 @@ jobs:
       pool:
           vmImage: 'windows-latest'
       steps:
+          - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/electron/distribute-electron.yaml
             parameters:
                 platforms: -w # linux disabled until https://github.com/electron-userland/electron-builder/issues/4318 resolved
@@ -80,6 +81,7 @@ jobs:
       pool:
           vmImage: 'macOS-10.14'
       steps:
+          - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/electron/distribute-electron.yaml
             parameters:
                 platforms: -m

--- a/pipeline/electron/distribute-electron.yaml
+++ b/pipeline/electron/distribute-electron.yaml
@@ -5,8 +5,6 @@ parameters:
     platforms: '' # electron-builder platforms, e.g. -wl for win/linux, -m for mac, etc
 
 steps:
-    - template: ../install-node-prerequisites.yaml
-
     - script: yarn dist:electron ${{ parameters.platforms }}
       displayName: create electron distributables
 

--- a/pipeline/electron/product-build.yaml
+++ b/pipeline/electron/product-build.yaml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 jobs:
-    - job: 'build-product-windows'
+    - job: 'build_product_windows'
 
       pool:
           vmImage: 'windows-latest'

--- a/pipeline/electron/product-build.yaml
+++ b/pipeline/electron/product-build.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+jobs:
+    - job: 'build-product-windows'
+
+      pool:
+          vmImage: 'windows-latest'
+
+      steps:
+          - template: ../install-node-prerequisites.yaml
+          - template: electron-e2e-test-interactive.yaml
+          - template: electron-e2e-publish-results.yaml
+
+          - template: distribute-electron.yaml


### PR DESCRIPTION
#### Description of changes

This PR updates the sample electron YAML to use a valid job name. It also refactors the distribute-electron.yaml to pull node-prereqs out. This way the node-prereqs only happen once per job. After this PR is in, development on this YAML will occur on a branch on the main repo to enable better/more frequent iteration. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
