### PR TITLE
feat: add telemetry to action/action messages for cards related UI

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -274,7 +274,11 @@ if (isNaN(tabId) === false) {
                 createIssueDetailsBuilder(PlainTextFormatter),
             );
 
-            const cardSelectionMessageCreator = new CardSelectionMessageCreator(actionMessageDispatcher);
+            const cardSelectionMessageCreator = new CardSelectionMessageCreator(
+                actionMessageDispatcher,
+                telemetryFactory,
+                TelemetryEventSource.DetailsView,
+            );
             const windowUtils = new WindowUtils();
 
             const fileURLProvider = new FileURLProvider(windowUtils, provideBlob);

--- a/src/background/actions/card-selection-action-creator.ts
+++ b/src/background/actions/card-selection-action-creator.ts
@@ -7,7 +7,7 @@ import { getStoreStateMessage, Messages } from '../../common/messages';
 import { CardSelectionActions } from '../actions/card-selection-actions';
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
-import { CardSelectionPayload, RuleExpandCollapsePayload } from './action-payloads';
+import { BaseActionPayload, CardSelectionPayload, RuleExpandCollapsePayload } from './action-payloads';
 
 export class CardSelectionActionCreator {
     constructor(
@@ -39,15 +39,18 @@ export class CardSelectionActionCreator {
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.RULE_EXPANSION_TOGGLED, payload);
     };
 
-    private onToggleVisualHelper = (): void => {
+    private onToggleVisualHelper = (payload: BaseActionPayload): void => {
         this.cardSelectionActions.toggleVisualHelper.invoke(null);
+        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.VISUAL_HELPER_TOGGLED, payload);
     };
 
-    private onCollapseAllRules = (): void => {
+    private onCollapseAllRules = (payload: BaseActionPayload): void => {
         this.cardSelectionActions.collapseAllRules.invoke(null);
+        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_COLLAPSED, payload);
     };
 
-    private onExpandAllRules = (): void => {
+    private onExpandAllRules = (payload: BaseActionPayload): void => {
         this.cardSelectionActions.expandAllRules.invoke(null);
+        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.ALL_RULES_EXPANDED, payload);
     };
 }

--- a/src/common/components/cards/collapsible-component-cards.tsx
+++ b/src/common/components/cards/collapsible-component-cards.tsx
@@ -45,7 +45,7 @@ const CollapsibleComponentCards = NamedFC<CollapsibleComponentCardsProps>(
             collapsedCSSClassName = null;
         }
 
-        const onClick = () => deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(id);
+        const onClick = (event: React.MouseEvent<HTMLDivElement>) => deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(id, event);
 
         return (
             <div className={css(containerClassName, collapsibleContainer, collapsedCSSClassName)}>

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -48,16 +48,16 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
         return <>{cardRows}</>;
     };
 
-    const cardClickHandler = (): void => {
+    const cardClickHandler = (event: React.SyntheticEvent): void => {
         if (isHighlightSupported) {
-            deps.cardSelectionMessageCreator.toggleCardSelection(result.ruleId, result.uid);
+            deps.cardSelectionMessageCreator.toggleCardSelection(result.ruleId, result.uid, event);
         }
     };
 
     const cardKeyPressHandler = (event: React.KeyboardEvent<any>): void => {
         if (event.keyCode === KeyCodeConstants.ENTER || event.keyCode === KeyCodeConstants.SPACEBAR) {
             event.preventDefault();
-            cardClickHandler();
+            cardClickHandler(event);
         }
     };
 

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -56,6 +56,9 @@ export const CONTENT_PAGE_OPENED: string = 'contentPageOpened';
 export const CONTENT_HYPERLINK_OPENED: string = 'contentHyperLinkOpened';
 export const CARD_SELECTION_TOGGLED: string = 'cardSelectionToggled';
 export const RULE_EXPANSION_TOGGLED: string = 'ruleExpansionToggled';
+export const VISUAL_HELPER_TOGGLED: string = 'visualHelperToggled';
+export const ALL_RULES_EXPANDED: string = 'allRulesExpanded';
+export const ALL_RULES_COLLAPSED: string = 'allRulesCollapsed';
 
 export const TriggeredByNotApplicable: TriggeredBy = 'N/A';
 export type TriggeredBy = 'mouseclick' | 'keypress' | 'shortcut' | 'N/A';

--- a/src/common/message-creators/card-selection-message-creator.ts
+++ b/src/common/message-creators/card-selection-message-creator.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CardSelectionPayload, RuleExpandCollapsePayload } from 'background/actions/action-payloads';
+import { BaseActionPayload, CardSelectionPayload, RuleExpandCollapsePayload } from 'background/actions/action-payloads';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { Messages } from 'common/messages';
@@ -38,21 +38,36 @@ export class CardSelectionMessageCreator {
         });
     }
 
