### PR TITLE
refactor: promisify browserAdapter sendMessageTo* APIs

### DIFF
--- a/src/background/tab-context-broadcaster.ts
+++ b/src/background/tab-context-broadcaster.ts
@@ -1,16 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { StoreUpdateMessage } from '../common/types/store-update-message';
 
 export class TabContextBroadcaster {
-    constructor(private readonly browserAdapter: BrowserAdapter) {}
+    constructor(
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly logger: Logger = createDefaultLogger(),
+    ) {}
 
-    public getBroadcastMessageDelegate = (tabId): ((message: StoreUpdateMessage<any>) => void) => {
-        return message => {
+    public getBroadcastMessageDelegate = (
+        tabId,
+    ): ((message: StoreUpdateMessage<any>) => Promise<void>) => {
+        return async message => {
             message.tabId = tabId;
-            this.browserAdapter.sendMessageToFrames(message);
-            this.browserAdapter.sendMessageToTab(tabId, message);
+            await Promise.all([
+                this.browserAdapter.sendMessageToFrames(message).catch(this.logger.error),
+                this.browserAdapter.sendMessageToTab(tabId, message).catch(this.logger.error),
+            ]);
         };
     };
 }

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -48,7 +48,7 @@ export class TabContextFactory {
     ) {}
 
     public createTabContext(
-        broadcastMessage: (message) => void,
+        broadcastMessage: (message) => Promise<void>,
         browserAdapter: BrowserAdapter,
         detailsViewController: DetailsViewController,
         tabId: number,

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -16,9 +16,9 @@ export interface BrowserAdapter {
     closeTab(tabId: number): void;
     switchToTab(tabId: number): void;
     getTab(tabId: number, onResolve: (tab: chrome.tabs.Tab) => void, onReject?: () => void): void;
-    sendMessageToTab(tabId: number, message: any): void;
-    sendMessageToFrames(message: any): void;
-    sendMessageToAllFramesAndTabs(message: any): void;
+    sendMessageToTab(tabId: number, message: any): Promise<void>;
+    sendMessageToFrames(message: any): Promise<void>;
+    sendMessageToAllFramesAndTabs(message: any): Promise<void>;
     requestPermissions(permissions: Permissions.Permissions): Promise<boolean>;
     executeScriptInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]>;
     insertCSSInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<void>;

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -106,22 +106,17 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         });
     }
 
