### PR TITLE
fix: adjust extension permissions

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,7 @@
     },
     "devtools_page": "Devtools/devtools.html",
     "web_accessible_resources": ["insights.html", "assessments/*", "injected/*", "background/*", "common/*", "DetailsView/*", "bundle/*"],
-    "permissions": ["storage", "webNavigation", "tabs", "notifications", "https://*/*", "http://*/*", "file://*/*"],
+    "permissions": ["storage", "webNavigation", "tabs", "notifications", "activeTab"],
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {

--- a/src/tests/end-to-end/common/browser-factory.ts
+++ b/src/tests/end-to-end/common/browser-factory.ts
@@ -1,32 +1,54 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { generateUID } from 'common/uid-generator';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as Puppeteer from 'puppeteer';
 import * as util from 'util';
-import { generateUID } from '../../../common/uid-generator';
 import { Browser } from './browser';
 import { popupPageElementIdentifiers } from './element-identifiers/popup-page-element-identifiers';
 import { DEFAULT_BROWSER_LAUNCH_TIMEOUT_MS } from './timeouts';
 
 export const chromeLogsPath = path.join(__dirname, '../../../../test-results/e2e/chrome-logs/');
 
-export function browserLogPath(browserInstanceId: string): string {
-    return path.join(chromeLogsPath, browserInstanceId);
-}
+export const browserLogPath = (browserInstanceId: string): string => path.join(chromeLogsPath, browserInstanceId);
+
+const fileExists = util.promisify(fs.exists);
+const writeFile = util.promisify(fs.writeFile);
+const readFile = util.promisify(fs.readFile);
 
 export interface ExtensionOptions {
     suppressFirstTimeDialog: boolean;
+    addLocalhostToPermissions?: boolean;
 }
 
 export async function launchBrowser(extensionOptions: ExtensionOptions): Promise<Browser> {
     const browserInstanceId = generateUID();
-    const puppeteerBrowser = await launchNewBrowser(browserInstanceId);
-    const browser = new Browser(browserInstanceId, puppeteerBrowser);
+
+    // only unpacked extension paths are supported
+    const devExtensionPath = `${(global as any).rootDir}/drop/extension/dev/product`;
+    const manifestPath = getManifestPath(devExtensionPath);
+
+    let onClose: () => Promise<void>;
+
+    if (extensionOptions.addLocalhostToPermissions) {
+        const originalManifest = await readFile(manifestPath);
+
+        const permissiveManifest = addLocalhostPermissionsToManifest(originalManifest.toString());
+
+        await writeFile(manifestPath, permissiveManifest);
+
+        onClose = async () => await writeFile(manifestPath, originalManifest.toString());
+    }
+
+    const puppeteerBrowser = await launchNewBrowser(browserInstanceId, devExtensionPath);
+
+    const browser = new Browser(browserInstanceId, puppeteerBrowser, onClose);
 
     if (extensionOptions.suppressFirstTimeDialog) {
         await suppressFirstTimeUsagePrompt(browser);
     }
+
     return browser;
 }
 
@@ -40,12 +62,12 @@ async function suppressFirstTimeUsagePrompt(browser: Browser): Promise<void> {
     await popupPage.close();
 }
 
-function fileExists(filePath: string): Promise<boolean> {
-    return new Promise(resolve => fs.exists(filePath, resolve));
+function getManifestPath(extensionPath: string): string {
+    return `${extensionPath}/manifest.json`;
 }
 
 async function verifyExtensionIsBuilt(extensionPath: string): Promise<void> {
-    const manifestPath = `${extensionPath}/manifest.json`;
+    const manifestPath = getManifestPath(extensionPath);
     if (!(await fileExists(manifestPath))) {
         throw new Error(
             `Cannot launch extension-enabled browser instance because extension has not been built.\n` +
@@ -55,10 +77,15 @@ async function verifyExtensionIsBuilt(extensionPath: string): Promise<void> {
     }
 }
 
-async function launchNewBrowser(browserInstanceId: string): Promise<Puppeteer.Browser> {
-    // only unpacked extension paths are supported
-    const extensionPath = `${(global as any).rootDir}/drop/extension/dev/product`;
+function addLocalhostPermissionsToManifest(originalManifest: string): string {
+    const manifest = JSON.parse(originalManifest);
 
+    manifest['permissions'].push('http://localhost:9050/*');
+
+    return JSON.stringify(manifest, null, 2);
+}
+
+async function launchNewBrowser(browserInstanceId: string, extensionPath: string): Promise<Puppeteer.Browser> {
     // It's important that we verify this before calling Puppeteer.launch because its behavior if the
     // extension can't be loaded is "the Chromium instance hangs with an alert and everything on Puppeteer's
     // end shows up as a generic timeout error with no meaningful logging".

--- a/src/tests/end-to-end/common/browser.ts
+++ b/src/tests/end-to-end/common/browser.ts
@@ -14,11 +14,19 @@ export class Browser {
     private memoizedBackgroundPage: BackgroundPage;
     private pages: Array<Page> = [];
 
-    constructor(private readonly browserInstanceId: string, private readonly underlyingBrowser: Puppeteer.Browser) {
+    constructor(
+        private readonly browserInstanceId: string,
+        private readonly underlyingBrowser: Puppeteer.Browser,
+        private readonly onClose?: () => Promise<void>,
+    ) {
         underlyingBrowser.on('disconnected', onBrowserDisconnected);
     }
 
     public async close(): Promise<void> {
+        if (this.onClose) {
+            await this.onClose();
+        }
+
         this.underlyingBrowser.removeListener('disconnected', onBrowserDisconnected);
         await this.underlyingBrowser.close();
     }

--- a/src/tests/end-to-end/tests/details-view/headings.test.ts
+++ b/src/tests/end-to-end/tests/details-view/headings.test.ts
@@ -15,7 +15,7 @@ describe('Headings Page', () => {
         let headingsPage: DetailsViewPage;
 
         beforeAll(async () => {
-            browser = await launchBrowser({ suppressFirstTimeDialog: true });
+            browser = await launchBrowser({ suppressFirstTimeDialog: true, addLocalhostToPermissions: true });
             targetPage = await browser.newTargetPage();
             headingsPage = await openHeadingsPage(browser, targetPage);
         });
@@ -39,7 +39,7 @@ describe('Headings Page', () => {
         let headingsPage: DetailsViewPage;
 
         beforeAll(async () => {
-            browser = await launchBrowser({ suppressFirstTimeDialog: true });
+            browser = await launchBrowser({ suppressFirstTimeDialog: true, addLocalhostToPermissions: true });
             targetPage = await browser.newTargetPage();
             headingsPage = await openHeadingsPage(browser, targetPage);
             await headingsPage.enableHighContrast();

--- a/src/tests/end-to-end/tests/popup/__snapshots__/adhoc-panel.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/adhoc-panel.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Ad hoc tools should display the pinned target page visualizations when enabling the "Automated checks" toggle 1`] = `
+exports[`Ad hoc tools ad hoc toggles should display the pinned target page visualizations when enabling the "Automated checks" toggle 1`] = `
 <DocumentFragment>
   <div
     id="insights-shadow-container"
@@ -59,7 +59,7 @@ exports[`Ad hoc tools should display the pinned target page visualizations when 
 </DocumentFragment>
 `;
 
-exports[`Ad hoc tools should display the pinned target page visualizations when enabling the "Color" toggle 1`] = `
+exports[`Ad hoc tools ad hoc toggles should display the pinned target page visualizations when enabling the "Color" toggle 1`] = `
 <DocumentFragment>
   <div
     id="insights-shadow-container"
@@ -78,7 +78,7 @@ exports[`Ad hoc tools should display the pinned target page visualizations when 
 </DocumentFragment>
 `;
 
-exports[`Ad hoc tools should display the pinned target page visualizations when enabling the "Headings" toggle 1`] = `
+exports[`Ad hoc tools ad hoc toggles should display the pinned target page visualizations when enabling the "Headings" toggle 1`] = `
 <DocumentFragment>
   <div
     id="insights-shadow-container"
@@ -125,7 +125,7 @@ exports[`Ad hoc tools should display the pinned target page visualizations when 
 </DocumentFragment>
 `;
 
-exports[`Ad hoc tools should display the pinned target page visualizations when enabling the "Landmarks" toggle 1`] = `
+exports[`Ad hoc tools ad hoc toggles should display the pinned target page visualizations when enabling the "Landmarks" toggle 1`] = `
 <DocumentFragment>
   <div
     id="insights-shadow-container"

--- a/src/tests/end-to-end/tests/popup/adhoc-panel.test.ts
+++ b/src/tests/end-to-end/tests/popup/adhoc-panel.test.ts
@@ -12,13 +12,6 @@ describe('Ad hoc tools', () => {
     let targetPage: TargetPage;
     let popupPage: PopupPage;
 
-    beforeEach(async () => {
-        browser = await launchBrowser({ suppressFirstTimeDialog: true });
-        targetPage = await browser.newTargetPage();
-        popupPage = await browser.newPopupPage(targetPage);
-        await popupPage.bringToFront();
-    });
-
     afterEach(async () => {
         if (browser) {
             await browser.close();
@@ -26,53 +19,80 @@ describe('Ad hoc tools', () => {
         }
     });
 
-    it('should have launchpad link that takes us to adhoc panel & is sticky', async () => {
-        await popupPage.gotoAdhocPanel();
+    describe('navigation', () => {
+        beforeEach(async () => {
+            browser = await launchBrowser({ suppressFirstTimeDialog: true });
+            targetPage = await browser.newTargetPage();
+            popupPage = await browser.newPopupPage(targetPage);
+            await popupPage.bringToFront();
+        });
 
-        // verify adhoc panel state is sticky
-        targetPage = await browser.newTargetPage();
-        popupPage = await browser.newPopupPage(targetPage);
-        await popupPage.verifyAdhocPanelLoaded();
-    });
-
-    it('should take back to Launch pad on clicking "Back to Launch pad" link & is sticky', async () => {
-        await popupPage.clickSelectorXPath(popupPageElementIdentifiers.adhocLaunchPadLinkXPath);
-        await popupPage.clickSelector(popupPageElementIdentifiers.backToLaunchPadLink);
-
-        await popupPage.verifyLaunchPadLoaded();
-
-        // verify adhoc panel state is sticky
-        targetPage = await browser.newTargetPage();
-        popupPage = await browser.newPopupPage(targetPage);
-        await popupPage.verifyLaunchPadLoaded();
-    });
-
-    it('should pass accessibility validation', async () => {
-        await popupPage.gotoAdhocPanel();
-
-        const results = await scanForAccessibilityIssues(popupPage, '*');
-        expect(results).toHaveLength(0);
-    });
-
-    it('should pass accessibility validation in high contrast', async () => {
-        const detailsViewPage = await browser.newDetailsViewPage(targetPage);
-        await detailsViewPage.enableHighContrast();
-
-        await popupPage.bringToFront();
-        await popupPage.gotoAdhocPanel();
-
-        const results = await scanForAccessibilityIssues(popupPage, '*');
-        expect(results).toHaveLength(0);
-    });
-
-    it.each(['Automated checks', 'Landmarks', 'Headings', 'Color'])(
-        'should display the pinned target page visualizations when enabling the "%s" toggle',
-        async (toggleAriaLabel: string) => {
+        it('should have launchpad link that takes us to adhoc panel & is sticky', async () => {
             await popupPage.gotoAdhocPanel();
 
-            await popupPage.enableToggleByAriaLabel(toggleAriaLabel);
+            // verify ad hoc panel state is sticky
+            targetPage = await browser.newTargetPage();
+            popupPage = await browser.newPopupPage(targetPage);
+            await popupPage.verifyAdhocPanelLoaded();
+        });
 
-            expect(await targetPage.getShadowRootHtmlSnapshot()).toMatchSnapshot();
-        },
-    );
+        it('should take back to Launch pad on clicking "Back to Launch pad" link & is sticky', async () => {
+            await popupPage.clickSelectorXPath(popupPageElementIdentifiers.adhocLaunchPadLinkXPath);
+            await popupPage.clickSelector(popupPageElementIdentifiers.backToLaunchPadLink);
+
+            await popupPage.verifyLaunchPadLoaded();
+
+            // verify ad hoc panel state is sticky
+            targetPage = await browser.newTargetPage();
+            popupPage = await browser.newPopupPage(targetPage);
+            await popupPage.verifyLaunchPadLoaded();
+        });
+    });
+
+    describe('ad hoc toggles', () => {
+        beforeEach(async () => {
+            browser = await launchBrowser({ suppressFirstTimeDialog: true, addLocalhostToPermissions: true });
+            targetPage = await browser.newTargetPage();
+            popupPage = await browser.newPopupPage(targetPage);
+            await popupPage.bringToFront();
+        });
+
+        it.each(['Automated checks', 'Landmarks', 'Headings', 'Color'])(
+            'should display the pinned target page visualizations when enabling the "%s" toggle',
+            async (toggleAriaLabel: string) => {
+                await popupPage.gotoAdhocPanel();
+
+                await popupPage.enableToggleByAriaLabel(toggleAriaLabel);
+
+                expect(await targetPage.getShadowRootHtmlSnapshot()).toMatchSnapshot();
+            },
+        );
+    });
+
+    describe('a11y scan', () => {
+        beforeEach(async () => {
+            browser = await launchBrowser({ suppressFirstTimeDialog: true, addLocalhostToPermissions: true });
+            targetPage = await browser.newTargetPage();
+            popupPage = await browser.newPopupPage(targetPage);
+            await popupPage.bringToFront();
+        });
+
+        it('should pass accessibility validation', async () => {
+            await popupPage.gotoAdhocPanel();
+
+            const results = await scanForAccessibilityIssues(popupPage, '*');
+            expect(results).toHaveLength(0);
+        });
+
+        it('should pass accessibility validation in high contrast', async () => {
+            const detailsViewPage = await browser.newDetailsViewPage(targetPage);
+            await detailsViewPage.enableHighContrast();
+
+            await popupPage.bringToFront();
+            await popupPage.gotoAdhocPanel();
+
+            const results = await scanForAccessibilityIssues(popupPage, '*');
+            expect(results).toHaveLength(0);
+        });
+    });
 });

--- a/src/tests/end-to-end/tests/target-page/issue-dialog.test.ts
+++ b/src/tests/end-to-end/tests/target-page/issue-dialog.test.ts
@@ -13,7 +13,7 @@ describe('Target Page issue dialog', () => {
     let popupPage: PopupPage;
 
     beforeAll(async () => {
-        browser = await launchBrowser({ suppressFirstTimeDialog: true });
+        browser = await launchBrowser({ suppressFirstTimeDialog: true, addLocalhostToPermissions: true });
         targetPage = await browser.newTargetPage();
         popupPage = await browser.newPopupPage(targetPage);
     });

--- a/src/tests/end-to-end/tests/target-page/tabstop.test.ts
+++ b/src/tests/end-to-end/tests/target-page/tabstop.test.ts
@@ -14,7 +14,7 @@ describe('tabstop tests', () => {
     let popupPage: PopupPage;
 
     beforeEach(async () => {
-        browser = await launchBrowser({ suppressFirstTimeDialog: true });
+        browser = await launchBrowser({ suppressFirstTimeDialog: true, addLocalhostToPermissions: true });
         targetPage = await browser.newTargetPage({ testResourcePath: 'native-widgets/input-type-radio.html' });
     });
 

--- a/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
+++ b/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
@@ -13,7 +13,7 @@ describe('Target Page visualization boxes', () => {
     let popupPage: PopupPage;
 
     beforeEach(async () => {
-        browser = await launchBrowser({ suppressFirstTimeDialog: true });
+        browser = await launchBrowser({ suppressFirstTimeDialog: true, addLocalhostToPermissions: true });
         targetPage = await browser.newTargetPage();
         popupPage = await browser.newPopupPage(targetPage);
         await popupPage.gotoAdhocPanel();


### PR DESCRIPTION
#### Description of changes

Using `"activeTab"` permissions instead of wide-matching patterns (`"https://*/*", "http://*/*", "file://*/*"`) in order to avoid getting flagged with **in pending review** status when updating the extension on google web store.

We have filed issue #1591 to track cannary not being properly update since 10/24 but this affect all of our extensions. This is related to chrome extension permissions and an effort to prevent malisious extension on the web store. Chrome developer website has a [transition guide](https://developer.chrome.com/extensions/runtime_host_permissions).

While changing the permissions seems to be working fine on the extension itself(we have a pending general-pass validation session from the team), the change has broke end to end test where we need to inject js/css to the target page (e.g, there is a test for the ad hoc panel where we enable each and every toggle that breaks with a permissions denied-kind of error).

This is due to how the `"activeTab"` permission works. Simply put, our extension gets permissions to inject js/css when the user activates our extension. There are basically 2 ways this happen:
1. the user clicks/press the extension icon on the extensions bar righ by the address bar
1. the user users our extension's shortcut to activate it.

We're using `Puppeteer` for our end-to-end tests and there is currently no API to efectivle use 1. as mentioned [here](https://github.com/GoogleChrome/puppeteer/issues/2486).

I tried option 2. by using `Puppeteer`'s [Keyboard](https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#class-keyboard) api to no success. I also looked at a couple of npm packages that send keyboard strokes at the OS level (most notably: [kbm-robot](https://github.com/kylepaulsen/kbm-robot), [node-key-sender](https://github.com/garimpeiro-it/node-key-sender)) but they relay on `Java`, which seems a medium to mayor size/impact decission for our infrastructure. After that, I didn't want to invest more time with this approach as we need to unblock ourselves as fast as we can, finding a balance between time spend, robustness and correctness on the approach we choose.

The choosen approach was based on @dbjorge suggestion to follow this chrome ligthouse [PR](https://github.com/GoogleChrome/lighthouse/pull/4640) where they decided to modified the `manifest.json`, adding a permission to facilitated e2e testing.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: fixes #1591
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
