### PR TITLE
fix: adding all-url,all-file permissions back

### DIFF
--- a/src/DetailsView/components/no-content-available.tsx
+++ b/src/DetailsView/components/no-content-available.tsx
@@ -14,9 +14,8 @@ export const NoContentAvailable = NamedFC('NoContentAvailable', () => {
             <ul>
                 <li>If the target page was closed, you can close this tab or reuse it for something else.</li>
                 <li>
-                    If the URL was changed on the target page, you can reactivate this tab by pressing the{' '}
-                    <Markup.Term>{productName}</Markup.Term> extension icon on the browser toolbar or by using the extension keyboard
-                    shortcuts.
+                    If the URL was changed on the target page, you can reactivate <Markup.Term>{productName}</Markup.Term> by selecting the
+                    extension icon on the browser toolbar or by using the extension keyboard shortcuts.
                 </li>
             </ul>
         </main>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,7 @@
     },
     "devtools_page": "Devtools/devtools.html",
     "web_accessible_resources": ["insights.html", "assessments/*", "injected/*", "background/*", "common/*", "DetailsView/*", "bundle/*"],
-    "permissions": ["storage", "webNavigation", "tabs", "notifications", "activeTab"],
+    "permissions": ["storage", "webNavigation", "tabs", "notifications", "https://*/*", "http://*/*", "file://*/*"],
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/no-content-available.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/no-content-available.test.tsx.snap
@@ -12,12 +12,11 @@ exports[`NoContentAvailable renders stale view for default 1`] = `
       If the target page was closed, you can close this tab or reuse it for something else.
     </li>
     <li>
-      If the URL was changed on the target page, you can reactivate this tab by pressing the
-       
+      If the URL was changed on the target page, you can reactivate 
       <Term>
         Accessibility Insights for Web
       </Term>
-       extension icon on the browser toolbar or by using the extension keyboard shortcuts.
+       by selecting the extension icon on the browser toolbar or by using the extension keyboard shortcuts.
     </li>
   </ul>
 </main>


### PR DESCRIPTION
#### Description of changes

In order to release all the fixes and new features we haven't yet, we are changing the permissions back (remove `"activeTab"` and re-add the original permissions). We are going to release and wait the 5 to 7 business days it takes for our extension to go through the review process.

We are not changing the logic we already have to show the **No content available** message on the details view; that'll be a "preview" of how our extension will work once we finally change to make full use of "activeTab" + optional all-url, all-files permissions.

I also update the **No content available" text to make it more clear how to "reactivate" our extension on existing details view tab.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
