### PR TITLE
feat(permissions): restore activeTab. re-enable related e2e test

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -23,7 +23,7 @@
     },
     "devtools_page": "Devtools/devtools.html",
     "web_accessible_resources": ["insights.html", "assessments/*", "injected/*", "background/*", "common/*", "DetailsView/*", "bundle/*"],
-    "permissions": ["storage", "webNavigation", "tabs", "notifications", "https://*/*", "http://*/*", "file://*/*"],
+    "permissions": ["storage", "webNavigation", "tabs", "notifications", "activeTab"],
     "commands": {
         "_execute_browser_action": {
             "suggested_key": {

--- a/src/tests/end-to-end/tests/details-view/cross-origin-iframe.test.ts
+++ b/src/tests/end-to-end/tests/details-view/cross-origin-iframe.test.ts
@@ -30,8 +30,7 @@ describe('scanning', () => {
         testResourceServer.stopServer(testResourceServerConfig);
     });
 
-    // skipping the test as we re-introduce all-origin permissions back into the extension.
-    describe.skip('with localhost permissions only', () => {
+    describe('with localhost permissions only', () => {
         beforeEach(async () => {
             await launchFastPassWithExtraPermissions('fake-activeTab');
         });


### PR DESCRIPTION
#### Description of changes

Changing permissions back to use `activeTab`. Additionally, re-enabling a cross-origin e2e test that was broken because of having all-origin permissions.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
