### PR TITLE
chore: introduce electron e2e reliability build similar to e2e-reliability

### DIFF
--- a/pipeline/electron/electron-e2e-job-per-environment.yaml
+++ b/pipeline/electron/electron-e2e-job-per-environment.yaml
@@ -1,0 +1,32 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+parameters:
+    jobNameSuffix: ''
+    windowsImage: 'windows-2019'
+    macImage: 'macOS-10.14'
+    linuxImage: 'ubuntu-16.04'
+
+jobs:
+    - job: 'electron_e2e_tests_windows${{ parameters.jobNameSuffix }}'
+      pool:
+          vmImage: ${{ parameters.windowsImage }}
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./electron-e2e-test-interactive.yaml
+          - template: ./electron-e2e-publish-results.yaml
+
+    - job: 'electron_e2e_tests_mac${{ parameters.jobNameSuffix }}'
+      pool:
+          vmImage: ${{ parameters.macImage }}
+      steps:
+          - template: ./install-node-prerequisites.yaml
+          - template: ./electron-e2e-test-interactive.yaml
+          - template: ./e2e-test-publish-results.yaml
+
+    - job: 'electron_e2e_tests_linux${{ parameters.jobNameSuffix }}'
+      pool:
+          vmImage: ${{ parameters.linuxImage }}
+      steps:
+          - template: ./electron-e2e-test-linux.yaml
+          - template: ./e2e-test-publish-results.yaml

--- a/pipeline/electron/electron-e2e-job-per-environment.yaml
+++ b/pipeline/electron/electron-e2e-job-per-environment.yaml
@@ -12,7 +12,7 @@ jobs:
       pool:
           vmImage: ${{ parameters.windowsImage }}
       steps:
-          - template: ./install-node-prerequisites.yaml
+          - template: ../install-node-prerequisites.yaml
           - template: ./electron-e2e-test-interactive.yaml
           - template: ./electron-e2e-publish-results.yaml
 
@@ -20,7 +20,7 @@ jobs:
       pool:
           vmImage: ${{ parameters.macImage }}
       steps:
-          - template: ./install-node-prerequisites.yaml
+          - template: ../install-node-prerequisites.yaml
           - template: ./electron-e2e-test-interactive.yaml
           - template: ./e2e-test-publish-results.yaml
 
@@ -28,5 +28,6 @@ jobs:
       pool:
           vmImage: ${{ parameters.linuxImage }}
       steps:
+          - template: ../install-node-prerequisites.yaml
           - template: ./electron-e2e-test-linux.yaml
           - template: ./e2e-test-publish-results.yaml

--- a/pipeline/electron/electron-e2e-job-per-environment.yaml
+++ b/pipeline/electron/electron-e2e-job-per-environment.yaml
@@ -22,7 +22,7 @@ jobs:
       steps:
           - template: ../install-node-prerequisites.yaml
           - template: ./electron-e2e-test-interactive.yaml
-          - template: ./e2e-test-publish-results.yaml
+          - template: ./electron-e2e-publish-results.yaml
 
     - job: 'electron_e2e_tests_linux${{ parameters.jobNameSuffix }}'
       pool:
@@ -30,4 +30,4 @@ jobs:
       steps:
           - template: ../install-node-prerequisites.yaml
           - template: ./electron-e2e-test-linux.yaml
-          - template: ./e2e-test-publish-results.yaml
+          - template: ./electron-e2e-publish-results.yaml

--- a/pipeline/electron/electron-e2e-reliability.yaml
+++ b/pipeline/electron/electron-e2e-reliability.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+trigger:
+    - master
+    - e2e-reliability/*
+pr:
+    paths:
+        include:
+            - src/tests/electron/
+
+jobs:
+    - template: ./electron-e2e-job-per-environment.yaml
+      parameters: { jobNameSuffix: _1 }
+
+    - template: ./electron-e2e-job-per-environment.yaml
+      parameters: { jobNameSuffix: _2 }
+
+    - template: ./electron-e2e-job-per-environment.yaml
+      parameters: { jobNameSuffix: _3 }
+
+    - template: ./electron-e2e-job-per-environment.yaml
+      parameters: { jobNameSuffix: _4 }
+
+    - template: ./electron-e2e-job-per-environment.yaml
+      parameters: { jobNameSuffix: _5 }


### PR DESCRIPTION
#### Description of changes
To keep our end-to-end reliable in long term, it is a good idea that we create a reliability build for electron end to end as we keep adding more tests and code to our electron code base.

On similar footprint as our current e2e-reliability build pipeline, adding this new electron-e2e-reliability build with a little different trigger point.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
