### PR TITLE
refactor: promisify is allowed file scheme access

### DIFF
--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -23,7 +23,6 @@ export interface BrowserAdapter {
     createNotification(options: Notifications.CreateNotificationOptions): Promise<string>;
     getRuntimeLastError(): chrome.runtime.LastError;
     isAllowedFileSchemeAccessP(): Promise<boolean>;
-    isAllowedFileSchemeAccess(callback: Function): void;
     addListenerToLocalStorage(callback: (changes: object) => void): void;
     getManageExtensionUrl(): string;
     addListenerOnConnect(callback: (port: chrome.runtime.Port) => void): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -22,7 +22,7 @@ export interface BrowserAdapter {
     getRunTimeId(): string;
     createNotification(options: Notifications.CreateNotificationOptions): Promise<string>;
     getRuntimeLastError(): chrome.runtime.LastError;
-    isAllowedFileSchemeAccessP(): Promise<boolean>;
+    isAllowedFileSchemeAccess(): Promise<boolean>;
     addListenerToLocalStorage(callback: (changes: object) => void): void;
     getManageExtensionUrl(): string;
     addListenerOnConnect(callback: (port: chrome.runtime.Port) => void): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -22,6 +22,7 @@ export interface BrowserAdapter {
     getRunTimeId(): string;
     createNotification(options: Notifications.CreateNotificationOptions): Promise<string>;
     getRuntimeLastError(): chrome.runtime.LastError;
+    isAllowedFileSchemeAccessP(): Promise<boolean>;
     isAllowedFileSchemeAccess(callback: Function): void;
     addListenerToLocalStorage(callback: (changes: object) => void): void;
     getManageExtensionUrl(): string;

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -112,7 +112,7 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return browser.notifications.create(options);
     }
 
-    public isAllowedFileSchemeAccessP(): Promise<boolean> {
+    public isAllowedFileSchemeAccess(): Promise<boolean> {
         return browser.extension.isAllowedFileSchemeAccess();
     }
 

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -112,6 +112,10 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return browser.notifications.create(options);
     }
 
+    public isAllowedFileSchemeAccessP(): Promise<boolean> {
+        return browser.extension.isAllowedFileSchemeAccess();
+    }
+
     public isAllowedFileSchemeAccess(callback: (isAllowed: boolean) => void): void {
         chrome.extension.isAllowedFileSchemeAccess(callback);
     }

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -116,10 +116,6 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return browser.extension.isAllowedFileSchemeAccess();
     }
 
-    public isAllowedFileSchemeAccess(callback: (isAllowed: boolean) => void): void {
-        chrome.extension.isAllowedFileSchemeAccess(callback);
-    }
-
     public addListenerToLocalStorage(callback: (changes: object) => void): void {
         chrome.storage.onChanged.addListener(callback);
     }

--- a/src/common/url-validator.ts
+++ b/src/common/url-validator.ts
@@ -26,6 +26,6 @@ export class UrlValidator {
     }
 
     private checkAccessToFileUrl(): Promise<boolean> {
-        return this.browserAdapter.isAllowedFileSchemeAccessP();
+        return this.browserAdapter.isAllowedFileSchemeAccess();
     }
 }

--- a/src/common/url-validator.ts
+++ b/src/common/url-validator.ts
@@ -26,8 +26,6 @@ export class UrlValidator {
     }
 
     private checkAccessToFileUrl(): Promise<boolean> {
-        return new Promise<boolean>(resolve => {
-            this.browserAdapter.isAllowedFileSchemeAccess(resolve);
-        });
+        return this.browserAdapter.isAllowedFileSchemeAccessP();
     }
 }

--- a/src/tests/unit/tests/common/url-validator.test.ts
+++ b/src/tests/unit/tests/common/url-validator.test.ts
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
-import { IMock, It, Mock } from 'typemoq';
-
+import { IMock, Mock } from 'typemoq';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { UrlValidator } from '../../../../common/url-validator';
 

--- a/src/tests/unit/tests/common/url-validator.test.ts
+++ b/src/tests/unit/tests/common/url-validator.test.ts
@@ -38,10 +38,8 @@ describe('UrlValidatorTest', () => {
     test('isSupportedUrl: file', async () => {
         const url: string = 'file://test';
         browserAdapterMock
-            .setup(b => b.isAllowedFileSchemeAccess(It.is(isFunction)))
-            .callback(callback => {
-                callback(true);
-            })
+            .setup(b => b.isAllowedFileSchemeAccessP())
+            .returns(() => Promise.resolve(true))
             .verifiable();
 
         const isSupported = await testSubject.isSupportedUrl(url);
@@ -53,10 +51,8 @@ describe('UrlValidatorTest', () => {
     test('isFileUrl, but have no access, so isNotSupportedUrl', async () => {
         const url: string = 'file://yes/I/am!';
         browserAdapterMock
-            .setup(b => b.isAllowedFileSchemeAccess(It.is(isFunction)))
-            .callback(callback => {
-                callback(false);
-            })
+            .setup(b => b.isAllowedFileSchemeAccessP())
+            .returns(() => Promise.resolve(false))
             .verifiable();
 
         const isSupported = await testSubject.isSupportedUrl(url);

--- a/src/tests/unit/tests/common/url-validator.test.ts
+++ b/src/tests/unit/tests/common/url-validator.test.ts
@@ -38,7 +38,7 @@ describe('UrlValidatorTest', () => {
     test('isSupportedUrl: file', async () => {
         const url: string = 'file://test';
         browserAdapterMock
-            .setup(b => b.isAllowedFileSchemeAccessP())
+            .setup(b => b.isAllowedFileSchemeAccess())
             .returns(() => Promise.resolve(true))
             .verifiable();
 
@@ -51,7 +51,7 @@ describe('UrlValidatorTest', () => {
     test('isFileUrl, but have no access, so isNotSupportedUrl', async () => {
         const url: string = 'file://yes/I/am!';
         browserAdapterMock
-            .setup(b => b.isAllowedFileSchemeAccessP())
+            .setup(b => b.isAllowedFileSchemeAccess())
             .returns(() => Promise.resolve(false))
             .verifiable();
 


### PR DESCRIPTION
#### Description of changes

This is part of a long-run refactor to promisify all (possible) `chrome.*` calls.

In this case, promisifying `isAllowedFileSchemeAccess`.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
