### PR TITLE
refactor: introduce injection action creator

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { TestMode } from '../../common/configs/test-mode';
-import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
-import * as TelemetryEvents from '../../common/extension-telemetry-events';
-import { getStoreStateMessage, Messages } from '../../common/messages';
-import { NotificationCreator } from '../../common/notification-creator';
-import { StoreNames } from '../../common/stores/store-names';
-import { VisualizationType } from '../../common/types/visualization-type';
-import { ScanCompletedPayload } from '../../injected/analyzers/analyzer';
-import { DictionaryNumberTo } from '../../types/common-types';
+import { TestMode } from 'common/configs/test-mode';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import * as TelemetryEvents from 'common/extension-telemetry-events';
+import { getStoreStateMessage, Messages } from 'common/messages';
+import { NotificationCreator } from 'common/notification-creator';
+import { StoreNames } from 'common/stores/store-names';
+import { VisualizationType } from 'common/types/visualization-type';
+import { ScanCompletedPayload } from 'injected/analyzers/analyzer';
+import { DictionaryNumberTo } from 'types/common-types';
+
 import { VisualizationActions } from '../actions/visualization-actions';
 import { VisualizationScanResultActions } from '../actions/visualization-scan-result-actions';
 import { DetailsViewController } from '../details-view-controller';
@@ -68,8 +69,6 @@ export class ActionCreator {
         );
         this.interpreter.registerTypeToPayloadCallback(visualizationMessages.Issues.UpdateFocusedInstance, this.onUpdateFocusedInstance);
 
-        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.State.InjectionCompleted, this.injectionCompleted);
-        this.interpreter.registerTypeToPayloadCallback(visualizationMessages.State.InjectionStarted, this.injectionStarted);
         this.interpreter.registerTypeToPayloadCallback(
             getStoreStateMessage(StoreNames.VisualizationStore),
             this.getVisualizationToggleCurrentState,
@@ -260,14 +259,6 @@ export class ActionCreator {
         } else {
             this.visualizationActions.disableVisualization.invoke(payload.test);
         }
-    };
-
-    private injectionCompleted = (): void => {
-        this.visualizationActions.injectionCompleted.invoke(null);
-    };
-
-    private injectionStarted = (): void => {
-        this.visualizationActions.injectionStarted.invoke(null);
     };
 
     private getVisualizationToggleCurrentState = (): void => {

--- a/src/background/actions/action-hub.ts
+++ b/src/background/actions/action-hub.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
 
+import { InjectionActions } from 'background/actions/injection-actions';
 import { TabActions } from '../actions/tab-actions';
 import { VisualizationActions } from '../actions/visualization-actions';
 import { VisualizationScanResultActions } from '../actions/visualization-scan-result-actions';
@@ -29,6 +30,7 @@ export class ActionHub {
     public pathSnippetActions: PathSnippetActions;
     public scanResultActions: UnifiedScanResultActions;
     public cardSelectionActions: CardSelectionActions;
+    public injectionActions: InjectionActions;
 
     constructor() {
         this.visualizationActions = new VisualizationActions();
@@ -44,5 +46,6 @@ export class ActionHub {
         this.pathSnippetActions = new PathSnippetActions();
         this.scanResultActions = new UnifiedScanResultActions();
         this.cardSelectionActions = new CardSelectionActions();
+        this.injectionActions = new InjectionActions();
     }
 }

--- a/src/background/actions/injection-action-creator.ts
+++ b/src/background/actions/injection-action-creator.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Messages } from 'common/messages';
+import { InjectionActions } from '../actions/injection-actions';
+import { Interpreter } from '../interpreter';
+
+export class InjectionActionCreator {
+    constructor(private readonly interpreter: Interpreter, private readonly injectionActions: InjectionActions) {}
+
+    public registerCallbacks(): void {
+        this.interpreter.registerTypeToPayloadCallback(Messages.Visualizations.State.InjectionStarted, this.injectionStarted);
+        this.interpreter.registerTypeToPayloadCallback(Messages.Visualizations.State.InjectionCompleted, this.injectionCompleted);
+    }
+
+    private injectionStarted = (): void => this.injectionActions.injectionStarted.invoke(null);
+
+    private injectionCompleted = (): void => this.injectionActions.injectionCompleted.invoke(null);
+}

--- a/src/background/actions/injection-actions.ts
+++ b/src/background/actions/injection-actions.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Action } from 'common/flux/action';
+
+export class InjectionActions {
+    public readonly injectionCompleted = new Action();
+    public readonly injectionStarted = new Action();
+}

