### PR TITLE
refactor: pass logger from composition root

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -367,7 +367,7 @@ if (isNaN(tabId) === false) {
             );
             renderer.render();
 
-            const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan), new HTMLElementUtils(), logger);
+            const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan, logger), new HTMLElementUtils(), logger);
             window.A11YSelfValidator = a11ySelfValidator;
         },
         () => {

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -220,7 +220,7 @@ if (isNaN(tabId) === false) {
             const scopingFlagsHandler = new PreviewFeatureFlagsHandler(getAllFeatureFlagDetails());
             const dropdownClickHandler = new DropdownClickHandler(dropdownActionMessageCreator, TelemetryEventSource.DetailsView);
 
-            const navigatorUtils = new NavigatorUtils(window.navigator);
+            const navigatorUtils = new NavigatorUtils(window.navigator, logger);
             const extensionVersion = browserAdapter.getManifest().version;
             const axeVersion = getVersion();
             const browserSpec = navigatorUtils.getBrowserSpec();

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -104,6 +104,7 @@ import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-t
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
 import { MasterCheckBoxConfigProvider } from './handlers/master-checkbox-config-provider';
 import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-handler';
+import { createDefaultLogger } from 'common/logging/default-logger';
 
 declare const window: AutoChecker & Window;
 
@@ -366,7 +367,8 @@ if (isNaN(tabId) === false) {
             );
             renderer.render();
 
-            const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan), new HTMLElementUtils());
+            const logger = createDefaultLogger();
+            const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan), new HTMLElementUtils(), logger);
             window.A11YSelfValidator = a11ySelfValidator;
         },
         () => {

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -6,6 +6,7 @@ import { assessmentsProviderWithFeaturesEnabled } from 'assessments/assessments-
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
 import { CardsVisualizationModifierButtons } from 'common/components/cards/cards-visualization-modifier-buttons';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
+import { createDefaultLogger } from 'common/logging/default-logger';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { loadTheme } from 'office-ui-fabric-react';
@@ -27,7 +28,6 @@ import { ReactStaticRenderer } from 'reports/react-static-renderer';
 import { ReportGenerator } from 'reports/report-generator';
 import { ReportHtmlGenerator } from 'reports/report-html-generator';
 import { ReportNameGenerator } from 'reports/report-name-generator';
-
 import { A11YSelfValidator } from '../common/a11y-self-validator';
 import { AxeInfo } from '../common/axe-info';
 import { provideBlob } from '../common/blob-provider';
@@ -104,7 +104,6 @@ import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-t
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
 import { MasterCheckBoxConfigProvider } from './handlers/master-checkbox-config-provider';
 import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-handler';
-import { createDefaultLogger } from 'common/logging/default-logger';
 
 declare const window: AutoChecker & Window;
 
@@ -172,7 +171,8 @@ if (isNaN(tabId) === false) {
                 cardSelectionStore,
             ]);
 
-            const actionMessageDispatcher = new RemoteActionMessageDispatcher(browserAdapter.sendMessageToFrames, tab.id);
+            const logger = createDefaultLogger();
+            const actionMessageDispatcher = new RemoteActionMessageDispatcher(browserAdapter.sendMessageToFrames, tab.id, logger);
 
             const detailsViewActionMessageCreator = new DetailsViewActionMessageCreator(telemetryFactory, actionMessageDispatcher);
             const scopingActionMessageCreator = new ScopingActionMessageCreator(
@@ -367,7 +367,6 @@ if (isNaN(tabId) === false) {
             );
             renderer.render();
 
-            const logger = createDefaultLogger();
             const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan), new HTMLElementUtils(), logger);
             window.A11YSelfValidator = a11ySelfValidator;
         },

--- a/src/background/actions/shortcuts-page-action-creator.ts
+++ b/src/background/actions/shortcuts-page-action-creator.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { SHORTCUT_CONFIGURE_OPEN } from 'common/extension-telemetry-events';
-import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { Messages } from 'common/messages';
 
 import { Interpreter } from '../interpreter';
@@ -14,7 +14,7 @@ export class ShortcutsPageActionCreator {
         private readonly interpreter: Interpreter,
         private readonly shortcutsPageController: ShortcutsPageController,
         private readonly telemetryEventHandler: TelemetryEventHandler,
-        private readonly logger = createDefaultLogger(),
+        private readonly logger: Logger,
     ) {}
 
     public registerCallbacks(): void {

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -137,6 +137,7 @@ async function initialize(): Promise<void> {
         globalContext,
         tabToContextMap,
         browserAdapter,
+        logger,
     );
     messageDistributor.initialize();
 

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -85,6 +85,8 @@ async function initialize(): Promise<void> {
         AxeInfo.Default.version,
     );
 
+    const logger = createDefaultLogger();
+
     const globalContext = GlobalContextFactory.createContext(
         browserAdapter,
         telemetryEventHandler,
@@ -97,6 +99,7 @@ async function initialize(): Promise<void> {
         environmentInfoProvider.getEnvironmentInfo(),
         browserAdapter,
         browserAdapter,
+        logger,
     );
     telemetryLogger.initialize(globalContext.featureFlagsController);
 
@@ -106,7 +109,6 @@ async function initialize(): Promise<void> {
     );
     telemetryStateListener.initialize();
 
-    const logger = createDefaultLogger();
     const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter, logger);
     const detailsViewController = new DetailsViewController(browserAdapter);
 

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -127,6 +127,7 @@ async function initialize(): Promise<void> {
         telemetryDataFactory,
         globalContext.stores.userConfigurationStore,
         browserAdapter,
+        logger,
     );
     chromeCommandHandler.initialize();
 

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -106,7 +106,8 @@ async function initialize(): Promise<void> {
     );
     telemetryStateListener.initialize();
 
-    const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter);
+    const logger = createDefaultLogger();
+    const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter, logger);
     const detailsViewController = new DetailsViewController(browserAdapter);
 
     const tabToContextMap: TabToContextMap = {};
@@ -142,7 +143,6 @@ async function initialize(): Promise<void> {
     );
 
     const promiseFactory = createDefaultPromiseFactory();
