### PR TITLE
feat(releases): switch to assisted installer experience

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -9,3 +9,5 @@ extraMetadata:
 mac:
     target: dmg # can be changed to a zip, app or something else. ref: https://www.electron.build/configuration/mac
     identity: null
+nsis:
+    oneClick: false


### PR DESCRIPTION
#### Description of changes

The Windows installer we are exploring (NSIS) allows a one-click silent experience upon first install or an assisted experience. The assisted experience seems more guided & accessible to me - the user can choose whether they want to install it per-user / per-system and Narrator reads the content out. This PR changes the experimental installer to an assisted experience.

https://www.electron.build/configuration/nsis

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
