### PR TITLE
refactor: remove unnecessary interface from visualization-scan-result-data

### DIFF
--- a/src/common/types/store-data/visualization-scan-result-data.ts
+++ b/src/common/types/store-data/visualization-scan-result-data.ts
@@ -6,15 +6,12 @@ import { TabStopEvent } from '../../../injected/tab-stops-listener';
 import { ScanResults } from '../../../scanner/iruleresults';
 import { DictionaryStringTo } from '../../../types/common-types';
 
-interface ScanResultData<TSelector> {
-    fullAxeResultsMap: DictionaryStringTo<TSelector>;
+interface IssuesScanResultData {
     scanResult?: ScanResults;
-}
-
-interface IssuesScanResultData extends ScanResultData<HtmlElementAxeResults> {
+    fullAxeResultsMap: DictionaryStringTo<HtmlElementAxeResults>;
+    fullIdToRuleResultMap: DictionaryStringTo<DecoratedAxeNodeResult>;
     selectedAxeResultsMap: DictionaryStringTo<HtmlElementAxeResults>;
     selectedIdToRuleResultMap: DictionaryStringTo<DecoratedAxeNodeResult>;
-    fullIdToRuleResultMap: DictionaryStringTo<DecoratedAxeNodeResult>;
 }
 
 export interface TabbedElementData extends TabStopEvent {


### PR DESCRIPTION
#### Description of changes

Small refactor inlining an unnecessary generic interface in visualization-scan-result-data

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
