### PR TITLE
fix: high contrast styling for cards UI

### DIFF
--- a/src/common/components/cards/instance-details-footer.scss
+++ b/src/common/components/cards/instance-details-footer.scss
@@ -13,7 +13,7 @@
 
     padding-left: 12px;
 
-    border-top: 0.5px solid $neutral-10;
+    border-top: 0.5px solid $card-footer-border;
     border-bottom-left-radius: inherit;
     border-bottom-right-radius: inherit;
 

--- a/src/common/components/cards/rule-resources.scss
+++ b/src/common/components/cards/rule-resources.scss
@@ -16,6 +16,7 @@
     box-shadow: 0px 0.3px 0.9px rgba(0, 0, 0, 0.108), 0px 1.6px 3.6px rgba(0, 0, 0, 0.132);
 
     border-radius: 4px;
+    border: 1px solid $card-border;
 
     line-height: 20px;
 

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -92,6 +92,7 @@
     --menu-background: --acrylic-light;
     --menu-border: --menu-background;
     --screenshot-image-outline: #8b8b8b;
+    --card-border: transparent;
 
     // Landmark colors
     --landmark-contentinfo: #00a88c;
@@ -160,6 +161,7 @@
         --menu-background: var(--light-black);
         --menu-border: var(--grey);
         --screenshot-image-outline: var(--white);
+        --card-border: var(--white);
     }
 }
 
@@ -256,6 +258,7 @@ $menu-item-background-active: var(--menu-item-background-active);
 $menu-border: var(--menu-border);
 $menu-background: var(--menu-background);
 $screenshot-image-outline: var(--screenshot-image-outline);
+$card-border: var(--card-border);
 
 // consistent colors
 $always-white: #ffffff;

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -93,6 +93,7 @@
     --menu-border: --menu-background;
     --screenshot-image-outline: #8b8b8b;
     --card-border: transparent;
+    --card-footer-border: var(--neutral-10);
 
     // Landmark colors
     --landmark-contentinfo: #00a88c;
@@ -162,6 +163,7 @@
         --menu-border: var(--grey);
         --screenshot-image-outline: var(--white);
         --card-border: var(--white);
+        --card-footer-border: var(--white);
     }
 }
 
@@ -259,6 +261,7 @@ $menu-border: var(--menu-border);
 $menu-background: var(--menu-background);
 $screenshot-image-outline: var(--screenshot-image-outline);
 $card-border: var(--card-border);
+$card-footer-border: var(--card-footer-border);
 
 // consistent colors
 $always-white: #ffffff;

--- a/src/reports/components/instance-details.scss
+++ b/src/reports/components/instance-details.scss
@@ -36,7 +36,7 @@
 }
 
 .instance-details-card.selected:focus {
-    outline-offset: 6px;
+    outline-offset: 8px;
 }
 
 .instance-details-card:hover {

--- a/src/reports/components/instance-details.scss
+++ b/src/reports/components/instance-details.scss
@@ -14,6 +14,7 @@
 
 .instance-details-card {
     border-radius: 4px;
+    border: 1px solid $card-border;
     outline-style: 'border-style';
     box-shadow: 0px 0.6px 1.8px $box-shadow-108, 0px 3.2px 7.2px $box-shadow-132;
     margin-bottom: 16px;
@@ -25,8 +26,13 @@
     outline: 5px solid $communication-tint-10;
 }
 
+.instance-details-card.selected {
+    border: 1px solid transparent;
+}
+
 .instance-details-card:focus {
     outline: 2px solid $primary-text;
+    outline-offset: 2px;
 }
 
 .instance-details-card.selected:focus {


### PR DESCRIPTION
#### Description of changes

Note: Recreated the PR to see if the checks would run this time.

This fixes the styling for cards UI, according to the the mock, for high contrast. Note: this makes a minor modification to the styling in cards UI when not in high-contrast but it's negligible.

Mock:
![image](https://user-images.githubusercontent.com/32555133/68902735-f5424c00-06ed-11ea-8e2e-0ffd741cc143.png)

Gif:
![cardselectionhighcontrast](https://user-images.githubusercontent.com/32555133/68903015-aa750400-06ee-11ea-8334-068b3b50f5dd.gif)

Updated with the footer border as well:

![image](https://user-images.githubusercontent.com/32555133/68904945-36d5f580-06f4-11ea-8287-013a6833c674.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
