### PR TITLE
refactor: automated checks report does not uses ScanResults

### DIFF
--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -118,7 +118,6 @@ export class IssuesTable extends React.Component<IssuesTableProps> {
                     exportResultsType={'AutomatedChecks'}
                     htmlGenerator={reportGenerator.generateFastPassAutomatedChecksReport.bind(
                         reportGenerator,
-                        scanResult,
                         scanDate,
                         pageTitle,
                         pageUrl,

--- a/src/DetailsView/components/report-export-component-factory.tsx
+++ b/src/DetailsView/components/report-export-component-factory.tsx
@@ -60,7 +60,6 @@ export function getReportExportComponentForFastPass(props: CommandBarProps): JSX
         exportResultsType: 'AutomatedChecks',
         htmlGenerator: description =>
             reportGenerator.generateFastPassAutomatedChecksReport(
-                scanResult,
                 scanDate,
                 tabStoreData.title,
                 tabStoreData.url,

--- a/src/reports/components/report-sections/full-rule-header.tsx
+++ b/src/reports/components/report-sections/full-rule-header.tsx
@@ -19,12 +19,12 @@ export type FullRuleHeaderDeps = {
 
 export type FullRuleHeaderProps = {
     deps: FullRuleHeaderDeps;
-    cardResult: CardRuleResult;
+    cardRuleResult: CardRuleResult;
     outcomeType: InstanceOutcomeType;
 };
 
 export const FullRuleHeader = NamedFC<FullRuleHeaderProps>('FullRuleHeader', props => {
-    const { outcomeType, deps, cardResult } = props;
+    const { outcomeType, deps, cardRuleResult: cardResult } = props;
 
     const outcomeText = outcomeTypeSemantics[props.outcomeType].pastTense;
     const ariaDescribedBy = `${kebabCase(outcomeText)}-rule-${cardResult.id}-description`;

--- a/src/reports/components/report-sections/full-rule-header.tsx
+++ b/src/reports/components/report-sections/full-rule-header.tsx
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { kebabCase } from 'lodash';
-import * as React from 'react';
-
 import { GuidanceLinks } from 'common/components/guidance-links';
 import { GuidanceTags } from 'common/components/guidance-tags';
 import { NewTabLink } from 'common/components/new-tab-link';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { NamedFC } from 'common/react/named-fc';
-import { RuleResult } from 'scanner/iruleresults';
+import { CardRuleResult } from 'common/types/store-data/card-view-model';
+import { kebabCase } from 'lodash';
+import * as React from 'react';
+
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { OutcomeChip } from '../outcome-chip';
 import { outcomeTypeSemantics } from '../outcome-type';
@@ -19,15 +19,15 @@ export type FullRuleHeaderDeps = {
 
 export type FullRuleHeaderProps = {
     deps: FullRuleHeaderDeps;
-    rule: RuleResult;
+    cardResult: CardRuleResult;
     outcomeType: InstanceOutcomeType;
 };
 
 export const FullRuleHeader = NamedFC<FullRuleHeaderProps>('FullRuleHeader', props => {
-    const { rule, outcomeType, deps } = props;
+    const { outcomeType, deps, cardResult } = props;
 
     const outcomeText = outcomeTypeSemantics[props.outcomeType].pastTense;
-    const ariaDescribedBy = `${kebabCase(outcomeText)}-rule-${rule.id}-description`;
+    const ariaDescribedBy = `${kebabCase(outcomeText)}-rule-${cardResult.id}-description`;
 
     const renderCountBadge = () => {
         if (outcomeType !== 'fail') {
@@ -36,14 +36,14 @@ export const FullRuleHeader = NamedFC<FullRuleHeaderProps>('FullRuleHeader', pro
 
         return (
             <span aria-hidden="true">
-                <OutcomeChip count={rule.nodes.length} outcomeType={outcomeType} />
+                <OutcomeChip count={cardResult.nodes.length} outcomeType={outcomeType} />
             </span>
         );
     };
 
     const renderRuleLink = () => {
-        const ruleId = rule.id;
-        const ruleUrl = rule.helpUrl;
+        const ruleId = cardResult.id;
+        const ruleUrl = cardResult.url;
         return (
             <span className="rule-details-id">
                 <NewTabLink href={ruleUrl} aria-label={`rule ${ruleId}`} aria-describedby={ariaDescribedBy}>
@@ -54,19 +54,19 @@ export const FullRuleHeader = NamedFC<FullRuleHeaderProps>('FullRuleHeader', pro
     };
 
     const renderGuidanceLinks = () => {
-        return <GuidanceLinks links={rule.guidanceLinks} />;
+        return <GuidanceLinks links={cardResult.guidance} />;
     };
 
     const renderDescription = () => {
         return (
             <span className="rule-details-description" id={ariaDescribedBy}>
-                {rule.description}
+                {cardResult.description}
             </span>
         );
     };
 
     const renderGuidanceTags = () => {
-        return <GuidanceTags deps={deps} links={rule.guidanceLinks} />;
+        return <GuidanceTags deps={deps} links={cardResult.guidance} />;
     };
 
     return (

--- a/src/reports/components/report-sections/not-applicable-checks-section.tsx
+++ b/src/reports/components/report-sections/not-applicable-checks-section.tsx
@@ -13,16 +13,16 @@ export type NotApplicableChecksSectionProps = Pick<SectionProps, 'deps' | 'cards
 export const NotApplicableChecksSection = NamedFC<NotApplicableChecksSectionProps>(
     'NotApplicableChecksSection',
     ({ deps, cardsViewData }) => {
-        const cardResults = cardsViewData.cards.inapplicable;
+        const cardRuleResults = cardsViewData.cards.inapplicable;
 
         return (
             <CollapsibleResultSection
                 deps={deps}
                 title="Not applicable checks"
-                cardResults={cardResults}
+                cardRuleResults={cardRuleResults}
                 containerClassName="result-section"
                 outcomeType="inapplicable"
-                badgeCount={cardResults.length}
+                badgeCount={cardRuleResults.length}
                 containerId="not-applicable-checks-section"
             />
         );

--- a/src/reports/components/report-sections/not-applicable-checks-section.tsx
+++ b/src/reports/components/report-sections/not-applicable-checks-section.tsx
@@ -8,20 +8,23 @@ import { SectionProps } from './report-section-factory';
 
 export type NotApplicableChecksSectionDeps = CollapsibleResultSectionDeps;
 
-export type NotApplicableChecksSectionProps = Pick<SectionProps, 'scanResult' | 'deps'>;
+export type NotApplicableChecksSectionProps = Pick<SectionProps, 'deps' | 'cardsViewData'>;
 
-export const NotApplicableChecksSection = NamedFC<NotApplicableChecksSectionProps>('NotApplicableChecksSection', ({ scanResult, deps }) => {
-    const rules = scanResult.inapplicable;
+export const NotApplicableChecksSection = NamedFC<NotApplicableChecksSectionProps>(
+    'NotApplicableChecksSection',
+    ({ deps, cardsViewData }) => {
+        const cardResults = cardsViewData.cards.inapplicable;
 
-    return (
-        <CollapsibleResultSection
-            deps={deps}
-            title="Not applicable checks"
-            rules={rules}
-            containerClassName="result-section"
-            outcomeType="inapplicable"
-            badgeCount={rules.length}
-            containerId="not-applicable-checks-section"
-        />
-    );
-});
+        return (
+            <CollapsibleResultSection
+                deps={deps}
+                title="Not applicable checks"
+                cardResults={cardResults}
+                containerClassName="result-section"
+                outcomeType="inapplicable"
+                badgeCount={cardResults.length}
+                containerId="not-applicable-checks-section"
+            />
+        );
+    },
+);

--- a/src/reports/components/report-sections/passed-checks-section.tsx
+++ b/src/reports/components/report-sections/passed-checks-section.tsx
@@ -11,16 +11,16 @@ export type PassedChecksSectionDeps = CollapsibleResultSectionDeps;
 export type PassedChecksSectionProps = Pick<SectionProps, 'deps' | 'cardsViewData'>;
 
 export const PassedChecksSection = NamedFC<PassedChecksSectionProps>('PassedChecksSection', ({ deps, cardsViewData }) => {
-    const cardResults = cardsViewData.cards.pass;
+    const cardRuleResults = cardsViewData.cards.pass;
 
     return (
         <CollapsibleResultSection
             deps={deps}
             title="Passed checks"
-            cardResults={cardResults}
+            cardRuleResults={cardRuleResults}
             containerClassName="result-section"
             outcomeType="pass"
-            badgeCount={cardResults.length}
+            badgeCount={cardRuleResults.length}
             containerId="passed-checks-section"
         />
     );

--- a/src/reports/components/report-sections/passed-checks-section.tsx
+++ b/src/reports/components/report-sections/passed-checks-section.tsx
@@ -8,18 +8,19 @@ import { SectionProps } from './report-section-factory';
 
 export type PassedChecksSectionDeps = CollapsibleResultSectionDeps;
 
-export type PassedChecksSectionProps = Pick<SectionProps, 'scanResult' | 'deps'>;
+export type PassedChecksSectionProps = Pick<SectionProps, 'deps' | 'cardsViewData'>;
 
-export const PassedChecksSection = NamedFC<PassedChecksSectionProps>('PassedChecksSection', ({ scanResult, deps }) => {
-    const rules = scanResult.passes;
+export const PassedChecksSection = NamedFC<PassedChecksSectionProps>('PassedChecksSection', ({ deps, cardsViewData }) => {
+    const cardResults = cardsViewData.cards.pass;
+
     return (
         <CollapsibleResultSection
             deps={deps}
             title="Passed checks"
-            rules={rules}
+            cardResults={cardResults}
             containerClassName="result-section"
             outcomeType="pass"
-            badgeCount={rules.length}
+            badgeCount={cardResults.length}
             containerId="passed-checks-section"
         />
     );

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -23,7 +23,6 @@ export type SectionProps = {
     description: string;
     scanDate: Date;
     environmentInfo: EnvironmentInfo;
-    scanResult: ScanResults;
     toUtcString: (date: Date) => string;
     getCollapsibleScript: () => string;
     getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks;

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -5,7 +5,6 @@ import { EnvironmentInfo } from 'common/environment-info-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { ReactFCWithDisplayName } from 'common/react/named-fc';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
-import { ScanResults } from 'scanner/iruleresults';
 
 import { CardsViewModel } from '../../../common/types/store-data/card-view-model';
 import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';

--- a/src/reports/components/report-sections/rules-only.tsx
+++ b/src/reports/components/report-sections/rules-only.tsx
@@ -11,15 +11,15 @@ export type RulesOnlyDeps = FullRuleHeaderDeps;
 
 export type RulesOnlyProps = {
     deps: RulesOnlyDeps;
-    cardResults: CardRuleResult[];
+    cardRuleResults: CardRuleResult[];
     outcomeType: InstanceOutcomeType;
 };
 
-export const RulesOnly = NamedFC<RulesOnlyProps>('RulesOnly', ({ outcomeType, deps, cardResults }) => {
+export const RulesOnly = NamedFC<RulesOnlyProps>('RulesOnly', ({ outcomeType, deps, cardRuleResults: cardResults }) => {
     return (
         <div className="rule-details-group">
-            {cardResults.map(cardResult => (
-                <FullRuleHeader deps={deps} key={cardResult.id} cardResult={cardResult} outcomeType={outcomeType} />
+            {cardResults.map(cardRuleResult => (
+                <FullRuleHeader deps={deps} key={cardRuleResult.id} cardRuleResult={cardRuleResult} outcomeType={outcomeType} />
             ))}
         </div>
     );

--- a/src/reports/components/report-sections/rules-only.tsx
+++ b/src/reports/components/report-sections/rules-only.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
+import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import * as React from 'react';
-import { RuleResult } from 'scanner/iruleresults';
+
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { FullRuleHeader, FullRuleHeaderDeps } from './full-rule-header';
 
@@ -10,16 +11,16 @@ export type RulesOnlyDeps = FullRuleHeaderDeps;
 
 export type RulesOnlyProps = {
     deps: RulesOnlyDeps;
-    rules: RuleResult[];
+    cardResults: CardRuleResult[];
     outcomeType: InstanceOutcomeType;
 };
 
-export const RulesOnly = NamedFC<RulesOnlyProps>('RulesOnly', ({ rules, outcomeType, deps }) => {
+export const RulesOnly = NamedFC<RulesOnlyProps>('RulesOnly', ({ outcomeType, deps, cardResults }) => {
     return (
         <div className="rule-details-group">
-            {rules.map(rule => {
-                return <FullRuleHeader deps={deps} key={rule.id} rule={rule} outcomeType={outcomeType} />;
-            })}
+            {cardResults.map(cardResult => (
+                <FullRuleHeader deps={deps} key={cardResult.id} cardResult={cardResult} outcomeType={outcomeType} />
+            ))}
         </div>
     );
 });

--- a/src/reports/components/report-sections/summary-section.tsx
+++ b/src/reports/components/report-sections/summary-section.tsx
@@ -7,22 +7,23 @@ import { allInstanceOutcomeTypes, InstanceOutcomeType } from '../instance-outcom
 import { OutcomeSummaryBar } from '../outcome-summary-bar';
 import { SectionProps } from './report-section-factory';
 
-export type SummarySectionProps = Pick<SectionProps, 'scanResult'>;
+export type SummarySectionProps = Pick<SectionProps, 'cardsViewData'>;
 
 export const SummarySection = NamedFC<SummarySectionProps>('SummarySection', props => {
-    const scanResult = props.scanResult;
+    const { cards } = props.cardsViewData;
+
     const countSummary: { [type in InstanceOutcomeType]: number } = {
-        fail: scanResult.violations.reduce((total, violation) => {
-            return total + violation.nodes.length;
+        fail: cards.fail.reduce((total, currentFail) => {
+            return total + currentFail.nodes.length;
         }, 0),
-        pass: scanResult.passes.length,
-        inapplicable: scanResult.inapplicable.length,
+        pass: cards.pass.length,
+        inapplicable: cards.inapplicable.length,
     };
 
     return (
         <div className="summary-section">
             <h2>Summary</h2>
-            <OutcomeSummaryBar {...props} outcomeStats={countSummary} iconStyleInverted={true} allOutcomeTypes={allInstanceOutcomeTypes} />
+            <OutcomeSummaryBar outcomeStats={countSummary} iconStyleInverted={true} allOutcomeTypes={allInstanceOutcomeTypes} />
         </div>
     );
 });

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -5,8 +5,6 @@ import { AssessmentStoreData } from 'common/types/store-data/assessment-result-d
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
-import { ScanResults } from 'scanner/iruleresults';
-
 import { AssessmentReportHtmlGenerator } from './assessment-report-html-generator';
 import { ReportHtmlGenerator } from './report-html-generator';
 import { ReportNameGenerator } from './report-name-generator';
@@ -23,14 +21,13 @@ export class ReportGenerator {
     }
 
     public generateFastPassAutomatedChecksReport(
-        scanResult: ScanResults,
         scanDate: Date,
         pageTitle: string,
         pageUrl: string,
         cardsViewData: CardsViewModel,
         description: string,
     ): string {
-        return this.reportHtmlGenerator.generateHtml(scanResult, scanDate, pageTitle, pageUrl, description, cardsViewData);
+        return this.reportHtmlGenerator.generateHtml(scanDate, pageTitle, pageUrl, description, cardsViewData);
     }
 
     public generateAssessmentReport(

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -8,7 +8,6 @@ import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
-import { ScanResults } from 'scanner/iruleresults';
 
 import { ReportHead } from './components/report-head';
 import { ReportBody, ReportBodyProps } from './components/report-sections/report-body';
@@ -21,21 +20,14 @@ export class ReportHtmlGenerator {
         private readonly sectionFactory: ReportSectionFactory,
         private readonly reactStaticRenderer: ReactStaticRenderer,
         private readonly environmentInfo: EnvironmentInfo,
-        private readonly getCollpasibleScript: () => string,
+        private readonly getCollapsibleScript: () => string,
         private readonly utcDateConverter: (scanDate: Date) => string,
         private readonly getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks,
         private readonly fixInstructionProcessor: FixInstructionProcessor,
         private readonly getPropertyConfiguration: (id: string) => Readonly<PropertyConfiguration>,
     ) {}
 
-    public generateHtml(
-        scanResult: ScanResults,
-        scanDate: Date,
-        pageTitle: string,
-        pageUrl: string,
-        description: string,
-        cardsViewData: CardsViewModel,
-    ): string {
+    public generateHtml(scanDate: Date, pageTitle: string, pageUrl: string, description: string, cardsViewData: CardsViewModel): string {
         const headElement: JSX.Element = <ReportHead />;
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(headElement);
 
@@ -44,7 +36,6 @@ export class ReportHtmlGenerator {
             pageUrl,
             description,
             scanDate,
-            scanResult,
             deps: {
                 fixInstructionProcessor: this.fixInstructionProcessor,
                 collapsibleControl: ReportCollapsibleContainerControl,
@@ -56,7 +47,7 @@ export class ReportHtmlGenerator {
             cardsViewData: cardsViewData,
             environmentInfo: this.environmentInfo,
             toUtcString: this.utcDateConverter,
-            getCollapsibleScript: this.getCollpasibleScript,
+            getCollapsibleScript: this.getCollapsibleScript,
             getGuidanceTagsFromGuidanceLinks: this.getGuidanceTagsFromGuidanceLinks,
             fixInstructionProcessor: this.fixInstructionProcessor,
         } as SectionProps;

--- a/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
@@ -100,7 +100,6 @@ describe('ReportExportComponentPropsFactory', () => {
         reportGeneratorMock
             .setup(reportGenerator =>
                 reportGenerator.generateFastPassAutomatedChecksReport(
-                    scanResult,
                     theDate,
                     tabStoreData.title,
                     tabStoreData.url,

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/not-applicable-checks-sections.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/not-applicable-checks-sections.test.tsx.snap
@@ -3,17 +3,17 @@
 exports[`NotApplicableChecksSection renders 1`] = `
 <CollapsibleResultSection
   badgeCount={3}
-  containerClassName="result-section"
-  containerId="not-applicable-checks-section"
-  deps={Object {}}
-  outcomeType="inapplicable"
-  rules={
+  cardResults={
     Array [
       Object {},
       Object {},
       Object {},
     ]
   }
+  containerClassName="result-section"
+  containerId="not-applicable-checks-section"
+  deps={Object {}}
+  outcomeType="inapplicable"
   title="Not applicable checks"
 />
 `;

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/not-applicable-checks-sections.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/not-applicable-checks-sections.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`NotApplicableChecksSection renders 1`] = `
 <CollapsibleResultSection
   badgeCount={3}
-  cardResults={
+  cardRuleResults={
     Array [
       Object {},
       Object {},

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/passed-checks-sections.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/passed-checks-sections.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`PassedChecksSection renders 1`] = `
 <CollapsibleResultSection
   badgeCount={3}
-  cardResults={
+  cardRuleResults={
     Array [
       Object {},
       Object {},

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/passed-checks-sections.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/passed-checks-sections.test.tsx.snap
@@ -3,17 +3,17 @@
 exports[`PassedChecksSection renders 1`] = `
 <CollapsibleResultSection
   badgeCount={3}
-  containerClassName="result-section"
-  containerId="passed-checks-section"
-  deps={Object {}}
-  outcomeType="pass"
-  rules={
+  cardResults={
     Array [
       Object {},
       Object {},
       Object {},
     ]
   }
+  containerClassName="result-section"
+  containerId="passed-checks-section"
+  deps={Object {}}
+  outcomeType="pass"
   title="Passed checks"
 />
 `;

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/rules-only.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/rules-only.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`RulesOnly renders 1`] = `
   className="rule-details-group"
 >
   <FullRuleHeader
-    cardResult={
+    cardRuleResult={
       Object {
         "id": "1",
       }
@@ -14,7 +14,7 @@ exports[`RulesOnly renders 1`] = `
     outcomeType="pass"
   />
   <FullRuleHeader
-    cardResult={
+    cardRuleResult={
       Object {
         "id": "2",
       }
@@ -23,7 +23,7 @@ exports[`RulesOnly renders 1`] = `
     outcomeType="pass"
   />
   <FullRuleHeader
-    cardResult={
+    cardRuleResult={
       Object {
         "id": "3",
       }

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/rules-only.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/rules-only.test.tsx.snap
@@ -5,31 +5,31 @@ exports[`RulesOnly renders 1`] = `
   className="rule-details-group"
 >
   <FullRuleHeader
-    deps={Object {}}
-    outcomeType="pass"
-    rule={
+    cardResult={
       Object {
         "id": "1",
       }
     }
-  />
-  <FullRuleHeader
     deps={Object {}}
     outcomeType="pass"
-    rule={
+  />
+  <FullRuleHeader
+    cardResult={
       Object {
         "id": "2",
       }
     }
-  />
-  <FullRuleHeader
     deps={Object {}}
     outcomeType="pass"
-    rule={
+  />
+  <FullRuleHeader
+    cardResult={
       Object {
         "id": "3",
       }
     }
+    deps={Object {}}
+    outcomeType="pass"
   />
 </div>
 `;

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-section.test.tsx.snap
@@ -23,25 +23,6 @@ exports[`SummarySection failure only 1`] = `
         "pass": 0,
       }
     }
-    scanResult={
-      Object {
-        "inapplicable": Array [],
-        "passes": Array [],
-        "violations": Array [
-          Object {
-            "nodes": Array [
-              Object {},
-            ],
-          },
-          Object {
-            "nodes": Array [
-              Object {},
-              Object {},
-            ],
-          },
-        ],
-      }
-    }
   />
 </div>
 `;
@@ -67,32 +48,6 @@ exports[`SummarySection failures + not applicable + passes 1`] = `
         "fail": 3,
         "inapplicable": 3,
         "pass": 2,
-      }
-    }
-    scanResult={
-      Object {
-        "inapplicable": Array [
-          Object {},
-          Object {},
-          Object {},
-        ],
-        "passes": Array [
-          Object {},
-          Object {},
-        ],
-        "violations": Array [
-          Object {
-            "nodes": Array [
-              Object {},
-            ],
-          },
-          Object {
-            "nodes": Array [
-              Object {},
-              Object {},
-            ],
-          },
-        ],
       }
     }
   />
@@ -122,29 +77,6 @@ exports[`SummarySection failures + not applicable only 1`] = `
         "pass": 0,
       }
     }
-    scanResult={
-      Object {
-        "inapplicable": Array [
-          Object {},
-          Object {},
-          Object {},
-        ],
-        "passes": Array [],
-        "violations": Array [
-          Object {
-            "nodes": Array [
-              Object {},
-            ],
-          },
-          Object {
-            "nodes": Array [
-              Object {},
-              Object {},
-            ],
-          },
-        ],
-      }
-    }
   />
 </div>
 `;
@@ -170,28 +102,6 @@ exports[`SummarySection failures + passes only 1`] = `
         "fail": 3,
         "inapplicable": 0,
         "pass": 2,
-      }
-    }
-    scanResult={
-      Object {
-        "inapplicable": Array [],
-        "passes": Array [
-          Object {},
-          Object {},
-        ],
-        "violations": Array [
-          Object {
-            "nodes": Array [
-              Object {},
-            ],
-          },
-          Object {
-            "nodes": Array [
-              Object {},
-              Object {},
-            ],
-          },
-        ],
       }
     }
   />
@@ -221,20 +131,6 @@ exports[`SummarySection not applicable + passes only 1`] = `
         "pass": 2,
       }
     }
-    scanResult={
-      Object {
-        "inapplicable": Array [
-          Object {},
-          Object {},
-          Object {},
-        ],
-        "passes": Array [
-          Object {},
-          Object {},
-        ],
-        "violations": Array [],
-      }
-    }
   />
 </div>
 `;
@@ -262,16 +158,6 @@ exports[`SummarySection not applicable only 1`] = `
         "pass": 2,
       }
     }
-    scanResult={
-      Object {
-        "inapplicable": Array [],
-        "passes": Array [
-          Object {},
-          Object {},
-        ],
-        "violations": Array [],
-      }
-    }
   />
 </div>
 `;
@@ -297,16 +183,6 @@ exports[`SummarySection passes only 1`] = `
         "fail": 0,
         "inapplicable": 0,
         "pass": 2,
-      }
-    }
-    scanResult={
-      Object {
-        "inapplicable": Array [],
-        "passes": Array [
-          Object {},
-          Object {},
-        ],
-        "violations": Array [],
       }
     }
   />

--- a/src/tests/unit/tests/reports/components/report-sections/full-rule-header.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/full-rule-header.test.tsx
@@ -28,7 +28,7 @@ describe('FullRuleHeader', () => {
     it.each(allInstanceOutcomeTypes)('renders, outcomeType = %s', outcomeType => {
         const props: FullRuleHeaderProps = {
             deps: depsStub,
-            cardResult: rule,
+            cardRuleResult: rule,
             outcomeType,
         };
 

--- a/src/tests/unit/tests/reports/components/report-sections/full-rule-header.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/full-rule-header.test.tsx
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { allInstanceOutcomeTypes } from 'reports/components/instance-outcome-type';
 import { FullRuleHeader, FullRuleHeaderDeps, FullRuleHeaderProps } from 'reports/components/report-sections/full-rule-header';
-import { RuleResult } from 'scanner/iruleresults';
 
 describe('FullRuleHeader', () => {
     const depsStub = {} as FullRuleHeaderDeps;
-    const rule = {
-        helpUrl: 'url://help.url',
+    const rule: CardRuleResult = {
+        url: 'url://help.url',
         id: 'rule id',
         description: 'rule description',
-        guidanceLinks: [
+        guidance: [
             {
                 href: 'url://guidance-01.link',
                 text: 'guidance-01',
@@ -22,13 +22,13 @@ describe('FullRuleHeader', () => {
                 text: 'guidance-02',
             },
         ],
-        nodes: [{} as AxeNodeResult],
-    } as RuleResult;
+        nodes: [{}],
+    } as CardRuleResult;
 
     it.each(allInstanceOutcomeTypes)('renders, outcomeType = %s', outcomeType => {
         const props: FullRuleHeaderProps = {
             deps: depsStub,
-            rule: rule,
+            cardResult: rule,
             outcomeType,
         };
 

--- a/src/tests/unit/tests/reports/components/report-sections/not-applicable-checks-sections.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/not-applicable-checks-sections.test.tsx
@@ -1,28 +1,26 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardRuleResult, CardsViewModel } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import {
     NotApplicableChecksSection,
     NotApplicableChecksSectionProps,
 } from 'reports/components/report-sections/not-applicable-checks-section';
-import { RuleResult } from 'scanner/iruleresults';
-
-import { SectionDeps } from '../../../../../../reports/components/report-sections/report-section-factory';
+import { SectionDeps } from 'reports/components/report-sections/report-section-factory';
 
 describe('NotApplicableChecksSection', () => {
     it('renders', () => {
         const props: NotApplicableChecksSectionProps = {
             deps: {} as SectionDeps,
-            scanResult: {
-                inapplicable: [{} as RuleResult, {} as RuleResult, {} as RuleResult],
-                violations: [],
-                passes: [],
-                incomplete: [],
-                timestamp: 'today',
-                targetPageTitle: 'page title',
-                targetPageUrl: 'url://page.url',
-            },
+            cardsViewData: {
+                cards: {
+                    inapplicable: [{} as CardRuleResult, {} as CardRuleResult, {} as CardRuleResult],
+                    fail: [],
+                    pass: [],
+                    unknown: [],
+                },
+            } as CardsViewModel,
         };
 
         const wrapper = shallow(<NotApplicableChecksSection {...props} />);

--- a/src/tests/unit/tests/reports/components/report-sections/passed-checks-sections.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/passed-checks-sections.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardRuleResult, CardsViewModel } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { PassedChecksSection, PassedChecksSectionProps } from 'reports/components/report-sections/passed-checks-section';
-import { RuleResult } from 'scanner/iruleresults';
 
 import { SectionDeps } from '../../../../../../reports/components/report-sections/report-section-factory';
 
@@ -11,15 +11,14 @@ describe('PassedChecksSection', () => {
     it('renders', () => {
         const props: PassedChecksSectionProps = {
             deps: {} as SectionDeps,
-            scanResult: {
-                passes: [{} as RuleResult, {} as RuleResult, {} as RuleResult],
-                violations: [],
-                inapplicable: [],
-                incomplete: [],
-                timestamp: 'today',
-                targetPageTitle: 'page title',
-                targetPageUrl: 'url://page.url',
-            },
+            cardsViewData: {
+                cards: {
+                    pass: [{} as CardRuleResult, {} as CardRuleResult, {} as CardRuleResult],
+                    fail: [],
+                    inapplicable: [],
+                    unknown: [],
+                },
+            } as CardsViewModel,
         };
 
         const wrapper = shallow(<PassedChecksSection {...props} />);

--- a/src/tests/unit/tests/reports/components/report-sections/rules-only.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/rules-only.test.tsx
@@ -11,7 +11,7 @@ describe('RulesOnly', () => {
     it('renders', () => {
         const cardResults = [{ id: '1' } as CardRuleResult, { id: '2' } as CardRuleResult, { id: '3' } as CardRuleResult];
 
-        const wrapped = shallow(<RulesOnly deps={depsStub} outcomeType={'pass'} cardResults={cardResults} />);
+        const wrapped = shallow(<RulesOnly deps={depsStub} outcomeType={'pass'} cardRuleResults={cardResults} />);
 
         expect(wrapped.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/reports/components/report-sections/rules-only.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/rules-only.test.tsx
@@ -1,17 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { RulesOnly, RulesOnlyDeps } from 'reports/components/report-sections/rules-only';
-import { RuleResult } from 'scanner/iruleresults';
 
 describe('RulesOnly', () => {
     const depsStub = {} as RulesOnlyDeps;
 
     it('renders', () => {
-        const rules = [{ id: '1' } as RuleResult, { id: '2' } as RuleResult, { id: '3' } as RuleResult];
+        const cardResults = [{ id: '1' } as CardRuleResult, { id: '2' } as CardRuleResult, { id: '3' } as CardRuleResult];
 
-        const wrapped = shallow(<RulesOnly deps={depsStub} outcomeType={'pass'} rules={rules} />);
+        const wrapped = shallow(<RulesOnly deps={depsStub} outcomeType={'pass'} cardResults={cardResults} />);
 
         expect(wrapped.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/reports/components/report-sections/summary-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/summary-section.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { SummarySection, SummarySectionProps } from 'reports/components/report-sections/summary-section';
-import { ScanResults } from 'scanner/iruleresults';
 
 describe('SummarySection', () => {
     const noViolations = [];
@@ -20,68 +20,82 @@ describe('SummarySection', () => {
     ];
     const passes = [{}, {}];
     const nonApplicable = [{}, {}, {}];
-    const scenarios: [string, ScanResults][] = [
+    const scenarios: [string, CardsViewModel][] = [
         [
             'failure only',
             {
-                violations,
-                passes: noPasses,
-                inapplicable: noNonApplicable,
-            } as ScanResults,
+                cards: {
+                    fail: violations,
+                    pass: noPasses,
+                    inapplicable: noNonApplicable,
+                },
+            } as CardsViewModel,
         ],
         [
             'not applicable only',
             {
-                violations: noViolations,
-                passes,
-                inapplicable: noNonApplicable,
-            } as ScanResults,
+                cards: {
+                    fail: noViolations,
+                    pass: passes,
+                    inapplicable: noNonApplicable,
+                },
+            } as CardsViewModel,
         ],
         [
             'passes only',
             {
-                violations: noViolations,
-                passes,
-                inapplicable: noNonApplicable,
-            } as ScanResults,
+                cards: {
+                    fail: noViolations,
+                    pass: passes,
+                    inapplicable: noNonApplicable,
+                },
+            } as CardsViewModel,
         ],
         [
             'failures + not applicable only',
             {
-                violations: violations,
-                passes: noPasses,
-                inapplicable: nonApplicable,
-            } as ScanResults,
+                cards: {
+                    fail: violations,
+                    pass: noPasses,
+                    inapplicable: nonApplicable,
+                },
+            } as CardsViewModel,
         ],
         [
             'failures + passes only',
             {
-                violations: violations,
-                passes: passes,
-                inapplicable: noNonApplicable,
-            } as ScanResults,
+                cards: {
+                    fail: violations,
+                    pass: passes,
+                    inapplicable: noNonApplicable,
+                },
+            } as CardsViewModel,
         ],
         [
             'not applicable + passes only',
             {
-                violations: noViolations,
-                passes: passes,
-                inapplicable: nonApplicable,
-            } as ScanResults,
+                cards: {
+                    fail: noViolations,
+                    pass: passes,
+                    inapplicable: nonApplicable,
+                },
+            } as CardsViewModel,
         ],
         [
             'failures + not applicable + passes',
             {
-                violations: violations,
-                passes: passes,
-                inapplicable: nonApplicable,
-            } as ScanResults,
+                cards: {
+                    fail: violations,
+                    pass: passes,
+                    inapplicable: nonApplicable,
+                },
+            } as CardsViewModel,
         ],
     ];
 
-    it.each(scenarios)('%s', (_, scanResult) => {
+    it.each(scenarios)('%s', (_, cardsViewData) => {
         const props: SummarySectionProps = {
-            scanResult,
+            cardsViewData: cardsViewData,
         };
         const wrapper = shallow(<SummarySection {...props} />);
 

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -8,12 +8,11 @@ import { AssessmentReportHtmlGenerator } from 'reports/assessment-report-html-ge
 import { ReportGenerator } from 'reports/report-generator';
 import { ReportHtmlGenerator } from 'reports/report-html-generator';
 import { ReportNameGenerator } from 'reports/report-name-generator';
-import { ScanResults } from 'scanner/iruleresults';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { exampleUnifiedStatusResults } from '../common/components/cards/sample-view-model-data';
 
 describe('ReportGenerator', () => {
-    const scanResult: ScanResults = {} as any;
     const date = new Date(2018, 2, 12, 15, 46);
     const title = 'title';
     const url = 'http://url/';
@@ -34,7 +33,6 @@ describe('ReportGenerator', () => {
         dataBuilderMock
             .setup(builder =>
                 builder.generateHtml(
-                    It.isObjectWith(scanResult),
                     It.isValue(date),
                     It.isValue(title),
                     It.isValue(url),
@@ -45,7 +43,7 @@ describe('ReportGenerator', () => {
             .returns(() => 'returned-data');
 
         const testObject = new ReportGenerator(nameBuilderMock.object, dataBuilderMock.object, assessmentReportHtmlGeneratorMock.object);
-        const actual = testObject.generateFastPassAutomatedChecksReport(scanResult, date, title, url, cardsViewDataStub, description);
+        const actual = testObject.generateFastPassAutomatedChecksReport(date, title, url, cardsViewDataStub, description);
 
         expect(actual).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/reports/report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/report-html-generator.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { noCardInteractionsSupported } from 'common/components/cards/card-interaction-support';
 import { NullComponent } from 'common/components/null-component';
 import { DateProvider } from 'common/date-provider';
 import { EnvironmentInfo } from 'common/environment-info-provider';
@@ -8,13 +9,11 @@ import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 import { ReportHead } from 'reports/components/report-head';
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';
+import { ReportCollapsibleContainerControl } from 'reports/components/report-sections/report-collapsible-container';
 import { ReportSectionFactory, SectionDeps } from 'reports/components/report-sections/report-section-factory';
 import { ReactStaticRenderer } from 'reports/react-static-renderer';
 import { ReportHtmlGenerator } from 'reports/report-html-generator';
-import { ScanResults } from 'scanner/iruleresults';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
-import { noCardInteractionsSupported } from '../../../../common/components/cards/card-interaction-support';
-import { ReportCollapsibleContainerControl } from '../../../../reports/components/report-sections/report-collapsible-container';
 import { exampleUnifiedStatusResults } from '../common/components/cards/sample-view-model-data';
 
 describe('ReportHtmlGenerator', () => {
@@ -22,7 +21,6 @@ describe('ReportHtmlGenerator', () => {
         const browserSpec: string = 'browser-spect';
         const extensionVersion: string = 'extension-version';
         const axeCoreVersion: string = 'axe-version';
-        const scanResult: ScanResults = {} as any;
         const scanDate: Date = new Date(2018, 2, 12, 16, 24);
         const pageTitle: string = 'page-title';
         const pageUrl: string = 'https://page-url/';
@@ -58,7 +56,6 @@ describe('ReportHtmlGenerator', () => {
             pageUrl,
             description,
             scanDate,
-            scanResult,
             environmentInfo,
             toUtcString: getUTCStringFromDateStub,
             getCollapsibleScript: getScriptMock.object,
@@ -90,7 +87,7 @@ describe('ReportHtmlGenerator', () => {
             getPropertyConfigurationStub,
         );
 
-        const actual = testObject.generateHtml(scanResult, scanDate, pageTitle, pageUrl, description, {
+        const actual = testObject.generateHtml(scanDate, pageTitle, pageUrl, description, {
             cards: exampleUnifiedStatusResults,
             visualHelperEnabled: true,
             allCardsCollapsed: true,


### PR DESCRIPTION
#### Description of changes

Current `ReportHtmlGenerator.generateHtml` expect a `scanResult: ScanResults` and a `cardsViewData: CardsViewModel` parameters.
Both `scanResult` and `cardsViewData` have analogous information (rule results, passes, fails, etc) so technically speaking we don't need both.

In this PR I'm removing the old `scanResult` in favor on using the `cardsViewData` only.

Checked the report works properly with both the old details list and the new cards UI.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
