### PR TITLE
refactor: move fix-instructions-panel to common folder from injected and move to css modules

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -1210,28 +1210,6 @@ div.insights-file-issue-details-dialog-container {
                             margin: 0px;
                             -webkit-padding-start: 20px;
                         }
-                        .fix-content {
-                            .insights-fix-instruction-list {
-                                li {
-                                    span.fix-instruction-color-box {
-                                        width: 14px;
-                                        height: 14px;
-                                        display: inline-block;
-                                        vertical-align: -15%;
-                                        margin: 0px 2px;
-                                        border: 1px solid $always-black;
-                                    }
-                                }
-                                .screen-reader-only {
-                                    position: absolute;
-                                    left: -10000px;
-                                    top: auto;
-                                    width: 1px;
-                                    height: 1px;
-                                    overflow: hidden;
-                                }
-                            }
-                        }
                     }
                     .issue-detail-select-message {
                         padding-top: 10px;

--- a/src/DetailsView/components/Issues-details-pane.tsx
+++ b/src/DetailsView/components/Issues-details-pane.tsx
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
+import { FixInstructionPanel, FixInstructionPanelDeps } from 'common/components/fix-instruction-panel';
 import { CopyIssueDetailsButton, CopyIssueDetailsButtonDeps } from '../../common/components/copy-issue-details-button';
 import { GuidanceLinks } from '../../common/components/guidance-links';
 import { GuidanceTags, GuidanceTagsDeps } from '../../common/components/guidance-tags';
@@ -13,7 +14,6 @@ import { CreateIssueDetailsTextData } from '../../common/types/create-issue-deta
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { UserConfigurationStoreData } from '../../common/types/store-data/user-configuration-store';
 import { CheckType } from '../../injected/components/details-dialog';
-import { FixInstructionPanel, FixInstructionPanelDeps } from '../../injected/components/fix-instruction-panel';
 import { DecoratedAxeNodeResult } from '../../injected/scanner-utils';
 import { AxeResultToIssueFilingDataConverter } from '../../issue-filing/rule-result-to-issue-filing-data';
 import { DictionaryStringTo } from '../../types/common-types';

--- a/src/DetailsView/components/Issues-details-pane.tsx
+++ b/src/DetailsView/components/Issues-details-pane.tsx
@@ -84,8 +84,8 @@ export class IssuesDetailsPane extends React.Component<IssuesDetailsPaneProps, I
         );
     }
 
-    private renderFixInstructionsTitleElement(titleText: string, className: string): JSX.Element {
-        return <div className={className}>{titleText}</div>;
+    private renderFixInstructionsTitleElement(titleText: string): JSX.Element {
+        return <div>{titleText}</div>;
     }
 
     private renderSingleIssue(result: DecoratedAxeNodeResult): JSX.Element {

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -34,6 +34,7 @@ import { provideBlob } from '../common/blob-provider';
 import { ChromeAdapter } from '../common/browser-adapters/chrome-adapter';
 import { allCardInteractionsSupported } from '../common/components/cards/card-interaction-support';
 import { CardsCollapsibleControl } from '../common/components/cards/collapsible-component-cards';
+import { FixInstructionProcessor } from '../common/components/fix-instruction-processor';
 import { NewTabLink } from '../common/components/new-tab-link';
 import { getPropertyConfiguration } from '../common/configs/unified-result-property-configurations';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -78,7 +79,6 @@ import { VisualizationStoreData } from '../common/types/store-data/visualization
 import { UrlParser } from '../common/url-parser';
 import { WindowUtils } from '../common/window-utils';
 import { contentPages } from '../content';
-import { FixInstructionProcessor } from '../injected/fix-instruction-processor';
 import { ScannerUtils } from '../injected/scanner-utils';
 import { createIssueDetailsBuilder } from '../issue-filing/common/create-issue-details-builder';
 import { IssueFilingUrlStringUtils } from '../issue-filing/common/issue-filing-url-string-utils';

--- a/src/common/components/cards/how-to-fix-card-row.scss
+++ b/src/common/components/cards/how-to-fix-card-row.scss
@@ -10,24 +10,4 @@
             margin-bottom: 4px;
         }
     }
-    :global(.insights-fix-instruction-list) {
-        li {
-            :global(span.fix-instruction-color-box) {
-                width: 14px;
-                height: 14px;
-                display: inline-block;
-                vertical-align: -5%;
-                margin: 0px 2px;
-                border: 1px solid $always-black;
-            }
-        }
-        .screen-reader-only {
-            position: absolute;
-            left: -10000px;
-            top: auto;
-            width: 1px;
-            height: 1px;
-            overflow: hidden;
-        }
-    }
 }

--- a/src/common/components/cards/how-to-fix-card-row.tsx
+++ b/src/common/components/cards/how-to-fix-card-row.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { CardRowProps } from '../../../common/configs/unified-result-property-configurations';
 import { NamedFC } from '../../../common/react/named-fc';
 import { CheckType } from '../../../injected/components/details-dialog';
