### PR TITLE
refactor: preview features container

### DIFF
--- a/src/DetailsView/components/no-displayable-preview-features-message.tsx
+++ b/src/DetailsView/components/no-displayable-preview-features-message.tsx
@@ -1,15 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { DisplayableStrings } from '../../common/constants/displayable-strings';
+import { DisplayableStrings } from 'common/constants/displayable-strings';
 import * as styles from './no-displayable-preview-features-message.scss';
 
 export const componentId = 'no-displayable-feature-flag-message';
-export const NoDisplayableFeatureFlagMessage = () => (
+export const NoDisplayableFeatureFlagMessage = NamedFC('NoDisplayableFeatureFlagMessage', () => (
     <>
         <div id={componentId} className={styles.noPreviewFeatureMessage}>
             {DisplayableStrings.noPreviewFeatureDisplayMessage}
         </div>
     </>
-);
+));

--- a/src/DetailsView/components/preview-features-container.tsx
+++ b/src/DetailsView/components/preview-features-container.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DisplayableStrings } from 'common/constants/displayable-strings';
 import { NamedFC } from 'common/react/named-fc';
+import { DisplayableFeatureFlag } from 'common/types/store-data/displayable-feature-flag';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import * as React from 'react';
 
-import { DisplayableStrings } from '../../common/constants/displayable-strings';
-import { DisplayableFeatureFlag } from '../../common/types/store-data/displayable-feature-flag';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { PreviewFeatureFlagsHandler } from '../handlers/preview-feature-flags-handler';
 import { NoDisplayableFeatureFlagMessage } from './no-displayable-preview-features-message';

--- a/src/DetailsView/components/preview-features-container.tsx
+++ b/src/DetailsView/components/preview-features-container.tsx
@@ -25,9 +25,11 @@ export class PreviewFeaturesContainer extends React.Component<PreviewFeaturesCon
         const displayableFeatureFlags: DisplayableFeatureFlag[] = this.props.previewFeatureFlagsHandler.getDisplayableFeatureFlags(
             this.props.featureFlagData,
         );
+
         if (displayableFeatureFlags.length === 0) {
             return <NoDisplayableFeatureFlagMessage />;
         }
