### PR TITLE
test: adhoc panel timeout flakyness fix

### DIFF
--- a/src/tests/end-to-end/common/element-identifiers/popup-page-element-identifiers.ts
+++ b/src/tests/end-to-end/common/element-identifiers/popup-page-element-identifiers.ts
@@ -6,7 +6,7 @@ export const popupPageElementIdentifiers = {
     launchPad: '#new-launch-pad',
     launchPadItemTitle: '.launch-pad-item-title',
     adhocPanel: '.ad-hoc-tools-panel',
-    adhocLaunchPadLinkXPath: "//button[text()='Ad hoc tools']",
+    gotoAdhocToolsButton: '#ad-hoc-tools',
     backToLaunchPadLink: '#back-to-launchpad-link',
     hamburgerMenuButton: '#feedback-collapse-menu-button',
     hamburgerMenu: '.popup-menu',

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -206,11 +206,6 @@ export class Page {
         });
     }
 
-    public async clickSelectorXPath(xpath: string): Promise<void> {
-        const element = await this.waitForSelectorXPath(xpath);
-        await this.clickElementHandle(element);
-    }
-
     public async clickDescendentSelector(
         parentElement: Puppeteer.ElementHandle<Element>,
         descendentSelector: string,

--- a/src/tests/end-to-end/common/page-controllers/popup-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/popup-page.ts
@@ -26,7 +26,7 @@ export class PopupPage extends Page {
     }
 
     public async gotoAdhocPanel(): Promise<void> {
-        await this.clickSelectorXPath(popupPageElementIdentifiers.adhocLaunchPadLinkXPath);
+        await this.clickSelector(popupPageElementIdentifiers.gotoAdhocToolsButton);
         await this.verifyAdhocPanelLoaded();
     }
 

--- a/src/tests/end-to-end/tests/popup/adhoc-panel.test.ts
+++ b/src/tests/end-to-end/tests/popup/adhoc-panel.test.ts
@@ -36,7 +36,7 @@ describe('Popup -> Ad-hoc tools', () => {
     });
 
     it('should take back to Launch pad on clicking "Back to Launch pad" link & is sticky', async () => {
-        await popupPage.clickSelectorXPath(popupPageElementIdentifiers.adhocLaunchPadLinkXPath);
+        await popupPage.clickSelector(popupPageElementIdentifiers.gotoAdhocToolsButton);
         await popupPage.clickSelector(popupPageElementIdentifiers.backToLaunchPadLink);
 
         await popupPage.verifyLaunchPadLoaded();


### PR DESCRIPTION
#### Description of changes

We have some flakyness on our e2e test for the ad hoc tools panel. Specifically:
```node
  TimeoutError: waiting for selector ".ad-hoc-tools-panel" failed: timeout 5000ms exceeded

      129 |     public async waitForSelector(selector: string, options?: Puppeteer.WaitForSelectorOptions): Promise<Puppeteer.ElementHandle<Element>> {
      130 |         return await this.screenshotOnError(
    > 131 |             async () => await this.underlyingPage.waitForSelector(selector, { timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS, ...options }),
          |                                                   ^
      132 |         );
      133 |     }
      134 | 
```

Build reference [here](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=53956) (look for attempt #1)

This PR is an attempt to fix this by changing clicking using xpath for clicking using an id-based selector

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
