### PR TITLE
feat(electron-update): send osName from platform as part of telemetry

### DIFF
--- a/src/electron/views/device-connect-view/send-app-initialized-telemetry.ts
+++ b/src/electron/views/device-connect-view/send-app-initialized-telemetry.ts
@@ -3,12 +3,17 @@
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { TelemetryEventSource, TriggeredByNotApplicable } from 'common/extension-telemetry-events';
 import { APP_INITIALIZED } from 'electron/common/electron-telemetry-events';
+import { PlatformInfo } from 'electron/window-management/platform-info';
 
-export const sendAppInitializedTelemetryEvent = (telemetryEventHandler: TelemetryEventHandler) => {
+export const sendAppInitializedTelemetryEvent = (
+    telemetryEventHandler: TelemetryEventHandler,
+    platformInfo: PlatformInfo,
+) => {
     telemetryEventHandler.publishTelemetry(APP_INITIALIZED, {
         telemetry: {
             triggeredBy: TriggeredByNotApplicable,
             source: TelemetryEventSource.ElectronDeviceConnect,
+            os: platformInfo.getOsName(),
         },
     });
 };

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -110,6 +110,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             storageAdapter,
         );
         const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
+        const platformInfo = new PlatformInfo(process);
 
         const userConfigurationStore = new UserConfigurationStore(
             persistedData.userConfigurationData,
@@ -260,6 +261,6 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
         const renderer = new RootContainerRenderer(ReactDOM.render, document, props);
         renderer.render();
 
-        sendAppInitializedTelemetryEvent(telemetryEventHandler);
+        sendAppInitializedTelemetryEvent(telemetryEventHandler, platformInfo);
     },
 );

--- a/src/electron/window-management/platform-info.ts
+++ b/src/electron/window-management/platform-info.ts
@@ -24,4 +24,8 @@ export class PlatformInfo {
     public isMac(): boolean {
         return this.getOs() === OSType.Mac;
     }
+
+    public getOsName(): string {
+        return this.currentProcess.platform || null;
+    }
 }

--- a/src/tests/unit/tests/electron/views/device-connect-view/send-app-initialized-telemetry.test.ts
+++ b/src/tests/unit/tests/electron/views/device-connect-view/send-app-initialized-telemetry.test.ts
@@ -5,24 +5,28 @@ import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-hand
 import { TelemetryEventSource, TriggeredByNotApplicable } from 'common/extension-telemetry-events';
 import { APP_INITIALIZED } from 'electron/common/electron-telemetry-events';
 import { sendAppInitializedTelemetryEvent } from 'electron/views/device-connect-view/send-app-initialized-telemetry';
+import { PlatformInfo } from 'electron/window-management/platform-info';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('sendAppInitializedTelemetry', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
-
+    let platformInfoMock: IMock<PlatformInfo>;
     const testSubject = sendAppInitializedTelemetryEvent;
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        platformInfoMock = Mock.ofType<PlatformInfo>();
     });
 
     it('send telemetry', () => {
-        testSubject(telemetryEventHandlerMock.object);
+        platformInfoMock.setup(x => x.getOsName()).returns(() => 'osName');
+        testSubject(telemetryEventHandlerMock.object, platformInfoMock.object);
 
         const expectedTelemetry: BaseActionPayload = {
             telemetry: {
                 source: TelemetryEventSource.ElectronDeviceConnect,
                 triggeredBy: TriggeredByNotApplicable,
+                os: 'osName',
             },
         };
 

--- a/src/tests/unit/tests/electron/window-management/platform-info.test.ts
+++ b/src/tests/unit/tests/electron/window-management/platform-info.test.ts
@@ -33,4 +33,18 @@ describe(PlatformInfo, () => {
 
         expect(testSubject.isMac()).toBe(true);
     });
+
+    describe('getOsName', () => {
+        type GetOsTestCase = { platformName: typeof process.platform; osType: OSType };
+
+        test.each([
+            { platformName: 'linux', osType: OSType.Linux },
+            { platformName: 'darwin', osType: OSType.Mac },
+            { platformName: 'win32', osType: OSType.Windows },
+        ] as GetOsTestCase[])('validate getOs %o', (testCase: GetOsTestCase) => {
+            processMock.setup(p => p.platform).returns(() => testCase.platformName);
+
+            expect(testSubject.getOsName()).toBe(testCase.platformName);
+        });
+    });
 });

--- a/src/tests/unit/tests/electron/window-management/platform-info.test.ts
+++ b/src/tests/unit/tests/electron/window-management/platform-info.test.ts
@@ -41,7 +41,7 @@ describe(PlatformInfo, () => {
             { platformName: 'linux', osType: OSType.Linux },
             { platformName: 'darwin', osType: OSType.Mac },
             { platformName: 'win32', osType: OSType.Windows },
-        ] as GetOsTestCase[])('validate getOs %o', (testCase: GetOsTestCase) => {
+        ] as GetOsTestCase[])('validate getOsName %o', (testCase: GetOsTestCase) => {
             processMock.setup(p => p.platform).returns(() => testCase.platformName);
 
             expect(testSubject.getOsName()).toBe(testCase.platformName);


### PR DESCRIPTION
#### Description of changes
Part of the electron-update feature is a requirement to send platformInfo in our telemetry. I changed our initialization telemetry event to include `os` as a property with `currentProcess` from node.
I didn't use `process` directly and added `getOSName` a function in our `PlatformInfo` class because the other `getOs` function returned from an enum, which essentially is a number.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
