### PR TITLE
refactor: remove unused browser-adapter functions

### DIFF
--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -12,7 +12,6 @@ export interface BrowserAdapter {
     tabsQuery(query: chrome.tabs.QueryInfo, callback: (result: chrome.tabs.Tab[]) => void): void;
     createActiveTab(url: string): Promise<Tabs.Tab>;
     createTabInNewWindow(url: string): Promise<Tabs.Tab>;
-    closeTab(tabId: number): void;
     switchToTab(tabId: number): void;
     getTab(tabId: number, onResolve: (tab: chrome.tabs.Tab) => void, onReject?: () => void): void;
     sendMessageToTab(tabId: number, message: any): Promise<void>;
@@ -23,7 +22,6 @@ export interface BrowserAdapter {
     createNotification(options: Notifications.CreateNotificationOptions): Promise<string>;
     getRuntimeLastError(): chrome.runtime.LastError;
     isAllowedFileSchemeAccess(callback: Function): void;
-    addListenerToLocalStorage(callback: (changes: object) => void): void;
     getManageExtensionUrl(): string;
     addListenerOnConnect(callback: (port: chrome.runtime.Port) => void): void;
     addListenerOnMessage(

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -70,10 +70,6 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return browser.windows.create({ url, focused: true }).then(window => window.tabs[0]);
     }
 
-    public closeTab(tabId: number): void {
-        chrome.tabs.remove(tabId);
-    }
-
     public switchToTab(tabId: number): void {
         const props = {
             active: true,
@@ -114,10 +110,6 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
 
     public isAllowedFileSchemeAccess(callback: (isAllowed: boolean) => void): void {
         chrome.extension.isAllowedFileSchemeAccess(callback);
-    }
-
-    public addListenerToLocalStorage(callback: (changes: object) => void): void {
-        chrome.storage.onChanged.addListener(callback);
     }
 
     public addCommandListener(callback: (command: string) => void): void {


### PR DESCRIPTION
#### Description of changes

Found a couple of functions we're not actually using anywhere. Removing said functions from both, type and class.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
