### PR TITLE
fix: electron e2e issue with resize by putting a timeout after resize

### DIFF
--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -28,7 +28,7 @@ export class AppController {
     }
 
     public async openDeviceConnectionDialog(): Promise<DeviceConnectionDialogController> {
-        await this.setToMinimumSupportedWindowSize();
+        this.resizeWindow();
 
         await dismissTelemetryOptInDialog(this.app);
 
@@ -45,14 +45,21 @@ export class AppController {
         const automatedChecksView = new AutomatedChecksViewController(this.client);
         await automatedChecksView.waitForViewVisible();
 
-        await this.setToMinimumSupportedWindowSize();
+        this.resizeWindow();
 
         return automatedChecksView;
     }
 
-    private async setToMinimumSupportedWindowSize(): Promise<void> {
+    private resizeWindow(): void {
+        let resizeId;
+        this.app.browserWindow.addListener('resize', () => {
+            clearTimeout(resizeId);
+            resizeId = setTimeout(this.setToMinimumSupportedWindowSize, 500);
+        });
+    }
+
+    private setToMinimumSupportedWindowSize(): void {
         this.app.browserWindow.setBounds({ width: mainWindowConfig.minWidth, height: mainWindowConfig.minHeight });
         this.app.browserWindow.unmaximize();
-        await this.app.client.waitUntilWindowLoaded();
     }
 }

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -28,7 +28,7 @@ export class AppController {
     }
 
     public async openDeviceConnectionDialog(): Promise<DeviceConnectionDialogController> {
-        this.setToMinimumSupportedWindowSize();
+        await this.setToMinimumSupportedWindowSize();
 
         await dismissTelemetryOptInDialog(this.app);
 
@@ -45,13 +45,14 @@ export class AppController {
         const automatedChecksView = new AutomatedChecksViewController(this.client);
         await automatedChecksView.waitForViewVisible();
 
-        this.setToMinimumSupportedWindowSize();
+        await this.setToMinimumSupportedWindowSize();
 
         return automatedChecksView;
     }
 
-    private setToMinimumSupportedWindowSize(): void {
+    private async setToMinimumSupportedWindowSize(): Promise<void> {
         this.app.browserWindow.setBounds({ width: mainWindowConfig.minWidth, height: mainWindowConfig.minHeight });
         this.app.browserWindow.unmaximize();
+        await this.app.client.waitUntilWindowLoaded();
     }
 }


### PR DESCRIPTION
#### Description of changes
Fix the electron e2e issue with button click by making window wait till its fully loaded (resize ends with a load event)

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
