### PR TITLE
refactor: Moved element-snapshot-formatter to common directory for all tests

### DIFF
--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ElementHandle } from 'puppeteer';
-import { Page } from './page-controllers/page';
+import { Page } from '../end-to-end/common/page-controllers/page';
 
 export async function formatPageElementForSnapshot(page: Page, selector: string): Promise<Node> {
     const outerHtml = await page.getOuterHTMLOfSelector(selector);

--- a/src/tests/end-to-end/common/page-controllers/target-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/target-page.ts
@@ -3,7 +3,7 @@
 import { ElementHandle } from 'puppeteer';
 import * as Puppeteer from 'puppeteer';
 
-import { formatChildElementForSnapshot } from '../element-snapshot-formatter';
+import { formatChildElementForSnapshot } from 'tests/common/element-snapshot-formatter';
 import { getTestResourceUrl } from '../test-resources';
 import { Page, PageOptions } from './page';
 

--- a/src/tests/end-to-end/tests/common/settings-drop-down.test.ts
+++ b/src/tests/end-to-end/tests/common/settings-drop-down.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { formatPageElementForSnapshot } from 'tests/common/element-snapshot-formatter';
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
 import { CommonSelectors } from '../../common/element-identifiers/common-selectors';
-import { formatPageElementForSnapshot } from '../../common/element-snapshot-formatter';
 import { Page } from '../../common/page-controllers/page';
 import { TargetPage } from '../../common/page-controllers/target-page';
 import { scanForAccessibilityIssues } from '../../common/scan-for-accessibility-issues';

--- a/src/tests/end-to-end/tests/content/guidance-content.test.ts
+++ b/src/tests/end-to-end/tests/content/guidance-content.test.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { formatPageElementForSnapshot } from 'tests/common/element-snapshot-formatter';
 import { ContentPage } from 'tests/end-to-end/common/page-controllers/content-page';
 import { contentPages } from '../../../../content';
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
 import { GuidanceContentSelectors } from '../../common/element-identifiers/common-selectors';
-import { formatPageElementForSnapshot } from '../../common/element-snapshot-formatter';
 import { scanForAccessibilityIssues } from '../../common/scan-for-accessibility-issues';
 
 describe('Guidance Content pages', () => {

--- a/src/tests/end-to-end/tests/details-view/preview-features.test.ts
+++ b/src/tests/end-to-end/tests/details-view/preview-features.test.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { formatPageElementForSnapshot } from 'tests/common/element-snapshot-formatter';
 import { componentId } from '../../../../DetailsView/components/no-displayable-preview-features-message';
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
 import { CommonSelectors } from '../../common/element-identifiers/common-selectors';
 import { detailsViewSelectors } from '../../common/element-identifiers/details-view-selectors';
-import { formatPageElementForSnapshot } from '../../common/element-snapshot-formatter';
 import { DetailsViewPage } from '../../common/page-controllers/details-view-page';
 import { PopupPage } from '../../common/page-controllers/popup-page';
 import { TargetPage } from '../../common/page-controllers/target-page';

--- a/src/tests/end-to-end/tests/popup/first-time-dialog.test.ts
+++ b/src/tests/end-to-end/tests/popup/first-time-dialog.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { formatPageElementForSnapshot } from 'tests/common/element-snapshot-formatter';
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
 import { popupPageElementIdentifiers } from '../../common/element-identifiers/popup-page-element-identifiers';
-import { formatPageElementForSnapshot } from '../../common/element-snapshot-formatter';
 import { PopupPage } from '../../common/page-controllers/popup-page';
 import { TargetPage } from '../../common/page-controllers/target-page';
 import { scanForAccessibilityIssues } from '../../common/scan-for-accessibility-issues';

--- a/src/tests/end-to-end/tests/popup/hamburger-menu.test.ts
+++ b/src/tests/end-to-end/tests/popup/hamburger-menu.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { formatPageElementForSnapshot } from 'tests/common/element-snapshot-formatter';
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
 import { popupPageElementIdentifiers } from '../../common/element-identifiers/popup-page-element-identifiers';
-import { formatPageElementForSnapshot } from '../../common/element-snapshot-formatter';
 import { PopupPage } from '../../common/page-controllers/popup-page';
 import { TargetPage } from '../../common/page-controllers/target-page';
 import { scanForAccessibilityIssues } from '../../common/scan-for-accessibility-issues';

--- a/src/tests/end-to-end/tests/popup/launchpad.test.ts
+++ b/src/tests/end-to-end/tests/popup/launchpad.test.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { formatPageElementForSnapshot } from 'tests/common/element-snapshot-formatter';
 import { Browser } from '../../common/browser';
 import { launchBrowser } from '../../common/browser-factory';
 import { popupPageElementIdentifiers } from '../../common/element-identifiers/popup-page-element-identifiers';
-import { formatPageElementForSnapshot } from '../../common/element-snapshot-formatter';
 import { PopupPage } from '../../common/page-controllers/popup-page';
 import { TargetPage } from '../../common/page-controllers/target-page';
 import { scanForAccessibilityIssues } from '../../common/scan-for-accessibility-issues';

--- a/src/tests/unit/tests/reports/package/integration.test.ts
+++ b/src/tests/unit/tests/reports/package/integration.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { AxeResults } from 'axe-core';
 import { reporterFactory } from 'reports/package/reporter-factory';
-import { formatHtmlForSnapshot } from 'tests/end-to-end/common/element-snapshot-formatter';
+import { formatHtmlForSnapshot } from 'tests/common/element-snapshot-formatter';
 import { scanIssues } from 'tests/unit/tests/reports/package/scans/scan-issues';
 import { scanNoIssues } from 'tests/unit/tests/reports/package/scans/scan-no-issues';
 


### PR DESCRIPTION
#### Description of changes

Now that we are consuming element-snapshot-formatter in both unit and e2e tests it seemed right to move it to a common directory for shared code for any kind of test. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [n/a] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
