### PR TITLE
fix: start over-toogle on fast pass

### DIFF
--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import { FeatureFlags } from 'common/feature-flags';
-import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { StartOverDropdown, StartOverProps } from 'DetailsView/components/start-over-dropdown';
 import { ActionButton } from 'office-ui-fabric-react/lib/Button';
@@ -34,7 +32,7 @@ export function getStartOverComponentForFastPass(props: CommandBarProps): JSX.El
     return (
         <ActionButton
             iconProps={{ iconName: 'Refresh' }}
-            onClick={(event: SupportedMouseEvent) => detailsViewActionMessageCreator.rescanVisualization(selectedTest, event)}
+            onClick={event => detailsViewActionMessageCreator.rescanVisualization(selectedTest, event)}
             disabled={props.visualizationStoreData.scanning !== null}
         >
             Start over

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -28,10 +28,6 @@ export function getStartOverComponentForFastPass(props: CommandBarProps): JSX.El
         return null;
     }
 
-    if (!props.visualizationScanResultData.issues.scanResult) {
-        return null;
-    }
-
     const selectedTest = props.visualizationStoreData.selectedFastPassDetailsView;
     const detailsViewActionMessageCreator = props.deps.detailsViewActionMessageCreator;
 

--- a/src/DetailsView/components/target-page-changed-view.tsx
+++ b/src/DetailsView/components/target-page-changed-view.tsx
@@ -21,20 +21,25 @@ export const TargetPageChangedView = NamedFC<TargetPageChangedViewProps>('Target
 
     const toggleText = 'The target page was changed. Use the toggle to enable the visualization in the current target page.';
     const startOverText = 'The target page has changed. Use the start over button to scan the new target page.';
-    const displayedText = props.featureFlagStoreData[FeatureFlags.universalCardsUI] ? startOverText : toggleText;
+
+    const isCardsUIEnabled = props.featureFlagStoreData[FeatureFlags.universalCardsUI];
+    const displayedText = isCardsUIEnabled ? startOverText : toggleText;
+    const toggle = !isCardsUIEnabled ? (
+        <Toggle
+            onText="On"
+            offText="Off"
+            checked={false}
+            onClick={props.toggleClickHandler}
+            label={toggleLabel}
+            className="details-view-toggle"
+        />
+    ) : null;
 
     return (
         <div className="target-page-changed">
             <h1>{title}</h1>
             <div className="target-page-changed-subtitle">{subtitle}</div>
-            <Toggle
-                onText="On"
-                offText="Off"
-                checked={false}
-                onClick={props.toggleClickHandler}
-                label={toggleLabel}
-                className="details-view-toggle"
-            />
+            {toggle}
             <p>{displayedText}</p>
         </div>
     );

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StartOverComponentPropsFactory getStartOverComponentPropsForAssessment, component matches snapshot 1`] = `
+exports[`StartOverComponentFactory getStartOverComponentForAssessments renders 1`] = `
 <StartOverDropdown
   deps={Object {}}
   requirementKey="test step"
@@ -9,7 +9,9 @@ exports[`StartOverComponentPropsFactory getStartOverComponentPropsForAssessment,
 />
 `;
 
-exports[`StartOverComponentPropsFactory getStartOverComponentPropsForFastPass, CardsUI is true, scanResults is not null, scanning is false, component matches snapshot 1`] = `
+exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders CardsUI is false => component is null 1`] = `null`;
+
+exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders CardsUI is true, scanResults is not null, scanning is false => component matches snapshot 1`] = `
 <CustomizedActionButton
   disabled={false}
   iconProps={
@@ -23,7 +25,7 @@ exports[`StartOverComponentPropsFactory getStartOverComponentPropsForFastPass, C
 </CustomizedActionButton>
 `;
 
-exports[`StartOverComponentPropsFactory getStartOverComponentPropsForFastPass, CardsUI is true, scanResults is not null, scanning is true, component matches snapshot 1`] = `
+exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders CardsUI is true, scanResults is not null, scanning is true => component matches snapshot 1`] = `
 <CustomizedActionButton
   disabled={true}
   iconProps={
@@ -36,3 +38,7 @@ exports[`StartOverComponentPropsFactory getStartOverComponentPropsForFastPass, C
   Start over
 </CustomizedActionButton>
 `;
+
+exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders CardsUI is true, scanResults is null => component is null 1`] = `null`;
+
+exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders CardsUI is undefined => component is null 1`] = `null`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
@@ -39,6 +39,18 @@ exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders
 </CustomizedActionButton>
 `;
 
-exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders CardsUI is true, scanResults is null => component is null 1`] = `null`;
+exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders CardsUI is true, scanResults is null => component matches snapshot 1`] = `
+<CustomizedActionButton
+  disabled={false}
+  iconProps={
+    Object {
+      "iconName": "Refresh",
+    }
+  }
+  onClick={[Function]}
+>
+  Start over
+</CustomizedActionButton>
+`;
 
 exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders CardsUI is undefined => component is null 1`] = `null`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
