### PR TITLE
feat(permissions): wire permissions store to scan incomplete warning detector

### DIFF
--- a/src/injected/client-store-listener.ts
+++ b/src/injected/client-store-listener.ts
@@ -4,6 +4,7 @@ import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
@@ -19,6 +20,7 @@ export interface TargetPageStoreData {
     assessmentStoreData: AssessmentStoreData;
     userConfigurationStoreData: UserConfigurationStoreData;
     cardSelectionStoreData: CardSelectionStoreData;
+    permissionsStateStoreData: PermissionsStateStoreData;
 }
 
 export class ClientStoreListener {

--- a/src/injected/scan-incomplete-warning-detector.ts
+++ b/src/injected/scan-incomplete-warning-detector.ts
@@ -1,18 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BaseStore } from 'common/base-store';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { IframeDetector } from './iframe-detector';
 
-export interface CrossOriginPermissionDetector {
-    hasCrossOriginPermissions(): boolean;
-}
-
 export class ScanIncompleteWarningDetector {
-    constructor(private iframeDetector: IframeDetector, private crossOriginPermissionDetector: CrossOriginPermissionDetector) {}
+    constructor(private iframeDetector: IframeDetector, private permissionsStateStore: BaseStore<PermissionsStateStoreData>) {}
 
     public detectScanIncompleteWarnings = () => {
         const warnings: ScanIncompleteWarningId[] = [];
-        if (this.iframeDetector.hasIframes() && !this.crossOriginPermissionDetector.hasCrossOriginPermissions()) {
+        if (this.iframeDetector.hasIframes() && !this.permissionsStateStore.getState().hasAllUrlAndFilePermissions) {
             warnings.push('missing-required-cross-origin-permissions');
         }
         return warnings;

--- a/src/tests/unit/tests/injected/scan-incomplete-warning-detector.test.ts
+++ b/src/tests/unit/tests/injected/scan-incomplete-warning-detector.test.ts
@@ -1,31 +1,33 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BaseStore } from 'common/base-store';
+import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { IframeDetector } from 'injected/iframe-detector';
-import { CrossOriginPermissionDetector, ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 import { IMock, Mock } from 'typemoq';
 
 describe('ScanIncompleteWarningDetector', () => {
     let testSubject: ScanIncompleteWarningDetector;
     let iframeDetectorMock: IMock<IframeDetector>;
-    let crossOriginPermissionDetectorMock: IMock<CrossOriginPermissionDetector>;
+    let permissionsStateStoreMock: IMock<BaseStore<PermissionsStateStoreData>>;
 
     beforeEach(() => {
-        crossOriginPermissionDetectorMock = Mock.ofType<CrossOriginPermissionDetector>();
+        permissionsStateStoreMock = Mock.ofType<BaseStore<PermissionsStateStoreData>>();
         iframeDetectorMock = Mock.ofType<IframeDetector>();
-        testSubject = new ScanIncompleteWarningDetector(iframeDetectorMock.object, crossOriginPermissionDetectorMock.object);
+        testSubject = new ScanIncompleteWarningDetector(iframeDetectorMock.object, permissionsStateStoreMock.object);
     });
 
     it.each`
-        iframesDetected | crossOriginPermissions | expectedResults
-        ${true}         | ${true}                | ${[]}
-        ${true}         | ${false}               | ${['missing-required-cross-origin-permissions']}
-        ${false}        | ${true}                | ${[]}
-        ${false}        | ${false}               | ${[]}
+        iframesDetected | hasAllUrlAndFilePermissions | expectedResults
+        ${true}         | ${true}                     | ${[]}
+        ${true}         | ${false}                    | ${['missing-required-cross-origin-permissions']}
+        ${false}        | ${true}                     | ${[]}
+        ${false}        | ${false}                    | ${[]}
     `(
         'should detect $expectedResults if iframesDetected=$iframesDetected and crossOriginPermissions=$crossOriginPermissions',
-        ({ iframesDetected, crossOriginPermissions, expectedResults }) => {
+        ({ iframesDetected, hasAllUrlAndFilePermissions, expectedResults }) => {
             iframeDetectorMock.setup(m => m.hasIframes()).returns(() => iframesDetected);
-            crossOriginPermissionDetectorMock.setup(m => m.hasCrossOriginPermissions()).returns(() => crossOriginPermissions);
+            permissionsStateStoreMock.setup(m => m.getState()).returns(() => ({ hasAllUrlAndFilePermissions }));
 
             expect(testSubject.detectScanIncompleteWarnings()).toStrictEqual(expectedResults);
         },


### PR DESCRIPTION
#### Description of changes

This PR initializes a store proxy for the new permissions state store in the injected page and hooks it up to the scan incomplete warning detector.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1657504
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
