### PR TITLE
refactor: promisify create tab new window

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -236,9 +236,12 @@ export class ActionCreator {
         this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
     };
 
-    private onOpenPreviewFeaturesPanel = (payload: BaseActionPayload, tabId: number): void => {
+    private onOpenPreviewFeaturesPanel = async (
+        payload: BaseActionPayload,
+        tabId: number,
+    ): Promise<void> => {
         this.previewFeaturesActions.openPreviewFeatures.invoke(null);
-        this.showDetailsView(tabId);
+        await this.detailsViewController.showDetailsViewP(tabId);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PREVIEW_FEATURES_OPEN, payload);
     };
 
@@ -290,12 +293,15 @@ export class ActionCreator {
         this.visualizationActions.scrollRequested.invoke(null);
     };
 
-    private onDetailsViewOpen = (payload: OnDetailsViewOpenPayload, tabId: number): void => {
+    private onDetailsViewOpen = async (
+        payload: OnDetailsViewOpenPayload,
+        tabId: number,
+    ): Promise<void> => {
         if (this.shouldEnableToggleOnDetailsViewOpen(payload.detailsViewType)) {
             this.enableToggleOnDetailsViewOpen(payload.detailsViewType, tabId);
         }
 
-        this.onPivotChildSelected(payload, tabId);
+        await this.onPivotChildSelected(payload, tabId);
     };
 
     private shouldEnableToggleOnDetailsViewOpen(visualizationType: VisualizationType): boolean {
@@ -324,10 +330,13 @@ export class ActionCreator {
         };
     }
 
-    private onPivotChildSelected = (payload: OnDetailsViewOpenPayload, tabId: number): void => {
+    private onPivotChildSelected = async (
+        payload: OnDetailsViewOpenPayload,
+        tabId: number,
+    ): Promise<void> => {
         this.previewFeaturesActions.closePreviewFeatures.invoke(null);
         this.visualizationActions.updateSelectedPivotChild.invoke(payload);
-        this.showDetailsView(tabId);
+        await this.detailsViewController.showDetailsViewP(tabId);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PIVOT_CHILD_SELECTED, payload);
     };
 
@@ -337,10 +346,6 @@ export class ActionCreator {
             TelemetryEvents.DETAILS_VIEW_PIVOT_ACTIVATED,
             payload,
         );
-    };
-
-    private showDetailsView = (tabId: number): void => {
-        this.detailsViewController.showDetailsView(tabId);
     };
 
     private onVisualizationToggle = (payload: VisualizationTogglePayload): void => {

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -3,6 +3,8 @@
 import { TestMode } from 'common/configs/test-mode';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import * as TelemetryEvents from 'common/extension-telemetry-events';
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { NotificationCreator } from 'common/notification-creator';
 import { StoreNames } from 'common/stores/store-names';
@@ -52,6 +54,7 @@ export class ActionCreator {
         private readonly notificationCreator: NotificationCreator,
         private readonly visualizationConfigurationFactory: VisualizationConfigurationFactory,
         private readonly targetTabController: TargetTabController,
+        private readonly logger: Logger = createDefaultLogger(),
     ) {
         this.visualizationActions = actionHub.visualizationActions;
         this.previewFeaturesActions = actionHub.previewFeaturesActions;
@@ -241,7 +244,9 @@ export class ActionCreator {
         tabId: number,
     ): Promise<void> => {
         this.previewFeaturesActions.openPreviewFeatures.invoke(null);
-        await this.detailsViewController.showDetailsView(tabId);
+        await this.detailsViewController
+            .showDetailsView(tabId)
+            .catch(e => this.logger.error(e.message));
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PREVIEW_FEATURES_OPEN, payload);
     };
 
@@ -336,7 +341,9 @@ export class ActionCreator {
     ): Promise<void> => {
         this.previewFeaturesActions.closePreviewFeatures.invoke(null);
         this.visualizationActions.updateSelectedPivotChild.invoke(payload);
-        await this.detailsViewController.showDetailsView(tabId);
+        await this.detailsViewController
+            .showDetailsView(tabId)
+            .catch(e => this.logger.error(e.message));
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PIVOT_CHILD_SELECTED, payload);
     };
 

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -241,7 +241,7 @@ export class ActionCreator {
         tabId: number,
     ): Promise<void> => {
         this.previewFeaturesActions.openPreviewFeatures.invoke(null);
-        await this.detailsViewController.showDetailsViewP(tabId);
+        await this.detailsViewController.showDetailsView(tabId);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PREVIEW_FEATURES_OPEN, payload);
     };
 
@@ -336,7 +336,7 @@ export class ActionCreator {
     ): Promise<void> => {
         this.previewFeaturesActions.closePreviewFeatures.invoke(null);
         this.visualizationActions.updateSelectedPivotChild.invoke(payload);
-        await this.detailsViewController.showDetailsViewP(tabId);
+        await this.detailsViewController.showDetailsView(tabId);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PIVOT_CHILD_SELECTED, payload);
     };
 

--- a/src/background/actions/content-action-creator.ts
+++ b/src/background/actions/content-action-creator.ts
@@ -32,7 +32,7 @@ export class ContentActionCreator {
 
     private onOpenContentPanel = async (payload: ContentPayload, tabId: number): Promise<void> => {
         this.contentActions.openContentPanel.invoke(payload);
-        await this.detailsViewController.showDetailsViewP(tabId).catch(this.logger.error);
+        await this.detailsViewController.showDetailsView(tabId).catch(this.logger.error);
         this.telemetryEventHandler.publishTelemetry(CONTENT_PANEL_OPENED, payload);
     };
 

--- a/src/background/actions/content-action-creator.ts
+++ b/src/background/actions/content-action-creator.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CONTENT_PANEL_CLOSED, CONTENT_PANEL_OPENED } from 'common/extension-telemetry-events';
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { Messages } from 'common/messages';
-
 import { DetailsViewController } from '../details-view-controller';
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
@@ -15,6 +16,7 @@ export class ContentActionCreator {
         private readonly contentActions: ContentActions,
         private readonly telemetryEventHandler: TelemetryEventHandler,
         private readonly detailsViewController: DetailsViewController,
+        private readonly logger: Logger = createDefaultLogger(),
     ) {}
 
     public registerCallbacks(): void {
@@ -28,9 +30,9 @@ export class ContentActionCreator {
         );
     }
 
-    private onOpenContentPanel = (payload: ContentPayload, tabId: number): void => {
+    private onOpenContentPanel = async (payload: ContentPayload, tabId: number): Promise<void> => {
         this.contentActions.openContentPanel.invoke(payload);
-        this.showDetailsView(tabId);
+        await this.detailsViewController.showDetailsViewP(tabId).catch(this.logger.error);
         this.telemetryEventHandler.publishTelemetry(CONTENT_PANEL_OPENED, payload);
     };
 
@@ -38,8 +40,4 @@ export class ContentActionCreator {
         this.contentActions.closeContentPanel.invoke(null);
         this.telemetryEventHandler.publishTelemetry(CONTENT_PANEL_CLOSED, payload);
     };
-
-    private showDetailsView(tabId: number): void {
-        this.detailsViewController.showDetailsView(tabId);
-    }
 }

