### PR TITLE
refactor: Add all possible scenarios to rule based view model provider unit tests

### DIFF
--- a/src/tests/unit/common/__snapshots__/rule-based-view-model-provider.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/rule-based-view-model-provider.test.ts.snap
@@ -1,6 +1,470 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isHighlighted": true, "isSelected": false} 1`] = `
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isHighlighted": false, "isSelected": false, "visualHelperEnabled": false} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "hidden",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isHighlighted": false, "isSelected": false, "visualHelperEnabled": true} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "hidden",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isHighlighted": false, "isSelected": true, "visualHelperEnabled": false} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "hidden",
+            "identifiers": null,
+            "isSelected": true,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isHighlighted": false, "isSelected": true, "visualHelperEnabled": true} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "hidden",
+            "identifiers": null,
+            "isSelected": true,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isHighlighted": true, "isSelected": false, "visualHelperEnabled": false} 1`] = `
 Object {
   "allCardsCollapsed": true,
   "cards": Object {
@@ -116,7 +580,355 @@ Object {
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isHighlighted": false, "isSelected": false} 1`] = `
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isHighlighted": true, "isSelected": false, "visualHelperEnabled": true} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "visible",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isHighlighted": true, "isSelected": true, "visualHelperEnabled": false} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "visible",
+            "identifiers": null,
+            "isSelected": true,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": false, "isHighlighted": true, "isSelected": true, "visualHelperEnabled": true} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "visible",
+            "identifiers": null,
+            "isSelected": true,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isHighlighted": false, "isSelected": false, "visualHelperEnabled": false} 1`] = `
 Object {
   "allCardsCollapsed": true,
   "cards": Object {
@@ -232,7 +1044,703 @@ Object {
 }
 `;
 
-exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isHighlighted": true, "isSelected": true} 1`] = `
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isHighlighted": false, "isSelected": false, "visualHelperEnabled": true} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": true,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "hidden",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isHighlighted": false, "isSelected": true, "visualHelperEnabled": false} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": true,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "hidden",
+            "identifiers": null,
+            "isSelected": true,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isHighlighted": false, "isSelected": true, "visualHelperEnabled": true} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": true,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "hidden",
+            "identifiers": null,
+            "isSelected": true,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isHighlighted": true, "isSelected": false, "visualHelperEnabled": false} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": true,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "visible",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isHighlighted": true, "isSelected": false, "visualHelperEnabled": true} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": true,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "visible",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isHighlighted": true, "isSelected": true, "visualHelperEnabled": false} 1`] = `
+Object {
+  "allCardsCollapsed": true,
+  "cards": Object {
+    "fail": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": true,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "visible",
+            "identifiers": null,
+            "isSelected": true,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "fail",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "fail",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "inapplicable": Array [
+      Object {
+        "description": "stub_description_rule3",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule3",
+            "text": "stub_guidance_text_rule3",
+          },
+        ],
+        "id": "rule3",
+        "isExpanded": false,
+        "nodes": Array [],
+        "status": "inapplicable",
+        "url": "stub_url_rule3",
+      },
+    ],
+    "pass": Array [
+      Object {
+        "description": "stub_description_rule1",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule1",
+            "text": "stub_guidance_text_rule1",
+          },
+        ],
+        "id": "rule1",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule1",
+            "status": "pass",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "pass",
+        "url": "stub_url_rule1",
+      },
+    ],
+    "unknown": Array [
+      Object {
+        "description": "stub_description_rule2",
+        "guidance": Array [
+          Object {
+            "href": "stub_guidance_href_rule2",
+            "text": "stub_guidance_text_rule2",
+          },
+        ],
+        "id": "rule2",
+        "isExpanded": false,
+        "nodes": Array [
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+          Object {
+            "descriptors": null,
+            "highlightStatus": "unavailable",
+            "identifiers": null,
+            "isSelected": false,
+            "resolution": null,
+            "ruleId": "rule2",
+            "status": "unknown",
+            "uid": "stub_uid",
+          },
+        ],
+        "status": "unknown",
+        "url": "stub_url_rule2",
+      },
+    ],
+  },
+  "visualHelperEnabled": true,
+}
+`;
+
+exports[`RuleBasedViewModelProvider getUnifiedRuleResults for combination {"isExpanded": true, "isHighlighted": true, "isSelected": true, "visualHelperEnabled": true} 1`] = `
 Object {
   "allCardsCollapsed": true,
   "cards": Object {

--- a/src/tests/unit/common/rule-based-view-model-provider.test.ts
+++ b/src/tests/unit/common/rule-based-view-model-provider.test.ts
@@ -5,6 +5,13 @@ import { getCardViewData } from 'common/rule-based-view-model-provider';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { InstanceResultStatus, UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
 
+type TestScenario = {
+    isExpanded: boolean;
+    isSelected: boolean;
+    isHighlighted: boolean;
+    visualHelperEnabled: boolean;
+};
+
 describe('RuleBasedViewModelProvider', () => {
     const emptyCardSelectionViewData = {} as CardSelectionViewData;
 
@@ -32,11 +39,7 @@ describe('RuleBasedViewModelProvider', () => {
         expect(actualResults).toEqual(null);
     });
 
-    const testScenarios = [
-        { isExpanded: true, isSelected: true, isHighlighted: true },
-        { isExpanded: false, isSelected: false, isHighlighted: true },
-        { isExpanded: true, isSelected: false, isHighlighted: false },
-    ];
+    const testScenarios = createTestScenarios();
 
     it.each(testScenarios)('getUnifiedRuleResults for combination %p', testScenario => {
         const rules = getSampleRules();
@@ -51,8 +54,8 @@ describe('RuleBasedViewModelProvider', () => {
         const cardSelectionViewData: CardSelectionViewData = {
             expandedRuleIds: testScenario.isExpanded ? ['rule1'] : [],
             highlightedResultUids: testScenario.isHighlighted ? ['stub_uid'] : [],
-            selectedResultUids: testScenario.isExpanded && testScenario.isSelected ? ['stub_uid'] : [],
-            visualHelperEnabled: true,
+            selectedResultUids: testScenario.isSelected ? ['stub_uid'] : [],
+            visualHelperEnabled: testScenario.visualHelperEnabled,
         };
 
         const actualResults: CardsViewModel = getCardViewData(rules, results, cardSelectionViewData);
@@ -93,5 +96,25 @@ describe('RuleBasedViewModelProvider', () => {
             descriptors: null,
             resolution: null,
         };
+    }
+
+    function createTestScenarios(): TestScenario[] {
+        const scenarios: TestScenario[] = [];
+
+        // tslint:disable-next-line: no-bitwise
+        const matchesBit = (i: number, bit: number) => (i & Math.pow(2, bit)) !== 0;
+
+        for (let i = 0; i < 16; ++i) {
+            const scenario: TestScenario = {
+                isExpanded: matchesBit(i, 0),
+                isHighlighted: matchesBit(i, 1),
+                isSelected: matchesBit(i, 2),
+                visualHelperEnabled: matchesBit(i, 3),
+            };
+
+            scenarios.push(scenario);
+        }
+
+        return scenarios;
     }
 });


### PR DESCRIPTION
#### Description of changes

If you look at rule-based-view-model-provider.test.ts before this change, you will see that only three of a possible 8 test scenarios were being tested.

Admittedly, some test scenarios were unexpected, such as
{ isExpanded: false, isSelected: true, isHighlighted: false },
because this possibility __should__ never be produced by getCardSelectionViewData.

However, valid test scenarios such as
{ isExpanded: true, isSelected: false, isHighlighted: true },
and
{ isExpanded: false, isSelected: false, isHighlighted: false }
were never tested.

I Assert that unit tests are not just for testing the things we expect, but also for testing the things we don' t expect. Therefore, I have added code to create all the possible input scenarios.

Furthermore, I have added the 8 possible scenarios for when the newly added CardSelectionViewData.visualHelperEnabled field is present, bringing the total number of scenarios up to 16.

The astute observer will note that, for the moment, the visualHelperEnabled field of cards view data is always set to true. I'm not touching the production code which sets visualHelperEnabled in this PR so that in the next PR, the changes in the unit test snapshots will be clearly visible as a result of changing the production code.

The last thing to note about this change is that while the unit tests have grown, the production code has not changed; and we have validated the production code empirically. Therefore, the new snapshots added in this change are, practically speaking, representative of the expected behavior.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