-    public collapseAllRules(): void {
+    public collapseAllRules(event: React.SyntheticEvent): void {
+        const payload: BaseActionPayload = {
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
         this.dispatcher.dispatchMessage({
             messageType: Messages.CardSelection.CollapseAllRules,
+            payload,
         });
     }
 
-    public expandAllRules(): void {
+    public expandAllRules(event: React.SyntheticEvent): void {
+        const payload: BaseActionPayload = {
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
         this.dispatcher.dispatchMessage({
             messageType: Messages.CardSelection.ExpandAllRules,
+            payload,
         });
     }
 
-    public toggleVisualHelper(): void {
+    public toggleVisualHelper(event: React.SyntheticEvent): void {
+        const payload: BaseActionPayload = {
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
+        };
+
         this.dispatcher.dispatchMessage({
             messageType: Messages.CardSelection.ToggleVisualHelper,
+            payload,
         });
     }
 }

--- a/src/common/message-creators/card-selection-message-creator.ts
+++ b/src/common/message-creators/card-selection-message-creator.ts
@@ -1,16 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CardSelectionPayload, RuleExpandCollapsePayload } from 'background/actions/action-payloads';
+import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { Messages } from 'common/messages';
+import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 
 export class CardSelectionMessageCreator {
-    constructor(private readonly dispatcher: ActionMessageDispatcher) {}
+    constructor(
+        private readonly dispatcher: ActionMessageDispatcher,
+        private readonly telemetryFactory: TelemetryDataFactory,
+        private readonly source: TelemetryEventSource,
+    ) {}
 
-    public toggleCardSelection(ruleId: string, resultInstanceUid: string): void {
+    public toggleCardSelection(ruleId: string, resultInstanceUid: string, event: React.SyntheticEvent): void {
         const payload: CardSelectionPayload = {
             resultInstanceUid,
             ruleId,
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
         };
 
         this.dispatcher.dispatchMessage({

--- a/src/common/message-creators/card-selection-message-creator.ts
+++ b/src/common/message-creators/card-selection-message-creator.ts
@@ -26,9 +26,10 @@ export class CardSelectionMessageCreator {
         });
     }
 
-    public toggleRuleExpandCollapse(ruleId: string): void {
+    public toggleRuleExpandCollapse(ruleId: string, event: React.SyntheticEvent): void {
         const payload: RuleExpandCollapsePayload = {
             ruleId,
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, this.source),
         };
 
         this.dispatcher.dispatchMessage({

--- a/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseActionPayload, CardSelectionPayload } from 'background/actions/action-payloads';
+import { BaseActionPayload, CardSelectionPayload, RuleExpandCollapsePayload } from 'background/actions/action-payloads';
 import { CardSelectionActionCreator } from 'background/actions/card-selection-action-creator';
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
@@ -34,6 +34,25 @@ describe('CardSelectionActionCreator', () => {
         toggleCardSelectionMock.verifyAll();
         telemetryEventHandlerMock.verify(
             handler => handler.publishTelemetry(TelemetryEvents.CARD_SELECTION_TOGGLED, payload),
+            Times.once(),
+        );
+    });
+
+    test('onRuleExpansionToggle', () => {
+        const payload: RuleExpandCollapsePayload = {
+            ruleId: 'test-rule-id',
+        };
+        const ruleExpansionToggleMock = createActionMock(payload);
+        const actionsMock = createActionsMock('toggleRuleExpandCollapse', ruleExpansionToggleMock.object);
+        const interpreterMock = createInterpreterMock(Messages.CardSelection.RuleExpansionToggled, payload, tabId);
+
+        const testSubject = new CardSelectionActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+
+        testSubject.registerCallbacks();
+
+        ruleExpansionToggleMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.RULE_EXPANSION_TOGGLED, payload),
             Times.once(),
         );
     });

--- a/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CardSelectionPayload } from 'background/actions/action-payloads';
+import { BaseActionPayload, CardSelectionPayload } from 'background/actions/action-payloads';
 import { CardSelectionActionCreator } from 'background/actions/card-selection-action-creator';
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
@@ -39,39 +39,54 @@ describe('CardSelectionActionCreator', () => {
     });
 
     test('onToggleVisualHelper', () => {
+        const payloadStub: BaseActionPayload = {};
         const toggleVisualHelperMock = createActionMock(null);
         const actionsMock = createActionsMock('toggleVisualHelper', toggleVisualHelperMock.object);
-        const interpreterMock = createInterpreterMock(Messages.CardSelection.ToggleVisualHelper, tabId);
+        const interpreterMock = createInterpreterMock(Messages.CardSelection.ToggleVisualHelper, payloadStub, tabId);
 
         const testSubject = new CardSelectionActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
 
         testSubject.registerCallbacks();
 
         toggleVisualHelperMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.VISUAL_HELPER_TOGGLED, payloadStub),
+            Times.once(),
+        );
     });
 
     test('onCollapseAllRules', () => {
+        const payloadStub: BaseActionPayload = {};
         const collapseAllRulesActionMock = createActionMock(null);
         const actionsMock = createActionsMock('collapseAllRules', collapseAllRulesActionMock.object);
-        const interpreterMock = createInterpreterMock(Messages.CardSelection.CollapseAllRules, tabId);
+        const interpreterMock = createInterpreterMock(Messages.CardSelection.CollapseAllRules, payloadStub, tabId);
 
         const testSubject = new CardSelectionActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
 
         testSubject.registerCallbacks();
 
         collapseAllRulesActionMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.ALL_RULES_COLLAPSED, payloadStub),
+            Times.once(),
+        );
     });
 
     test('onExpandAllRules', () => {
+        const payloadStub: BaseActionPayload = {};
         const expandAllRulesActionMock = createActionMock(null);
         const actionsMock = createActionsMock('expandAllRules', expandAllRulesActionMock.object);
-        const interpreterMock = createInterpreterMock(Messages.CardSelection.ExpandAllRules, tabId);
+        const interpreterMock = createInterpreterMock(Messages.CardSelection.ExpandAllRules, payloadStub, tabId);
 
         const testSubject = new CardSelectionActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
 
         testSubject.registerCallbacks();
 
         expandAllRulesActionMock.verifyAll();
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.ALL_RULES_EXPANDED, payloadStub),
+            Times.once(),
+        );
     });
 
     function createActionsMock<ActionName extends keyof CardSelectionActions>(

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/instance-details.test.tsx.snap
@@ -34,6 +34,8 @@ exports[`InstanceDetails isSelected drives the styling for the card 1`] = `
           "cardSelectionMessageCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "dispatcher": undefined,
+            "source": undefined,
+            "telemetryFactory": undefined,
           },
           "getPropertyConfigById": [Function],
         }
@@ -92,6 +94,8 @@ exports[`InstanceDetails isSelected drives the styling for the card 2`] = `
           "cardSelectionMessageCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "dispatcher": undefined,
+            "source": undefined,
+            "telemetryFactory": undefined,
           },
           "getPropertyConfigById": [Function],
         }
