### PR TITLE
feat: target page changed message is different when cards UI is enabled

### DIFF
--- a/src/DetailsView/components/adhoc-issues-test-view.tsx
+++ b/src/DetailsView/components/adhoc-issues-test-view.tsx
@@ -28,6 +28,7 @@ function createTargetPageChangedView(props: AdhocIssuesTestViewProps): JSX.Eleme
             displayableData={props.configuration.displayableData}
             visualizationType={selectedTest}
             toggleClickHandler={clickHandler}
+            featureFlagStoreData={props.featureFlagStoreData}
         />
     );
 }

--- a/src/DetailsView/components/adhoc-static-test-view.tsx
+++ b/src/DetailsView/components/adhoc-static-test-view.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import * as React from 'react';
-
 import { ContentReference } from 'views/content/content-page';
+
 import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
 import { NamedFC } from '../../common/react/named-fc';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
@@ -23,6 +24,7 @@ export interface AdhocStaticTestViewProps {
     configuration: VisualizationConfiguration;
     content?: ContentReference;
     guidance?: ContentReference;
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export const AdhocStaticTestView = NamedFC<AdhocStaticTestViewProps>('AdhocStaticTestView', ({ children, ...props }) => {
@@ -33,7 +35,12 @@ export const AdhocStaticTestView = NamedFC<AdhocStaticTestViewProps>('AdhocStati
 
     if (props.tabStoreData.isChanged) {
         return (
-            <TargetPageChangedView displayableData={displayableData} visualizationType={selectedTest} toggleClickHandler={clickHandler} />
+            <TargetPageChangedView
+                displayableData={displayableData}
+                visualizationType={selectedTest}
+                toggleClickHandler={clickHandler}
+                featureFlagStoreData={props.featureFlagStoreData}
+            />
         );
     }
 

--- a/src/DetailsView/components/target-page-changed-view.tsx
+++ b/src/DetailsView/components/target-page-changed-view.tsx
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FeatureFlags } from 'common/feature-flags';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import * as React from 'react';
 
@@ -11,10 +13,15 @@ export interface TargetPageChangedViewProps {
     visualizationType: VisualizationType;
     displayableData: DisplayableVisualizationTypeData;
     toggleClickHandler: (event) => void;
+    featureFlagStoreData: FeatureFlagStoreData;
 }
 
 export const TargetPageChangedView = NamedFC<TargetPageChangedViewProps>('TargetPageChangedView', props => {
     const { title = '', toggleLabel = '', subtitle } = props.displayableData;
+
+    const oldText = 'The target page was changed. Use the toggle to enable the visualization in the current target page.';
+    const cardsUIText = 'The target page has changed. Use the start over button to scan this new target page.';
+    const displayedText = props.featureFlagStoreData[FeatureFlags.universalCardsUI] ? cardsUIText : oldText;
 
     return (
         <div className="target-page-changed">
@@ -28,7 +35,7 @@ export const TargetPageChangedView = NamedFC<TargetPageChangedViewProps>('Target
                 label={toggleLabel}
                 className="details-view-toggle"
             />
-            <p>The target page was changed. Use the toggle to enable the visualization in the current target page.</p>
+            <p>{displayedText}</p>
         </div>
     );
 });

--- a/src/DetailsView/components/target-page-changed-view.tsx
+++ b/src/DetailsView/components/target-page-changed-view.tsx
@@ -19,9 +19,9 @@ export interface TargetPageChangedViewProps {
 export const TargetPageChangedView = NamedFC<TargetPageChangedViewProps>('TargetPageChangedView', props => {
     const { title = '', toggleLabel = '', subtitle } = props.displayableData;
 
-    const oldText = 'The target page was changed. Use the toggle to enable the visualization in the current target page.';
-    const cardsUIText = 'The target page has changed. Use the start over button to scan the new target page.';
-    const displayedText = props.featureFlagStoreData[FeatureFlags.universalCardsUI] ? cardsUIText : oldText;
+    const toggleText = 'The target page was changed. Use the toggle to enable the visualization in the current target page.';
+    const startOverText = 'The target page has changed. Use the start over button to scan the new target page.';
+    const displayedText = props.featureFlagStoreData[FeatureFlags.universalCardsUI] ? startOverText : toggleText;
 
     return (
         <div className="target-page-changed">

--- a/src/DetailsView/components/target-page-changed-view.tsx
+++ b/src/DetailsView/components/target-page-changed-view.tsx
@@ -20,7 +20,7 @@ export const TargetPageChangedView = NamedFC<TargetPageChangedViewProps>('Target
     const { title = '', toggleLabel = '', subtitle } = props.displayableData;
 
     const oldText = 'The target page was changed. Use the toggle to enable the visualization in the current target page.';
-    const cardsUIText = 'The target page has changed. Use the start over button to scan this new target page.';
+    const cardsUIText = 'The target page has changed. Use the start over button to scan the new target page.';
     const displayedText = props.featureFlagStoreData[FeatureFlags.universalCardsUI] ? cardsUIText : oldText;
 
     return (

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-static-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/adhoc-static-test-view.test.tsx.snap
@@ -96,4 +96,4 @@ exports[`AdhocStaticTestView render handles no content & no guidance 1`] = `
                 }]} visualizationEnabled={true} onToggleClick={[Function: clickHandlerStub]} title=\\"test title\\" toggleLabel=\\"test toggle label\\" content={[undefined]} guidance={[undefined]} />"
 `;
 
-exports[`AdhocStaticTestView should return target page changed view as tab is changed 1`] = `"<TargetPageChangedView displayableData={{...}} visualizationType={-1} toggleClickHandler={[Function: clickHandlerStub]} />"`;
+exports[`AdhocStaticTestView should return target page changed view as tab is changed 1`] = `"<TargetPageChangedView displayableData={{...}} visualizationType={-1} toggleClickHandler={[Function: clickHandlerStub]} featureFlagStoreData={[undefined]} />"`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TargetPageChangedView renders with feature flag enabled 1`] = `
+<div
+  className="target-page-changed"
+>
+  <h1>
+    test title
+  </h1>
+  <div
+    className="target-page-changed-subtitle"
+  />
+  <StyledToggleBase
+    checked={false}
+    className="details-view-toggle"
+    label="test toggle label"
+    offText="Off"
+    onClick={[Function]}
+    onText="On"
+  />
+  <p>
+    The target page has changed. Use the start over button to scan this new target page.
+  </p>
+</div>
+`;
+
 exports[`TargetPageChangedView renders with optional subtitle 1`] = `
 <div
   className="target-page-changed"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`TargetPageChangedView renders with feature flag enabled 1`] = `
     onText="On"
   />
   <p>
-    The target page has changed. Use the start over button to scan this new target page.
+    The target page has changed. Use the start over button to scan the new target page.
   </p>
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
@@ -1,21 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FeatureFlags } from 'common/feature-flags';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+
 import { DisplayableVisualizationTypeData } from '../../../../../common/configs/visualization-configuration-factory';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { TargetPageChangedView, TargetPageChangedViewProps } from '../../../../../DetailsView/components/target-page-changed-view';
 
 describe('TargetPageChangedView', () => {
     it('renders without optional subtitle', () => {
-        testRenderWithOptionalSubtitle(undefined);
+        testRenderWithOptionalSubtitle(undefined, false);
+    });
+
+    it('renders with feature flag enabled', () => {
+        testRenderWithOptionalSubtitle(undefined, true);
     });
 
     it('renders with optional subtitle', () => {
-        testRenderWithOptionalSubtitle(<span>test subtitle content</span>);
+        testRenderWithOptionalSubtitle(<span>test subtitle content</span>, false);
     });
 
-    function testRenderWithOptionalSubtitle(subtitle?: JSX.Element): void {
+    function testRenderWithOptionalSubtitle(subtitle: JSX.Element, featureFlagEnabled: boolean): void {
         const visualizationType = VisualizationType.Landmarks;
         const clickHandlerStub: () => void = () => {};
         const displayableData = {
@@ -28,6 +34,9 @@ describe('TargetPageChangedView', () => {
             visualizationType,
             displayableData,
             toggleClickHandler: clickHandlerStub,
+            featureFlagStoreData: {
+                [FeatureFlags.universalCardsUI]: featureFlagEnabled,
+            },
         };
 
         const wrapped = shallow(<TargetPageChangedView {...props} />);


### PR DESCRIPTION
#### Description of changes

The changes to the header bar require we change the message in the target page changed dialog (based on whether the feature flag is enabled).

![image](https://user-images.githubusercontent.com/32555133/68240064-0211c200-ffc1-11e9-901c-1e458bfe15ea.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
