### PR TITLE
test: fix electron e2e race condition around resizing/unmaximizing

### DIFF
--- a/src/common/promises/promise-factory.ts
+++ b/src/common/promises/promise-factory.ts
@@ -2,24 +2,57 @@
 // Licensed under the MIT License.
 
 type TimeoutPromise = <T>(promise: Promise<T>, delayInMilliseconds: number) => Promise<T>;
+type PollOptions = {
+    pollIntervalInMilliseconds?: number;
+    timeoutInMilliseconds?: number;
+};
+type PollPromise = (predicate: () => Promise<boolean>, options?: PollOptions) => Promise<void>;
 
 export type PromiseFactory = {
     timeout: TimeoutPromise;
+    poll: PollPromise;
 };
 
 const createTimeout: TimeoutPromise = <T>(promise: Promise<T>, delayInMilliseconds: number) => {
     const timeout = new Promise<T>((resolve, reject) => {
         const timeoutId = setTimeout(() => {
             clearTimeout(timeoutId);
-            reject(`Timed out ${delayInMilliseconds} ms`);
+            reject(new Error(`Timed out after ${delayInMilliseconds} ms`));
         }, delayInMilliseconds);
     });
 
     return Promise.race([promise, timeout]);
 };
 
+const createPollPromise: PollPromise = async (predicate: () => Promise<boolean>, options?: PollOptions) => {
+    options = {
+        pollIntervalInMilliseconds: 50,
+        timeoutInMilliseconds: 5000,
+        ...options,
+    };
+
+    let timedOut = false;
+    const timeoutHandle = setTimeout(() => (timedOut = true), options.timeoutInMilliseconds);
+    do {
+        if (await predicate()) {
+            clearTimeout(timeoutHandle);
+            return;
+        }
+
+        if (timedOut) {
+            break;
+        }
+
+        // false positive
+        // tslint:disable-next-line: no-string-based-set-timeout
+        await new Promise(resolve => setTimeout(resolve, options.pollIntervalInMilliseconds));
+    } while (!timedOut);
+    throw new Error(`Timed out after polling for ${options.timeoutInMilliseconds} ms`);
+};
+
 export const createDefaultPromiseFactory = (): PromiseFactory => {
     return {
         timeout: createTimeout,
+        poll: createPollPromise,
     };
 };

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -28,7 +28,7 @@ export class AppController {
     }
 
     public async openDeviceConnectionDialog(): Promise<DeviceConnectionDialogController> {
-        await this.setToMinimumSupportedWindowSize();
+        this.resizeWindow();
 
         await dismissTelemetryOptInDialog(this.app);
 
@@ -45,14 +45,21 @@ export class AppController {
         const automatedChecksView = new AutomatedChecksViewController(this.client);
         await automatedChecksView.waitForViewVisible();
 
-        await this.setToMinimumSupportedWindowSize();
+        this.resizeWindow();
 
         return automatedChecksView;
     }
 
-    private async setToMinimumSupportedWindowSize(): Promise<void> {
+    private resizeWindow(): void {
+        let resizeId;
+        this.app.browserWindow.addListener('resize', () => {
+            clearTimeout(resizeId);
+            resizeId = setTimeout(this.setToMinimumSupportedWindowSize, 500);
+        });
+    }
+
+    private setToMinimumSupportedWindowSize(): void {
         this.app.browserWindow.setBounds({ width: mainWindowConfig.minWidth, height: mainWindowConfig.minHeight });
         this.app.browserWindow.unmaximize();
-        await this.app.client.waitUntilWindowLoaded();
     }
 }

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -28,7 +28,7 @@ export class AppController {
     }
 
     public async openDeviceConnectionDialog(): Promise<DeviceConnectionDialogController> {
-        this.setToMinimumSupportedWindowSize();
+        await this.setToMinimumSupportedWindowSize();
 
         await dismissTelemetryOptInDialog(this.app);
 
@@ -45,13 +45,14 @@ export class AppController {
         const automatedChecksView = new AutomatedChecksViewController(this.client);
         await automatedChecksView.waitForViewVisible();
 
-        this.setToMinimumSupportedWindowSize();
+        await this.setToMinimumSupportedWindowSize();
 
         return automatedChecksView;
     }
 
-    private setToMinimumSupportedWindowSize(): void {
+    private async setToMinimumSupportedWindowSize(): Promise<void> {
         this.app.browserWindow.setBounds({ width: mainWindowConfig.minWidth, height: mainWindowConfig.minHeight });
         this.app.browserWindow.unmaximize();
+        await this.app.client.waitUntilWindowLoaded();
     }
 }

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -1,15 +1,40 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { createDefaultPromiseFactory } from 'common/promises/promise-factory';
 import { mainWindowConfig } from 'electron/main/main-window-config';
 import { Application } from 'spectron';
 import { DeviceConnectionDialogController } from 'tests/electron/common/view-controllers/device-connection-dialog-controller';
 import { testResourceServerConfig } from 'tests/electron/setup/test-resource-server-config';
+import { DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS } from 'tests/end-to-end/common/timeouts';
 import * as WebDriverIO from 'webdriverio';
 import { dismissTelemetryOptInDialog } from '../dismiss-telemetry-opt-in-dialog';
 import { AutomatedChecksViewController } from './automated-checks-view-controller';
 
+// These are workarounds for https://github.com/electron-userland/spectron/issues/343
+//
+// Note that this is *not an exhaustive list* of the actually-promise APIs from spectron; this is
+// only the set of APIs we happen to be using as of writing.
+declare module 'spectron' {
+    export interface SpectronWebContents {
+        getTitle(): Promise<string>;
+    }
+    export interface SpectronWindow {
+        getBounds(): Promise<Electron.Rectangle>;
+        isMaximized(): Promise<boolean>;
+
+        // Note: Promise only defers for webdriver to accept the command, does *not* wait for
+        // command to actually have taken effect
+        unmaximize(): Promise<void>;
+
+        // Note: Promise only defers for webdriver to accept the command, does *not* wait for
+        // command to actually have taken effect
+        setBounds(bounds: Partial<Electron.Rectangle>): Promise<void>;
+    }
+}
+
 export class AppController {
     public client: WebDriverIO.Client<void>;
+    private promiseFactory = createDefaultPromiseFactory();
 
     constructor(public app: Application) {
         this.client = app.client;
@@ -22,8 +47,6 @@ export class AppController {
     }
 
     public async getTitle(): Promise<string> {
-        // Typings are inaccurate; see https://github.com/electron-userland/spectron/issues/343
-        // tslint:disable-next-line: await-promise
         return await this.app.webContents.getTitle();
     }
 
@@ -57,13 +80,18 @@ export class AppController {
         await this.setBounds(minimumSupportedBounds);
     }
 
-    private setBounds(bounds: { width: number; height: number }): Promise<void> {
-        // Typings are inaccurate; see https://github.com/electron-userland/spectron/issues/343
-        return this.app.browserWindow.setBounds(bounds) as any;
+    private async setBounds(bounds: { width: number; height: number }): Promise<void> {
+        await this.app.browserWindow.setBounds(bounds);
+
+        const boundsAreSetTo = candidateBounds => bounds.width === candidateBounds.width && bounds.height === candidateBounds.height;
+        const boundsAreSet = async () => boundsAreSetTo(await this.app.browserWindow.getBounds());
+        await this.promiseFactory.poll(boundsAreSet, { timeoutInMilliseconds: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS });
     }
 
-    private unmaximize(): Promise<void> {
-        // Typings are inaccurate; see https://github.com/electron-userland/spectron/issues/343
-        return this.app.browserWindow.unmaximize() as any;
+    private async unmaximize(): Promise<void> {
+        await this.app.browserWindow.unmaximize();
+
+        const isUnmaximized = async () => !(await this.app.browserWindow.isMaximized());
+        await this.promiseFactory.poll(isUnmaximized, { timeoutInMilliseconds: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS });
     }
 }

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -10,6 +10,8 @@ import * as WebDriverIO from 'webdriverio';
 import { dismissTelemetryOptInDialog } from '../dismiss-telemetry-opt-in-dialog';
 import { AutomatedChecksViewController } from './automated-checks-view-controller';
 
+const promiseFactory = createDefaultPromiseFactory();
+
 // These are workarounds for https://github.com/electron-userland/spectron/issues/343
 //
 // Note that this is *not an exhaustive list* of the actually-promise APIs from spectron; this is
@@ -34,7 +36,6 @@ declare module 'spectron' {
 
 export class AppController {
     public client: WebDriverIO.Client<void>;
-    private promiseFactory = createDefaultPromiseFactory();
 
     constructor(public app: Application) {
         this.client = app.client;
@@ -85,13 +86,19 @@ export class AppController {
 
         const boundsAreSetTo = candidateBounds => bounds.width === candidateBounds.width && bounds.height === candidateBounds.height;
         const boundsAreSet = async () => boundsAreSetTo(await this.app.browserWindow.getBounds());
-        await this.promiseFactory.poll(boundsAreSet, { timeoutInMilliseconds: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS });
+        await promiseFactory.poll(boundsAreSet, { timeoutInMilliseconds: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS });
+
+        // The browser takes a little time to settle and re-render the DOM
+        await promiseFactory.waitForDuration(200);
     }
 
     private async unmaximize(): Promise<void> {
         await this.app.browserWindow.unmaximize();
 
         const isUnmaximized = async () => !(await this.app.browserWindow.isMaximized());
-        await this.promiseFactory.poll(isUnmaximized, { timeoutInMilliseconds: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS });
+        await promiseFactory.poll(isUnmaximized, { timeoutInMilliseconds: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS });
+
+        // The browser takes a little time to settle and re-render the DOM
+        await promiseFactory.waitForDuration(200);
     }
 }

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -22,13 +22,13 @@ export class AppController {
     }
 
     public async getTitle(): Promise<string> {
-        // getTitle() is normally synchronous in Electron, but Spectron overrides this and makes it async, confusing Typescript
+        // Typings are inaccurate; see https://github.com/electron-userland/spectron/issues/343
         // tslint:disable-next-line: await-promise
         return await this.app.webContents.getTitle();
     }
 
     public async openDeviceConnectionDialog(): Promise<DeviceConnectionDialogController> {
-        this.resizeWindow();
+        await this.setToMinimumSupportedWindowSize();
 
         await dismissTelemetryOptInDialog(this.app);
 
@@ -45,21 +45,25 @@ export class AppController {
         const automatedChecksView = new AutomatedChecksViewController(this.client);
         await automatedChecksView.waitForViewVisible();
 
-        this.resizeWindow();
+        await this.setToMinimumSupportedWindowSize();
 
         return automatedChecksView;
     }
 
-    private resizeWindow(): void {
-        let resizeId;
-        this.app.browserWindow.addListener('resize', () => {
-            clearTimeout(resizeId);
-            resizeId = setTimeout(this.setToMinimumSupportedWindowSize, 500);
-        });
+    private async setToMinimumSupportedWindowSize(): Promise<void> {
+        await this.unmaximize();
+
+        const minimumSupportedBounds = { width: mainWindowConfig.minWidth, height: mainWindowConfig.minHeight };
+        await this.setBounds(minimumSupportedBounds);
     }
 
-    private setToMinimumSupportedWindowSize(): void {
-        this.app.browserWindow.setBounds({ width: mainWindowConfig.minWidth, height: mainWindowConfig.minHeight });
-        this.app.browserWindow.unmaximize();
+    private setBounds(bounds: { width: number; height: number }): Promise<void> {
+        // Typings are inaccurate; see https://github.com/electron-userland/spectron/issues/343
+        return this.app.browserWindow.setBounds(bounds) as any;
+    }
+
+    private unmaximize(): Promise<void> {
+        // Typings are inaccurate; see https://github.com/electron-userland/spectron/issues/343
+        return this.app.browserWindow.unmaximize() as any;
     }
 }

--- a/src/tests/electron/tests/device-connection-dialog.test.ts
+++ b/src/tests/electron/tests/device-connection-dialog.test.ts
@@ -22,7 +22,7 @@ describe('device connection dialog', () => {
         }
     });
 
-    it('should use the expected window title', async () => {
+    it.only('should use the expected window title', async () => {
         expect(await app.getTitle()).toBe('Accessibility Insights for Android');
     });
 

--- a/src/tests/electron/tests/device-connection-dialog.test.ts
+++ b/src/tests/electron/tests/device-connection-dialog.test.ts
@@ -22,7 +22,7 @@ describe('device connection dialog', () => {
         }
     });
 
-    it.only('should use the expected window title', async () => {
+    it('should use the expected window title', async () => {
         expect(await app.getTitle()).toBe('Accessibility Insights for Android');
     });
 

--- a/src/tests/unit/tests/common/promises/__snapshots__/promise-factory.test.ts.snap
+++ b/src/tests/unit/tests/common/promises/__snapshots__/promise-factory.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PromiseFactory poll times out if the predicate does not become true 1`] = `[Error: Timed out after polling for 10 ms]`;
+
+exports[`PromiseFactory timeout times out 1`] = `[Error: Timed out after 1 ms]`;


### PR DESCRIPTION
#### Description of changes

Fixes a source of flakiness in electron E2Es where the tests weren't properly waiting for the window-resize operations they invoked to complete.

This was introduced due to inaccurate Spectron typings; the Spectron typings implied that the resize/unmaximize operations were synchronous, but in fact they are promise-based. See https://github.com/electron-userland/spectron/issues/343

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: fixes #1846
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
