### PR TITLE
fix: move interactive no-drag styles to electron root

### DIFF
--- a/src/electron/views/device-connect-view/device-connect-view.scss
+++ b/src/electron/views/device-connect-view/device-connect-view.scss
@@ -17,12 +17,4 @@
         flex: 1 1 auto;
         overflow: auto;
     }
-
-    button {
-        -webkit-app-region: no-drag;
-    }
-
-    input {
-        -webkit-app-region: no-drag;
-    }
 }

--- a/src/electron/views/root-container/components/root-container.scss
+++ b/src/electron/views/root-container/components/root-container.scss
@@ -9,3 +9,11 @@ body {
     overflow: hidden;
     background-color: $neutral-0;
 }
+
+button {
+    -webkit-app-region: no-drag;
+}
+
+input {
+    -webkit-app-region: no-drag;
+}


### PR DESCRIPTION
#### Description of changes
A recent change in scss file caused the interactive elements on the telemetry dialog in the electron product to stop accepting mouse interaction. This happens because `-webkit-app-region: no-drag` was not set on those elements. Even though the telemetry dialog is a child of the device connect view, it actually renders as a sibling. This PR moves the `-webkit-app-region: no-drag` properties for buttons and inputs out to apply globally so that we don't have to worry about similar problems in the future.

Before:
![before](https://user-images.githubusercontent.com/4615491/71019319-01377a00-20af-11ea-8b71-94b055d96ede.gif)
After:
![after](https://user-images.githubusercontent.com/4615491/71019371-114f5980-20af-11ea-9765-ce81646f5e63.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