+
         return (
             <div>
                 <div className="preview-features-description">{DisplayableStrings.previewFeaturesDescription}</div>

--- a/src/DetailsView/components/preview-features-container.tsx
+++ b/src/DetailsView/components/preview-features-container.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
 import { DisplayableStrings } from '../../common/constants/displayable-strings';
@@ -20,21 +21,19 @@ export interface PreviewFeaturesContainerProps {
     previewFeatureFlagsHandler: PreviewFeatureFlagsHandler;
 }
 
-export class PreviewFeaturesContainer extends React.Component<PreviewFeaturesContainerProps> {
-    public render(): JSX.Element {
-        const displayableFeatureFlags: DisplayableFeatureFlag[] = this.props.previewFeatureFlagsHandler.getDisplayableFeatureFlags(
-            this.props.featureFlagData,
-        );
+export const PreviewFeaturesContainer = NamedFC<PreviewFeaturesContainerProps>('PreviewFeaturesContainer', props => {
+    const displayableFeatureFlags: DisplayableFeatureFlag[] = props.previewFeatureFlagsHandler.getDisplayableFeatureFlags(
+        props.featureFlagData,
+    );
 
-        if (displayableFeatureFlags.length === 0) {
-            return <NoDisplayableFeatureFlagMessage />;
-        }
-
-        return (
-            <div>
-                <div className="preview-features-description">{DisplayableStrings.previewFeaturesDescription}</div>
-                <PreviewFeaturesToggleList deps={this.props.deps} displayedFeatureFlags={displayableFeatureFlags} />
-            </div>
-        );
+    if (displayableFeatureFlags.length === 0) {
+        return <NoDisplayableFeatureFlagMessage />;
     }
-}
+
+    return (
+        <div>
+            <div className="preview-features-description">{DisplayableStrings.previewFeaturesDescription}</div>
+            <PreviewFeaturesToggleList deps={props.deps} displayedFeatureFlags={displayableFeatureFlags} />
+        </div>
+    );
+});

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/preview-features-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/preview-features-container.test.tsx.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PreviewFeaturesContainerTest renders all available preview features 1`] = `
+<div>
+  <div
+    className="preview-features-description"
+  >
+    The following preview features are available for your evalution. Help us make them better!
+  </div>
+  <PreviewFeaturesToggleList
+    deps={
+      Object {
+        "detailsViewActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "addPathForValidation": [Function],
+          "cancelStartOver": [Function],
+          "cancelStartOverAllAssessments": [Function],
+          "changeAssessmentVisualizationState": [Function],
+          "changeManualRequirementStatus": [Function],
+          "changeManualTestStatus": [Function],
+          "clearPathSnippetData": [Function],
+          "closePreviewFeaturesPanel": [Function],
+          "closeScopingPanel": [Function],
+          "closeSettingsPanel": [Function],
+          "continuePreviousAssessment": [Function],
+          "copyIssueDetailsClicked": [Function],
+          "dispatcher": undefined,
+          "editFailureInstance": [Function],
+          "removeFailureInstance": [Function],
+          "rescanVisualization": [Function],
+          "setFeatureFlag": [Function],
+          "startOverAllAssessments": [Function],
+          "switchToTargetTab": [Function],
+          "telemetryFactory": undefined,
+          "undoManualRequirementStatusChange": [Function],
+          "undoManualTestStatusChange": [Function],
+        },
+      }
+    }
+    displayedFeatureFlags={
+      Array [
+        Object {
+          "displayableDescription": "test description 1",
+          "displayableName": "test name 1",
+          "enabled": true,
+          "id": "test-id-1",
+        },
+        Object {
+          "displayableDescription": "test description 2",
+          "displayableName": "test name 2",
+          "enabled": false,
+          "id": "test-id-2",
+        },
+      ]
+    }
+  />
+</div>
+`;
+
+exports[`PreviewFeaturesContainerTest renders special message when there is no preview features available 1`] = `<NoDisplayableFeatureFlagMessage />`;

--- a/src/tests/unit/tests/DetailsView/components/preview-features-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/preview-features-container.test.tsx
@@ -23,6 +23,7 @@ describe('PreviewFeaturesContainerTest', () => {
             enabled: false,
         },
     ];
+
     const detailsViewActionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator);
     const previewFeatureFlagsHandlerMock = Mock.ofType(PreviewFeatureFlagsHandler);
 

--- a/src/tests/unit/tests/DetailsView/components/preview-features-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/preview-features-container.test.tsx
@@ -1,16 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DisplayableFeatureFlag } from 'common/types/store-data/displayable-feature-flag';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { PreviewFeaturesContainer, PreviewFeaturesContainerProps } from 'DetailsView/components/preview-features-container';
+import { PreviewFeatureFlagsHandler } from 'DetailsView/handlers/preview-feature-flags-handler';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock } from 'typemoq';
-
-import { DisplayableStrings } from '../../../../../common/constants/displayable-strings';
-import { DisplayableFeatureFlag } from '../../../../../common/types/store-data/displayable-feature-flag';
-import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
-import { NoDisplayableFeatureFlagMessage } from '../../../../../DetailsView/components/no-displayable-preview-features-message';
-import { PreviewFeaturesContainer, PreviewFeaturesContainerProps } from '../../../../../DetailsView/components/preview-features-container';
-import { PreviewFeaturesToggleList } from '../../../../../DetailsView/components/preview-features-toggle-list';
-import { PreviewFeatureFlagsHandler } from '../../../../../DetailsView/handlers/preview-feature-flags-handler';
 
 describe('PreviewFeaturesContainerTest', () => {
     let displayableFeatureFlagsStub: DisplayableFeatureFlag[] = [
@@ -29,6 +25,7 @@ describe('PreviewFeaturesContainerTest', () => {
     ];
     const detailsViewActionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator);
     const previewFeatureFlagsHandlerMock = Mock.ofType(PreviewFeatureFlagsHandler);
+
     const featureFlagStoreDataStub = {};
     const props: PreviewFeaturesContainerProps = {
         deps: {
@@ -38,42 +35,28 @@ describe('PreviewFeaturesContainerTest', () => {
         previewFeatureFlagsHandler: previewFeatureFlagsHandlerMock.object,
     };
 
-    test('constructor', () => {
-        const testSubject = new PreviewFeaturesContainer({} as PreviewFeaturesContainerProps);
-        expect(testSubject).toBeDefined();
-    });
+    describe('renders', () => {
+        it('all available preview features', () => {
+            previewFeatureFlagsHandlerMock
+                .setup(handler => handler.getDisplayableFeatureFlags(featureFlagStoreDataStub))
+                .returns(() => displayableFeatureFlagsStub);
 
-    test('render', () => {
-        previewFeatureFlagsHandlerMock
-            .setup(pffm => pffm.getDisplayableFeatureFlags(featureFlagStoreDataStub))
-            .returns(() => displayableFeatureFlagsStub)
-            .verifiable();
+            const testSubject = shallow(<PreviewFeaturesContainer {...props} />);
 
-        const testSubject = new PreviewFeaturesContainer(props);
+            expect(testSubject.getElement()).toMatchSnapshot();
+        });
 
-        const deps = {
-            detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
-        };
-        const expectedComponent = (
-            <div>
-                <div className="preview-features-description">{DisplayableStrings.previewFeaturesDescription}</div>
-                <PreviewFeaturesToggleList deps={deps} displayedFeatureFlags={displayableFeatureFlagsStub} />
-            </div>
-        );
+        it('special message when there is no preview features available', () => {
+            displayableFeatureFlagsStub = [];
 
-        expect(testSubject.render()).toEqual(expectedComponent);
-        previewFeatureFlagsHandlerMock.verifyAll();
-    });
+            previewFeatureFlagsHandlerMock
+                .setup(handler => handler.getDisplayableFeatureFlags(featureFlagStoreDataStub))
+                .returns(() => displayableFeatureFlagsStub)
+                .verifiable();
 
-    test('no feature flag component is rendered when no feature flag is displayable', () => {
-        displayableFeatureFlagsStub = [];
+            const testSubject = shallow(<PreviewFeaturesContainer {...props} />);
 
-        previewFeatureFlagsHandlerMock
-            .setup(pffm => pffm.getDisplayableFeatureFlags(featureFlagStoreDataStub))
-            .returns(() => displayableFeatureFlagsStub)
-            .verifiable();
-
-        const testSubject = shallow(<PreviewFeaturesContainer {...props} />);
-        expect(testSubject.getElement()).toEqual(<NoDisplayableFeatureFlagMessage />);
+            expect(testSubject.getElement()).toMatchSnapshot();
+        });
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/preview-features-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/preview-features-container.test.tsx
@@ -52,8 +52,7 @@ describe('PreviewFeaturesContainerTest', () => {
 
             previewFeatureFlagsHandlerMock
                 .setup(handler => handler.getDisplayableFeatureFlags(featureFlagStoreDataStub))
-                .returns(() => displayableFeatureFlagsStub)
-                .verifiable();
+                .returns(() => displayableFeatureFlagsStub);
 
             const testSubject = shallow(<PreviewFeaturesContainer {...props} />);
 


### PR DESCRIPTION
#### Description of changes

Minor improvemns around `PreviewFeaturesContainer` component:
- Convert component to be a `NamedFC`
- Convert `NoDisplayableFeatureFlagMessage` to be a `NamedFC` (helps with the testing)
- Convert `PreviewFeaturesContainer` test to use snapshot testing

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
