### PR TITLE
feat(consistend-cards-ui): enable the visual helper in card selection store when scan is completed

### DIFF
--- a/src/background/stores/card-selection-store.ts
+++ b/src/background/stores/card-selection-store.ts
@@ -137,6 +137,8 @@ export class CardSelectionStore extends BaseStoreImpl<CardSelectionStoreData> {
             this.state.rules[result.ruleId].cards[result.uid] = false;
         });
 
+        this.state.visualHelperEnabled = true;
+
         this.emitChanged();
     };
 }

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -61,7 +61,7 @@ describe('CardSelectionStore Test', () => {
                     },
                 },
             },
-            visualHelperEnabled: false,
+            visualHelperEnabled: true,
         };
 
         createStoreForUnifiedScanResultActions('scanCompleted')


### PR DESCRIPTION
#### Description of changes

Currently, the ```visualHelperEnabled``` state is always false and as such, the right items are not highlighted on a scan. Modified this to set the state to true when a scan is completed, making sure the right items are highlighted.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