--- a/src/background/actions/visualization-actions.ts
+++ b/src/background/actions/visualization-actions.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from '../../common/flux/action';
-import { VisualizationType } from '../../common/types/visualization-type';
+import { Action } from 'common/flux/action';
+import { VisualizationType } from 'common/types/visualization-type';
 import { ToggleActionPayload, UpdateSelectedDetailsViewPayload, UpdateSelectedPivot } from './action-payloads';
 
 export class VisualizationActions {

--- a/src/background/stores/tab-context-store-hub.ts
+++ b/src/background/stores/tab-context-store-hub.ts
@@ -31,6 +31,7 @@ export class TabContextStoreHub implements StoreHub {
         this.visualizationStore = new VisualizationStore(
             actionHub.visualizationActions,
             actionHub.tabActions,
+            actionHub.injectionActions,
             visualizationConfigurationFactory,
         );
         this.visualizationStore.initialize();

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -1,14 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { TestMode } from '../../common/configs/test-mode';
-import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
-import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
-import { EnumHelper } from '../../common/enum-helper';
-import { Tab } from '../../common/itab';
-import { StoreNames } from '../../common/stores/store-names';
-import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
-import { AssessmentScanData, TestsEnabledState, VisualizationStoreData } from '../../common/types/store-data/visualization-store-data';
-import { VisualizationType } from '../../common/types/visualization-type';
+import { InjectionActions } from 'background/actions/injection-actions';
+import { TestMode } from 'common/configs/test-mode';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { EnumHelper } from 'common/enum-helper';
+import { Tab } from 'common/itab';
+import { StoreNames } from 'common/stores/store-names';
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { AssessmentScanData, TestsEnabledState, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+
 import {
     AssessmentToggleActionPayload,
     ToggleActionPayload,
@@ -22,17 +24,20 @@ import { BaseStoreImpl } from './base-store-impl';
 export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
     private visualizationActions: VisualizationActions;
     private tabActions: TabActions;
+    private injectionActions: InjectionActions;
     private visualizationConfigurationFactory: VisualizationConfigurationFactory;
 
     constructor(
         visualizationActions: VisualizationActions,
         tabActions: TabActions,
+        injectionActions: InjectionActions,
         visualizationConfigurationFactory: VisualizationConfigurationFactory,
     ) {
         super(StoreNames.VisualizationStore);
 
         this.visualizationActions = visualizationActions;
         this.tabActions = tabActions;
+        this.injectionActions = injectionActions;
         this.visualizationConfigurationFactory = visualizationConfigurationFactory;
     }
 
@@ -52,8 +57,8 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
         this.visualizationActions.updateSelectedPivotChild.addListener(this.onUpdateSelectedPivotChild);
         this.visualizationActions.updateSelectedPivot.addListener(this.onUpdateSelectedPivot);
 
-        this.visualizationActions.injectionCompleted.addListener(this.injectionCompleted);
-        this.visualizationActions.injectionStarted.addListener(this.injectionStarted);
+        this.injectionActions.injectionCompleted.addListener(this.onInjectionCompleted);
+        this.injectionActions.injectionStarted.addListener(this.onInjectionStarted);
     }
 
     public getDefaultState(): VisualizationStoreData {
@@ -224,13 +229,13 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
         this.emitChanged();
     };
 
-    private injectionCompleted = (): void => {
+    private onInjectionCompleted = (): void => {
         this.state.injectingInProgress = false;
         this.state.injectingStarted = false;
         this.emitChanged();
     };
 
-    private injectionStarted = (): void => {
+    private onInjectionStarted = (): void => {
         if (this.state.injectingStarted) {
             return;
         }

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -8,6 +8,7 @@ import { PromiseFactory } from 'common/promises/promise-factory';
 import { StateDispatcher } from 'common/state-dispatcher';
 import { WindowUtils } from 'common/window-utils';
 
+import { InjectionActionCreator } from 'background/actions/injection-action-creator';
 import { ActionCreator } from './actions/action-creator';
 import { ActionHub } from './actions/action-hub';
 import { CardSelectionActionCreator } from './actions/card-selection-action-creator';
@@ -111,6 +112,8 @@ export class TabContextFactory {
             this.telemetryEventHandler,
         );
 
+        const injectionActionCreator = new InjectionActionCreator(interpreter, actionsHub.injectionActions);
+
         const injectorController = new InjectorController(
             new ContentScriptInjector(browserAdapter, this.promiseFactory),
             storeHub.visualizationStore,
@@ -141,6 +144,7 @@ export class TabContextFactory {
         contentActionCreator.registerCallbacks();
         scanResultActionCreator.registerCallbacks();
         cardSelectionActionCreator.registerCallbacks();
+        injectionActionCreator.registerCallbacks();
 
         injectorController.initialize();
         const dispatcher = new StateDispatcher(broadcastMessage, storeHub);

--- a/src/tests/unit/common/visualization-store-data-builder.ts
+++ b/src/tests/unit/common/visualization-store-data-builder.ts
@@ -12,7 +12,7 @@ import { BaseDataBuilder } from './base-data-builder';
 export class VisualizationStoreDataBuilder extends BaseDataBuilder<VisualizationStoreData> {
     constructor() {
         super();
-        this.data = new VisualizationStore(null, null, new VisualizationConfigurationFactory()).getDefaultState();
+        this.data = new VisualizationStore(null, null, null, new VisualizationConfigurationFactory()).getDefaultState();
     }
 
     public withFocusedTarget(target: string[]): VisualizationStoreDataBuilder {

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -973,6 +973,7 @@ class ActionCreatorValidator {
         pathSnippetActions: null,
         scanResultActions: null,
         cardSelectionActions: null,
+        injectionActions: null,
     };
 
     private telemetryEventHandlerStrictMock = Mock.ofType<TelemetryEventHandler>(null, MockBehavior.Strict);

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -494,34 +494,6 @@ describe('ActionCreatorTest', () => {
         testScanCompleteWithExpectedParams(key, message, actionName, telemetryEventName);
     });
 
-    test('registerCallback for injectionCompleted', () => {
-        const actionName = 'injectionCompleted';
-        const builder = new ActionCreatorValidator()
-            .setupRegistrationCallback(VisualizationMessage.State.InjectionCompleted)
-            .setupActionOnVisualizationActions(actionName)
-            .setupVisualizationActionWithInvokeParameter(actionName, null);
-
-        const actionCreator = builder.buildActionCreator();
-
-        actionCreator.registerCallbacks();
-
-        builder.verifyAll();
-    });
-
-    test('registerCallback for injectionStarted', () => {
-        const actionName = 'injectionStarted';
-        const builder = new ActionCreatorValidator()
-            .setupRegistrationCallback(VisualizationMessage.State.InjectionStarted)
-            .setupActionOnVisualizationActions(actionName)
-            .setupVisualizationActionWithInvokeParameter(actionName, null);
-
-        const actionCreator = builder.buildActionCreator();
-
-        actionCreator.registerCallbacks();
-
-        builder.verifyAll();
-    });
-
     test('registerCallback for tabbed element added', () => {
         const tabbedElement: AddTabbedElementPayload = {
             tabbedElements: [

--- a/src/tests/unit/tests/background/actions/action-hub.test.ts
+++ b/src/tests/unit/tests/background/actions/action-hub.test.ts
@@ -4,6 +4,7 @@ import { ActionHub } from 'background/actions/action-hub';
 import { AssessmentActions } from 'background/actions/assessment-actions';
 import { ContentActions } from 'background/actions/content-actions';
 import { DevToolActions } from 'background/actions/dev-tools-actions';
+import { InjectionActions } from 'background/actions/injection-actions';
 import { InspectActions } from 'background/actions/inspect-actions';
 import { PreviewFeaturesActions } from 'background/actions/preview-features-actions';
 import { ScopingActions } from 'background/actions/scoping-actions';
@@ -35,4 +36,5 @@ function runTypeAsserts(hub: ActionHub): void {
     expect(hub.visualizationScanResultActions).toBeInstanceOf(VisualizationScanResultActions);
     expect(hub.inspectActions).toBeInstanceOf(InspectActions);
     expect(hub.contentActions).toBeInstanceOf(ContentActions);
+    expect(hub.injectionActions).toBeInstanceOf(InjectionActions);
 }

--- a/src/tests/unit/tests/background/actions/injection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/injection-action-creator.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { InjectionActionCreator } from 'background/actions/injection-action-creator';
+import { InjectionActions } from 'background/actions/injection-actions';
+import { Messages } from 'common/messages';
+import { createActionMock, createInterpreterMock } from 'tests/unit/tests/background/global-action-creators/action-creator-test-helpers';
+import { IMock, Mock } from 'typemoq';
+
+describe('InjectionActionCreator', () => {
+    it('handles InjectionStarted message', () => {
+        const injectionStartedMock = createActionMock(null);
+        const actionsMock = createActionsMock('injectionStarted', injectionStartedMock.object);
+        const interpreterMock = createInterpreterMock(Messages.Visualizations.State.InjectionStarted, null);
+
+        const testSubject = new InjectionActionCreator(interpreterMock.object, actionsMock.object);
+
+        testSubject.registerCallbacks();
+
+        injectionStartedMock.verifyAll();
+    });
+
+    it.only('handles InjectionCompleted message', () => {
+        const injectionCompletedMock = createActionMock<void>(null);
+        const actionsMock = createActionsMock('injectionCompleted', injectionCompletedMock.object);
+        const interpreterMock = createInterpreterMock(Messages.Visualizations.State.InjectionCompleted, null);
+
+        const testSubject = new InjectionActionCreator(interpreterMock.object, actionsMock.object);
+
+        testSubject.registerCallbacks();
+
+        injectionCompletedMock.verifyAll();
+    });
+
+    function createActionsMock<ActionName extends keyof InjectionActions>(
+        actionName: ActionName,
+        action: InjectionActions[ActionName],
+    ): IMock<InjectionActions> {
+        const actionsMock = Mock.ofType<InjectionActions>();
+        actionsMock.setup(actions => actions[actionName]).returns(() => action);
+        return actionsMock;
+    }
+});

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -10,6 +10,7 @@ import {
     UpdateSelectedDetailsViewPayload,
     UpdateSelectedPivot,
 } from 'background/actions/action-payloads';
+import { InjectionActions } from 'background/actions/injection-actions';
 import { TabActions } from 'background/actions/tab-actions';
 import { VisualizationActions } from 'background/actions/visualization-actions';
 import { VisualizationStore } from 'background/stores/visualization-store';
@@ -662,7 +663,7 @@ describe('VisualizationStoreTest ', () => {
             .testListenerToNeverBeCalled(initialState, expectedState);
     });
 
-    test('injectionCompleted', () => {
+    test('onInjectionCompleted', () => {
         const actionName = 'injectionCompleted';
 
         const initialState = new VisualizationStoreDataBuilder().build();
@@ -672,10 +673,10 @@ describe('VisualizationStoreTest ', () => {
             .with('injectingStarted', false)
             .build();
 
-        createStoreTesterForVisualizationActions(actionName).testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForInjectionActions(actionName).testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('injectionStarted when injectingStarted is false', () => {
+    test('onInjectionStarted when injectingStarted is false', () => {
         const actionName = 'injectionStarted';
 
         const initialState = new VisualizationStoreDataBuilder().with('injectingStarted', false).build();
@@ -685,10 +686,10 @@ describe('VisualizationStoreTest ', () => {
             .with('injectingStarted', true)
             .build();
 
-        createStoreTesterForVisualizationActions(actionName).testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForInjectionActions(actionName).testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('injectionStarted when injectingStarted is true', () => {
+    test('onInjectionStarted when injectingStarted is true', () => {
         const actionName = 'injectionStarted';
 
         const initialState = new VisualizationStoreDataBuilder().with('injectingStarted', true).build();
@@ -698,7 +699,7 @@ describe('VisualizationStoreTest ', () => {
             .with('injectingStarted', true)
             .build();
 
-        createStoreTesterForVisualizationActions(actionName).testListenerToNeverBeCalled(initialState, expectedState);
+        createStoreTesterForInjectionActions(actionName).testListenerToNeverBeCalled(initialState, expectedState);
     });
 
     test('onScrollRequested', () => {
@@ -802,7 +803,7 @@ describe('VisualizationStoreTest ', () => {
 
     function createStoreTesterForTabActions(actionName: keyof TabActions): StoreTester<VisualizationStoreData, TabActions> {
         const factory = (actions: TabActions) =>
-            new VisualizationStore(new VisualizationActions(), actions, new VisualizationConfigurationFactory());
+            new VisualizationStore(new VisualizationActions(), actions, new InjectionActions(), new VisualizationConfigurationFactory());
 
         return new StoreTester(TabActions, actionName, factory);
     }
@@ -811,8 +812,17 @@ describe('VisualizationStoreTest ', () => {
         actionName: keyof VisualizationActions,
     ): StoreTester<VisualizationStoreData, VisualizationActions> {
         const factory = (actions: VisualizationActions) =>
-            new VisualizationStore(actions, new TabActions(), new VisualizationConfigurationFactory());
+            new VisualizationStore(actions, new TabActions(), new InjectionActions(), new VisualizationConfigurationFactory());
 
         return new StoreTester(VisualizationActions, actionName, factory);
+    }
+
+    function createStoreTesterForInjectionActions(
+        actionName: keyof InjectionActions,
+    ): StoreTester<VisualizationStoreData, InjectionActions> {
+        const factory = (actions: InjectionActions) =>
+            new VisualizationStore(new VisualizationActions(), new TabActions(), actions, new VisualizationConfigurationFactory());
+
+        return new StoreTester(InjectionActions, actionName, factory);
     }
 });


### PR DESCRIPTION
#### Description of changes

As part of the browser extension permissions effort, we need a to make some changes on how and when we inject our scripts into the target page.

In this refactor, the injection related code is move out of the `ActionCreator` into a more specific action creator. A new `InjectionActions` class has been created and all related classes (`VisualizationStore` is notable here) have been updated.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