-    const logger = createDefaultLogger();
 
     const tabContextFactory = new TabContextFactory(
         visualizationConfigurationFactory,

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -118,6 +118,7 @@ async function initialize(): Promise<void> {
     const notificationCreator = new NotificationCreator(
         browserAdapter,
         visualizationConfigurationFactory,
+        logger,
     );
 
     const chromeCommandHandler = new ChromeCommandHandler(

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -80,7 +80,7 @@ async function initialize(): Promise<void> {
 
     const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
 
-    const browserSpec = new NavigatorUtils(window.navigator).getBrowserSpec();
+    const browserSpec = new NavigatorUtils(window.navigator, logger).getBrowserSpec();
     const environmentInfoProvider = new EnvironmentInfoProvider(
         browserAdapter.getVersion(),
         browserSpec,

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -64,7 +64,9 @@ async function initialize(): Promise<void> {
     const assessmentsProvider = Assessments;
     const windowUtils = new WindowUtils();
     const telemetryDataFactory = new TelemetryDataFactory();
-    const telemetryLogger = new TelemetryLogger();
+
+    const logger = createDefaultLogger();
+    const telemetryLogger = new TelemetryLogger(logger);
 
     const { installationData } = userData;
     const telemetryClient = getTelemetryClient(
@@ -84,8 +86,6 @@ async function initialize(): Promise<void> {
         browserSpec,
         AxeInfo.Default.version,
     );
-
-    const logger = createDefaultLogger();
 
     const globalContext = GlobalContextFactory.createContext(
         browserAdapter,

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { AppInsights } from 'applicationinsights-js';
 import { Assessments } from 'assessments/assessments';
-
 import { AxeInfo } from '../common/axe-info';
 import { ChromeAdapter } from '../common/browser-adapters/chrome-adapter';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -143,6 +142,7 @@ async function initialize(): Promise<void> {
     );
 
     const promiseFactory = createDefaultPromiseFactory();
+    const logger = createDefaultLogger();
 
     const tabContextFactory = new TabContextFactory(
         visualizationConfigurationFactory,
@@ -152,6 +152,7 @@ async function initialize(): Promise<void> {
         globalContext.stores.assessmentStore,
         assessmentsProvider,
         promiseFactory,
+        logger,
     );
 
     const clientHandler = new TargetPageController(
@@ -160,7 +161,7 @@ async function initialize(): Promise<void> {
         browserAdapter,
         detailsViewController,
         tabContextFactory,
-        createDefaultLogger(),
+        logger,
     );
 
     clientHandler.initialize();

--- a/src/background/browser-message-broadcaster-factory.ts
+++ b/src/background/browser-message-broadcaster-factory.ts
@@ -1,17 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { createDefaultLogger } from 'common/logging/default-logger';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { Logger } from 'common/logging/logger';
 import { inspect } from 'util';
-import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 
 export type MessageBroadcaster = (message: any) => Promise<void>;
 
 export class BrowserMessageBroadcasterFactory {
-    constructor(
-        private readonly browserAdapter: BrowserAdapter,
-        private readonly logger: Logger = createDefaultLogger(),
-    ) {}
+    constructor(private readonly browserAdapter: BrowserAdapter, private readonly logger: Logger) {}
 
     public allTabsBroadcaster: MessageBroadcaster = async (message: any) => {
         // Ordering sendMessageToFrames before tabsQuery is necessary to prevent the race

--- a/src/background/chrome-command-handler.ts
+++ b/src/background/chrome-command-handler.ts
@@ -5,7 +5,6 @@ import { CommandsAdapter } from '../common/browser-adapters/commands-adapter';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { DisplayableStrings } from '../common/constants/displayable-strings';
 import { ToggleTelemetryData } from '../common/extension-telemetry-events';
-import { createDefaultLogger } from '../common/logging/default-logger';
 import { Logger } from '../common/logging/logger';
 import { Messages } from '../common/messages';
 import { NotificationCreator } from '../common/notification-creator';
@@ -36,7 +35,7 @@ export class ChromeCommandHandler {
         private telemetryDataFactory: TelemetryDataFactory,
         private userConfigurationStore: UserConfigurationStore,
         private commandsAdapter: CommandsAdapter,
-        private logger: Logger = createDefaultLogger(),
+        private logger: Logger,
     ) {}
 
     public initialize(): void {

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { CommandsAdapter } from '../common/browser-adapters/commands-adapter';
 import { StorageAdapter } from '../common/browser-adapters/storage-adapter';
@@ -43,6 +43,7 @@ export class GlobalContextFactory {
         environmentInfo: EnvironmentInfo,
         storageAdapter: StorageAdapter,
         commandsAdapter: CommandsAdapter,
+        logger: Logger,
     ): GlobalContext {
         const interpreter = new Interpreter();
 
@@ -111,7 +112,7 @@ export class GlobalContextFactory {
 
         const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(
             browserAdapter,
-            createDefaultLogger(),
+            logger,
         );
         const dispatcher = new StateDispatcher(
             messageBroadcasterFactory.allTabsBroadcaster,

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -117,6 +117,7 @@ export class GlobalContextFactory {
         const dispatcher = new StateDispatcher(
             messageBroadcasterFactory.allTabsBroadcaster,
             globalStoreHub,
+            logger,
         );
         dispatcher.initialize();
 

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { createDefaultLogger } from 'common/logging/default-logger';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { CommandsAdapter } from '../common/browser-adapters/commands-adapter';
 import { StorageAdapter } from '../common/browser-adapters/storage-adapter';
@@ -108,7 +109,10 @@ export class GlobalContextFactory {
         scopingActionCreator.registerCallback();
         featureFlagsActionCreator.registerCallbacks();
 
-        const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(browserAdapter);
+        const messageBroadcasterFactory = new BrowserMessageBroadcasterFactory(
+            browserAdapter,
+            createDefaultLogger(),
+        );
         const dispatcher = new StateDispatcher(
             messageBroadcasterFactory.allTabsBroadcaster,
             globalStoreHub,

--- a/src/background/message-distributor.ts
+++ b/src/background/message-distributor.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
-import { createDefaultLogger } from '../common/logging/default-logger';
 import { Logger } from '../common/logging/logger';
 import { InterpreterMessage } from '../common/message';
 import { Tab } from './../common/itab.d';
@@ -17,7 +16,7 @@ export class MessageDistributor {
         private readonly globalContext: GlobalContext,
         private readonly tabToContextMap: TabToContextMap,
         private readonly browserAdapter: BrowserAdapter,
-        private readonly logger: Logger = createDefaultLogger(),
+        private readonly logger: Logger,
     ) {}
 
     public initialize(): void {

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -174,7 +174,7 @@ export class TabContextFactory {
         injectionActionCreator.registerCallbacks();
 
         injectorController.initialize();
-        const dispatcher = new StateDispatcher(broadcastMessage, storeHub);
+        const dispatcher = new StateDispatcher(broadcastMessage, storeHub, this.logger);
         dispatcher.initialize();
 
         return new TabContext(interpreter, storeHub);

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -3,7 +3,6 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
-import { createDefaultLogger } from 'common/logging/default-logger';
 import { Logger } from 'common/logging/logger';
 import { NotificationCreator } from 'common/notification-creator';
 import { PromiseFactory } from 'common/promises/promise-factory';

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -3,11 +3,12 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { NotificationCreator } from 'common/notification-creator';
 import { PromiseFactory } from 'common/promises/promise-factory';
 import { StateDispatcher } from 'common/state-dispatcher';
 import { WindowUtils } from 'common/window-utils';
-
 import { ActionCreator } from './actions/action-creator';
 import { ActionHub } from './actions/action-hub';
 import { CardSelectionActionCreator } from './actions/card-selection-action-creator';
@@ -45,6 +46,7 @@ export class TabContextFactory {
         private assessmentStore: AssessmentStore,
         private assessmentsProvider: AssessmentsProvider,
         private readonly promiseFactory: PromiseFactory,
+        private readonly logger: Logger,
     ) {}
 
     public createTabContext(
@@ -66,6 +68,7 @@ export class TabContextFactory {
             interpreter,
             shortcutsPageController,
             this.telemetryEventHandler,
+            this.logger,
         );
 
         const actionCreator = new ActionCreator(

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -60,6 +60,7 @@ export class TabContextFactory {
         const notificationCreator = new NotificationCreator(
             browserAdapter,
             this.visualizationConfigurationFactory,
+            this.logger,
         );
         const shortcutsPageController = new ShortcutsPageController(browserAdapter);
 

--- a/src/background/telemetry/telemetry-logger.ts
+++ b/src/background/telemetry/telemetry-logger.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FeatureFlags } from '../../common/feature-flags';
-import { createDefaultLogger } from '../../common/logging/default-logger';
 import { Logger } from '../../common/logging/logger';
 import { FeatureFlagChecker } from '../feature-flag-checker';
 import { TelemetryBaseData } from './telemetry-base-data';
@@ -9,7 +8,7 @@ import { TelemetryBaseData } from './telemetry-base-data';
 export class TelemetryLogger {
     private featureFlagChecker: FeatureFlagChecker;
 
-    constructor(private logger: Logger = createDefaultLogger()) {}
+    constructor(private logger: Logger) {}
 
     public initialize(featureFlagChecker: FeatureFlagChecker): void {
         this.featureFlagChecker = featureFlagChecker;

--- a/src/common/a11y-self-validator.ts
+++ b/src/common/a11y-self-validator.ts
@@ -3,7 +3,6 @@
 import { ScannerUtils } from '../injected/scanner-utils';
 import { ScanResults } from '../scanner/iruleresults';
 import { HTMLElementUtils } from './html-element-utils';
-import { createDefaultLogger } from './logging/default-logger';
 import { Logger } from './logging/logger';
 
 export interface LoggedRule {
@@ -22,7 +21,7 @@ export interface LoggedNode {
 }
 
 export class A11YSelfValidator {
-    constructor(private scannerUtils: ScannerUtils, private docUtils: HTMLElementUtils, private logger: Logger = createDefaultLogger()) {}
+    constructor(private scannerUtils: ScannerUtils, private docUtils: HTMLElementUtils, private logger: Logger) {}
 
     public validate(): void {
         this.scannerUtils.scan(null, this.logAxeResults);

--- a/src/common/message-creators/remote-action-message-dispatcher.ts
+++ b/src/common/message-creators/remote-action-message-dispatcher.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { PayloadWithEventName } from 'background/actions/action-payloads';
-import { createDefaultLogger } from 'common/logging/default-logger';
 import { Logger } from 'common/logging/logger';
+
 import { TelemetryData } from '../extension-telemetry-events';
 import { InterpreterMessage, Message } from '../message';
 import { Messages } from '../messages';
@@ -12,7 +12,7 @@ export class RemoteActionMessageDispatcher implements ActionMessageDispatcher {
     constructor(
         private readonly postMessageDelegate: (message: InterpreterMessage) => Promise<void>,
         private readonly tabId: number,
-        private readonly logger: Logger = createDefaultLogger(),
+        private readonly logger: Logger,
     ) {}
 
     public dispatchMessage(message: Message): void {

--- a/src/common/navigator-utils.ts
+++ b/src/common/navigator-utils.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { createDefaultLogger } from 'common/logging/default-logger';
 import { Logger } from 'common/logging/logger';
 
 export class NavigatorUtils {
-    constructor(private navigatorInfo: Navigator, private logger: Logger = createDefaultLogger()) {}
+    constructor(private navigatorInfo: Navigator, private logger: Logger) {}
 
     public getBrowserSpec(): string {
         const userAgent = this.navigatorInfo.userAgent;

--- a/src/common/notification-creator.ts
+++ b/src/common/notification-creator.ts
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { createDefaultLogger } from 'common/logging/default-logger';
 import { Logger } from 'common/logging/logger';
 import { VisualizationType } from 'common/types/visualization-type';
 import { isEmpty } from 'lodash';
 import { DictionaryStringTo } from 'types/common-types';
-
 import { BrowserAdapter } from './browser-adapters/browser-adapter';
 import { VisualizationConfigurationFactory } from './configs/visualization-configuration-factory';
 
@@ -13,7 +11,7 @@ export class NotificationCreator {
     constructor(
         private readonly browserAdapter: BrowserAdapter,
         private readonly visualizationConfigurationFactory: VisualizationConfigurationFactory,
-        private readonly logger: Logger = createDefaultLogger(),
+        private readonly logger: Logger,
     ) {}
 
     public createNotification(message: string): void {

--- a/src/common/state-dispatcher.ts
+++ b/src/common/state-dispatcher.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { StoreHub } from 'background/stores/store-hub';
-import { createDefaultLogger } from 'common/logging/default-logger';
 import { Logger } from 'common/logging/logger';
 import { BaseStore } from './base-store';
 import { GenericStoreMessageTypes } from './constants/generic-store-messages-types';
@@ -11,7 +10,7 @@ export class StateDispatcher {
     constructor(
         private readonly broadcastMessage: (message: StoreUpdateMessage<any>) => Promise<void>,
         private readonly stores: StoreHub,
-        private readonly logger: Logger = createDefaultLogger(),
+        private readonly logger: Logger,
     ) {
         this.broadcastMessage = broadcastMessage;
         this.stores = stores;

--- a/src/electron/platform/android/scan-controller.ts
+++ b/src/electron/platform/android/scan-controller.ts
@@ -3,7 +3,7 @@
 import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { InstanceCount, TelemetryEventSource } from 'common/extension-telemetry-events';
-import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import {
     SCAN_COMPLETED,
     SCAN_FAILED,
@@ -23,7 +23,7 @@ export class ScanController {
         private readonly unifiedResultsBuilder: UnifiedScanCompletedPayloadBuilder,
         private readonly telemetryEventHandler: TelemetryEventHandler,
         private readonly getCurrentDate: () => Date,
-        private readonly logger = createDefaultLogger(),
+        private readonly logger: Logger,
     ) {}
 
     public initialize(): void {

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -11,6 +11,7 @@ import { Interpreter } from 'background/interpreter';
 import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { UnifiedScanResultStore } from 'background/stores/unified-scan-result-store';
 import { onlyHighlightingSupported } from 'common/components/cards/card-interaction-support';
+import { CardsVisualizationModifierButtons } from 'common/components/cards/cards-visualization-modifier-buttons';
 import { CardsCollapsibleControl } from 'common/components/cards/collapsible-component-cards';
 import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { getPropertyConfiguration } from 'common/configs/unified-result-property-configurations';
@@ -18,6 +19,7 @@ import { DateProvider } from 'common/date-provider';
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { createDefaultLogger } from 'common/logging/default-logger';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { UserConfigMessageCreator } from 'common/message-creators/user-config-message-creator';
 import { getCardViewData } from 'common/rule-based-view-model-provider';
@@ -45,8 +47,6 @@ import { PlatformInfo } from 'electron/window-management/platform-info';
 import { WindowFrameListener } from 'electron/window-management/window-frame-listener';
 import { WindowFrameUpdater } from 'electron/window-management/window-frame-updater';
 import * as ReactDOM from 'react-dom';
-
-import { CardsVisualizationModifierButtons } from 'common/components/cards/cards-visualization-modifier-buttons';
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
 import { IndexedDBDataKeys } from '../../background/IndexedDBDataKeys';
@@ -98,7 +98,8 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
         const installationData: InstallationData = persistedData.installationData;
 
         const telemetryDataFactory = new TelemetryDataFactory();
-        const telemetryLogger = new TelemetryLogger();
+        const logger = createDefaultLogger();
+        const telemetryLogger = new TelemetryLogger(logger);
         telemetryLogger.initialize(new RiggedFeatureFlagChecker());
 
         const telemetryClient = getTelemetryClient(

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -206,6 +206,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             unifiedResultsBuilder,
             telemetryEventHandler,
             DateProvider.getCurrentDate,
+            logger,
         );
 
         scanController.initialize();

--- a/src/injected/frameCommunicators/frame-communicator.ts
+++ b/src/injected/frameCommunicators/frame-communicator.ts
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Q from 'q';
-
 import { HTMLElementUtils } from '../../common/html-element-utils';
-import { createDefaultLogger } from '../../common/logging/default-logger';
 import { Logger } from '../../common/logging/logger';
 import { ErrorMessageContent } from './error-message-content';
 import { FrameMessageResponseCallback, WindowMessageHandler } from './window-message-handler';
@@ -29,7 +27,7 @@ export class FrameCommunicator {
         protected windowMessageHandler: WindowMessageHandler,
         protected htmlElementUtils: HTMLElementUtils,
         private q: typeof Q,
-        private logger: Logger = createDefaultLogger(),
+        private logger: Logger,
     ) {
         this.window = window;
         this.document = document;

--- a/src/injected/frameCommunicators/html-element-axe-results-helper.ts
+++ b/src/injected/frameCommunicators/html-element-axe-results-helper.ts
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { forOwn } from 'lodash';
-
 import { HTMLElementUtils } from '../../common/html-element-utils';
-import { createDefaultLogger } from '../../common/logging/default-logger';
 import { Logger } from '../../common/logging/logger';
 import { DictionaryStringTo } from '../../types/common-types';
 import { HtmlElementAxeResults } from '../scanner-utils';
@@ -24,7 +22,7 @@ export interface AssessmentVisualizationInstance extends AxeResultsWithFrameLeve
 }
 
 export class HtmlElementAxeResultsHelper {
-    constructor(private htmlElementUtils: HTMLElementUtils, private logger: Logger = createDefaultLogger()) {}
+    constructor(private htmlElementUtils: HTMLElementUtils, private logger: Logger) {}
 
     public splitResultsByFrame(elementResults: AxeResultsWithFrameLevel[]): HTMLIFrameResult[] {
         const frameSelectorToResultsMap = this.getFrameSelectorToResultMap(elementResults);

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -2,20 +2,20 @@
 // Licensed under the MIT License.
 import { Assessments } from 'assessments/assessments';
 import { EnumHelper } from 'common/enum-helper';
+import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
+import { createDefaultLogger } from 'common/logging/default-logger';
 import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationType } from 'common/types/visualization-type';
 import { ClientStoreListener, TargetPageStoreData } from 'injected/client-store-listener';
+import { ElementBasedViewModelCreator } from 'injected/element-based-view-model-creator';
 import { FocusChangeHandler } from 'injected/focus-change-handler';
+import { getDecoratedAxeNode } from 'injected/get-decorated-axe-node';
 import { isVisualizationEnabled } from 'injected/is-visualization-enabled';
 import { TargetPageVisualizationUpdater } from 'injected/target-page-visualization-updater';
 import { visualizationNeedsUpdate } from 'injected/visualization-needs-update';
 import { VisualizationStateChangeHandler } from 'injected/visualization-state-change-handler';
-
-import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
-import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
-import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
-import { ElementBasedViewModelCreator } from 'injected/element-based-view-model-creator';
-import { getDecoratedAxeNode } from 'injected/get-decorated-axe-node';
 import { AxeInfo } from '../common/axe-info';
 import { InspectConfigurationFactory } from '../common/configs/inspect-configuration-factory';
 import { DateProvider } from '../common/date-provider';
@@ -67,7 +67,6 @@ import { SelectorMapHelper } from './selector-map-helper';
 import { ShadowUtils } from './shadow-utils';
 import { TargetPageActionMessageCreator } from './target-page-action-message-creator';
 import { WindowInitializer } from './window-initializer';
-import { createDefaultLogger } from 'common/logging/default-logger';
 
 export class MainWindowInitializer extends WindowInitializer {
     protected frameCommunicator: FrameCommunicator;
@@ -120,11 +119,9 @@ export class MainWindowInitializer extends WindowInitializer {
             this.browserAdapter,
         );
 
-        const actionMessageDispatcher = new RemoteActionMessageDispatcher(
-            this.browserAdapter.sendMessageToFrames,
-            null,
-            createDefaultLogger(),
-        );
+        const logger = createDefaultLogger();
+
+        const actionMessageDispatcher = new RemoteActionMessageDispatcher(this.browserAdapter.sendMessageToFrames, null, logger);
 
         const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(actionMessageDispatcher);
 
@@ -156,7 +153,7 @@ export class MainWindowInitializer extends WindowInitializer {
 
         const userConfigMessageCreator = new UserConfigMessageCreator(actionMessageDispatcher);
 
-        const browserSpec = new NavigatorUtils(window.navigator).getBrowserSpec();
+        const browserSpec = new NavigatorUtils(window.navigator, logger).getBrowserSpec();
 
         const environmentInfoProvider = new EnvironmentInfoProvider(this.appDataAdapter.getVersion(), browserSpec, AxeInfo.Default.version);
 

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -224,7 +224,7 @@ export class MainWindowInitializer extends WindowInitializer {
             this.tabStopsListener,
             this.scopingStoreProxy,
             this.browserAdapter.sendMessageToFrames,
-            new ScannerUtils(scan, generateUID),
+            new ScannerUtils(scan, logger, generateUID),
             telemetryDataFactory,
             DateProvider.getCurrentDate,
             this.visualizationConfigurationFactory,

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -67,6 +67,7 @@ import { SelectorMapHelper } from './selector-map-helper';
 import { ShadowUtils } from './shadow-utils';
 import { TargetPageActionMessageCreator } from './target-page-action-message-creator';
 import { WindowInitializer } from './window-initializer';
+import { createDefaultLogger } from 'common/logging/default-logger';
 
 export class MainWindowInitializer extends WindowInitializer {
     protected frameCommunicator: FrameCommunicator;
@@ -119,7 +120,11 @@ export class MainWindowInitializer extends WindowInitializer {
             this.browserAdapter,
         );
 
-        const actionMessageDispatcher = new RemoteActionMessageDispatcher(this.browserAdapter.sendMessageToFrames, null);
+        const actionMessageDispatcher = new RemoteActionMessageDispatcher(
+            this.browserAdapter.sendMessageToFrames,
+            null,
+            createDefaultLogger(),
+        );
 
         const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(actionMessageDispatcher);
 

--- a/src/injected/scanner-utils.ts
+++ b/src/injected/scanner-utils.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CheckData } from 'injected/element-based-view-model-creator';
-
-import { createDefaultLogger } from '../common/logging/default-logger';
 import { Logger } from '../common/logging/logger';
 import { scan as scanRunner } from '../scanner/exposed-apis';
 import { RuleResult, ScanResults } from '../scanner/iruleresults';
@@ -31,11 +29,7 @@ export interface HtmlElementAxeResults {
 }
 
 export class ScannerUtils {
-    public constructor(
-        private scanner: typeof scanRunner,
-        private generateUID?: () => string,
-        private logger: Logger = createDefaultLogger(),
-    ) {}
+    public constructor(private scanner: typeof scanRunner, private logger: Logger, private generateUID?: () => string) {}
 
     public scan(options: ScanOptions, callback: (results: ScanResults) => void): void {
         this.scanner(

--- a/src/injected/shadow-initializer.ts
+++ b/src/injected/shadow-initializer.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
-import { createDefaultLogger } from '../common/logging/default-logger';
 import { Logger } from '../common/logging/logger';
 import { HTMLElementUtils } from './../common/html-element-utils';
 import { rootContainerId } from './constants';
@@ -10,11 +9,7 @@ export class ShadowInitializer {
     public static readonly injectedCssPath: string = 'injected/styles/default/injected.css';
     public static readonly generatedBundleInjectedCssPath: string = 'bundle/injected.css';
 
-    constructor(
-        private browserAdapter: BrowserAdapter,
-        private htmlElementUtils: HTMLElementUtils,
-        private logger: Logger = createDefaultLogger(),
-    ) {}
+    constructor(private browserAdapter: BrowserAdapter, private htmlElementUtils: HTMLElementUtils, private logger: Logger) {}
 
     public async initialize(): Promise<void> {
         try {

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -92,7 +92,7 @@ export class WindowInitializer {
         );
         this.drawingController = new DrawingController(
             this.frameCommunicator,
-            new HtmlElementAxeResultsHelper(htmlElementUtils),
+            new HtmlElementAxeResultsHelper(htmlElementUtils, logger),
             htmlElementUtils,
         );
         this.scrollingController = new ScrollingController(this.frameCommunicator, htmlElementUtils);

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -66,7 +66,7 @@ export class WindowInitializer {
 
         new RootContainerCreator(htmlElementUtils).create(rootContainerId);
 
-        this.shadowInitializer = new ShadowInitializer(this.browserAdapter, htmlElementUtils);
+        this.shadowInitializer = new ShadowInitializer(this.browserAdapter, htmlElementUtils, logger);
         asyncInitializationSteps.push(this.shadowInitializer.initialize());
 
         this.visualizationConfigurationFactory = new VisualizationConfigurationFactory();

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -61,7 +61,8 @@ export class WindowInitializer {
         this.windowUtils = new WindowUtils();
         const htmlElementUtils = new HTMLElementUtils();
         this.clientUtils = new ClientUtils(window);
-        this.scannerUtils = new ScannerUtils(scan);
+        const logger = createDefaultLogger();
+        this.scannerUtils = new ScannerUtils(scan, logger);
 
         new RootContainerCreator(htmlElementUtils).create(rootContainerId);
 
@@ -74,7 +75,6 @@ export class WindowInitializer {
             this.windowUtils,
             new WindowMessageMarshaller(this.browserAdapter, generateUID),
         );
-        const logger = createDefaultLogger();
         this.frameCommunicator = new FrameCommunicator(windowMessageHandler, htmlElementUtils, Q, logger);
         this.tabStopsListener = new TabStopsListener(this.frameCommunicator, this.windowUtils, htmlElementUtils, this.scannerUtils);
         const drawerProvider = new DrawerProvider(

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { getRTL } from '@uifabric/utilities';
-import * as Q from 'q';
-
+import { createDefaultLogger } from 'common/logging/default-logger';
 import { NavigatorUtils } from 'common/navigator-utils';
+import * as Q from 'q';
 import { AppDataAdapter } from '../common/browser-adapters/app-data-adapter';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { ChromeAdapter } from '../common/browser-adapters/chrome-adapter';
@@ -79,7 +79,7 @@ export class WindowInitializer {
         const drawerProvider = new DrawerProvider(
             htmlElementUtils,
             this.windowUtils,
-            new NavigatorUtils(window.navigator),
+            new NavigatorUtils(window.navigator, createDefaultLogger()),
             new ShadowUtils(new HTMLElementUtils()),
             new DrawerUtils(document),
             this.clientUtils,

--- a/src/injected/window-initializer.ts
+++ b/src/injected/window-initializer.ts
@@ -74,12 +74,13 @@ export class WindowInitializer {
             this.windowUtils,
             new WindowMessageMarshaller(this.browserAdapter, generateUID),
         );
-        this.frameCommunicator = new FrameCommunicator(windowMessageHandler, htmlElementUtils, Q);
+        const logger = createDefaultLogger();
+        this.frameCommunicator = new FrameCommunicator(windowMessageHandler, htmlElementUtils, Q, logger);
         this.tabStopsListener = new TabStopsListener(this.frameCommunicator, this.windowUtils, htmlElementUtils, this.scannerUtils);
         const drawerProvider = new DrawerProvider(
             htmlElementUtils,
             this.windowUtils,
-            new NavigatorUtils(window.navigator, createDefaultLogger()),
+            new NavigatorUtils(window.navigator, logger),
             new ShadowUtils(new HTMLElementUtils()),
             new DrawerUtils(document),
             this.clientUtils,

--- a/src/popup/popup-init.ts
+++ b/src/popup/popup-init.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { createDefaultLogger } from 'common/logging/default-logger';
 import { UAParser } from 'ua-parser-js';
-
 import { ChromeAdapter } from '../common/browser-adapters/chrome-adapter';
 import { initializeFabricIcons } from '../common/fabric-icons';
 import { createSupportedBrowserChecker } from '../common/is-supported-browser';
@@ -20,6 +20,7 @@ const popupInitializer: PopupInitializer = new PopupInitializer(
     browserAdapter,
     targetTabFinder,
     isSupportedBrowser,
+    createDefaultLogger(),
 );
 
 // tslint:disable-next-line:no-floating-promises - top-level entry points are intentionally floating promises

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -12,7 +12,6 @@ import { EnumHelper } from '../common/enum-helper';
 import { TelemetryEventSource } from '../common/extension-telemetry-events';
 import { HTMLElementUtils } from '../common/html-element-utils';
 import { IsSupportedBrowser } from '../common/is-supported-browser';
-import { createDefaultLogger } from '../common/logging/default-logger';
 import { Logger } from '../common/logging/logger';
 import { ContentActionMessageCreator } from '../common/message-creators/content-action-message-creator';
 import { DropdownActionMessageCreator } from '../common/message-creators/dropdown-action-message-creator';
@@ -58,7 +57,7 @@ export class PopupInitializer {
         private readonly browserAdapter: BrowserAdapter,
         private readonly targetTabFinder: TargetTabFinder,
         private readonly isSupportedBrowser: IsSupportedBrowser,
-        private logger: Logger = createDefaultLogger(),
+        private logger: Logger,
     ) {}
 
     public initialize(): Promise<void> {

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -91,6 +91,7 @@ export class PopupInitializer {
         const actionMessageDispatcher = new RemoteActionMessageDispatcher(
             this.browserAdapter.sendMessageToFrames,
             tab.id,
+            this.logger,
         );
         const visualizationActionCreator = new VisualizationActionMessageCreator(
             actionMessageDispatcher,

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -246,7 +246,7 @@ export class PopupInitializer {
         popupActionMessageCreator.popupInitialized(tab);
 
         const a11ySelfValidator = new A11YSelfValidator(
-            new ScannerUtils(scan),
+            new ScannerUtils(scan, this.logger),
             new HTMLElementUtils(),
             this.logger,
         );

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -247,6 +247,7 @@ export class PopupInitializer {
         const a11ySelfValidator = new A11YSelfValidator(
             new ScannerUtils(scan),
             new HTMLElementUtils(),
+            this.logger,
         );
         window.A11YSelfValidator = a11ySelfValidator;
     };

--- a/src/tests/unit/tests/background/chrome-command-handler.test.ts
+++ b/src/tests/unit/tests/background/chrome-command-handler.test.ts
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { ChromeCommandHandler } from 'background/chrome-command-handler';
 import { Interpreter } from 'background/interpreter';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
 import { TabContextStoreHub } from 'background/stores/tab-context-store-hub';
 import { VisualizationStore } from 'background/stores/visualization-store';
 import { TabContext, TabToContextMap } from 'background/tab-context';
+import { Logger } from 'common/logging/logger';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { BaseStore } from '../../../../common/base-store';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { CommandsAdapter } from '../../../../common/browser-adapters/commands-adapter';
@@ -23,27 +24,30 @@ import { VisualizationType } from '../../../../common/types/visualization-type';
 import { UrlValidator } from '../../../../common/url-validator';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 
-let testSubject: ChromeCommandHandler;
-let browserAdapterMock: IMock<BrowserAdapter>;
-let commandsAdapterMock: IMock<CommandsAdapter>;
-let urlValidatorMock: IMock<UrlValidator>;
-let tabToContextMap: TabToContextMap;
-let visualizationStoreMock: IMock<BaseStore<VisualizationStoreData>>;
-let interpreterMock: IMock<Interpreter>;
-let commandCallback: (commandId: string) => Promise<void>;
-let existingTabId: number;
-let notificationCreatorMock: IMock<NotificationCreator>;
-let storeState: VisualizationStoreData;
-let simulatedIsFirstTimeUserConfiguration: boolean;
-let simulatedIsSupportedUrlResponse: boolean;
-let simulatedActiveTabId: Number;
-let simulatedActiveTabUrl: string;
-
-const visualizationConfigurationFactory = new VisualizationConfigurationFactory();
-const testSource: TelemetryEventSource = TelemetryEventSource.ShortcutCommand;
-
 describe('ChromeCommandHandlerTest', () => {
+    let testSubject: ChromeCommandHandler;
+    let browserAdapterMock: IMock<BrowserAdapter>;
+    let commandsAdapterMock: IMock<CommandsAdapter>;
+    let urlValidatorMock: IMock<UrlValidator>;
+    let tabToContextMap: TabToContextMap;
+    let visualizationStoreMock: IMock<BaseStore<VisualizationStoreData>>;
+    let interpreterMock: IMock<Interpreter>;
+    let loggerMock: IMock<Logger>;
+
+    let commandCallback: (commandId: string) => Promise<void>;
+    let existingTabId: number;
+    let notificationCreatorMock: IMock<NotificationCreator>;
+    let storeState: VisualizationStoreData;
+    let simulatedIsFirstTimeUserConfiguration: boolean;
+    let simulatedIsSupportedUrlResponse: boolean;
+    let simulatedActiveTabId: Number;
+    let simulatedActiveTabUrl: string;
+    let visualizationConfigurationFactory: VisualizationConfigurationFactory;
+
+    const testSource: TelemetryEventSource = TelemetryEventSource.ShortcutCommand;
+
     beforeEach(() => {
+        visualizationConfigurationFactory = new VisualizationConfigurationFactory();
         interpreterMock = Mock.ofType(Interpreter);
 
         visualizationStoreMock = Mock.ofType(VisualizationStore, MockBehavior.Strict);
@@ -93,6 +97,8 @@ describe('ChromeCommandHandlerTest', () => {
                 };
             });
 
+        loggerMock = Mock.ofType<Logger>();
+
         testSubject = new ChromeCommandHandler(
             tabToContextMap,
             browserAdapterMock.object,
@@ -102,6 +108,7 @@ describe('ChromeCommandHandlerTest', () => {
             new TelemetryDataFactory(),
             userConfigurationStoreMock.object,
             commandsAdapterMock.object,
+            loggerMock.object,
         );
 
         testSubject.initialize();
@@ -296,9 +303,9 @@ describe('ChromeCommandHandlerTest', () => {
             notificationCreatorMock.verifyAll();
         },
     );
-});
 
-function getArbitraryValidChromeCommand(): string {
-    const configuration = visualizationConfigurationFactory.getConfiguration(VisualizationType.Issues);
-    return configuration.chromeCommand;
-}
+    function getArbitraryValidChromeCommand(): string {
+        const configuration = visualizationConfigurationFactory.getConfiguration(VisualizationType.Issues);
+        return configuration.chromeCommand;
+    }
+});

--- a/src/tests/unit/tests/background/global-context-factory.test.ts
+++ b/src/tests/unit/tests/background/global-context-factory.test.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock } from 'typemoq';
-
 import { PersistedData } from 'background/get-persisted-data';
 import { GlobalContext } from 'background/global-context';
 import { GlobalContextFactory } from 'background/global-context-factory';
@@ -11,6 +9,8 @@ import { CommandStore } from 'background/stores/global/command-store';
 import { FeatureFlagStore } from 'background/stores/global/feature-flag-store';
 import { LaunchPanelStore } from 'background/stores/global/launch-panel-store';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { Logger } from 'common/logging/logger';
+import { IMock, It, Mock } from 'typemoq';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { CommandsAdapter } from '../../../../common/browser-adapters/commands-adapter';
 import { StorageAdapter } from '../../../../common/browser-adapters/storage-adapter';
@@ -27,6 +27,8 @@ describe('GlobalContextFactoryTest', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let telemetryDataFactoryMock: IMock<TelemetryDataFactory>;
     let issueFilingServiceProviderMock: IMock<IssueFilingServiceProvider>;
+    let loggerMock: IMock<Logger>;
+
     let environmentInfoStub: EnvironmentInfo;
     let userDataStub: LocalStorageData;
     let idbInstance: IndexedDBAPI;
@@ -36,6 +38,7 @@ describe('GlobalContextFactoryTest', () => {
         storageAdapterMock = Mock.ofType<StorageAdapter>();
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         commandsAdapterMock = Mock.ofType<CommandsAdapter>();
+        loggerMock = Mock.ofType<Logger>();
         browserAdapterMock.setup(adapter => adapter.sendMessageToFrames(It.isAny())).returns(() => Promise.resolve());
         browserAdapterMock.setup(adapter => adapter.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.resolve());
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler);
@@ -61,6 +64,7 @@ describe('GlobalContextFactoryTest', () => {
             environmentInfoStub,
             storageAdapterMock.object,
             commandsAdapterMock.object,
+            loggerMock.object,
         );
 
         expect(globalContext).toBeInstanceOf(GlobalContext);

--- a/src/tests/unit/tests/background/message-distributor.test.ts
+++ b/src/tests/unit/tests/background/message-distributor.test.ts
@@ -15,7 +15,7 @@ describe('MessageDistributorTest', () => {
     let tabToInterpreterMap: TabToContextMap;
     let globalContextMock: IMock<GlobalContext>;
     let globalInterpreter: Interpreter;
-    let consoleLoggerMock: IMock<Logger>;
+    let loggerMock: IMock<Logger>;
 
     let distributeMessageCallback: (message: any, sender?: Sender) => void;
 
@@ -26,13 +26,8 @@ describe('MessageDistributorTest', () => {
         globalContextMock = Mock.ofType(GlobalContext);
         globalContextMock.setup(x => x.interpreter).returns(() => globalInterpreter);
 
-        consoleLoggerMock = Mock.ofType<Logger>();
-        testSubject = new MessageDistributor(
-            globalContextMock.object,
-            tabToInterpreterMap,
-            mockBrowserAdapter.object,
-            consoleLoggerMock.object,
-        );
+        loggerMock = Mock.ofType<Logger>();
+        testSubject = new MessageDistributor(globalContextMock.object, tabToInterpreterMap, mockBrowserAdapter.object, loggerMock.object);
 
         mockBrowserAdapter
             .setup(adapter => adapter.addListenerOnMessage(It.isAny()))

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -1,7 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
 import { DetailsViewController } from 'background/details-view-controller';
 import { Interpreter } from 'background/interpreter';
@@ -17,6 +15,8 @@ import { TabContext } from 'background/tab-context';
 import { TabContextFactory } from 'background/tab-context-factory';
 import { TargetTabController } from 'background/target-tab-controller';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { Logger } from 'common/logging/logger';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { UnifiedScanResultStore } from '../../../../background/stores/unified-scan-result-store';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
@@ -35,12 +35,12 @@ function getConfigs(visualizationType: VisualizationType): VisualizationConfigur
 describe('TabContextFactoryTest', () => {
     let mockDetailsViewController: IMock<DetailsViewController>;
     let mockBrowserAdapter: IMock<BrowserAdapter>;
+    let mockLogger: IMock<Logger>;
 
-    beforeAll(() => {
+    beforeEach(() => {
         mockBrowserAdapter = Mock.ofType<BrowserAdapter>();
-
+        mockLogger = Mock.ofType<Logger>();
         mockDetailsViewController = Mock.ofType<DetailsViewController>();
-        mockBrowserAdapter.reset();
     });
 
     it('createInterpreter', () => {
@@ -86,6 +86,7 @@ describe('TabContextFactoryTest', () => {
             assessmentStore.object,
             assessmentProvider.object,
             promiseFactoryMock.object,
+            mockLogger.object,
         );
 
         const tabContext = testObject.createTabContext(

--- a/src/tests/unit/tests/common/message-creators/remote-action-message-dispatcher.test.ts
+++ b/src/tests/unit/tests/common/message-creators/remote-action-message-dispatcher.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { Logger } from 'common/logging/logger';
 import { IMock, It, Mock, Times } from 'typemoq';
+
 import { BaseTelemetryData, TelemetryEventSource } from '../../../../../common/extension-telemetry-events';
 import { Message } from '../../../../../common/message';
 import { RemoteActionMessageDispatcher } from '../../../../../common/message-creators/remote-action-message-dispatcher';
@@ -9,10 +10,13 @@ import { Messages } from '../../../../../common/messages';
 
 describe('RemoteActionMessageDispatcher', () => {
     let postMessageMock: IMock<(message: Message) => Promise<void>>;
+    let loggerMock: IMock<Logger>;
 
     beforeEach(() => {
         postMessageMock = Mock.ofType<(message: Message) => Promise<void>>();
         postMessageMock.setup(m => m(It.isAny())).returns(() => Promise.resolve());
+
+        loggerMock = Mock.ofType<Logger>();
     });
 
     describe('dispatchMessage', () => {
@@ -22,7 +26,7 @@ describe('RemoteActionMessageDispatcher', () => {
 
         it('handles numeric tabId', () => {
             const tabId = -1;
-            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, tabId);
+            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, tabId, loggerMock.object);
 
             testObject.dispatchMessage(message);
 
@@ -30,14 +34,13 @@ describe('RemoteActionMessageDispatcher', () => {
         });
 
         it('handles null tabId', () => {
-            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, null);
+            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, null, loggerMock.object);
             testObject.dispatchMessage(message);
 
             postMessageMock.verify(post => post(It.isValue(message)), Times.once());
         });
 
         it('propagates errors from postMessage to logger.error', () => {
-            const loggerMock = Mock.ofType<Logger>();
             const expectedError = 'expected error';
             postMessageMock.reset();
             postMessageMock.setup(m => m(It.isAny())).returns(() => Promise.reject(expectedError));
@@ -54,7 +57,7 @@ describe('RemoteActionMessageDispatcher', () => {
 
         it('handles numberic tabId', () => {
             const tabId = -1;
-            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, tabId);
+            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, tabId, loggerMock.object);
 
             testObject.dispatchType(messageType);
 
@@ -67,7 +70,7 @@ describe('RemoteActionMessageDispatcher', () => {
         });
 
         it('handles null tabId', () => {
-            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, null);
+            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, null, loggerMock.object);
 
             testObject.dispatchType(messageType);
 
@@ -88,7 +91,7 @@ describe('RemoteActionMessageDispatcher', () => {
 
         it('handles numeric tabId', () => {
             const tabId = -1;
-            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, tabId);
+            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, tabId, loggerMock.object);
 
             testObject.sendTelemetry(eventName, eventData);
 
@@ -105,7 +108,7 @@ describe('RemoteActionMessageDispatcher', () => {
         });
 
         it('handles null tabId', () => {
-            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, null);
+            const testObject = new RemoteActionMessageDispatcher(postMessageMock.object, null, loggerMock.object);
 
             testObject.sendTelemetry(eventName, eventData);
 

--- a/src/tests/unit/tests/common/navigator-utils.test.ts
+++ b/src/tests/unit/tests/common/navigator-utils.test.ts
@@ -30,7 +30,8 @@ describe('NavigatorUtils', () => {
             const navigatorInfo = {
                 userAgent: userAgent,
             };
-            const testSubject = new NavigatorUtils(navigatorInfo as Navigator);
+            const loggerMock = Mock.ofType<Logger>();
+            const testSubject = new NavigatorUtils(navigatorInfo as Navigator, loggerMock.object);
             const actual = testSubject.getBrowserSpec();
             expect(actual).toEqual(expected);
         }
@@ -60,11 +61,12 @@ describe('NavigatorUtils', () => {
         });
 
         it('passes through to the underlying Clipboard in the happy path', async () => {
+            const loggerMock = Mock.ofType<Logger>();
             const clipboardMock = Mock.ofType<Clipboard>();
             const mockNavigatorInfo = {
                 clipboard: clipboardMock.object,
             } as Navigator;
-            const testSubject = new NavigatorUtils(mockNavigatorInfo);
+            const testSubject = new NavigatorUtils(mockNavigatorInfo, loggerMock.object);
 
             const testText = 'test text';
             clipboardMock

--- a/src/tests/unit/tests/common/state-dispatcher.test.ts
+++ b/src/tests/unit/tests/common/state-dispatcher.test.ts
@@ -47,7 +47,8 @@ describe('StateDispatcherTest', () => {
             .returns(() => Promise.resolve())
             .verifiable();
 
-        const stateDispatcher = new StateDispatcher(broadcastMock.object, storeHubStrictMock.object);
+        const loggerMock = Mock.ofType<Logger>();
+        const stateDispatcher = new StateDispatcher(broadcastMock.object, storeHubStrictMock.object, loggerMock.object);
         stateDispatcher.initialize();
 
         storeMock.verifyAll();
@@ -87,7 +88,8 @@ describe('StateDispatcherTest', () => {
         const broadcastMock = Mock.ofType<(message: Object) => Promise<void>>();
         broadcastMock.setup(m => m(It.isAny())).returns(() => Promise.resolve());
 
-        const stateDispatcher = new StateDispatcher(broadcastMock.object, storeHubMock.object);
+        const loggerMock = Mock.ofType<Logger>();
+        const stateDispatcher = new StateDispatcher(broadcastMock.object, storeHubMock.object, loggerMock.object);
         stateDispatcher.initialize();
 
         broadcastMock.reset();

--- a/src/tests/unit/tests/injected/scanner-utils.test.ts
+++ b/src/tests/unit/tests/injected/scanner-utils.test.ts
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { ScopingInputTypes } from 'background/scoping-input-types';
 import { ScopingStore } from 'background/stores/global/scoping-store';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { Logger } from '../../../../common/logging/logger';
 import { ScopingStoreData } from '../../../../common/types/store-data/scoping-store-data';
 import { DecoratedAxeNodeResult, HtmlElementAxeResults, ScannerUtils } from '../../../../injected/scanner-utils';
@@ -26,7 +25,7 @@ describe('ScannerUtilsTest', () => {
             .returns(() => scopingState)
             .verifiable();
         const loggerMock = Mock.ofType<Logger>();
-        testSubject = new ScannerUtils(scannerMock.object, null, loggerMock.object);
+        testSubject = new ScannerUtils(scannerMock.object, loggerMock.object, null);
         scopingState = {
             selectors: {
                 [ScopingInputTypes.include]: [],
@@ -210,7 +209,8 @@ describe('ScannerUtilsTest', () => {
         const generateUIDMock = Mock.ofInstance(() => {
             return null;
         });
-        testSubject = new ScannerUtils(scannerMock.object, generateUIDMock.object);
+        const loggerMock = Mock.ofType<Logger>();
+        testSubject = new ScannerUtils(scannerMock.object, loggerMock.object, generateUIDMock.object);
 
         generateUIDMock
             .setup(generate => generate())

--- a/src/tests/unit/tests/views/insights/dependencies.test.ts
+++ b/src/tests/unit/tests/views/insights/dependencies.test.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { initializeFabricIcons } from 'common/fabric-icons';
+import { Logger } from 'common/logging/logger';
 import { ContentActionMessageCreator } from 'common/message-creators/content-action-message-creator';
 import * as ReactDOM from 'react-dom';
 import { Mock } from 'typemoq';
@@ -11,7 +12,7 @@ import { RendererDeps } from 'views/insights/renderer';
 describe('rendererDependencies', () => {
     let subject: RendererDeps;
     beforeAll(() => {
-        subject = rendererDependencies(Mock.ofType<BrowserAdapter>().object);
+        subject = rendererDependencies(Mock.ofType<BrowserAdapter>().object, Mock.ofType<Logger>().object);
     });
 
     it('includes dom', () => {

--- a/src/views/insights/dependencies.ts
+++ b/src/views/insights/dependencies.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { createDefaultLogger } from 'common/logging/default-logger';
+import { Logger } from 'common/logging/logger';
 import { loadTheme } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
 import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
@@ -17,10 +17,10 @@ import { UserConfigurationStoreData } from '../../common/types/store-data/user-c
 import { contentPages } from '../../content';
 import { RendererDeps } from './renderer';
 
-export const rendererDependencies: (browserAdapter: BrowserAdapter) => RendererDeps = browserAdapter => {
+export const rendererDependencies: (browserAdapter: BrowserAdapter, logger: Logger) => RendererDeps = (browserAdapter, logger) => {
     const url = new URL(window.location.href);
     const tabId = parseInt(url.searchParams.get('tabId'), 10);
-    const actionMessageDispatcher = new RemoteActionMessageDispatcher(browserAdapter.sendMessageToFrames, tabId, createDefaultLogger());
+    const actionMessageDispatcher = new RemoteActionMessageDispatcher(browserAdapter.sendMessageToFrames, tabId, logger);
 
     const telemetryFactory = new TelemetryDataFactory();
 

--- a/src/views/insights/dependencies.ts
+++ b/src/views/insights/dependencies.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { createDefaultLogger } from 'common/logging/default-logger';
 import { loadTheme } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
-
 import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
 import { TelemetryEventSource } from '../../common/extension-telemetry-events';
 import { initializeFabricIcons } from '../../common/fabric-icons';
@@ -20,7 +20,7 @@ import { RendererDeps } from './renderer';
 export const rendererDependencies: (browserAdapter: BrowserAdapter) => RendererDeps = browserAdapter => {
     const url = new URL(window.location.href);
     const tabId = parseInt(url.searchParams.get('tabId'), 10);
-    const actionMessageDispatcher = new RemoteActionMessageDispatcher(browserAdapter.sendMessageToFrames, tabId);
+    const actionMessageDispatcher = new RemoteActionMessageDispatcher(browserAdapter.sendMessageToFrames, tabId, createDefaultLogger());
 
     const telemetryFactory = new TelemetryDataFactory();
 

--- a/src/views/insights/initializer.ts
+++ b/src/views/insights/initializer.ts
@@ -12,5 +12,6 @@ import { renderer } from './renderer';
 const browserAdapter = new ChromeAdapter();
 renderer(rendererDependencies(browserAdapter));
 
-const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan), new HTMLElementUtils(), createDefaultLogger());
+const logger = createDefaultLogger();
+const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan, logger), new HTMLElementUtils(), logger);
 (window as any).A11YSelfValidator = a11ySelfValidator;

--- a/src/views/insights/initializer.ts
+++ b/src/views/insights/initializer.ts
@@ -10,8 +10,8 @@ import { rendererDependencies } from './dependencies';
 import { renderer } from './renderer';
 
 const browserAdapter = new ChromeAdapter();
-renderer(rendererDependencies(browserAdapter));
-
 const logger = createDefaultLogger();
+renderer(rendererDependencies(browserAdapter, logger));
+
 const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan, logger), new HTMLElementUtils(), logger);
 (window as any).A11YSelfValidator = a11ySelfValidator;

--- a/src/views/insights/initializer.ts
+++ b/src/views/insights/initializer.ts
@@ -3,6 +3,7 @@
 import { A11YSelfValidator } from 'common/a11y-self-validator';
 import { ChromeAdapter } from 'common/browser-adapters/chrome-adapter';
 import { HTMLElementUtils } from 'common/html-element-utils';
+import { createDefaultLogger } from 'common/logging/default-logger';
 import { ScannerUtils } from 'injected/scanner-utils';
 import { scan } from 'scanner/exposed-apis';
 import { rendererDependencies } from './dependencies';
@@ -11,5 +12,5 @@ import { renderer } from './renderer';
 const browserAdapter = new ChromeAdapter();
 renderer(rendererDependencies(browserAdapter));
 
-const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan), new HTMLElementUtils());
+const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan), new HTMLElementUtils(), createDefaultLogger());
 (window as any).A11YSelfValidator = a11ySelfValidator;


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

We have a lot of constructors using a default value for their `logger` dependency. This is fine in general but it defeats the purpose of having composition roots (as we definitely do).

In this PR, I update most of the `logger` constructor params to not have a default value, forcing the creation of a logger instance to happen either on the composition root or on a factory-like class.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