@@ -60,14 +60,6 @@ exports[`TargetPageChangedView renders with subtitle=undefined and feature flag=
   <div
     className="target-page-changed-subtitle"
   />
-  <StyledToggleBase
-    checked={false}
-    className="details-view-toggle"
-    label="test toggle label"
-    offText="Off"
-    onClick={[Function]}
-    onText="On"
-  />
   <p>
     The target page has changed. Use the start over button to scan the new target page.
   </p>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-page-changed-view.test.tsx.snap
@@ -1,6 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TargetPageChangedView renders with feature flag enabled 1`] = `
+exports[`TargetPageChangedView renders with subtitle=test subtitle content and feature flag= false 1`] = `
+<div
+  className="target-page-changed"
+>
+  <h1>
+    test title
+  </h1>
+  <div
+    className="target-page-changed-subtitle"
+  >
+    test subtitle content
+  </div>
+  <StyledToggleBase
+    checked={false}
+    className="details-view-toggle"
+    label="test toggle label"
+    offText="Off"
+    onClick={[Function]}
+    onText="On"
+  />
+  <p>
+    The target page was changed. Use the toggle to enable the visualization in the current target page.
+  </p>
+</div>
+`;
+
+exports[`TargetPageChangedView renders with subtitle=undefined and feature flag= false 1`] = `
+<div
+  className="target-page-changed"
+>
+  <h1>
+    test title
+  </h1>
+  <div
+    className="target-page-changed-subtitle"
+  />
+  <StyledToggleBase
+    checked={false}
+    className="details-view-toggle"
+    label="test toggle label"
+    offText="Off"
+    onClick={[Function]}
+    onText="On"
+  />
+  <p>
+    The target page was changed. Use the toggle to enable the visualization in the current target page.
+  </p>
+</div>
+`;
+
+exports[`TargetPageChangedView renders with subtitle=undefined and feature flag= true 1`] = `
 <div
   className="target-page-changed"
 >