@@ -145,6 +149,8 @@ exports[`InstanceDetails renders 1`] = `
                 "cardSelectionMessageCreator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "dispatcher": undefined,
+                  "source": undefined,
+                  "telemetryFactory": undefined,
                 },
                 "getPropertyConfigById": [Function],
               }
@@ -165,6 +171,8 @@ exports[`InstanceDetails renders 1`] = `
                 "cardSelectionMessageCreator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "dispatcher": undefined,
+                  "source": undefined,
+                  "telemetryFactory": undefined,
                 },
                 "getPropertyConfigById": [Function],
               }
@@ -185,6 +193,8 @@ exports[`InstanceDetails renders 1`] = `
                 "cardSelectionMessageCreator": proxy {
                   "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                   "dispatcher": undefined,
+                  "source": undefined,
+                  "telemetryFactory": undefined,
                 },
                 "getPropertyConfigById": [Function],
               }
@@ -216,6 +226,8 @@ exports[`InstanceDetails renders 1`] = `
           "cardSelectionMessageCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "dispatcher": undefined,
+            "source": undefined,
+            "telemetryFactory": undefined,
           },
           "getPropertyConfigById": [Function],
         }
@@ -285,6 +297,8 @@ exports[`InstanceDetails renders nothing when there is no card row config for th
           "cardSelectionMessageCreator": proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "dispatcher": undefined,
+            "source": undefined,
+            "telemetryFactory": undefined,
           },
           "getPropertyConfigById": [Function],
         }

--- a/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
@@ -22,7 +22,9 @@ describe('CollapsibleComponentCardsTest', () => {
     forOwn(optionalPropertiesObject, (propertyValues, propertyName) => {
         propertyValues.forEach(value => {
             test(`render with ${propertyName} set to: ${value}`, () => {
-                cardSelectionMessageCreatorMock.setup(mock => mock.toggleRuleExpandCollapse(It.isAnyString())).verifiable(Times.never());
+                cardSelectionMessageCreatorMock
+                    .setup(mock => mock.toggleRuleExpandCollapse(It.isAnyString(), It.isAny()))
+                    .verifiable(Times.never());
 
                 const props: CollapsibleComponentCardsProps = {
                     header: <div>Some header</div>,
@@ -41,7 +43,8 @@ describe('CollapsibleComponentCardsTest', () => {
     });
 
     test('toggle from expanded to collapsed', () => {
-        cardSelectionMessageCreatorMock.setup(mock => mock.toggleRuleExpandCollapse(It.isAnyString())).verifiable(Times.once());
+        const eventStub = {} as React.SyntheticEvent;
+        cardSelectionMessageCreatorMock.setup(mock => mock.toggleRuleExpandCollapse(It.isAnyString(), eventStub)).verifiable(Times.once());
 
         const props: CollapsibleComponentCardsProps = {
             header: <div>Some header</div>,
@@ -58,7 +61,7 @@ describe('CollapsibleComponentCardsTest', () => {
         expect(result.getElement()).toMatchSnapshot('expanded');
 
         const button = result.find('CustomizedActionButton');
-        button.simulate('click');
+        button.simulate('click', eventStub);
         expect(result.getElement()).toMatchSnapshot('collapsed');
 
         cardSelectionMessageCreatorMock.verifyAll();

--- a/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/instance-details.test.tsx
@@ -43,7 +43,7 @@ describe('InstanceDetails', () => {
     it('renders', () => {
         setupGetPropertyConfigByIdMock();
         cardSelectionMessageCreatorMock
-            .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString()))
+            .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString(), It.isAny()))
             .verifiable(Times.never());
 
         const testSubject = shallow(<InstanceDetails {...props} />);
@@ -54,16 +54,17 @@ describe('InstanceDetails', () => {
 
     it('dispatches the card selection message when card is clicked', () => {
         setupGetPropertyConfigByIdMock();
+        const eventStub = {} as React.SyntheticEvent;
 
         cardSelectionMessageCreatorMock
-            .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString()))
+            .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString(), eventStub))
             .verifiable(Times.once());
 
         const wrapper = shallow(<InstanceDetails {...props} />);
         const divElem = wrapper.find(`.${instanceDetailsCard}`);
         expect(divElem.length).toBe(1);
 
-        divElem.simulate('click');
+        divElem.simulate('click', eventStub);
 
         cardSelectionMessageCreatorMock.verifyAll();
     });
@@ -81,7 +82,7 @@ describe('InstanceDetails', () => {
         setupGetPropertyConfigByIdMock();
 
         cardSelectionMessageCreatorMock
-            .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString()))
+            .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString(), It.isAny()))
             .verifiable(Times.never());
 
         const wrapper = shallow(<InstanceDetails {...props} />);
@@ -96,17 +97,18 @@ describe('InstanceDetails', () => {
     const supportedKeyCodes = [KeyCodeConstants.ENTER, KeyCodeConstants.SPACEBAR];
     it.each(supportedKeyCodes)('dispatches the card selection message when key with keycode %s is pressed', keyCode => {
         const preventDefaultMock = jest.fn();
+        const eventStub = { keyCode: keyCode, preventDefault: preventDefaultMock } as any;
         setupGetPropertyConfigByIdMock();
 
         cardSelectionMessageCreatorMock
-            .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString()))
+            .setup(mock => mock.toggleCardSelection(It.isAnyString(), It.isAnyString(), eventStub))
             .verifiable(Times.once());
 
         const wrapper = shallow(<InstanceDetails {...props} />);
         const divElem = wrapper.find(`.${instanceDetailsCard}`);
         expect(divElem.length).toBe(1);
 
-        divElem.simulate('keydown', { keyCode: keyCode, preventDefault: preventDefaultMock });
+        divElem.simulate('keydown', eventStub);
 
         cardSelectionMessageCreatorMock.verifyAll();
         expect(preventDefaultMock).toHaveBeenCalled();

--- a/src/tests/unit/tests/common/message-creators/card-selection-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/card-selection-message-creator.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CardSelectionPayload, RuleExpandCollapsePayload } from 'background/actions/action-payloads';
+import { BaseActionPayload, CardSelectionPayload, RuleExpandCollapsePayload } from 'background/actions/action-payloads';
 import { BaseTelemetryData, TelemetryEventSource } from 'common/extension-telemetry-events';
 import { Message } from 'common/message';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
@@ -68,31 +68,52 @@ describe('Card Selection Message Creator', () => {
     });
 
     test('collapseAllRules', () => {
-        const expectedMessage: Message = {
-            messageType: Messages.CardSelection.CollapseAllRules,
+        const payload: BaseActionPayload = {
+            telemetry: telemetryStub,
         };
 
-        testSubject.collapseAllRules();
+        const expectedMessage: Message = {
+            messageType: Messages.CardSelection.CollapseAllRules,
+            payload,
+        };
+
+        telemetryDataFactoryMock.setup(tdfm => tdfm.withTriggeredByAndSource(eventStub, sourceStub)).returns(() => telemetryStub);
+
+        testSubject.collapseAllRules(eventStub);
 
         dispatcherMock.verify(dm => dm.dispatchMessage(expectedMessage), Times.once());
     });
 
     test('expandAllRules', () => {
-        const expectedMessage: Message = {
-            messageType: Messages.CardSelection.ExpandAllRules,
+        const payload: BaseActionPayload = {
+            telemetry: telemetryStub,
         };
 
-        testSubject.expandAllRules();
+        const expectedMessage: Message = {
+            messageType: Messages.CardSelection.ExpandAllRules,
+            payload,
+        };
+
+        telemetryDataFactoryMock.setup(tdfm => tdfm.withTriggeredByAndSource(eventStub, sourceStub)).returns(() => telemetryStub);
+
+        testSubject.expandAllRules(eventStub);
 
         dispatcherMock.verify(dm => dm.dispatchMessage(expectedMessage), Times.once());
     });
 
     test('toggleVisualHelper', () => {
-        const expectedMessage: Message = {
-            messageType: Messages.CardSelection.ToggleVisualHelper,
+        const payload: BaseActionPayload = {
+            telemetry: telemetryStub,
         };
 
-        testSubject.toggleVisualHelper();
+        const expectedMessage: Message = {
+            messageType: Messages.CardSelection.ToggleVisualHelper,
+            payload,
+        };
+
+        telemetryDataFactoryMock.setup(tdfm => tdfm.withTriggeredByAndSource(eventStub, sourceStub)).returns(() => telemetryStub);
+
+        testSubject.toggleVisualHelper(eventStub);
 
         dispatcherMock.verify(dm => dm.dispatchMessage(expectedMessage), Times.once());
     });

--- a/src/tests/unit/tests/common/message-creators/card-selection-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/card-selection-message-creator.test.ts
@@ -7,7 +7,6 @@ import { CardSelectionMessageCreator } from 'common/message-creators/card-select
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { Messages } from 'common/messages';
 import { TelemetryDataFactory } from 'common/telemetry-data-factory';
-import { EventStub, EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, Times } from 'typemoq';
 
 describe('Card Selection Message Creator', () => {

--- a/src/tests/unit/tests/common/message-creators/card-selection-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/card-selection-message-creator.test.ts
@@ -52,6 +52,7 @@ describe('Card Selection Message Creator', () => {
         const ruleId = 'test-rule-id';
         const payload: RuleExpandCollapsePayload = {
             ruleId,
+            telemetry: telemetryStub,
         };
 
         const expectedMessage: Message = {
@@ -59,7 +60,9 @@ describe('Card Selection Message Creator', () => {
             payload,
         };
 
-        testSubject.toggleRuleExpandCollapse(ruleId);
+        telemetryDataFactoryMock.setup(tdfm => tdfm.withTriggeredByAndSource(eventStub, sourceStub)).returns(() => telemetryStub);
+
+        testSubject.toggleRuleExpandCollapse(ruleId, eventStub);
 
         dispatcherMock.verify(handler => handler.dispatchMessage(expectedMessage), Times.once());
     });


### PR DESCRIPTION
#### Description of changes

The card selection message creator was missing the telemetry necessary in the payload to fire telemetry for events. This adds that in addition to publishing telemetry for the new actions (expand/collapse all rules, toggleVisualHelper). Further, it back-fills a missing test for onRuleExpansionToggle.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
