### PR TITLE
fix: "turn on automated checks" text is outdated

### DIFF
--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -183,11 +183,21 @@ export class IssuesTable extends React.Component<IssuesTableProps> {
         const isCardsUIEnabled = this.props.featureFlags[FeatureFlags.universalCardsUI];
         const commandBar = !isCardsUIEnabled ? this.renderCommandBar() : null;
 
+        const disabledMessage = isCardsUIEnabled ? (
+            <span>
+                Use the <Markup.Term>start over</Markup.Term> button to scan the target page.
+            </span>
+        ) : (
+            <span>
+                Turn on <Markup.Term>{this.configuration.displayableData.title}</Markup.Term> to see a list of failures.
+            </span>
+        );
+
         return (
             <>
                 {commandBar}
                 <div className="details-disabled-message" role="alert">
-                    Turn on <Markup.Term>{this.configuration.displayableData.title}</Markup.Term> to see a list of failures.
+                    {disabledMessage}
                 </div>
             </>
         );

--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -185,7 +185,7 @@ export class IssuesTable extends React.Component<IssuesTableProps> {
 
         const disabledMessage = isCardsUIEnabled ? (
             <span>
-                Use the <Markup.Term>start over</Markup.Term> button to scan the target page.
+                Use the <Markup.Term>Start over</Markup.Term> button to scan the target page.
             </span>
         ) : (
             <span>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`IssuesTableTest automated checks disabled 1`] = `
+exports[`IssuesTableTest automated checks disabled universalCardsUI = false 1`] = `
 <div
   className="issues-table"
 >
@@ -33,6 +33,34 @@ exports[`IssuesTableTest automated checks disabled 1`] = `
             Automated checks
           </Term>
            to see a list of failures.
+        </span>
+      </div>
+    </React.Fragment>
+  </div>
+</div>
+`;
+
+exports[`IssuesTableTest automated checks disabled universalCardsUI = true 1`] = `
+<div
+  className="issues-table"
+>
+  <h1>
+    test title
+  </h1>
+  <div
+    className="issues-table-content"
+  >
+    <React.Fragment>
+      <div
+        className="details-disabled-message"
+        role="alert"
+      >
+        <span>
+          Use the 
+          <Term>
+            Start over
+          </Term>
+           button to scan the target page.
         </span>
       </div>
     </React.Fragment>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
@@ -27,11 +27,13 @@ exports[`IssuesTableTest automated checks disabled 1`] = `
         className="details-disabled-message"
         role="alert"
       >
-        Turn on 
-        <Term>
-          Automated checks
-        </Term>
-         to see a list of failures.
+        <span>
+          Turn on 
+          <Term>
+            Automated checks
+          </Term>
+           to see a list of failures.
+        </span>
       </div>
     </React.Fragment>
   </div>

--- a/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { DateProvider } from 'common/date-provider';
+import { FeatureFlags } from 'common/feature-flags';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { IssuesTable, IssuesTableDeps, IssuesTableProps } from 'DetailsView/components/issues-table';
 import { DetailsRowData, IssuesTableHandler } from 'DetailsView/components/issues-table-handler';
@@ -44,22 +45,25 @@ describe('IssuesTableTest', () => {
         expect(wrapped.debug()).toMatchSnapshot();
     });
 
-    it('automated checks disabled', () => {
-        const issuesEnabled = false;
-        const selectionMock = Mock.ofType<ISelection>(Selection);
+    describe('automated checks disabled', () => {
+        it.each([false, true])('universalCardsUI = %s', universalCardsUI => {
+            const issuesEnabled = false;
+            const selectionMock = Mock.ofType<ISelection>(Selection);
 
-        const toggleClickHandlerMock = Mock.ofInstance(event => {});
+            const toggleClickHandlerMock = Mock.ofInstance(event => {});
 
-        const props = new TestPropsBuilder()
-            .setDeps(deps)
-            .setIssuesEnabled(issuesEnabled)
-            .setIssuesSelection(selectionMock.object)
-            .setToggleClickHandler(toggleClickHandlerMock.object)
-            .build();
+            const props = new TestPropsBuilder()
+                .setFeatureFlag(FeatureFlags.universalCardsUI, universalCardsUI)
+                .setDeps(deps)
+                .setIssuesEnabled(issuesEnabled)
+                .setIssuesSelection(selectionMock.object)
+                .setToggleClickHandler(toggleClickHandlerMock.object)
+                .build();
 
-        const wrapped = shallow(<IssuesTable {...props} />);
+            const wrapped = shallow(<IssuesTable {...props} />);
 
-        expect(wrapped.getElement()).toMatchSnapshot();
+            expect(wrapped.getElement()).toMatchSnapshot();
+        });
     });
 
     it('spinner for scanning state', () => {


### PR DESCRIPTION
#### Description of changes

Using the cards ui feature flag to make the text different when the automated checks are disabled.

**Fix for cards ui**
![01 - disabled message cards ui](https://user-images.githubusercontent.com/2837582/69684750-8f02e500-106e-11ea-81b9-81386b80638b.png)

**Not changed for details list**
![02 - disabled message details list](https://user-images.githubusercontent.com/2837582/69684757-932f0280-106e-11ea-9859-8b03a33464d4.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1754
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