@@ -20,58 +70,6 @@ exports[`TargetPageChangedView renders with feature flag enabled 1`] = `
   />
   <p>
     The target page has changed. Use the start over button to scan the new target page.
-  </p>
-</div>
-`;
-
-exports[`TargetPageChangedView renders with optional subtitle 1`] = `
-<div
-  className="target-page-changed"
->
-  <h1>
-    test title
-  </h1>
-  <div
-    className="target-page-changed-subtitle"
-  >
-    <span>
-      test subtitle content
-    </span>
-  </div>
-  <StyledToggleBase
-    checked={false}
-    className="details-view-toggle"
-    label="test toggle label"
-    offText="Off"
-    onClick={[Function]}
-    onText="On"
-  />
-  <p>
-    The target page was changed. Use the toggle to enable the visualization in the current target page.
-  </p>
-</div>
-`;
-
-exports[`TargetPageChangedView renders without optional subtitle 1`] = `
-<div
-  className="target-page-changed"
->
-  <h1>
-    test title
-  </h1>
-  <div
-    className="target-page-changed-subtitle"
-  />
-  <StyledToggleBase
-    checked={false}
-    className="details-view-toggle"
-    label="test toggle label"
-    offText="Off"
-    onClick={[Function]}
-    onText="On"
-  />
-  <p>
-    The target page was changed. Use the toggle to enable the visualization in the current target page.
   </p>
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -3,15 +3,20 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
 import { FeatureFlags } from 'common/feature-flags';
+import { NamedFC } from 'common/react/named-fc';
 import { AssessmentNavState, AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
-import { DetailsViewCommandBarDeps, DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { CommandBarProps, DetailsViewCommandBarDeps, DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { getStartOverComponentForAssessment, getStartOverComponentForFastPass } from 'DetailsView/components/start-over-component-factory';
+import { shallow } from 'enzyme';
+import * as React from 'react';
 import { ScanResults } from 'scanner/iruleresults';
-import { IMock, Mock, MockBehavior } from 'typemoq';
+import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('StartOverComponentFactory', () => {
     const theTitle = 'the title';
@@ -133,6 +138,24 @@ describe('StartOverComponentFactory', () => {
                 const rendered = getStartOverComponentForFastPass(props);
 
                 expect(rendered).toMatchSnapshot();
+            });
+        });
+
+        describe('user interaction', () => {
+            it('handles action button on click properly', () => {
+                const event = new EventStubFactory().createKeypressEvent() as any;
+
+                const actionMessageCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
+
+                setCardsUiFlag(true);
+                const props = getProps(false);
+                props.deps.detailsViewActionMessageCreator = actionMessageCreatorMock.object;
+
+                const Wrapper = NamedFC<CommandBarProps>('WrappedStartOver', getStartOverComponentForFastPass);
+                const wrapped = shallow(<Wrapper {...props} />);
+                wrapped.simulate('click', event);
+
+                actionMessageCreatorMock.verify(creator => creator.rescanVisualization(theTestType, event), Times.once());
             });
         });
     });

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -13,7 +13,7 @@ import { getStartOverComponentForAssessment, getStartOverComponentForFastPass } 
 import { ScanResults } from 'scanner/iruleresults';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
-describe('StartOverComponentPropsFactory', () => {
+describe('StartOverComponentFactory', () => {
     const theTitle = 'the title';
     const theTestStep = 'test step';
     const theTestType = VisualizationType.ColorSensoryAssessment;
@@ -82,52 +82,58 @@ describe('StartOverComponentPropsFactory', () => {
         featureFlagStoreData[FeatureFlags.universalCardsUI] = flagValue;
     }
 
-    test('getStartOverComponentPropsForAssessment, component matches snapshot', () => {
-        const props = getProps(true);
-        const rendered = getStartOverComponentForAssessment(props);
+    describe('getStartOverComponentForAssessments', () => {
+        it('renders', () => {
+            const props = getProps(true);
+            const rendered = getStartOverComponentForAssessment(props);
 
-        expect(rendered).toMatchSnapshot();
+            expect(rendered).toMatchSnapshot();
+        });
     });
 
-    test('getStartOverComponentPropsForFastPass, CardsUI is undefined, component  is null', () => {
-        const props = getProps(false);
-        const rendered = getStartOverComponentForFastPass(props);
+    describe('getStartOverComponentPropsForFastPass', () => {
+        describe('renders', () => {
+            test('CardsUI is undefined => component is null', () => {
+                const props = getProps(false);
+                const rendered = getStartOverComponentForFastPass(props);
 
-        expect(rendered).toBeNull();
-    });
+                expect(rendered).toMatchSnapshot();
+            });
 
-    test('getStartOverComponentPropsForFastPass, CardsUI is false, component  is null', () => {
-        setCardsUiFlag(false);
-        const props = getProps(false);
-        const rendered = getStartOverComponentForFastPass(props);
+            test('CardsUI is false => component is null', () => {
+                setCardsUiFlag(false);
+                const props = getProps(false);
+                const rendered = getStartOverComponentForFastPass(props);
 
-        expect(rendered).toBeNull();
-    });
+                expect(rendered).toMatchSnapshot();
+            });
 
-    test('getStartOverComponentPropsForFastPass, CardsUI is true, scanResults is null, component is null', () => {
-        setCardsUiFlag(true);
-        const props = getProps(false);
-        const rendered = getStartOverComponentForFastPass(props);
+            test('CardsUI is true, scanResults is null => component is null', () => {
+                setCardsUiFlag(true);
+                const props = getProps(false);
+                const rendered = getStartOverComponentForFastPass(props);
 
-        expect(rendered).toBeNull();
-    });
+                expect(rendered).toMatchSnapshot();
+            });
 
-    test('getStartOverComponentPropsForFastPass, CardsUI is true, scanResults is not null, scanning is false, component matches snapshot', () => {
-        setScanResult();
-        setCardsUiFlag(true);
-        const props = getProps(false);
-        const rendered = getStartOverComponentForFastPass(props);
+            test('CardsUI is true, scanResults is not null, scanning is false => component matches snapshot', () => {
+                setScanResult();
+                setCardsUiFlag(true);
+                const props = getProps(false);
+                const rendered = getStartOverComponentForFastPass(props);
 
-        expect(rendered).toMatchSnapshot();
-    });
+                expect(rendered).toMatchSnapshot();
+            });
 
-    test('getStartOverComponentPropsForFastPass, CardsUI is true, scanResults is not null, scanning is true, component matches snapshot', () => {
-        setScanResult();
-        setCardsUiFlag(true);
-        scanning = 'some string';
-        const props = getProps(false);
-        const rendered = getStartOverComponentForFastPass(props);
+            test('CardsUI is true, scanResults is not null, scanning is true => component matches snapshot', () => {
+                setScanResult();
+                setCardsUiFlag(true);
+                scanning = 'some string';
+                const props = getProps(false);
+                const rendered = getStartOverComponentForFastPass(props);
 
-        expect(rendered).toMatchSnapshot();
+                expect(rendered).toMatchSnapshot();
+            });
+        });
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -108,7 +108,7 @@ describe('StartOverComponentFactory', () => {
                 expect(rendered).toMatchSnapshot();
             });
 
-            test('CardsUI is true, scanResults is null => component is null', () => {
+            test('CardsUI is true, scanResults is null => component matches snapshot', () => {
                 setCardsUiFlag(true);
                 const props = getProps(false);
                 const rendered = getStartOverComponentForFastPass(props);

--- a/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DisplayableVisualizationTypeData } from 'common/configs/visualization-configuration-factory';
 import { FeatureFlags } from 'common/feature-flags';
+import { VisualizationType } from 'common/types/visualization-type';
+import { TargetPageChangedView, TargetPageChangedViewProps } from 'DetailsView/components/target-page-changed-view';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-
-import { DisplayableVisualizationTypeData } from '../../../../../common/configs/visualization-configuration-factory';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { TargetPageChangedView, TargetPageChangedViewProps } from '../../../../../DetailsView/components/target-page-changed-view';
 
 describe('TargetPageChangedView', () => {
     it('renders without optional subtitle', () => {

--- a/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/target-page-changed-view.test.tsx
@@ -8,19 +8,12 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('TargetPageChangedView', () => {
-    it('renders without optional subtitle', () => {
-        testRenderWithOptionalSubtitle(undefined, false);
-    });
-
-    it('renders with feature flag enabled', () => {
-        testRenderWithOptionalSubtitle(undefined, true);
-    });
-
-    it('renders with optional subtitle', () => {
-        testRenderWithOptionalSubtitle(<span>test subtitle content</span>, false);
-    });
-
-    function testRenderWithOptionalSubtitle(subtitle: JSX.Element, featureFlagEnabled: boolean): void {
+    it.each`
+        subtitle                   | isCardsUIEnabled
+        ${undefined}               | ${true}
+        ${undefined}               | ${false}
+        ${'test subtitle content'} | ${false}
+    `('renders with subtitle=$subtitle and feature flag= $isCardsUIEnabled', ({ subtitle, isCardsUIEnabled }) => {
         const visualizationType = VisualizationType.Landmarks;
         const clickHandlerStub: () => void = () => {};
         const displayableData = {
@@ -34,12 +27,12 @@ describe('TargetPageChangedView', () => {
             displayableData,
             toggleClickHandler: clickHandlerStub,
             featureFlagStoreData: {
-                [FeatureFlags.universalCardsUI]: featureFlagEnabled,
+                [FeatureFlags.universalCardsUI]: isCardsUIEnabled,
             },
         };
 
         const wrapped = shallow(<TargetPageChangedView {...props} />);
 
         expect(wrapped.getElement()).toMatchSnapshot();
-    }
+    });
 });


### PR DESCRIPTION
#### Description of changes

Currently, when the Cards UI is enabled (this is by default on master right now), the **Start over** button dissapear and the **Show failures** toggle shows up again when the user changes the target page url.

The expected behavior is: only the **Start over** button should be used when the Cards UI is enabled.

**Notes**
It may be easier to review this commit by commit.

**Before: with the bug**
![01 - bug](https://user-images.githubusercontent.com/2837582/69290135-c1669b00-0bb3-11ea-83e9-8ebf1815abf8.gif)

**After: bug fixed**
![02 - fixed](https://user-images.githubusercontent.com/2837582/69290142-c6c3e580-0bb3-11ea-8da3-f2b1d13166c4.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
