### PR TITLE
test: add background page window.insightsUserConfiguration controller for E2Es to use

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -9,7 +9,7 @@ import { VisualizationConfigurationFactory } from '../common/configs/visualizati
 import { EnvironmentInfoProvider } from '../common/environment-info-provider';
 import { getIndexedDBStore } from '../common/indexedDB/get-indexeddb-store';
 import { IndexedDBAPI, IndexedDBUtil } from '../common/indexedDB/indexedDB';
-import { InsightsFeatureFlags } from '../common/insights-feature-flags';
+import { InsightsWindowExtensions } from '../common/insights-window-extensions';
 import { createDefaultLogger } from '../common/logging/default-logger';
 import { NavigatorUtils } from '../common/navigator-utils';
 import { NotificationCreator } from '../common/notification-creator';
@@ -38,7 +38,7 @@ import { TelemetryLogger } from './telemetry/telemetry-logger';
 import { TelemetryStateListener } from './telemetry/telemetry-state-listener';
 import { cleanKeysFromStorage } from './user-stored-data-cleaner';
 
-declare var window: Window & InsightsFeatureFlags;
+declare var window: Window & InsightsWindowExtensions;
 
 async function initialize(): Promise<void> {
     const browserAdapter = new ChromeAdapter();
@@ -139,6 +139,7 @@ async function initialize(): Promise<void> {
     devToolsBackgroundListener.initialize();
 
     window.insightsFeatureFlags = globalContext.featureFlagsController;
+    window.insightsUserConfiguration = globalContext.userConfigurationController;
 
     await cleanKeysFromStoragePromise;
 }

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -26,6 +26,7 @@ import { Interpreter } from './interpreter';
 import { LocalStorageData } from './storage-data';
 import { GlobalStoreHub } from './stores/global/global-store-hub';
 import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
+import { UserConfigurationController } from './user-configuration-controller';
 
 export class GlobalContextFactory {
     public static createContext(
@@ -56,6 +57,7 @@ export class GlobalContextFactory {
         );
 
         const featureFlagsController = new FeatureFlagsController(globalStoreHub.featureFlagStore, interpreter);
+        const userConfigurationController = new UserConfigurationController(interpreter);
 
         globalStoreHub.initialize();
 
@@ -95,6 +97,6 @@ export class GlobalContextFactory {
         );
         assessmentChangeHandler.initialize();
 
-        return new GlobalContext(interpreter, globalStoreHub, featureFlagsController);
+        return new GlobalContext(interpreter, globalStoreHub, featureFlagsController, userConfigurationController);
     }
 }

--- a/src/background/global-context.ts
+++ b/src/background/global-context.ts
@@ -3,15 +3,13 @@
 import { FeatureFlagsController } from './feature-flags-controller';
 import { Interpreter } from './interpreter';
 import { GlobalStoreHub } from './stores/global/global-store-hub';
+import { UserConfigurationController } from './user-configuration-controller';
 
 export class GlobalContext {
-    public readonly interpreter: Interpreter;
-    public readonly featureFlagsController: FeatureFlagsController;
-    public readonly stores: GlobalStoreHub;
-
-    constructor(interpreter: Interpreter, storeHub: GlobalStoreHub, featureFlagsController: FeatureFlagsController) {
-        this.interpreter = interpreter;
-        this.stores = storeHub;
-        this.featureFlagsController = featureFlagsController;
-    }
+    constructor(
+        public readonly interpreter: Interpreter,
+        public readonly stores: GlobalStoreHub,
+        public readonly featureFlagsController: FeatureFlagsController,
+        public readonly userConfigurationController: UserConfigurationController,
+    ) {}
 }

--- a/src/background/user-configuration-controller.ts
+++ b/src/background/user-configuration-controller.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Message } from 'common/message';
+import { Messages } from 'common/messages';
+import { SetHighContrastModePayload, SetTelemetryStatePayload } from './actions/action-payloads';
+import { Interpreter } from './interpreter';
+
+export class UserConfigurationController {
+    constructor(private interpreter: Interpreter) {}
+
+    public setHighContrastMode(enableHighContrast: boolean): void {
+        const payload: SetHighContrastModePayload = {
+            enableHighContrast,
+        };
+        const message: Message = {
+            messageType: Messages.UserConfig.SetHighContrastConfig,
+            payload: payload,
+            tabId: null,
+        };
+        this.interpreter.interpret(message);
+    }
+
+    public setTelemetryState(enableTelemetry: boolean): void {
+        const payload: SetTelemetryStatePayload = {
+            enableTelemetry,
+        };
+        const message: Message = {
+            messageType: Messages.UserConfig.SetTelemetryConfig,
+            payload: payload,
+            tabId: null,
+        };
+        this.interpreter.interpret(message);
+    }
+}