-import { FixInstructionPanel } from '../../../injected/components/fix-instruction-panel';
+import { FixInstructionPanel } from '../fix-instruction-panel';
 import * as styles from './how-to-fix-card-row.scss';
 import { SimpleCardRow } from './simple-card-row';
 

--- a/src/common/components/cards/how-to-fix-card-row.tsx
+++ b/src/common/components/cards/how-to-fix-card-row.tsx
@@ -46,8 +46,8 @@ export const HowToFixWebCardRow = NamedFC<HowToFixWebCardRowProps>('HowToFixWebC
         return { message: s };
     };
 
-    const renderFixInstructionsTitleElement = (titleText: string, className: string) => {
-        return <div className={className}>{titleText}</div>;
+    const renderFixInstructionsTitleElement = (titleText: string) => {
+        return <div>{titleText}</div>;
     };
 
     return <SimpleCardRow label="How to fix" content={renderFixInstructionsContent()} rowKey={`how-to-fix-row-${props.index}`} />;

--- a/src/common/components/cards/result-section-content.tsx
+++ b/src/common/components/cards/result-section-content.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CardsVisualizationModifierButtonsProps } from 'common/components/cards/cards-visualization-modifier-buttons';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 
 import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { NamedFC } from 'common/react/named-fc';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 
 import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';

--- a/src/common/components/fix-instruction-panel.scss
+++ b/src/common/components/fix-instruction-panel.scss
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../styles/colors.scss';
+
+.insights-fix-instruction-list {
+    li {
+        span.fix-instruction-color-box {
+            width: 14px;
+            height: 14px;
+            display: inline-block;
+            vertical-align: -5%;
+            margin: 0px 2px;
+            border: 1px solid $always-black;
+        }
+    }
+
+    .screen-reader-only {
+        position: absolute;
+        left: -10000px;
+        top: auto;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+    }
+}

--- a/src/common/components/fix-instruction-panel.tsx
+++ b/src/common/components/fix-instruction-panel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { CheckType } from 'injected/components/details-dialog';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 import * as styles from './fix-instruction-panel.scss';
 

--- a/src/common/components/fix-instruction-panel.tsx
+++ b/src/common/components/fix-instruction-panel.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { CheckType } from 'injected/components/details-dialog';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 
-import { NamedFC } from '../../common/react/named-fc';
-import { FixInstructionProcessor } from '../fix-instruction-processor';
-import { CheckType } from './details-dialog';
+import { NamedFC } from '../react/named-fc';
 
 export interface FixInstructionPanelDeps {
     fixInstructionProcessor: FixInstructionProcessor;

--- a/src/common/components/fix-instruction-panel.tsx
+++ b/src/common/components/fix-instruction-panel.tsx
@@ -3,6 +3,7 @@
 import { CheckType } from 'injected/components/details-dialog';
 import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
+import * as styles from './fix-instruction-panel.scss';
 
 import { NamedFC } from '../react/named-fc';
 
@@ -47,8 +48,8 @@ export const FixInstructionPanel = NamedFC<FixInstructionPanelProps>('FixInstruc
 
     return (
         <div>
-            {props.renderTitleElement(title, 'insights-fix-instruction-title')}
-            <ul className="insights-fix-instruction-list">{renderInstructions(props.checkType)}</ul>
+            {props.renderTitleElement(title, null)}
+            <ul className={styles.insightsFixInstructionList}>{renderInstructions(props.checkType)}</ul>
         </div>
     );
 });

