### PR TITLE
feat(electron-update): call autoupdate after mainwindow is loaded

### DIFF
--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -13,7 +13,6 @@ const electronAutoUpdateCheck = new AutoUpdaterClient(autoUpdater);
 let recurringUpdateCheck;
 
 const createWindow = () => {
-    recurringUpdateCheck = setupRecurringUpdateCheck();
     const os = platformInfo.getOs();
     mainWindow = new BrowserWindow({
         show: false,
@@ -41,6 +40,10 @@ const createWindow = () => {
         mainWindow.show();
         enableDevMode(mainWindow);
     });
+
+    checkForUpdates()
+        .then(() => console.log('checked for updates'))
+        .catch(console.log);
 };
 
 const enableDevMode = (window: BrowserWindow) => {
@@ -51,10 +54,15 @@ const enableDevMode = (window: BrowserWindow) => {
     }
 };
 
-const setupRecurringUpdateCheck = () => {
-    return setInterval(async () => {
-        await electronAutoUpdateCheck.check();
+const setupRecurringUpdateCheck = async () => {
+    recurringUpdateCheck = setInterval(async () => {
+        await checkForUpdates();
     }, 60 * 60 * 1000);
+};
+
+const checkForUpdates: () => Promise<void> = async () => {
+    await electronAutoUpdateCheck.check();
+    await setupRecurringUpdateCheck();
 };
 
 app.on('ready', createWindow);

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -9,8 +9,8 @@ import * as path from 'path';
 let mainWindow: BrowserWindow;
 const platformInfo = new PlatformInfo(process);
 
-const electronAutoUpdateCheck = new AutoUpdaterClient(autoUpdater);
 let recurringUpdateCheck;
+const electronAutoUpdateCheck = new AutoUpdaterClient(autoUpdater);
 
 const createWindow = () => {
     const os = platformInfo.getOs();
@@ -41,8 +41,12 @@ const createWindow = () => {
         enableDevMode(mainWindow);
     });
 
-    checkForUpdates()
-        .then(() => console.log('checked for updates'))
+    electronAutoUpdateCheck
+        .check()
+        .then(() => {
+            console.log('checked for updates');
+            setupRecurringUpdateCheck();
+        })
         .catch(console.log);
 };
 
@@ -54,15 +58,10 @@ const enableDevMode = (window: BrowserWindow) => {
     }
 };
 
-const setupRecurringUpdateCheck = async () => {
+const setupRecurringUpdateCheck = () => {
     recurringUpdateCheck = setInterval(async () => {
-        await checkForUpdates();
+        await electronAutoUpdateCheck.check();
     }, 60 * 60 * 1000);
-};
-
-const checkForUpdates: () => Promise<void> = async () => {
-    await electronAutoUpdateCheck.check();
-    await setupRecurringUpdateCheck();
 };
 
 app.on('ready', createWindow);


### PR DESCRIPTION
#### Description of changes

This PR fixes a small issue where `autoUpdate` was not getting called even once when the window was loaded and this would have created a situation where the autoupdate is just called after the user has spent an hour on the app, which is not what we want.

After this change, the check for update will be called once when the main window is loaded and that function also sets up an 1 hour recurring check

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
