### PR TITLE
refactor: removed parameter for requirement for startOverTest (not used)

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -190,11 +190,10 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
-    public startOverAssessment(event: React.MouseEvent<any>, test: VisualizationType, requirement: string): void {
+    public startOverTest(event: React.MouseEvent<any>, test: VisualizationType): void {
         const telemetry = this.telemetryFactory.forAssessmentActionFromDetailsView(test, event);
         const payload: ToggleActionPayload = {
             test,
-            requirement,
             telemetry,
         };
 

--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -198,7 +198,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.StartOver,
+            messageType: Messages.Assessment.StartOverTest,
             payload,
         });
     }

--- a/src/DetailsView/components/start-over-dropdown.tsx
+++ b/src/DetailsView/components/start-over-dropdown.tsx
@@ -143,9 +143,9 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
 
     private onStartTestOver = (event: React.MouseEvent<any>): void => {
         const detailsViewActionMessageCreator = this.props.deps.detailsViewActionMessageCreator;
-        const { requirementKey, test } = this.props;
+        const { test } = this.props;
 
-        detailsViewActionMessageCreator.startOverAssessment(event, test, requirementKey);
+        detailsViewActionMessageCreator.startOverTest(event, test);
 
         this.setState({ dialogState: 'none' });
     };

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -142,7 +142,7 @@ export class ActionCreator {
             this.onAssessmentScanCompleted,
         );
         this.interpreter.registerTypeToPayloadCallback(
-            Messages.Assessment.StartOver,
+            Messages.Assessment.StartOverTest,
             this.onStartOver,
         );
         this.interpreter.registerTypeToPayloadCallback(

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -51,7 +51,7 @@ export class AssessmentActionCreator {
             this.onAssessmentScanCompleted,
         );
         this.interpreter.registerTypeToPayloadCallback(
-            AssessmentMessages.StartOver,
+            AssessmentMessages.StartOverTest,
             this.onStartOverAssessment,
         );
         this.interpreter.registerTypeToPayloadCallback(

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -119,7 +119,7 @@ export class Messages {
         TrackingCompleted: `${messagePrefix}/assessment/tab-stops/recording-completed`,
         CancelStartOver: `${messagePrefix}/assessment/cancel-start-over`,
         CancelStartOverAllAssessments: `${messagePrefix}/assessment/cancel-start-over-all-assessments`,
-        StartOver: `${messagePrefix}/assessment/startOver`,
+        StartOverTest: `${messagePrefix}/assessment/startOverTest`,
         StartOverAllAssessments: `${messagePrefix}/assessment/startOverAllAssessments`,
         EnableVisualHelper: `${messagePrefix}/assessment/enableVisualHelper`,
         EnableVisualHelperWithoutScan: `${messagePrefix}/assessment/enableVisualHelperWithoutScan`,

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -269,7 +269,6 @@ describe('DetailsViewActionMessageCreatorTest', () => {
     });
 
     test('startOverTest', () => {
-        const requirementStub = 'fake-requirement';
         const event = eventStubFactory.createMouseClickEvent() as any;
         const telemetry: AssessmentTelemetryData = {
             triggeredBy: 'mouseclick',

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -268,7 +268,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         dispatcherMock.verify(dispatcher => dispatcher.sendTelemetry(DETAILS_VIEW_OPEN, telemetry), Times.once());
     });
 
-    test('startOverAssessment', () => {
+    test('startOverTest', () => {
         const requirementStub = 'fake-requirement';
         const event = eventStubFactory.createMouseClickEvent() as any;
         const telemetry: AssessmentTelemetryData = {
@@ -281,7 +281,6 @@ describe('DetailsViewActionMessageCreatorTest', () => {
             messageType: Messages.Assessment.StartOver,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
-                requirement: requirementStub,
                 telemetry,
             },
         };
@@ -290,7 +289,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
             .setup(tf => tf.forAssessmentActionFromDetailsView(VisualizationType.HeadingsAssessment, event))
             .returns(() => telemetry);
 
-        testSubject.startOverAssessment(event, VisualizationType.HeadingsAssessment, requirementStub);
+        testSubject.startOverTest(event, VisualizationType.HeadingsAssessment);
 
         dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)), Times.once());
     });

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -277,7 +277,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         };
 
         const expectedMessage = {
-            messageType: Messages.Assessment.StartOver,
+            messageType: Messages.Assessment.StartOverTest,
             payload: {
                 test: VisualizationType.HeadingsAssessment,
                 telemetry,

--- a/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
@@ -115,9 +115,7 @@ describe('StartOverDropdownTest', () => {
     });
 
     it('should start over a test', () => {
-        detailsViewActionMessageCreatorMock
-            .setup(creator => creator.startOverAssessment(event, defaultProps.test, defaultProps.requirementKey))
-            .verifiable(Times.once());
+        detailsViewActionMessageCreatorMock.setup(creator => creator.startOverTest(event, defaultProps.test)).verifiable(Times.once());
 
         const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
         rendered.find(ActionButton).simulate('click', event);

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -621,7 +621,7 @@ describe('ActionCreatorTest', () => {
         const disableActionName = 'disableVisualization';
 
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Assessment.StartOver, [payload, tabId])
+            .setupRegistrationCallback(Messages.Assessment.StartOverTest, [payload, tabId])
             .setupActionOnVisualizationActions(disableActionName)
             .setupVisualizationActionWithInvokeParameter(disableActionName, payload.test)
             .setupTelemetrySend(TelemetryEvents.START_OVER_TEST, payload, 1);

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -311,7 +311,7 @@ describe('AssessmentActionCreatorTest', () => {
 
         const resetDataMock = createActionMock(payload);
         const actionsMock = createActionsMock('resetData', resetDataMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.StartOver, payload);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.StartOverTest, payload);
 
         const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
 


### PR DESCRIPTION
#### Description of changes

The start over operation operates for a test and not for a requirement. As such, I've removed that as a parameter from the function call (and renamed the function to startOverTest, since that is more appropriate).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
