### PR TITLE
chore: update all uses of css modules to use import * as styles

### DIFF
--- a/src/DetailsView/components/action-and-cancel-buttons-component.tsx
+++ b/src/DetailsView/components/action-and-cancel-buttons-component.tsx
@@ -4,7 +4,7 @@ import { isEmpty } from 'lodash';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
-import { actionAndCancelButtonsComponent, actionCancelButtonCol } from './action-and-cancel-buttons-component.scss';
+import * as styles from './action-and-cancel-buttons-component.scss';
 
 export interface ActionAndCancelButtonsComponentProps {
     isHidden: boolean;
@@ -18,11 +18,11 @@ export interface ActionAndCancelButtonsComponentProps {
 export class ActionAndCancelButtonsComponent extends React.Component<ActionAndCancelButtonsComponentProps> {
     public render(): JSX.Element {
         return (
-            <div className={actionAndCancelButtonsComponent} hidden={this.props.isHidden}>
-                <div className={actionCancelButtonCol}>
+            <div className={styles.actionAndCancelButtonsComponent} hidden={this.props.isHidden}>
+                <div className={styles.actionCancelButtonCol}>
                     <DefaultButton text={'Cancel'} onClick={this.props.cancelButtonOnClick} />
                 </div>
-                <div className={actionCancelButtonCol}>
+                <div className={styles.actionCancelButtonCol}>
                     <DefaultButton
                         primary={true}
                         text={this.props.primaryButtonText}

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -15,7 +15,7 @@ import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag
 import { VisualizationType } from '../../common/types/visualization-type';
 import { ActionAndCancelButtonsComponent } from './action-and-cancel-buttons-component';
 import { FailureInstancePanelDetails } from './failure-instance-panel-details';
-import { editButton, failureInstancePanel, observedFailureTextfield } from './failure-instance-panel.scss';
+import * as styles from './failure-instance-panel.scss';
 import { GenericPanel, GenericPanelProps } from './generic-panel';
 
 export interface FailureInstancePanelControlProps {
@@ -104,7 +104,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
             );
         } else {
             return (
-                <Link className={editButton} onClick={this.openFailureInstancePanel}>
+                <Link className={styles.editButton} onClick={this.openFailureInstancePanel}>
                     <Icon iconName="edit" ariaLabel={'edit instance'} />
                 </Link>
             );
@@ -116,7 +116,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
 
         const panelProps: GenericPanelProps = {
             isOpen: this.state.isPanelOpen,
-            className: failureInstancePanel,
+            className: styles.failureInstancePanel,
             onDismiss: this.closeFailureInstancePanel,
             title:
                 this.props.actionType === CapturedInstanceActionType.CREATE
@@ -135,7 +135,7 @@ export class FailureInstancePanelControl extends React.Component<FailureInstance
                     featureFlagStoreData={this.props.featureFlagStoreData}
                 />
                 <TextField
-                    className={observedFailureTextfield}
+                    className={styles.observedFailureTextfield}
                     label="Comment"
                     styles={getStyles}
                     multiline={true}

--- a/src/DetailsView/components/no-content-available.tsx
+++ b/src/DetailsView/components/no-content-available.tsx
@@ -5,11 +5,11 @@ import { NamedFC } from 'common/react/named-fc';
 import { productName } from 'content/strings/application';
 import * as React from 'react';
 
-import { noContentAvailable } from './no-content-available.scss';
+import * as styles from './no-content-available.scss';
 
 export const NoContentAvailable = NamedFC('NoContentAvailable', () => {
     return (
-        <main className={noContentAvailable}>
+        <main className={styles.noContentAvailable}>
             <h1>No content available</h1>
             <ul>
                 <li>If the target page was closed, you can close this tab or reuse it for something else.</li>

--- a/src/DetailsView/components/overview-content/help-links.tsx
+++ b/src/DetailsView/components/overview-content/help-links.tsx
@@ -5,7 +5,7 @@ import { HyperlinkDefinition } from 'views/content/content-page';
 
 import { ExternalLink, ExternalLinkDeps } from '../../../common/components/external-link';
 import { NamedFC } from '../../../common/react/named-fc';
-import { helpLink } from './help-links.scss';
+import * as styles from './help-links.scss';
 
 export type HelpLinksDeps = ExternalLinkDeps;
 
@@ -19,7 +19,7 @@ export const HelpLinks = NamedFC('HelpLinks', (props: HelpLinksProps) => {
     return (
         <>
             {linkInformation.map((link: HyperlinkDefinition) => (
-                <div className={helpLink} key={link.href}>
+                <div className={styles.helpLink} key={link.href}>
                     <ExternalLink deps={props.deps} href={link.href}>
                         {link.text}
                     </ExternalLink>

--- a/src/DetailsView/components/overview-content/overview-content-container.tsx
+++ b/src/DetailsView/components/overview-content/overview-content-container.tsx
@@ -13,7 +13,7 @@ import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-f
 import { TabStoreData } from '../../../common/types/store-data/tab-store-data';
 import { DetailsViewActionMessageCreator } from '../../actions/details-view-action-message-creator';
 import { TargetChangeDialog, TargetChangeDialogDeps } from '../target-change-dialog';
-import { overviewHelpSection } from './overview-content-container.scss';
+import * as styles from './overview-content-container.scss';
 import { OverviewHeading } from './overview-heading';
 import { OverviewHelpSection, OverviewHelpSectionDeps } from './overview-help-section';
 
@@ -74,7 +74,7 @@ export const OverviewContainer = NamedFC<OverviewContainerProps>('OverviewContai
                 <OverviewHeading />
                 <AssessmentReportSummary summary={summaryData} />
             </section>
-            <section className={overviewHelpSection}>
+            <section className={styles.overviewHelpSection}>
                 <OverviewHelpSection linkDataSource={linkDataSource} deps={deps} />
             </section>
         </div>

--- a/src/DetailsView/components/overview-content/overview-heading.tsx
+++ b/src/DetailsView/components/overview-content/overview-heading.tsx
@@ -4,14 +4,14 @@ import { productName } from 'content/strings/application';
 import * as React from 'react';
 
 import { NamedFC } from '../../../common/react/named-fc';
-import { overviewHeading, overviewHeadingContent } from './overview-heading.scss';
+import * as styles from './overview-heading.scss';
 
 export const OverviewHeading = NamedFC('OverviewHeading', () => {
     return (
         <>
-            <div className={overviewHeading}>
+            <div className={styles.overviewHeading}>
                 <h1>Overview</h1>
-                <div className={overviewHeadingContent}>
+                <div className={styles.overviewHeadingContent}>
                     This page contains a summary that indicates the progress of your assessment. An assessment is a manual experience in
                     which you navigate through a set of tests that cover all WCAG 2.1 AA success criteria. Each test has one or more
                     requirements that can be:

--- a/src/DetailsView/components/overview-content/overview-help-section.tsx
+++ b/src/DetailsView/components/overview-content/overview-help-section.tsx
@@ -5,7 +5,7 @@ import { HyperlinkDefinition } from 'views/content/content-page';
 
 import { NamedFC } from '../../../common/react/named-fc';
 import { HelpLinks, HelpLinksDeps } from './help-links';
-import { helpHeading, overviewHelpContainer } from './overview-help-section.scss';
+import * as styles from './overview-help-section.scss';
 
 export type OverviewHelpSectionDeps = HelpLinksDeps;
 
@@ -16,8 +16,8 @@ export interface OverviewHelpSectionProps {
 
 export const OverviewHelpSection = NamedFC('OverviewHelpSection', (props: OverviewHelpSectionProps) => {
     return (
-        <section className={overviewHelpContainer}>
-            <h3 className={helpHeading}>Help</h3>
+        <section className={styles.overviewHelpContainer}>
+            <h3 className={styles.helpHeading}>Help</h3>
             <HelpLinks linkInformation={props.linkDataSource} deps={props.deps} />
         </section>
     );

--- a/src/DetailsView/components/requirement-link.tsx
+++ b/src/DetailsView/components/requirement-link.tsx
@@ -5,7 +5,7 @@ import { INavLink } from 'office-ui-fabric-react/lib/Nav';
 import * as React from 'react';
 
 import { ManualTestStatus } from '../../common/types/manual-test-status';
-import { reqDescription, reqIndex, reqName } from './requirement-link.scss';
+import * as styles from './requirement-link.scss';
 import { StatusIcon } from './status-icon';
 
 export interface RequirementLinkProps {
@@ -26,9 +26,9 @@ export class RequirementLink extends React.Component<RequirementLinkProps> {
 
     public renderRequirementDescriptionWithIndex(): JSX.Element {
         return (
-            <div className={css('ms-Button-label', reqDescription)}>
-                <span className={reqIndex}>{this.props.link.index}</span>
-                <span className={reqName}>{this.props.link.name}.</span>
+            <div className={css('ms-Button-label', styles.reqDescription)}>
+                <span className={styles.reqIndex}>{this.props.link.index}</span>
+                <span className={styles.reqName}>{this.props.link.name}.</span>
                 {this.props.link.description}
             </div>
         );
@@ -36,8 +36,8 @@ export class RequirementLink extends React.Component<RequirementLinkProps> {
 
     public renderRequirementDescriptionWithoutIndex(): JSX.Element {
         return (
-            <div className={css('ms-Button-label', reqDescription)}>
-                <span className={reqName}>{this.props.link.name}.</span>
+            <div className={css('ms-Button-label', styles.reqDescription)}>
+                <span className={styles.reqName}>{this.props.link.name}.</span>
                 {this.props.link.description}
             </div>
         );

--- a/src/DetailsView/components/test-status-choice-group.tsx
+++ b/src/DetailsView/components/test-status-choice-group.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 
 import { ManualTestStatus } from '../../common/types/manual-test-status';
 import { VisualizationType } from '../../common/types/visualization-type';
-import { radioButtonGroup, radioLabel, undoButton, undoButtonIcon } from './test-status-choice-group.scss';
+import * as styles from './test-status-choice-group.scss';
 
 export interface TestStatusChoiceGroupProps {
     test: VisualizationType;
@@ -42,7 +42,7 @@ export class TestStatusChoiceGroup extends React.Component<TestStatusChoiceGroup
     public render(): JSX.Element {
         return (
             <div>
-                <div className={radioButtonGroup}>
+                <div className={styles.radioButtonGroup}>
                     <ChoiceGroup
                         className={ManualTestStatus[this.props.status]}
                         onChange={this.onChange}
@@ -62,7 +62,7 @@ export class TestStatusChoiceGroup extends React.Component<TestStatusChoiceGroup
 
     private onRenderLabel = (option: IChoiceGroupOption): JSX.Element => {
         return (
-            <span id={option.labelId} className={radioLabel} aria-label={option.text}>
+            <span id={option.labelId} className={styles.radioLabel} aria-label={option.text}>
                 {this.props.isLabelVisible ? option.text : ''}
             </span>
         );
@@ -74,8 +74,8 @@ export class TestStatusChoiceGroup extends React.Component<TestStatusChoiceGroup
         }
 
         return (
-            <Link className={undoButton} onClick={this.onUndoClicked}>
-                <Icon className={undoButtonIcon} iconName="undo" ariaLabel={'undo'} />
+            <Link className={styles.undoButton} onClick={this.onUndoClicked}>
+                <Icon className={styles.undoButtonIcon} iconName="undo" ariaLabel={'undo'} />
             </Link>
         );
     }

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -16,7 +16,7 @@ import { IssueFilingServiceProperties, UserConfigurationStoreData } from '../../
 import { IssueFilingButtonDeps } from '../issue-filing-button';
 import { Toast, ToastDeps } from '../toast';
 import { CardInteractionSupport } from './card-interaction-support';
-import { kebabMenu, kebabMenuButton, kebabMenuCallout } from './card-kebab-menu-button.scss';
+import * as styles from './card-kebab-menu-button.scss';
 
 export type CardKebabMenuButtonDeps = {
     issueDetailsTextGenerator: IssueDetailsTextGenerator;
@@ -63,16 +63,16 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
             // calculation in this component's parent.
             <div onKeyDown={handleKeyDown}>
                 <ActionButton
-                    className={kebabMenuButton}
+                    className={styles.kebabMenuButton}
                     ariaLabel={this.props.kebabMenuAriaLabel || 'More actions'}
                     onRenderMenuIcon={MoreActionsMenuIcon}
                     menuProps={{
-                        className: kebabMenu,
+                        className: styles.kebabMenu,
                         directionalHint: DirectionalHint.bottomRightEdge,
                         shouldFocusOnMount: true,
                         items: this.getMenuItems(),
                         calloutProps: {
-                            className: kebabMenuCallout,
+                            className: styles.kebabMenuCallout,
                         },
                     }}
                 />

--- a/src/common/components/cards/how-to-fix-card-row.tsx
+++ b/src/common/components/cards/how-to-fix-card-row.tsx
@@ -6,7 +6,7 @@ import { CardRowProps } from '../../../common/configs/unified-result-property-co
 import { NamedFC } from '../../../common/react/named-fc';
 import { CheckType } from '../../../injected/components/details-dialog';
 import { FixInstructionPanel } from '../../../injected/components/fix-instruction-panel';
-import { howToFixContent } from './how-to-fix-card-row.scss';
+import * as styles from './how-to-fix-card-row.scss';
 import { SimpleCardRow } from './simple-card-row';
 
 export interface HowToFixWebPropertyData {
@@ -25,7 +25,7 @@ export const HowToFixWebCardRow = NamedFC<HowToFixWebCardRowProps>('HowToFixWebC
 
     const renderFixInstructionsContent = () => {
         return (
-            <div className={howToFixContent}>
+            <div className={styles.howToFixContent}>
                 <FixInstructionPanel
                     deps={deps}
                     checkType={CheckType.All}

--- a/src/common/components/cards/instance-details-footer.tsx
+++ b/src/common/components/cards/instance-details-footer.tsx
@@ -12,7 +12,7 @@ import * as React from 'react';
 
 import { CardInteractionSupport } from './card-interaction-support';
 import { CardKebabMenuButton, CardKebabMenuButtonDeps } from './card-kebab-menu-button';
-import { foot, highlightStatus } from './instance-details-footer.scss';
+import * as styles from './instance-details-footer.scss';
 
 export type HighlightState = 'visible' | 'hidden' | 'unavailable';
 
@@ -77,7 +77,7 @@ export const InstanceDetailsFooter = NamedFC<InstanceDetailsFooterProps>('Instan
         }[highlightState];
 
         return (
-            <div className={highlightStatus}>
+            <div className={styles.highlightStatus}>
                 {icon}
                 <Label>{label}</Label>
             </div>
@@ -85,7 +85,7 @@ export const InstanceDetailsFooter = NamedFC<InstanceDetailsFooterProps>('Instan
     };
 
     return (
-        <div className={foot}>
+        <div className={styles.foot}>
             {renderHighlightStatus()}
             {renderKebabMenu()}
         </div>

--- a/src/common/components/cards/instance-details-group.tsx
+++ b/src/common/components/cards/instance-details-group.tsx
@@ -9,7 +9,7 @@ import { TargetAppData, UnifiedRule } from '../../../common/types/store-data/uni
 import { CardRuleResult } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { InstanceDetails, InstanceDetailsDeps } from './instance-details';
-import { instanceDetailsList } from './instance-details-group.scss';
+import * as styles from './instance-details-group.scss';
 
 export type InstanceDetailsGroupDeps = {
     getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks;
@@ -33,7 +33,7 @@ export const InstanceDetailsGroup = NamedFC<InstanceDetailsGroupProps>('Instance
     };
 
     return (
-        <ul className={instanceDetailsList} aria-label="failed instances with path, snippet and how to fix information">
+        <ul className={styles.instanceDetailsList} aria-label="failed instances with path, snippet and how to fix information">
             {nodes.map((node, index) => (
                 <li key={`instance-details-${index}`}>
                     <InstanceDetails

--- a/src/common/components/cards/result-section-title.tsx
+++ b/src/common/components/cards/result-section-title.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import { InstanceOutcomeType } from '../../../reports/components/instance-outcome-type';
 import { OutcomeChip } from '../../../reports/components/outcome-chip';
-import { outcomeChipContainer, resultSectionTitle, title } from './result-section-title.scss';
+import * as styles from './result-section-title.scss';
 
 export type ResultSectionTitleProps = {
     title: string;
@@ -23,14 +23,14 @@ export const ResultSectionTitle = NamedFC<ResultSectionTitleProps>('ResultSectio
     );
 
     return (
-        <span className={resultSectionTitle}>
+        <span className={styles.resultSectionTitle}>
             <span className="screen-reader-only">
                 {props.title} {props.shouldAlertFailuresCount ? alertingFailuresCount : props.badgeCount}
             </span>
-            <span className={title} aria-hidden="true">
+            <span className={styles.title} aria-hidden="true">
                 {props.title}
             </span>
-            <span className={outcomeChipContainer} aria-hidden="true">
+            <span className={styles.outcomeChipContainer} aria-hidden="true">
                 <OutcomeChip outcomeType={props.outcomeType} count={props.badgeCount} />
             </span>
         </span>

--- a/src/common/components/cards/result-section.tsx
+++ b/src/common/components/cards/result-section.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 import { ResultSectionContent, ResultSectionContentDeps, ResultSectionContentProps } from './result-section-content';
 import { ResultSectionTitle, ResultSectionTitleProps } from './result-section-title';
-import { resultSection } from './result-section.scss';
+import * as styles from './result-section.scss';
 
 export type ResultSectionDeps = ResultSectionContentDeps;
 
@@ -20,7 +20,7 @@ export const ResultSection = NamedFC<ResultSectionProps>('ResultSection', props 
     const { containerClassName } = props;
 
     return (
-        <div className={css(containerClassName, resultSection)}>
+        <div className={css(containerClassName, styles.resultSection)}>
             <h2>
                 <ResultSectionTitle {...props} />
             </h2>

--- a/src/common/components/cards/rule-resources.tsx
+++ b/src/common/components/cards/rule-resources.tsx
@@ -8,7 +8,7 @@ import { UnifiedRule } from 'common/types/store-data/unified-data-interface';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 
-import { moreResourcesTitle, ruleDetailsId, ruleMoreResources } from './rule-resources.scss';
+import * as styles from './rule-resources.scss';
 
 export type RuleResourcesDeps = GuidanceTagsDeps;
 
@@ -22,7 +22,7 @@ export const RuleResources = NamedFC<RuleResourcesProps>('RuleResources', ({ dep
         return null;
     }
 
-    const renderTitle = () => <div className={moreResourcesTitle}>Resources for this rule</div>;
+    const renderTitle = () => <div className={styles.moreResourcesTitle}>Resources for this rule</div>;
 
     const renderRuleLink = () => {
         if (rule.url == null) {
@@ -32,7 +32,7 @@ export const RuleResources = NamedFC<RuleResourcesProps>('RuleResources', ({ dep
         const ruleId = rule.id;
         const ruleUrl = rule.url;
         return (
-            <span className={ruleDetailsId}>
+            <span className={styles.ruleDetailsId}>
                 <NewTabLink href={ruleUrl}>More information about {ruleId}</NewTabLink>
             </span>
         );
@@ -42,7 +42,7 @@ export const RuleResources = NamedFC<RuleResourcesProps>('RuleResources', ({ dep
     const renderGuidanceTags = () => <GuidanceTags deps={deps} links={rule.guidance} />;
 
     return (
-        <div className={ruleMoreResources}>
+        <div className={styles.ruleMoreResources}>
             {renderTitle()}
             {renderRuleLink()}
             <span>

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -13,7 +13,7 @@ import { CardRuleResult } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { CollapsibleComponentCardsProps } from './collapsible-component-cards';
 import { RuleContent, RuleContentDeps } from './rule-content';
-import { collapsibleRuleDetailsGroup, ruleDetailsGroup } from './rules-with-instances.scss';
+import * as styles from './rules-with-instances.scss';
 
 export type RulesWithInstancesDeps = RuleContentDeps & {
     collapsibleControl: (props: CollapsibleComponentCardsProps) => JSX.Element;
@@ -46,7 +46,7 @@ export const RulesWithInstances = NamedFC<RulesWithInstancesProps>(
                         targetAppInfo={targetAppInfo}
                     />
                 ),
-                containerClassName: css(collapsibleRuleDetailsGroup),
+                containerClassName: css(styles.collapsibleRuleDetailsGroup),
                 buttonAriaLabel: buttonAriaLabel,
                 headingLevel: 3,
                 deps: deps,
@@ -55,7 +55,7 @@ export const RulesWithInstances = NamedFC<RulesWithInstancesProps>(
         };
 
         return (
-            <div className={ruleDetailsGroup}>
+            <div className={styles.ruleDetailsGroup}>
                 {rules.map((rule, idx) => {
                     const { pastTense } = outcomeTypeSemantics[outcomeType];
                     const buttonAriaLabel = `${rule.id} ${rule.nodes.length} ${pastTense} ${rule.description}`;

--- a/src/common/components/scanning-spinner/scanning-spinner.tsx
+++ b/src/common/components/scanning-spinner/scanning-spinner.tsx
@@ -3,7 +3,7 @@
 import { NamedFC } from 'common/react/named-fc';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { scanningSpinner } from './scanning-spinner.scss';
+import * as styles from './scanning-spinner.scss';
 
 export type ScanningSpinnerProps = {
     isSpinning: boolean;
@@ -16,5 +16,13 @@ export const ScanningSpinner = NamedFC<ScanningSpinnerProps>('ScanningSpinner', 
         return null;
     }
 
-    return <Spinner className={scanningSpinner} size={SpinnerSize.large} label={props.label} role="alert" aria-live={props['aria-live']} />;
+    return (
+        <Spinner
+            className={styles.scanningSpinner}
+            size={SpinnerSize.large}
+            label={props.label}
+            role="alert"
+            aria-live={props['aria-live']}
+        />
+    );
 });

--- a/src/common/components/toast.tsx
+++ b/src/common/components/toast.tsx
@@ -3,7 +3,7 @@
 import { css } from '@uifabric/utilities';
 import * as React from 'react';
 import { WindowUtils } from '../window-utils';
-import { toastContainer, toastContent } from './toast.scss';
+import * as styles from './toast.scss';
 
 export type ToastDeps = {
     windowUtils: WindowUtils;
@@ -47,8 +47,8 @@ export class Toast extends React.Component<ToastProps, ToastState> {
 
     public render(): JSX.Element {
         return (
-            <div className={toastContainer} aria-live="polite">
-                {this.state.toastVisible ? <div className={css('ms-fadeIn100', toastContent)}>{this.state.content}</div> : null}
+            <div className={styles.toastContainer} aria-live="polite">
+                {this.state.toastVisible ? <div className={css('ms-fadeIn100', styles.toastContent)}>{this.state.content}</div> : null}
             </div>
         );
     }

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -21,7 +21,7 @@ import { ScreenshotView } from 'electron/views/screenshot/screenshot-view';
 import { ScreenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
 import * as React from 'react';
 
-import { automatedChecksPanelLayout, automatedChecksView } from './automated-checks-view.scss';
+import * as styles from './automated-checks-view.scss';
 import { CommandBar, CommandBarDeps } from './components/command-bar';
 import { HeaderSection } from './components/header-section';
 
@@ -72,9 +72,9 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
 
     private renderLayout(primaryContent: JSX.Element, optionalSidePanel?: JSX.Element): JSX.Element {
         return (
-            <div className={automatedChecksView}>
+            <div className={styles.automatedChecksView}>
                 <TitleBar deps={this.props.deps} windowStateStoreData={this.props.windowStateStoreData}></TitleBar>
-                <div className={automatedChecksPanelLayout}>
+                <div className={styles.automatedChecksPanelLayout}>
                     <div className={mainContentWrapper}>
                         <CommandBar
                             deps={this.props.deps}

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -8,7 +8,7 @@ import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import { CommandBar as UICommandBar, ICommandBarItemProps } from 'office-ui-fabric-react/lib/CommandBar';
 import * as React from 'react';
 
-import { buttonIcon, commandBar, menuItemButton } from './command-bar.scss';
+import * as styles from './command-bar.scss';
 
 export type CommandBarDeps = {
     scanActionCreator: ScanActionCreator;
@@ -28,10 +28,10 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: Command
         key: 'rescan',
         name: 'Rescan',
         iconProps: {
-            className: buttonIcon,
+            className: styles.buttonIcon,
             iconName: 'Refresh',
         },
-        className: menuItemButton,
+        className: styles.menuItemButton,
         onClick: onRescanClick,
         disabled: props.scanStoreData.status === ScanStatus.Scanning,
     };
@@ -40,5 +40,5 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: Command
     const items: ICommandBarItemProps[] = [rescanCommandBarItem];
     const farItems: ICommandBarItemProps[] = [];
 
-    return <UICommandBar items={items} farItems={farItems} className={commandBar} />;
+    return <UICommandBar items={items} farItems={farItems} className={styles.commandBar} />;
 });

--- a/src/electron/views/automated-checks/components/title-bar.tsx
+++ b/src/electron/views/automated-checks/components/title-bar.tsx
@@ -10,7 +10,7 @@ import { WindowStateStoreData } from 'electron/flux/types/window-state-store-dat
 import { WindowTitle, WindowTitleDeps } from 'electron/views/device-connect-view/components/window-title';
 import { BrandWhite } from 'icons/brand/white/brand-white';
 import { MaximizeRestoreButton } from './maximize-restore-button';
-import { titleBar } from './title-bar.scss';
+import * as styles from './title-bar.scss';
 
 export type TitleBarDeps = {
     windowFrameActionCreator: WindowFrameActionCreator;
@@ -64,7 +64,7 @@ export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps
             actionableIcons={icons}
             windowStateStoreData={props.windowStateStoreData}
             deps={props.deps}
-            className={titleBar}
+            className={styles.titleBar}
         >
             <BrandWhite />
         </WindowTitle>

--- a/src/electron/views/device-connect-view/components/device-connect-body.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-body.tsx
@@ -5,7 +5,7 @@ import { BrowserWindow } from 'electron';
 import * as React from 'react';
 
 import { DeviceConnectState } from '../../../flux/types/device-connect-state';
-import { deviceConnectBody } from './device-connect-body.scss';
+import * as styles from './device-connect-body.scss';
 import { DeviceConnectConnectedDevice } from './device-connect-connected-device';
 import { DeviceConnectFooter, DeviceConnectFooterDeps } from './device-connect-footer';
 import { DeviceConnectHeader } from './device-connect-header';
@@ -31,7 +31,7 @@ export const DeviceConnectBody = NamedFC<DeviceConnectBodyProps>('DeviceConnectB
     const canStartTesting = props.viewState.deviceConnectState === DeviceConnectState.Connected;
 
     return (
-        <div className={deviceConnectBody}>
+        <div className={styles.deviceConnectBody}>
             <DeviceConnectHeader />
             <DeviceConnectPortEntry deps={props.deps} viewState={{ deviceConnectState: props.viewState.deviceConnectState }} />
             <DeviceConnectConnectedDevice

--- a/src/electron/views/device-connect-view/components/device-connect-footer.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-footer.tsx
@@ -6,7 +6,7 @@ import { WindowStateActionCreator } from 'electron/flux/action-creator/window-st
 import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import * as React from 'react';
 
-import { deviceConnectFooter, footerButtonCancel, footerButtonStart } from './device-connect-footer.scss';
+import * as styles from './device-connect-footer.scss';
 
 export interface DeviceConnectFooterDeps {
     windowStateActionCreator: WindowStateActionCreator;
@@ -22,10 +22,10 @@ export interface DeviceConnectFooterProps {
 export const DeviceConnectFooter = NamedFC<DeviceConnectFooterProps>('DeviceConnectFooter', (props: DeviceConnectFooterProps) => {
     const onCancelClick = () => props.cancelClick();
     return (
-        <footer className={deviceConnectFooter}>
-            <DefaultButton className={footerButtonCancel} onClick={onCancelClick} text="Cancel"></DefaultButton>
+        <footer className={styles.deviceConnectFooter}>
+            <DefaultButton className={styles.footerButtonCancel} onClick={onCancelClick} text="Cancel"></DefaultButton>
             <PrimaryButton
-                className={footerButtonStart}
+                className={styles.footerButtonStart}
                 onClick={() => {
                     props.deps.windowStateActionCreator.setRoute({ routeId: 'resultsView' });
                     props.deps.windowFrameActionCreator.maximize();

--- a/src/electron/views/device-connect-view/components/device-connect-header.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-header.tsx
@@ -3,12 +3,12 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { deviceConnectHeader } from './device-connect-header.scss';
+import * as styles from './device-connect-header.scss';
 import { ElectronLink } from './electron-link';
 
 export const DeviceConnectHeader = NamedFC('DeviceConnectHeader', () => {
     return (
-        <header className={deviceConnectHeader}>
+        <header className={styles.deviceConnectHeader}>
             <h2>Connect to your android device</h2>
             <ElectronLink href="https://go.microsoft.com/fwlink/?linkid=2101252">How do I connect to my device?</ElectronLink>
         </header>

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 
 import { DeviceConnectActionCreator } from '../../../flux/action-creator/device-connect-action-creator';
 import { DeviceConnectState } from '../../../flux/types/device-connect-state';
-import { deviceConnectPortEntry, portNumberField } from './device-connect-port-entry.scss';
+import * as styles from './device-connect-port-entry.scss';
 
 export type DeviceConnectPortEntryViewState = {
     deviceConnectState: DeviceConnectState;
@@ -34,13 +34,13 @@ export class DeviceConnectPortEntry extends React.Component<DeviceConnectPortEnt
 
     public render(): JSX.Element {
         return (
-            <div className={deviceConnectPortEntry}>
+            <div className={styles.deviceConnectPortEntry}>
                 <h3>Android device port number</h3>
                 <MaskedTextField
                     ariaLabel="Port number"
                     onChange={this.onPortTextChanged}
                     placeholder="12345"
-                    className={portNumberField}
+                    className={styles.portNumberField}
                     maskChar=""
                     mask="99999"
                     onKeyDown={this.onEnterKey}

--- a/src/electron/views/device-connect-view/components/window-title.tsx
+++ b/src/electron/views/device-connect-view/components/window-title.tsx
@@ -7,7 +7,7 @@ import { PlatformInfo } from 'electron/window-management/platform-info';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 
-import { actionableIconsContainer, headerText, macWindowTitle, titleContainer, windowTitle } from './window-title.scss';
+import * as styles from './window-title.scss';
 
 export interface WindowTitleDeps {
     platformInfo: PlatformInfo;
@@ -26,16 +26,16 @@ export const WindowTitle = NamedFC<WindowTitleProps>('WindowTitle', (props: Wind
         return null;
     }
 
-    const windowTitleClassNames = [windowTitle, props.className];
+    const windowTitleClassNames = [styles.windowTitle, props.className];
 
     if (props.deps.platformInfo.isMac()) {
-        windowTitleClassNames.push(macWindowTitle);
+        windowTitleClassNames.push(styles.macWindowTitle);
     }
     return (
         <header className={css(...windowTitleClassNames)}>
-            <div className={titleContainer}>
+            <div className={styles.titleContainer}>
                 {props.children}
-                <h1 className={headerText}>{props.title}</h1>
+                <h1 className={styles.headerText}>{props.title}</h1>
             </div>
             {getIconsContainer(props)}
         </header>
@@ -44,7 +44,7 @@ export const WindowTitle = NamedFC<WindowTitleProps>('WindowTitle', (props: Wind
 
 function getIconsContainer(props: WindowTitleProps): JSX.Element {
     if (!props.deps.platformInfo.isMac() && !isEmpty(props.actionableIcons)) {
-        return <div className={actionableIconsContainer}>{props.actionableIcons}</div>;
+        return <div className={styles.actionableIconsContainer}>{props.actionableIcons}</div>;
     }
 
     return null;

--- a/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
@@ -5,7 +5,7 @@ import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import * as React from 'react';
 
-import { deviceDisconnectedPopup, titleContainer, titleText } from './device-disconnected-popup.scss';
+import * as styles from './device-disconnected-popup.scss';
 import { StatusCautionIcon } from './status-caution-icon';
 
 export type DeviceDisconnectedPopupProps = {
@@ -18,9 +18,9 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
     'DeviceDisconnectedPopup',
     ({ deviceName, onConnectNewDevice, onRescanDevice }) => {
         const title: JSX.Element = (
-            <div className={titleContainer}>
+            <div className={styles.titleContainer}>
                 <StatusCautionIcon />
-                <span className={titleText}>Device disconnected</span>
+                <span className={styles.titleText}>Device disconnected</span>
             </div>
         );
 
@@ -33,7 +33,7 @@ export const DeviceDisconnectedPopup = NamedFC<DeviceDisconnectedPopupProps>(
                 }}
                 modalProps={{
                     isBlocking: true,
-                    className: deviceDisconnectedPopup,
+                    className: styles.deviceDisconnectedPopup,
                 }}
                 hidden={false}
                 minWidth={416}

--- a/src/reports/components/report-sections/footer-section.tsx
+++ b/src/reports/components/report-sections/footer-section.tsx
@@ -6,12 +6,12 @@ import { NewTabLink } from 'common/components/new-tab-link';
 import { NamedFC } from 'common/react/named-fc';
 import { toolName } from 'content/strings/application';
 
-import { reportFooter, reportFooterContainer } from './footer-section.scss';
+import * as styles from './footer-section.scss';
 
 export const FooterSection = NamedFC('FooterSection', () => {
     return (
-        <div className={reportFooterContainer}>
-            <div className={reportFooter} role="contentinfo">
+        <div className={styles.reportFooterContainer}>
+            <div className={styles.reportFooter} role="contentinfo">
                 This automated checks result was generated using <b id="tool-name">{toolName}</b>, a tool that helps debug and find
                 accessibility issues earlier. Get more information & download this tool at{' '}
                 <NewTabLink

--- a/src/reports/components/report-sections/no-failed-instances-congrats.tsx
+++ b/src/reports/components/report-sections/no-failed-instances-congrats.tsx
@@ -3,13 +3,13 @@
 import * as React from 'react';
 
 import { NamedFC } from 'common/react/named-fc';
-import { reportCongratsHead, reportCongratsInfo, reportCongratsMessage } from './no-failed-instances-congrats.scss';
+import * as styles from './no-failed-instances-congrats.scss';
 
 export const NoFailedInstancesCongrats = NamedFC('NoFailedInstancesCongrats', () => {
     return (
-        <div className={reportCongratsMessage}>
-            <div className={reportCongratsHead}>Congratulations!</div>
-            <div className={reportCongratsInfo}>No failed automated checks were found.</div>
+        <div className={styles.reportCongratsMessage}>
+            <div className={styles.reportCongratsHead}>Congratulations!</div>
+            <div className={styles.reportCongratsInfo}>No failed automated checks were found.</div>
         </div>
     );
 });


### PR DESCRIPTION
#### Description of changes

Per today's Engineering Discussion, updating all imports of css modules to use `import * as styles from './this-component.scss'`

Intentionally leaves out-of-scope any secondary updates of import ordering/grouping.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
