### PR TITLE
fix: use class name from scss.d file

### DIFF
--- a/src/reports/components/report-sections/rules-only.tsx
+++ b/src/reports/components/report-sections/rules-only.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import * as styles from 'common/components/cards/rules-with-instances.scss';
 import { NamedFC } from 'common/react/named-fc';
 import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import * as React from 'react';
-
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { FullRuleHeader, FullRuleHeaderDeps } from './full-rule-header';
 
@@ -17,7 +17,7 @@ export type RulesOnlyProps = {
 
 export const RulesOnly = NamedFC<RulesOnlyProps>('RulesOnly', ({ outcomeType, deps, cardRuleResults: cardResults }) => {
     return (
-        <div className="rule-details-group">
+        <div className={styles.ruleDetailsGroup}>
             {cardResults.map(cardRuleResult => (
                 <FullRuleHeader deps={deps} key={cardRuleResult.id} cardRuleResult={cardRuleResult} outcomeType={outcomeType} />
             ))}

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/rules-only.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/rules-only.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`RulesOnly renders 1`] = `
 <div
-  className="rule-details-group"
+  className="ruleDetailsGroup"
 >
   <FullRuleHeader
     cardRuleResult={

--- a/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
@@ -3977,7 +3977,7 @@ exports[`report package integration with issues 1`] = `
               id="content-container-passed-checks-section"
             >
               <div
-                class="rule-details-group"
+                class="ruleDetailsGroup"
               >
                 <div
                   class="rule-detail"
@@ -4634,7 +4634,7 @@ exports[`report package integration with issues 1`] = `
               id="content-container-not-applicable-checks-section"
             >
               <div
-                class="rule-details-group"
+                class="ruleDetailsGroup"
               >
                 <div
                   class="rule-detail"
@@ -6694,7 +6694,7 @@ exports[`report package integration with no issues 1`] = `
               id="content-container-passed-checks-section"
             >
               <div
-                class="rule-details-group"
+                class="ruleDetailsGroup"
               >
                 <div
                   class="rule-detail"
@@ -8051,7 +8051,7 @@ exports[`report package integration with no issues 1`] = `
               id="content-container-not-applicable-checks-section"
             >
               <div
-                class="rule-details-group"
+                class="ruleDetailsGroup"
               >
                 <div
                   class="rule-detail"


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

We are hardcoding a class name for `RulesOnly` component. This works fine on "dev" mode builds but breaks on "production" mode builds. The main reason is: on production mode, we add a hash as a suffix to all class names (to avoid name collision) while on dev mode we don't change the class names at all.

Using the class name from the corresponding scss.d.ts file fix this issue

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
