### PR TITLE
refactor: renaming types using type as a suffix

### DIFF
--- a/src/common/uid-generator.ts
+++ b/src/common/uid-generator.ts
@@ -2,6 +2,6 @@
 // Licensed under the MIT License.
 import * as uuid4 from 'uuid/v4';
 
-export type UUIDGeneratorType = () => string;
+export type UUIDGenerator = () => string;
 
-export let generateUID: UUIDGeneratorType = uuid4;
+export let generateUID: UUIDGenerator = uuid4;

--- a/src/electron/flux/action-creator/device-connect-action-creator.ts
+++ b/src/electron/flux/action-creator/device-connect-action-creator.ts
@@ -4,13 +4,13 @@ import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-hand
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { VALIDATE_PORT } from 'electron/common/electron-telemetry-events';
 
-import { FetchScanResultsType } from '../../platform/android/fetch-scan-results';
+import { ScanResultsFetcher } from '../../platform/android/fetch-scan-results';
 import { DeviceActions } from '../action/device-actions';
 
 export class DeviceConnectActionCreator {
     constructor(
         private readonly deviceActions: DeviceActions,
-        private readonly fetchScanResults: FetchScanResultsType,
+        private readonly fetchScanResults: ScanResultsFetcher,
         private readonly telemetryEventHandler: TelemetryEventHandler,
     ) {}
 

--- a/src/electron/platform/android/fetch-scan-results.ts
+++ b/src/electron/platform/android/fetch-scan-results.ts
@@ -3,11 +3,11 @@
 import axios from 'axios';
 import { ScanResults } from './scan-results';
 
-export type FetchScanResultsType = (port: number) => Promise<ScanResults>;
+export type ScanResultsFetcher = (port: number) => Promise<ScanResults>;
 
 export type HttpGet = typeof axios.get;
 
-export const createFetchScanResults = (httpGet: HttpGet): FetchScanResultsType => {
+export const createScanResultsFetcher = (httpGet: HttpGet): ScanResultsFetcher => {
     return async (port: number) => {
         const response = await httpGet(`http://localhost:${port}/axe/result`);
         return new ScanResults(response.data);

--- a/src/electron/platform/android/scan-controller.ts
+++ b/src/electron/platform/android/scan-controller.ts
@@ -7,7 +7,7 @@ import { createDefaultLogger } from 'common/logging/default-logger';
 import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
 import { PortPayload } from 'electron/flux/action/device-action-payloads';
 import { ScanActions } from 'electron/flux/action/scan-actions';
-import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
+import { ScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
 import { RuleResultsData, ScanResults } from 'electron/platform/android/scan-results';
 import { UnifiedScanCompletedPayloadBuilder } from 'electron/platform/android/unified-result-builder';
 
@@ -15,7 +15,7 @@ export class ScanController {
     constructor(
         private readonly scanActions: ScanActions,
         private readonly unifiedScanResultAction: UnifiedScanResultActions,
-        private readonly fetchScanResults: FetchScanResultsType,
+        private readonly fetchScanResults: ScanResultsFetcher,
         private readonly unifiedResultsBuilder: UnifiedScanCompletedPayloadBuilder,
         private readonly telemetryEventHandler: TelemetryEventHandler,
         private readonly getCurrentDate: () => Date,

--- a/src/electron/platform/android/scan-results-to-unified-results.ts
+++ b/src/electron/platform/android/scan-results-to-unified-results.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { InstanceResultStatus, UnifiedDescriptors, UnifiedResult } from 'common/types/store-data/unified-data-interface';
-import { UUIDGeneratorType } from 'common/uid-generator';
+import { UUIDGenerator } from 'common/uid-generator';
 import { DictionaryStringTo } from 'types/common-types';
 import { RuleInformation } from './rule-information';
 import { RuleInformationProviderType } from './rule-information-provider-type';
@@ -11,13 +11,13 @@ import { RuleResultsData, ScanResults, ViewElementData } from './scan-results';
 export type ConvertScanResultsToUnifiedResultsDelegate = (
     scanResults: ScanResults,
     ruleInformationProvider: RuleInformationProviderType,
-    uuidGenerator: UUIDGeneratorType,
+    uuidGenerator: UUIDGenerator,
 ) => UnifiedResult[];
 
 export function convertScanResultsToUnifiedResults(
     scanResults: ScanResults,
     ruleInformationProvider: RuleInformationProviderType,
-    uuidGenerator: UUIDGeneratorType,
+    uuidGenerator: UUIDGenerator,
 ): UnifiedResult[] {
     if (!scanResults || !scanResults.ruleResults) {
         return [];
@@ -29,7 +29,7 @@ export function convertScanResultsToUnifiedResults(
 function createUnifiedResultsFromScanResults(
     scanResults: ScanResults,
     ruleInformationProvider: RuleInformationProviderType,
-    uuidGenerator: UUIDGeneratorType,
+    uuidGenerator: UUIDGenerator,
 ): UnifiedResult[] {
     const viewElementLookup: DictionaryStringTo<ViewElementData> = createViewElementLookup(scanResults);
     const unifiedResults: UnifiedResult[] = [];
@@ -68,7 +68,7 @@ function createUnifiedResult(
     ruleInformation: RuleInformation,
     ruleResult: RuleResultsData,
     viewElementLookup: DictionaryStringTo<ViewElementData>,
-    uuidGenerator: UUIDGeneratorType,
+    uuidGenerator: UUIDGenerator,
 ): UnifiedResult {
     return {
         uid: uuidGenerator(),

--- a/src/electron/platform/android/scan-results-to-unified-rules.ts
+++ b/src/electron/platform/android/scan-results-to-unified-rules.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { UnifiedRule } from 'common/types/store-data/unified-data-interface';
-import { UUIDGeneratorType } from 'common/uid-generator';
+import { UUIDGenerator } from 'common/uid-generator';
 import { RuleInformation } from './rule-information';
 import { RuleInformationProviderType } from './rule-information-provider-type';
 import { ScanResults } from './scan-results';
@@ -10,13 +10,13 @@ import { ScanResults } from './scan-results';
 export type ConvertScanResultsToUnifiedRulesDelegate = (
     scanResults: ScanResults,
     ruleInformationProvider: RuleInformationProviderType,
-    uuidGenerator: UUIDGeneratorType,
+    uuidGenerator: UUIDGenerator,
 ) => UnifiedRule[];
 
 export function convertScanResultsToUnifiedRules(
     scanResults: ScanResults,
     ruleInformationProvider: RuleInformationProviderType,
-    uuidGenerator: UUIDGeneratorType,
+    uuidGenerator: UUIDGenerator,
 ): UnifiedRule[] {
     if (!scanResults) {
         return [];
@@ -40,7 +40,7 @@ export function convertScanResultsToUnifiedRules(
     return unifiedRules;
 }
 
-function createUnifiedRuleFromRuleResult(ruleInformation: RuleInformation, uuidGenerator: UUIDGeneratorType): UnifiedRule {
+function createUnifiedRuleFromRuleResult(ruleInformation: RuleInformation, uuidGenerator: UUIDGenerator): UnifiedRule {
     return {
         uid: uuidGenerator(),
         id: ruleInformation.ruleId,

--- a/src/electron/platform/android/unified-result-builder.ts
+++ b/src/electron/platform/android/unified-result-builder.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
-import { generateUID, UUIDGeneratorType } from 'common/uid-generator';
+import { generateUID, UUIDGenerator } from 'common/uid-generator';
 import { ToolDataDelegate } from 'electron/common/application-properties-provider';
 import { RuleInformationProvider } from 'electron/platform/android/rule-information-provider';
 import { RuleInformationProviderType } from 'electron/platform/android/rule-information-provider-type';
@@ -26,7 +26,7 @@ export const createBuilder = (
     getUnifiedRules: ConvertScanResultsToUnifiedRulesDelegate,
     getPlatformData: ConvertScanResultsToPlatformDataDelegate,
     ruleInformationProvider: RuleInformationProviderType,
-    uuidGenerator: UUIDGeneratorType,
+    uuidGenerator: UUIDGenerator,
     getToolData: ToolDataDelegate,
 ) => (scanResults: ScanResults): UnifiedScanCompletedPayload => {
     const payload: UnifiedScanCompletedPayload = {

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -33,7 +33,7 @@ import { WindowFrameActions } from 'electron/flux/action/window-frame-actions';
 import { WindowStateActions } from 'electron/flux/action/window-state-actions';
 import { ScanStore } from 'electron/flux/store/scan-store';
 import { WindowStateStore } from 'electron/flux/store/window-state-store';
-import { createFetchScanResults } from 'electron/platform/android/fetch-scan-results';
+import { createScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
 import { ScanController } from 'electron/platform/android/scan-controller';
 import { createDefaultBuilder } from 'electron/platform/android/unified-result-builder';
 import { RootContainerProps, RootContainerState } from 'electron/views/root-container/components/root-container';
@@ -138,7 +138,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
     const telemetryStateListener = new TelemetryStateListener(userConfigurationStore, telemetryEventHandler);
     telemetryStateListener.initialize();
 
-    const fetchScanResults = createFetchScanResults(axios.get);
+    const fetchScanResults = createScanResultsFetcher(axios.get);
 
     const interpreter = new Interpreter();
     const dispatcher = new DirectActionMessageDispatcher(interpreter);

--- a/src/injected/adapters/scan-results-to-unified-results.ts
+++ b/src/injected/adapters/scan-results-to-unified-results.ts
@@ -3,11 +3,11 @@
 import { flatMap } from 'lodash';
 
 import { InstanceResultStatus, UnifiedResult } from '../../common/types/store-data/unified-data-interface';
-import { UUIDGeneratorType } from '../../common/uid-generator';
+import { UUIDGenerator } from '../../common/uid-generator';
 import { AxeNodeResult, RuleResult, ScanResults } from '../../scanner/iruleresults';
 import { IssueFilingUrlStringUtils } from './../../issue-filing/common/issue-filing-url-string-utils';
 
-export type ConvertScanResultsToUnifiedResultsDelegate = (scanResults: ScanResults, uuidGenerator: UUIDGeneratorType) => UnifiedResult[];
+export type ConvertScanResultsToUnifiedResultsDelegate = (scanResults: ScanResults, uuidGenerator: UUIDGenerator) => UnifiedResult[];
 
 interface RuleResultData {
     status: InstanceResultStatus;
@@ -25,14 +25,14 @@ interface CreationData extends RuleResultData {
     };
 }
 
-export const convertScanResultsToUnifiedResults = (scanResults: ScanResults, uuidGenerator: UUIDGeneratorType): UnifiedResult[] => {
+export const convertScanResultsToUnifiedResults = (scanResults: ScanResults, uuidGenerator: UUIDGenerator): UnifiedResult[] => {
     if (!scanResults) {
         return [];
     }
     return createUnifiedResultsFromScanResults(scanResults, uuidGenerator);
 };
 
-const createUnifiedResultsFromScanResults = (scanResults: ScanResults, uuidGenerator: UUIDGeneratorType): UnifiedResult[] => {
+const createUnifiedResultsFromScanResults = (scanResults: ScanResults, uuidGenerator: UUIDGenerator): UnifiedResult[] => {
     return [
         ...createUnifiedResultsFromRuleResults(scanResults.violations, 'fail', uuidGenerator),
         ...createUnifiedResultsFromRuleResults(scanResults.passes, 'pass', uuidGenerator),
@@ -42,7 +42,7 @@ const createUnifiedResultsFromScanResults = (scanResults: ScanResults, uuidGener
 const createUnifiedResultsFromRuleResults = (
     ruleResults: RuleResult[],
     status: InstanceResultStatus,
-    uuidGenerator: UUIDGeneratorType,
+    uuidGenerator: UUIDGenerator,
 ): UnifiedResult[] => {
     const unifiedResultFromRuleResults = (ruleResults || []).map(result =>
         createUnifiedResultsFromRuleResult(result, status, uuidGenerator),
@@ -54,7 +54,7 @@ const createUnifiedResultsFromRuleResults = (
 const createUnifiedResultsFromRuleResult = (
     ruleResult: RuleResult,
     status: InstanceResultStatus,
-    uuidGenerator: UUIDGeneratorType,
+    uuidGenerator: UUIDGenerator,
 ): UnifiedResult[] => {
     return ruleResult.nodes.map(node => {
         const data: RuleResultData = {
@@ -69,7 +69,7 @@ const createUnifiedResultsFromRuleResult = (
 const createUnifiedResultFromNode = (
     nodeResult: AxeNodeResult,
     ruleResultData: RuleResultData,
-    uuidGenerator: UUIDGeneratorType,
+    uuidGenerator: UUIDGenerator,
 ): UnifiedResult => {
     return createUnifiedResult(
         {
@@ -87,7 +87,7 @@ const createUnifiedResultFromNode = (
     );
 };
 
-const createUnifiedResult = (data: CreationData, uuidGenerator: UUIDGeneratorType): UnifiedResult => {
+const createUnifiedResult = (data: CreationData, uuidGenerator: UUIDGenerator): UnifiedResult => {
     return {
         uid: uuidGenerator(),
         status: data.status,

--- a/src/injected/analyzers/unified-result-sender.ts
+++ b/src/injected/analyzers/unified-result-sender.ts
@@ -3,7 +3,7 @@
 import { UnifiedScanCompletedPayload } from '../../background/actions/action-payloads';
 import { EnvironmentInfoProvider } from '../../common/environment-info-provider';
 import { Messages } from '../../common/messages';
-import { UUIDGeneratorType } from '../../common/uid-generator';
+import { UUIDGenerator } from '../../common/uid-generator';
 import { ConvertScanResultsToUnifiedResultsDelegate } from '../adapters/scan-results-to-unified-results';
 import { ConvertScanResultsToUnifiedRulesDelegate } from '../adapters/scan-results-to-unified-rules';
 import { AxeAnalyzerResult } from './analyzer';
@@ -15,7 +15,7 @@ export class UnifiedResultSender {
         private readonly convertScanResultsToUnifiedResults: ConvertScanResultsToUnifiedResultsDelegate,
         private readonly convertScanResultsToUnifiedRules: ConvertScanResultsToUnifiedRulesDelegate,
         private readonly environmentInfoProvider: EnvironmentInfoProvider,
-        private readonly generateUID: UUIDGeneratorType,
+        private readonly generateUID: UUIDGenerator,
     ) {}
 
     public sendResults: PostResolveCallback = (axeResults: AxeAnalyzerResult) => {

--- a/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
@@ -7,7 +7,7 @@ import { VALIDATE_PORT } from 'electron/common/electron-telemetry-events';
 import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
 import { ConnectedDevicePayload, PortPayload } from 'electron/flux/action/device-action-payloads';
 import { DeviceActions } from 'electron/flux/action/device-actions';
-import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
+import { ScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import { IMock, It, Mock, Times } from 'typemoq';
 
@@ -18,7 +18,7 @@ describe('DeviceConnectActionCreator', () => {
 
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let deviceActionsMock: IMock<DeviceActions>;
-    let fetchScanResultsMock: IMock<FetchScanResultsType>;
+    let fetchScanResultsMock: IMock<ScanResultsFetcher>;
     let connectingMock: IMock<Action<PortPayload>>;
 
     let testSubject: DeviceConnectActionCreator;
@@ -27,7 +27,7 @@ describe('DeviceConnectActionCreator', () => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
         deviceActionsMock = Mock.ofType<DeviceActions>();
         connectingMock = Mock.ofType<Action<PortPayload>>();
-        fetchScanResultsMock = Mock.ofType<FetchScanResultsType>();
+        fetchScanResultsMock = Mock.ofType<ScanResultsFetcher>();
 
         deviceActionsMock.setup(actions => actions.connecting).returns(() => connectingMock.object);
 

--- a/src/tests/unit/tests/electron/platform/android/fetch-scan-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/fetch-scan-results.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AxiosResponse } from 'axios';
-import { createScanResultsFetcher, ScanResultsFetcher, HttpGet } from 'electron/platform/android/fetch-scan-results';
+import { createScanResultsFetcher, HttpGet, ScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import { IMock, Mock } from 'typemoq';
 

--- a/src/tests/unit/tests/electron/platform/android/fetch-scan-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/fetch-scan-results.test.ts
@@ -1,20 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AxiosResponse } from 'axios';
-import { createFetchScanResults, FetchScanResultsType, HttpGet } from 'electron/platform/android/fetch-scan-results';
+import { createScanResultsFetcher, ScanResultsFetcher, HttpGet } from 'electron/platform/android/fetch-scan-results';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import { IMock, Mock } from 'typemoq';
 
 describe('fetchScanResults', () => {
     let httpGetMock: IMock<HttpGet>;
 
-    let testSubject: FetchScanResultsType;
+    let testSubject: ScanResultsFetcher;
 
     const port = 10101;
 
     beforeEach(() => {
         httpGetMock = Mock.ofType<HttpGet>();
-        testSubject = createFetchScanResults(httpGetMock.object);
+        testSubject = createScanResultsFetcher(httpGetMock.object);
     });
 
     it('returns a ScanResults instance', async () => {

--- a/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
@@ -9,7 +9,7 @@ import { Logger } from 'common/logging/logger';
 import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
 import { PortPayload } from 'electron/flux/action/device-action-payloads';
 import { ScanActions } from 'electron/flux/action/scan-actions';
-import { FetchScanResultsType } from 'electron/platform/android/fetch-scan-results';
+import { ScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
 import { ScanController } from 'electron/platform/android/scan-controller';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import { UnifiedScanCompletedPayloadBuilder } from 'electron/platform/android/unified-result-builder';
@@ -33,7 +33,7 @@ describe('ScanController', () => {
     };
 
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
-    let fetchScanResultsMock: IMock<FetchScanResultsType>;
+    let fetchScanResultsMock: IMock<ScanResultsFetcher>;
     let getCurrentDateMock: IMock<() => Date>;
     let loggerMock: IMock<Logger>;
 
@@ -49,7 +49,7 @@ describe('ScanController', () => {
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
-        fetchScanResultsMock = Mock.ofType<FetchScanResultsType>();
+        fetchScanResultsMock = Mock.ofType<ScanResultsFetcher>();
         scanActionsMock = Mock.ofType<ScanActions>();
 
         scanStartedMock = Mock.ofType<Action<PortPayload>>();

--- a/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UUIDGeneratorType } from 'common/uid-generator';
+import { UUIDGenerator } from 'common/uid-generator';
 import { ToolDataDelegate } from 'electron/common/application-properties-provider';
 import { RuleInformationProviderType } from 'electron/platform/android/rule-information-provider-type';
 import { ScanResults } from 'electron/platform/android/scan-results';
@@ -15,7 +15,7 @@ describe('buildUnifiedScanCompletedPayload', () => {
     const exampleScanResults = new ScanResults(axeRuleResultExample);
 
     it('builds the payload', () => {
-        const generateUIDMock = Mock.ofType<UUIDGeneratorType>();
+        const generateUIDMock = Mock.ofType<UUIDGenerator>();
 
         const ruleInformationProviderMock = Mock.ofType<RuleInformationProviderType>();
 


### PR DESCRIPTION
#### Description of changes

This comes from our last engineering discussion.

Renaming:
- `UUIGeneratorType` to `UUIDGenerator`
- `FetchScanRestulsType` to `ScanResultsFetcher`

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
