### PR TITLE
fix: card view state is reset after link is clicked

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -252,6 +252,7 @@ if (isNaN(tabId) === false) {
             scopingStore.setTabId(tab.id);
             inspectStore.setTabId(tab.id);
             unifiedScanResultStore.setTabId(tab.id);
+            cardSelectionStore.setTabId(tab.id);
 
             const actionInitiators = {
                 ...contentActionMessageCreator.initiators,


### PR DESCRIPTION
#### Description of changes

The card selection store in details view relies on a store proxy. The store proxy relies on having a tab Id to filter to messages that it receives (since the details view is simply a page with a tabId in a parameter inside the URL). The issue was that the store is receiving messages but was never setup with any tabId.

This seems to indicate a future re-factoring that would reduce these kind of issues: necessitate a tabId on creation and in the scenarios where we don't need it (the target page) we can specifically pass null. At least visually, we do not have to go searching in different places to "initialize" something.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1800 
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
