### PR TITLE
feat(permissions): add ScanIncompleteWarning data into result stores

### DIFF
--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -10,6 +10,7 @@ import { Tab } from 'common/itab';
 import { CreateIssueDetailsTextData } from 'common/types/create-issue-details-text-data';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { ManualTestStatus } from 'common/types/manual-test-status';
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import {
     PlatformData,
     ScreenshotData,
@@ -161,6 +162,7 @@ export interface UnifiedScanCompletedPayload extends BaseActionPayload {
     rules: UnifiedRule[];
     toolInfo: ToolData;
     targetAppInfo: TargetAppData;
+    scanIncompleteWarnings?: ScanIncompleteWarningId[];
     screenshotData?: ScreenshotData;
     platformInfo?: PlatformData;
 }

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -385,6 +385,7 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         );
         assessmentData.generatedAssessmentInstancesMap = generatedAssessmentInstancesMap;
         assessmentData.testStepStatus[step].isStepScanned = true;
+        assessmentData.scanIncompleteWarnings = payload.scanIncompleteWarnings;
         this.updateTestStepStatusOnScanUpdate(assessmentData, step, test);
         this.emitChanged();
     };

--- a/src/background/stores/unified-scan-result-store.ts
+++ b/src/background/stores/unified-scan-result-store.ts
@@ -17,6 +17,7 @@ export class UnifiedScanResultStore extends BaseStoreImpl<UnifiedScanResultStore
             rules: null,
             toolInfo: null,
             targetAppInfo: null,
+            scanIncompleteWarnings: null,
             screenshotData: null,
             platformInfo: null,
         };
@@ -34,6 +35,7 @@ export class UnifiedScanResultStore extends BaseStoreImpl<UnifiedScanResultStore
         this.state.rules = payload.rules;
         this.state.toolInfo = payload.toolInfo;
         this.state.targetAppInfo = payload.targetAppInfo;
+        this.state.scanIncompleteWarnings = payload.scanIncompleteWarnings;
         this.state.screenshotData = payload.screenshotData;
         this.state.platformInfo = payload.platformInfo;
         this.emitChanged();

--- a/src/common/types/scan-incomplete-warnings.ts
+++ b/src/common/types/scan-incomplete-warnings.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This is a string-enum, but we only one type right now
+export type ScanIncompleteWarningId = 'missing-required-cross-origin-permissions';

--- a/src/common/types/scan-incomplete-warnings.ts
+++ b/src/common/types/scan-incomplete-warnings.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// This is a string-enum, but we only one type right now
+// This is a string-enum, but we only have one type right now
 export type ScanIncompleteWarningId = 'missing-required-cross-origin-permissions';

--- a/src/common/types/store-data/assessment-result-data.ts
+++ b/src/common/types/store-data/assessment-result-data.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { DictionaryStringTo } from '../../../types/common-types';
 import { Tab } from '../../itab';
 import { ManualTestStatus, ManualTestStatusData } from '../manual-test-status';
