### PR TITLE
test: add readiness checks to target page e2es before interacting with visualizations

### DIFF
--- a/src/tests/end-to-end/common/element-identifiers/target-page-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/target-page-selectors.ts
@@ -11,6 +11,7 @@ export const TargetPageInjectedComponentSelectors = {
 export const TabStopShadowDomSelectors = {
     svg: 'svg',
     lines: 'line',
-    ellipse: 'ellipse',
+    opaqueEllipse: 'ellipse:not([fill="transparent"])',
+    transparentEllipse: 'ellipse[fill="transparent"]',
     text: 'text',
 };

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -181,12 +181,18 @@ export class Page {
         });
     }
 
-    public async getShadowRootOfSelector(selector: string): Promise<Puppeteer.ElementHandle<Element>> {
-        return await this.screenshotOnError(async () =>
-            (
-                await this.underlyingPage.evaluateHandle(selectorInEval => document.querySelector(selectorInEval).shadowRoot, selector)
-            ).asElement(),
-        );
+    public async waitForShadowRootOfSelector(selector: string): Promise<Puppeteer.ElementHandle<Element>> {
+        return await this.screenshotOnError(async () => {
+            const shadowRootHandle = await this.underlyingPage.waitForFunction(
+                selectorInEval => {
+                    const container = document.querySelector(selectorInEval);
+                    return container == undefined ? undefined : container.shadowRoot;
+                },
+                { timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS },
+                selector,
+            );
+            return shadowRootHandle.asElement();
+        });
     }
 
     public async clickSelector(selector: string): Promise<void> {

--- a/src/tests/end-to-end/common/page-controllers/target-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/target-page.ts
@@ -31,12 +31,25 @@ export class TargetPage extends Page {
         super(underlyingPage, options);
     }
 
-    public async getShadowRoot(): Promise<ElementHandle<Element>> {
-        return await this.getShadowRootOfSelector('#insights-shadow-host');
+    public async waitForSelectorInShadowRoot(
+        selector: string,
+        options?: Puppeteer.WaitForSelectorOptions,
+    ): Promise<Puppeteer.JSHandle<any>> {
+        const shadowRoot = await this.waitForShadowRoot();
+        return this.waitForDescendentSelector(shadowRoot, selector, options);
     }
 
-    public async getShadowRootHtmlSnapshot(): Promise<Node> {
-        const shadowRoot = await this.getShadowRoot();
+    public async clickSelectorInShadowRoot(selector: string): Promise<void> {
+        const shadowRoot = await this.waitForShadowRoot();
+        await this.clickDescendentSelector(shadowRoot, selector, { visible: true });
+    }
+
+    public async waitForShadowRoot(): Promise<ElementHandle<Element>> {
+        return await this.waitForShadowRootOfSelector('#insights-shadow-host');
+    }
+
+    public async waitForShadowRootHtmlSnapshot(): Promise<Node> {
+        const shadowRoot = await this.waitForShadowRoot();
         return await formatChildElementForSnapshot(shadowRoot, '#insights-shadow-container');
     }
 }

--- a/src/tests/end-to-end/tests/popup/adhoc-panel.test.ts
+++ b/src/tests/end-to-end/tests/popup/adhoc-panel.test.ts
@@ -65,7 +65,7 @@ describe('Popup -> Ad-hoc tools', () => {
             await popupPage.enableToggleByAriaLabel(toggleAriaLabel);
 
             await targetPage.bringToFront();
-            expect(await targetPage.getShadowRootHtmlSnapshot()).toMatchSnapshot();
+            expect(await targetPage.waitForShadowRootHtmlSnapshot()).toMatchSnapshot();
         },
     );
 });

--- a/src/tests/end-to-end/tests/target-page/issue-dialog.test.ts
+++ b/src/tests/end-to-end/tests/target-page/issue-dialog.test.ts
@@ -31,9 +31,7 @@ describe('Target Page issue dialog', () => {
 
         await targetPage.bringToFront();
 
-        const shadowRoot = await targetPage.getShadowRoot();
-        await targetPage.clickDescendentSelector(shadowRoot, TargetPageInjectedComponentSelectors.failureLabel, { visible: true });
-
+        await targetPage.clickSelectorInShadowRoot(TargetPageInjectedComponentSelectors.failureLabel);
         await targetPage.waitForSelector(TargetPageInjectedComponentSelectors.issueDialog);
 
         const results = await scanForAccessibilityIssues(targetPage, TargetPageInjectedComponentSelectors.issueDialog);

--- a/src/tests/end-to-end/tests/target-page/tabstop.test.ts
+++ b/src/tests/end-to-end/tests/target-page/tabstop.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
-import { TabStopShadowDomSelectors, TargetPageInjectedComponentSelectors } from '../../common/element-identifiers/target-page-selectors';
+import { TabStopShadowDomSelectors } from '../../common/element-identifiers/target-page-selectors';
 import { PopupPage } from '../../common/page-controllers/popup-page';
 import { TargetPage } from '../../common/page-controllers/target-page';
 

--- a/src/tests/end-to-end/tests/target-page/tabstop.test.ts
+++ b/src/tests/end-to-end/tests/target-page/tabstop.test.ts
@@ -1,14 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ElementHandle } from 'puppeteer';
-
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
 import { TabStopShadowDomSelectors, TargetPageInjectedComponentSelectors } from '../../common/element-identifiers/target-page-selectors';
 import { PopupPage } from '../../common/page-controllers/popup-page';
 import { TargetPage } from '../../common/page-controllers/target-page';
 
-describe('tabstop tests', () => {
+describe('Tab stops visualization', () => {
     let browser: Browser;
     let targetPage: TargetPage;
     let popupPage: PopupPage;
@@ -24,36 +22,35 @@ describe('tabstop tests', () => {
         }
     });
 
-    test('works when tabstop is triggered from adhoc panel', async () => {
+    it('should show the expected visuals in the target page after enabling from popup and tabbing through target page', async () => {
         popupPage = await browser.newPopupPage(targetPage);
         await popupPage.gotoAdhocPanel();
         await popupPage.enableToggleByAriaLabel('Tab stops');
 
         await targetPage.bringToFront();
+        await targetPage.waitForShadowRoot();
 
+        // Should highlight first element with a transparent circle
         await targetPage.keyPress('Tab');
-        await targetPage.keyPress('Tab');
-        await targetPage.keyPress('Tab');
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.svg);
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.transparentEllipse);
 
-        const shadowRoot = await targetPage.getShadowRoot();
-        await targetPage.waitForDescendentSelector(shadowRoot, TargetPageInjectedComponentSelectors.tabStopVisulizationStart, {
-            visible: true,
-        });
+        // Should highlight second element with a transparent circle and change first element's
+        // highlight to an opaque circle with a "1" in it, connected by a line
+        await targetPage.keyPress('Tab');
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.svg);
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.transparentEllipse);
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.opaqueEllipse);
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.lines);
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.text);
 
-        await validateTabStopVisualizationOnTargetPage(shadowRoot);
+        // Only 2 focusable elements on this test page, so should move focus to the browser chrome
+        // without changing the visualizations
+        await targetPage.keyPress('Tab');
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.svg);
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.transparentEllipse);
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.opaqueEllipse);
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.lines);
+        await targetPage.waitForSelectorInShadowRoot(TabStopShadowDomSelectors.text);
     });
