### PR TITLE
feat(and-screenshot): inject ScreenshotViewModel into the ScreenshotView

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -4,6 +4,7 @@ import { ScanningSpinner } from 'common/components/scanning-spinner/scanning-spi
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { GetUnifiedRuleResultsDelegate } from 'common/rule-based-view-model-provider';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { CardRuleResultsByStatus } from 'common/types/store-data/card-view-model';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { CardsView, CardsViewDeps } from 'DetailsView/components/cards-view';
@@ -17,6 +18,7 @@ import { TitleBar, TitleBarDeps } from 'electron/views/automated-checks/componen
 import { mainContentWrapper } from 'electron/views/device-connect-view/device-connect-view.scss';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
 import { ScreenshotView } from 'electron/views/screenshot/screenshot-view';
+import { ScreenshotViewModel } from 'electron/views/screenshot/screenshot-view-model';
 import { ScreenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
 import * as React from 'react';
 
@@ -50,6 +52,34 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
     }
 
     public render(): JSX.Element {
+        const { status } = this.props.scanStoreData;
+        if (status === ScanStatus.Failed) {
+            return this.renderLayout(this.renderDeviceDisconnected());
+        } else if (status === ScanStatus.Completed) {
+            const { unifiedScanResultStoreData, cardSelectionStoreData, deps } = this.props;
+            const { rules, results } = unifiedScanResultStoreData;
+            const cardSelectionViewData = deps.getCardSelectionViewData(cardSelectionStoreData);
+            const ruleResultsByStatus = deps.getUnifiedRuleResultsDelegate(rules, results, cardSelectionViewData);
+            const screenshotViewModel = deps.screenshotViewModelProvider(
+                unifiedScanResultStoreData,
+                cardSelectionViewData.highlightedResultUids,
+            );
+
+            return this.renderLayout(this.renderResults(ruleResultsByStatus), this.renderScreenshotSidePanel(screenshotViewModel));
+        } else {
+            return this.renderLayout(this.renderScanningSpinner());
+        }
+    }
+
+    private renderScreenshotSidePanel(screenshotViewModel: ScreenshotViewModel): JSX.Element {
+        return (
+            <div className={screenshotView}>
+                <ScreenshotView viewModel={screenshotViewModel} />
+            </div>
+        );
+    }
+
+    private renderLayout(primaryContent: JSX.Element, optionalSidePanel?: JSX.Element): JSX.Element {
         return (
             <div className={automatedChecksView}>
                 <TitleBar deps={this.props.deps} windowStateStoreData={this.props.windowStateStoreData}></TitleBar>
@@ -62,24 +92,16 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                         />
                         <main>
                             <HeaderSection />
-                            {this.renderScanning()}
-                            {this.renderDeviceDisconnected()}
-                            {this.renderResults()}
+                            {primaryContent}
                         </main>
                     </div>
-                    <div className={screenshotView}>
-                        <ScreenshotView />
-                    </div>
+                    {optionalSidePanel}
                 </div>
             </div>
         );
     }
 
     private renderDeviceDisconnected(): JSX.Element {
-        if (this.props.scanStoreData.status !== ScanStatus.Failed) {
-            return null;
-        }
-
         return (
             <DeviceDisconnectedPopup
                 deviceName={this.props.deviceStoreData.connectedDevice}
@@ -89,7 +111,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
         );
     }
 
