### PR TITLE
chore: remove preview build from drop

### DIFF
--- a/targets.config.js
+++ b/targets.config.js
@@ -103,20 +103,6 @@ module.exports = {
         bundleFolder: 'prodBundle',
         mustExistFile: 'background.bundle.js',
     },
-    preview: {
-        release: true,
-        config: {
-            options: {
-                ...publicOptions,
-                ...icons.production,
-                fullName: 'Accessibility Insights for Web - Preview',
-                telemetryBuildName: 'Preview',
-                productCategory: 'extension',
-            },
-        },
-        bundleFolder: 'prodBundle',
-        mustExistFile: 'background.bundle.js',
-    },
     electron: {
         config: {
             options: {


### PR DESCRIPTION
#### Description of changes

We are generating `preview` drop using our `targets.config.js` but we dont publish this and never use it. So removing this to avoid even generating this.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
