### PR TITLE
test: electron e2e reliability: wait for screenshot view before querying its descendents

### DIFF
--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -19,6 +19,7 @@ describe('AutomatedChecksView', () => {
     beforeEach(async () => {
         app = await createApplication();
         automatedChecksView = await app.openAutomatedChecksView();
+        await automatedChecksView.waitForScreenshotViewVisible();
     });
 
     afterEach(async () => {
@@ -77,8 +78,6 @@ describe('AutomatedChecksView', () => {
     }
 
     it('ScreenshotView renders screenshot image from specified source', async () => {
-        await automatedChecksView.waitForScreenshotViewVisible();
-
         const resultExamplePath = path.join(testResourceServerConfig.absolutePath, 'axe/result.json');
         const axeRuleResultExample = JSON.parse(fs.readFileSync(resultExamplePath, { encoding: 'utf-8' }));
 


### PR DESCRIPTION
#### Description of changes

This PR attempts to resolve the e2e_linux_electron failure seen in [this build](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=48934). The test failed because on initial load of the automated checks view, it found 0 rule groups rather than the expected set; I think the issue is that it's only waiting for the root container to exist, rather than waiting for its contents, so this PR updates the tests to more consistently wait for an indication that the contents have rendered (by waiting for the screenshot view, which only shows up after scanning is complete).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