--- a/src/background/actions/details-view-action-creator.ts
+++ b/src/background/actions/details-view-action-creator.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { SETTINGS_PANEL_CLOSE, SETTINGS_PANEL_OPEN } from 'common/extension-telemetry-events';
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { DetailsViewRightContentPanelType } from 'DetailsView/components/left-nav/details-view-right-content-panel-type';
-
 import { DetailsViewController } from '../details-view-controller';
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
@@ -17,6 +18,7 @@ export class DetailsViewActionCreator {
         private readonly detailsViewActions: DetailsViewActions,
         private readonly detailsViewController: DetailsViewController,
         private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly logger: Logger = createDefaultLogger(),
     ) {}
 
     public registerCallback(): void {
@@ -38,9 +40,12 @@ export class DetailsViewActionCreator {
         );
     }
 
-    private onOpenSettingsPanel = (payload: BaseActionPayload, tabId: number): void => {
+    private onOpenSettingsPanel = async (
+        payload: BaseActionPayload,
+        tabId: number,
+    ): Promise<void> => {
         this.detailsViewActions.openSettingsPanel.invoke(null);
-        this.detailsViewController.showDetailsView(tabId);
+        await this.detailsViewController.showDetailsViewP(tabId).catch(this.logger.error);
         this.telemetryEventHandler.publishTelemetry(SETTINGS_PANEL_OPEN, payload);
     };
 

--- a/src/background/actions/details-view-action-creator.ts
+++ b/src/background/actions/details-view-action-creator.ts
@@ -45,7 +45,7 @@ export class DetailsViewActionCreator {
         tabId: number,
     ): Promise<void> => {
         this.detailsViewActions.openSettingsPanel.invoke(null);
-        await this.detailsViewController.showDetailsViewP(tabId).catch(this.logger.error);
+        await this.detailsViewController.showDetailsView(tabId).catch(this.logger.error);
         this.telemetryEventHandler.publishTelemetry(SETTINGS_PANEL_OPEN, payload);
     };
 

--- a/src/background/actions/scoping-panel-action-creator.ts
+++ b/src/background/actions/scoping-panel-action-creator.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { SCOPING_CLOSE, SCOPING_OPEN } from 'common/extension-telemetry-events';
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { Messages } from 'common/messages';
 import { DetailsViewController } from '../details-view-controller';
 import { Interpreter } from '../interpreter';
@@ -14,6 +16,7 @@ export class ScopingPanelActionCreator {
         private readonly scopingActions: ScopingActions,
         private readonly telemetryEventHandler: TelemetryEventHandler,
         private readonly detailsViewController: DetailsViewController,
+        private readonly logger: Logger = createDefaultLogger(),
     ) {}
 
     public registerCallbacks(): void {
@@ -26,9 +29,9 @@ export class ScopingPanelActionCreator {
         );
     }
 
-    private onOpenScopingPanel(payload: BaseActionPayload, tabId: number): void {
+    private async onOpenScopingPanel(payload: BaseActionPayload, tabId: number): Promise<void> {
         this.scopingActions.openScopingPanel.invoke(null);
-        this.detailsViewController.showDetailsView(tabId);
+        await this.detailsViewController.showDetailsViewP(tabId).catch(this.logger.error);
         this.telemetryEventHandler.publishTelemetry(SCOPING_OPEN, payload);
     }
 

--- a/src/background/actions/scoping-panel-action-creator.ts
+++ b/src/background/actions/scoping-panel-action-creator.ts
@@ -28,16 +28,12 @@ export class ScopingPanelActionCreator {
 
     private onOpenScopingPanel(payload: BaseActionPayload, tabId: number): void {
         this.scopingActions.openScopingPanel.invoke(null);
-        this.showDetailsView(tabId);
+        this.detailsViewController.showDetailsView(tabId);
         this.telemetryEventHandler.publishTelemetry(SCOPING_OPEN, payload);
     }
 
     private onCloseScopingPanel(payload: BaseActionPayload): void {
         this.scopingActions.closeScopingPanel.invoke(null);
         this.telemetryEventHandler.publishTelemetry(SCOPING_CLOSE, payload);
-    }
-
-    private showDetailsView(tabId: number): void {
-        this.detailsViewController.showDetailsView(tabId);
     }
 }

--- a/src/background/actions/scoping-panel-action-creator.ts
+++ b/src/background/actions/scoping-panel-action-creator.ts
@@ -31,7 +31,7 @@ export class ScopingPanelActionCreator {
 
     private async onOpenScopingPanel(payload: BaseActionPayload, tabId: number): Promise<void> {
         this.scopingActions.openScopingPanel.invoke(null);
-        await this.detailsViewController.showDetailsViewP(tabId).catch(this.logger.error);
+        await this.detailsViewController.showDetailsView(tabId).catch(this.logger.error);
         this.telemetryEventHandler.publishTelemetry(SCOPING_OPEN, payload);
     }
 

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -34,6 +34,21 @@ export class DetailsViewController {
         );
     }
 
+    public showDetailsViewP(targetTabId: number): Promise<void> {
+        const detailsViewTabId = this.tabIdToDetailsViewMap[targetTabId];
+
+        if (detailsViewTabId != null) {
+            this.browserAdapter.switchToTab(detailsViewTabId);
+            return;
+        }
+
+        return this.browserAdapter
+            .createTabInNewWindowP(this.getDetailsUrl(targetTabId))
+            .then(tab => {
+                this.tabIdToDetailsViewMap[targetTabId] = tab.id;
+            });
+    }
+
     private onUpdateTab = (
         tabId: number,
         changeInfo: chrome.tabs.TabChangeInfo,

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -18,7 +18,7 @@ export class DetailsViewController {
         this.detailsViewRemovedHandler = handler;
     }
 
-    public showDetailsViewP(targetTabId: number): Promise<void> {
+    public showDetailsView(targetTabId: number): Promise<void> {
         const detailsViewTabId = this.tabIdToDetailsViewMap[targetTabId];
 
         if (detailsViewTabId != null) {

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -18,22 +18,6 @@ export class DetailsViewController {
         this.detailsViewRemovedHandler = handler;
     }
 
-    public showDetailsView(targetTabId: number): void {
-        const detailsViewTabId = this.tabIdToDetailsViewMap[targetTabId];
-
-        if (detailsViewTabId != null) {
-            this.browserAdapter.switchToTab(detailsViewTabId);
-            return;
-        }
-
-        this.browserAdapter.createTabInNewWindow(
-            this.getDetailsUrl(targetTabId),
-            (tab: chrome.tabs.Tab) => {
-                this.tabIdToDetailsViewMap[targetTabId] = tab.id;
-            },
-        );
-    }
-
     public showDetailsViewP(targetTabId: number): Promise<void> {
         const detailsViewTabId = this.tabIdToDetailsViewMap[targetTabId];
 

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -27,7 +27,7 @@ export class DetailsViewController {
         }
 
         return this.browserAdapter
-            .createTabInNewWindowP(this.getDetailsUrl(targetTabId))
+            .createTabInNewWindow(this.getDetailsUrl(targetTabId))
             .then(tab => {
                 this.tabIdToDetailsViewMap[targetTabId] = tab.id;
             });

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -18,7 +18,7 @@ export class DetailsViewController {
         this.detailsViewRemovedHandler = handler;
     }
 
-    public showDetailsView(targetTabId: number): Promise<void> {
+    public async showDetailsView(targetTabId: number): Promise<void> {
         const detailsViewTabId = this.tabIdToDetailsViewMap[targetTabId];
 
         if (detailsViewTabId != null) {
@@ -26,11 +26,9 @@ export class DetailsViewController {
             return;
         }
 
-        return this.browserAdapter
-            .createTabInNewWindow(this.getDetailsUrl(targetTabId))
-            .then(tab => {
-                this.tabIdToDetailsViewMap[targetTabId] = tab.id;
-            });
+        const tab = await this.browserAdapter.createTabInNewWindow(this.getDetailsUrl(targetTabId));
+
+        this.tabIdToDetailsViewMap[targetTabId] = tab.id;
     }
 
     private onUpdateTab = (

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -11,7 +11,6 @@ export interface BrowserAdapter {
     addListenerOnWindowsFocusChanged(callback: (windowId: number) => void): void;
     tabsQuery(query: chrome.tabs.QueryInfo, callback: (result: chrome.tabs.Tab[]) => void): void;
     createActiveTab(url: string): Promise<Tabs.Tab>;
-    createTabInNewWindow(url: string, callback?: (tab: chrome.tabs.Tab) => void): void;
     createTabInNewWindowP(url: string): Promise<Tabs.Tab>;
     createInactiveTab(url: string, callback: (tab: chrome.tabs.Tab) => void): void;
     closeTab(tabId: number): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -11,7 +11,7 @@ export interface BrowserAdapter {
     addListenerOnWindowsFocusChanged(callback: (windowId: number) => void): void;
     tabsQuery(query: chrome.tabs.QueryInfo, callback: (result: chrome.tabs.Tab[]) => void): void;
     createActiveTab(url: string): Promise<Tabs.Tab>;
-    createTabInNewWindowP(url: string): Promise<Tabs.Tab>;
+    createTabInNewWindow(url: string): Promise<Tabs.Tab>;
     createInactiveTab(url: string, callback: (tab: chrome.tabs.Tab) => void): void;
     closeTab(tabId: number): void;
     switchToTab(tabId: number): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -12,6 +12,7 @@ export interface BrowserAdapter {
     tabsQuery(query: chrome.tabs.QueryInfo, callback: (result: chrome.tabs.Tab[]) => void): void;
     createActiveTab(url: string): Promise<Tabs.Tab>;
     createTabInNewWindow(url: string, callback?: (tab: chrome.tabs.Tab) => void): void;
+    createTabInNewWindowP(url: string): Promise<Tabs.Tab>;
     createInactiveTab(url: string, callback: (tab: chrome.tabs.Tab) => void): void;
     closeTab(tabId: number): void;
     switchToTab(tabId: number): void;

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -77,6 +77,10 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         );
     }
 
+    public createTabInNewWindowP(url: string): Promise<Tabs.Tab> {
+        return browser.windows.create({ url, focused: true }).then(window => window.tabs[0]);
+    }
+
     public createInactiveTab(url: string, callback: (tab: chrome.tabs.Tab) => void): void {
         chrome.tabs.create(
             {

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -65,18 +65,6 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return browser.tabs.create({ url, active: true, pinned: false });
     }
 
-    public createTabInNewWindow(url: string, callback?: (tab: chrome.tabs.Tab) => void): void {
-        chrome.windows.create(
-            {
-                url: url,
-                focused: true,
-            },
-            window => {
-                callback(window.tabs[0]);
-            },
-        );
-    }
-
     public createTabInNewWindowP(url: string): Promise<Tabs.Tab> {
         return browser.windows.create({ url, focused: true }).then(window => window.tabs[0]);
     }

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -65,7 +65,7 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return browser.tabs.create({ url, active: true, pinned: false });
     }
 
-    public createTabInNewWindowP(url: string): Promise<Tabs.Tab> {
+    public createTabInNewWindow(url: string): Promise<Tabs.Tab> {
         return browser.windows.create({ url, focused: true }).then(window => window.tabs[0]);
     }
 

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -51,8 +51,6 @@ import { Logger } from 'common/logging/logger';
 const VisualizationMessage = Messages.Visualizations;
 const PreviewFeaturesMessage = Messages.PreviewFeatures;
 
-//
-
 describe('ActionCreatorTest', () => {
     const testSource: TelemetryEventSource = -1 as TelemetryEventSource;
 

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -36,6 +36,7 @@ import {
     TriggeredBy,
 } from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
+import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { NotificationCreator } from 'common/notification-creator';
 import { StoreNames } from 'common/stores/store-names';
@@ -46,7 +47,6 @@ import { forOwn } from 'lodash';
 import { tick } from 'tests/unit/common/tick';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DictionaryStringTo } from 'types/common-types';
-import { Logger } from 'common/logging/logger';
 
 const VisualizationMessage = Messages.Visualizations;
 const PreviewFeaturesMessage = Messages.PreviewFeatures;

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -207,7 +207,7 @@ describe('ActionCreatorTest', () => {
             .setupActionOnVisualizationActions(updateViewActionName)
             .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
-            .setupShowDetailsViewP(tabId, Promise.resolve());
+            .setupShowDetailsView(tabId, Promise.resolve());
 
         const actionCreator = validator.buildActionCreator();
 
@@ -241,7 +241,7 @@ describe('ActionCreatorTest', () => {
             .setupActionOnVisualizationActions(updateViewActionName)
             .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
-            .setupShowDetailsViewP(tabId, Promise.resolve());
+            .setupShowDetailsView(tabId, Promise.resolve());
 
         const actionCreator = validator.buildActionCreator();
 
@@ -284,7 +284,7 @@ describe('ActionCreatorTest', () => {
             .setupVisualizationActionWithInvokeParameter(enablingIssuesActionName, enableVisualizationTelemetryPayload)
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
             .setupTelemetrySend(TelemetryEvents.AUTOMATED_CHECKS_TOGGLE, enableVisualizationTelemetryPayload, tabId)
-            .setupShowDetailsViewP(tabId, Promise.resolve());
+            .setupShowDetailsView(tabId, Promise.resolve());
 
         const actionCreator = validator.buildActionCreator();
 
@@ -317,7 +317,7 @@ describe('ActionCreatorTest', () => {
             .setupActionOnVisualizationActions(updateViewActionName)
             .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
-            .setupShowDetailsViewP(tabId, Promise.resolve());
+            .setupShowDetailsView(tabId, Promise.resolve());
 
         const actionCreator = validator.buildActionCreator();
 
@@ -491,7 +491,7 @@ describe('ActionCreatorTest', () => {
             .setupActionOnPreviewFeaturesActions(closePreviewFeaturesActionName)
             .setupPreviewFeaturesActionWithInvokeParameter(closePreviewFeaturesActionName, null)
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, 1)
-            .setupShowDetailsViewP(tabId, Promise.resolve());
+            .setupShowDetailsView(tabId, Promise.resolve());
 
         const actionCreator = builder.buildActionCreator();
 
@@ -772,7 +772,7 @@ describe('ActionCreatorTest', () => {
             .setupRegistrationCallback(PreviewFeaturesMessage.OpenPanel, [telemetryInfo, tabId])
             .setupActionOnPreviewFeaturesActions(actionName)
             .setupTelemetrySend(TelemetryEvents.PREVIEW_FEATURES_OPEN, telemetryInfo, tabId)
-            .setupShowDetailsViewP(tabId, Promise.resolve())
+            .setupShowDetailsView(tabId, Promise.resolve())
             .setupPreviewFeaturesActionWithInvokeParameter(actionName, null);
 
         const actionCreator = validator.buildActionCreator();
@@ -1035,9 +1035,9 @@ class ActionCreatorValidator {
         return this;
     }
 
-    public setupShowDetailsViewP(tabId: number, result: Promise<void>): ActionCreatorValidator {
+    public setupShowDetailsView(tabId: number, result: Promise<void>): ActionCreatorValidator {
         this.detailsViewControllerStrictMock
-            .setup(controller => controller.showDetailsViewP(tabId))
+            .setup(controller => controller.showDetailsView(tabId))
             .returns(() => result)
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/background/actions/content-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/content-action-creator.test.ts
@@ -55,9 +55,9 @@ describe('ContentActionMessageCreator', () => {
         });
 
         it('when showing the details view throws an error, the error should be logged', async () => {
-            const errorMessage = 'error on showDetailsViewP';
+            const errorMessage = 'error on showDetailsView';
             detailsViewControllerMock
-                .setup(controller => controller.showDetailsViewP(tabId))
+                .setup(controller => controller.showDetailsView(tabId))
                 .returns(() => Promise.reject(errorMessage))
                 .verifiable(Times.once());
 
@@ -73,7 +73,7 @@ describe('ContentActionMessageCreator', () => {
 
         it('when there is no error from showing the details view', async () => {
             detailsViewControllerMock
-                .setup(controller => controller.showDetailsViewP(tabId))
+                .setup(controller => controller.showDetailsView(tabId))
                 .returns(() => Promise.resolve())
                 .verifiable(Times.once());
 

--- a/src/tests/unit/tests/background/actions/content-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/content-action-creator.test.ts
@@ -11,7 +11,7 @@ import { IMock, Mock, Times } from 'typemoq';
 
 import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
-describe('ContentPanelActionMessageCreator', () => {
+describe('ContentActionMessageCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
 
     beforeEach(() => {

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -49,7 +49,7 @@ describe('DetailsViewActionCreatorTest', () => {
             const errorMessage = 'error on showDetailsView';
 
             detailsViewControllerMock
-                .setup(controller => controller.showDetailsViewP(tabId))
+                .setup(controller => controller.showDetailsView(tabId))
                 .returns(() => Promise.reject(errorMessage))
                 .verifiable(Times.once());
 
@@ -75,7 +75,7 @@ describe('DetailsViewActionCreatorTest', () => {
 
         it('when showDetailsView succeed', async () => {
             detailsViewControllerMock
-                .setup(controller => controller.showDetailsViewP(tabId))
+                .setup(controller => controller.showDetailsView(tabId))
                 .returns(() => Promise.resolve())
                 .verifiable(Times.once());
 

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -4,18 +4,17 @@ import { BaseActionPayload } from 'background/actions/action-payloads';
 import { DetailsViewActionCreator } from 'background/actions/details-view-action-creator';
 import { DetailsViewActions } from 'background/actions/details-view-actions';
 import { DetailsViewController } from 'background/details-view-controller';
+import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { SETTINGS_PANEL_CLOSE, SETTINGS_PANEL_OPEN, TelemetryEventSource, TriggeredBy } from 'common/extension-telemetry-events';
+import { Action } from 'common/flux/action';
+import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { DetailsViewRightContentPanelType } from 'DetailsView/components/left-nav/details-view-right-content-panel-type';
-import { IMock, Mock, Times } from 'typemoq';
-
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 import { tick } from 'tests/unit/common/tick';
-import { Action } from 'common/flux/action';
-import { Interpreter } from 'background/interpreter';
-import { Logger } from 'common/logging/logger';
+import { IMock, Mock, Times } from 'typemoq';
+import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('DetailsViewActionCreatorTest', () => {
     let detailsViewControllerMock: IMock<DetailsViewController>;

--- a/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
@@ -7,12 +7,12 @@ import { DetailsViewController } from 'background/details-view-controller';
 import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { SCOPING_CLOSE, SCOPING_OPEN } from 'common/extension-telemetry-events';
-import { Messages } from 'common/messages';
-import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 import { Action } from 'common/flux/action';
 import { Logger } from 'common/logging/logger';
+import { Messages } from 'common/messages';
 import { tick } from 'tests/unit/common/tick';
+import { IMock, Mock, MockBehavior, Times } from 'typemoq';
+import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('ScopingPanelActionCreatorTest', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;

--- a/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
@@ -4,23 +4,27 @@ import { BaseActionPayload } from 'background/actions/action-payloads';
 import { ScopingActions } from 'background/actions/scoping-actions';
 import { ScopingPanelActionCreator } from 'background/actions/scoping-panel-action-creator';
 import { DetailsViewController } from 'background/details-view-controller';
+import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { SCOPING_CLOSE, SCOPING_OPEN } from 'common/extension-telemetry-events';
 import { Messages } from 'common/messages';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-
 import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('ScopingPanelActionCreatorTest', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let detailsViewControllerStrictMock: IMock<DetailsViewController>;
+    let actionsMocks: IMock<ScopingActions>;
+    let interpreterMock: IMock<Interpreter>;
+
+    let testObject: ScopingPanelActionCreator;
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
-        detailsViewControllerStrictMock = Mock.ofType<DetailsViewController>(null, MockBehavior.Strict);
+        detailsViewControllerStrictMock = Mock.ofType<DetailsViewController>(undefined, MockBehavior.Strict);
     });
 
-    it('should handle OpenPanel message', () => {
+    it('handles OpenPanel message', () => {
         const tabId = -1;
         const payload: BaseActionPayload = {};
 
@@ -29,40 +33,40 @@ describe('ScopingPanelActionCreatorTest', () => {
         detailsViewControllerStrictMock.setup(dc => dc.showDetailsView(tabId)).verifiable(Times.once());
 
         const openScopingPanelMock = createActionMock(null);
-        const actionsMocks = createActionsMock('openScopingPanel', openScopingPanelMock.object);
-        const interpreterMock = createInterpreterMock(Messages.Scoping.OpenPanel, payload, tabId);
+        actionsMocks = createActionsMock('openScopingPanel', openScopingPanelMock.object);
+        interpreterMock = createInterpreterMock(Messages.Scoping.OpenPanel, payload, tabId);
 
-        const newTestObject = new ScopingPanelActionCreator(
+        testObject = new ScopingPanelActionCreator(
             interpreterMock.object,
             actionsMocks.object,
             telemetryEventHandlerMock.object,
             detailsViewControllerStrictMock.object,
         );
 
-        newTestObject.registerCallbacks();
+        testObject.registerCallbacks();
 
         openScopingPanelMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();
         detailsViewControllerStrictMock.verifyAll();
     });
 
-    test('should handle ClosePanel message', () => {
+    test('handles ClosePanel message', () => {
         const payload: BaseActionPayload = {};
 
         telemetryEventHandlerMock.setup(tp => tp.publishTelemetry(SCOPING_CLOSE, payload)).verifiable(Times.once());
 
         const closeScopingPanelActionMock = createActionMock(null);
-        const actionsMocks = createActionsMock('closeScopingPanel', closeScopingPanelActionMock.object);
-        const interpreterMock = createInterpreterMock(Messages.Scoping.ClosePanel, payload);
+        actionsMocks = createActionsMock('closeScopingPanel', closeScopingPanelActionMock.object);
+        interpreterMock = createInterpreterMock(Messages.Scoping.ClosePanel, payload);
 
-        const newTestObject = new ScopingPanelActionCreator(
+        testObject = new ScopingPanelActionCreator(
             interpreterMock.object,
             actionsMocks.object,
             telemetryEventHandlerMock.object,
             detailsViewControllerStrictMock.object,
         );
 
-        newTestObject.registerCallbacks();
+        testObject.registerCallbacks();
 
         closeScopingPanelActionMock.verifyAll();
         telemetryEventHandlerMock.verifyAll();

--- a/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
@@ -52,7 +52,7 @@ describe('ScopingPanelActionCreatorTest', () => {
 
         it('when showDetailsView succeed', async () => {
             detailsViewControllerStrictMock
-                .setup(controller => controller.showDetailsViewP(tabId))
+                .setup(controller => controller.showDetailsView(tabId))
                 .returns(() => Promise.resolve())
                 .verifiable(Times.once());
 
@@ -69,7 +69,7 @@ describe('ScopingPanelActionCreatorTest', () => {
             const errorMessage = 'error on showDetailsView';
 
             detailsViewControllerStrictMock
-                .setup(controller => controller.showDetailsViewP(tabId))
+                .setup(controller => controller.showDetailsView(tabId))
                 .returns(() => Promise.reject(errorMessage))
                 .verifiable(Times.once());
 

--- a/src/tests/unit/tests/background/details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/details-view-controller.test.ts
@@ -34,8 +34,7 @@ describe('DetailsViewControllerTest', () => {
         const targetTabId = 12;
         const detailsViewTabId = 10;
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
+        setupCreateDetailsView(targetTabId)
             .callback((url, func) => {
                 func({
                     id: detailsViewTabId,
@@ -53,11 +52,9 @@ describe('DetailsViewControllerTest', () => {
         const detailsViewTabId = 10;
         let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
-            .callback((url, func) => {
-                createTabCallback = func;
-            });
+        setupCreateDetailsView(targetTabId).callback((url, func) => {
+            createTabCallback = func;
+        });
 
         // call show details once
         testSubject.showDetailsView(targetTabId);
@@ -68,7 +65,7 @@ describe('DetailsViewControllerTest', () => {
 
         mockBrowserAdapter.reset();
 
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.never());
+        setupCreateDetailsViewForAnyUrl(Times.never());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
@@ -83,11 +80,9 @@ describe('DetailsViewControllerTest', () => {
         const detailsViewTabId = 10;
         let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
-            .callback((url, func) => {
-                createTabCallback = func;
-            });
+        setupCreateDetailsView(targetTabId).callback((url, func) => {
+            createTabCallback = func;
+        });
 
         // call show details once
         testSubject.showDetailsView(targetTabId);
@@ -101,7 +96,7 @@ describe('DetailsViewControllerTest', () => {
         // update target tab
         onUpdateTabCallback(targetTabId, null, null);
 
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.never());
+        setupCreateDetailsViewForAnyUrl(Times.never());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
@@ -121,11 +116,9 @@ describe('DetailsViewControllerTest', () => {
 
         testSubject.setupDetailsViewTabRemovedHandler(detailsViewRemovedHandlerMock.object);
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
-            .callback((url, func) => {
-                createTabCallback = func;
-            });
+        setupCreateDetailsView(targetTabId).callback((url, func) => {
+            createTabCallback = func;
+        });
 
         // call show details once
         testSubject.showDetailsView(targetTabId);
@@ -144,7 +137,7 @@ describe('DetailsViewControllerTest', () => {
             });
         onUpdateTabCallback(detailsViewTabId, { url: 'www.bing.com/DetailsView/detailsView.html?tabId=' + targetTabId }, null);
 
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.once());
+        setupCreateDetailsViewForAnyUrl(Times.once());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
@@ -160,11 +153,9 @@ describe('DetailsViewControllerTest', () => {
         const detailsViewTabId = 10;
         let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
-            .callback((url, func) => {
-                createTabCallback = func;
-            });
+        setupCreateDetailsView(targetTabId).callback((url, func) => {
+            createTabCallback = func;
+        });
 
         // call show details once
         testSubject.showDetailsView(targetTabId);
@@ -180,7 +171,7 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
         onUpdateTabCallback(detailsViewTabId, { url: 'chromeExt://ext_id/DetailsView/detailsView.html?tabId=90' }, null);
 
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.once());
+        setupCreateDetailsViewForAnyUrl(Times.once());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
@@ -195,11 +186,9 @@ describe('DetailsViewControllerTest', () => {
         const detailsViewTabId = 10;
         let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
-            .callback((url, func) => {
-                createTabCallback = func;
-            });
+        setupCreateDetailsView(targetTabId).callback((url, func) => {
+            createTabCallback = func;
+        });
 
         // call show details once
         testSubject.showDetailsView(targetTabId);
@@ -219,7 +208,7 @@ describe('DetailsViewControllerTest', () => {
             });
         onUpdateTabCallback(detailsViewTabId, { url: 'chromeExt://ext_Id/detailsView/detailsView.html?tabId=' + targetTabId }, null);
 
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.never());
+        setupCreateDetailsViewForAnyUrl(Times.never());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
@@ -234,11 +223,9 @@ describe('DetailsViewControllerTest', () => {
         const detailsViewTabId = 10;
         let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
-            .callback((url, func) => {
-                createTabCallback = func;
-            });
+        setupCreateDetailsView(targetTabId).callback((url, func) => {
+            createTabCallback = func;
+        });
 
         // call show details once
         testSubject.showDetailsView(targetTabId);
@@ -258,7 +245,7 @@ describe('DetailsViewControllerTest', () => {
             });
         onUpdateTabCallback(detailsViewTabId, { title: 'issues' }, null);
 
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.never());
+        setupCreateDetailsViewForAnyUrl(Times.never());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
@@ -273,11 +260,9 @@ describe('DetailsViewControllerTest', () => {
         const detailsViewTabId = 10;
         let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
-            .callback((url, func) => {
-                createTabCallback = func;
-            });
+        setupCreateDetailsView(targetTabId).callback((url, func) => {
+            createTabCallback = func;
+        });
 
         // call show details once
         testSubject.showDetailsView(targetTabId);
@@ -297,7 +282,7 @@ describe('DetailsViewControllerTest', () => {
             });
         onUpdateTabCallback(123, { title: 'issues' }, null);
 
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.never());
+        setupCreateDetailsViewForAnyUrl(Times.never());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
@@ -312,11 +297,9 @@ describe('DetailsViewControllerTest', () => {
         const detailsViewTabId = 10;
         let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
-            .callback((url, func) => {
-                createTabCallback = func;
-            });
+        setupCreateDetailsView(targetTabId).callback((url, func) => {
+            createTabCallback = func;
+        });
 
         // call show details once
         testSubject.showDetailsView(targetTabId);
@@ -330,7 +313,7 @@ describe('DetailsViewControllerTest', () => {
         // remove target tab
         onTabRemoveCallback(targetTabId, null);
 
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.once());
+        setupCreateDetailsViewForAnyUrl(Times.once());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
@@ -345,11 +328,9 @@ describe('DetailsViewControllerTest', () => {
         const detailsViewTabId = 10;
         let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
-            .callback((url, func) => {
-                createTabCallback = func;
-            });
+        setupCreateDetailsView(targetTabId).callback((url, func) => {
+            createTabCallback = func;
+        });
         const detailsViewRemovedHandlerMock = Mock.ofInstance((tabId: number) => {});
         detailsViewRemovedHandlerMock.setup(handler => handler(targetTabId)).verifiable(Times.once());
         testSubject.setupDetailsViewTabRemovedHandler(detailsViewRemovedHandlerMock.object);
@@ -366,7 +347,7 @@ describe('DetailsViewControllerTest', () => {
         // remove details tab
         onTabRemoveCallback(detailsViewTabId, null);
 
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.once());
+        setupCreateDetailsViewForAnyUrl(Times.once());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
@@ -382,11 +363,9 @@ describe('DetailsViewControllerTest', () => {
         const detailsViewTabId = 10;
         let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
-            .callback((url, func) => {
-                createTabCallback = func;
-            });
+        setupCreateDetailsView(targetTabId).callback((url, func) => {
+            createTabCallback = func;
+        });
         // call show details once
         testSubject.showDetailsView(targetTabId);
 
@@ -399,7 +378,7 @@ describe('DetailsViewControllerTest', () => {
         // remove details tab
         onTabRemoveCallback(detailsViewTabId, null);
 
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.once());
+        setupCreateDetailsViewForAnyUrl(Times.once());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
@@ -414,11 +393,9 @@ describe('DetailsViewControllerTest', () => {
         const detailsViewTabId = 10;
         let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()))
-            .callback((url, func) => {
-                createTabCallback = func;
-            });
+        setupCreateDetailsView(targetTabId).callback((url, func) => {
+            createTabCallback = func;
+        });
 
         // call show details once
         testSubject.showDetailsView(targetTabId);
@@ -432,7 +409,7 @@ describe('DetailsViewControllerTest', () => {
         // remove details tab
         onTabRemoveCallback(100, null);
 
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(Times.never());
+        setupCreateDetailsViewForAnyUrl(Times.never());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
@@ -441,4 +418,14 @@ describe('DetailsViewControllerTest', () => {
 
         mockBrowserAdapter.verifyAll();
     });
+
+    const setupCreateDetailsView = (targetTabId: number) => {
+        return mockBrowserAdapter.setup(adapter =>
+            adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()),
+        );
+    };
+
+    const setupCreateDetailsViewForAnyUrl = (times: Times) => {
+        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(times);
+    };
 });

--- a/src/tests/unit/tests/background/details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/details-view-controller.test.ts
@@ -68,7 +68,7 @@ describe('DetailsViewControllerTest', () => {
             const errorMessage = 'error creating new window (from browser adapter)';
 
             mockBrowserAdapter
-                .setup(adapter => adapter.createTabInNewWindowP('DetailsView/detailsView.html?tabId=' + targetTabId))
+                .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId))
                 .returns(() => Promise.reject(errorMessage))
                 .verifiable(Times.once());
 
@@ -341,13 +341,13 @@ describe('DetailsViewControllerTest', () => {
 
     const setupCreateDetailsViewP = (targetTabId: number, resultingDetailsViewTabId: number) => {
         return mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindowP('DetailsView/detailsView.html?tabId=' + targetTabId))
+            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId))
             .returns(() => Promise.resolve({ id: resultingDetailsViewTabId } as Tabs.Tab));
     };
 
     const setupCreateDetailsViewPForAnyUrl = (times: Times) => {
         mockBrowserAdapter
-            .setup(adapter => adapter.createTabInNewWindowP(It.isAny()))
+            .setup(adapter => adapter.createTabInNewWindow(It.isAny()))
             .returns(() => Promise.resolve({ id: -1 } as Tabs.Tab))
             .verifiable(times);
     };

--- a/src/tests/unit/tests/background/details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/details-view-controller.test.ts
@@ -31,14 +31,14 @@ describe('DetailsViewControllerTest', () => {
         testSubject = new DetailsViewController(mockBrowserAdapter.object);
     });
 
-    describe('showDetailsViewP', () => {
+    describe('showDetailsView', () => {
         it('creates a details view the first time', async () => {
             const targetTabId = 12;
             const detailsViewTabId = 10;
 
             setupCreateDetailsViewP(targetTabId, detailsViewTabId).verifiable(Times.once());
 
-            await testSubject.showDetailsViewP(targetTabId);
+            await testSubject.showDetailsView(targetTabId);
 
             mockBrowserAdapter.verifyAll();
         });
@@ -49,7 +49,7 @@ describe('DetailsViewControllerTest', () => {
 
             setupCreateDetailsViewP(targetTabId, detailsViewTabId).verifiable(Times.once());
 
-            await testSubject.showDetailsViewP(targetTabId);
+            await testSubject.showDetailsView(targetTabId);
 
             mockBrowserAdapter.reset();
 
@@ -58,7 +58,7 @@ describe('DetailsViewControllerTest', () => {
             mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
             // call show details second time
-            await testSubject.showDetailsViewP(targetTabId);
+            await testSubject.showDetailsView(targetTabId);
 
             mockBrowserAdapter.verifyAll();
         });
@@ -72,7 +72,7 @@ describe('DetailsViewControllerTest', () => {
                 .returns(() => Promise.reject(errorMessage))
                 .verifiable(Times.once());
 
-            await expect(testSubject.showDetailsViewP(targetTabId)).rejects.toEqual(errorMessage);
+            await expect(testSubject.showDetailsView(targetTabId)).rejects.toEqual(errorMessage);
 
             mockBrowserAdapter.verifyAll();
         });
@@ -85,7 +85,7 @@ describe('DetailsViewControllerTest', () => {
         setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.reset();
 
@@ -97,7 +97,7 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
         // call show details second time
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
@@ -114,7 +114,7 @@ describe('DetailsViewControllerTest', () => {
         setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.reset();
 
@@ -128,7 +128,7 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
         // call show details second time
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.verifyAll();
         detailsViewRemovedHandlerMock.verifyAll();
@@ -141,7 +141,7 @@ describe('DetailsViewControllerTest', () => {
         setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.reset();
 
@@ -155,7 +155,7 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
         // call show details second time
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
@@ -167,7 +167,7 @@ describe('DetailsViewControllerTest', () => {
         setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.reset();
 
@@ -181,7 +181,7 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
         // call show details second time
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
@@ -193,7 +193,7 @@ describe('DetailsViewControllerTest', () => {
         setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.reset();
 
@@ -207,7 +207,7 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
         // call show details second time
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
@@ -219,7 +219,7 @@ describe('DetailsViewControllerTest', () => {
         setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.reset();
 
@@ -233,7 +233,7 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
         // call show details second time
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
@@ -245,7 +245,7 @@ describe('DetailsViewControllerTest', () => {
         setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.reset();
 
@@ -257,7 +257,7 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
         // call show details second time
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
@@ -273,7 +273,7 @@ describe('DetailsViewControllerTest', () => {
         testSubject.setupDetailsViewTabRemovedHandler(detailsViewRemovedHandlerMock.object);
 
         // call show details once
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.reset();
 
@@ -285,7 +285,7 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
         // call show details second time
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.verifyAll();
         detailsViewRemovedHandlerMock.verifyAll();
@@ -298,7 +298,7 @@ describe('DetailsViewControllerTest', () => {
         setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.reset();
 
@@ -310,7 +310,7 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
         // call show details second time
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
@@ -322,7 +322,7 @@ describe('DetailsViewControllerTest', () => {
         setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.reset();
 
@@ -334,7 +334,7 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
         // call show details second time
-        await testSubject.showDetailsViewP(targetTabId);
+        await testSubject.showDetailsView(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });

--- a/src/tests/unit/tests/background/details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/details-view-controller.test.ts
@@ -78,136 +78,70 @@ describe('DetailsViewControllerTest', () => {
         });
     });
 
-    test('showDetailsView first time', () => {
-        const targetTabId = 12;
-        const detailsViewTabId = 10;
-
-        setupCreateDetailsView(targetTabId)
-            .callback((url, func) => {
-                func({
-                    id: detailsViewTabId,
-                } as chrome.tabs.Tab);
-            })
-            .verifiable(Times.once());
-
-        testSubject.showDetailsView(targetTabId);
-
-        mockBrowserAdapter.verifyAll();
-    });
-
-    test('showDetailsView second time', () => {
+    test('showDetailsView after target tab updated', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
 
-        setupCreateDetailsView(targetTabId).callback((url, func) => {
-            func({
-                id: detailsViewTabId,
-            } as chrome.tabs.Tab);
-        });
+        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        testSubject.showDetailsView(targetTabId);
-
-        mockBrowserAdapter.reset();
-
-        setupCreateDetailsViewForAnyUrl(Times.never());
-
-        mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
-
-        // call show details second time
-        testSubject.showDetailsView(targetTabId);
-
-        mockBrowserAdapter.verifyAll();
-    });
-
-    test('showDetailsView after target tab updated', () => {
-        const targetTabId = 5;
-        const detailsViewTabId = 10;
-        let createTabCallback: (tab: chrome.tabs.Tab) => void;
-
-        setupCreateDetailsView(targetTabId).callback((url, func) => {
-            createTabCallback = func;
-        });
-
-        // call show details once
-        testSubject.showDetailsView(targetTabId);
-
-        createTabCallback({
-            id: detailsViewTabId,
-        } as chrome.tabs.Tab);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.reset();
 
         // update target tab
         onUpdateTabCallback(targetTabId, null, null);
 
-        setupCreateDetailsViewForAnyUrl(Times.never());
+        setupCreateDetailsViewPForAnyUrl(Times.never());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
         // call show details second time
-        testSubject.showDetailsView(targetTabId);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
 
-    test('showDetailsView after details tab navigated to another page', () => {
+    test('showDetailsView after details tab navigated to another page', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
-        let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
         const detailsViewRemovedHandlerMock = Mock.ofInstance((tabId: number) => {});
         detailsViewRemovedHandlerMock.setup(handler => handler(targetTabId)).verifiable(Times.once());
 
         testSubject.setupDetailsViewTabRemovedHandler(detailsViewRemovedHandlerMock.object);
 
-        setupCreateDetailsView(targetTabId).callback((url, func) => {
-            createTabCallback = func;
-        });
+        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        testSubject.showDetailsView(targetTabId);
-
-        createTabCallback({
-            id: detailsViewTabId,
-        } as chrome.tabs.Tab);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.reset();
 
         // update details tab
-        mockBrowserAdapter
-            .setup(adapter => adapter.getRunTimeId())
-            .returns(() => {
-                return 'ext_id';
-            });
+        mockBrowserAdapter.setup(adapter => adapter.getRunTimeId()).returns(() => 'ext_id');
+
         onUpdateTabCallback(detailsViewTabId, { url: 'www.bing.com/DetailsView/detailsView.html?tabId=' + targetTabId }, null);
 
-        setupCreateDetailsViewForAnyUrl(Times.once());
+        setupCreateDetailsViewPForAnyUrl(Times.once());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
         // call show details second time
-        testSubject.showDetailsView(targetTabId);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.verifyAll();
         detailsViewRemovedHandlerMock.verifyAll();
     });
 
-    test('showDetailsView after details tab navigated to different details page', () => {
+    test('showDetailsView after details tab navigated to different details page', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
-        let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        setupCreateDetailsView(targetTabId).callback((url, func) => {
-            createTabCallback = func;
-        });
+        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        testSubject.showDetailsView(targetTabId);
-
-        createTabCallback({
-            id: detailsViewTabId,
-        } as chrome.tabs.Tab);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.reset();
 
@@ -216,250 +150,191 @@ describe('DetailsViewControllerTest', () => {
         mockBrowserAdapter.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
         onUpdateTabCallback(detailsViewTabId, { url: 'chromeExt://ext_id/DetailsView/detailsView.html?tabId=90' }, null);
 
-        setupCreateDetailsViewForAnyUrl(Times.once());
+        setupCreateDetailsViewPForAnyUrl(Times.once());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
         // call show details second time
-        testSubject.showDetailsView(targetTabId);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
 
-    test('showDetailsView after details tab refresh', () => {
+    test('showDetailsView after details tab refresh', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
-        let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        setupCreateDetailsView(targetTabId).callback((url, func) => {
-            createTabCallback = func;
-        });
+        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        testSubject.showDetailsView(targetTabId);
-
-        createTabCallback({
-            id: detailsViewTabId,
-        } as chrome.tabs.Tab);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.reset();
 
         // update details tab
         const extensionId = 'ext_id';
-        mockBrowserAdapter
-            .setup(it => it.getRunTimeId())
-            .returns(() => {
-                return extensionId;
-            });
+        mockBrowserAdapter.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
         onUpdateTabCallback(detailsViewTabId, { url: 'chromeExt://ext_Id/detailsView/detailsView.html?tabId=' + targetTabId }, null);
 
-        setupCreateDetailsViewForAnyUrl(Times.never());
+        setupCreateDetailsViewPForAnyUrl(Times.never());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
         // call show details second time
-        testSubject.showDetailsView(targetTabId);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
 
-    test('showDetailsView after details tab title update', () => {
+    test('showDetailsView after details tab title update', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
-        let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        setupCreateDetailsView(targetTabId).callback((url, func) => {
-            createTabCallback = func;
-        });
+        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        testSubject.showDetailsView(targetTabId);
-
-        createTabCallback({
-            id: detailsViewTabId,
-        } as chrome.tabs.Tab);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.reset();
 
         // update details tab
         const extensionId = 'ext_id';
-        mockBrowserAdapter
-            .setup(adapter => adapter.getRunTimeId())
-            .returns(() => {
-                return extensionId;
-            });
+        mockBrowserAdapter.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
         onUpdateTabCallback(detailsViewTabId, { title: 'issues' }, null);
 
-        setupCreateDetailsViewForAnyUrl(Times.never());
+        setupCreateDetailsViewPForAnyUrl(Times.never());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
         // call show details second time
-        testSubject.showDetailsView(targetTabId);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
 
-    test('showDetailsView after random tab updated', () => {
+    test('showDetailsView after random tab updated', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
-        let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        setupCreateDetailsView(targetTabId).callback((url, func) => {
-            createTabCallback = func;
-        });
+        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        testSubject.showDetailsView(targetTabId);
-
-        createTabCallback({
-            id: detailsViewTabId,
-        } as chrome.tabs.Tab);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.reset();
 
         // remove details tab
         const extensionId = 'ext_id';
-        mockBrowserAdapter
-            .setup(adapter => adapter.getRunTimeId())
-            .returns(() => {
-                return extensionId;
-            });
+        mockBrowserAdapter.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
         onUpdateTabCallback(123, { title: 'issues' }, null);
 
-        setupCreateDetailsViewForAnyUrl(Times.never());
+        setupCreateDetailsViewPForAnyUrl(Times.never());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
         // call show details second time
-        testSubject.showDetailsView(targetTabId);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
 
-    test('showDetailsView after target tab removed', () => {
+    test('showDetailsView after target tab removed', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
-        let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        setupCreateDetailsView(targetTabId).callback((url, func) => {
-            createTabCallback = func;
-        });
+        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        testSubject.showDetailsView(targetTabId);
-
-        createTabCallback({
-            id: detailsViewTabId,
-        } as chrome.tabs.Tab);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.reset();
 
         // remove target tab
         onTabRemoveCallback(targetTabId, null);
 
-        setupCreateDetailsViewForAnyUrl(Times.once());
+        setupCreateDetailsViewPForAnyUrl(Times.once());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
         // call show details second time
-        testSubject.showDetailsView(targetTabId);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
 
-    test('showDetailsView after details tab removed', () => {
+    test('showDetailsView after details tab removed', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
-        let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        setupCreateDetailsView(targetTabId).callback((url, func) => {
-            createTabCallback = func;
-        });
+        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+
         const detailsViewRemovedHandlerMock = Mock.ofInstance((tabId: number) => {});
         detailsViewRemovedHandlerMock.setup(handler => handler(targetTabId)).verifiable(Times.once());
         testSubject.setupDetailsViewTabRemovedHandler(detailsViewRemovedHandlerMock.object);
 
         // call show details once
-        testSubject.showDetailsView(targetTabId);
-
-        createTabCallback({
-            id: detailsViewTabId,
-        } as chrome.tabs.Tab);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.reset();
 
         // remove details tab
         onTabRemoveCallback(detailsViewTabId, null);
 
-        setupCreateDetailsViewForAnyUrl(Times.once());
+        setupCreateDetailsViewPForAnyUrl(Times.once());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
         // call show details second time
-        testSubject.showDetailsView(targetTabId);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.verifyAll();
         detailsViewRemovedHandlerMock.verifyAll();
     });
 
-    test('showDetailsView after details tab removed, remove handler not set', () => {
+    test('showDetailsView after details tab removed, remove handler not set', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
-        let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        setupCreateDetailsView(targetTabId).callback((url, func) => {
-            createTabCallback = func;
-        });
+        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+
         // call show details once
-        testSubject.showDetailsView(targetTabId);
-
-        createTabCallback({
-            id: detailsViewTabId,
-        } as chrome.tabs.Tab);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.reset();
 
         // remove details tab
         onTabRemoveCallback(detailsViewTabId, null);
 
-        setupCreateDetailsViewForAnyUrl(Times.once());
+        setupCreateDetailsViewPForAnyUrl(Times.once());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
 
         // call show details second time
-        testSubject.showDetailsView(targetTabId);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
 
-    test('showDetailsView after random tab removed', () => {
+    test('showDetailsView after random tab removed', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
-        let createTabCallback: (tab: chrome.tabs.Tab) => void;
 
-        setupCreateDetailsView(targetTabId).callback((url, func) => {
-            createTabCallback = func;
-        });
+        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
 
         // call show details once
-        testSubject.showDetailsView(targetTabId);
-
-        createTabCallback({
-            id: detailsViewTabId,
-        } as chrome.tabs.Tab);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.reset();
 
         // remove details tab
         onTabRemoveCallback(100, null);
 
-        setupCreateDetailsViewForAnyUrl(Times.never());
+        setupCreateDetailsViewPForAnyUrl(Times.never());
 
         mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
 
         // call show details second time
-        testSubject.showDetailsView(targetTabId);
+        await testSubject.showDetailsViewP(targetTabId);
 
         mockBrowserAdapter.verifyAll();
     });
@@ -470,20 +345,10 @@ describe('DetailsViewControllerTest', () => {
             .returns(() => Promise.resolve({ id: resultingDetailsViewTabId } as Tabs.Tab));
     };
 
-    const setupCreateDetailsView = (targetTabId: number) => {
-        return mockBrowserAdapter.setup(adapter =>
-            adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId, It.isAny()),
-        );
-    };
-
     const setupCreateDetailsViewPForAnyUrl = (times: Times) => {
         mockBrowserAdapter
             .setup(adapter => adapter.createTabInNewWindowP(It.isAny()))
             .returns(() => Promise.resolve({ id: -1 } as Tabs.Tab))
             .verifiable(times);
-    };
-
-    const setupCreateDetailsViewForAnyUrl = (times: Times) => {
-        mockBrowserAdapter.setup(adapter => adapter.createTabInNewWindow(It.isAny(), It.isAny())).verifiable(times);
     };
 });


### PR DESCRIPTION
#### Description of changes

This is part of a long-run refactor to promisify all (possible) `chrome.*` calls.

In this case, promisifying `createTabInNewWindow`.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