--- a/src/common/insights-window-extensions.ts
+++ b/src/common/insights-window-extensions.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FeatureFlagsController } from 'background/feature-flags-controller';
+import { UserConfigurationController } from 'background/user-configuration-controller';
 
-export type InsightsFeatureFlags = {
+export type InsightsWindowExtensions = {
     insightsFeatureFlags: FeatureFlagsController;
+    insightsUserConfiguration: UserConfigurationController;
 };

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -12,12 +12,17 @@ export const detailsViewSelectors = {
 
     gearButton: '.gear-options-icon',
     settingsButton: 'button[name="Settings"]',
-    settingsPanel: '.settings-panel',
-    highContrastToggle: 'button#enable-high-contrast-mode',
-    highContrastToggleCheckedStateSelector: 'button#enable-high-contrast-mode[aria-checked="true"]',
 };
 
 export const overviewSelectors = {
     overview: '.overview',
     overviewHeading: '.overview-heading',
+};
+
+export const settingsPanelSelectors = {
+    settingsPanel: '.settings-panel',
+    highContrastModeToggle: 'button#enable-high-contrast-mode',
+    telemetryStateToggle: 'button#enable-telemetry',
+    enabledToggle: (toggleSelector: string) => `${toggleSelector}[aria-checked="true"]`,
+    disabledToggle: (toggleSelector: string) => `${toggleSelector}[aria-checked="false"]`,
 };

--- a/src/tests/end-to-end/common/page-controllers/background-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/background-page.ts
@@ -1,9 +1,45 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { InsightsWindowExtensions } from 'common/insights-window-extensions';
 import * as Puppeteer from 'puppeteer';
+import { DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS } from 'tests/end-to-end/common/timeouts';
 import { Page, PageOptions } from './page';
 
+declare var window: Window & InsightsWindowExtensions;
+
+// We can't use the default polling behavior of waitForFunction with the background page
+// because it is based on animation frames, which don't run in the background page.
+const POLLING_INTERVAL_MS = 50;
+
 export class BackgroundPage extends Page {
+    public async waitForInitialization(): Promise<void> {
+        await this.underlyingPage.waitForFunction(
+            () => {
+                const initialized = window.insightsUserConfiguration != undefined;
+                return initialized;
+            },
+            { timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS, polling: POLLING_INTERVAL_MS },
+        );
+    }
+
+    public async setHighContrastMode(enableHighContrast: boolean): Promise<void> {
+        await this.waitForInitialization();
+        await this.evaluate(enable => {
+            window.insightsUserConfiguration.setHighContrastMode(enable);
+            return Promise.resolve();
+        }, enableHighContrast);
+    }
+
+    public async setTelemetryState(enableTelemetry: boolean): Promise<void> {
+        await this.waitForInitialization();
+        await this.evaluate(enable => {
+            console.log('inside in-browser setTelemetryState');
+            window.insightsUserConfiguration.setTelemetryState(enable);
+            console.log('finishing in-browser setTelemetryState');
+            return Promise.resolve();
+        }, enableTelemetry);
+    }
+
     constructor(underlyingPage: Puppeteer.Page, options?: PageOptions) {
         super(underlyingPage, options);
     }

--- a/src/tests/end-to-end/common/page-controllers/background-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/background-page.ts
@@ -26,17 +26,13 @@ export class BackgroundPage extends Page {
         await this.waitForInitialization();
         await this.evaluate(enable => {
             window.insightsUserConfiguration.setHighContrastMode(enable);
-            return Promise.resolve();
         }, enableHighContrast);
     }
 
     public async setTelemetryState(enableTelemetry: boolean): Promise<void> {
         await this.waitForInitialization();
         await this.evaluate(enable => {
-            console.log('inside in-browser setTelemetryState');
             window.insightsUserConfiguration.setTelemetryState(enable);
-            console.log('finishing in-browser setTelemetryState');
-            return Promise.resolve();
         }, enableTelemetry);
     }
 

--- a/src/tests/end-to-end/common/page-controllers/details-view-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/details-view-page.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import * as Puppeteer from 'puppeteer';
 import { CommonSelectors } from '../element-identifiers/common-selectors';
-import { detailsViewSelectors } from '../element-identifiers/details-view-selectors';
+import { detailsViewSelectors, settingsPanelSelectors } from '../element-identifiers/details-view-selectors';
 import { Page, PageOptions } from './page';
 
 export class DetailsViewPage extends Page {
@@ -33,21 +33,38 @@ export class DetailsViewPage extends Page {
 
         await this.clickSelector(detailsViewSelectors.gearButton);
         await this.clickSelector(detailsViewSelectors.settingsButton);
-        await this.waitForSelector(detailsViewSelectors.settingsPanel);
+        await this.waitForSelector(settingsPanelSelectors.settingsPanel);
     }
 
     public async closeSettingsPanel(): Promise<void> {
-        await this.waitForSelector(detailsViewSelectors.settingsPanel);
+        await this.waitForSelector(settingsPanelSelectors.settingsPanel);
 
         await this.keyPress('Escape');
-        await this.waitForSelectorToDisappear(detailsViewSelectors.settingsPanel);
+        await this.waitForSelectorToDisappear(settingsPanelSelectors.settingsPanel);
     }
 
+    public async setToggleState(toggleSelector: string, newState: boolean): Promise<void> {
+        const toggle = await this.waitForSelector(toggleSelector);
+        const oldState = (await (await toggle.getProperty('checked')).jsonValue()) as boolean;
+        if (oldState !== newState) {
+            await this.clickSelector(toggleSelector);
+            await this.expectToggleState(toggleSelector, newState);
+        }
+    }
+
+    public async expectToggleState(toggleSelector: string, expectedState: boolean): Promise<void> {
+        const toggleInStateSelector = expectedState
+            ? settingsPanelSelectors.enabledToggle(toggleSelector)
+            : settingsPanelSelectors.disabledToggle(toggleSelector);
+
+        await this.waitForSelector(toggleInStateSelector);
+    }
+
+    // TODO: replace usages with backgroundPage()
     public async enableHighContrast(): Promise<void> {
         await this.openSettingsPanel();
 
-        await this.clickSelector(detailsViewSelectors.highContrastToggle);
-        await this.waitForSelector(detailsViewSelectors.highContrastToggleCheckedStateSelector);
+        await this.setToggleState(settingsPanelSelectors.highContrastModeToggle, true);
         await this.waitForSelector(CommonSelectors.highContrastThemeSelector);
 
         await this.closeSettingsPanel();

--- a/src/tests/end-to-end/tests/details-view/settings-panel.test.ts
+++ b/src/tests/end-to-end/tests/details-view/settings-panel.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { Browser } from 'tests/end-to-end/common/browser';
+import { launchBrowser } from 'tests/end-to-end/common/browser-factory';
+import { CommonSelectors } from 'tests/end-to-end/common/element-identifiers/common-selectors';
+import { settingsPanelSelectors } from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
+import { BackgroundPage } from 'tests/end-to-end/common/page-controllers/background-page';
+import { DetailsViewPage } from 'tests/end-to-end/common/page-controllers/details-view-page';
+import { TargetPage } from 'tests/end-to-end/common/page-controllers/target-page';
+import { scanForAccessibilityIssues } from 'tests/end-to-end/common/scan-for-accessibility-issues';
+
+describe('Details View -> Settings Panel', () => {
+    let browser: Browser;
+    let targetPage: TargetPage;
+    let detailsViewPage: DetailsViewPage;
+    let backgroundPage: BackgroundPage;
+
+    beforeAll(async () => {
+        browser = await launchBrowser({ suppressFirstTimeDialog: true });
+        targetPage = await browser.newTargetPage();
+        await browser.newPopupPage(targetPage);
+        backgroundPage = await browser.backgroundPage();
+        detailsViewPage = await browser.newDetailsViewPage(targetPage);
+        await detailsViewPage.openSettingsPanel();
+    });
+
+    afterAll(async () => {
+        if (browser) {
+            await browser.close();
+            browser = undefined;
+        }
+    });
+
+    describe('Telemetry toggle', () => {
+        it('should default to "off" in the usual configuration our E2E tests use', async () => {
+            await detailsViewPage.expectToggleState(settingsPanelSelectors.telemetryStateToggle, false);
+        });
+
+        it('should reflect the state applied via the background page insightsUserConfiguration controller all other tests use', async () => {
+            await backgroundPage.setTelemetryState(true);
+            await detailsViewPage.expectToggleState(settingsPanelSelectors.telemetryStateToggle, true);
+
+            await backgroundPage.setTelemetryState(false);
+            await detailsViewPage.expectToggleState(settingsPanelSelectors.telemetryStateToggle, false);
+        });
+    });
+
+    describe('High Contrast Mode toggle', () => {
+        it('should default to non-high-contrast mode', async () => {
+            await detailsViewPage.expectToggleState(settingsPanelSelectors.highContrastModeToggle, false);
+        });
+
+        it('should apply the appropriate CSS style when High Contrast Mode setting is toggled', async () => {
+            await detailsViewPage.setToggleState(settingsPanelSelectors.highContrastModeToggle, true);
+            await detailsViewPage.waitForSelector(CommonSelectors.highContrastThemeSelector);
+
+            await detailsViewPage.setToggleState(settingsPanelSelectors.highContrastModeToggle, false);
+            await detailsViewPage.waitForSelectorToDisappear(CommonSelectors.highContrastThemeSelector);
+        });
+
+        it('should reflect the state applied via the background page insightsUserConfiguration controller all other tests use', async () => {
+            await backgroundPage.setHighContrastMode(true);
+            await detailsViewPage.expectToggleState(settingsPanelSelectors.highContrastModeToggle, true);
+
+            await backgroundPage.setHighContrastMode(false);
+            await detailsViewPage.expectToggleState(settingsPanelSelectors.highContrastModeToggle, false);
+        });
+    });
+
+    it.each([true, false])('should pass accessibility validation with highContrastMode=%s', async highContrastMode => {
+        await backgroundPage.setHighContrastMode(highContrastMode);
+
+        const results = await scanForAccessibilityIssues(detailsViewPage, settingsPanelSelectors.settingsPanel);
+        expect(results).toHaveLength(0);
+    });
+});

--- a/src/tests/unit/tests/background/user-configuration-controller.test.ts
+++ b/src/tests/unit/tests/background/user-configuration-controller.test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { IMock, Mock, Times } from 'typemoq';
+
+import { Interpreter } from 'background/interpreter';
+import { UserConfigurationController } from 'background/user-configuration-controller';
+import { Message } from 'common/message';
+import { Messages } from 'common/messages';
+
+describe('UserConfigurationController', () => {
+    let testSubject: UserConfigurationController;
+    let interpreterMock: IMock<Interpreter>;
+
+    beforeEach(() => {
+        interpreterMock = Mock.ofType<Interpreter>();
+        testSubject = new UserConfigurationController(interpreterMock.object);
+    });
+
+    it.each([true, false])('setHighContrastMode(%s) sends the expected interpreter message', (enabled: boolean) => {
+        const expectedMessage: Message = {
+            messageType: Messages.UserConfig.SetHighContrastConfig,
+            payload: { enableHighContrast: enabled },
+            tabId: null,
+        };
+        testSubject.setHighContrastMode(enabled);
+        interpreterMock.verify(i => i.interpret(expectedMessage), Times.once());
+    });
+
+    it.each([true, false])('setTelemetryState(%s) sends the expected interpreter message', (enabled: boolean) => {
+        const expectedMessage: Message = {
+            messageType: Messages.UserConfig.SetTelemetryConfig,
+            payload: { enableTelemetry: enabled },
+            tabId: null,
+        };
+        testSubject.setTelemetryState(enabled);
+        interpreterMock.verify(i => i.interpret(expectedMessage), Times.once());
+    });
+});


### PR DESCRIPTION
#### Description of changes

This PR introduces a new controller on the background page console similar to the existing `window.insightsFeatureFlags` controller named `window.insightsUserConfiguration`. We want this primarily so that e2e tests can be updated to use it rather than UI to do most user configuration tasks (particularly, dismissing the initial telemetry prompt and setting high contrast mode), since the current strategy of setting high contrast mode via the UI has the following repercussions:

* causes issues for the upcoming permission changes (many tests attempt to toggle details view settings from states that will soon be "tab closed" pages)
* takes a lot of unnecessary time
* causes a lot of unnecessary instability

This PR introduces the new controller, updates existing browser setup to use it for suppressing the telemetry dialog, and adds a new `settings-panel.test.ts` to verify that the new config controller works in sync with the settings panel UI (so we can still keep the test coverage verifying that the high contrast toggle actually works).

Despite adding a new file of e2e tests, this PR cuts off about a minute (~12%) off the e2e runtime on build agents. On my dev box, the followup change to use this strategy for high contrast settings cuts off another few minutes (~35%).

Out of scope: updating all existing e2e tests to use the new infrastructure for high contrast mode toggling. That turns out to be a large change on its own since it updates a bunch of tests to stop doing so much redundant "normal" vs "high-contrast" setup and changes a lot of snapshots accordingly, so l extracted it for a later PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
