### PR TITLE
refactor: promisify inject api calls

### DIFF
--- a/src/background/injector-controller.ts
+++ b/src/background/injector-controller.ts
@@ -59,7 +59,7 @@ export class InjectorController {
             }, InjectorController.injectionStartedWaitTime);
 
             // tslint:disable-next-line:no-floating-promises - grandfathered
-            this.injector.injectScripts(tabId).then(() => {
+            this.injector.injectScriptsP(tabId).then(() => {
                 this.interpreter.interpret({
                     messageType: Messages.Visualizations.State.InjectionCompleted,
                     tabId: tabId,

--- a/src/background/injector-controller.ts
+++ b/src/background/injector-controller.ts
@@ -59,7 +59,7 @@ export class InjectorController {
             }, InjectorController.injectionStartedWaitTime);
 
             // tslint:disable-next-line:no-floating-promises - grandfathered
-            this.injector.injectScriptsP(tabId).then(() => {
+            this.injector.injectScripts(tabId).then(() => {
                 this.interpreter.interpret({
                     messageType: Messages.Visualizations.State.InjectionCompleted,
                     tabId: tabId,

--- a/src/background/injector/content-script-injector.ts
+++ b/src/background/injector/content-script-injector.ts
@@ -13,23 +13,23 @@ export class ContentScriptInjector {
 
     constructor(private readonly browserAdapter: BrowserAdapter, private readonly promiseFactory: PromiseFactory) {}
 
-    public injectScriptsP(tabId: number): Promise<void> {
-        this.injectCssFilesConcurrentlyP(tabId);
-        const inject = Promise.all([this.injectJsFilesInOrderP(tabId)]).then(() => Promise.resolve());
+    public injectScripts(tabId: number): Promise<void> {
+        this.injectCssFilesConcurrently(tabId);
+        const inject = Promise.all([this.injectJsFilesInOrder(tabId)]).then(() => Promise.resolve());
 
         return this.promiseFactory.timeout(inject, ContentScriptInjector.timeoutInMilliSec);
     }
 
-    private injectCssFilesConcurrentlyP(tabId: number): void {
-        ContentScriptInjector.cssFiles.forEach(file => this.injectCssFileP(tabId, file));
+    private injectCssFilesConcurrently(tabId: number): void {
+        ContentScriptInjector.cssFiles.forEach(file => this.injectCssFile(tabId, file));
     }
 
-    private injectJsFilesInOrderP(tabId: number): Promise<any[]> {
+    private injectJsFilesInOrder(tabId: number): Promise<any[]> {
         const files = ContentScriptInjector.jsFiles;
-        return Promise.all(files.map(file => this.injectJsFileP(tabId, file))).then(results => flatten(results));
+        return Promise.all(files.map(file => this.injectJsFile(tabId, file))).then(results => flatten(results));
     }
 
-    private injectJsFileP(tabId: number, file: string): Promise<any[]> {
+    private injectJsFile(tabId: number, file: string): Promise<any[]> {
         return this.browserAdapter.executeScriptInTab(tabId, {
             allFrames: true,
             file,
@@ -37,7 +37,7 @@ export class ContentScriptInjector {
         });
     }
 
-    private injectCssFileP(tabId: number, file: string): Promise<void> {
+    private injectCssFile(tabId: number, file: string): Promise<void> {
         return this.browserAdapter.insertCSSInTab(tabId, {
             allFrames: true,
             file,

--- a/src/background/injector/content-script-injector.ts
+++ b/src/background/injector/content-script-injector.ts
@@ -30,7 +30,7 @@ export class ContentScriptInjector {
     }
 
     private injectJsFileP(tabId: number, file: string): Promise<any[]> {
-        return this.browserAdapter.executeScriptInTabP(tabId, {
+        return this.browserAdapter.executeScriptInTab(tabId, {
             allFrames: true,
             file,
             runAt: 'document_start',
@@ -38,7 +38,7 @@ export class ContentScriptInjector {
     }
 
     private injectCssFileP(tabId: number, file: string): Promise<void> {
-        return this.browserAdapter.insertCSSInTabP(tabId, {
+        return this.browserAdapter.insertCSSInTab(tabId, {
             allFrames: true,
             file,
         });

--- a/src/background/injector/content-script-injector.ts
+++ b/src/background/injector/content-script-injector.ts
@@ -14,6 +14,9 @@ export class ContentScriptInjector {
     constructor(private readonly browserAdapter: BrowserAdapter, private readonly promiseFactory: PromiseFactory) {}
 
     public injectScripts(tabId: number): Promise<void> {
+        // We need the JS to be injected before we can continue (ie, before we resolve the promise),
+        // because the tab can't receive other messages until that's done, but it's okay for the CSS
+        // to keep loading in the background after-the-fact, so it's fire-and-forget.
         this.injectCssFilesConcurrently(tabId);
         const inject = Promise.all([this.injectJsFilesInOrder(tabId)]).then(() => Promise.resolve());
 

--- a/src/background/injector/content-script-injector.ts
+++ b/src/background/injector/content-script-injector.ts
@@ -13,18 +13,6 @@ export class ContentScriptInjector {
 
     constructor(private readonly browserAdapter: BrowserAdapter, private readonly promiseFactory: PromiseFactory) {}
 
-    public injectScripts(tabId: number): Promise<void> {
-        const inject = new Promise<null>(resolve => {
-            // We need the JS to be injected before we can continue (ie, before we resolve the promise),
-            // because the tab can't receive other messages until that's done, but it's okay for the CSS
-            // to keep loading in the background after-the-fact, so it's fire-and-forget.
-            this.injectCssFilesConcurrently(tabId, ContentScriptInjector.cssFiles);
-            this.injectJsFilesInOrder(tabId, ContentScriptInjector.jsFiles, resolve);
-        });
-
-        return this.promiseFactory.timeout(inject, ContentScriptInjector.timeoutInMilliSec);
-    }
-
     public injectScriptsP(tabId: number): Promise<void> {
         this.injectCssFilesConcurrentlyP(tabId);
         const inject = Promise.all([this.injectJsFilesInOrderP(tabId)]).then(() => Promise.resolve());
@@ -32,25 +20,8 @@ export class ContentScriptInjector {
         return this.promiseFactory.timeout(inject, ContentScriptInjector.timeoutInMilliSec);
     }
 
-    private injectCssFilesConcurrently(tabId: number, files: string[]): void {
-        ContentScriptInjector.cssFiles.forEach(file => {
-            this.injectCssFile(tabId, file);
-        });
-    }
-
     private injectCssFilesConcurrentlyP(tabId: number): void {
         ContentScriptInjector.cssFiles.forEach(file => this.injectCssFileP(tabId, file));
-        // return Promise.all(ContentScriptInjector.cssFiles.map(file => this.injectCssFileP(tabId, file))).then(() => Promise.resolve());
-    }
-
-    private injectJsFilesInOrder(tabId: number, files: string[], callback: Function): void {
-        if (files.length > 0) {
-            this.injectJsFile(tabId, files[0], () => {
-                this.injectJsFilesInOrder(tabId, files.slice(1, files.length), callback);
-            });
-        } else {
-            callback();
-        }
     }
 
     private injectJsFilesInOrderP(tabId: number): Promise<any[]> {
@@ -58,30 +29,11 @@ export class ContentScriptInjector {
         return Promise.all(files.map(file => this.injectJsFileP(tabId, file))).then(results => flatten(results));
     }
 
-    private injectJsFile(tabId: number, file: string, callback?: (result: any[]) => void): void {
-        this.browserAdapter.executeScriptInTab(
-            tabId,
-            {
-                allFrames: true,
-                file: file,
-                runAt: 'document_start',
-            },
-            callback,
-        );
-    }
-
     private injectJsFileP(tabId: number, file: string): Promise<any[]> {
         return this.browserAdapter.executeScriptInTabP(tabId, {
             allFrames: true,
             file,
             runAt: 'document_start',
-        });
-    }
-
-    private injectCssFile(tabId: number, file: string): void {
-        this.browserAdapter.insertCSSInTab(tabId, {
-            allFrames: true,
-            file: file,
         });
     }
 

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -20,8 +20,8 @@ export interface BrowserAdapter {
     sendMessageToTab(tabId: number, message: any): void;
     sendMessageToFrames(message: any): void;
     sendMessageToAllFramesAndTabs(message: any): void;
-    executeScriptInTabP(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]>;
-    insertCSSInTabP(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void>;
+    executeScriptInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]>;
+    insertCSSInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void>;
     getRunTimeId(): string;
     createNotification(options: chrome.notifications.NotificationOptions): void;
     getRuntimeLastError(): chrome.runtime.LastError;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -1,7 +1,6 @@
-import { ExtensionTypes } from 'webextension-polyfill-ts';
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ExtensionTypes } from 'webextension-polyfill-ts';
 
 export interface BrowserAdapter {
     getAllWindows(getInfo: chrome.windows.GetInfo, callback: (chromeWindows: chrome.windows.Window[]) => void): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -20,9 +20,7 @@ export interface BrowserAdapter {
     sendMessageToTab(tabId: number, message: any): void;
     sendMessageToFrames(message: any): void;
     sendMessageToAllFramesAndTabs(message: any): void;
-    executeScriptInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: (result: any[]) => void): void;
     executeScriptInTabP(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]>;
-    insertCSSInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: Function): void;
     insertCSSInTabP(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void>;
     getRunTimeId(): string;
     createNotification(options: chrome.notifications.NotificationOptions): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -1,3 +1,5 @@
+import { ExtensionTypes } from 'webextension-polyfill-ts';
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
@@ -19,7 +21,9 @@ export interface BrowserAdapter {
     sendMessageToFrames(message: any): void;
     sendMessageToAllFramesAndTabs(message: any): void;
     executeScriptInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: (result: any[]) => void): void;
+    executeScriptInTabP(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]>;
     insertCSSInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: Function): void;
+    insertCSSInTabP(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void>;
     getRunTimeId(): string;
     createNotification(options: chrome.notifications.NotificationOptions): void;
     getRuntimeLastError(): chrome.runtime.LastError;

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { browser } from 'webextension-polyfill-ts';
+import { browser, ExtensionTypes } from 'webextension-polyfill-ts';
 import { BrowserAdapter } from './browser-adapter';
 import { CommandsAdapter } from './commands-adapter';
 import { StorageAdapter } from './storage-adapter';
@@ -53,12 +53,20 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         });
     }
 
+    public executeScriptInTabP(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]> {
+        return browser.tabs.executeScript(tabId, details);
+    }
+
     public executeScriptInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: (result: any[]) => void): void {
         chrome.tabs.executeScript(tabId, details, callback);
     }
 
     public insertCSSInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: Function): void {
         chrome.tabs.insertCSS(tabId, details, callback);
+    }
+
+    public insertCSSInTabP(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void> {
+        return browser.tabs.insertCSS(tabId, details);
     }
 
     public createTab(url: string, callback?: (tab: chrome.tabs.Tab) => void): void {

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -53,11 +53,11 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         });
     }
 
-    public executeScriptInTabP(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]> {
+    public executeScriptInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]> {
         return browser.tabs.executeScript(tabId, details);
     }
 
-    public insertCSSInTabP(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void> {
+    public insertCSSInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void> {
         return browser.tabs.insertCSS(tabId, details);
     }
 

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -57,14 +57,6 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return browser.tabs.executeScript(tabId, details);
     }
 
-    public executeScriptInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: (result: any[]) => void): void {
-        chrome.tabs.executeScript(tabId, details, callback);
-    }
-
-    public insertCSSInTab(tabId: number, details: chrome.tabs.InjectDetails, callback?: Function): void {
-        chrome.tabs.insertCSS(tabId, details, callback);
-    }
-
     public insertCSSInTabP(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void> {
         return browser.tabs.insertCSS(tabId, details);
     }

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -47,7 +47,7 @@ describe('ContentScriptInjector', () => {
 
             ContentScriptInjector.cssFiles.forEach(cssFile => {
                 const expectedDetails = { allFrames: true, file: cssFile };
-                browserAdapterMock.setup(adapter => adapter.insertCSSInTabP(testTabId, expectedDetails)).returns(() => Promise.resolve());
+                browserAdapterMock.setup(adapter => adapter.insertCSSInTab(testTabId, expectedDetails)).returns(() => Promise.resolve());
             });
 
             await testSubject.injectScriptsP(testTabId);
@@ -61,7 +61,7 @@ describe('ContentScriptInjector', () => {
             ContentScriptInjector.jsFiles.forEach(jsFile => {
                 const expectedDetails: ExtensionTypes.InjectDetails = { allFrames: true, file: jsFile, runAt: 'document_start' };
                 browserAdapterMock
-                    .setup(adapter => adapter.executeScriptInTabP(testTabId, expectedDetails))
+                    .setup(adapter => adapter.executeScriptInTab(testTabId, expectedDetails))
                     .returns(() => Promise.resolve([]));
             });
 
@@ -78,7 +78,7 @@ describe('ContentScriptInjector', () => {
             // simulate JS injection taking a while,
             // only completing asynchronously when we explicitly invoke the resolve function from the returned promise
             browserAdapterMock
-                .setup(adapter => adapter.executeScriptInTabP(It.isAny(), It.isObjectWith({ file: ContentScriptInjector.jsFiles[0] })))
+                .setup(adapter => adapter.executeScriptInTab(It.isAny(), It.isObjectWith({ file: ContentScriptInjector.jsFiles[0] })))
                 .returns(
                     () =>
                         new Promise(resolve => {
@@ -110,11 +110,11 @@ describe('ContentScriptInjector', () => {
         });
 
         function setupInsertCSSToSucceedImmediately(): void {
-            browserAdapterMock.setup(adapter => adapter.insertCSSInTabP(It.isAny(), It.isAny())).returns(() => Promise.resolve());
+            browserAdapterMock.setup(adapter => adapter.insertCSSInTab(It.isAny(), It.isAny())).returns(() => Promise.resolve());
         }
 
         function setupExecuteScriptToSucceedImmediately(): void {
-            browserAdapterMock.setup(adapter => adapter.executeScriptInTabP(It.isAny(), It.isAny())).returns(() => Promise.resolve([]));
+            browserAdapterMock.setup(adapter => adapter.executeScriptInTab(It.isAny(), It.isAny())).returns(() => Promise.resolve([]));
         }
     });
 });

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock, Times } from 'typemoq';
-
 import { ContentScriptInjector } from 'background/injector/content-script-injector';
-import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
-import { PromiseFactory } from '../../../../common/promises/promise-factory';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { PromiseFactory } from 'common/promises/promise-factory';
+import { IMock, It, Mock, Times } from 'typemoq';
+import { ExtensionTypes } from 'webextension-polyfill-ts';
 
 describe('ContentScriptInjector', () => {
     const testTabId = 1;
@@ -26,7 +26,7 @@ describe('ContentScriptInjector', () => {
             .returns(() => Promise.resolve({}))
             .verifiable(Times.once());
 
-        await testSubject.injectScripts(testTabId);
+        await testSubject.injectScriptsP(testTabId);
 
         promiseFactoryMock.verifyAll();
     });
@@ -34,7 +34,7 @@ describe('ContentScriptInjector', () => {
     it('rejects if a timeout occurs', async () => {
         promiseFactoryMock.setup(factory => factory.timeout(It.isAny(), It.isAny())).returns(() => Promise.reject('artificial timeout'));
 
-        await expect(testSubject.injectScripts(testTabId)).rejects.toBe('artificial timeout');
+        await expect(testSubject.injectScriptsP(testTabId)).rejects.toBe('artificial timeout');
     });
 
     describe('when no timeout occurs', () => {
@@ -47,13 +47,10 @@ describe('ContentScriptInjector', () => {
 
             ContentScriptInjector.cssFiles.forEach(cssFile => {
                 const expectedDetails = { allFrames: true, file: cssFile };
-                browserAdapterMock
-                    .setup(adapter => adapter.insertCSSInTab(testTabId, expectedDetails, It.isAny()))
-                    .callback(resolveCallbackImmediately)
-                    .verifiable(Times.once());
+                browserAdapterMock.setup(adapter => adapter.insertCSSInTabP(testTabId, expectedDetails)).returns(() => Promise.resolve());
             });
 
-            await testSubject.injectScripts(testTabId);
+            await testSubject.injectScriptsP(testTabId);
 
             browserAdapterMock.verifyAll();
         });
@@ -62,14 +59,13 @@ describe('ContentScriptInjector', () => {
             setupInsertCSSToSucceedImmediately();
 
             ContentScriptInjector.jsFiles.forEach(jsFile => {
-                const expectedDetails = { allFrames: true, file: jsFile, runAt: 'document_start' };
+                const expectedDetails: ExtensionTypes.InjectDetails = { allFrames: true, file: jsFile, runAt: 'document_start' };
                 browserAdapterMock
-                    .setup(adapter => adapter.executeScriptInTab(testTabId, expectedDetails, It.isAny()))
-                    .callback(resolveCallbackImmediately)
-                    .verifiable(Times.once());
+                    .setup(adapter => adapter.executeScriptInTabP(testTabId, expectedDetails))
+                    .returns(() => Promise.resolve([]));
             });
 
-            await testSubject.injectScripts(testTabId);
+            await testSubject.injectScriptsP(testTabId);
 
             browserAdapterMock.verifyAll();
         });
@@ -77,26 +73,27 @@ describe('ContentScriptInjector', () => {
         it('resolves only after JS files have finished injecting', async () => {
             setupInsertCSSToSucceedImmediately();
 
-            let callbackPassedToExecuteScript: Function;
+            let resolvable: Function;
 
-            // simulate JS injection taking a while, only completing asynchronously when we explicitly invoke the callback
+            // simulate JS injection taking a while,
+            // only completing asynchronously when we explicitly invoke the resolve function from the returned promise
             browserAdapterMock
-                .setup(adapter =>
-                    adapter.executeScriptInTab(It.isAny(), It.isObjectWith({ file: ContentScriptInjector.jsFiles[0] }), It.isAny()),
-                )
-                .callback((tabId, details, passedCallback) => {
-                    callbackPassedToExecuteScript = passedCallback;
-                });
+                .setup(adapter => adapter.executeScriptInTabP(It.isAny(), It.isObjectWith({ file: ContentScriptInjector.jsFiles[0] })))
+                .returns(
+                    () =>
+                        new Promise(resolve => {
+                            resolvable = resolve;
+                        }),
+                );
 
             let returnedPromiseCompleted = false;
-            const returnedPromise = testSubject.injectScripts(testTabId).then(() => {
+            const returnedPromise = testSubject.injectScriptsP(testTabId).then(() => {
                 returnedPromiseCompleted = true;
             });
 
-            expect(callbackPassedToExecuteScript).toBeDefined();
             expect(returnedPromiseCompleted).toBe(false);
 
-            callbackPassedToExecuteScript(); // simulate JS injection finishing
+            resolvable(); // simulate JS injection finishing
             await returnedPromise;
 
             expect(returnedPromiseCompleted).toBe(true);
@@ -107,27 +104,17 @@ describe('ContentScriptInjector', () => {
 
             // Intentionally don't set up insertCSS callbacks to be called
 
-            await testSubject.injectScripts(testTabId);
+            await testSubject.injectScriptsP(testTabId);
 
             // expect to not timeout
         });
 
-        function resolveCallbackImmediately(tabId: any, details: any, callback?: Function): void {
-            if (callback) {
-                callback();
-            }
-        }
-
         function setupInsertCSSToSucceedImmediately(): void {
-            browserAdapterMock
-                .setup(adapter => adapter.insertCSSInTab(It.isAny(), It.isAny(), It.isAny()))
-                .callback(resolveCallbackImmediately);
+            browserAdapterMock.setup(adapter => adapter.insertCSSInTabP(It.isAny(), It.isAny())).returns(() => Promise.resolve());
         }
 
         function setupExecuteScriptToSucceedImmediately(): void {
-            browserAdapterMock
-                .setup(adapter => adapter.executeScriptInTab(It.isAny(), It.isAny(), It.isAny()))
-                .callback(resolveCallbackImmediately);
+            browserAdapterMock.setup(adapter => adapter.executeScriptInTabP(It.isAny(), It.isAny())).returns(() => Promise.resolve([]));
         }
     });
 });

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -26,7 +26,7 @@ describe('ContentScriptInjector', () => {
             .returns(() => Promise.resolve({}))
             .verifiable(Times.once());
 
-        await testSubject.injectScriptsP(testTabId);
+        await testSubject.injectScripts(testTabId);
 
         promiseFactoryMock.verifyAll();
     });
@@ -34,7 +34,7 @@ describe('ContentScriptInjector', () => {
     it('rejects if a timeout occurs', async () => {
         promiseFactoryMock.setup(factory => factory.timeout(It.isAny(), It.isAny())).returns(() => Promise.reject('artificial timeout'));
 
-        await expect(testSubject.injectScriptsP(testTabId)).rejects.toBe('artificial timeout');
+        await expect(testSubject.injectScripts(testTabId)).rejects.toBe('artificial timeout');
     });
 
     describe('when no timeout occurs', () => {
@@ -50,7 +50,7 @@ describe('ContentScriptInjector', () => {
                 browserAdapterMock.setup(adapter => adapter.insertCSSInTab(testTabId, expectedDetails)).returns(() => Promise.resolve());
             });
 
-            await testSubject.injectScriptsP(testTabId);
+            await testSubject.injectScripts(testTabId);
 
             browserAdapterMock.verifyAll();
         });
@@ -65,7 +65,7 @@ describe('ContentScriptInjector', () => {
                     .returns(() => Promise.resolve([]));
             });
 
-            await testSubject.injectScriptsP(testTabId);
+            await testSubject.injectScripts(testTabId);
 
             browserAdapterMock.verifyAll();
         });
@@ -87,7 +87,7 @@ describe('ContentScriptInjector', () => {
                 );
 
             let returnedPromiseCompleted = false;
-            const returnedPromise = testSubject.injectScriptsP(testTabId).then(() => {
+            const returnedPromise = testSubject.injectScripts(testTabId).then(() => {
                 returnedPromiseCompleted = true;
             });
 
@@ -104,7 +104,7 @@ describe('ContentScriptInjector', () => {
 
             // Intentionally don't set up insertCSS callbacks to be called
 
-            await testSubject.injectScriptsP(testTabId);
+            await testSubject.injectScripts(testTabId);
 
             // expect to not timeout
         });

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -241,10 +241,8 @@ class InjectorControllerValidator {
 
     public setupInjectScriptsCall(calledWithTabId: number, numTimes: number): InjectorControllerValidator {
         this.mockInjector
-            .setup(injector => injector.injectScripts(calledWithTabId))
-            .returns(tabId => {
-                return this.injectedScriptsDeferred.promise as any;
-            })
+            .setup(injector => injector.injectScriptsP(calledWithTabId))
+            .returns(() => this.injectedScriptsDeferred.promise as any)
             .verifiable(Times.exactly(numTimes));
 
         return this;

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -241,7 +241,7 @@ class InjectorControllerValidator {
 
     public setupInjectScriptsCall(calledWithTabId: number, numTimes: number): InjectorControllerValidator {
         this.mockInjector
-            .setup(injector => injector.injectScriptsP(calledWithTabId))
+            .setup(injector => injector.injectScripts(calledWithTabId))
             .returns(() => this.injectedScriptsDeferred.promise as any)
             .verifiable(Times.exactly(numTimes));
 


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->
As part of the permissions works, I'd like to convert `executeScriptInTab` and `insertCSSInTab` from using callbacks to use promises. This will help on how we handle permissions when injecting in a future PR.

As a note: we already converted `getUserData`, `setUserData` and `removeUserData` (all part of `StorageAdpater` type) successfully in the past.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
