### PR TITLE
feat(electron-update): Add task to prepare & publish electron artifact

### DIFF
--- a/pipeline/electron/distribute-publish-electron-linux.yaml
+++ b/pipeline/electron/distribute-publish-electron-linux.yaml
@@ -11,8 +11,4 @@ steps:
           ELECTRON_MIRROR: $(ELECTRON_MIRROR)
           ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR)
 
-    - task: PublishBuildArtifacts@1
-      inputs:
-          pathtoPublish: '$(System.DefaultWorkingDirectory)/dist'
-          artifactName: $(Agent.JobName)
-      displayName: publish dist
+    - template: prepare-publish-artifact.yaml

--- a/pipeline/electron/distribute-sign-publish-electron-mac.yaml
+++ b/pipeline/electron/distribute-sign-publish-electron-mac.yaml
@@ -32,8 +32,4 @@ steps:
     - script: yarn update:electron-checksum
       displayName: update electron checksum after signing
 
-    - task: PublishBuildArtifacts@1
-      inputs:
-          pathtoPublish: '$(System.DefaultWorkingDirectory)/dist'
-          artifactName: $(Agent.JobName)
-      displayName: publish dist
+    - template: prepare-publish-artifact.yaml

--- a/pipeline/electron/distribute-sign-publish-electron-windows.yaml
+++ b/pipeline/electron/distribute-sign-publish-electron-windows.yaml
@@ -53,8 +53,4 @@ steps:
     - script: yarn update:electron-checksum
       displayName: update electron checksum after signing
 
-    - task: PublishBuildArtifacts@1
-      inputs:
-          pathtoPublish: '$(System.DefaultWorkingDirectory)/dist'
-          artifactName: $(Agent.JobName)
-      displayName: publish dist
+    - template: prepare-publish-artifact.yaml

--- a/pipeline/electron/prepare-publish-artifact.yaml
+++ b/pipeline/electron/prepare-publish-artifact.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+steps:
+    - task: CopyFiles@2
+      displayName: 'Copy package files to upload'
+      inputs:
+          SourceFolder: '$(System.DefaultWorkingDirectory)/dist'
+          Contents: |
+              latest*.yml
+              Accessibility Insights for Android*.*
+          TargetFolder: '$(System.DefaultWorkingDirectory)/dist/upload'
+          CleanTargetFolder: true
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+          pathtoPublish: '$(System.DefaultWorkingDirectory)/dist'
+          artifactName: $(Agent.JobName)
+      displayName: publish dist

--- a/pipeline/electron/prepare-publish-artifact.yaml
+++ b/pipeline/electron/prepare-publish-artifact.yaml
@@ -3,7 +3,7 @@
 
 steps:
     - task: CopyFiles@2
-      displayName: 'Copy package files to upload'
+      displayName: 'copy package files to upload'
       inputs:
           SourceFolder: '$(System.DefaultWorkingDirectory)/dist'
           Contents: |


### PR DESCRIPTION
#### Description of changes
Currently, we publish an artifact for the electron build that includes both the packed and unpacked versions of the product for each platform. This is useful for testing purposes, but we only need the packed version for the actual release process. This PR adds a build step that copies only the files we need to release into a separate directory for use in the release pipeline. The artifact is then published as usual.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
