### PR TITLE
test: expand web e2e a11y tests to include rule tags wcag21a/wcag21aa

### DIFF
--- a/src/tests/end-to-end/common/scan-for-accessibility-issues.ts
+++ b/src/tests/end-to-end/common/scan-for-accessibility-issues.ts
@@ -15,7 +15,7 @@ export async function scanForAccessibilityIssues(page: Page, selector: string): 
     const axeResults = (await page.evaluate(selectorInEvaluate => {
         return axe.run(
             { include: [selectorInEvaluate] } as ElementContext,
-            { runOnly: { type: 'tag', values: ['wcag2a', 'wcag2aa'] } } as ElementContext,
+            { runOnly: { type: 'tag', values: ['wcag2a', 'wcag21a', 'wcag2aa', 'wcag21aa'] } } as ElementContext,
         );
     }, selector)) as AxeResults;
 


### PR DESCRIPTION
#### Description of changes

Updates the way our e2e tests invoke axe-core to include WCAG 2.1 rules (they were previously only including WCAG 2.0 rules).

Electron e2e tests already include these tags.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