-
-    async function validateTabStopVisualizationOnTargetPage(shadowRoot: ElementHandle<Element>): Promise<void> {
-        const svgs = await shadowRoot.$$(TabStopShadowDomSelectors.svg);
-        const ellipses = await shadowRoot.$$(TabStopShadowDomSelectors.ellipse);
-        const lines = await shadowRoot.$$(TabStopShadowDomSelectors.lines);
-        const texts = await shadowRoot.$$(TabStopShadowDomSelectors.text);
-
-        // 3 tabs produce 1 svg, 2 ellipses, 1 texts and 1 line between them
-
-        expect(svgs).toHaveLength(1);
-        expect(ellipses).toHaveLength(2);
-        expect(lines).toHaveLength(1);
-        expect(texts).toHaveLength(1);
-    }
 });

--- a/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
+++ b/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
@@ -31,10 +31,7 @@ describe('Target Page visualization boxes', () => {
     it.each(adhocTools)('for adhoc tool "%s" should pass accessibility validation', async adhocTool => {
         await popupPage.enableToggleByAriaLabel(adhocTool);
 
-        const shadowRoot = await targetPage.getShadowRoot();
-        await targetPage.waitForDescendentSelector(shadowRoot, TargetPageInjectedComponentSelectors.insightsVisualizationBox, {
-            visible: true,
-        });
+        await targetPage.waitForSelectorInShadowRoot(TargetPageInjectedComponentSelectors.insightsVisualizationBox, { visible: true });
 
         const results = await scanForAccessibilityIssues(targetPage, TargetPageInjectedComponentSelectors.insightsRootContainer);
         expect(results).toHaveLength(0);


### PR DESCRIPTION
#### Description of changes

This PR aims to improve an e2e reliability issue that already existed but was exacerbated by #1717 (see [motivating failure](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=51673)), where the tabstop tests attempt to interact with the tab stop visualization on the target page before they verify that the target page visualizations are in a ready state. With this PR:

* The test now waits for the injected shadow root to be present on the target page before attempting to issue "Tab" keystrokes
* The test's expectations about the resulting tab stop visualizations are now in the form of "expect visualization to reach target state within timeout", rather than "expect visualization state to be X right now"

Cleans up a little page controller method naming nearby as well.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
