### PR TITLE
fix: stopped switcher from moving outside the header

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -234,10 +234,6 @@ div.insights-file-issue-details-dialog-container {
 #details-container {
     display: flex;
     flex-direction: column;
-
-    .details-view-body {
-        margin-top: $detailsViewHeaderBarHeight;
-    }
     .ms-Nav-compositeLink a {
         border-left: $pivotItemLeftBorderWidth $pivotItemBorderStyle $neutral-0;
         border-top: 0px;
@@ -308,8 +304,18 @@ div.insights-file-issue-details-dialog-container {
     }
     .header-bar {
         padding-left: 12px;
-        position: fixed;
+        position: relative;
         z-index: 1000;
+        display: flex;
+        justify-content: space-between;
+        min-width: 550px;
+        .header-text {
+            padding-top: unset;
+        }
+        .header-text-switcher {
+            display: flex;
+            align-items: center;
+        }
         .gear-options-button-component {
             float: right;
             margin-right: 16px;

--- a/src/DetailsView/components/header.tsx
+++ b/src/DetailsView/components/header.tsx
@@ -24,9 +24,11 @@ export class Header extends React.Component<HeaderProps> {
     public render(): JSX.Element {
         return (
             <header className="header-bar">
-                <HeaderIcon deps={this.props.deps} />
-                <div className="ms-font-m header-text">{title}</div>
-                {this.renderSwitcher()}
+                <div className="header-text-switcher">
+                    <HeaderIcon deps={this.props.deps} />
+                    <div className="ms-font-m header-text">{title}</div>
+                    {this.renderSwitcher()}
+                </div>
                 {this.renderButton()}
             </header>
         );

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/header.test.tsx.snap
@@ -2,9 +2,11 @@
 
 exports[`HeaderTest render: no feature flag store data 1`] = `
 "<header className=\\"header-bar\\">
-  <Component deps={{...}} />
-  <div className=\\"ms-font-m header-text\\">
-    Accessibility Insights for Web
+  <div className=\\"header-text-switcher\\">
+    <Component deps={{...}} />
+    <div className=\\"ms-font-m header-text\\">
+      Accessibility Insights for Web
+    </div>
   </div>
 </header>"
 `;
@@ -13,18 +15,22 @@ exports[`HeaderTest render: tabClosed is false 1`] = `
 <header
   className="header-bar"
 >
-  <Component
-    deps={null}
-  />
   <div
-    className="ms-font-m header-text"
+    className="header-text-switcher"
   >
-    Accessibility Insights for Web
+    <Component
+      deps={null}
+    />
+    <div
+      className="ms-font-m header-text"
+    >
+      Accessibility Insights for Web
+    </div>
+    <Switcher
+      deps={null}
+      pivotKey={2}
+    />
   </div>
-  <Switcher
-    deps={null}
-    pivotKey={2}
-  />
   <GearOptionsButtonComponent
     dropdownClickHandler={
       proxy {
@@ -49,13 +55,17 @@ exports[`HeaderTest render: tabClosed is true 1`] = `
 <header
   className="header-bar"
 >
-  <Component
-    deps={null}
-  />
   <div
-    className="ms-font-m header-text"
+    className="header-text-switcher"
   >
-    Accessibility Insights for Web
+    <Component
+      deps={null}
+    />
+    <div
+      className="ms-font-m header-text"
+    >
+      Accessibility Insights for Web
+    </div>
   </div>
 </header>
 `;


### PR DESCRIPTION
#### Description of changes
Changed the header bar to be a flex box. This was done to make sure all components of the header bar were centered at all times. Fixes the switcher position problem as mentioned in issue #1219 . I wrapped the logo, header text and switcher div keeping the gear option outside.

No bookmarklet:
![image](https://user-images.githubusercontent.com/48139461/68904315-aacfc800-070b-11ea-8274-60780a777584.png)

With bookmarklet without fix:
![image](https://user-images.githubusercontent.com/48139461/68904614-5c6ef900-070c-11ea-8f58-5bb9509062ab.png)

With bookmarklet and fix:
![image](https://user-images.githubusercontent.com/48139461/68904292-9d1a4280-070b-11ea-9bc1-42f69dc6ac53.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1219 
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
