### PR TITLE
chore: remove noise during Parsing test by adding offset attrs to <stop> SVG elements

### DIFF
--- a/src/icons/brand/blue/brand-blue.tsx
+++ b/src/icons/brand/blue/brand-blue.tsx
@@ -75,15 +75,15 @@ export const BrandBlue = NamedFC('BrandBlue', () => (
                 <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
             </filter>
             <linearGradient id="paint0_linear" x1="14.3166" y1="16.8744" x2="5.92409" y2="8.23504" gradientUnits="userSpaceOnUse">
-                <stop stopColor="#073A5F" stopOpacity="0.3" />
+                <stop offset="0" stopColor="#073A5F" stopOpacity="0.3" />
                 <stop offset="1" stopColor="#CFEBFF" stopOpacity="0" />
             </linearGradient>
             <linearGradient id="paint1_linear" x1="14.3166" y1="16.8744" x2="4.4082" y2="6.85716" gradientUnits="userSpaceOnUse">
-                <stop stopColor="#00070C" stopOpacity="0.29" />
+                <stop offset="0" stopColor="#00070C" stopOpacity="0.29" />
                 <stop offset="1" stopColor="#004880" stopOpacity="0" />
             </linearGradient>
             <linearGradient id="paint2_linear" x1="11.3179" y1="20.1024" x2="11.2867" y2="7.1103" gradientUnits="userSpaceOnUse">
-                <stop stopColor="#00070C" stopOpacity="0.29" />
+                <stop offset="0" stopColor="#00070C" stopOpacity="0.29" />
                 <stop offset="1" stopColor="#003064" stopOpacity="0" />
             </linearGradient>
         </defs>

--- a/src/icons/brand/white/brand-white.tsx
+++ b/src/icons/brand/white/brand-white.tsx
@@ -75,15 +75,15 @@ export const BrandWhite = NamedFC('BrandWhite', () => (
                 <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape" />
             </filter>
             <linearGradient id="paint0_linear" x1="14.3166" y1="16.8744" x2="5.92409" y2="8.23504" gradientUnits="userSpaceOnUse">
-                <stop stopColor="#073A5F" stopOpacity="0.3" />
+                <stop offset="0" stopColor="#073A5F" stopOpacity="0.3" />
                 <stop offset="1" stopColor="#CFEBFF" stopOpacity="0" />
             </linearGradient>
             <linearGradient id="paint1_linear" x1="14.3166" y1="16.8744" x2="5.92409" y2="8.23504" gradientUnits="userSpaceOnUse">
-                <stop stopColor="#165B8E" stopOpacity="0.29" />
+                <stop offset="0" stopColor="#165B8E" stopOpacity="0.29" />
                 <stop offset="1" stopColor="white" stopOpacity="0" />
             </linearGradient>
             <linearGradient id="paint2_linear" x1="11.3179" y1="20.1024" x2="11.0819" y2="11.1606" gradientUnits="userSpaceOnUse">
-                <stop stopColor="#165B8E" stopOpacity="0.29" />
+                <stop offset="0" stopColor="#165B8E" stopOpacity="0.29" />
                 <stop offset="1" stopColor="#D6E9F7" stopOpacity="0" />
             </linearGradient>
         </defs>


### PR DESCRIPTION
#### Description of changes

When validating the and-screenshot feature against the AI4Web parsing test, there was some noise from the validator because our brand-images use SVG `<stop>` elements without an `offset` attribute. MDN suggests that this is supposed to be fine (they default to 0, which is what we want), but since adding the attributes is harmless anyway, I thought it would be nice to reduce the noise we see from the validator.

No UI change.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