@@ -28,6 +29,7 @@ export interface AssessmentData {
     generatedAssessmentInstancesMap?: InstanceIdToInstanceDataMap;
     manualTestStepResultMap?: RequirementIdToResultMap;
     testStepStatus: ManualTestStatusData;
+    scanIncompleteWarnings?: ScanIncompleteWarningId[];
 }
 
 export interface ManualTestStepResult {

--- a/src/common/types/store-data/unified-data-interface.ts
+++ b/src/common/types/store-data/unified-data-interface.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { BoundingRectangle } from 'electron/platform/android/scan-results';
 import { GuidanceLink } from '../../../scanner/rule-to-links-mappings';
+import { ScanIncompleteWarningId } from '../scan-incomplete-warnings';
 
 // this is similar to `TestEngine` interface from axe-core
 export interface ScanEngineProperties {
@@ -55,6 +56,7 @@ export interface UnifiedScanResultStoreData {
     platformInfo?: PlatformData;
     toolInfo?: ToolData;
     targetAppInfo?: TargetAppData;
+    scanIncompleteWarnings?: ScanIncompleteWarningId[];
     screenshotData?: ScreenshotData;
 }
 

--- a/src/injected/analyzers/analyzer-provider.ts
+++ b/src/injected/analyzers/analyzer-provider.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IframeDetector } from 'injected/iframe-detector';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 
 import { BaseStore } from '../../common/base-store';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
@@ -33,7 +33,7 @@ export class AnalyzerProvider {
         private readonly visualizationConfigFactory: VisualizationConfigurationFactory,
         private filterResultsByRules: IResultRuleFilter,
         private sendConvertedResults: PostResolveCallback,
-        private iframeDetector: IframeDetector,
+        private scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
     ) {
         this.tabStopsListener = tabStopsListener;
         this.scopingStore = scopingStore;
@@ -53,7 +53,7 @@ export class AnalyzerProvider {
             this.telemetryDataFactory,
             this.visualizationConfigFactory,
             null,
-            this.iframeDetector,
+            this.scanIncompleteWarningDetector,
         );
     }
 
@@ -69,7 +69,7 @@ export class AnalyzerProvider {
             this.telemetryDataFactory,
             this.visualizationConfigFactory,
             this.sendConvertedResults,
-            this.iframeDetector,
+            this.scanIncompleteWarningDetector,
         );
     }
 
@@ -83,15 +83,21 @@ export class AnalyzerProvider {
             this.telemetryDataFactory,
             this.visualizationConfigFactory,
             this.filterResultsByRules,
-            this.iframeDetector,
+            this.scanIncompleteWarningDetector,
         );
     }
 
     public createFocusTrackingAnalyzer(config: FocusAnalyzerConfiguration): Analyzer {
-        return new TabStopsAnalyzer(config, this.tabStopsListener, new WindowUtils(), this.sendMessageDelegate, this.iframeDetector);
+        return new TabStopsAnalyzer(
+            config,
+            this.tabStopsListener,
+            new WindowUtils(),
+            this.sendMessageDelegate,
+            this.scanIncompleteWarningDetector,
+        );
     }
 
     public createBaseAnalyzer(config: AnalyzerConfiguration): Analyzer {
-        return new BaseAnalyzer(config, this.sendMessageDelegate, this.iframeDetector);
+        return new BaseAnalyzer(config, this.sendMessageDelegate, this.scanIncompleteWarningDetector);
     }
 }

--- a/src/injected/analyzers/analyzer.ts
+++ b/src/injected/analyzers/analyzer.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { BaseActionPayload } from 'background/actions/action-payloads';
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { IAnalyzerTelemetryCallback } from '../../common/types/analyzer-telemetry-callbacks';
 import { SingleElementSelector } from '../../common/types/store-data/scoping-store-data';
 import { TelemetryProcessor } from '../../common/types/telemetry-processor';
