### PR TITLE
test: skip activeTab only test

### DIFF
--- a/src/tests/end-to-end/tests/details-view/cross-origin-iframe.test.ts
+++ b/src/tests/end-to-end/tests/details-view/cross-origin-iframe.test.ts
@@ -30,7 +30,8 @@ describe('scanning', () => {
         testResourceServer.stopServer(testResourceServerConfig);
     });
 
-    describe('with localhost permissions only', () => {
+    // skipping the test as we re-introduce all-origin permissions back into the extension.
+    describe.skip('with localhost permissions only', () => {
         beforeEach(async () => {
             await launchFastPassWithExtraPermissions('fake-activeTab');
         });


### PR DESCRIPTION
#### Description of changes

Re-adding **all-origin** permissions break an e2e test which assumes **activeTab**-like permissions.

This PR mark the test as skip (for now).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
