### PR TITLE
refactor: rename Tab.Update and Tab.Change messages to be distinguishable

### DIFF
--- a/src/background/actions/tab-action-creator.ts
+++ b/src/background/actions/tab-action-creator.ts
@@ -19,12 +19,16 @@ export class TabActionCreator {
     ) {}
 
     public registerCallbacks(): void {
-        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Update, payload => this.tabActions.tabUpdate.invoke(payload));
+        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.NewTabCreated, payload =>
+            this.tabActions.newTabCreated.invoke(payload),
+        );
         this.interpreter.registerTypeToPayloadCallback(getStoreStateMessage(StoreNames.TabStore), () =>
             this.tabActions.getCurrentState.invoke(null),
         );
         this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Remove, () => this.tabActions.tabRemove.invoke(null));
-        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Change, payload => this.tabActions.tabChange.invoke(payload));
+        this.interpreter.registerTypeToPayloadCallback(Messages.Tab.ExistingTabUpdated, payload =>
+            this.tabActions.existingTabUpdated.invoke(payload),
+        );
         this.interpreter.registerTypeToPayloadCallback(Messages.Tab.Switch, this.onSwitchToTargetTab);
         this.interpreter.registerTypeToPayloadCallback(Messages.Tab.VisibilityChange, (payload: PageVisibilityChangeTabPayload) =>
             this.tabActions.tabVisibilityChange.invoke(payload.hidden),

--- a/src/background/actions/tab-actions.ts
+++ b/src/background/actions/tab-actions.ts
@@ -5,10 +5,10 @@ import { Action } from '../../common/flux/action';
 import { Tab } from '../../common/itab.d';
 
 export class TabActions {
-    public readonly tabUpdate = new Action<Tab>();
+    public readonly newTabCreated = new Action<Tab>();
     public readonly getCurrentState = new Action();
     public readonly injectedScripts = new Action();
     public readonly tabRemove = new Action();
-    public readonly tabChange = new Action<Tab>();
+    public readonly existingTabUpdated = new Action<Tab>();
     public readonly tabVisibilityChange = new Action<boolean>();
 }

--- a/src/background/stores/inspect-store.ts
+++ b/src/background/stores/inspect-store.ts
@@ -31,7 +31,7 @@ export class InspectStore extends BaseStoreImpl<InspectStoreData> {
         this.inspectActions.getCurrentState.addListener(this.onGetCurrentState);
         this.inspectActions.changeInspectMode.addListener(this.onChangeInspectMode);
         this.inspectActions.setHoveredOverSelector.addListener(this.onSetHoveredOverSelector);
-        this.tabActions.tabChange.addListener(this.onTabChange);
+        this.tabActions.existingTabUpdated.addListener(this.onTabChange);
     }
 
     private onChangeInspectMode = (payload: InspectPayload): void => {

--- a/src/background/stores/tab-store.ts
+++ b/src/background/stores/tab-store.ts
@@ -32,10 +32,10 @@ export class TabStore extends BaseStoreImpl<TabStoreData> {
     }
 
     protected addActionListeners(): void {
-        this.tabActions.tabUpdate.addListener(this.onTabUpdate);
+        this.tabActions.newTabCreated.addListener(this.onNewTabCreated);
         this.tabActions.getCurrentState.addListener(this.onGetCurrentState);
         this.tabActions.tabRemove.addListener(this.onTabRemove);
-        this.tabActions.tabChange.addListener(this.onTabChange);
+        this.tabActions.existingTabUpdated.addListener(this.onExistingTabUpdated);
         this.tabActions.tabVisibilityChange.addListener(this.onVisibilityChange);
         this.visualizationActions.updateSelectedPivotChild.addListener(this.resetTabChange);
 
@@ -52,7 +52,7 @@ export class TabStore extends BaseStoreImpl<TabStoreData> {
         this.emitChanged();
     };
 
-    private onTabUpdate = (payload: Tab): void => {
+    private onNewTabCreated = (payload: Tab): void => {
         this.state.id = payload.id;
         this.state.title = payload.title;
         this.state.url = payload.url;
@@ -64,7 +64,7 @@ export class TabStore extends BaseStoreImpl<TabStoreData> {
         this.emitChanged();
     };
 
-    private onTabChange = (payload: Tab): void => {
+    private onExistingTabUpdated = (payload: Tab): void => {
         this.state.title = payload.title;
         this.state.url = payload.url;
         this.state.isChanged = true;

--- a/src/background/stores/visualization-scan-result-store.ts
+++ b/src/background/stores/visualization-scan-result-store.ts
@@ -54,7 +54,7 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         this.visualizationScanResultsActions.addTabbedElement.addListener(this.onAddTabbedElement);
         this.visualizationScanResultsActions.disableTabStop.addListener(this.onTabStopsDisabled);
 
-        this.tabActions.tabChange.addListener(this.onTabChange);
+        this.tabActions.existingTabUpdated.addListener(this.onExistingTabUpdated);
     }
 
     private onTabStopsDisabled = (): void => {
@@ -125,7 +125,7 @@ export class VisualizationScanResultStore extends BaseStoreImpl<VisualizationSca
         this.emitChanged();
     };
 
-    private onTabChange = (): void => {
+    private onExistingTabUpdated = (): void => {
         this.state = this.getDefaultState();
         this.emitChanged();
     };

--- a/src/background/stores/visualization-store.ts
+++ b/src/background/stores/visualization-store.ts
@@ -52,7 +52,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
         this.visualizationActions.scrollRequested.addListener(this.onScrollRequested);
 
         this.visualizationActions.getCurrentState.addListener(this.onGetCurrentState);
-        this.tabActions.tabChange.addListener(this.onTabChange);
+        this.tabActions.existingTabUpdated.addListener(this.onExistingTabUpdated);
 
         this.visualizationActions.updateSelectedPivotChild.addListener(this.onUpdateSelectedPivotChild);
         this.visualizationActions.updateSelectedPivot.addListener(this.onUpdateSelectedPivot);
@@ -128,7 +128,7 @@ export class VisualizationStore extends BaseStoreImpl<VisualizationStoreData> {
         return isStateChanged;
     }
 
-    private onTabChange = (payload: Tab): void => {
+    private onExistingTabUpdated = (payload: Tab): void => {
         this.state = {
             ...this.getDefaultState(),
             selectedFastPassDetailsView: this.state.selectedFastPassDetailsView,

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -89,10 +89,10 @@ export class TargetPageController {
 
     private postTabUpdate = (tabId: number): void => {
         if (this.hasTabContext(tabId)) {
-            this.sendTabChangedAction(tabId);
+            this.sendExistingTabUpdatedAction(tabId);
         } else {
             this.addTabContext(tabId);
-            this.sendTabUpdateAction(tabId);
+            this.sendNewTabCreatedAction(tabId);
         }
     };
 
@@ -106,7 +106,7 @@ export class TargetPageController {
         return tabId in this.targetPageTabIdToContextMap;
     }
 
-    private sendTabAction(tabId: number, messageType: string, errorMessagePrefix: string): void {
+    private sendTabAction(tabId: number, messageType: string): void {
         this.browserAdapter.getTab(
             tabId,
             (tab: chrome.tabs.Tab) => {
@@ -121,17 +121,17 @@ export class TargetPageController {
                 }
             },
             () => {
-                this.logger.log(`${errorMessagePrefix} tab with Id ${tabId} not found`);
+                this.logger.log(`${messageType}: tab with Id ${tabId} not found`);
             },
         );
     }
 
-    private sendTabChangedAction(tabId: number): void {
-        this.sendTabAction(tabId, Messages.Tab.Change, 'changed');
+    private sendExistingTabUpdatedAction(tabId: number): void {
+        this.sendTabAction(tabId, Messages.Tab.ExistingTabUpdated);
     }
 
-    private sendTabUpdateAction(tabId: number): void {
-        this.sendTabAction(tabId, Messages.Tab.Update, 'updated');
+    private sendNewTabCreatedAction(tabId: number): void {
+        this.sendTabAction(tabId, Messages.Tab.NewTabCreated);
     }
 
     private sendTabVisibilityChangeAction(tabId: number, isHidden: boolean): void {

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -101,11 +101,11 @@ export class Messages {
     };
 
     public static readonly Tab = {
-        Update: `${messagePrefix}/tab/update`,
+        NewTabCreated: `${messagePrefix}/tab/newTabCreated`,
         Remove: `${messagePrefix}/tab/remove`,
-        Change: `${messagePrefix}/targetTab/changed`,
-        Switch: `${messagePrefix}/targetTab/switch`,
-        VisibilityChange: `${messagePrefix}/targetTab/visibilitychange`,
+        ExistingTabUpdated: `${messagePrefix}/tab/existingTabUpdated`,
+        Switch: `${messagePrefix}/tab/switch`,
+        VisibilityChange: `${messagePrefix}/tab/visibilitychange`,
     };
 
     public static readonly Assessment = {

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -22,22 +22,22 @@ describe('TestActionCreatorTest', () => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
     });
 
-    it('handles Tab.Update message', () => {
+    it('handles Tab.NewTabCreated message', () => {
         const payload: Tab = {
             id: -1,
             title: 'test tab title',
             url: 'test url',
         };
 
-        const tabUpdateMock = createActionMock(payload);
-        const actionsMock = createActionsMock('tabUpdate', tabUpdateMock.object);
-        const interpreterMock = createInterpreterMock(Messages.Tab.Update, payload);
+        const actionMock = createActionMock(payload);
+        const actionsMock = createActionsMock('newTabCreated', actionMock.object);
+        const interpreterMock = createInterpreterMock(Messages.Tab.NewTabCreated, payload);
 
         const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null);
 
         testSubject.registerCallbacks();
 
-        tabUpdateMock.verifyAll();
+        actionMock.verifyAll();
     });
 
     it('handles Tab.GetCurrent message', () => {
@@ -64,22 +64,22 @@ describe('TestActionCreatorTest', () => {
         tabRemoveMock.verifyAll();
     });
 
-    it('handles Tab.Change message', () => {
+    it('handles Tab.ExistingTabUpdated message', () => {
         const payload: Tab = {
             id: -1,
             title: 'test tab title',
             url: 'test url',
         };
 
-        const tabChangeMock = createActionMock(payload);
-        const actionsMock = createActionsMock('tabChange', tabChangeMock.object);
-        const interpreterMock = createInterpreterMock(Messages.Tab.Change, payload);
+        const actionMock = createActionMock(payload);
+        const actionsMock = createActionsMock('existingTabUpdated', actionMock.object);
+        const interpreterMock = createInterpreterMock(Messages.Tab.ExistingTabUpdated, payload);
 
         const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null);
 
         testSubject.registerCallbacks();
 
-        tabChangeMock.verifyAll();
+        actionMock.verifyAll();
     });
 
     it('handles Tab.Switch message', () => {

--- a/src/tests/unit/tests/background/inspect-store.test.ts
+++ b/src/tests/unit/tests/background/inspect-store.test.ts
@@ -54,12 +54,12 @@ describe('InspectStoreTest', () => {
             .testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on tabChange', () => {
+    test('on existingTabUpdated', () => {
         const initialState = getDefaultState();
         initialState.hoveredOverSelector = ['some selector'];
         initialState.inspectMode = InspectMode.scopingAddInclude;
         const finalState = getDefaultState();
-        createStoreForTabActions('tabChange')
+        createStoreForTabActions('existingTabUpdated')
             .withActionParam(null)
             .testListenerToBeCalledOnce(initialState, finalState);
     });

--- a/src/tests/unit/tests/background/stores/tab-store.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-store.test.ts
@@ -20,7 +20,7 @@ describe('TabStoreTest', () => {
         expect(testObject.getId()).toBe(StoreNames[StoreNames.TabStore]);
     });
 
-    test('onTabUpdate', () => {
+    test('onNewTabCreated', () => {
         const initialState = new TabStoreDataBuilder().build();
 
         const payload: Tab = {
@@ -35,7 +35,7 @@ describe('TabStoreTest', () => {
             .with('url', payload.url)
             .build();
 
-        createStoreTesterForTabActions('tabUpdate')
+        createStoreTesterForTabActions('newTabCreated')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
@@ -55,7 +55,7 @@ describe('TabStoreTest', () => {
         createStoreTesterForTabActions('tabRemove').testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onTabChange', () => {
+    test('onExistingTabUpdated', () => {
         const initialState: TabStoreData = new TabStoreDataBuilder()
             .with('url', 'url 1')
             .with('title', 'title 1')
@@ -72,7 +72,7 @@ describe('TabStoreTest', () => {
             .with('isChanged', true)
             .build();
 
-        createStoreTesterForTabActions('tabChange')
+        createStoreTesterForTabActions('existingTabUpdated')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, finalState);
     });

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -503,7 +503,7 @@ describe('VisualizationScanResultStoreTest', () => {
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onTabChange', () => {
+    test('onExistingTabUpdated', () => {
         const initialState = new VisualizationScanResultStoreDataBuilder()
             .withIssuesSelectedTargets({})
             .withScanResult(VisualizationType.Headings, [])
@@ -512,7 +512,7 @@ describe('VisualizationScanResultStoreTest', () => {
 
         const expectedState = new VisualizationScanResultStoreDataBuilder().build();
 
-        createStoreTesterForTabActions('tabChange').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForTabActions('existingTabUpdated').testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     function createStoreTesterForVisualizationScanResultActions(

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -783,8 +783,8 @@ describe('VisualizationStoreTest ', () => {
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    test('onTabChange', () => {
-        const actionName = 'tabChange';
+    test('onExistingTabUpdated', () => {
+        const actionName = 'existingTabUpdated';
         const visualizationType = VisualizationType.Headings;
         const pivot = DetailsViewPivotType.allTest;
         const expectedState = new VisualizationStoreDataBuilder()

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -114,7 +114,7 @@ describe('TargetPageControllerTest', () => {
             data: 'abc',
         };
         const interpretInput: Message = {
-            messageType: Messages.Tab.Update,
+            messageType: Messages.Tab.NewTabCreated,
             payload: getTabCallbackInput,
             tabId: tabId,
         };
@@ -148,7 +148,7 @@ describe('TargetPageControllerTest', () => {
                 rejectCallback = reject;
             })
             .verifiable(Times.once());
-        loggerMock.setup(logger => logger.log(`updated tab with Id ${tabId} not found`)).verifiable(Times.once());
+        loggerMock.setup(logger => logger.log(It.is(s => s.endsWith(`tab with Id ${tabId} not found`)))).verifiable(Times.once());
 
         setupCreateTabContextMock(broadcastDelegate, tabContextMock, tabId);
 
@@ -290,7 +290,7 @@ describe('TargetPageControllerTest', () => {
 
         openTabIds.forEach((tabId, index) => {
             const interpretInput: Message = {
-                messageType: Messages.Tab.Update,
+                messageType: Messages.Tab.NewTabCreated,
                 payload: tabs[tabId],
                 tabId: tabId,
             };
@@ -355,7 +355,7 @@ describe('TargetPageControllerTest', () => {
         };
 
         const interpretInput: Message = {
-            messageType: Messages.Tab.Change,
+            messageType: Messages.Tab.ExistingTabUpdated,
             payload: getTabCallbackInput,
             tabId: tabId,
         };
@@ -382,7 +382,7 @@ describe('TargetPageControllerTest', () => {
                 onReject = reject;
             })
             .verifiable(Times.once());
-        loggerMock.setup(logger => logger.log(`changed tab with Id ${tabId} not found`)).verifiable(Times.once());
+        loggerMock.setup(logger => logger.log(It.is(s => s.endsWith(`tab with Id ${tabId} not found`)))).verifiable(Times.once());
 
         testSubject = createTabControllerWithoutFeatureFlag(tabInterpreterMap);
         testSubject.initialize();
@@ -658,7 +658,7 @@ describe('TargetPageControllerTest', () => {
         };
 
         const interpretInput: Message = {
-            messageType: Messages.Tab.Change,
+            messageType: Messages.Tab.ExistingTabUpdated,
             payload: getTabCallbackInput,
             tabId: tabId,
         };
@@ -712,7 +712,7 @@ describe('TargetPageControllerTest', () => {
                 onReject = reject;
             })
             .verifiable(Times.once());
-        loggerMock.setup(logger => logger.log(`changed tab with Id ${tabId} not found`)).verifiable(Times.once());
+        loggerMock.setup(logger => logger.log(It.is(s => s.endsWith(`tab with Id ${tabId} not found`)))).verifiable(Times.once());
 
         testSubject = createTabControllerWithoutFeatureFlag({ [tabId]: null });
         testSubject.initialize();


### PR DESCRIPTION
#### Description of changes

While @smoralesd and I were looking over the tab change/update machinery, we found ourselves frequently confused by the difference between `Tab.Change` and `Tab.Update` messages. This PR updates them (and associated helpers/actions) to more accurately reflect their purpose.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
