### PR TITLE
chore: restore setup to windows package name

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,7 +19,7 @@ mac:
     identity: null
 
 win:
-    artifactName: ${productName}.${ext}
+    artifactName: ${productName} setup.${ext}
     icon: extension/icons/brand/blue/brand-blue-512px.png
     publisherName: 'Microsoft Corporation'
     target: nsis


### PR DESCRIPTION
PR #1859 removed "setup" from the windows electron package name in addition to the version number. Based on (this issue)[https://github.com/electron-userland/electron-builder/issues/4312#issuecomment-559171985], that was a mistake--updates stopped installing on Windows. This restores setup to the package name on Windows.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
