### PR TITLE
feat(and-screenshot): add break-all to rule headers to improve rendering at 400% zoom

### DIFF
--- a/src/common/components/cards/rules-with-instances.scss
+++ b/src/common/components/cards/rules-with-instances.scss
@@ -21,6 +21,7 @@
         :global(.rule-details-id) {
             font-family: $semiBoldFontFamily;
             color: $primary-text;
+            word-break: break-all;
 
             a {
                 font-family: $semiBoldFontFamily;
@@ -30,6 +31,7 @@
 
         :global(.rule-detail-description) {
             color: $secondary-text !important;
+            word-break: break-all;
         }
 
         :global(.guidance-links) {


### PR DESCRIPTION
#### Description of changes

This change enables rule header text to break within words if necessary, consistent with how the text within the cards already works. This fixes some rendering-off-the-side issues in electron at 400% zoom + 1280px width.

##### Before:

![screenshot of rule text flowing off the side of the pane](https://user-images.githubusercontent.com/376284/68720740-1b88b000-0565-11ea-9016-434e0d525af0.png)

##### After:

![screenshot of same rule text now wrapping instead of flowing off the side](https://user-images.githubusercontent.com/376284/68720756-2b07f900-0565-11ea-8d87-6fd010f65ab6.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
