### PR TITLE
fix: match cards title to mocks

### DIFF
--- a/src/common/components/cards/rules-with-instances.scss
+++ b/src/common/components/cards/rules-with-instances.scss
@@ -10,7 +10,7 @@
         padding: 16px 8px;
 
         display: flex;
-        align-items: center;
+        align-items: baseline;
         text-align: left;
 
         :global(.outcome-chip) {

--- a/src/reports/components/report-sections/minimal-rule-header.scss
+++ b/src/reports/components/report-sections/minimal-rule-header.scss
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.outcome-chip-container {
+    min-width: 50px;
+}

--- a/src/reports/components/report-sections/minimal-rule-header.tsx
+++ b/src/reports/components/report-sections/minimal-rule-header.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
+import { outcomeChipContainer } from 'reports/components/report-sections/minimal-rule-header.scss';
 
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { OutcomeChip } from '../outcome-chip';
@@ -36,7 +37,7 @@ export const MinimalRuleHeader = NamedFC<MinimalRuleHeaderProps>('MinimalRuleHea
 
     return (
         <span className="rule-detail">
-            <span>{renderCountBadge()}</span>
+            <span className={outcomeChipContainer}>{renderCountBadge()}</span>
             <span>
                 {renderRuleName()}: {renderDescription()}
             </span>

--- a/src/reports/components/report-sections/minimal-rule-header.tsx
+++ b/src/reports/components/report-sections/minimal-rule-header.tsx
@@ -36,8 +36,9 @@ export const MinimalRuleHeader = NamedFC<MinimalRuleHeaderProps>('MinimalRuleHea
 
     return (
         <span className="rule-detail">
+            <span>{renderCountBadge()}</span>
             <span>
-                {renderCountBadge()} {renderRuleName()}: {renderDescription()}
+                {renderRuleName()}: {renderDescription()}
             </span>
         </span>
     );

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/minimal-rule-header.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/minimal-rule-header.test.tsx.snap
@@ -4,7 +4,9 @@ exports[`MinimalRuleHeader renders, outcomeType = fail 1`] = `
 <span
   className="rule-detail"
 >
-  <span>
+  <span
+    className="outcomeChipContainer"
+  >
     <span
       aria-hidden="true"
     >
@@ -34,7 +36,9 @@ exports[`MinimalRuleHeader renders, outcomeType = inapplicable 1`] = `
 <span
   className="rule-detail"
 >
-  <span />
+  <span
+    className="outcomeChipContainer"
+  />
   <span>
     <span
       className="rule-details-id"
@@ -55,7 +59,9 @@ exports[`MinimalRuleHeader renders, outcomeType = pass 1`] = `
 <span
   className="rule-detail"
 >
-  <span />
+  <span
+    className="outcomeChipContainer"
+  />
   <span>
     <span
       className="rule-details-id"

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/minimal-rule-header.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/minimal-rule-header.test.tsx.snap
@@ -13,7 +13,8 @@ exports[`MinimalRuleHeader renders, outcomeType = fail 1`] = `
         outcomeType="fail"
       />
     </span>
-     
+  </span>
+  <span>
     <span
       className="rule-details-id"
     >
@@ -33,8 +34,8 @@ exports[`MinimalRuleHeader renders, outcomeType = inapplicable 1`] = `
 <span
   className="rule-detail"
 >
+  <span />
   <span>
-     
     <span
       className="rule-details-id"
     >
@@ -54,8 +55,8 @@ exports[`MinimalRuleHeader renders, outcomeType = pass 1`] = `
 <span
   className="rule-detail"
 >
+  <span />
   <span>
-     
     <span
       className="rule-details-id"
     >

--- a/src/tests/unit/tests/reports/components/report-sections/minimal-rule-header.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/minimal-rule-header.test.tsx
@@ -19,7 +19,6 @@ describe('MinimalRuleHeader', () => {
         };
 
         const wrapped = shallow(<MinimalRuleHeader {...props} />);
-
         expect(wrapped.getElement()).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Description of changes

As per a comment in the previous PR, the text for the rule should not go under the outcome chip. This modifies the component to make that happen. Gif below of how it looks:

![cardstitleresizewithminwidth](https://user-images.githubusercontent.com/32555133/68633310-47912c00-04a6-11ea-9b57-ad9bf6431329.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
