### PR TITLE
fix: minor typo in Headings test of Assessments

### DIFF
--- a/src/assessments/headings/test-steps/heading-level.tsx
+++ b/src/assessments/headings/test-steps/heading-level.tsx
@@ -31,11 +31,8 @@ const headingLevelHowToTest: JSX.Element = (
         <ol>
             <li>
                 In the target page, examine each heading to verify that its{' '}
-                <Markup.Emphasis>programmatic</Markup.Emphasis>
-                level matches the level that's presented <Markup.Emphasis>
-                    visually
-                </Markup.Emphasis>{' '}
-                (through font style).
+                <Markup.Emphasis>programmatic</Markup.Emphasis> level matches the level that's
+                presented <Markup.Emphasis>visually</Markup.Emphasis> (through font style).
                 <ol>
                     <li>
                         Lower-level headings should be more prominent than higher-level headings.


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

- In Assessment > Headings > Heading level: added a space between a word that has Markup.Emphasis and a word without any styling

Before:
![image](https://user-images.githubusercontent.com/48259897/70094501-7c8d2c00-15d7-11ea-8b39-15348a23c969.png)

After:
![image](https://user-images.githubusercontent.com/48259897/70094837-34223e00-15d8-11ea-9c78-a41b673f020a.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
