### PR TITLE
refactor: promisify create notification

### DIFF
--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ExtensionTypes, Permissions, Tabs } from 'webextension-polyfill-ts';
+import { ExtensionTypes, Notifications, Permissions, Tabs } from 'webextension-polyfill-ts';
 
 export interface BrowserAdapter {
     getAllWindows(getInfo: chrome.windows.GetInfo, callback: (chromeWindows: chrome.windows.Window[]) => void): void;
@@ -24,6 +24,7 @@ export interface BrowserAdapter {
     insertCSSInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void>;
     getRunTimeId(): string;
     createNotification(options: chrome.notifications.NotificationOptions): void;
+    createNotificationP(options: Notifications.CreateNotificationOptions): Promise<string>;
     getRuntimeLastError(): chrome.runtime.LastError;
     isAllowedFileSchemeAccess(callback: Function): void;
     addListenerToLocalStorage(callback: (changes: object) => void): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -23,7 +23,6 @@ export interface BrowserAdapter {
     executeScriptInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]>;
     insertCSSInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void>;
     getRunTimeId(): string;
-    createNotification(options: chrome.notifications.NotificationOptions): void;
     createNotificationP(options: Notifications.CreateNotificationOptions): Promise<string>;
     getRuntimeLastError(): chrome.runtime.LastError;
     isAllowedFileSchemeAccess(callback: Function): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -23,7 +23,7 @@ export interface BrowserAdapter {
     executeScriptInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]>;
     insertCSSInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void>;
     getRunTimeId(): string;
-    createNotificationP(options: Notifications.CreateNotificationOptions): Promise<string>;
+    createNotification(options: Notifications.CreateNotificationOptions): Promise<string>;
     getRuntimeLastError(): chrome.runtime.LastError;
     isAllowedFileSchemeAccess(callback: Function): void;
     addListenerToLocalStorage(callback: (changes: object) => void): void;

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { browser, ExtensionTypes, Permissions, Tabs, Notifications } from 'webextension-polyfill-ts';
+import { browser, ExtensionTypes, Notifications, Permissions, Tabs } from 'webextension-polyfill-ts';
 import { BrowserAdapter } from './browser-adapter';
 import { CommandsAdapter } from './commands-adapter';
 import { StorageAdapter } from './storage-adapter';

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { browser, ExtensionTypes, Permissions, Tabs } from 'webextension-polyfill-ts';
+import { browser, ExtensionTypes, Permissions, Tabs, Notifications } from 'webextension-polyfill-ts';
 import { BrowserAdapter } from './browser-adapter';
 import { CommandsAdapter } from './commands-adapter';
 import { StorageAdapter } from './storage-adapter';
@@ -142,6 +142,10 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
 
     public createNotification(options: chrome.notifications.NotificationOptions): void {
         chrome.notifications.create(options);
+    }
+
+    public createNotificationP(options: Notifications.CreateNotificationOptions): Promise<string> {
+        return browser.notifications.create(options);
     }
 
     public isAllowedFileSchemeAccess(callback: (isAllowed: boolean) => void): void {

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -140,10 +140,6 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return chrome.runtime.lastError;
     }
 
-    public createNotification(options: chrome.notifications.NotificationOptions): void {
-        chrome.notifications.create(options);
-    }
-
     public createNotificationP(options: Notifications.CreateNotificationOptions): Promise<string> {
         return browser.notifications.create(options);
     }

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -140,7 +140,7 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return chrome.runtime.lastError;
     }
 
-    public createNotificationP(options: Notifications.CreateNotificationOptions): Promise<string> {
+    public createNotification(options: Notifications.CreateNotificationOptions): Promise<string> {
         return browser.notifications.create(options);
     }
 

--- a/src/common/notification-creator.ts
+++ b/src/common/notification-creator.ts
@@ -8,13 +8,10 @@ import { BrowserAdapter } from './browser-adapters/browser-adapter';
 import { VisualizationConfigurationFactory } from './configs/visualization-configuration-factory';
 
 export class NotificationCreator {
-    private browserAdapter: BrowserAdapter;
-    private visualizationConfigurationFactory: VisualizationConfigurationFactory;
-
-    constructor(browserAdapter: BrowserAdapter, visualizationConfigurationFactory: VisualizationConfigurationFactory) {
-        this.browserAdapter = browserAdapter;
-        this.visualizationConfigurationFactory = visualizationConfigurationFactory;
-    }
+    constructor(
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly visualizationConfigurationFactory: VisualizationConfigurationFactory,
+    ) {}
 
     public createNotification(message: string): void {
         if (message) {

--- a/src/common/notification-creator.ts
+++ b/src/common/notification-creator.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { VisualizationType } from 'common/types/visualization-type';
 import * as _ from 'lodash';
+import { DictionaryStringTo } from 'types/common-types';
 
-import { VisualizationType } from '../common/types/visualization-type';
-import { DictionaryStringTo } from '../types/common-types';
 import { BrowserAdapter } from './browser-adapters/browser-adapter';
 import { VisualizationConfigurationFactory } from './configs/visualization-configuration-factory';
 
@@ -19,12 +19,14 @@ export class NotificationCreator {
     public createNotification(message: string): void {
         if (message) {
             const manifest = this.browserAdapter.getManifest();
-            this.browserAdapter.createNotification({
-                type: 'basic',
-                message: message,
-                title: manifest.name,
-                iconUrl: '../' + manifest.icons[128],
-            });
+            this.browserAdapter
+                .createNotificationP({
+                    type: 'basic',
+                    message: message,
+                    title: manifest.name,
+                    iconUrl: '../' + manifest.icons[128],
+                })
+                .catch(console.error);
         }
     }
 

--- a/src/common/notification-creator.ts
+++ b/src/common/notification-creator.ts
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { VisualizationType } from 'common/types/visualization-type';
-import * as _ from 'lodash';
+import { isEmpty } from 'lodash';
 import { DictionaryStringTo } from 'types/common-types';
 
 import { BrowserAdapter } from './browser-adapters/browser-adapter';
@@ -11,6 +13,7 @@ export class NotificationCreator {
     constructor(
         private readonly browserAdapter: BrowserAdapter,
         private readonly visualizationConfigurationFactory: VisualizationConfigurationFactory,
+        private readonly logger: Logger = createDefaultLogger(),
     ) {}
 
     public createNotification(message: string): void {
@@ -23,7 +26,7 @@ export class NotificationCreator {
                     title: manifest.name,
                     iconUrl: '../' + manifest.icons[128],
                 })
-                .catch(console.error);
+                .catch(this.logger.error);
         }
     }
 
@@ -32,9 +35,10 @@ export class NotificationCreator {
         key: string,
         visualizationType: VisualizationType,
     ): void {
-        if (_.isEmpty(selectorMap)) {
+        if (isEmpty(selectorMap)) {
             const configuration = this.visualizationConfigurationFactory.getConfiguration(visualizationType);
             const notificationMessage = configuration.getNotificationMessage(selectorMap, key);
+
             if (notificationMessage != null) {
                 this.createNotification(notificationMessage);
             }

--- a/src/common/notification-creator.ts
+++ b/src/common/notification-creator.ts
@@ -20,7 +20,7 @@ export class NotificationCreator {
         if (message) {
             const manifest = this.browserAdapter.getManifest();
             this.browserAdapter
-                .createNotificationP({
+                .createNotification({
                     type: 'basic',
                     message: message,
                     title: manifest.name,

--- a/src/tests/unit/tests/common/notification-creator.test.ts
+++ b/src/tests/unit/tests/common/notification-creator.test.ts
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { NotificationCreator } from 'common/notification-creator';
+import { VisualizationType } from 'common/types/visualization-type';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
-import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
-import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
-import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
-import { NotificationCreator } from '../../../../common/notification-creator';
-import { VisualizationType } from '../../../../common/types/visualization-type';
 
 describe('NotificationCreator', () => {
     let browserAdapterMock: IMock<BrowserAdapter>;
@@ -15,6 +14,7 @@ describe('NotificationCreator', () => {
     let testObject: NotificationCreator;
     const key: string = 'the-key';
     const visualizationType: VisualizationType = -1;
+    const manifestStub: chrome.runtime.Manifest = { name: 'testname', icons: { 128: 'iconUrl' } } as any;
 
     beforeEach(() => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
@@ -31,24 +31,20 @@ describe('NotificationCreator', () => {
     test('createNotification, happy path', () => {
         const notificationMessage = 'the-message';
 
-        browserAdapterMock
-            .setup(x => x.getManifest())
-            .returns(() => {
-                return { name: 'testname', icons: { 128: 'iconUrl' } } as any;
-            })
-            .verifiable(Times.once());
+        browserAdapterMock.setup(adapter => adapter.getManifest()).returns(() => manifestStub);
 
         browserAdapterMock
-            .setup(x => x.createNotification(It.isAny()))
-            .returns(message => {
-                const expectedMessage = {
-                    type: 'basic',
-                    message: notificationMessage,
-                    title: 'testname',
-                    iconUrl: '../iconUrl',
-                };
-                expect(message).toEqual(expectedMessage);
-            })
+            .setup(adapter =>
+                adapter.createNotificationP(
+                    It.isValue({
+                        type: 'basic',
+                        message: notificationMessage,
+                        title: 'testname',
+                        iconUrl: '../iconUrl',
+                    }),
+                ),
+            )
+            .returns(() => Promise.resolve('test-notification-id'))
             .verifiable(Times.once());
 
         testObject.createNotification(notificationMessage);
@@ -58,24 +54,20 @@ describe('NotificationCreator', () => {
     test('createNotificationByVisualizationKey, happy path', () => {
         const notificationMessage = 'the-message';
 
-        browserAdapterMock
-            .setup(x => x.getManifest())
-            .returns(() => {
-                return { name: 'testname', icons: { 128: 'iconUrl' } } as any;
-            })
-            .verifiable(Times.once());
+        browserAdapterMock.setup(adapter => adapter.getManifest()).returns(() => manifestStub);
 
         browserAdapterMock
-            .setup(x => x.createNotification(It.isAny()))
-            .returns(message => {
-                const expectedMessage = {
-                    type: 'basic',
-                    message: notificationMessage,
-                    title: 'testname',
-                    iconUrl: '../iconUrl',
-                };
-                expect(message).toEqual(expectedMessage);
-            })
+            .setup(adapter =>
+                adapter.createNotificationP(
+                    It.isValue({
+                        type: 'basic',
+                        message: notificationMessage,
+                        title: 'testname',
+                        iconUrl: '../iconUrl',
+                    }),
+                ),
+            )
+            .returns(() => Promise.resolve('test-notification-id'))
             .verifiable(Times.once());
 
         const selectorStub = {};

--- a/src/tests/unit/tests/common/notification-creator.test.ts
+++ b/src/tests/unit/tests/common/notification-creator.test.ts
@@ -35,7 +35,7 @@ describe('NotificationCreator', () => {
 
         browserAdapterMock
             .setup(adapter =>
-                adapter.createNotificationP(
+                adapter.createNotification(
                     It.isValue({
                         type: 'basic',
                         message: notificationMessage,
@@ -58,7 +58,7 @@ describe('NotificationCreator', () => {
 
         browserAdapterMock
             .setup(adapter =>
-                adapter.createNotificationP(
+                adapter.createNotification(
                     It.isValue({
                         type: 'basic',
                         message: notificationMessage,

--- a/src/tests/unit/tests/common/notification-creator.test.ts
+++ b/src/tests/unit/tests/common/notification-creator.test.ts
@@ -3,15 +3,19 @@
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { Logger } from 'common/logging/logger';
 import { NotificationCreator } from 'common/notification-creator';
 import { VisualizationType } from 'common/types/visualization-type';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { Notifications } from 'webextension-polyfill-ts';
 
 describe('NotificationCreator', () => {
     let browserAdapterMock: IMock<BrowserAdapter>;
     let configFactoryMock: IMock<VisualizationConfigurationFactory>;
     let getNotificationMessageMock: IMock<(selectorMap, key) => string>;
+    let loggerMock: IMock<Logger>;
     let testObject: NotificationCreator;
+
     const key: string = 'the-key';
     const visualizationType: VisualizationType = -1;
     const manifestStub: chrome.runtime.Manifest = { name: 'testname', icons: { 128: 'iconUrl' } } as any;
@@ -20,35 +24,54 @@ describe('NotificationCreator', () => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
         configFactoryMock = Mock.ofType(VisualizationConfigurationFactory, MockBehavior.Strict);
         getNotificationMessageMock = Mock.ofInstance(selector => null);
-        testObject = new NotificationCreator(browserAdapterMock.object, configFactoryMock.object);
+        loggerMock = Mock.ofType<Logger>();
+        testObject = new NotificationCreator(browserAdapterMock.object, configFactoryMock.object, loggerMock.object);
     });
 
-    test('createNotification, no message', () => {
-        testObject.createNotification(null);
-        verifyAll();
-    });
+    describe('createNotification', () => {
+        test('no message', () => {
+            testObject.createNotification(null);
+            verifyAll();
+        });
 
-    test('createNotification, happy path', () => {
-        const notificationMessage = 'the-message';
+        describe('with message', () => {
+            const notificationMessage = 'the-message';
+            const notificationOptions: Notifications.CreateNotificationOptions = {
+                type: 'basic',
+                message: notificationMessage,
+                title: 'testname',
+                iconUrl: '../iconUrl',
+            };
 
-        browserAdapterMock.setup(adapter => adapter.getManifest()).returns(() => manifestStub);
+            beforeEach(() => {
+                browserAdapterMock.setup(adapter => adapter.getManifest()).returns(() => manifestStub);
+            });
 
-        browserAdapterMock
-            .setup(adapter =>
-                adapter.createNotification(
-                    It.isValue({
-                        type: 'basic',
-                        message: notificationMessage,
-                        title: 'testname',
-                        iconUrl: '../iconUrl',
-                    }),
-                ),
-            )
-            .returns(() => Promise.resolve('test-notification-id'))
-            .verifiable(Times.once());
+            test('is created', () => {
+                browserAdapterMock
+                    .setup(adapter => adapter.createNotification(It.isValue(notificationOptions)))
+                    .returns(() => Promise.resolve('test-notification-id'))
+                    .verifiable(Times.once());
 
-        testObject.createNotification(notificationMessage);
-        verifyAll();
+                testObject.createNotification(notificationMessage);
+
+                verifyAll();
+            });
+
+            test('fails', () => {
+                const errorMessage = 'dummy error';
+
+                browserAdapterMock
+                    .setup(adapter => adapter.createNotification(It.isValue(notificationOptions)))
+                    .returns(() => Promise.reject(errorMessage))
+                    .verifiable(Times.once());
+
+                testObject.createNotification(notificationMessage);
+
+                loggerMock.verify(logger => logger.error(errorMessage), Times.once());
+                verifyAll();
+            });
+        });
     });
 
     test('createNotificationByVisualizationKey, happy path', () => {


### PR DESCRIPTION
#### Description of changes

This is part of a long-run refactor to promisify all (possible) `chrome.*` calls.

In this case, promisifying `createNotification`.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
