### PR TITLE
fix: Issue Filing label not being read in the Settings Pane

### DIFF
--- a/src/DetailsView/components/settings-panel/settings/issue-filing/issue-filing-settings.tsx
+++ b/src/DetailsView/components/settings-panel/settings/issue-filing/issue-filing-settings.tsx
@@ -16,7 +16,7 @@ export const IssueFilingSettings = NamedFC<SettingsProps>('IssueFilingSettings',
 
     return (
         <>
-            <h3>Issue filing</h3>
+            <h3 id="issue-filing">Issue filing</h3>
             <IssueFilingSettingsContainer
                 deps={deps}
                 selectedIssueFilingService={selectedIssueFilingService}

--- a/src/issue-filing/components/issue-filing-settings-container.tsx
+++ b/src/issue-filing/components/issue-filing-settings-container.tsx
@@ -31,13 +31,13 @@ export const IssueFilingSettingsContainer = NamedFC<IssueFilingSettingsContainer
     const issueFilingServices = deps.issueFilingServiceProvider.allVisible();
 
     return (
-        <>
+        <div aria-labelledby="issue-filing">
             <IssueFilingChoiceGroup
                 onSelectedServiceChange={props.onSelectedServiceChange}
                 selectedIssueFilingService={selectedIssueFilingService}
                 issueFilingServices={issueFilingServices}
             />
             <SettingsForm deps={deps} settings={selectedIssueFilingServiceData} onPropertyUpdateCallback={props.onPropertyUpdateCallback} />
-        </>
+        </div>
     );
 });

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/settings/issue-filing/__snapshots__/issue-filing-settings.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/settings/issue-filing/__snapshots__/issue-filing-settings.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`IssueFilingSettings renders 1`] = `
 <React.Fragment>
-  <h3>
+  <h3
+    id="issue-filing"
+  >
     Issue filing
   </h3>
   <IssueFilingSettingsContainer

--- a/src/tests/unit/tests/issue-filing/components/__snapshots__/issue-filing-settings-container.test.tsx.snap
+++ b/src/tests/unit/tests/issue-filing/components/__snapshots__/issue-filing-settings-container.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`IssueFilingSettingsContainerTest render 1`] = `
-<React.Fragment>
+<div
+  aria-labelledby="issue-filing"
+>
   <IssueFilingChoiceGroup
     issueFilingServices={
       Array [
@@ -38,5 +40,5 @@ exports[`IssueFilingSettingsContainerTest render 1`] = `
       }
     }
   />
-</React.Fragment>
+</div>
 `;


### PR DESCRIPTION
The Issue Filing label was not read by NVDA/Narrator, so users were not told the context of the radio buttons/options; they simply heard "Github" or "Azure Boards". With the changes in this PR, users will now hear "Issue Filing" before they are read the options.

#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [X] Addresses an existing issue: Bug 1644155
- [X] Ran `yarn fastpass`
- [X] Added/updated relevant unit test(s) (and ran `yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS
