### PR TITLE
feat(consistent-cards-UI): Update card selection view data with visual helper

### DIFF
--- a/src/common/get-card-selection-view-data.ts
+++ b/src/common/get-card-selection-view-data.ts
@@ -11,6 +11,7 @@ export interface CardSelectionViewData {
     highlightedResultUids: string[]; // page elements to highlight
     selectedResultUids: string[]; // indicates selected cards
     expandedRuleIds: string[];
+    visualHelperEnabled: boolean;
 }
 
 export type GetCardSelectionViewData = (storeData: CardSelectionStoreData) => CardSelectionViewData;
@@ -22,7 +23,14 @@ export const getCardSelectionViewData: GetCardSelectionViewData = (storeData: Ca
         return viewData;
     }
 
+    viewData.visualHelperEnabled = storeData.visualHelperEnabled || false;
+
     viewData.expandedRuleIds = getRuleIdsOfExpandedRules(storeData.rules);
+
+    if (!storeData.visualHelperEnabled) {
+        // no selected cards; no highlighted instances
+        return viewData;
+    }
 
     if (viewData.expandedRuleIds.length === 0) {
         viewData.highlightedResultUids = getAllResultUids(storeData.rules);
@@ -43,6 +51,7 @@ function getEmptyViewData(): CardSelectionViewData {
         highlightedResultUids: [],
         selectedResultUids: [],
         expandedRuleIds: [],
+        visualHelperEnabled: false,
     };
 
     return viewData;

--- a/src/tests/unit/common/rule-based-view-model-provider.test.ts
+++ b/src/tests/unit/common/rule-based-view-model-provider.test.ts
@@ -52,6 +52,7 @@ describe('RuleBasedViewModelProvider', () => {
             expandedRuleIds: testScenario.isExpanded ? ['rule1'] : [],
             highlightedResultUids: testScenario.isHighlighted ? ['stub_uid'] : [],
             selectedResultUids: testScenario.isExpanded && testScenario.isSelected ? ['stub_uid'] : [],
+            visualHelperEnabled: true,
         };
 
         const actualResults: CardsViewModel = getCardViewData(rules, results, cardSelectionViewData);

--- a/src/tests/unit/tests/common/get-card-selection-view-data.test.ts
+++ b/src/tests/unit/tests/common/get-card-selection-view-data.test.ts
@@ -25,21 +25,22 @@ describe('getCardSelectionStoreviewData', () => {
                     },
                 },
             },
-            visualHelperEnabled: false,
+            visualHelperEnabled: true,
         };
 
         initialState = cloneDeep(defaultState);
     });
 
