### PR TITLE
refactor: renaming delegates types

### DIFF
--- a/src/electron/common/application-properties-provider.ts
+++ b/src/electron/common/application-properties-provider.ts
@@ -5,9 +5,9 @@ import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { androidAppTitle } from 'content/strings/application';
 import { ScanResults } from 'electron/platform/android/scan-results';
 
-export type ToolDataDelegate = (scanResults: ScanResults) => ToolData;
+export type ToolDataGetter = (scanResults: ScanResults) => ToolData;
 
-export const createGetToolDataDelegate = (appDataAdapter: AppDataAdapter): ToolDataDelegate => {
+export const createToolDataGetter = (appDataAdapter: AppDataAdapter): ToolDataGetter => {
     return scanResults => {
         return {
             scanEngineProperties: {

--- a/src/electron/platform/android/rule-information.ts
+++ b/src/electron/platform/android/rule-information.ts
@@ -6,14 +6,14 @@ import { RuleResultsData } from './scan-results';
 
 export type GetUnifiedFormattableResolutionDelegate = (ruleResultsData: RuleResultsData) => UnifiedFormattableResolution;
 
-export type IncludeThisResultDelegate = (ruleResultsData: RuleResultsData) => boolean;
+export type ShouldIncludeResultPredicate = (ruleResultsData: RuleResultsData) => boolean;
 
 export class RuleInformation {
     constructor(
         readonly ruleId: string,
         readonly ruleDescription: string,
         readonly getUnifiedFormattableResolutionDelegate: GetUnifiedFormattableResolutionDelegate,
-        readonly includeThisResultDelegate: IncludeThisResultDelegate,
+        readonly shouldIncludeResult: ShouldIncludeResultPredicate,
     ) {}
 
     public getUnifiedFormattableResolution(ruleResultsData: RuleResultsData): UnifiedFormattableResolution {
@@ -21,6 +21,6 @@ export class RuleInformation {
     }
 
     public includeThisResult(ruleResultsData: RuleResultsData): boolean {
-        return this.includeThisResultDelegate(ruleResultsData);
+        return this.shouldIncludeResult(ruleResultsData);
     }
 }

--- a/src/electron/platform/android/unified-result-builder.ts
+++ b/src/electron/platform/android/unified-result-builder.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
 import { generateUID, UUIDGeneratorType } from 'common/uid-generator';
-import { ToolDataDelegate } from 'electron/common/application-properties-provider';
+import { ToolDataGetter } from 'electron/common/application-properties-provider';
 import { RuleInformationProvider } from 'electron/platform/android/rule-information-provider';
 import { RuleInformationProviderType } from 'electron/platform/android/rule-information-provider-type';
 import { ScanResults } from 'electron/platform/android/scan-results';
@@ -27,7 +27,7 @@ export const createBuilder = (
     getPlatformData: ConvertScanResultsToPlatformDataDelegate,
     ruleInformationProvider: RuleInformationProviderType,
     uuidGenerator: UUIDGeneratorType,
-    getToolData: ToolDataDelegate,
+    getToolData: ToolDataGetter,
 ) => (scanResults: ScanResults): UnifiedScanCompletedPayload => {
     const payload: UnifiedScanCompletedPayload = {
         scanResult: getUnifiedResults(scanResults, ruleInformationProvider, uuidGenerator),
@@ -42,7 +42,7 @@ export const createBuilder = (
     return payload;
 };
 
-export const createDefaultBuilder = (getToolData: ToolDataDelegate) => {
+export const createDefaultBuilder = (getToolData: ToolDataGetter) => {
     return createBuilder(
         convertScanResultsToUnifiedResults,
         convertScanResultsToUnifiedRules,

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -24,7 +24,7 @@ import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { CardsViewDeps } from 'DetailsView/components/cards-view';
 import { remote } from 'electron';
 import { DirectActionMessageDispatcher } from 'electron/adapters/direct-action-message-dispatcher';
-import { createGetToolDataDelegate } from 'electron/common/application-properties-provider';
+import { createToolDataGetter } from 'electron/common/application-properties-provider';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
@@ -163,7 +163,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then((persistedDat
     const windowFrameListener = new WindowFrameListener(windowStateActionCreator, currentWindow);
     windowFrameListener.initialize();
 
-    const getToolData = createGetToolDataDelegate(appDataAdapter);
+    const getToolData = createToolDataGetter(appDataAdapter);
     const unifiedResultsBuilder = createDefaultBuilder(getToolData);
     const scanController = new ScanController(
         scanActions,

--- a/src/tests/unit/tests/electron/common/application-properties-provider.test.ts
+++ b/src/tests/unit/tests/electron/common/application-properties-provider.test.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AppDataAdapter } from 'common/browser-adapters/app-data-adapter';
-import { createGetToolDataDelegate } from 'electron/common/application-properties-provider';
+import { createToolDataGetter } from 'electron/common/application-properties-provider';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import { Mock } from 'typemoq';
 
-describe('ToolDataDelegate', () => {
+describe('ToolDataGetter', () => {
     it('returns proper tool data', () => {
         const appDataAdapterMock = Mock.ofType<AppDataAdapter>();
         appDataAdapterMock.setup(adapter => adapter.getVersion()).returns(() => 'test-version');
@@ -13,7 +13,7 @@ describe('ToolDataDelegate', () => {
         const scanResultsMock = Mock.ofType<ScanResults>();
         scanResultsMock.setup(results => results.axeVersion).returns(() => 'test-axe-version');
 
-        const testSubject = createGetToolDataDelegate(appDataAdapterMock.object);
+        const testSubject = createToolDataGetter(appDataAdapterMock.object);
 
         const result = testSubject(scanResultsMock.object);
 

--- a/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import { UnifiedFormattableResolution } from 'common/types/store-data/unified-data-interface';
 import {
     GetUnifiedFormattableResolutionDelegate,
-    IncludeThisResultDelegate,
     RuleInformation,
+    ShouldIncludeResultPredicate,
 } from 'electron/platform/android/rule-information';
 import { RuleResultsData } from 'electron/platform/android/scan-results';
 import { Mock } from 'typemoq';
@@ -65,7 +64,7 @@ describe('RuleInformation', () => {
         };
 
         for (const expectedResult of expectedResults) {
-            const includeThisResultMock = Mock.ofType<IncludeThisResultDelegate>();
+            const includeThisResultMock = Mock.ofType<ShouldIncludeResultPredicate>();
             includeThisResultMock.setup(func => func(testData)).returns(() => expectedResult);
 
             const ruleInformation = new RuleInformation(null, null, null, includeThisResultMock.object);

--- a/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
@@ -111,7 +111,7 @@ export function buildRuleInformation(ruleId: string, includeResults: boolean = t
             const summary: string = 'How to fix ' + ruleId;
             return ({ howtoFixSummary: summary } as unknown) as UnifiedResolution;
         },
-        includeThisResultDelegate: r => {
+        shouldIncludeResult: r => {
             expect('includeThisResultDelegate').toBe('This code should never execute');
             return null;
         },

--- a/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { UUIDGeneratorType } from 'common/uid-generator';
-import { ToolDataDelegate } from 'electron/common/application-properties-provider';
+import { ToolDataGetter } from 'electron/common/application-properties-provider';
 import { RuleInformationProviderType } from 'electron/platform/android/rule-information-provider-type';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import { ConvertScanResultsToPlatformDataDelegate } from 'electron/platform/android/scan-results-to-platform-data';
@@ -58,7 +58,7 @@ describe('buildUnifiedScanCompletedPayload', () => {
                 deviceName: 'test-device-name',
             }));
 
-        const getToolDataMock = Mock.ofType<ToolDataDelegate>();
+        const getToolDataMock = Mock.ofType<ToolDataGetter>();
         getToolDataMock
             .setup(getter => getter(exampleScanResults))
             .returns(() => {


### PR DESCRIPTION
#### Description of changes

This comes from our last engineering discussion.

Renaming:
- `ToolDataDelegate` to `ToolDataGetter`
- `IncludeThisResultDelegate` to `ShouldIncludeResultPredicate`

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
