### PR TITLE
feat(consistent-cards-ui): Restore feature flag control of command bar items

### DIFF
--- a/src/DetailsView/components/report-export-component-factory.tsx
+++ b/src/DetailsView/components/report-export-component-factory.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { FeatureFlags } from 'common/feature-flags';
 import { VisualizationType } from 'common/types/visualization-type';
 import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { ReportExportComponent, ReportExportComponentProps } from 'DetailsView/components/report-export-component';
@@ -31,6 +32,10 @@ export function getReportExportComponentForAssessment(props: CommandBarProps): J
 }
 
 export function getReportExportComponentForFastPass(props: CommandBarProps): JSX.Element {
+    if (!props.featureFlagStoreData[FeatureFlags.universalCardsUI]) {
+        return null;
+    }
+
     const scanResult = props.visualizationScanResultData.issues.scanResult;
 
     if (!scanResult) {

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { FeatureFlags } from 'common/feature-flags';
 import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { StartOverDropdown, StartOverProps } from 'DetailsView/components/start-over-dropdown';
@@ -24,6 +25,10 @@ export function getStartOverComponentForAssessment(props: CommandBarProps): JSX.
 }
 
 export function getStartOverComponentForFastPass(props: CommandBarProps): JSX.Element {
+    if (!props.featureFlagStoreData[FeatureFlags.universalCardsUI]) {
+        return null;
+    }
+
     if (!props.visualizationScanResultData.issues.scanResult) {
         return null;
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component-factory.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ReportExportComponentPropsFactory getReportExportComponentForAssessment
 </Fragment>"
 `;
 
-exports[`ReportExportComponentPropsFactory getReportExportComponentForFastPass, scanResults is not null, test is Issues, properties are set 1`] = `
+exports[`ReportExportComponentPropsFactory getReportExportComponentForFastPass, CardsUI is true, scanResults is not null, test is Issues, properties are set 1`] = `
 "<Fragment>
   <CustomizedActionButton iconProps={{...}} onClick={[Function]}>
     Export result

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`StartOverComponentPropsFactory getStartOverComponentPropsForAssessment,
 />
 `;
 
-exports[`StartOverComponentPropsFactory getStartOverComponentPropsForFastPass, scanResults is not null, scanning is false, component matches snapshot 1`] = `
+exports[`StartOverComponentPropsFactory getStartOverComponentPropsForFastPass, CardsUI is true, scanResults is not null, scanning is false, component matches snapshot 1`] = `
 <CustomizedActionButton
   disabled={false}
   iconProps={
@@ -23,7 +23,7 @@ exports[`StartOverComponentPropsFactory getStartOverComponentPropsForFastPass, s
 </CustomizedActionButton>
 `;
 
-exports[`StartOverComponentPropsFactory getStartOverComponentPropsForFastPass, scanResults is not null, scanning is true, component matches snapshot 1`] = `
+exports[`StartOverComponentPropsFactory getStartOverComponentPropsForFastPass, CardsUI is true, scanResults is not null, scanning is true, component matches snapshot 1`] = `
 <CustomizedActionButton
   disabled={true}
   iconProps={

--- a/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
@@ -111,6 +111,10 @@ describe('ReportExportComponentPropsFactory', () => {
             .returns(() => theGeneratorOutput);
     }
 
+    function setCardsUiFlag(flag: boolean): void {
+        featureFlagStoreData['universalCardsUI'] = true;
+    }
+
     function setSelectedFastPassDetailsView(test: VisualizationType): void {
         visualizationStoreData = {
             selectedFastPassDetailsView: test,
@@ -134,14 +138,23 @@ describe('ReportExportComponentPropsFactory', () => {
         actionMessageCreatorMock.verifyAll();
     });
 
-    test('getReportExportComponentForFastPass, scanResults is null, props is null', () => {
+    test('getReportExportComponentForFastPass, CardsUI is false, props is null', () => {
         const props = getProps();
         const component: JSX.Element = getReportExportComponentForFastPass(props);
 
         expect(component).toBeNull();
     });
 
-    test('getReportExportComponentForFastPass, scanResults is not null, test is Tabstop, props is null', () => {
+    test('getReportExportComponentForFastPass, CardsUI is true, scanResults is null, props is null', () => {
+        setCardsUiFlag(true);
+        const props = getProps();
+        const component: JSX.Element = getReportExportComponentForFastPass(props);
+
+        expect(component).toBeNull();
+    });
+
+    test('getReportExportComponentForFastPass, CardsUI is true, scanResults is not null, test is Tabstop, props is null', () => {
+        setCardsUiFlag(true);
         setScanResults();
         setSelectedFastPassDetailsView(VisualizationType.TabStops);
         const props = getProps();
@@ -150,8 +163,9 @@ describe('ReportExportComponentPropsFactory', () => {
         expect(component).toBeNull();
     });
 
-    test('getReportExportComponentForFastPass, scanResults is not null, test is Issues, properties are set', () => {
+    test('getReportExportComponentForFastPass, CardsUI is true, scanResults is not null, test is Issues, properties are set', () => {
         cardsViewData = {} as CardsViewModel;
+        setCardsUiFlag(true);
         setScanResults();
         setSelectedFastPassDetailsView(VisualizationType.Issues);
         setAutomatedChecksReportGenerator();

--- a/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { FeatureFlags } from 'common/feature-flags';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
@@ -112,7 +113,7 @@ describe('ReportExportComponentPropsFactory', () => {
     }
 
     function setCardsUiFlag(flag: boolean): void {
-        featureFlagStoreData['universalCardsUI'] = true;
+        featureFlagStoreData[FeatureFlags.universalCardsUI] = true;
     }
 
     function setSelectedFastPassDetailsView(test: VisualizationType): void {

--- a/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
@@ -112,8 +112,8 @@ describe('ReportExportComponentPropsFactory', () => {
             .returns(() => theGeneratorOutput);
     }
 
-    function setCardsUiFlag(flag: boolean): void {
-        featureFlagStoreData[FeatureFlags.universalCardsUI] = true;
+    function setCardsUiFlag(flagValue: boolean): void {
+        featureFlagStoreData[FeatureFlags.universalCardsUI] = flagValue;
     }
 
     function setSelectedFastPassDetailsView(test: VisualizationType): void {
@@ -139,7 +139,15 @@ describe('ReportExportComponentPropsFactory', () => {
         actionMessageCreatorMock.verifyAll();
     });
 
+    test('getReportExportComponentForFastPass, CardsUI is undefined, props is null', () => {
+        const props = getProps();
+        const component: JSX.Element = getReportExportComponentForFastPass(props);
+
+        expect(component).toBeNull();
+    });
+
     test('getReportExportComponentForFastPass, CardsUI is false, props is null', () => {
+        setCardsUiFlag(false);
         const props = getProps();
         const component: JSX.Element = getReportExportComponentForFastPass(props);
 

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -3,6 +3,7 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
 import { AssessmentNavState, AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -18,6 +19,7 @@ describe('StartOverComponentPropsFactory', () => {
 
     let assessment: Readonly<Assessment>;
     let assessmentsProviderMock: IMock<AssessmentsProvider>;
+    let featureFlagStoreData: FeatureFlagStoreData;
     let assessmentStoreData: AssessmentStoreData;
     let visualizationScanResultData: VisualizationScanResultData;
     let scanResult: ScanResults;
@@ -25,6 +27,7 @@ describe('StartOverComponentPropsFactory', () => {
 
     beforeEach(() => {
         assessmentsProviderMock = Mock.ofType<AssessmentsProvider>(undefined, MockBehavior.Loose);
+        featureFlagStoreData = {};
         scanResult = null;
         scanning = null;
     });
@@ -62,6 +65,7 @@ describe('StartOverComponentPropsFactory', () => {
 
         return {
             deps,
+            featureFlagStoreData,
             assessmentStoreData,
             assessmentsProvider: assessmentsProviderMock.object,
             visualizationScanResultData,
@@ -73,6 +77,10 @@ describe('StartOverComponentPropsFactory', () => {
         scanResult = {} as ScanResults;
     }
 
+    function setCardsUiFlag(flag: boolean): void {
+        featureFlagStoreData['universalCardsUI'] = true;
+    }
+
     test('getStartOverComponentPropsForAssessment, component matches snapshot', () => {
         const props = getProps(true);
         const rendered = getStartOverComponentForAssessment(props);
@@ -80,23 +88,33 @@ describe('StartOverComponentPropsFactory', () => {
         expect(rendered).toMatchSnapshot();
     });
 
-    test('getStartOverComponentPropsForFastPass, scanResults is null, component is null', () => {
+    test('getStartOverComponentPropsForFastPass, CardsUI is false, component  is null', () => {
         const props = getProps(false);
         const rendered = getStartOverComponentForFastPass(props);
 
         expect(rendered).toBeNull();
     });
 
-    test('getStartOverComponentPropsForFastPass, scanResults is not null, scanning is false, component matches snapshot', () => {
+    test('getStartOverComponentPropsForFastPass, CardsUI is true, scanResults is null, component is null', () => {
+        setCardsUiFlag(true);
+        const props = getProps(false);
+        const rendered = getStartOverComponentForFastPass(props);
+
+        expect(rendered).toBeNull();
+    });
+
+    test('getStartOverComponentPropsForFastPass, CardsUI is true, scanResults is not null, scanning is false, component matches snapshot', () => {
         setScanResult();
+        setCardsUiFlag(true);
         const props = getProps(false);
         const rendered = getStartOverComponentForFastPass(props);
 
         expect(rendered).toMatchSnapshot();
     });
 
-    test('getStartOverComponentPropsForFastPass, scanResults is not null, scanning is true, component matches snapshot', () => {
+    test('getStartOverComponentPropsForFastPass, CardsUI is true, scanResults is not null, scanning is true, component matches snapshot', () => {
         setScanResult();
+        setCardsUiFlag(true);
         scanning = 'some string';
         const props = getProps(false);
         const rendered = getStartOverComponentForFastPass(props);

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
+import { FeatureFlags } from 'common/feature-flags';
 import { AssessmentNavState, AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
@@ -78,7 +79,7 @@ describe('StartOverComponentPropsFactory', () => {
     }
 
     function setCardsUiFlag(flag: boolean): void {
-        featureFlagStoreData['universalCardsUI'] = true;
+        featureFlagStoreData[FeatureFlags.universalCardsUI] = true;
     }
 
     test('getStartOverComponentPropsForAssessment, component matches snapshot', () => {

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -78,8 +78,8 @@ describe('StartOverComponentPropsFactory', () => {
         scanResult = {} as ScanResults;
     }
 
-    function setCardsUiFlag(flag: boolean): void {
-        featureFlagStoreData[FeatureFlags.universalCardsUI] = true;
+    function setCardsUiFlag(flagValue: boolean): void {
+        featureFlagStoreData[FeatureFlags.universalCardsUI] = flagValue;
     }
 
     test('getStartOverComponentPropsForAssessment, component matches snapshot', () => {
@@ -89,7 +89,15 @@ describe('StartOverComponentPropsFactory', () => {
         expect(rendered).toMatchSnapshot();
     });
 
+    test('getStartOverComponentPropsForFastPass, CardsUI is undefined, component  is null', () => {
+        const props = getProps(false);
+        const rendered = getStartOverComponentForFastPass(props);
+
+        expect(rendered).toBeNull();
+    });
+
     test('getStartOverComponentPropsForFastPass, CardsUI is false, component  is null', () => {
+        setCardsUiFlag(false);
         const props = getProps(false);
         const rendered = getStartOverComponentForFastPass(props);
 


### PR DESCRIPTION
#### Description of changes

[This commit](https://github.com/microsoft/accessibility-insights-web/pull/1676/commits/5ff9521421d1a7010aa7b861b4ffe96652a3e5c8) prematurely removed the ability to control the new command bar via feature flag. This PR reverts that commit.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above

![FeatureFlag](https://user-images.githubusercontent.com/45672944/68892310-91ad2400-06d7-11ea-99b1-53742509a408.gif)


- [ ] (UI changes only) Verified usability with NVDA/JAWS