-    test('all rules collapsed, expect all highlights', () => {
+    test('all rules collapsed, visual helper enabled, expect all highlights', () => {
         const viewData = getCardSelectionViewData(initialState);
 
         expect(viewData.highlightedResultUids).toEqual(['sampleUid1', 'sampleUid2', 'sampleUid3', 'sampleUid4']);
         expect(viewData.expandedRuleIds).toEqual([]);
         expect(viewData.selectedResultUids).toEqual([]);
+        expect(viewData.visualHelperEnabled).toEqual(true);
     });
 
-    test('all rules expanded, expect all highlights', () => {
+    test('all rules expanded, visual helper enabled, expect all highlights', () => {
         initialState.rules['sampleRuleId1'].isExpanded = true;
         initialState.rules['sampleRuleId2'].isExpanded = true;
 
@@ -48,9 +49,10 @@ describe('getCardSelectionStoreviewData', () => {
         expect(viewData.highlightedResultUids).toEqual(['sampleUid1', 'sampleUid2', 'sampleUid3', 'sampleUid4']);
         expect(viewData.expandedRuleIds).toEqual(['sampleRuleId1', 'sampleRuleId2']);
         expect(viewData.selectedResultUids).toEqual([]);
+        expect(viewData.visualHelperEnabled).toEqual(true);
     });
 
-    test('one rule expanded, expect some highlights', () => {
+    test('one rule expanded, visual helper enabled, expect some highlights', () => {
         initialState.rules['sampleRuleId1'].isExpanded = true;
 
         const viewData = getCardSelectionViewData(initialState);
@@ -58,9 +60,10 @@ describe('getCardSelectionStoreviewData', () => {
         expect(viewData.highlightedResultUids).toEqual(['sampleUid1', 'sampleUid2']);
         expect(viewData.expandedRuleIds).toEqual(['sampleRuleId1']);
         expect(viewData.selectedResultUids).toEqual([]);
+        expect(viewData.visualHelperEnabled).toEqual(true);
     });
 
-    test('all rules expanded, one card selected, expect one highlight', () => {
+    test('all rules expanded, visual helper enabled, one card selected, expect one highlight', () => {
         initialState.rules['sampleRuleId1'].isExpanded = true;
         initialState.rules['sampleRuleId2'].isExpanded = true;
         initialState.rules['sampleRuleId2'].cards['sampleUid3'] = true;
@@ -70,9 +73,10 @@ describe('getCardSelectionStoreviewData', () => {
         expect(viewData.highlightedResultUids).toEqual(['sampleUid3']);
         expect(viewData.expandedRuleIds).toEqual(['sampleRuleId1', 'sampleRuleId2']);
         expect(viewData.selectedResultUids).toEqual(['sampleUid3']);
+        expect(viewData.visualHelperEnabled).toEqual(true);
     });
 
-    test('all rules collapsed, one card selected, expect all highlights', () => {
+    test('all rules collapsed, visual helper enabled , one card selected, expect all highlights', () => {
         initialState.rules['sampleRuleId2'].cards['sampleUid3'] = true;
 
         const viewData = getCardSelectionViewData(initialState);
@@ -80,6 +84,21 @@ describe('getCardSelectionStoreviewData', () => {
         expect(viewData.highlightedResultUids).toEqual(['sampleUid1', 'sampleUid2', 'sampleUid3', 'sampleUid4']);
         expect(viewData.expandedRuleIds).toEqual([]);
         expect(viewData.selectedResultUids).toEqual([]);
+        expect(viewData.visualHelperEnabled).toEqual(true);
+    });
+
+    test('all rules expanded, visual helper disabled, one card selected, expect no highlights or selected cards but rules still expanded', () => {
+        initialState.rules['sampleRuleId1'].isExpanded = true;
+        initialState.rules['sampleRuleId2'].isExpanded = true;
+        initialState.rules['sampleRuleId2'].cards['sampleUid3'] = true;
+        initialState.visualHelperEnabled = false;
+
+        const viewData = getCardSelectionViewData(initialState);
+
+        expect(viewData.highlightedResultUids).toEqual([]);
+        expect(viewData.expandedRuleIds).toEqual(['sampleRuleId1', 'sampleRuleId2']);
+        expect(viewData.selectedResultUids).toEqual([]);
+        expect(viewData.visualHelperEnabled).toEqual(false);
     });
 
     test('null store data, expect no results', () => {
@@ -88,6 +107,7 @@ describe('getCardSelectionStoreviewData', () => {
         expect(viewData.highlightedResultUids).toEqual([]);
         expect(viewData.expandedRuleIds).toEqual([]);
         expect(viewData.selectedResultUids).toEqual([]);
+        expect(viewData.visualHelperEnabled).toEqual(false);
     });
 
     test('invalid store data, expect no results', () => {
@@ -96,5 +116,6 @@ describe('getCardSelectionStoreviewData', () => {
         expect(viewData.highlightedResultUids).toEqual([]);
         expect(viewData.expandedRuleIds).toEqual([]);
         expect(viewData.selectedResultUids).toEqual([]);
+        expect(viewData.visualHelperEnabled).toEqual(false);
     });
 });


### PR DESCRIPTION
#### Description of changes

The intent of the change is that when the visual helper is disabled, no cards are selected and no instances are highlighted. Rule expansion should remain unchanged.

Note: the change to rule-based-view-model-provider.test.ts was only to add the visualHelperEnabled field because the code in rule-based-view-model-provider.ts only returns true for this field... for now... watch this space.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
