### PR TITLE
feat(releases): map env variables in YAML to enable electron-mirror 

### DIFF
--- a/pipeline/electron/distribute-electron.yaml
+++ b/pipeline/electron/distribute-electron.yaml
@@ -7,6 +7,9 @@ parameters:
 steps:
     - script: yarn pack:electron ${{ parameters.platforms }}
       displayName: pack electron distributables
+      env:
+          ELECTRON_MIRROR: $(ELECTRON_MIRROR)
+          ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR)
 
     - task: PublishBuildArtifacts@1
       inputs:


### PR DESCRIPTION
#### Description of changes
This PR maps the environment variables ELECTRON_MIRROR and ELECTRON_CUSTOM_DIR to the create-electron-distributables step so that [electron-download](https://www.npmjs.com/package/electron-download) / electron-builder can use them. This allows us to run the pipelines with electron from a given URL.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
