### PR TITLE
refactor: Rename generateFastPassAutomatedCheckReport

### DIFF
--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -116,7 +116,7 @@ export class IssuesTable extends React.Component<IssuesTableProps> {
                     reportGenerator={reportGenerator}
                     pageTitle={pageTitle}
                     exportResultsType={'AutomatedChecks'}
-                    htmlGenerator={reportGenerator.generateFastPassAutomateChecksReport.bind(
+                    htmlGenerator={reportGenerator.generateFastPassAutomatedChecksReport.bind(
                         reportGenerator,
                         scanResult,
                         scanDate,

--- a/src/DetailsView/components/report-export-component-factory.tsx
+++ b/src/DetailsView/components/report-export-component-factory.tsx
@@ -54,7 +54,7 @@ export function getReportExportComponentForFastPass(props: CommandBarProps): JSX
         pageTitle: tabStoreData.title,
         exportResultsType: 'AutomatedChecks',
         htmlGenerator: description =>
-            reportGenerator.generateFastPassAutomateChecksReport(
+            reportGenerator.generateFastPassAutomatedChecksReport(
                 scanResult,
                 scanDate,
                 tabStoreData.title,

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -22,7 +22,7 @@ export class ReportGenerator {
         return this.reportNameGenerator.generateName(baseName, scanDate, pageTitle);
     }
 
-    public generateFastPassAutomateChecksReport(
+    public generateFastPassAutomatedChecksReport(
         scanResult: ScanResults,
         scanDate: Date,
         pageTitle: string,

--- a/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
@@ -99,7 +99,7 @@ describe('ReportExportComponentPropsFactory', () => {
     function setAutomatedChecksReportGenerator(): void {
         reportGeneratorMock
             .setup(reportGenerator =>
-                reportGenerator.generateFastPassAutomateChecksReport(
+                reportGenerator.generateFastPassAutomatedChecksReport(
                     scanResult,
                     theDate,
                     tabStoreData.title,

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -45,7 +45,7 @@ describe('ReportGenerator', () => {
             .returns(() => 'returned-data');
 
         const testObject = new ReportGenerator(nameBuilderMock.object, dataBuilderMock.object, assessmentReportHtmlGeneratorMock.object);
-        const actual = testObject.generateFastPassAutomateChecksReport(scanResult, date, title, url, cardsViewDataStub, description);
+        const actual = testObject.generateFastPassAutomatedChecksReport(scanResult, date, title, url, cardsViewDataStub, description);
 
         expect(actual).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

As called out in #1676, `generateFastPassAutomatedCheckReport` should be named `generateFastPassAutomatedChecksReport` for consistency. This makes that change. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
