### PR TITLE
feat(permissions): pipe scan incomplete warnings to unified result scan payloads

### DIFF
--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -162,7 +162,7 @@ export interface UnifiedScanCompletedPayload extends BaseActionPayload {
     rules: UnifiedRule[];
     toolInfo: ToolData;
     targetAppInfo: TargetAppData;
-    scanIncompleteWarnings?: ScanIncompleteWarningId[];
+    scanIncompleteWarnings: ScanIncompleteWarningId[];
     screenshotData?: ScreenshotData;
     platformInfo?: PlatformData;
 }

--- a/src/electron/platform/android/unified-result-builder.ts
+++ b/src/electron/platform/android/unified-result-builder.ts
@@ -39,6 +39,7 @@ export const createBuilder = (
         targetAppInfo: {
             name: scanResults.appIdentifier,
         },
+        scanIncompleteWarnings: [],
         screenshotData: scanResults.screenshot,
     };
     return payload;

--- a/src/injected/analyzers/unified-result-sender.ts
+++ b/src/injected/analyzers/unified-result-sender.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { UnifiedScanCompletedPayload } from '../../background/actions/action-payloads';
 import { EnvironmentInfoProvider } from '../../common/environment-info-provider';
 import { Messages } from '../../common/messages';
@@ -16,6 +17,7 @@ export class UnifiedResultSender {
         private readonly convertScanResultsToUnifiedRules: ConvertScanResultsToUnifiedRulesDelegate,
         private readonly environmentInfoProvider: EnvironmentInfoProvider,
         private readonly generateUID: UUIDGenerator,
+        private readonly scanIncompleteWarningDetector: ScanIncompleteWarningDetector,
     ) {}
 
     public sendResults: PostResolveCallback = (axeResults: AxeAnalyzerResult) => {
@@ -27,6 +29,7 @@ export class UnifiedResultSender {
                 name: axeResults.originalResult.targetPageTitle,
                 url: axeResults.originalResult.targetPageUrl,
             },
+            scanIncompleteWarnings: this.scanIncompleteWarningDetector.detectScanIncompleteWarnings(),
         };
 
         this.sendMessage({

--- a/src/injected/main-window-initializer.ts
+++ b/src/injected/main-window-initializer.ts
@@ -215,14 +215,6 @@ export class MainWindowInitializer extends WindowInitializer {
 
         this.frameUrlSearchInitiator.listenToStore();
 
-        const unifiedResultSender = new UnifiedResultSender(
-            this.browserAdapter.sendMessageToFrames,
-            convertScanResultsToUnifiedResults,
-            convertScanResultsToUnifiedRules,
-            environmentInfoProvider,
-            generateUID,
-        );
-
         // TODO: use something based on the permissions store instead once that's piped in
         const crossOriginPermissionDetector: CrossOriginPermissionDetector = {
             hasCrossOriginPermissions: () => true,
@@ -230,6 +222,15 @@ export class MainWindowInitializer extends WindowInitializer {
 
         const iframeDetector = new IframeDetector(document);
         const scanIncompleteWarningDetector = new ScanIncompleteWarningDetector(iframeDetector, crossOriginPermissionDetector);
+
+        const unifiedResultSender = new UnifiedResultSender(
+            this.browserAdapter.sendMessageToFrames,
+            convertScanResultsToUnifiedResults,
+            convertScanResultsToUnifiedRules,
+            environmentInfoProvider,
+            generateUID,
+            scanIncompleteWarningDetector,
+        );
 
         const analyzerProvider = new AnalyzerProvider(
             this.tabStopsListener,

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -17,6 +17,7 @@ describe('UnifiedScanResultActionCreator', () => {
             rules: [],
             toolInfo: {} as ToolData,
             targetAppInfo: { name: 'app name' },
+            scanIncompleteWarnings: [],
         };
 
         const scanCompletedMock = createActionMock(payload);

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/unified-result-builder.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/unified-result-builder.test.ts.snap
@@ -22,6 +22,7 @@ Object {
       "url": "test-url",
     },
   ],
+  "scanIncompleteWarnings": Array [],
   "scanResult": Array [
     Object {
       "descriptors": null,

--- a/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
@@ -17,6 +17,7 @@ import { isFunction } from 'lodash';
 import { tick } from 'tests/unit/common/tick';
 import { axeRuleResultExample } from 'tests/unit/tests/electron/flux/action-creator/scan-result-example';
 import { ExpectedCallType, IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 
 describe('ScanController', () => {
     const port = 1111;
@@ -128,6 +129,7 @@ describe('ScanController', () => {
                     version: 'test-scan-engine-version',
                 },
             },
+            scanIncompleteWarnings: ['test-scan-incomplete-warning' as ScanIncompleteWarningId],
         };
 
         unifiedResultsBuilderMock.setup(builder => builder(scanResults)).returns(() => unifiedPayload);

--- a/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
@@ -6,6 +6,7 @@ import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-hand
 import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
 import { Logger } from 'common/logging/logger';
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
 import { PortPayload } from 'electron/flux/action/device-action-payloads';
 import { ScanActions } from 'electron/flux/action/scan-actions';
@@ -17,7 +18,6 @@ import { isFunction } from 'lodash';
 import { tick } from 'tests/unit/common/tick';
 import { axeRuleResultExample } from 'tests/unit/tests/electron/flux/action-creator/scan-result-example';
 import { ExpectedCallType, IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 
 describe('ScanController', () => {
     const port = 1111;

--- a/src/tests/unit/tests/injected/analyzers/unified-result-sender.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/unified-result-sender.test.ts
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { IMock, Mock, Times } from 'typemoq';
 import { UnifiedScanCompletedPayload } from '../../../../../background/actions/action-payloads';
 import { EnvironmentInfoProvider } from '../../../../../common/environment-info-provider';
@@ -37,12 +39,17 @@ describe('sendConvertedResults', () => {
         convertToUnifiedRulesMock.setup(m => m(axeInputResults)).returns(val => unifiedRules);
         environmentInfoProviderMock.setup(provider => provider.getToolData()).returns(() => toolInfo);
 
+        const stubScanIncompleteWarnings = ['test-scan-incomplete-warning' as ScanIncompleteWarningId];
+        const scanIncompleteWarningDetectorMock = Mock.ofType<ScanIncompleteWarningDetector>();
+        scanIncompleteWarningDetectorMock.setup(m => m.detectScanIncompleteWarnings()).returns(() => stubScanIncompleteWarnings);
+
         const testSubject = new UnifiedResultSender(
             sendDelegate.object,
             convertToUnifiedMock.object,
             convertToUnifiedRulesMock.object,
             environmentInfoProviderMock.object,
             uuidGeneratorStub,
+            scanIncompleteWarningDetectorMock.object,
         );
 
         testSubject.sendResults({
@@ -62,6 +69,7 @@ describe('sendConvertedResults', () => {
                 name: 'title',
                 url: 'url',
             },
+            scanIncompleteWarnings: stubScanIncompleteWarnings,
         };
         const expectedMessage: Message = {
             messageType: Messages.UnifiedScan.ScanCompleted,


### PR DESCRIPTION
#### Description of changes

This PR wires up data into `UnifiedScanCompletePayload`s for the new `scanIncompleteWarnings` property. In android, we unconditionally pass an empty list, and in web, we delegate to the same previously-added `ScanIncompleteWarningDetector` previously added to populate assessment data. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1655462
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
