### PR TITLE
chore: add 100-column ruler to vscode project settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
     "tslint.configFile": "tslint.json",
     "typescript.reportStyleChecksAsWarnings": true,
     "typescript.preferences.importModuleSpecifier": "non-relative",
-
     "psi-header.changes-tracking": {
         "autoHeader": "autoSave",
         "isActive": true
@@ -35,6 +34,6 @@
     "files.insertFinalNewline": true,
     "prettier.requireConfig": true,
     "editor.formatOnSave": true,
-    "editor.rulers": [140],
+    "editor.rulers": [100, 140],
     "typescript.tsdk": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
#### Description of changes

Now that we've decided on 100col as our new limit, adding a new 100-col ruler to our workspace vscode settings (leaving the 140col as well until we finish updating existing code)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
