### PR TITLE
refactor: move platform electron installers to separate build

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -64,28 +64,6 @@ jobs:
                 artifactName: 'drop'
             displayName: publish drop
 
-    # CI build only
-    - job: 'publish_electron_windows_linux'
-      condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
-      pool:
-          vmImage: 'windows-latest'
-      steps:
-          - template: pipeline/install-node-prerequisites.yaml
-          - template: pipeline/electron/distribute-electron.yaml
-            parameters:
-                platforms: -w # linux disabled until https://github.com/electron-userland/electron-builder/issues/4318 resolved
-
-    # CI build only
-    - job: 'publish_electron_mac'
-      condition: and(always(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
-      pool:
-          vmImage: 'macOS-10.14'
-      steps:
-          - template: pipeline/install-node-prerequisites.yaml
-          - template: pipeline/electron/distribute-electron.yaml
-            parameters:
-                platforms: -m
-
     - job: 'e2e_mac_web_electron'
       pool:
           vmImage: macOS-10.14

--- a/pipeline/electron/product-build.yaml
+++ b/pipeline/electron/product-build.yaml
@@ -12,3 +12,25 @@ jobs:
           - template: electron-e2e-publish-results.yaml
 
           - template: distribute-electron.yaml
+
+    - job: 'build_product_linux'
+
+      pool:
+          vmImage: 'ubuntu-16.04'
+
+      steps:
+          - template: ../install-node-prerequisites.yaml
+          - template: electron-e2e-test-linux.yaml
+          - template: electron-e2e-publish-results.yaml
+
+          - template: distribute-electron.yaml
+
+    - job: 'build_product_mac'
+      pool:
+          vmImage: macOS-10.14
+      steps:
+          - template: ../install-node-prerequisites.yaml
+          - template: electron-e2e-test-interactive.yaml
+          - template: electron-e2e-publish-results.yaml
+
+          - template: distribute-electron.yaml


### PR DESCRIPTION
#### Description of changes

This PR moves all platform-specific electron installers to a separate build. This keeps the CI lightweight and removes some flakiness inherent in electron-builder. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