--- a/src/common/components/fix-instruction-panel.tsx
+++ b/src/common/components/fix-instruction-panel.tsx
@@ -15,7 +15,7 @@ export interface FixInstructionPanelProps {
     deps: FixInstructionPanelDeps;
     checkType: CheckType;
     checks: { message: string }[];
-    renderTitleElement: (titleText: string, className: string) => JSX.Element;
+    renderTitleElement: (titleText: string) => JSX.Element;
 }
 
 export const FixInstructionPanel = NamedFC<FixInstructionPanelProps>('FixInstructionPanel', props => {
@@ -48,7 +48,7 @@ export const FixInstructionPanel = NamedFC<FixInstructionPanelProps>('FixInstruc
 
     return (
         <div>
-            {props.renderTitleElement(title, null)}
+            {props.renderTitleElement(title)}
             <ul className={styles.insightsFixInstructionList}>{renderInstructions(props.checkType)}</ul>
         </div>
     );

--- a/src/common/components/fix-instruction-processor.tsx
+++ b/src/common/components/fix-instruction-processor.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
+import * as styles from './cards/fix-instruction-color-box.scss';
 
 type ColorMatch = {
     splitIndex: number;
@@ -70,14 +71,18 @@ export class FixInstructionProcessor {
         return (
             <>
                 <span aria-hidden="true">{result}</span>
-                <span className="screen-reader-only">{fixInstruction}</span>
+                <span className={styles.screenReaderOnly}>{fixInstruction}</span>
             </>
         );
     }
 
     private createColorBox(colorHexValue: string, keyIndex: number): JSX.Element {
         return (
-            <span key={`instruction-split-${keyIndex}`} className="fix-instruction-color-box" style={{ backgroundColor: colorHexValue }} />
+            <span
+                key={`instruction-split-${keyIndex}`}
+                className={styles.fixInstructionColorBox}
+                style={{ backgroundColor: colorHexValue }}
+            />
         );
     }
 }

--- a/src/common/configs/unified-result-property-configurations.tsx
+++ b/src/common/configs/unified-result-property-configurations.tsx
@@ -4,11 +4,11 @@ import { ClassNameCardRow } from 'common/components/cards/class-name-card-row';
 import { ContentDescriptionCardRow } from 'common/components/cards/content-description-card-row';
 
 import { TextCardRow } from 'common/components/cards/text-card-row';
-import { FixInstructionProcessor } from '../../injected/fix-instruction-processor';
 import { HowToFixAndroidCardRow } from '../components/cards/how-to-fix-android-card-row';
 import { HowToFixWebCardRow } from '../components/cards/how-to-fix-card-row';
 import { PathCardRow } from '../components/cards/path-card-row';
 import { SnippetCardRow } from '../components/cards/snippet-card-row';
+import { FixInstructionProcessor } from '../components/fix-instruction-processor';
 import { ReactFCWithDisplayName } from '../react/named-fc';
 
 export type PropertyType = 'css-selector' | 'how-to-fix-web' | 'snippet' | 'className' | 'contentDescription' | 'text' | 'howToFixFormat';

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -12,6 +12,7 @@ import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { UnifiedScanResultStore } from 'background/stores/unified-scan-result-store';
 import { onlyHighlightingSupported } from 'common/components/cards/card-interaction-support';
 import { CardsCollapsibleControl } from 'common/components/cards/collapsible-component-cards';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { getPropertyConfiguration } from 'common/configs/unified-result-property-configurations';
 import { DateProvider } from 'common/date-provider';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
@@ -40,7 +41,6 @@ import { RootContainerProps, RootContainerState } from 'electron/views/root-cont
 import { PlatformInfo } from 'electron/window-management/platform-info';
 import { WindowFrameListener } from 'electron/window-management/window-frame-listener';
 import { WindowFrameUpdater } from 'electron/window-management/window-frame-updater';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as ReactDOM from 'react-dom';
 
 import { CardsVisualizationModifierButtons } from 'common/components/cards/cards-visualization-modifier-buttons';

--- a/src/injected/components/details-dialog.tsx
+++ b/src/injected/components/details-dialog.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FixInstructionPanel, FixInstructionPanelDeps } from 'common/components/fix-instruction-panel';
 import { isEmpty, size } from 'lodash';
 import { css } from 'office-ui-fabric-react';
 import { Dialog, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import * as React from 'react';
-
 import { HyperlinkDefinition } from 'views/content/content-page';
+
 import { BaseStore } from '../../common/base-store';
 import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
 import { GuidanceLinks } from '../../common/components/guidance-links';
@@ -20,7 +21,6 @@ import { DetailsDialogHandler } from '../details-dialog-handler';
 import { DecoratedAxeNodeResult } from '../scanner-utils';
 import { TargetPageActionMessageCreator } from '../target-page-action-message-creator';
 import { CommandBar, CommandBarDeps, CommandBarProps } from './command-bar';
-import { FixInstructionPanel, FixInstructionPanelDeps } from './fix-instruction-panel';
 import { IssueDetailsNavigationControls, IssueDetailsNavigationControlsProps } from './issue-details-navigation-controls';
 
 export enum CheckType {

--- a/src/injected/components/details-dialog.tsx
+++ b/src/injected/components/details-dialog.tsx
@@ -165,8 +165,8 @@ export class DetailsDialog extends React.Component<DetailsDialogProps, DetailsDi
         return <IssueDetailsNavigationControls {...navigationControlsProps} />;
     }
 
-    private renderSectionTitle(sectionTitle: string, className?: string): JSX.Element {
-        return <h3 className={css('insights-dialog-section-title', className)}>{sectionTitle}</h3>;
+    private renderSectionTitle(sectionTitle: string): JSX.Element {
+        return <h3 className={css('insights-dialog-section-title')}>{sectionTitle}</h3>;
     }
 
     private renderRuleName(rule: DecoratedAxeNodeResult): JSX.Element {

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -6,6 +6,7 @@ import { NavigatorUtils } from 'common/navigator-utils';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
+import { FixInstructionProcessor } from '../common/components/fix-instruction-processor';
 import { NewTabLink } from '../common/components/new-tab-link';
 import { FeatureFlags } from '../common/feature-flags';
 import { HTMLElementUtils } from '../common/html-element-utils';
@@ -19,7 +20,6 @@ import { AxeResultToIssueFilingDataConverter } from '../issue-filing/rule-result
 import { DictionaryStringTo } from '../types/common-types';
 import { rootContainerId } from './constants';
 import { DetailsDialogHandler } from './details-dialog-handler';
-import { FixInstructionProcessor } from './fix-instruction-processor';
 import { ErrorMessageContent } from './frameCommunicators/error-message-content';
 import { FrameCommunicator, MessageRequest } from './frameCommunicators/frame-communicator';
 import { FrameMessageResponseCallback } from './frameCommunicators/window-message-handler';

--- a/src/injected/styles/injected.scss
+++ b/src/injected/styles/injected.scss
@@ -325,27 +325,6 @@
                 margin: 8px 8px 0px 8px !important;
                 padding-left: 8px !important;
             }
-
-            .insights-fix-instruction-list {
-                li {
-                    span.fix-instruction-color-box {
-                        width: 14px;
-                        height: 14px;
-                        display: inline-block;
-                        vertical-align: -5%;
-                        margin: 0px 2px;
-                        border: 1px solid $always-black;
-                    }
-                }
-                .screen-reader-only {
-                    position: absolute;
-                    left: -10000px;
-                    top: auto;
-                    width: 1px;
-                    height: 1px;
-                    overflow: hidden;
-                }
-            }
         }
 
         .insights-dialog-target-button-container {

--- a/src/reports/components/instance-details.scss
+++ b/src/reports/components/instance-details.scss
@@ -86,30 +86,6 @@
     display: flex;
 }
 
-.how-to-fix-content {
-    .insights-fix-instruction-list {
-        li {
-            span.fix-instruction-color-box {
-                width: 14px;
-                height: 14px;
-                display: inline-block;
-                vertical-align: -5%;
-                margin: 0px 2px;
-                border: 1px solid $always-black;
-            }
-        }
-
-        .screen-reader-only {
-            position: absolute;
-            left: -10000px;
-            top: auto;
-            width: 1px;
-            height: 1px;
-            overflow: hidden;
-        }
-    }
-}
-
 .report-instance-table .instance-list-row-content.content-snipppet {
     font-family: Consolas, Segoe UI, Courier New, monospace;
     white-space: normal;

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FailedInstancesSectionDeps } from 'common/components/cards/failed-instances-section';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { EnvironmentInfo } from 'common/environment-info-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { ReactFCWithDisplayName } from 'common/react/named-fc';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 
 import { CardsViewModel } from '../../../common/types/store-data/card-view-model';
 import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -16,12 +16,12 @@ import { DocumentUtils } from 'scanner/document-utils';
 import { HelpUrlGetter } from 'scanner/help-url-getter';
 import { MessageDecorator } from 'scanner/message-decorator';
 import { ResultDecorator } from 'scanner/result-decorator';
+import { FixInstructionProcessor } from '../../common/components/fix-instruction-processor';
 import { getPropertyConfiguration } from '../../common/configs/unified-result-property-configurations';
 import { DateProvider } from '../../common/date-provider';
 import { EnvironmentInfoProvider } from '../../common/environment-info-provider';
 import { initializeFabricIcons } from '../../common/fabric-icons';
 import { GetGuidanceTagsFromGuidanceLinks } from '../../common/get-guidance-tags-from-guidance-links';
-import { FixInstructionProcessor } from '../../injected/fix-instruction-processor';
 import { AxeReportParameters, ReporterFactory } from './accessibilityInsightsReport';
 import { Reporter } from './reporter';
 

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { noCardInteractionsSupported } from 'common/components/cards/card-interaction-support';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { NullComponent } from 'common/components/null-component';
 import { PropertyConfiguration } from 'common/configs/unified-result-property-configurations';
 import { EnvironmentInfo } from 'common/environment-info-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 import { ReportHead } from './components/report-head';
 import { ReportBody, ReportBodyProps } from './components/report-sections/report-body';

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-details-pane.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-details-pane.test.tsx.snap
@@ -79,9 +79,7 @@ exports[`IssuesDetailsPaneTest render with single selection, test copy to clipbo
 `;
 
 exports[`IssuesDetailsPaneTest renderTitleElement passed to embedded FixInstructionPanels should match snapshot 1`] = `
-<div
-  className="test-class-name"
->
+<div>
   test title
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/issues-details-pane.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-details-pane.test.tsx
@@ -3,6 +3,7 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
+import { FixInstructionPanel } from 'common/components/fix-instruction-panel';
 import { HyperlinkDefinition } from 'views/content/content-page';
 import { IssueFilingButton } from '../../../../../common/components/issue-filing-button';
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
@@ -13,7 +14,6 @@ import {
     IssuesDetailsPaneDeps,
     IssuesDetailsPaneProps,
 } from '../../../../../DetailsView/components/Issues-details-pane';
-import { FixInstructionPanel } from '../../../../../injected/components/fix-instruction-panel';
 import { DecoratedAxeNodeResult } from '../../../../../injected/scanner-utils';
 import { AxeResultToIssueFilingDataConverter } from '../../../../../issue-filing/rule-result-to-issue-filing-data';
 import { DictionaryStringTo } from '../../../../../types/common-types';

--- a/src/tests/unit/tests/DetailsView/components/issues-details-pane.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-details-pane.test.tsx
@@ -51,7 +51,7 @@ describe('IssuesDetailsPaneTest', () => {
             .first()
             .prop('renderTitleElement');
 
-        const titleElement = renderTitleElement('test title', 'test-class-name');
+        const titleElement = renderTitleElement('test title');
         expect(titleElement).toMatchSnapshot();
     });
 

--- a/src/tests/unit/tests/common/components/cards/how-to-fix-android-card-row.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/how-to-fix-android-card-row.test.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 
 import { HowToFixAndroidCardRow, HowToFixAndroidCardRowProps } from 'common/components/cards/how-to-fix-android-card-row';
 import { IMock, It, Mock } from 'typemoq';
-import { FixInstructionProcessor } from '../../../../../../injected/fix-instruction-processor';
+import { FixInstructionProcessor } from '../../../../../../common/components/fix-instruction-processor';
 
 describe(HowToFixAndroidCardRow, () => {
     let fixInstructionProcessorMock: IMock<FixInstructionProcessor>;

--- a/src/tests/unit/tests/common/components/cards/how-to-fix-card-row.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/how-to-fix-card-row.test.tsx
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { HowToFixWebCardRow, HowToFixWebCardRowProps } from 'common/components/cards/how-to-fix-card-row';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock } from 'typemoq';
-
-import { FixInstructionProcessor } from '../../../../../../common/components/fix-instruction-processor';
 
 describe('HowToFixWebCardRow', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/common/components/cards/how-to-fix-card-row.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/how-to-fix-card-row.test.tsx
@@ -5,7 +5,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock } from 'typemoq';
 
-import { FixInstructionProcessor } from '../../../../../../injected/fix-instruction-processor';
+import { FixInstructionProcessor } from '../../../../../../common/components/fix-instruction-processor';
 
 describe('HowToFixWebCardRow', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/common/components/cards/instance-details-group.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/instance-details-group.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { InstanceDetailsGroup, InstanceDetailsGroupDeps, InstanceDetailsGroupProps } from 'common/components/cards/instance-details-group';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 import { Mock } from 'typemoq';
 

--- a/src/tests/unit/tests/common/components/cards/rules-with-instances.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/rules-with-instances.test.tsx
@@ -2,8 +2,8 @@
 // Licensed under the MIT License.
 import { CollapsibleComponentCardsProps } from 'common/components/cards/collapsible-component-cards';
 import { RulesWithInstances, RulesWithInstancesDeps } from 'common/components/cards/rules-with-instances';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { shallow } from 'enzyme';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 import { IMock, Mock } from 'typemoq';
 

--- a/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
+++ b/src/tests/unit/tests/injected/__snapshots__/fix-instruction-processor.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`FixInstructionProcessor background and foreground on the message (mind 
       Element has insufficient color contrast of 2.52 (background color: 
     </span>
     <span
-      className="fix-instruction-color-box"
+      className="fixInstructionColorBox"
       style={
         Object {
           "backgroundColor": "#8a94a8",
@@ -20,7 +20,7 @@ exports[`FixInstructionProcessor background and foreground on the message (mind 
       #8a94a8, foreground color: 
     </span>
     <span
-      className="fix-instruction-color-box"
+      className="fixInstructionColorBox"
       style={
         Object {
           "backgroundColor": "#e7ecd8",
@@ -32,7 +32,7 @@ exports[`FixInstructionProcessor background and foreground on the message (mind 
     </span>
   </span>
   <span
-    className="screen-reader-only"
+    className="screenReaderOnly"
   >
     Element has insufficient color contrast of 2.52 (background color: #8a94a8, foreground color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
   </span>
@@ -48,7 +48,7 @@ exports[`FixInstructionProcessor background color on the message 1`] = `
       color contrast of 2.52 (background color: 
     </span>
     <span
-      className="fix-instruction-color-box"
+      className="fixInstructionColorBox"
       style={
         Object {
           "backgroundColor": "#8a94a8",
@@ -60,7 +60,7 @@ exports[`FixInstructionProcessor background color on the message 1`] = `
     </span>
   </span>
   <span
-    className="screen-reader-only"
+    className="screenReaderOnly"
   >
     color contrast of 2.52 (background color: #8a94a8; nothing else to match here)
   </span>
@@ -76,7 +76,7 @@ exports[`FixInstructionProcessor foreground and background color on the message 
       Element has insufficient color contrast of 2.52 (foreground color: 
     </span>
     <span
-      className="fix-instruction-color-box"
+      className="fixInstructionColorBox"
       style={
         Object {
           "backgroundColor": "#8a94a8",
@@ -87,7 +87,7 @@ exports[`FixInstructionProcessor foreground and background color on the message 
       #8a94a8, background color: 
     </span>
     <span
-      className="fix-instruction-color-box"
+      className="fixInstructionColorBox"
       style={
         Object {
           "backgroundColor": "#e7ecd8",
@@ -99,7 +99,7 @@ exports[`FixInstructionProcessor foreground and background color on the message 
     </span>
   </span>
   <span
-    className="screen-reader-only"
+    className="screenReaderOnly"
   >
     Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt, font weight: normal). Expected contrast ratio of 4.5:1
   </span>
@@ -115,7 +115,7 @@ exports[`FixInstructionProcessor foreground color on the message 1`] = `
       color contrast of 2.52 (foreground color: 
     </span>
     <span
-      className="fix-instruction-color-box"
+      className="fixInstructionColorBox"
       style={
         Object {
           "backgroundColor": "#8a94a8",
@@ -127,7 +127,7 @@ exports[`FixInstructionProcessor foreground color on the message 1`] = `
     </span>
   </span>
   <span
-    className="screen-reader-only"
+    className="screenReaderOnly"
   >
     color contrast of 2.52 (foreground color: #8a94a8; nothing else to match here)
   </span>
@@ -149,7 +149,7 @@ exports[`FixInstructionProcessor we assume only one instance of fore/background 
       first foreground color: 
     </span>
     <span
-      className="fix-instruction-color-box"
+      className="fixInstructionColorBox"
       style={
         Object {
           "backgroundColor": "#ffffff",
@@ -160,7 +160,7 @@ exports[`FixInstructionProcessor we assume only one instance of fore/background 
       #ffffff, second foreground: #000000, first background color: 
     </span>
     <span
-      className="fix-instruction-color-box"
+      className="fixInstructionColorBox"
       style={
         Object {
           "backgroundColor": "#AAAAAA",
@@ -172,7 +172,7 @@ exports[`FixInstructionProcessor we assume only one instance of fore/background 
     </span>
   </span>
   <span
-    className="screen-reader-only"
+    className="screenReaderOnly"
   >
     first foreground color: #ffffff, second foreground: #000000, first background color: #AAAAAA, second background color: #bbBBbb
   </span>

--- a/src/tests/unit/tests/injected/components/__snapshots__/fix-instruction-panel.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/fix-instruction-panel.test.tsx.snap
@@ -2,9 +2,7 @@
 
 exports[`FixInstructionPanelTests render all checks 1`] = `
 <div>
-  <div
-    className={null}
-  >
+  <div>
     Fix ALL of the following:
   </div>
   <ul
@@ -26,9 +24,7 @@ exports[`FixInstructionPanelTests render all checks 1`] = `
 
 exports[`FixInstructionPanelTests render instruction only one check 1`] = `
 <div>
-  <div
-    className={null}
-  >
+  <div>
     Fix the following:
   </div>
   <ul
@@ -45,9 +41,7 @@ exports[`FixInstructionPanelTests render instruction only one check 1`] = `
 
 exports[`FixInstructionPanelTests render none checks 1`] = `
 <div>
-  <div
-    className={null}
-  >
+  <div>
     Fix ALL of the following:
   </div>
   <ul

--- a/src/tests/unit/tests/injected/components/__snapshots__/fix-instruction-panel.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/fix-instruction-panel.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`FixInstructionPanelTests render all checks 1`] = `
 <div>
   <div
-    className="insights-fix-instruction-title"
+    className={null}
   >
     Fix ALL of the following:
   </div>
   <ul
-    className="insights-fix-instruction-list"
+    className="insightsFixInstructionList"
   >
     <li>
       <React.Fragment>
@@ -27,12 +27,12 @@ exports[`FixInstructionPanelTests render all checks 1`] = `
 exports[`FixInstructionPanelTests render instruction only one check 1`] = `
 <div>
   <div
-    className="insights-fix-instruction-title"
+    className={null}
   >
     Fix the following:
   </div>
   <ul
-    className="insights-fix-instruction-list"
+    className="insightsFixInstructionList"
   >
     <li>
       <React.Fragment>
@@ -46,12 +46,12 @@ exports[`FixInstructionPanelTests render instruction only one check 1`] = `
 exports[`FixInstructionPanelTests render none checks 1`] = `
 <div>
   <div
-    className="insights-fix-instruction-title"
+    className={null}
   >
     Fix ALL of the following:
   </div>
   <ul
-    className="insights-fix-instruction-list"
+    className="insightsFixInstructionList"
   >
     <li>
       <React.Fragment>

--- a/src/tests/unit/tests/injected/components/fix-instruction-panel.test.tsx
+++ b/src/tests/unit/tests/injected/components/fix-instruction-panel.test.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FixInstructionPanel, FixInstructionPanelProps } from 'common/components/fix-instruction-panel';
 import { shallow } from 'enzyme';
+import { CheckType } from 'injected/components/details-dialog';
+import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
-import { CheckType } from '../../../../../injected/components/details-dialog';
-import { FixInstructionPanel, FixInstructionPanelProps } from '../../../../../injected/components/fix-instruction-panel';
-import { FixInstructionProcessor } from '../../../../../injected/fix-instruction-processor';
 
 describe('FixInstructionPanelTests', () => {
     let fixInstructionProcessorMock: IMock<FixInstructionProcessor>;
@@ -16,7 +16,7 @@ describe('FixInstructionPanelTests', () => {
     });
 
     test('render all checks', () => {
-        const allchecks: FormattedCheckResult[] = [
+        const allChecks: FormattedCheckResult[] = [
             {
                 message: 'message',
                 id: 'id1',
@@ -31,7 +31,7 @@ describe('FixInstructionPanelTests', () => {
 
         const props: FixInstructionPanelProps = {
             checkType: CheckType.All,
-            checks: allchecks,
+            checks: allChecks,
             renderTitleElement: renderTitleAsDiv,
             deps: {
                 fixInstructionProcessor: fixInstructionProcessorMock.object,
@@ -44,7 +44,7 @@ describe('FixInstructionPanelTests', () => {
     });
 
     test('render instruction only one check', () => {
-        const allchecks: FormattedCheckResult[] = [
+        const allChecks: FormattedCheckResult[] = [
             {
                 message: 'message',
                 id: 'id1',
@@ -54,7 +54,7 @@ describe('FixInstructionPanelTests', () => {
 
         const props: FixInstructionPanelProps = {
             checkType: CheckType.All,
-            checks: allchecks,
+            checks: allChecks,
             renderTitleElement: renderTitleAsDiv,
             deps: {
                 fixInstructionProcessor: fixInstructionProcessorMock.object,

--- a/src/tests/unit/tests/injected/components/fix-instruction-panel.test.tsx
+++ b/src/tests/unit/tests/injected/components/fix-instruction-panel.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FixInstructionPanel, FixInstructionPanelProps } from 'common/components/fix-instruction-panel';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { shallow } from 'enzyme';
 import { CheckType } from 'injected/components/details-dialog';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior } from 'typemoq';
 

--- a/src/tests/unit/tests/injected/components/fix-instruction-panel.test.tsx
+++ b/src/tests/unit/tests/injected/components/fix-instruction-panel.test.tsx
@@ -111,7 +111,7 @@ describe('FixInstructionPanelTests', () => {
         expect(wrapped.getElement()).toMatchSnapshot();
     });
 
-    function renderTitleAsDiv(titleText: string, className: string): JSX.Element {
-        return <div className={className}>{titleText}</div>;
+    function renderTitleAsDiv(titleText: string): JSX.Element {
+        return <div>{titleText}</div>;
     }
 });

--- a/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
+++ b/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FixInstructionProcessor } from '../../../../common/components/fix-instruction-processor';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 
 describe('FixInstructionProcessor', () => {
     let testSubject: FixInstructionProcessor;

--- a/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
+++ b/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FixInstructionProcessor } from '../../../../injected/fix-instruction-processor';
+import { FixInstructionProcessor } from '../../../../common/components/fix-instruction-processor';
 
 describe('FixInstructionProcessor', () => {
     let testSubject: FixInstructionProcessor;

--- a/src/tests/unit/tests/reports/components/report-sections/report-body.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/report-body.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FailedInstancesSectionDeps } from 'common/components/cards/failed-instances-section';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { NamedFC } from 'common/react/named-fc';
 import { shallow } from 'enzyme';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';
 import { ReportSectionFactory, SectionProps } from 'reports/components/report-sections/report-section-factory';

--- a/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
@@ -729,13 +729,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         No valid skip link found
@@ -931,13 +929,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         <span
@@ -947,14 +943,14 @@ exports[`report package integration with issues 1`] = `
                                             Element has insufficient color contrast of 2.52 (foreground color: 
                                           </span>
                                           <span
-                                            class="fix-instruction-color-box"
+                                            class="fixInstructionColorBox"
                                             style="background-color:#8a94a8"
                                           />
                                           <span>
                                             #8a94a8, background color: 
                                           </span>
                                           <span
-                                            class="fix-instruction-color-box"
+                                            class="fixInstructionColorBox"
                                             style="background-color:#e7ecd8"
                                           />
                                           <span>
@@ -962,7 +958,7 @@ exports[`report package integration with issues 1`] = `
                                           </span>
                                         </span>
                                         <span
-                                          class="screen-reader-only"
+                                          class="screenReaderOnly"
                                         >
                                           Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1
                                         </span>
@@ -1036,13 +1032,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         <span
@@ -1052,14 +1046,14 @@ exports[`report package integration with issues 1`] = `
                                             Element has insufficient color contrast of 2.52 (foreground color: 
                                           </span>
                                           <span
-                                            class="fix-instruction-color-box"
+                                            class="fixInstructionColorBox"
                                             style="background-color:#8a94a8"
                                           />
                                           <span>
                                             #8a94a8, background color: 
                                           </span>
                                           <span
-                                            class="fix-instruction-color-box"
+                                            class="fixInstructionColorBox"
                                             style="background-color:#e7ecd8"
                                           />
                                           <span>
@@ -1067,7 +1061,7 @@ exports[`report package integration with issues 1`] = `
                                           </span>
                                         </span>
                                         <span
-                                          class="screen-reader-only"
+                                          class="screenReaderOnly"
                                         >
                                           Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1
                                         </span>
@@ -1141,13 +1135,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         <span
@@ -1157,14 +1149,14 @@ exports[`report package integration with issues 1`] = `
                                             Element has insufficient color contrast of 2.52 (foreground color: 
                                           </span>
                                           <span
-                                            class="fix-instruction-color-box"
+                                            class="fixInstructionColorBox"
                                             style="background-color:#8a94a8"
                                           />
                                           <span>
                                             #8a94a8, background color: 
                                           </span>
                                           <span
-                                            class="fix-instruction-color-box"
+                                            class="fixInstructionColorBox"
                                             style="background-color:#e7ecd8"
                                           />
                                           <span>
@@ -1172,7 +1164,7 @@ exports[`report package integration with issues 1`] = `
                                           </span>
                                         </span>
                                         <span
-                                          class="screen-reader-only"
+                                          class="screenReaderOnly"
                                         >
                                           Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1
                                         </span>
@@ -1246,13 +1238,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         <span
@@ -1262,14 +1252,14 @@ exports[`report package integration with issues 1`] = `
                                             Element has insufficient color contrast of 2.52 (foreground color: 
                                           </span>
                                           <span
-                                            class="fix-instruction-color-box"
+                                            class="fixInstructionColorBox"
                                             style="background-color:#8a94a8"
                                           />
                                           <span>
                                             #8a94a8, background color: 
                                           </span>
                                           <span
-                                            class="fix-instruction-color-box"
+                                            class="fixInstructionColorBox"
                                             style="background-color:#e7ecd8"
                                           />
                                           <span>
@@ -1277,7 +1267,7 @@ exports[`report package integration with issues 1`] = `
                                           </span>
                                         </span>
                                         <span
-                                          class="screen-reader-only"
+                                          class="screenReaderOnly"
                                         >
                                           Element has insufficient color contrast of 2.52 (foreground color: #8a94a8, background color: #e7ecd8, font size: 12.0pt (16px), font weight: normal). Expected contrast ratio of 4.5:1
                                         </span>
@@ -1467,13 +1457,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         The &lt;html&gt; element does not have a lang attribute
@@ -1663,13 +1651,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         Element does not have an alt attribute
@@ -1758,13 +1744,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         Element does not have an alt attribute
@@ -1853,13 +1837,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         Element does not have an alt attribute
@@ -1948,13 +1930,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         Element does not have an alt attribute
@@ -2159,13 +2139,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -2251,13 +2229,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -2343,13 +2319,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -2435,13 +2409,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -2527,13 +2499,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -2619,13 +2589,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -2711,13 +2679,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -2803,13 +2769,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -2895,13 +2859,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -2987,13 +2949,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -3079,13 +3039,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -3171,13 +3129,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -3263,13 +3219,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix ONE of the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         aria-label attribute does not exist or is empty
@@ -3471,13 +3425,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         Document does not have a main landmark
@@ -3667,13 +3619,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         Page must have a level-one heading
@@ -3863,13 +3813,11 @@ exports[`report package integration with issues 1`] = `
                                   class="howToFixContent"
                                 >
                                   <div>
-                                    <div
-                                      class="insights-fix-instruction-title"
-                                    >
+                                    <div>
                                       Fix the following:
                                     </div>
                                     <ul
-                                      class="insights-fix-instruction-list"
+                                      class="insightsFixInstructionList"
                                     >
                                       <li>
                                         Some page content is not contained by landmarks

--- a/src/tests/unit/tests/reports/report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/report-html-generator.test.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { noCardInteractionsSupported } from 'common/components/cards/card-interaction-support';
+import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { NullComponent } from 'common/components/null-component';
 import { DateProvider } from 'common/date-provider';
 import { EnvironmentInfo } from 'common/environment-info-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
-import { FixInstructionProcessor } from 'injected/fix-instruction-processor';
 import * as React from 'react';
 import { ReportHead } from 'reports/components/report-head';
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';


### PR DESCRIPTION
#### Description of changes
This PR cleans out some of the stuff from `FixInstructionsPanel`. This achieves 2 things:

1. move component `FixInstructionsPanel` to common, which is where it belongs since its being used by `fastpass`, and `detailsDialog` both. `Injected` didn't seem like a good place to put this component.
2. move the css to css module to avoid having `injected.css` in our electron bundle due to classes being referenced from `injected.css`.

Next PR/Step: 
Try to find exact classes or components that are referencing `injected.scss` in electron and move them to css modules.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS

#### Screenshots

<img width="1903" alt="Screen Shot 2019-12-03 at 2 43 36 PM" src="https://user-images.githubusercontent.com/4496335/70096188-5bc6d580-15db-11ea-82f0-6ad34b1ff4ed.png">
![Uploading Screen Shot 2019-12-03 at 2.43.11 PM.png…]()

