### PR TITLE
feat(and-screenshot): add a 3:1 contrast border for the screenshot image

### DIFF
--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -91,6 +91,7 @@
     --spinner-text: var(--communication-primary);
     --menu-background: --acrylic-light;
     --menu-border: --menu-background;
+    --screenshot-image-outline: #8b8b8b;
 
     // Landmark colors
     --landmark-contentinfo: #00a88c;
@@ -158,6 +159,7 @@
         --menu-item-background-active: var(--communication-tint-40);
         --menu-background: var(--light-black);
         --menu-border: var(--grey);
+        --screenshot-image-outline: var(--white);
     }
 }
 
@@ -253,6 +255,7 @@ $menu-item-background-hover: var(--menu-item-background-hover);
 $menu-item-background-active: var(--menu-item-background-active);
 $menu-border: var(--menu-border);
 $menu-background: var(--menu-background);
+$screenshot-image-outline: var(--screenshot-image-outline);
 
 // consistent colors
 $always-white: #ffffff;

--- a/src/electron/views/screenshot/screenshot.scss
+++ b/src/electron/views/screenshot/screenshot.scss
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+@import '../../../common/styles/colors.scss';
+
 .screenshot-image {
     width: 100%;
     object-fit: contain;
-    box-shadow: 0px 6px 12px rgba(0, 0, 0, 0.2);
+    outline: 1px solid $screenshot-image-outline;
+    box-shadow: 0px 6px 12px $neutral-alpha-20;
 }


### PR DESCRIPTION
#### Description of changes

We were concerned that our screenshot might qualify as a "diagram" for the purposes of the WCAG 2.1 Graphic Contrast requirement, so we wanted to add a 3:1 contrast border on it. Note I'm using `outline` rather than `border` here to avoid pushing the image coordinates relative to the highlight boxes.

##### Typical case (our usual mock screenshot):

Before:

![screenshot of device screenshot before changes without border](https://user-images.githubusercontent.com/376284/68799409-f51e4f80-060c-11ea-9e0c-4d266faa9c64.png)

After:

![screenshot of device screenshot with new border](https://user-images.githubusercontent.com/376284/68798698-afad5280-060b-11ea-9111-6ba5f8a6f2f2.png)

##### Worst case (screenshot is flat color that matches the background

Before:

![screenshot of background-colored screenshot before changes without border](https://user-images.githubusercontent.com/376284/68799338-d9b34480-060c-11ea-8495-703726e65f21.png)

After:

![screenshot of background-colored screenshot before changes without border](https://user-images.githubusercontent.com/376284/68799319-ce601900-060c-11ea-9739-9979ce5ec657.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1638144
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
