### PR TITLE
fix: improve styling in cards + remove unnecessary css

### DIFF
--- a/src/common/components/cards/rules-with-instances.scss
+++ b/src/common/components/cards/rules-with-instances.scss
@@ -11,6 +11,7 @@
 
         display: flex;
         align-items: center;
+        text-align: left;
 
         :global(.outcome-chip) {
             vertical-align: middle;

--- a/src/reports/automated-checks-report.scss
+++ b/src/reports/automated-checks-report.scss
@@ -50,51 +50,6 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     }
 }
 
-.rule-details-group {
-    .rule-detail {
-        box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
-        font-size: 14px;
-
-        padding: 16px 8px;
-
-        display: flex;
-        align-items: center;
-
-        .outcome-chip {
-            vertical-align: middle;
-            margin-bottom: 2px;
-        }
-
-        .rule-details-id {
-            font-family: $semiBoldFontFamily;
-            color: $primary-text;
-
-            a {
-                font-family: $semiBoldFontFamily;
-                color: $primary-text !important;
-            }
-        }
-
-        .rule-detail-description {
-            color: $secondary-text !important;
-        }
-
-        .guidance-links {
-            a {
-                color: $secondary-text !important;
-            }
-        }
-    }
-}
-
-.collapsible-rule-details-group {
-    box-shadow: 0px 1px 0px rgba(0, 0, 0, 0.08);
-
-    .rule-detail {
-        box-shadow: unset;
-    }
-}
-
 .collapsible-container {
     @mixin transform($property) {
         -webkit-transform: $property;


### PR DESCRIPTION
#### Description of changes

I noticed the text would look odd when there was limited space for the cards, so I've left-aligned the text.

Also removed some dead css in automated-check-report.scss

Before:

![image](https://user-images.githubusercontent.com/32555133/68629600-43124680-0499-11ea-8b7f-bbf67c2daad3.png)

After:

![image](https://user-images.githubusercontent.com/32555133/68629571-2fff7680-0499-11ea-8087-c31b0b4b1793.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
