### PR TITLE
refactor: rename tab-controller

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -30,7 +30,7 @@ import { MessageDistributor } from './message-distributor';
 import { TabToContextMap } from './tab-context';
 import { TabContextBroadcaster } from './tab-context-broadcaster';
 import { TabContextFactory } from './tab-context-factory';
-import { TabController } from './tab-controller';
+import { TargetPageController } from './target-page-controller';
 import { TargetTabController } from './target-tab-controller';
 import { getTelemetryClient } from './telemetry/telemetry-client-provider';
 import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
@@ -124,7 +124,7 @@ async function initialize(): Promise<void> {
         promiseFactory,
     );
 
-    const clientHandler = new TabController(
+    const clientHandler = new TargetPageController(
         tabToContextMap,
         broadcaster,
         browserAdapter,

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -11,9 +11,9 @@ import { TabToContextMap } from './tab-context';
 import { TabContextBroadcaster } from './tab-context-broadcaster';
 import { TabContextFactory } from './tab-context-factory';
 
-export class TabController {
+export class TargetPageController {
     constructor(
-        private readonly tabIdToContextMap: TabToContextMap,
+        private readonly targetPageTabIdToContextMap: TabToContextMap,
         private readonly broadcaster: TabContextBroadcaster,
         private readonly browserAdapter: BrowserAdapter,
         private readonly detailsViewController: DetailsViewController,
@@ -103,14 +103,14 @@ export class TabController {
     };
 
     private hasTabContext(tabId: number): boolean {
-        return tabId in this.tabIdToContextMap;
+        return tabId in this.targetPageTabIdToContextMap;
     }
 
     private sendTabAction(tabId: number, messageType: string, errorMessagePrefix: string): void {
         this.browserAdapter.getTab(
             tabId,
             (tab: chrome.tabs.Tab) => {
-                const tabContext = this.tabIdToContextMap[tabId];
+                const tabContext = this.targetPageTabIdToContextMap[tabId];
                 if (tabContext) {
                     const interpreter = tabContext.interpreter;
                     interpreter.interpret({
@@ -138,7 +138,7 @@ export class TabController {
         if (!this.hasTabContext(tabId)) {
             return;
         }
-        const tabContext = this.tabIdToContextMap[tabId];
+        const tabContext = this.targetPageTabIdToContextMap[tabId];
         if (tabContext == null) {
             return;
         }
@@ -155,7 +155,7 @@ export class TabController {
     }
 
     private addTabContext(tabId: number): void {
-        this.tabIdToContextMap[tabId] = this.tabContextFactory.createTabContext(
+        this.targetPageTabIdToContextMap[tabId] = this.tabContextFactory.createTabContext(
             this.broadcaster.getBroadcastMessageDelegate(tabId),
             this.browserAdapter,
             this.detailsViewController,
@@ -164,7 +164,7 @@ export class TabController {
     }
 
     private onTabRemoved = (tabId: number, messageType: string): void => {
-        const tabContext = this.tabIdToContextMap[tabId];
+        const tabContext = this.targetPageTabIdToContextMap[tabId];
         if (tabContext) {
             const interpreter = tabContext.interpreter;
             interpreter.interpret({
@@ -177,7 +177,7 @@ export class TabController {
 
     private onTargetTabRemoved = (tabId: number): void => {
         this.onTabRemoved(tabId, Messages.Tab.Remove);
-        delete this.tabIdToContextMap[tabId];
+        delete this.targetPageTabIdToContextMap[tabId];
     };
 
     private onDetailsViewTabRemoved = (tabId: number): void => {

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -1,23 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { DetailsViewController } from 'background/details-view-controller';
 import { Interpreter } from 'background/interpreter';
 import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { TabToContextMap } from 'background/tab-context';
 import { TabContextBroadcaster } from 'background/tab-context-broadcaster';
 import { TabContextFactory } from 'background/tab-context-factory';
-import { TabController } from 'background/tab-controller';
+import { TargetPageController } from 'background/target-page-controller';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
-import { Message } from '../../../../common/message';
-import { Messages } from '../../../../common/messages';
-import { DictionaryStringTo } from '../../../../types/common-types';
-import { Logger } from './../../../../common/logging/logger';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { Logger } from 'common/logging/logger';
+import { Message } from 'common/message';
+import { Messages } from 'common/messages';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { DictionaryStringTo } from 'types/common-types';
 
-describe('TabControllerTest', () => {
-    let testSubject: TabController;
+describe('TargetPageControllerTest', () => {
+    let testSubject: TargetPageController;
     let mockBroadcasterStrictMock: IMock<TabContextBroadcaster>;
     let mockChromeAdapter: IMock<BrowserAdapter>;
     let mockDetailsViewController: IMock<DetailsViewController>;
@@ -37,8 +36,8 @@ describe('TabControllerTest', () => {
             .verifiable(Times.once());
     }
 
-    function createTabControllerWithoutFeatureFlag(tabContextMap: TabToContextMap): TabController {
-        return new TabController(
+    function createTabControllerWithoutFeatureFlag(tabContextMap: TabToContextMap): TargetPageController {
+        return new TargetPageController(
             tabContextMap,
             mockBroadcasterStrictMock.object,
             mockChromeAdapter.object,
@@ -65,7 +64,7 @@ describe('TabControllerTest', () => {
             })
             .verifiable(Times.once());
 
-        testSubject = new TabController(
+        testSubject = new TargetPageController(
             tabInterpreterMap,
             mockBroadcasterStrictMock.object,
             mockChromeAdapter.object,


### PR DESCRIPTION
#### Description of changes

The `TabController` is actually concerned with a target page tab (there is a `DetailsViewController` where a details view also lives on a tab, but is not handled by the `TabController`).

Hopefully, the new name makes more sense than the old one.

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1646440
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
