### PR TITLE
fix: properly null check the view model in failed instances section

### DIFF
--- a/src/common/components/cards/failed-instances-section.tsx
+++ b/src/common/components/cards/failed-instances-section.tsx
@@ -20,7 +20,7 @@ export type FailedInstancesSectionProps = {
 export const FailedInstancesSection = NamedFC<FailedInstancesSectionProps>(
     'FailedInstancesSection',
     ({ cardsViewData, deps, userConfigurationStoreData, targetAppInfo, shouldAlertFailuresCount }) => {
-        if (cardsViewData.cards == null) {
+        if (cardsViewData == null) {
             return null;
         }
 

--- a/src/common/components/cards/failed-instances-section.tsx
+++ b/src/common/components/cards/failed-instances-section.tsx
@@ -20,7 +20,7 @@ export type FailedInstancesSectionProps = {
 export const FailedInstancesSection = NamedFC<FailedInstancesSectionProps>(
     'FailedInstancesSection',
     ({ cardsViewData, deps, userConfigurationStoreData, targetAppInfo, shouldAlertFailuresCount }) => {
-        if (cardsViewData == null) {
+        if (cardsViewData == null || cardsViewData.cards == null) {
             return null;
         }
 

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/failed-instances-section.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/failed-instances-section.test.tsx.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FailedInstancesSection renders null cards property 1`] = `null`;
+
 exports[`FailedInstancesSection renders null results 1`] = `null`;
 
 exports[`FailedInstancesSection renders with alerting off 1`] = `

--- a/src/tests/unit/tests/common/components/cards/failed-instances-section.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/failed-instances-section.test.tsx
@@ -25,6 +25,7 @@ describe('FailedInstancesSection', () => {
             results                           | shouldAlertFailuresCount | description
             ${{ cards: resultsWithFailures }} | ${undefined}             | ${'with failures'}
             ${null}                           | ${undefined}             | ${'null results'}
+            ${{ cards: null }}                | ${undefined}             | ${'null cards property'}
             ${{ cards: nonEmptyResults }}     | ${true}                  | ${'with alerting on'}
             ${{ cards: nonEmptyResults }}     | ${false}                 | ${'with alerting off'}
         `('$description', ({ results, shouldAlertFailuresCount }) => {

--- a/src/tests/unit/tests/common/components/cards/failed-instances-section.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/failed-instances-section.test.tsx
@@ -22,15 +22,15 @@ describe('FailedInstancesSection', () => {
 
     describe('renders', () => {
         it.each`
-            results                | shouldAlertFailuresCount | description
-            ${resultsWithFailures} | ${undefined}             | ${'with failures'}
-            ${null}                | ${undefined}             | ${'null results'}
-            ${nonEmptyResults}     | ${true}                  | ${'with alerting on'}
-            ${nonEmptyResults}     | ${false}                 | ${'with alerting off'}
+            results                           | shouldAlertFailuresCount | description
+            ${{ cards: resultsWithFailures }} | ${undefined}             | ${'with failures'}
+            ${null}                           | ${undefined}             | ${'null results'}
+            ${{ cards: nonEmptyResults }}     | ${true}                  | ${'with alerting on'}
+            ${{ cards: nonEmptyResults }}     | ${false}                 | ${'with alerting off'}
         `('$description', ({ results, shouldAlertFailuresCount }) => {
             const props = {
                 deps: {} as FailedInstancesSectionDeps,
-                cardsViewData: { cards: results },
+                cardsViewData: results,
                 shouldAlertFailuresCount,
             } as FailedInstancesSectionProps;
 


### PR DESCRIPTION
#### Description of changes

The view model has the option be null when generated. This was missed in the re-factor.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