-    private renderScanning(): JSX.Element {
+    private renderScanningSpinner(): JSX.Element {
         return (
             <ScanningSpinner
                 isSpinning={this.props.scanStoreData.status === ScanStatus.Scanning}
@@ -99,18 +121,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
         );
     }
 
-    private renderResults(): JSX.Element {
-        if (this.props.scanStoreData.status !== ScanStatus.Completed) {
-            return null;
-        }
-
-        const { rules, results } = this.props.unifiedScanResultStoreData;
-        const ruleResultsByStatus = this.props.deps.getUnifiedRuleResultsDelegate(
-            rules,
-            results,
-            this.props.deps.getCardSelectionViewData(this.props.cardSelectionStoreData),
-        );
-
+    private renderResults(ruleResultsByStatus: CardRuleResultsByStatus): JSX.Element {
         return (
             <CardsView
                 deps={this.props.deps}

--- a/src/electron/views/screenshot/screenshot-view.tsx
+++ b/src/electron/views/screenshot/screenshot-view.tsx
@@ -2,8 +2,9 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
+import { ScreenshotViewModel } from './screenshot-view-model';
 
-export type ScreenshotViewProps = {};
+export type ScreenshotViewProps = { viewModel: ScreenshotViewModel };
 export const ScreenshotView = NamedFC<ScreenshotViewProps>('ScreenshotView', props => {
     return (
         <div>

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "scanActions": undefined,
         },
+        "screenshotViewModelProvider": [Function],
       }
     }
   />
@@ -31,6 +32,7 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
               "scanActions": undefined,
             },
+            "screenshotViewModelProvider": [Function],
           }
         }
         deviceStoreData={Object {}}
@@ -42,11 +44,6 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
       />
       <main>
         <HeaderSection />
-        <ScanningSpinner
-          aria-live="assertive"
-          isSpinning={false}
-          label="Scanning..."
-        />
         <CardsView
           deps={
             Object {
@@ -56,6 +53,16 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "scanActions": undefined,
               },
+              "screenshotViewModelProvider": [Function],
+            }
+          }
+          ruleResultsByStatus={
+            Object {
+              "fail": Array [
+                Object {
+                  "id": "test-fail-id",
+                },
+              ],
             }
           }
           targetAppInfo={
@@ -74,7 +81,13 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
     <div
       className="screenshotView"
     >
-      <ScreenshotView />
+      <ScreenshotView
+        viewModel={
+          Object {
+            "deviceName": "this should appear in snapshotted ScreenshotView props",
+          }
+        }
+      />
     </div>
   </div>
 </div>
@@ -133,22 +146,12 @@ exports[`AutomatedChecksView renders when status scan <Failed> 1`] = `
       />
       <main>
         <HeaderSection />
-        <ScanningSpinner
-          aria-live="assertive"
-          isSpinning={false}
-          label="Scanning..."
-        />
         <DeviceDisconnectedPopup
           deviceName="TEST DEVICE"
           onConnectNewDevice={[Function]}
           onRescanDevice={[Function]}
         />
       </main>
-    </div>
-    <div
-      className="screenshotView"
-    >
-      <ScreenshotView />
     </div>
   </div>
 </div>
@@ -214,11 +217,6 @@ exports[`AutomatedChecksView renders when status scan <Scanning> 1`] = `
         />
       </main>
     </div>
-    <div
-      className="screenshotView"
-    >
-      <ScreenshotView />
-    </div>
   </div>
 </div>
 `;
@@ -282,11 +280,6 @@ exports[`AutomatedChecksView renders when status scan <undefined> 1`] = `
           label="Scanning..."
         />
       </main>
-    </div>
-    <div
-      className="screenshotView"
-    >
-      <ScreenshotView />
     </div>
   </div>
 </div>

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CardSelectionViewData, getCardSelectionViewData, GetCardSelectionViewData } from 'common/get-card-selection-view-data';
-import { getUnifiedRuleResults, GetUnifiedRuleResultsDelegate } from 'common/rule-based-view-model-provider';
+import { CardSelectionViewData, getCardSelectionViewData } from 'common/get-card-selection-view-data';
+import { getUnifiedRuleResults } from 'common/rule-based-view-model-provider';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { CardRuleResult, CardRuleResultsByStatus } from 'common/types/store-data/card-view-model';
 import { UnifiedResult, UnifiedRule, UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
@@ -11,7 +11,7 @@ import { ScanStatus } from 'electron/flux/types/scan-status';
 import { AutomatedChecksView, AutomatedChecksViewProps } from 'electron/views/automated-checks/automated-checks-view';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
 import { ScreenshotViewModel } from 'electron/views/screenshot/screenshot-view-model';
-import { ScreenshotViewModelProvider, screenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
+import { screenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { It, Mock, Times } from 'typemoq';

--- a/src/tests/unit/tests/electron/views/screenshot/screenshot-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/screenshot/screenshot-view.test.tsx
@@ -1,13 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ScreenshotView, ScreenshotViewProps } from 'electron/views/screenshot/screenshot-view';
+import { ScreenshotView } from 'electron/views/screenshot/screenshot-view';
+import { ScreenshotViewModel } from 'electron/views/screenshot/screenshot-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('ScreenshotView', () => {
     it('renders', () => {
-        const props: ScreenshotViewProps = {};
-        const wrapper = shallow(<ScreenshotView {...props} />);
+        const viewModel: ScreenshotViewModel = {
+            screenshotData: null,
+            highlightBoxRectangles: [],
+            deviceName: null,
+        };
+        const wrapper = shallow(<ScreenshotView viewModel={viewModel} />);
 
         expect(wrapper.getElement()).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

Wires up the `AutomatedChecksView` to invoke its `ScreenshotViewModelProvider` dep and pass the resulting `ScreenshotViewModel` to the `ScreenshotView`.

This involved some refactoring of the `AutomatedChecksView` to enable re-using common "highlighted result uid" data between the cards and screenshot views.

While I was adding the unit test expectations to verify the data passed to/from the provider, I also updated the unit test to add the missing similar verifications of the interactions with the cards view providers.

#### Pull request checklist

- [x] Addresses an existing issue: 1628927
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
