### PR TITLE
fix: the command bar buttons don't wrap their text when window size is decreased

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -301,10 +301,6 @@ div.insights-file-issue-details-dialog-container {
                 color: $communication-primary;
             }
         }
-        .details-view-command-buttons {
-            display: flex;
-            margin-right: 16px;
-        }
     }
     .header-bar {
         padding-left: 12px;

--- a/src/DetailsView/components/details-view-command-bar.scss
+++ b/src/DetailsView/components/details-view-command-bar.scss
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+.details-view-command-buttons {
+    display: flex;
+    margin-right: 16px;
+    white-space: nowrap;
+}

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -6,11 +6,13 @@ import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { detailsViewCommandButtons } from 'DetailsView/components/details-view-command-bar.scss';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import { StartOverDeps } from 'DetailsView/components/start-over-dropdown';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
+
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
@@ -81,7 +83,7 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
 
         if (reportExportElement || startOverElement) {
             return (
-                <div className="details-view-command-buttons">
+                <div className={detailsViewCommandButtons}>
                     {reportExportElement}
                     {startOverElement}
                 </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-command-bar.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`DetailsViewCommandBar renders with export button, with start over 1`] =
       command-bar-test-tab-title
     </StyledLinkBase>
   </div>
-  <div className=\\"details-view-command-buttons\\">
+  <div className=\\"detailsViewCommandButtons\\">
     <CustomizedActionButton>
       Report Export Component
     </CustomizedActionButton>
@@ -27,7 +27,7 @@ exports[`DetailsViewCommandBar renders with export button, without start over 1`
       command-bar-test-tab-title
     </StyledLinkBase>
   </div>
-  <div className=\\"details-view-command-buttons\\">
+  <div className=\\"detailsViewCommandButtons\\">
     <CustomizedActionButton>
       Report Export Component
     </CustomizedActionButton>
@@ -43,7 +43,7 @@ exports[`DetailsViewCommandBar renders without export button, with start over 1`
       command-bar-test-tab-title
     </StyledLinkBase>
   </div>
-  <div className=\\"details-view-command-buttons\\">
+  <div className=\\"detailsViewCommandButtons\\">
     <CustomizedActionButton>
       Start Over Component
     </CustomizedActionButton>


### PR DESCRIPTION
#### Description of changes

Previously, the start over and export results button text would wrap. This is not necessary, so this PR makes sure they don't.

Before:
![image](https://user-images.githubusercontent.com/32555133/70175317-5759f580-168b-11ea-86c9-5314d929e38d.png)

After:
![image](https://user-images.githubusercontent.com/32555133/70175378-7193d380-168b-11ea-9da1-bd7c71714f8e.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
