### PR TITLE
fix: parsing error on the switcher

### DIFF
--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -36,10 +36,10 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
 
     private onRenderOption = (option: IDropdownOption): JSX.Element => {
         return (
-            <div className={styles.switcherDropdownOption} aria-hidden="true">
+            <span className={styles.switcherDropdownOption} aria-hidden="true">
                 {option.data && option.data.icon && <Icon iconName={option.data.icon} />}
                 <span>{option.text}</span>
-            </div>
+            </span>
         );
     };
 

--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -46,12 +46,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
     private onRenderTitle = (options: IDropdownOption[]): JSX.Element => {
         const option = options[0];
 
-        return (
-            <div className={styles.switcherDropdownOption} aria-hidden="true">
-                {option.data && option.data.icon && <Icon iconName={option.data.icon} />}
-                <span>{option.text}</span>
-            </div>
-        );
+        return this.onRenderOption(option);
     };
 
     private onOptionChange = (event, option?: IDropdownOption): void => {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
@@ -1,13 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Switcher render 1`] = `
+exports[`Switcher props dropdown has correct options 1`] = `
+Array [
+  Object {
+    "data": Object {
+      "icon": "Rocket",
+    },
+    "key": 0,
+    "text": "FastPass",
+  },
+  Object {
+    "data": Object {
+      "icon": "testBeaker",
+    },
+    "key": 2,
+    "text": "Assessment",
+  },
+]
+`;
+
+exports[`Switcher renders Switcher itself matches snapshot 1`] = `
 "<div className=\\"headerSwitcher\\">
   <StyledWithResponsiveMode className=\\"headerSwitcherDropdown\\" ariaLabel=\\"select activity\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function]} onRenderTitle={[Function]} onChange={[Function]} options={{...}} />
 </div>"
 `;
 
-exports[`Switcher render options 1`] = `
-"<div className=\\"headerSwitcher\\">
-  <StyledWithResponsiveMode className=\\"headerSwitcherDropdown\\" ariaLabel=\\"select activity\\" responsiveMode={2} selectedKey={0} onRenderOption={[Function]} onRenderTitle={[Function]} onChange={[Function]} options={{...}} />
-</div>"
+exports[`Switcher renders option renderer override matches snapshot  1`] = `
+<span
+  aria-hidden="true"
+  className="switcherDropdownOption"
+>
+  <StyledIconBase
+    iconName="Rocket"
+  />
+  <span>
+    FastPass
+  </span>
+</span>
 `;

--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -1,13 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { Switcher, SwitcherProps } from 'DetailsView/components/switcher';
 import { shallow } from 'enzyme';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
-
-import { DetailsViewPivotType } from '../../../../../common/types/details-view-pivot-type';
-import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
-import { Switcher, SwitcherProps } from '../../../../../DetailsView/components/switcher';
 
 describe('Switcher', () => {
     let defaultProps: SwitcherProps;
@@ -23,49 +22,70 @@ describe('Switcher', () => {
         };
     });
 
-    test('render', () => {
-        const renderer = shallow(<Switcher {...defaultProps} />);
+    describe('renders', () => {
+        it('Switcher itself matches snapshot', () => {
+            const renderer = shallow(<Switcher {...defaultProps} />);
 
-        expect(renderer.debug()).toMatchSnapshot();
+            expect(renderer.debug()).toMatchSnapshot();
+        });
+
+        it('option renderer override matches snapshot ', () => {
+            const renderer = shallow(<Switcher {...defaultProps} />);
+
+            const dropdown = renderer.find(Dropdown);
+
+            const options = dropdown.prop('options');
+
+            const onRenderOption = dropdown.prop('onRenderOption');
+
+            expect(onRenderOption(options[0])).toMatchSnapshot();
+        });
     });
 
-    test('render options', () => {
-        const renderer = shallow(<Switcher {...defaultProps} />);
-        renderer.find(Dropdown).simulate('click');
+    describe('props', () => {
+        it('dropdown has correct options', () => {
+            const renderer = shallow(<Switcher {...defaultProps} />);
 
-        expect(renderer.debug()).toMatchSnapshot();
+            const dropdown = renderer.find(Dropdown);
+
+            expect(dropdown.prop('options')).toMatchSnapshot();
+        });
     });
 
-    test('onOptionChange', () => {
-        detailsViewActionMessageCreatorMock
-            .setup(creator => creator.sendPivotItemClicked(DetailsViewPivotType[DetailsViewPivotType.assessment]))
-            .verifiable(Times.once());
-        const wrapper = shallow<Switcher>(<Switcher {...defaultProps} />);
-        const dropdown = wrapper.find(Dropdown);
+    describe('user interaction', () => {
+        it('triggers action message and state change when the user changes selection', () => {
+            detailsViewActionMessageCreatorMock
+                .setup(creator => creator.sendPivotItemClicked(DetailsViewPivotType[DetailsViewPivotType.assessment]))
+                .verifiable(Times.once());
+            const wrapper = shallow<Switcher>(<Switcher {...defaultProps} />);
+            const dropdown = wrapper.find(Dropdown);
 
-        expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.fastPass);
+            expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.fastPass);
 
-        dropdown.props().onChange(null, {
-            key: DetailsViewPivotType.assessment,
-        } as IDropdownOption);
+            dropdown.props().onChange(null, {
+                key: DetailsViewPivotType.assessment,
+            } as IDropdownOption);
 
-        expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.assessment);
-        detailsViewActionMessageCreatorMock.verifyAll();
+            expect(wrapper.state().selectedKey).toBe(DetailsViewPivotType.assessment);
+            detailsViewActionMessageCreatorMock.verifyAll();
+        });
     });
 
-    test('componentDidUpdate: pivotKey has changed', () => {
-        const newProps = {
-            ...defaultProps,
-            pivotKey: DetailsViewPivotType.assessment,
-        };
-        const component = shallow(<Switcher {...newProps} />).instance() as Switcher;
-        component.componentDidUpdate(defaultProps);
-        expect(component.state).toMatchObject({ selectedKey: DetailsViewPivotType.assessment });
-    });
+    describe('componentDidUpdate', () => {
+        it('pivotKey has changed', () => {
+            const newProps = {
+                ...defaultProps,
+                pivotKey: DetailsViewPivotType.assessment,
+            };
+            const component = shallow(<Switcher {...newProps} />).instance() as Switcher;
+            component.componentDidUpdate(defaultProps);
+            expect(component.state).toMatchObject({ selectedKey: DetailsViewPivotType.assessment });
+        });
 
-    test('componentDidUpdate: pivotKey has not changed', () => {
-        const component = shallow(<Switcher {...defaultProps} />).instance() as Switcher;
-        component.componentDidUpdate(defaultProps);
-        expect(component.state).toMatchObject({ selectedKey: DetailsViewPivotType.fastPass });
+        it('pivotKey has not changed', () => {
+            const component = shallow(<Switcher {...defaultProps} />).instance() as Switcher;
+            component.componentDidUpdate(defaultProps);
+            expect(component.state).toMatchObject({ selectedKey: DetailsViewPivotType.fastPass });
+        });
     });
 });


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

Currently the `Switcher` uses a `div` inside of an `span`. We do control the inner `div` but the `span` comes from the `Dropdown` component of **Office Fabric** so the direct way to solve this is to change the `div` into a `span`. Also, by doing this, there is no need to change css.

I updated the tests and added some missing ones.

**Notes**
There should be not visible changes on the UI for this PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
