### PR TITLE
refactor: store proxy takes in tabId via constructor

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -4,6 +4,7 @@ import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-defaul
 import { Assessments } from 'assessments/assessments';
 import { assessmentsProviderWithFeaturesEnabled } from 'assessments/assessments-feature-flag-filter';
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
+import { CardsVisualizationModifierButtons } from 'common/components/cards/cards-visualization-modifier-buttons';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
@@ -27,7 +28,6 @@ import { ReportGenerator } from 'reports/report-generator';
 import { ReportHtmlGenerator } from 'reports/report-html-generator';
 import { ReportNameGenerator } from 'reports/report-name-generator';
 
-import { CardsVisualizationModifierButtons } from 'common/components/cards/cards-visualization-modifier-buttons';
 import { A11YSelfValidator } from '../common/a11y-self-validator';
 import { AxeInfo } from '../common/axe-info';
 import { provideBlob } from '../common/blob-provider';
@@ -68,7 +68,6 @@ import { StoreNames } from '../common/stores/store-names';
 import { TelemetryDataFactory } from '../common/telemetry-data-factory';
 import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
 import { DetailsViewData } from '../common/types/store-data/details-view-data';
-import { InspectStoreData } from '../common/types/store-data/inspect-store-data';
 import { PathSnippetStoreData } from '../common/types/store-data/path-snippet-store-data';
 import { ScopingStoreData } from '../common/types/store-data/scoping-store-data';
 import { TabStoreData } from '../common/types/store-data/tab-store-data';
