### PR TITLE
refactor: promisify get all windows

### DIFF
--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -76,30 +76,30 @@ export class TargetPageController {
         });
     };
 
-    private onWindowFocusChanged = (windowId: number): void => {
-        this.browserAdapter.getAllWindows(
-            { populate: false, windowTypes: ['normal', 'popup'] },
-            (chromeWindows: chrome.windows.Window[]) => {
-                chromeWindows.forEach((chromeWindow: chrome.windows.Window) => {
-                    this.browserAdapter.tabsQuery(
-                        {
-                            active: true,
-                            windowId: chromeWindow.id,
-                        },
-                        (activeTabs: chrome.tabs.Tab[]) => {
-                            if (!this.browserAdapter.getRuntimeLastError()) {
-                                for (const activeTab of activeTabs) {
-                                    this.sendTabVisibilityChangeAction(
-                                        activeTab.id,
-                                        chromeWindow.state === 'minimized',
-                                    );
-                                }
-                            }
-                        },
-                    );
-                });
-            },
-        );
+    private onWindowFocusChanged = async (windowId: number): Promise<void> => {
+        const chromeWindows = await this.browserAdapter.getAllWindowsP({
+            populate: false,
+            windowTypes: ['normal', 'popup'],
+        });
+
+        chromeWindows.forEach(chromeWindow => {
+            this.browserAdapter.tabsQuery(
+                {
+                    active: true,
+                    windowId: chromeWindow.id,
+                },
+                (activeTabs: chrome.tabs.Tab[]) => {
+                    if (!this.browserAdapter.getRuntimeLastError()) {
+                        for (const activeTab of activeTabs) {
+                            this.sendTabVisibilityChangeAction(
+                                activeTab.id,
+                                chromeWindow.state === 'minimized',
+                            );
+                        }
+                    }
+                },
+            );
+        });
     };
 
     private handleTabUrlUpdate = (tabId: number, telemetry?: BaseTelemetryData): void => {

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -77,7 +77,7 @@ export class TargetPageController {
     };
 
     private onWindowFocusChanged = async (windowId: number): Promise<void> => {
-        const chromeWindows = await this.browserAdapter.getAllWindowsP({
+        const chromeWindows = await this.browserAdapter.getAllWindows({
             populate: false,
             windowTypes: ['normal', 'popup'],
         });

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -3,7 +3,7 @@
 import { ExtensionTypes, Notifications, Permissions, Tabs, Windows } from 'webextension-polyfill-ts';
 
 export interface BrowserAdapter {
-    getAllWindowsP(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]>;
+    getAllWindows(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]>;
     addListenerToTabsOnActivated(callback: (activeInfo: chrome.tabs.TabActiveInfo) => void): void;
     addListenerToTabsOnUpdated(callback: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => void): void;
     addListenerToTabsOnRemoved(callback: (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo) => void): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -3,7 +3,6 @@
 import { ExtensionTypes, Notifications, Permissions, Tabs, Windows } from 'webextension-polyfill-ts';
 
 export interface BrowserAdapter {
-    getAllWindows(getInfo: chrome.windows.GetInfo, callback: (chromeWindows: chrome.windows.Window[]) => void): void;
     getAllWindowsP(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]>;
     addListenerToTabsOnActivated(callback: (activeInfo: chrome.tabs.TabActiveInfo) => void): void;
     addListenerToTabsOnUpdated(callback: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => void): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -1,9 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ExtensionTypes, Notifications, Permissions, Tabs } from 'webextension-polyfill-ts';
+import { ExtensionTypes, Notifications, Permissions, Tabs, Windows } from 'webextension-polyfill-ts';
 
 export interface BrowserAdapter {
     getAllWindows(getInfo: chrome.windows.GetInfo, callback: (chromeWindows: chrome.windows.Window[]) => void): void;
+    getAllWindowsP(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]>;
     addListenerToTabsOnActivated(callback: (activeInfo: chrome.tabs.TabActiveInfo) => void): void;
     addListenerToTabsOnUpdated(callback: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => void): void;
     addListenerToTabsOnRemoved(callback: (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo) => void): void;

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -11,10 +11,6 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return `chrome://extensions/?id=${chrome.runtime.id}`;
     }
 
-    public getAllWindows(getInfo: chrome.windows.GetInfo, callback: (chromeWindows: chrome.windows.Window[]) => void): void {
-        chrome.windows.getAll(getInfo, callback);
-    }
-
     public getAllWindowsP(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]> {
         return browser.windows.getAll(getInfo);
     }

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -11,7 +11,7 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return `chrome://extensions/?id=${chrome.runtime.id}`;
     }
 
-    public getAllWindowsP(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]> {
+    public getAllWindows(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]> {
         return browser.windows.getAll(getInfo);
     }
 

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { browser, ExtensionTypes, Notifications, Permissions, Tabs } from 'webextension-polyfill-ts';
+import { browser, ExtensionTypes, Notifications, Permissions, Tabs, Windows } from 'webextension-polyfill-ts';
 
 import { BrowserAdapter } from './browser-adapter';
 import { CommandsAdapter } from './commands-adapter';
@@ -13,6 +13,10 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
 
     public getAllWindows(getInfo: chrome.windows.GetInfo, callback: (chromeWindows: chrome.windows.Window[]) => void): void {
         chrome.windows.getAll(getInfo, callback);
+    }
+
+    public getAllWindowsP(getInfo: Windows.GetAllGetInfoType): Promise<Windows.Window[]> {
+        return browser.windows.getAll(getInfo);
     }
 
     public addListenerToTabsOnActivated(callback: (activeInfo: chrome.tabs.TabActiveInfo) => void): void {

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -43,7 +43,7 @@ export function createSimulatedBrowserAdapter(tabs: chrome.tabs.Tab[], windows: 
     mock.setup(m => m.addListenerOnWindowsFocusChanged(It.is(isFunction))).callback(c => (mock.notifyWindowsFocusChanged = c));
 
     mock.setup(m => m.getRuntimeLastError()).returns(() => null);
-    mock.setup(m => m.getAllWindowsP(It.isAny())).returns(() => Promise.resolve(mock.windows as Windows.Window[]));
+    mock.setup(m => m.getAllWindows(It.isAny())).returns(() => Promise.resolve(mock.windows as Windows.Window[]));
     mock.setup(m => m.getTab(It.isAny(), It.isAny(), It.isAny())).callback((tabId, resolve, reject) => {
         const matchingTabs = mock.tabs.filter(tab => tab.id === tabId);
         if (matchingTabs.length === 1) {

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -3,6 +3,7 @@
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { isFunction } from 'lodash';
 import { IMock, It, Mock } from 'typemoq';
+import { Windows } from 'webextension-polyfill-ts';
 
 // This is a mock BrowserAdapter that maintains simulated state about which "windows" and "tabs"
 // exist and which listeners have been registered, and provides a few helper functions to simulate
@@ -42,7 +43,7 @@ export function createSimulatedBrowserAdapter(tabs: chrome.tabs.Tab[], windows: 
     mock.setup(m => m.addListenerOnWindowsFocusChanged(It.is(isFunction))).callback(c => (mock.notifyWindowsFocusChanged = c));
 
     mock.setup(m => m.getRuntimeLastError()).returns(() => null);
-    mock.setup(m => m.getAllWindows(It.isAny(), It.isAny())).callback((_, c) => c(mock.windows));
+    mock.setup(m => m.getAllWindowsP(It.isAny())).returns(() => Promise.resolve(mock.windows as Windows.Window[]));
     mock.setup(m => m.getTab(It.isAny(), It.isAny(), It.isAny())).callback((tabId, resolve, reject) => {
         const matchingTabs = mock.tabs.filter(tab => tab.id === tabId);
         if (matchingTabs.length === 1) {

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -13,6 +13,7 @@ import { isFunction, values } from 'lodash';
 import { createSimulatedBrowserAdapter, SimulatedBrowserAdapter } from 'tests/unit/common/simulated-browser-adapter';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DictionaryNumberTo } from 'types/common-types';
+import { tick } from 'tests/unit/common/tick';
 
 describe('TargetPageController', () => {
     let testSubject: TargetPageController;
@@ -208,11 +209,13 @@ describe('TargetPageController', () => {
                 ${'unrecognized'} | ${false}
             `(
                 'should send a Tab.VisibilityChange message with hidden=$expectedHiddenValue for active tabs in windows with state $windowState',
-                ({ windowState, expectedHiddenValue }) => {
+                async ({ windowState, expectedHiddenValue }) => {
                     mockBrowserAdapter.windows.forEach(w => {
                         w.state = windowState;
                     });
                     mockBrowserAdapter.notifyWindowsFocusChanged(irrelevantWindowId);
+
+                    await tick();
 
                     const expectedMessage = {
                         messageType: Messages.Tab.VisibilityChange,

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -11,9 +11,9 @@ import { Logger } from 'common/logging/logger';
 import { Messages } from 'common/messages';
 import { isFunction, values } from 'lodash';
 import { createSimulatedBrowserAdapter, SimulatedBrowserAdapter } from 'tests/unit/common/simulated-browser-adapter';
+import { tick } from 'tests/unit/common/tick';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DictionaryNumberTo } from 'types/common-types';
-import { tick } from 'tests/unit/common/tick';
 
 describe('TargetPageController', () => {
     let testSubject: TargetPageController;


### PR DESCRIPTION
#### Description of changes

This is part of a long-run refactor to promisify all (possible) `chrome.*` calls.

In this case, promisifying `getAllWindows`.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
