### PR TITLE
fix: disappearing "show failures" toggle under fast pass

### DIFF
--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -181,10 +181,16 @@ export class IssuesTable extends React.Component<IssuesTableProps> {
     }
 
     private renderDisabledMessage(): JSX.Element {
+        const isCardsUIEnabled = this.props.featureFlags[FeatureFlags.universalCardsUI];
+        const commandBar = !isCardsUIEnabled ? this.renderCommandBar() : null;
+
         return (
-            <div className="details-disabled-message" role="alert">
-                Turn on <Markup.Term>{this.configuration.displayableData.title}</Markup.Term> to see a list of failures.
-            </div>
+            <>
+                {commandBar}
+                <div className="details-disabled-message" role="alert">
+                    Turn on <Markup.Term>{this.configuration.displayableData.title}</Markup.Term> to see a list of failures.
+                </div>
+            </>
         );
     }
 

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
@@ -10,16 +10,30 @@ exports[`IssuesTableTest automated checks disabled 1`] = `
   <div
     className="issues-table-content"
   >
-    <div
-      className="details-disabled-message"
-      role="alert"
-    >
-      Turn on 
-      <Term>
-        Automated checks
-      </Term>
-       to see a list of failures.
-    </div>
+    <React.Fragment>
+      <div
+        className="details-view-command-bar"
+      >
+        <VisualizationToggle
+          checked={false}
+          className="automated-checks-details-view-toggle"
+          disabled={false}
+          label="Show failures"
+          onClick={[Function]}
+          visualizationName="Automated checks"
+        />
+      </div>
+      <div
+        className="details-disabled-message"
+        role="alert"
+      >
+        Turn on 
+        <Term>
+          Automated checks
+        </Term>
+         to see a list of failures.
+      </div>
+    </React.Fragment>
   </div>
 </div>
 `;


### PR DESCRIPTION
#### Description of changes

**Show failures** toggle disappear when it's toggle off. 

This happens under the old UI (the one that uses the details list)

**Before: toggle disappear**
![01 - bug](https://user-images.githubusercontent.com/2837582/69291146-24a5fc80-0bb7-11ea-9959-1f729e99e169.gif)

**After: fixed**
![02 - fix](https://user-images.githubusercontent.com/2837582/69291155-296ab080-0bb7-11ea-9456-e2a9ecfcc29a.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