@@ -122,27 +121,41 @@ if (isNaN(tabId) === false) {
         (tab: Tab): void => {
             const telemetryFactory = new TelemetryDataFactory();
 
-            const visualizationStore = new StoreProxy<VisualizationStoreData>(StoreNames[StoreNames.VisualizationStore], browserAdapter);
-            const tabStore = new StoreProxy<TabStoreData>(StoreNames[StoreNames.TabStore], browserAdapter);
+            const visualizationStore = new StoreProxy<VisualizationStoreData>(
+                StoreNames[StoreNames.VisualizationStore],
+                browserAdapter,
+                tab.id,
+            );
+            const tabStore = new StoreProxy<TabStoreData>(StoreNames[StoreNames.TabStore], browserAdapter, tab.id);
             const visualizationScanResultStore = new StoreProxy<VisualizationScanResultData>(
                 StoreNames[StoreNames.VisualizationScanResultStore],
                 browserAdapter,
+                tab.id,
             );
             const unifiedScanResultStore = new StoreProxy<UnifiedScanResultStoreData>(
                 StoreNames[StoreNames.UnifiedScanResultStore],
                 browserAdapter,
+                tab.id,
             );
-            const pathSnippetStore = new StoreProxy<PathSnippetStoreData>(StoreNames[StoreNames.PathSnippetStore], browserAdapter);
-            const detailsViewStore = new StoreProxy<DetailsViewData>(StoreNames[StoreNames.DetailsViewStore], browserAdapter);
-            const assessmentStore = new StoreProxy<AssessmentStoreData>(StoreNames[StoreNames.AssessmentStore], browserAdapter);
-            const featureFlagStore = new StoreProxy<DictionaryStringTo<boolean>>(StoreNames[StoreNames.FeatureFlagStore], browserAdapter);
-            const scopingStore = new StoreProxy<ScopingStoreData>(StoreNames[StoreNames.ScopingPanelStateStore], browserAdapter);
-            const inspectStore = new StoreProxy<InspectStoreData>(StoreNames[StoreNames.InspectStore], browserAdapter);
+            const pathSnippetStore = new StoreProxy<PathSnippetStoreData>(StoreNames[StoreNames.PathSnippetStore], browserAdapter, tab.id);
+            const detailsViewStore = new StoreProxy<DetailsViewData>(StoreNames[StoreNames.DetailsViewStore], browserAdapter, tab.id);
+            const assessmentStore = new StoreProxy<AssessmentStoreData>(StoreNames[StoreNames.AssessmentStore], browserAdapter, tab.id);
+            const featureFlagStore = new StoreProxy<DictionaryStringTo<boolean>>(
+                StoreNames[StoreNames.FeatureFlagStore],
+                browserAdapter,
+                tab.id,
+            );
+            const scopingStore = new StoreProxy<ScopingStoreData>(StoreNames[StoreNames.ScopingPanelStateStore], browserAdapter, tab.id);
             const userConfigStore = new StoreProxy<UserConfigurationStoreData>(
                 StoreNames[StoreNames.UserConfigurationStore],
                 browserAdapter,
+                tab.id,
             );
-            const cardSelectionStore = new StoreProxy<CardSelectionStoreData>(StoreNames[StoreNames.CardSelectionStore], browserAdapter);
+            const cardSelectionStore = new StoreProxy<CardSelectionStoreData>(
+                StoreNames[StoreNames.CardSelectionStore],
+                browserAdapter,
+                tab.id,
+            );
 
             const storesHub = new BaseClientStoresHub<DetailsViewContainerState>([
                 detailsViewStore,
@@ -243,16 +256,6 @@ if (isNaN(tabId) === false) {
                 browserSpec,
                 assessmentDefaultMessageGenerator,
             );
-
-            visualizationStore.setTabId(tab.id);
-            tabStore.setTabId(tab.id);
-            visualizationScanResultStore.setTabId(tab.id);
-            detailsViewStore.setTabId(tab.id);
-            assessmentStore.setTabId(tab.id);
-            scopingStore.setTabId(tab.id);
-            inspectStore.setTabId(tab.id);
-            unifiedScanResultStore.setTabId(tab.id);
-            cardSelectionStore.setTabId(tab.id);
 
             const actionInitiators = {
                 ...contentActionMessageCreator.initiators,

--- a/src/common/store-proxy.ts
+++ b/src/common/store-proxy.ts
@@ -15,10 +15,11 @@ export class StoreProxy<TState> extends Store implements BaseStore<TState> {
     private tabId: number;
     private browserAdapter: BrowserAdapter;
 
-    constructor(storeId: string, browserAdapter: BrowserAdapter) {
+    constructor(storeId: string, browserAdapter: BrowserAdapter, tabId: number = null) {
         super();
         this.storeId = storeId;
         this.browserAdapter = browserAdapter;
+        this.tabId = tabId;
         this.browserAdapter.addListenerOnMessage(this.onChange);
     }
 
@@ -57,10 +58,6 @@ export class StoreProxy<TState> extends Store implements BaseStore<TState> {
 
     public getId(): string {
         return this.storeId;
-    }
-
-    public setTabId(tabId: number): void {
-        this.tabId = tabId;
     }
 
     public dispose(): void {

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -87,9 +87,10 @@ export class PopupInitializer {
 
     private initializePopup = (): void => {
         const telemetryFactory = new TelemetryDataFactory();
+        const tab = this.targetTabInfo.tab;
         const actionMessageDispatcher = new RemoteActionMessageDispatcher(
             this.browserAdapter.sendMessageToFrames,
-            this.targetTabInfo.tab.id,
+            tab.id,
         );
         const visualizationActionCreator = new VisualizationActionMessageCreator(
             actionMessageDispatcher,
@@ -124,22 +125,27 @@ export class PopupInitializer {
         const visualizationStore = new StoreProxy<VisualizationStoreData>(
             visualizationStoreName,
             this.browserAdapter,
+            tab.id,
         );
         const launchPanelStateStore = new StoreProxy<LaunchPanelStoreData>(
             launchPanelStateStoreName,
             this.browserAdapter,
+            tab.id,
         );
         const commandStore = new StoreProxy<CommandStoreData>(
             commandStoreName,
             this.browserAdapter,
+            tab.id,
         );
         const featureFlagStore = new StoreProxy<FeatureFlagStoreData>(
             featureFlagStoreName,
             this.browserAdapter,
+            tab.id,
         );
         const userConfigurationStore = new StoreProxy<UserConfigurationStoreData>(
             userConfigurationStoreName,
             this.browserAdapter,
+            tab.id,
         );
 
         const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(
@@ -153,12 +159,6 @@ export class PopupInitializer {
             featureFlagStore,
             userConfigurationStore,
         ]);
-
-        visualizationStore.setTabId(this.targetTabInfo.tab.id);
-        commandStore.setTabId(this.targetTabInfo.tab.id);
-        featureFlagStore.setTabId(this.targetTabInfo.tab.id);
-        launchPanelStateStore.setTabId(this.targetTabInfo.tab.id);
-        userConfigurationStore.setTabId(this.targetTabInfo.tab.id);
 
         const visualizationConfigurationFactory = new VisualizationConfigurationFactory();
         const launchPadRowConfigurationFactory = new LaunchPadRowConfigurationFactory();
@@ -235,14 +235,14 @@ export class PopupInitializer {
             ReactDOM.render,
             document,
             window,
-            this.targetTabInfo.tab.url,
+            tab.url,
             this.targetTabInfo.hasAccess,
             launchPadRowConfigurationFactory,
             diagnosticViewToggleFactory,
             dropdownClickHandler,
         );
         renderer.render();
-        popupActionMessageCreator.popupInitialized(this.targetTabInfo.tab);
+        popupActionMessageCreator.popupInitialized(tab);
 
         const a11ySelfValidator = new A11YSelfValidator(
             new ScannerUtils(scan),

--- a/src/tests/unit/tests/common/store-proxy.test.ts
+++ b/src/tests/unit/tests/common/store-proxy.test.ts
@@ -11,10 +11,6 @@ import { StoreUpdateMessage } from '../../../../common/types/store-update-messag
 class TestableStoreProxy<TState> extends StoreProxy<TState> {
     public emitChangedCallCount: number = 0;
 
-    constructor(storeId: string, browserAdapter: BrowserAdapter) {
-        super(storeId, browserAdapter);
-    }
-
     public emitChanged(): void {
         this.emitChangedCallCount++;
     }
@@ -32,8 +28,7 @@ describe('StoreProxyTest', () => {
             })
             .verifiable();
 
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object);
-        storeProxy.setTabId(1);
+        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
 
         onChange.call(storeProxy, {
             type: GenericStoreMessageTypes.storeStateChanged,
@@ -61,8 +56,7 @@ describe('StoreProxyTest', () => {
             })
             .verifiable();
 
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object);
-        storeProxy.setTabId(1);
+        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
 
         const stateUpdateMessage: StoreUpdateMessage<string> = {
             type: GenericStoreMessageTypes.storeStateChanged,
@@ -96,7 +90,6 @@ describe('StoreProxyTest', () => {
             .verifiable();
 
         const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object);
-        storeProxy.setTabId(null);
 
         onChange.call(storeProxy, {
             type: GenericStoreMessageTypes.storeStateChanged,
@@ -122,8 +115,7 @@ describe('StoreProxyTest', () => {
             })
             .verifiable();
 
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object);
-        storeProxy.setTabId(1);
+        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
 
         onChange.call(storeProxy, {
             type: GenericStoreMessageTypes.storeStateChanged,
@@ -150,8 +142,7 @@ describe('StoreProxyTest', () => {
             })
             .verifiable();
 
-        const storeProxy = new TestableStoreProxy('GlobalStoreProxy', browserAdapterMock.object);
-        storeProxy.setTabId(1);
+        const storeProxy = new TestableStoreProxy('GlobalStoreProxy', browserAdapterMock.object, 1);
 
         onChange.call(storeProxy, {
             type: GenericStoreMessageTypes.storeStateChanged,
@@ -176,8 +167,7 @@ describe('StoreProxyTest', () => {
             })
             .verifiable();
 
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object);
-        storeProxy.setTabId(1);
+        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
 
         onChange.call(storeProxy, {
             type: GenericStoreMessageTypes.storeStateChanged,
@@ -203,8 +193,7 @@ describe('StoreProxyTest', () => {
             })
             .verifiable();
 
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object);
-        storeProxy.setTabId(1);
+        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
 
         onChange.call(storeProxy, {
             type: 'ANOTHER_KIND_OF_MESSAGE',
@@ -230,8 +219,7 @@ describe('StoreProxyTest', () => {
             })
             .verifiable();
 
-        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object);
-        storeProxy.setTabId(1);
+        const storeProxy = new TestableStoreProxy('TestStore', browserAdapterMock.object, 1);
 
         onChange.call(storeProxy, {
             type: 'STORE_UPDATED',


### PR DESCRIPTION
#### Description of changes

As per my previous PR, I feel like this PR will reduce future issues arising when creating new stores and using them in details/pop-up/etc views.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
