### PR TITLE
test: revert flaky resize operation from electron e2es

### DIFF
--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { mainWindowConfig } from 'electron/main/main-window-config';
 import { Application } from 'spectron';
 import { DeviceConnectionDialogController } from 'tests/electron/common/view-controllers/device-connection-dialog-controller';
 import { testResourceServerConfig } from 'tests/electron/setup/test-resource-server-config';
@@ -28,8 +27,6 @@ export class AppController {
     }
 
     public async openDeviceConnectionDialog(): Promise<DeviceConnectionDialogController> {
-        this.setToMinimumSupportedWindowSize();
-
         await dismissTelemetryOptInDialog(this.app);
 
         const deviceConnectionDialog = new DeviceConnectionDialogController(this.client);
@@ -45,13 +42,6 @@ export class AppController {
         const automatedChecksView = new AutomatedChecksViewController(this.client);
         await automatedChecksView.waitForViewVisible();
 
-        this.setToMinimumSupportedWindowSize();
-
         return automatedChecksView;
-    }
-
-    private setToMinimumSupportedWindowSize(): void {
-        this.app.browserWindow.setBounds({ width: mainWindowConfig.minWidth, height: mainWindowConfig.minHeight });
-        this.app.browserWindow.unmaximize();
     }
 }


### PR DESCRIPTION
#### Description of changes

An earlier PR added a "resize to minimum supported dimensions" operation to the setup of the electron E2E view controllers. Unfortunately, this introduced a source of flakiness (#1846), and attempts to update the resize behavior to avoid the flakiness have proven unsuccessful and hit their timebox (#1862), so reverting the changes until such time as they can be restored without affecting PR/CI builds

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: fixes #1846
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
