### PR TITLE
fix: Accessible name missing in certain custom widget requirement result instances

### DIFF
--- a/src/assessments/custom-widgets/test-steps/expected-input.tsx
+++ b/src/assessments/custom-widgets/test-steps/expected-input.tsx
@@ -59,7 +59,7 @@ export const ExpectedInput: Requirement = {
                     defaultValue: NoValue,
                 },
                 {
-                    propertyName: 'text',
+                    propertyName: 'accessibleName',
                     displayName: 'Accessible name',
                     defaultValue: NoValue,
                 },

--- a/src/assessments/custom-widgets/test-steps/instructions.tsx
+++ b/src/assessments/custom-widgets/test-steps/instructions.tsx
@@ -63,7 +63,7 @@ export const Instructions: Requirement = {
                     defaultValue: NoValue,
                 },
                 {
-                    propertyName: 'text',
+                    propertyName: 'accessibleName',
                     displayName: 'Accessible name',
                     defaultValue: NoValue,
                 },

--- a/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
+++ b/src/assessments/custom-widgets/test-steps/keyboard-interaction.tsx
@@ -60,7 +60,7 @@ export const KeyboardInteraction: Requirement = {
                     defaultValue: NoValue,
                 },
                 {
-                    propertyName: 'text',
+                    propertyName: 'accessibleName',
                     displayName: 'Accessible name',
                     defaultValue: NoValue,
                 },

--- a/src/assessments/custom-widgets/test-steps/role-state-property.tsx
+++ b/src/assessments/custom-widgets/test-steps/role-state-property.tsx
@@ -77,7 +77,7 @@ export const RoleStateProperty: Requirement = {
                     defaultValue: NoValue,
                 },
                 {
-                    propertyName: 'text',
+                    propertyName: 'accessibleName',
                     displayName: 'Accessible name',
                     defaultValue: NoValue,
                 },


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->
Some of the requirements in custom widgets did not display the custom name. A wrong property was being referenced causing this issue.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [X] Addresses an existing issue: #0000
- [X] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
