### PR TITLE
feat(consistent-cards-ui): added action message function for rescan visualization

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -18,7 +18,9 @@ import {
     ToggleActionPayload,
 } from 'background/actions/action-payloads';
 import { FeatureFlagPayload } from 'background/actions/feature-flag-actions';
+import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import * as React from 'react';
+
 import { ExportResultType } from '../../common/extension-telemetry-events';
 import * as TelemetryEvents from '../../common/extension-telemetry-events';
 import { Message } from '../../common/message';
@@ -483,4 +485,18 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
 
         this.dispatcher.dispatchMessage(message);
     }
+
+    public rescanVisualization = (test: VisualizationType, event: SupportedMouseEvent) => {
+        const payload: ToggleActionPayload = {
+            test: test,
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, TelemetryEvents.TelemetryEventSource.DetailsView),
+        };
+
+        const message: Message = {
+            messageType: Messages.Visualizations.Common.RescanVisualization,
+            payload,
+        };
+
+        this.dispatcher.dispatchMessage(message);
+    };
 }

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -22,7 +22,7 @@ import {
 } from '../../../../../common/extension-telemetry-events';
 import { Message } from '../../../../../common/message';
 import { Messages } from '../../../../../common/messages';
-import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
+import { SupportedMouseEvent, TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
 import { DetailsViewPivotType } from '../../../../../common/types/details-view-pivot-type';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
@@ -844,6 +844,29 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         };
 
         testSubject.changeRightContentPanel(viewTypeStub);
+
+        dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)), Times.once());
+    });
+
+    test('rescanVisualization', () => {
+        const testStub = -1;
+        const eventStub = {} as SupportedMouseEvent;
+        const telemetryStub = {
+            source: TelemetryEventSource.DetailsView,
+        } as BaseTelemetryData;
+        const expectedMessage = {
+            messageType: Messages.Visualizations.Common.RescanVisualization,
+            payload: {
+                test: testStub,
+                telemetry: telemetryStub,
+            },
+        };
+
+        telemetryFactoryMock
+            .setup(tf => tf.withTriggeredByAndSource(eventStub, TelemetryEventSource.DetailsView))
+            .returns(() => telemetryStub);
+
+        testSubject.rescanVisualization(testStub, eventStub);
 
         dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)), Times.once());
     });


### PR DESCRIPTION

#### Description of changes

We have a way to handle this message in the action creator per my last PR and now this is adding it to the details view to be able to fire that message (linked up by Dave later).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