-    public sendMessageToTab(tabId: number, message: any): void {
-        chrome.tabs.sendMessage(tabId, message);
+    public sendMessageToTab(tabId: number, message: any): Promise<void> {
+        return browser.tabs.sendMessage(tabId, message);
     }
 
-    public sendMessageToAllFramesAndTabs(message: any): void {
-        chrome.runtime.sendMessage(message);
-
-        chrome.tabs.query({}, tabs => {
-            for (let i = 0; i < tabs.length; ++i) {
-                chrome.tabs.sendMessage(tabs[i].id, message);
-            }
-        });
+    public async sendMessageToAllFramesAndTabs(message: any): Promise<void> {
+        const allTabs = await browser.tabs.query({});
+        await Promise.all([browser.runtime.sendMessage(message), ...allTabs.map(tab => browser.tabs.sendMessage(tab.id, message))]);
     }
 
-    public sendMessageToFrames(message: any): void {
-        chrome.runtime.sendMessage(message);
+    public sendMessageToFrames(message: any): Promise<void> {
+        return browser.runtime.sendMessage(message);
     }
 
     public setUserData(items: Object): Promise<void> {

--- a/src/common/message-creators/remote-action-message-dispatcher.ts
+++ b/src/common/message-creators/remote-action-message-dispatcher.ts
@@ -1,18 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { PayloadWithEventName } from 'background/actions/action-payloads';
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { TelemetryData } from '../extension-telemetry-events';
 import { InterpreterMessage, Message } from '../message';
 import { Messages } from '../messages';
 import { ActionMessageDispatcher } from './types/dispatcher';
 
 export class RemoteActionMessageDispatcher implements ActionMessageDispatcher {
-    constructor(private postMessageDelegate: (message: InterpreterMessage) => void, private tabId: number) {}
+    constructor(
+        private readonly postMessageDelegate: (message: InterpreterMessage) => Promise<void>,
+        private readonly tabId: number,
+        private readonly logger: Logger = createDefaultLogger(),
+    ) {}
 
     public dispatchMessage(message: Message): void {
         const interpreterMessage = this.decorateWithTabId(message);
 
-        this.postMessageDelegate(interpreterMessage);
+        this.postMessageDelegate(interpreterMessage).catch(this.logger.error);
     }
 
     public dispatchType(messageType: string): void {

--- a/src/common/state-dispatcher.ts
+++ b/src/common/state-dispatcher.ts
@@ -1,15 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { StoreHub } from 'background/stores/store-hub';
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { BaseStore } from './base-store';
 import { GenericStoreMessageTypes } from './constants/generic-store-messages-types';
 import { StoreUpdateMessage } from './types/store-update-message';
 
 export class StateDispatcher {
-    private broadcastMessage: (message: StoreUpdateMessage<any>) => void;
-    private stores: StoreHub;
-
-    constructor(broadcastMessage: (message: Object) => void, stores: StoreHub) {
+    constructor(
+        private readonly broadcastMessage: (message: StoreUpdateMessage<any>) => Promise<void>,
+        private readonly stores: StoreHub,
+        private readonly logger: Logger = createDefaultLogger(),
+    ) {
         this.broadcastMessage = broadcastMessage;
         this.stores = stores;
     }
@@ -32,7 +35,7 @@ export class StateDispatcher {
                 type: GenericStoreMessageTypes.storeStateChanged,
                 storeType: this.stores.getStoreType(),
                 payload: store.getState(),
-            });
+            }).catch(this.logger.error);
         };
     };
 }

--- a/src/tests/unit/tests/background/global-context-factory.test.ts
+++ b/src/tests/unit/tests/background/global-context-factory.test.ts
@@ -36,7 +36,7 @@ describe('GlobalContextFactoryTest', () => {
         storageAdapterMock = Mock.ofType<StorageAdapter>();
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         commandsAdapterMock = Mock.ofType<CommandsAdapter>();
-        browserAdapterMock.setup(adapter => adapter.sendMessageToAllFramesAndTabs(It.isAny()));
+        browserAdapterMock.setup(adapter => adapter.sendMessageToAllFramesAndTabs(It.isAny())).returns(() => Promise.resolve());
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler);
         telemetryDataFactoryMock = Mock.ofType(TelemetryDataFactory);
         issueFilingServiceProviderMock = Mock.ofType(IssueFilingServiceProvider);

--- a/src/tests/unit/tests/background/tab-context-broadcaster.test.ts
+++ b/src/tests/unit/tests/background/tab-context-broadcaster.test.ts
@@ -11,7 +11,7 @@ describe('TabContextBroadcaster', () => {
     describe('getBroadcastMessageDelegate', () => {
         it('produces the expected BrowserAdapter calls when invoked', async () => {
             const testTabId = 1;
-            const testMessage = { someData: 1 } as any;
+            const testMessage = { someData: 'test data' } as any;
             const expectedMessage = { tabId: testTabId, ...testMessage } as StoreUpdateMessage<any>;
 
             const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
@@ -32,7 +32,7 @@ describe('TabContextBroadcaster', () => {
         });
 
         it('propagates errors from sendMessageToFrames to its logger', async () => {
-            const testMessage = { someData: 1 } as any;
+            const testMessage = { someData: 'test data' } as any;
             const expectedError = 'error from sendMessageToFrames';
 
             const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
@@ -49,7 +49,7 @@ describe('TabContextBroadcaster', () => {
         });
 
         it('propagates errors from sendMessageToTab to its logger', async () => {
-            const testMessage = { someData: 1 } as any;
+            const testMessage = { someData: 'test data' } as any;
             const expectedError = 'error from sendMessageToTab';
 
             const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);

--- a/src/tests/unit/tests/background/tab-context-broadcaster.test.ts
+++ b/src/tests/unit/tests/background/tab-context-broadcaster.test.ts
@@ -1,16 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Mock, MockBehavior, Times, It } from 'typemoq';
+import { It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { TabContextBroadcaster } from 'background/tab-context-broadcaster';
 import { Logger } from 'common/logging/logger';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { StoreUpdateMessage } from '../../../../common/types/store-update-message';
-import { tick } from 'tests/unit/common/tick';
 
 describe('TabContextBroadcaster', () => {
     describe('getBroadcastMessageDelegate', () => {
-        it('produces the expected BrowserAdapter calls when invoked', () => {
+        it('produces the expected BrowserAdapter calls when invoked', async () => {
             const testTabId = 1;
             const testMessage = { someData: 1 } as any;
             const expectedMessage = { tabId: testTabId, ...testMessage } as StoreUpdateMessage<any>;
@@ -27,7 +26,7 @@ describe('TabContextBroadcaster', () => {
 
             const testSubject = new TabContextBroadcaster(browserAdapterMock.object);
 
-            testSubject.getBroadcastMessageDelegate(1)(testMessage);
+            await testSubject.getBroadcastMessageDelegate(1)(testMessage);
 
             browserAdapterMock.verifyAll();
         });
@@ -44,8 +43,7 @@ describe('TabContextBroadcaster', () => {
             loggerMock.setup(m => m.error(expectedError)).verifiable(Times.once());
             const testSubject = new TabContextBroadcaster(browserAdapterMock.object, loggerMock.object);
 
-            testSubject.getBroadcastMessageDelegate(1)(testMessage);
-            await tick();
+            await testSubject.getBroadcastMessageDelegate(1)(testMessage);
 
             loggerMock.verifyAll();
         });
@@ -62,8 +60,7 @@ describe('TabContextBroadcaster', () => {
             loggerMock.setup(m => m.error(expectedError)).verifiable(Times.once());
             const testSubject = new TabContextBroadcaster(browserAdapterMock.object, loggerMock.object);
 
-            testSubject.getBroadcastMessageDelegate(1)(testMessage);
-            await tick();
+            await testSubject.getBroadcastMessageDelegate(1)(testMessage);
 
             loggerMock.verifyAll();
         });

--- a/src/tests/unit/tests/background/tab-context-broadcaster.test.ts
+++ b/src/tests/unit/tests/background/tab-context-broadcaster.test.ts
@@ -1,25 +1,71 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { Mock, MockBehavior, Times, It } from 'typemoq';
 
 import { TabContextBroadcaster } from 'background/tab-context-broadcaster';
+import { Logger } from 'common/logging/logger';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { StoreUpdateMessage } from '../../../../common/types/store-update-message';
+import { tick } from 'tests/unit/common/tick';
 
-describe('TabContextBroadcasterTest', () => {
-    test('getBroadcastMessageDelegate', () => {
-        const testTabId = 1;
-        const testMessage = { someData: 1 } as any;
-        const expectedMessage = { tabId: testTabId, ...testMessage } as StoreUpdateMessage<any>;
+describe('TabContextBroadcaster', () => {
+    describe('getBroadcastMessageDelegate', () => {
+        it('produces the expected BrowserAdapter calls when invoked', () => {
+            const testTabId = 1;
+            const testMessage = { someData: 1 } as any;
+            const expectedMessage = { tabId: testTabId, ...testMessage } as StoreUpdateMessage<any>;
 
-        const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
-        browserAdapterMock.setup(ba => ba.sendMessageToFrames(expectedMessage)).verifiable(Times.once());
-        browserAdapterMock.setup(ba => ba.sendMessageToTab(testTabId, expectedMessage)).verifiable(Times.once());
+            const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToFrames(expectedMessage))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToTab(testTabId, expectedMessage))
+                .returns(() => Promise.resolve())
+                .verifiable(Times.once());
 
-        const testSubject = new TabContextBroadcaster(browserAdapterMock.object);
+            const testSubject = new TabContextBroadcaster(browserAdapterMock.object);
 
-        testSubject.getBroadcastMessageDelegate(1)(testMessage);
+            testSubject.getBroadcastMessageDelegate(1)(testMessage);
 
-        browserAdapterMock.verifyAll();
+            browserAdapterMock.verifyAll();
+        });
+
+        it('propagates errors from sendMessageToFrames to its logger', async () => {
+            const testMessage = { someData: 1 } as any;
+            const expectedError = 'error from sendMessageToFrames';
+
+            const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
+            browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.reject(expectedError));
+            browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.resolve());
+
+            const loggerMock = Mock.ofType<Logger>();
+            loggerMock.setup(m => m.error(expectedError)).verifiable(Times.once());
+            const testSubject = new TabContextBroadcaster(browserAdapterMock.object, loggerMock.object);
+
+            testSubject.getBroadcastMessageDelegate(1)(testMessage);
+            await tick();
+
+            loggerMock.verifyAll();
+        });
+
+        it('propagates errors from sendMessageToTab to its logger', async () => {
+            const testMessage = { someData: 1 } as any;
+            const expectedError = 'error from sendMessageToTab';
+
+            const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
+            browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.resolve());
+            browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.reject(expectedError));
+
+            const loggerMock = Mock.ofType<Logger>();
+            loggerMock.setup(m => m.error(expectedError)).verifiable(Times.once());
+            const testSubject = new TabContextBroadcaster(browserAdapterMock.object, loggerMock.object);
+
+            testSubject.getBroadcastMessageDelegate(1)(testMessage);
+            await tick();
+
+            loggerMock.verifyAll();
+        });
     });
 });

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -46,7 +46,7 @@ describe('TabContextFactoryTest', () => {
     it('createInterpreter', () => {
         const tabId = -1;
         const windowUtilsStub = Mock.ofType(WindowUtils);
-        const broadcastMock = Mock.ofInstance(message => {}, MockBehavior.Strict);
+        const broadcastMock = Mock.ofType<(message: Object) => Promise<void>>(null, MockBehavior.Strict);
         const telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler);
         const targetTabControllerMock = Mock.ofType(TargetTabController);
         const assessmentStore = Mock.ofType(AssessmentStore);
@@ -67,6 +67,7 @@ describe('TabContextFactoryTest', () => {
         storeNames.forEach(storeName => {
             broadcastMock
                 .setup(bm => bm(It.isObjectWith({ storeId: StoreNames[storeName] } as StoreUpdateMessage<any>)))
+                .returns(() => Promise.resolve())
                 .verifiable(Times.once());
         });
 
@@ -99,6 +100,7 @@ describe('TabContextFactoryTest', () => {
 
         broadcastMock
             .setup(bm => bm(It.isObjectWith({ storeId: StoreNames[StoreNames.VisualizationScanResultStore] } as StoreUpdateMessage<any>)))
+            .returns(() => Promise.resolve())
             .verifiable(Times.once());
 
         tabContext.interpreter.interpret({

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -18,7 +18,7 @@ describe('TargetPageController', () => {
     let testSubject: TargetPageController;
 
     let mockLogger: IMock<Logger>;
-    const stubBroadcastDelegate = (message: any) => {};
+    const stubBroadcastDelegate = (message: any) => Promise.resolve();
     let mockBroadcasterStrictMock: IMock<TabContextBroadcaster>;
     let mockTabContextFactory: IMock<TabContextFactory>;
     let mockBrowserAdapter: SimulatedBrowserAdapter;

--- a/src/tests/unit/tests/common/message-creators/remote-action-message-dispatcher.test.ts
+++ b/src/tests/unit/tests/common/message-creators/remote-action-message-dispatcher.test.ts
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Logger } from 'common/logging/logger';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { BaseTelemetryData, TelemetryEventSource } from '../../../../../common/extension-telemetry-events';
 import { Message } from '../../../../../common/message';
 import { RemoteActionMessageDispatcher } from '../../../../../common/message-creators/remote-action-message-dispatcher';
 import { Messages } from '../../../../../common/messages';
-import { Resolver } from 'dns';
-import { Logger } from 'common/logging/logger';
 
 describe('RemoteActionMessageDispatcher', () => {
     let postMessageMock: IMock<(message: Message) => Promise<void>>;

--- a/src/tests/unit/tests/common/state-dispatcher.test.ts
+++ b/src/tests/unit/tests/common/state-dispatcher.test.ts
@@ -24,11 +24,11 @@ describe('StateDispatcherTest', () => {
         const storeMock: IMock<BaseStore<StoreStubData>> = Mock.ofType<BaseStore<StoreStubData>>();
         const storeHubStrictMock = Mock.ofType<StoreHubStub>(null, MockBehavior.Strict);
         storeHubStrictMock
-            .setup(x => x.getAllStores())
+            .setup(hub => hub.getAllStores())
             .returns(() => [storeMock.object])
             .verifiable(Times.once());
         storeHubStrictMock
-            .setup(x => x.getStoreType())
+            .setup(hub => hub.getStoreType())
             .returns(() => StoreType.TabContextStore)
             .verifiable(Times.once());
 
@@ -68,8 +68,8 @@ describe('StateDispatcherTest', () => {
         const storeMock: IMock<BaseStore<StoreStubData>> = Mock.ofType<BaseStore<StoreStubData>>();
         const storeHubMock = Mock.ofType<StoreHubStub>(null, MockBehavior.Strict);
 
-        storeHubMock.setup(x => x.getAllStores()).returns(() => [storeMock.object]);
-        storeHubMock.setup(x => x.getStoreType()).returns(() => StoreType.TabContextStore);
+        storeHubMock.setup(hub => hub.getAllStores()).returns(() => [storeMock.object]);
+        storeHubMock.setup(hub => hub.getStoreType()).returns(() => StoreType.TabContextStore);
         storeMock.setup(sm => sm.getId()).returns(() => expectedMessage.storeId);
         storeMock.setup(sm => sm.getState()).returns(() => newstoreData);
         storeMock
@@ -115,8 +115,8 @@ describe('StateDispatcherTest', () => {
         const storeMock: IMock<BaseStore<StoreStubData>> = Mock.ofType<BaseStore<StoreStubData>>();
         const storeHubMock = Mock.ofType<StoreHubStub>(null, MockBehavior.Strict);
 
-        storeHubMock.setup(x => x.getAllStores()).returns(() => [storeMock.object]);
-        storeHubMock.setup(x => x.getStoreType()).returns(() => StoreType.TabContextStore);
+        storeHubMock.setup(hub => hub.getAllStores()).returns(() => [storeMock.object]);
+        storeHubMock.setup(hub => hub.getStoreType()).returns(() => StoreType.TabContextStore);
         storeMock.setup(sm => sm.getId()).returns(() => expectedMessage.storeId);
         storeMock.setup(sm => sm.getState()).returns(() => newstoreData);
         storeMock

--- a/src/tests/unit/tests/common/state-dispatcher.test.ts
+++ b/src/tests/unit/tests/common/state-dispatcher.test.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { StoreHub } from 'background/stores/store-hub';
+import { Logger } from 'common/logging/logger';
+import { tick } from 'tests/unit/common/tick';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { BaseStore } from '../../../../common/base-store';
 import { GenericStoreMessageTypes } from '../../../../common/constants/generic-store-messages-types';
@@ -39,9 +41,11 @@ describe('StateDispatcherTest', () => {
             .returns(() => newstoreData)
             .verifiable();
 
-        const defaultBoardcastMessage = (message: Object) => {};
-        const broadcastMock = Mock.ofInstance<(message: Object) => void>(defaultBoardcastMessage);
-        broadcastMock.setup(bc => bc(It.isValue(expectedMessage))).verifiable();
+        const broadcastMock = Mock.ofType<(message: Object) => Promise<void>>();
+        broadcastMock
+            .setup(bc => bc(It.isValue(expectedMessage)))
+            .returns(() => Promise.resolve())
+            .verifiable();
 
         const stateDispatcher = new StateDispatcher(broadcastMock.object, storeHubStrictMock.object);
         stateDispatcher.initialize();
@@ -80,16 +84,69 @@ describe('StateDispatcherTest', () => {
                 privateDispatcher = action;
             });
 
-        const defaultBoardcastMessage = (message: Object) => {};
-        const broadcastMock = Mock.ofInstance<(message: Object) => void>(defaultBoardcastMessage);
+        const broadcastMock = Mock.ofType<(message: Object) => Promise<void>>();
+        broadcastMock.setup(m => m(It.isAny())).returns(() => Promise.resolve());
 
         const stateDispatcher = new StateDispatcher(broadcastMock.object, storeHubMock.object);
         stateDispatcher.initialize();
+
         broadcastMock.reset();
+        broadcastMock
+            .setup(m => m(expectedMessage))
+            .returns(() => Promise.resolve())
+            .verifiable(Times.once());
 
         privateDispatcher.call(stateDispatcher);
 
-        broadcastMock.verify(bc => bc(It.isValue(expectedMessage)), Times.once());
+        broadcastMock.verifyAll();
+    });
+
+    test('propagate exceptions in broadcasting changes to logger.error', async () => {
+        const newstoreData: StoreStubData = { value: 'testValue' };
+        const expectedMessage: StoreUpdateMessage<StoreStubData> = {
+            isStoreUpdateMessage: true,
+            type: GenericStoreMessageTypes.storeStateChanged,
+            storeId: 'testStoreId',
+            storeType: StoreType.TabContextStore,
+            payload: newstoreData,
+        };
+
+        let privateDispatcher: Function;
+        const storeMock: IMock<BaseStore<StoreStubData>> = Mock.ofType<BaseStore<StoreStubData>>();
+        const storeHubMock = Mock.ofType<StoreHubStub>(null, MockBehavior.Strict);
+
+        storeHubMock.setup(x => x.getAllStores()).returns(() => [storeMock.object]);
+        storeHubMock.setup(x => x.getStoreType()).returns(() => StoreType.TabContextStore);
+        storeMock.setup(sm => sm.getId()).returns(() => expectedMessage.storeId);
+        storeMock.setup(sm => sm.getState()).returns(() => newstoreData);
+        storeMock
+            .setup(sm =>
+                sm.addChangedListener(
+                    It.is<Function>(handler => {
+                        return handler !== null;
+                    }),
+                ),
+            )
+            .callback(action => {
+                privateDispatcher = action;
+            });
+
+        const expectedError = 'expected broadcastMessage error';
+        const broadcastMock = Mock.ofType<(message: Object) => Promise<void>>();
+        broadcastMock.setup(m => m(It.isAny())).returns(() => Promise.resolve());
+
+        const loggerMock = Mock.ofType<Logger>();
+        loggerMock.setup(m => m.error(expectedError)).verifiable(Times.once());
+        const stateDispatcher = new StateDispatcher(broadcastMock.object, storeHubMock.object, loggerMock.object);
+        stateDispatcher.initialize();
+
+        broadcastMock.reset();
+        broadcastMock.setup(m => m(It.isAny())).returns(() => Promise.reject(expectedError));
+
+        privateDispatcher.call(stateDispatcher);
+        await tick();
+
+        loggerMock.verifyAll();
     });
 });
 


### PR DESCRIPTION
#### Description of changes

Continues promisifying our assorted browserAdapter APIs

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