@@ -26,7 +27,7 @@ export interface Analyzer {
 export interface ScanCompletedPayload<TSelectorValue> extends ScanBasePayload {
     selectorMap: DictionaryStringTo<TSelectorValue>;
     scanResult: ScanResults;
-    pageHasIframes: boolean;
+    scanIncompleteWarnings: ScanIncompleteWarningId[];
 }
 
 export interface ScanUpdatePayload extends ScanBasePayload {

--- a/src/injected/analyzers/base-analyzer.ts
+++ b/src/injected/analyzers/base-analyzer.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import * as Q from 'q';
 
-import { Message } from 'common/message';
-import { VisualizationType } from 'common/types/visualization-type';
-import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { Message } from '../../common/message';
+import { VisualizationType } from '../../common/types/visualization-type';
 import { Analyzer, AnalyzerConfiguration, AxeAnalyzerResult, ScanCompletedPayload } from './analyzer';
 
 export class BaseAnalyzer implements Analyzer {

--- a/src/injected/analyzers/base-analyzer.ts
+++ b/src/injected/analyzers/base-analyzer.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IframeDetector } from 'injected/iframe-detector';
 import * as Q from 'q';
 
-import { Message } from '../../common/message';
-import { VisualizationType } from '../../common/types/visualization-type';
+import { Message } from 'common/message';
+import { VisualizationType } from 'common/types/visualization-type';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { Analyzer, AnalyzerConfiguration, AxeAnalyzerResult, ScanCompletedPayload } from './analyzer';
 
 export class BaseAnalyzer implements Analyzer {
@@ -14,7 +14,11 @@ export class BaseAnalyzer implements Analyzer {
         originalResult: null,
     };
 
-    constructor(protected config: AnalyzerConfiguration, protected sendMessage: (message) => void, private iframeDetector: IframeDetector) {
+    constructor(
+        protected config: AnalyzerConfiguration,
+        protected sendMessage: (message) => void,
+        private scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
+    ) {
         this.visualizationType = config.testType;
     }
 
@@ -46,7 +50,7 @@ export class BaseAnalyzer implements Analyzer {
             selectorMap: analyzerResult.results,
             scanResult: originalAxeResult,
             testType: config.testType,
-            pageHasIframes: this.iframeDetector.hasIframes(),
+            scanIncompleteWarnings: this.scanIncompleteWarningDetector.detectScanIncompleteWarnings(),
         };
 
         return {

--- a/src/injected/analyzers/batched-rule-analyzer.ts
+++ b/src/injected/analyzers/batched-rule-analyzer.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IframeDetector } from 'injected/iframe-detector';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 
 import { BaseStore } from '../../common/base-store';
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
@@ -25,7 +25,7 @@ export class BatchedRuleAnalyzer extends RuleAnalyzer {
         protected telemetryFactory: TelemetryDataFactory,
         protected readonly visualizationConfigFactory: VisualizationConfigurationFactory,
         private postScanFilter: IResultRuleFilter,
-        iframeDetector: IframeDetector,
+        scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
     ) {
         super(
             config,
@@ -36,7 +36,7 @@ export class BatchedRuleAnalyzer extends RuleAnalyzer {
             telemetryFactory,
             visualizationConfigFactory,
             null,
-            iframeDetector,
+            scanIncompleteWarningDetector,
         );
         BatchedRuleAnalyzer.batchConfigs.push(config);
     }

--- a/src/injected/analyzers/rule-analyzer.ts
+++ b/src/injected/analyzers/rule-analyzer.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScopingInputTypes } from 'background/scoping-input-types';
-import { IframeDetector } from 'injected/iframe-detector';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import * as Q from 'q';
 
 import { BaseStore } from '../../common/base-store';
@@ -31,9 +31,9 @@ export class RuleAnalyzer extends BaseAnalyzer {
         protected telemetryFactory: TelemetryDataFactory,
         protected readonly visualizationConfigFactory: VisualizationConfigurationFactory,
         private postOnResolve: PostResolveCallback,
-        iframeDetector: IframeDetector,
+        scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
     ) {
-        super(config, sendMessageDelegate, iframeDetector);
+        super(config, sendMessageDelegate, scanIncompleteWarningDetector);
     }
 
     protected getResults = (): Q.Promise<AxeAnalyzerResult> => {

--- a/src/injected/analyzers/tab-stops-analyzer.ts
+++ b/src/injected/analyzers/tab-stops-analyzer.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IframeDetector } from 'injected/iframe-detector';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import * as Q from 'q';
 
 import { WindowUtils } from '../../common/window-utils';
@@ -26,9 +26,9 @@ export class TabStopsAnalyzer extends BaseAnalyzer {
         tabStopsListener: TabStopsListener,
         windowUtils: WindowUtils,
         sendMessageDelegate: (message) => void,
-        iframeDetector: IframeDetector,
+        scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
     ) {
-        super(config, sendMessageDelegate, iframeDetector);
+        super(config, sendMessageDelegate, scanIncompleteWarningDetector);
         this.tabStopsListener = tabStopsListener;
         this.windowUtils = windowUtils;
     }

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -69,6 +69,7 @@ import { SelectorMapHelper } from './selector-map-helper';
 import { ShadowUtils } from './shadow-utils';
 import { TargetPageActionMessageCreator } from './target-page-action-message-creator';
 import { WindowInitializer } from './window-initializer';
+import { ScanIncompleteWarningDetector, CrossOriginPermissionDetector } from 'injected/scan-incomplete-warning-detector';
 
 export class MainWindowInitializer extends WindowInitializer {
     protected frameCommunicator: FrameCommunicator;
@@ -222,6 +223,14 @@ export class MainWindowInitializer extends WindowInitializer {
             generateUID,
         );
 
+        // TODO: use something based on the permissions store instead once that's piped in
+        const crossOriginPermissionDetector: CrossOriginPermissionDetector = {
+            hasCrossOriginPermissions: () => true,
+        };
+
+        const iframeDetector = new IframeDetector(document);
+        const scanIncompleteWarningDetector = new ScanIncompleteWarningDetector(iframeDetector, crossOriginPermissionDetector);
+
         const analyzerProvider = new AnalyzerProvider(
             this.tabStopsListener,
             this.scopingStoreProxy,
@@ -232,7 +241,7 @@ export class MainWindowInitializer extends WindowInitializer {
             this.visualizationConfigurationFactory,
             filterResultsByRules,
             unifiedResultSender.sendResults,
-            new IframeDetector(document),
+            scanIncompleteWarningDetector,
         );
 
         const analyzerStateUpdateHandler = new AnalyzerStateUpdateHandler(this.visualizationConfigurationFactory);

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -14,6 +14,7 @@ import { FocusChangeHandler } from 'injected/focus-change-handler';
 import { getDecoratedAxeNode } from 'injected/get-decorated-axe-node';
 import { IframeDetector } from 'injected/iframe-detector';
 import { isVisualizationEnabled } from 'injected/is-visualization-enabled';
+import { CrossOriginPermissionDetector, ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { TargetPageVisualizationUpdater } from 'injected/target-page-visualization-updater';
 import { visualizationNeedsUpdate } from 'injected/visualization-needs-update';
 import { VisualizationStateChangeHandler } from 'injected/visualization-state-change-handler';
@@ -69,7 +70,6 @@ import { SelectorMapHelper } from './selector-map-helper';
 import { ShadowUtils } from './shadow-utils';
 import { TargetPageActionMessageCreator } from './target-page-action-message-creator';
 import { WindowInitializer } from './window-initializer';
-import { ScanIncompleteWarningDetector, CrossOriginPermissionDetector } from 'injected/scan-incomplete-warning-detector';
 
 export class MainWindowInitializer extends WindowInitializer {
     protected frameCommunicator: FrameCommunicator;

--- a/src/injected/scan-incomplete-warning-detector.ts
+++ b/src/injected/scan-incomplete-warning-detector.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import { IframeDetector } from './iframe-detector';
+
+export interface CrossOriginPermissionDetector {
+    hasCrossOriginPermissions(): boolean;
+}
+
+export class ScanIncompleteWarningDetector {
+    constructor(private iframeDetector: IframeDetector, private crossOriginPermissionDetector: CrossOriginPermissionDetector) {}
+
+    public detectScanIncompleteWarnings = () => {
+        const warnings: ScanIncompleteWarningId[] = [];
+        if (this.iframeDetector.hasIframes() && !this.crossOriginPermissionDetector.hasCrossOriginPermissions()) {
+            warnings.push('missing-required-cross-origin-permissions');
+        }
+        return warnings;
+    };
+}

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -594,7 +594,7 @@ describe('ActionCreatorTest', () => {
             scanResult: null,
             testType: VisualizationType.HeadingsAssessment,
             key: 'key',
-            pageHasIframes: true,
+            scanIncompleteWarnings: [],
         };
 
         const validator = new ActionCreatorValidator()

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -453,7 +453,7 @@ describe('AssessmentStoreTest', () => {
             scanResult: {} as ScanResults,
             testType: assessmentType,
             key: requirementKey,
-            pageHasIframes: true,
+            scanIncompleteWarnings: [],
         };
 
         const expectedInstanceMap = {};
@@ -467,6 +467,7 @@ describe('AssessmentStoreTest', () => {
                 ['assessment-1-step-2']: getDefaultTestStepData(),
                 ['assessment-1-step-3']: getDefaultTestStepData(),
             })
+            .with('scanIncompleteWarnings', [])
             .build();
 
         const finalState = getStateWithAssessment(assessmentData);

--- a/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { UnifiedScanCompletedPayload } from '../../../../../background/actions/action-payloads';
 import { UnifiedScanResultActions } from '../../../../../background/actions/unified-scan-result-actions';
 import { UnifiedScanResultStore } from '../../../../../background/stores/unified-scan-result-store';
@@ -26,6 +27,7 @@ describe('UnifiedScanResultStore Test', () => {
         expect(defaultState.results).toBeNull();
         expect(defaultState.rules).toBeNull();
         expect(defaultState.toolInfo).toBeNull();
+        expect(defaultState.scanIncompleteWarnings).toBeNull();
         expect(defaultState.screenshotData).toBeNull();
         expect(defaultState.platformInfo).toBeNull();
     });
@@ -56,6 +58,7 @@ describe('UnifiedScanResultStore Test', () => {
                     name: 'test-scan-engine-name',
                 },
             },
+            scanIncompleteWarnings: ['some-incomplete-warning-id' as ScanIncompleteWarningId],
             screenshotData: {
                 base64PngData: 'testScreenshotText',
             },
@@ -70,6 +73,7 @@ describe('UnifiedScanResultStore Test', () => {
             results: payload.scanResult,
             toolInfo: payload.toolInfo,
             targetAppInfo,
+            scanIncompleteWarnings: payload.scanIncompleteWarnings,
             screenshotData: payload.screenshotData,
             platformInfo: payload.platformInfo,
         };

--- a/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/analyzer-provider.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScopingStore } from 'background/stores/global/scoping-store';
-import { IframeDetector } from 'injected/iframe-detector';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { IMock, Mock } from 'typemoq';
 
 import { VisualizationConfigurationFactory } from '../../../../../common/configs/visualization-configuration-factory';
@@ -30,7 +30,7 @@ describe('AnalyzerProviderTests', () => {
     let analyzerMessageTypeStub: string;
     let filterResultsByRulesMock: IMock<IResultRuleFilter>;
     let sendConvertedResultsMock: IMock<PostResolveCallback>;
-    let iframeDetectorMock: IMock<IframeDetector>;
+    let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
 
     beforeEach(() => {
         typeStub = -1;
@@ -46,7 +46,7 @@ describe('AnalyzerProviderTests', () => {
         visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
         filterResultsByRulesMock = Mock.ofInstance(() => null);
         sendConvertedResultsMock = Mock.ofInstance(() => null);
-        iframeDetectorMock = Mock.ofType<IframeDetector>();
+        scanIncompleteWarningDetectorMock = Mock.ofType<ScanIncompleteWarningDetector>();
 
         testObject = new AnalyzerProvider(
             tabStopsListener.object,
@@ -58,7 +58,7 @@ describe('AnalyzerProviderTests', () => {
             visualizationConfigurationFactoryMock.object,
             filterResultsByRulesMock.object,
             sendConvertedResultsMock.object,
-            iframeDetectorMock.object,
+            scanIncompleteWarningDetectorMock.object,
         );
     });
 

--- a/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
@@ -1,34 +1,36 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IframeDetector } from 'injected/iframe-detector';
 import { IMock, It, Mock, Times } from 'typemoq';
 
-import { Message } from '../../../../../common/message';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { AnalyzerConfiguration } from '../../../../../injected/analyzers/analyzer';
-import { BaseAnalyzer } from '../../../../../injected/analyzers/base-analyzer';
+import { Message } from 'common/message';
+import { VisualizationType } from 'common/types/visualization-type';
+import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
+import { BaseAnalyzer } from 'injected/analyzers/base-analyzer';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 
 describe('BaseAnalyzerTest', () => {
     let testSubject: BaseAnalyzer;
     let configStub: AnalyzerConfiguration;
     let sendMessageMock: IMock<(message) => void>;
     let typeStub: VisualizationType;
-    let iframeDetectorMock: IMock<IframeDetector>;
+    let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
 
     beforeEach(() => {
         sendMessageMock = Mock.ofInstance(message => {});
-        iframeDetectorMock = Mock.ofType<IframeDetector>();
+        scanIncompleteWarningDetectorMock = Mock.ofType<ScanIncompleteWarningDetector>();
         typeStub = -1 as VisualizationType;
         configStub = {
             analyzerMessageType: 'sample message type',
             key: 'sample key',
             testType: typeStub,
         };
-        testSubject = new BaseAnalyzer(configStub, sendMessageMock.object, iframeDetectorMock.object);
+        testSubject = new BaseAnalyzer(configStub, sendMessageMock.object, scanIncompleteWarningDetectorMock.object);
     });
 
     test('analyze', async done => {
         const resultsStub = {};
+        const scanIncompleteWarnings: ScanIncompleteWarningId[] = ['missing-required-cross-origin-permissions'];
         const expectedMessage: Message = {
             messageType: configStub.analyzerMessageType,
             payload: {
@@ -36,11 +38,11 @@ describe('BaseAnalyzerTest', () => {
                 selectorMap: resultsStub,
                 scanResult: null,
                 testType: typeStub,
-                pageHasIframes: true,
+                scanIncompleteWarnings,
             },
         };
 
-        iframeDetectorMock.setup(idm => idm.hasIframes()).returns(() => true);
+        scanIncompleteWarningDetectorMock.setup(idm => idm.detectScanIncompleteWarnings()).returns(() => scanIncompleteWarnings);
 
         sendMessageMock
             .setup(smm => smm(It.isValue(expectedMessage)))

--- a/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
@@ -3,11 +3,11 @@
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { Message } from 'common/message';
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { VisualizationType } from 'common/types/visualization-type';
 import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { BaseAnalyzer } from 'injected/analyzers/base-analyzer';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
-import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 
 describe('BaseAnalyzerTest', () => {
     let testSubject: BaseAnalyzer;

--- a/src/tests/unit/tests/injected/analyzers/batched-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/batched-analyzer.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { ScopingInputTypes } from 'background/scoping-input-types';
 import { ScopingStore } from 'background/stores/global/scoping-store';
-import { IframeDetector } from 'injected/iframe-detector';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { clone, isFunction } from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
@@ -36,7 +36,7 @@ describe('BatchedRuleAnalyzer', () => {
     const title = 'test-name';
     const scanCallbacks: ((results: ScanResults) => void)[] = [];
     let resultConfigFilterMock: IMock<IResultRuleFilter>;
-    let iframeDetectorMock: IMock<IframeDetector>;
+    let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
 
     beforeEach(() => {
         typeStub = -1 as VisualizationType;
@@ -51,7 +51,7 @@ describe('BatchedRuleAnalyzer', () => {
                 return null;
             },
         };
-        iframeDetectorMock = Mock.ofType<IframeDetector>();
+        scanIncompleteWarningDetectorMock = Mock.ofType<ScanIncompleteWarningDetector>();
         dateMock = Mock.ofInstance(dateStub as Date);
         dateGetterMock = Mock.ofInstance(() => null);
         dateGetterMock.setup(dgm => dgm()).returns(() => dateMock.object);
@@ -73,7 +73,7 @@ describe('BatchedRuleAnalyzer', () => {
                 } as VisualizationConfiguration;
             })
             .verifiable();
-        iframeDetectorMock.setup(idm => idm.hasIframes()).returns(() => true);
+        scanIncompleteWarningDetectorMock.setup(idm => idm.detectScanIncompleteWarnings()).returns(() => []);
     });
 
     test('analyze', async done => {
@@ -219,7 +219,7 @@ describe('BatchedRuleAnalyzer', () => {
                 scanResult: results,
                 testType: config.testType,
                 telemetry: expectedTelemetryStub,
-                pageHasIframes: true,
+                scanIncompleteWarnings: [],
             },
         };
     }
@@ -246,7 +246,7 @@ describe('BatchedRuleAnalyzer', () => {
             telemetryDataFactoryMock.object,
             visualizationConfigurationFactoryMock.object,
             resultConfigFilterMock.object,
-            iframeDetectorMock.object,
+            scanIncompleteWarningDetectorMock.object,
         );
     }
 });

--- a/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { ScopingInputTypes } from 'background/scoping-input-types';
 import { ScopingStore } from 'background/stores/global/scoping-store';
-import { IframeDetector } from 'injected/iframe-detector';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { isFunction } from 'lodash';
 import { IMock, It, Mock, Times } from 'typemoq';
 
@@ -38,7 +38,7 @@ describe('RuleAnalyzer', () => {
     let configStub: RuleAnalyzerConfiguration;
     let scanCallback: (results: ScanResults) => void;
     let postResolveCallbackMock: IMock<PostResolveCallback>;
-    let iframeDetectorMock: IMock<IframeDetector>;
+    let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
 
     beforeEach(() => {
         typeStub = -1 as VisualizationType;
@@ -57,7 +57,7 @@ describe('RuleAnalyzer', () => {
         };
         dateMock = Mock.ofInstance(dateStub as Date);
         dateGetterMock = Mock.ofInstance(() => null);
-        iframeDetectorMock = Mock.ofType<IframeDetector>();
+        scanIncompleteWarningDetectorMock = Mock.ofType<ScanIncompleteWarningDetector>();
         dateGetterMock.setup(dgm => dgm()).returns(() => dateMock.object);
         scopingState = {
             selectors: {
@@ -77,7 +77,7 @@ describe('RuleAnalyzer', () => {
                 } as VisualizationConfiguration;
             })
             .verifiable();
-        iframeDetectorMock.setup(idm => idm.hasIframes()).returns(() => true);
+        scanIncompleteWarningDetectorMock.setup(idm => idm.detectScanIncompleteWarnings()).returns(() => []);
     });
 
     test('analyze', async done => {
@@ -124,7 +124,7 @@ describe('RuleAnalyzer', () => {
             telemetryDataFactoryMock.object,
             visualizationConfigurationFactoryMock.object,
             postResolveCallbackMock.object,
-            iframeDetectorMock.object,
+            scanIncompleteWarningDetectorMock.object,
         );
 
         const scanResults = createTestResults();
@@ -137,6 +137,7 @@ describe('RuleAnalyzer', () => {
                 scanResult: scanResults,
                 testType: typeStub,
                 telemetry: expectedTelemetryStub,
+                scanIncompleteWarnings: [],
             },
         };
 

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IframeDetector } from 'injected/iframe-detector';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { Message } from '../../../../../common/message';
@@ -20,11 +20,11 @@ describe('TabStopsAnalyzerTests', () => {
     let tabStopsListenerMock: IMock<TabStopsListener>;
     let tabEventHandler: (tabEvent: TabStopEvent) => void;
     let setTimeOutCallBack: () => void;
-    let iframeDetectorMock: IMock<IframeDetector>;
+    let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
 
     beforeEach(() => {
         windowUtilsMock = Mock.ofType(WindowUtils);
-        iframeDetectorMock = Mock.ofType<IframeDetector>();
+        scanIncompleteWarningDetectorMock = Mock.ofType<ScanIncompleteWarningDetector>();
         sendMessageMock = Mock.ofInstance(message => {}, MockBehavior.Strict);
         configStub = {
             analyzerProgressMessageType: 'sample progress message type',
@@ -37,14 +37,14 @@ describe('TabStopsAnalyzerTests', () => {
         setTimeOutCallBack = null;
         tabStopsListenerMock = Mock.ofType(TabStopsListener);
 
-        iframeDetectorMock.setup(idm => idm.hasIframes()).returns(() => true);
+        scanIncompleteWarningDetectorMock.setup(idm => idm.detectScanIncompleteWarnings()).returns(() => []);
 
         testSubject = new TabStopsAnalyzer(
             configStub,
             tabStopsListenerMock.object,
             windowUtilsMock.object,
             sendMessageMock.object,
-            iframeDetectorMock.object,
+            scanIncompleteWarningDetectorMock.object,
         );
         typeStub = -1 as VisualizationType;
     });
@@ -63,7 +63,7 @@ describe('TabStopsAnalyzerTests', () => {
                 selectorMap: resultsStub,
                 scanResult: null,
                 testType: typeStub,
-                pageHasIframes: true,
+                scanIncompleteWarnings: [],
             },
         };
         const expectedOnProgressMessage: Message = {
@@ -111,7 +111,7 @@ describe('TabStopsAnalyzerTests', () => {
                 selectorMap: resultsStub,
                 scanResult: null,
                 testType: typeStub,
-                pageHasIframes: true,
+                scanIncompleteWarnings: [],
             },
         };
         const expectedOnProgressMessage: Message = {

--- a/src/tests/unit/tests/injected/scan-incomplete-warning-detector.test.ts
+++ b/src/tests/unit/tests/injected/scan-incomplete-warning-detector.test.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { IframeDetector } from 'injected/iframe-detector';
+import { CrossOriginPermissionDetector, ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { IMock, Mock } from 'typemoq';
+
+describe('ScanIncompleteWarningDetector', () => {
+    let testSubject: ScanIncompleteWarningDetector;
+    let iframeDetectorMock: IMock<IframeDetector>;
+    let crossOriginPermissionDetectorMock: IMock<CrossOriginPermissionDetector>;
+
+    beforeEach(() => {
+        crossOriginPermissionDetectorMock = Mock.ofType<CrossOriginPermissionDetector>();
+        iframeDetectorMock = Mock.ofType<IframeDetector>();
+        testSubject = new ScanIncompleteWarningDetector(iframeDetectorMock.object, crossOriginPermissionDetectorMock.object);
+    });
+
+    it.each`
+        iframesDetected | crossOriginPermissions | expectedResults
+        ${true}         | ${true}                | ${[]}
+        ${true}         | ${false}               | ${['missing-required-cross-origin-permissions']}
+        ${false}        | ${true}                | ${[]}
+        ${false}        | ${false}               | ${[]}
+    `(
+        'should detect $expectedResults if iframesDetected=$iframesDetected and crossOriginPermissions=$crossOriginPermissions',
+        ({ iframesDetected, crossOriginPermissions, expectedResults }) => {
+            iframeDetectorMock.setup(m => m.hasIframes()).returns(() => iframesDetected);
+            crossOriginPermissionDetectorMock.setup(m => m.hasCrossOriginPermissions()).returns(() => crossOriginPermissions);
+
+            expect(testSubject.detectScanIncompleteWarnings()).toStrictEqual(expectedResults);
+        },
+    );
+});


### PR DESCRIPTION
#### Description of changes

This PR:

* Adds `scanIncompleteWarnings` data to the assessment and unified result stores
* Adds a new `ScanIncompleteWarningDetector` to handle populating the new data
* Updates the previously-done analyzer piping to pipe around the new `ScanIncompleteWarningDetector` instead of an `IframeDetector`
* Initializes the new detector in `main-window-initializer`

Out of scope (separate PRs):
* Wiring up the data from the permissions store @lisli1 sent out for PR recently to the new detector
* Consuming the new data in the new UI component @waabid has out for draft PR

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1655462
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [0/a] (UI changes only) Verified usability with NVDA/JAWS
