### PR TITLE
refactor: Fixed office-ui-fabric-react imports

### DIFF
--- a/src/DetailsView/actions/issues-selection-factory.ts
+++ b/src/DetailsView/actions/issues-selection-factory.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection } from 'office-ui-fabric-react';
 
 import { DetailsRowData } from '../components/issues-table-handler';
 import { DetailsViewActionMessageCreator } from './details-view-action-message-creator';

--- a/src/DetailsView/actions/issues-selection.tsx
+++ b/src/DetailsView/actions/issues-selection.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IObjectWithKey, ISelectionOptions, Selection } from 'office-ui-fabric-react/lib/DetailsList';
+import { IObjectWithKey, ISelectionOptions, Selection } from 'office-ui-fabric-react';
 
 export class IssuesSelection extends Selection {
     constructor(options?: ISelectionOptions) {

--- a/src/DetailsView/components/action-and-cancel-buttons-component.tsx
+++ b/src/DetailsView/components/action-and-cancel-buttons-component.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { isEmpty } from 'lodash';
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import * as styles from './action-and-cancel-buttons-component.scss';

--- a/src/DetailsView/components/assessment-instance-details-column.tsx
+++ b/src/DetailsView/components/assessment-instance-details-column.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { TooltipHost } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export interface AssessmentInstanceDetailsColumnProps {

--- a/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
+++ b/src/DetailsView/components/assessment-instance-edit-and-remove-control.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Icon } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';

--- a/src/DetailsView/components/assessment-instance-selected-button.tsx
+++ b/src/DetailsView/components/assessment-instance-selected-button.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as classNames from 'classnames';
-import { IconButton } from 'office-ui-fabric-react/lib/Button';
+import { IconButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { VisualizationType } from '../../common/types/visualization-type';
 

--- a/src/DetailsView/components/assessment-instance-table.tsx
+++ b/src/DetailsView/components/assessment-instance-table.tsx
@@ -3,14 +3,7 @@
 import { IRenderFunction } from '@uifabric/utilities';
 import { has } from 'lodash';
 import { ActionButton } from 'office-ui-fabric-react';
-import {
-    CheckboxVisibility,
-    ConstrainMode,
-    DetailsList,
-    IColumn,
-    IDetailsRowProps,
-    IObjectWithKey,
-} from 'office-ui-fabric-react';
+import { CheckboxVisibility, ConstrainMode, DetailsList, IColumn, IDetailsRowProps, IObjectWithKey } from 'office-ui-fabric-react';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 

--- a/src/DetailsView/components/assessment-instance-table.tsx
+++ b/src/DetailsView/components/assessment-instance-table.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { IRenderFunction } from '@uifabric/utilities';
 import { has } from 'lodash';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import { ActionButton } from 'office-ui-fabric-react';
 import {
     CheckboxVisibility,
     ConstrainMode,
@@ -10,8 +10,8 @@ import {
     IColumn,
     IDetailsRowProps,
     IObjectWithKey,
-} from 'office-ui-fabric-react/lib/DetailsList';
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
+} from 'office-ui-fabric-react';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';

--- a/src/DetailsView/components/assessment-table-column-config-handler.tsx
+++ b/src/DetailsView/components/assessment-table-column-config-handler.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { ColumnActionsMode, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
+import { ColumnActionsMode, IColumn } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { AssessmentNavState } from '../../common/types/store-data/assessment-result-data';
 import { MasterCheckBoxConfigProvider } from '../handlers/master-checkbox-config-provider';

--- a/src/DetailsView/components/base-left-nav.tsx
+++ b/src/DetailsView/components/base-left-nav.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { INavLink, Nav } from 'office-ui-fabric-react/lib/Nav';
+import { INavLink, Nav } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export type onBaseLeftNavItemClick = (event: React.MouseEvent<HTMLElement>, item: BaseLeftNavLink) => void;

--- a/src/DetailsView/components/details-group-header.tsx
+++ b/src/DetailsView/components/details-group-header.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { GroupHeader } from 'office-ui-fabric-react/lib/components/GroupedList/GroupHeader';
-import { IGroupDividerProps } from 'office-ui-fabric-react/lib/DetailsList';
+import { GroupHeader } from 'office-ui-fabric-react';
+import { IGroupDividerProps } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { GuidanceLinks } from '../../common/components/guidance-links';

--- a/src/DetailsView/components/details-list-issues-view.tsx
+++ b/src/DetailsView/components/details-list-issues-view.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -9,8 +9,8 @@ import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-vie
 import { detailsViewCommandButtons } from 'DetailsView/components/details-view-command-bar.scss';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import { StartOverDeps } from 'DetailsView/components/start-over-dropdown';
-import { Link } from 'office-ui-fabric-react/lib/Link';
-import { ITooltipHostStyles, TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { Link } from 'office-ui-fabric-react';
+import { ITooltipHostStyles, TooltipHost } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 

--- a/src/DetailsView/components/details-view-dropdown.tsx
+++ b/src/DetailsView/components/details-view-dropdown.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IPoint } from '@uifabric/utilities';
-import { DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
-import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { DirectionalHint } from 'office-ui-fabric-react';
+import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react';
+import { Icon } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export interface DetailsViewDropDownProps {

--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
-import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { PrimaryButton } from 'office-ui-fabric-react';
+import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react';
+import { TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ExportResultType } from '../../common/extension-telemetry-events';
 import { FileURLProvider } from '../../common/file-url-provider';

--- a/src/DetailsView/components/failure-details.tsx
+++ b/src/DetailsView/components/failure-details.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { Icon } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export interface FailureDetailsProps {

--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { clone, isEqual } from 'lodash';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { ILabelStyles } from 'office-ui-fabric-react/lib/Label';
-import { Link } from 'office-ui-fabric-react/lib/Link';
-import { ITextFieldStyles, TextField } from 'office-ui-fabric-react/lib/TextField';
+import { ActionButton } from 'office-ui-fabric-react';
+import { Icon } from 'office-ui-fabric-react';
+import { ILabelStyles } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
+import { ITextFieldStyles, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { FlaggedComponent } from '../../common/components/flagged-component';

--- a/src/DetailsView/components/failure-instance-panel-details.tsx
+++ b/src/DetailsView/components/failure-instance-panel-details.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { ILabelStyles } from 'office-ui-fabric-react/lib/Label';
-import { ITextFieldStyles, TextField } from 'office-ui-fabric-react/lib/TextField';
+import { DefaultButton } from 'office-ui-fabric-react';
+import { Icon } from 'office-ui-fabric-react';
+import { ILabelStyles } from 'office-ui-fabric-react';
+import { ITextFieldStyles, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NamedFC } from '../../common/react/named-fc';

--- a/src/DetailsView/components/generic-dialog.tsx
+++ b/src/DetailsView/components/generic-dialog.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
-import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
+import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react';
+import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NamedFC } from '../../common/react/named-fc';

--- a/src/DetailsView/components/generic-panel.tsx
+++ b/src/DetailsView/components/generic-panel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css, IRenderFunction } from '@uifabric/utilities';
-import { IPanelProps, Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
+import { IPanelProps, Panel, PanelType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export interface GenericPanelProps {

--- a/src/DetailsView/components/generic-toggle.tsx
+++ b/src/DetailsView/components/generic-toggle.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NamedFC } from '../../common/react/named-fc';

--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { cloneDeep, isEqual } from 'lodash';
-import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
+import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { EnvironmentInfoProvider } from '../../common/environment-info-provider';

--- a/src/DetailsView/components/issues-details-list.tsx
+++ b/src/DetailsView/components/issues-details-list.tsx
@@ -7,8 +7,8 @@ import {
     IColumn,
     ISelection,
     SelectionMode,
-} from 'office-ui-fabric-react/lib/DetailsList';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
+} from 'office-ui-fabric-react';
+import { Icon } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { RuleResult } from '../../scanner/iruleresults';

--- a/src/DetailsView/components/issues-details-list.tsx
+++ b/src/DetailsView/components/issues-details-list.tsx
@@ -1,13 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import {
-    ConstrainMode,
-    DetailsList,
-    DetailsListLayoutMode,
-    IColumn,
-    ISelection,
-    SelectionMode,
-} from 'office-ui-fabric-react';
+import { ConstrainMode, DetailsList, DetailsListLayoutMode, IColumn, ISelection, SelectionMode } from 'office-ui-fabric-react';
 import { Icon } from 'office-ui-fabric-react';
 import * as React from 'react';
 

--- a/src/DetailsView/components/issues-table-handler.ts
+++ b/src/DetailsView/components/issues-table-handler.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IObjectWithKey } from 'office-ui-fabric-react/lib/DetailsList';
-import { IGroup } from 'office-ui-fabric-react/lib/GroupedList';
+import { IObjectWithKey } from 'office-ui-fabric-react';
+import { IGroup } from 'office-ui-fabric-react';
 import { HyperlinkDefinition } from 'views/content/content-page';
 import { RuleResult } from '../../scanner/iruleresults';
 

--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -13,7 +13,7 @@ import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { VisualizationType } from 'common/types/visualization-type';
 import { DecoratedAxeNodeResult } from 'injected/scanner-utils';
-import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { RuleResult, ScanResults } from 'scanner/iruleresults';

--- a/src/DetailsView/components/left-nav/left-nav-icon.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-icon.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { INavLink } from 'office-ui-fabric-react/lib/Nav';
+import { INavLink } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { NamedFC } from '../../../common/react/named-fc';
 import { StatusIcon } from '../status-icon';

--- a/src/DetailsView/components/left-nav/overview-left-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/overview-left-nav-link.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { Icon } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NamedFC } from '../../../common/react/named-fc';

--- a/src/DetailsView/components/manual-test-step-view.tsx
+++ b/src/DetailsView/components/manual-test-step-view.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CheckboxVisibility, ConstrainMode, DetailsList } from 'office-ui-fabric-react/lib/DetailsList';
+import { CheckboxVisibility, ConstrainMode, DetailsList } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { escape } from 'lodash';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { ExportResultType } from '../../common/extension-telemetry-events';

--- a/src/DetailsView/components/requirement-link.tsx
+++ b/src/DetailsView/components/requirement-link.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
-import { INavLink } from 'office-ui-fabric-react/lib/Nav';
+import { INavLink } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { ManualTestStatus } from '../../common/types/manual-test-status';

--- a/src/DetailsView/components/scoping-panel.tsx
+++ b/src/DetailsView/components/scoping-panel.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { InspectActionMessageCreator } from '../../common/message-creators/inspect-action-message-creator';

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -3,7 +3,7 @@
 import { FeatureFlags } from 'common/feature-flags';
 import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { StartOverDropdown, StartOverProps } from 'DetailsView/components/start-over-dropdown';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export function getStartOverComponentForAssessment(props: CommandBarProps): JSX.Element {

--- a/src/DetailsView/components/start-over-dropdown.tsx
+++ b/src/DetailsView/components/start-over-dropdown.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IPoint } from '@uifabric/utilities';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { ActionButton } from 'office-ui-fabric-react';
+import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { VisualizationType } from '../../common/types/visualization-type';

--- a/src/DetailsView/components/status-icon.tsx
+++ b/src/DetailsView/components/status-icon.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { Icon } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { outcomeTypeSemanticsFromTestStatus } from 'reports/components/requirement-outcome-type';

--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { ResponsiveMode } from 'office-ui-fabric-react/lib/utilities/decorators/withResponsiveMode';
+import { Dropdown, IDropdownOption } from 'office-ui-fabric-react';
+import { Icon } from 'office-ui-fabric-react';
+import { ResponsiveMode } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';

--- a/src/DetailsView/components/target-change-dialog.tsx
+++ b/src/DetailsView/components/target-change-dialog.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { isEmpty } from 'lodash';
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
-import { Link } from 'office-ui-fabric-react/lib/Link';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { DefaultButton } from 'office-ui-fabric-react';
+import { DialogFooter, DialogType } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
+import { TooltipHost } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { css } from '@uifabric/utilities';

--- a/src/DetailsView/components/target-page-changed-view.tsx
+++ b/src/DetailsView/components/target-page-changed-view.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { FeatureFlags } from 'common/feature-flags';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { DisplayableVisualizationTypeData } from '../../common/configs/visualization-configuration-factory';

--- a/src/DetailsView/components/target-page-hidden-bar.tsx
+++ b/src/DetailsView/components/target-page-hidden-bar.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
+import { MessageBar, MessageBarType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export type TargetPageHiddenBarProps = {

--- a/src/DetailsView/components/test-status-choice-group.tsx
+++ b/src/DetailsView/components/test-status-choice-group.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { isEqual } from 'lodash';
-import { ChoiceGroup, IChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { ChoiceGroup, IChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react';
+import { Icon } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { ManualTestStatus } from '../../common/types/manual-test-status';

--- a/src/DetailsView/components/test-step-view.tsx
+++ b/src/DetailsView/components/test-step-view.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';

--- a/src/DetailsView/components/test-steps-nav.tsx
+++ b/src/DetailsView/components/test-steps-nav.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { INavLink, Nav } from 'office-ui-fabric-react/lib/Nav';
+import { INavLink, Nav } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';

--- a/src/DetailsView/components/test-view-container.tsx
+++ b/src/DetailsView/components/test-view-container.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection } from 'office-ui-fabric-react';
 
 import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
 import { NamedFC } from '../../common/react/named-fc';

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -3,7 +3,7 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { TargetAppData } from 'common/types/store-data/unified-data-interface';
-import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -3,8 +3,8 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
-import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
+import { ISelection } from 'office-ui-fabric-react';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { ThemeDeps } from '../common/components/theme';

--- a/src/DetailsView/details-view-renderer.tsx
+++ b/src/DetailsView/details-view-renderer.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Theme } from '../common/components/theme';

--- a/src/DetailsView/extensions/wait-for-all-requirements-to-complete.tsx
+++ b/src/DetailsView/extensions/wait-for-all-requirements-to-complete.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { OutcomeMath } from 'reports/components/outcome-math';

--- a/src/DetailsView/handlers/assessment-instance-table-handler.tsx
+++ b/src/DetailsView/handlers/assessment-instance-table-handler.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
+import { IColumn } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';

--- a/src/DetailsView/handlers/master-checkbox-config-provider.ts
+++ b/src/DetailsView/handlers/master-checkbox-config-provider.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as classNames from 'classnames';
-import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
+import { IColumn } from 'office-ui-fabric-react';
 
 import { AssessmentNavState } from '../../common/types/store-data/assessment-result-data';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';

--- a/src/assessments/assessment-builder.tsx
+++ b/src/assessments/assessment-builder.tsx
@@ -27,7 +27,7 @@ import {
 } from 'injected/visualization-instance-processor';
 import { DrawerProvider } from 'injected/visualization/drawer-provider';
 import { cloneDeep } from 'lodash';
-import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
+import { IColumn } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { DictionaryStringTo } from 'types/common-types';
 

--- a/src/assessments/types/requirement.ts
+++ b/src/assessments/types/requirement.ts
@@ -22,7 +22,7 @@ import {
 } from 'injected/visualization-instance-processor';
 import { Drawer } from 'injected/visualization/drawer';
 import { DrawerProvider } from 'injected/visualization/drawer-provider';
-import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
+import { IColumn } from 'office-ui-fabric-react';
 import { DictionaryStringTo } from 'types/common-types';
 import { ContentPageComponent, HyperlinkDefinition } from 'views/content/content-page';
 import { IGetMessageGenerator } from '../assessment-default-message-generator';

--- a/src/common/components/blocking-dialog.tsx
+++ b/src/common/components/blocking-dialog.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Dialog, IDialogProps } from 'office-ui-fabric-react/lib/Dialog';
+import { Dialog, IDialogProps } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NamedFC } from '../react/named-fc';

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { MoreActionsMenuIcon } from 'common/icons/more-actions-menu-icon';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import { DirectionalHint, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { ActionButton } from 'office-ui-fabric-react';
+import { DirectionalHint, IContextualMenuItem } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { IssueDetailsTextGenerator } from '../../../background/issue-details-text-generator';

--- a/src/common/components/cards/collapsible-component-cards.tsx
+++ b/src/common/components/cards/collapsible-component-cards.tsx
@@ -3,7 +3,7 @@
 import { css } from '@uifabric/utilities';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { NamedFC } from 'common/react/named-fc';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import * as styles from './collapsible-component-cards.scss';

--- a/src/common/components/collapsible-component.tsx
+++ b/src/common/components/collapsible-component.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export interface CollapsibleComponentProps {

--- a/src/common/components/copy-issue-details-button.tsx
+++ b/src/common/components/copy-issue-details-button.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
 import { NavigatorUtils } from 'common/navigator-utils';
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { CopyIcon } from '../../common/icons/copy-icon';

--- a/src/common/components/external-link.tsx
+++ b/src/common/components/external-link.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { ActionInitiators } from '../action/action-initiator';

--- a/src/common/components/gear-options-button-component.tsx
+++ b/src/common/components/gear-options-button-component.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { IContextualMenuItem } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { DetailsViewDropDown } from '../../DetailsView/components/details-view-dropdown';

--- a/src/common/components/issue-filing-button.tsx
+++ b/src/common/components/issue-filing-button.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { IssueFilingDialogDeps } from '../../DetailsView/components/issue-filing-dialog';

--- a/src/common/components/new-tab-link.tsx
+++ b/src/common/components/new-tab-link.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
-import { ILinkProps, Link } from 'office-ui-fabric-react/lib/Link';
+import { ILinkProps, Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NamedFC } from '../react/named-fc';

--- a/src/common/components/selector-input-list.tsx
+++ b/src/common/components/selector-input-list.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as _ from 'lodash/index';
-import { DefaultButton, IconButton } from 'office-ui-fabric-react/lib/Button';
-import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
-import { List } from 'office-ui-fabric-react/lib/List';
-import { ITextField, TextField } from 'office-ui-fabric-react/lib/TextField';
+import { DefaultButton, IconButton } from 'office-ui-fabric-react';
+import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react';
+import { List } from 'office-ui-fabric-react';
+import { ITextField, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { SingleElementSelector } from '../types/store-data/scoping-store-data';
 

--- a/src/common/components/telemetry-permission-dialog.tsx
+++ b/src/common/components/telemetry-permission-dialog.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { telemetryPopupCheckboxTitle, telemetryPopupTitle } from 'content/settings/improve-accessibility-insights';
-import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
-import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
-import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
+import { PrimaryButton } from 'office-ui-fabric-react';
+import { Checkbox } from 'office-ui-fabric-react';
+import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { PrivacyStatementPopupText, PrivacyStatementTextDeps } from './privacy-statement-text';
 import { TelemetryNotice, TelemetryNoticeDeps } from './telemetry-notice';

--- a/src/common/components/visualization-toggle.tsx
+++ b/src/common/components/visualization-toggle.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IToggle, IToggleProps, Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { IToggle, IToggleProps, Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export interface VisualizationToggleProps {

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -5,10 +5,7 @@ import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-crea
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
-import {
-    CommandBar as UICommandBar,
-    ICommandBarItemProps,
-} from 'office-ui-fabric-react';
+import { CommandBar as UICommandBar, ICommandBarItemProps } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import * as styles from './command-bar.scss';

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -8,7 +8,7 @@ import { ScanStoreData } from 'electron/flux/types/scan-store-data';
 import {
     CommandBar as UICommandBar,
     ICommandBarItemProps,
-} from 'office-ui-fabric-react/lib/CommandBar';
+} from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import * as styles from './command-bar.scss';

--- a/src/electron/views/automated-checks/components/maximize-restore-button.tsx
+++ b/src/electron/views/automated-checks/components/maximize-restore-button.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { RestoreIcon } from 'common/icons/restore-icon';

--- a/src/electron/views/automated-checks/components/title-bar.tsx
+++ b/src/electron/views/automated-checks/components/title-bar.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NamedFC } from 'common/react/named-fc';

--- a/src/electron/views/device-connect-view/components/device-connect-connected-device.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-connected-device.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
+import { Icon } from 'office-ui-fabric-react';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { DeviceConnectState } from '../../../flux/types/device-connect-state';

--- a/src/electron/views/device-connect-view/components/device-connect-footer.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-footer.tsx
@@ -3,7 +3,7 @@
 import { NamedFC } from 'common/react/named-fc';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
-import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import * as styles from './device-connect-footer.scss';

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { KeyCodeConstants } from 'common/constants/keycode-constants';
-import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
-import { MaskedTextField } from 'office-ui-fabric-react/lib/TextField';
+import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react';
+import { MaskedTextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { DeviceConnectActionCreator } from '../../../flux/action-creator/device-connect-action-creator';

--- a/src/electron/views/device-connect-view/components/electron-external-link.tsx
+++ b/src/electron/views/device-connect-view/components/electron-external-link.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
 import { Shell } from 'electron';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export interface ElectronExternalLinkProps {

--- a/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
+++ b/src/electron/views/device-disconnected-popup/device-disconnected-popup.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
+import { DefaultButton } from 'office-ui-fabric-react';
+import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import * as styles from './device-disconnected-popup.scss';

--- a/src/injected/components/command-bar.tsx
+++ b/src/injected/components/command-bar.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseButton, Button, DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { BaseButton, Button, DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { CopyIssueDetailsButton, CopyIssueDetailsButtonDeps } from '../../common/components/copy-issue-details-button';

--- a/src/injected/components/details-dialog.tsx
+++ b/src/injected/components/details-dialog.tsx
@@ -3,7 +3,7 @@
 import { FixInstructionPanel, FixInstructionPanelDeps } from 'common/components/fix-instruction-panel';
 import { isEmpty, size } from 'lodash';
 import { css } from 'office-ui-fabric-react';
-import { Dialog, DialogType } from 'office-ui-fabric-react/lib/Dialog';
+import { Dialog, DialogType } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { HyperlinkDefinition } from 'views/content/content-page';
 

--- a/src/injected/components/issue-details-navigation-controls.tsx
+++ b/src/injected/components/issue-details-navigation-controls.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { FeatureFlags } from '../../common/feature-flags';

--- a/src/issue-filing/components/issue-filing-choice-group.tsx
+++ b/src/issue-filing/components/issue-filing-choice-group.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
+import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NamedFC } from '../../common/react/named-fc';

--- a/src/issue-filing/services/azure-boards/azure-boards-issue-filing-service.tsx
+++ b/src/issue-filing/services/azure-boards/azure-boards-issue-filing-service.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { isEmpty } from 'lodash';
-import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+import { IDropdownOption } from 'office-ui-fabric-react';
 
 import { createFileIssueHandler } from '../../common/create-file-issue-handler';
 import { createSettingsGetter } from '../../common/create-settings-getter';

--- a/src/issue-filing/services/github/github-issue-filing-service.tsx
+++ b/src/issue-filing/services/github/github-issue-filing-service.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { isEmpty, isString } from 'lodash';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NamedFC } from '../../../common/react/named-fc';

--- a/src/popup/components/ad-hoc-tools-panel.tsx
+++ b/src/popup/components/ad-hoc-tools-panel.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Icon } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { DiagnosticViewToggleFactory } from './diagnostic-view-toggle-factory';

--- a/src/popup/components/diagnostic-view-toggle.tsx
+++ b/src/popup/components/diagnostic-view-toggle.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Link } from 'office-ui-fabric-react/lib/Link';
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
-import { IToggle } from 'office-ui-fabric-react/lib/Toggle';
+import { Link } from 'office-ui-fabric-react';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
+import { IToggle } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ContentLink, ContentLinkDeps } from 'views/content/content-link';
 import { VisualizationToggle } from '../../common/components/visualization-toggle';

--- a/src/popup/components/header-contextual-menu.tsx
+++ b/src/popup/components/header-contextual-menu.tsx
@@ -6,7 +6,7 @@ import {
     ContextualMenuItemType,
     DirectionalHint,
     IContextualMenuItem,
-} from 'office-ui-fabric-react/lib/ContextualMenu';
+} from 'office-ui-fabric-react';
 import * as React from 'react';
 import { TelemetryEventSource } from '../../common/extension-telemetry-events';
 import { NamedFC } from '../../common/react/named-fc';

--- a/src/popup/components/launch-pad-item-row.tsx
+++ b/src/popup/components/launch-pad-item-row.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { kebabCase, uniqueId } from 'lodash';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Icon } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export interface LaunchPadItemRowProps {

--- a/src/popup/components/launch-panel-header.tsx
+++ b/src/popup/components/launch-panel-header.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IconButton } from 'office-ui-fabric-react/lib/Button';
-import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { IconButton } from 'office-ui-fabric-react';
+import { IContextualMenuItem } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { GearOptionsButtonComponent } from '../../common/components/gear-options-button-component';
 import { DropdownClickHandler } from '../../common/dropdown-click-handler';

--- a/src/popup/components/popup-view.tsx
+++ b/src/popup/components/popup-view.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
 import { NewTabLink } from '../../common/components/new-tab-link';

--- a/src/popup/handlers/launch-panel-header-click-handler.ts
+++ b/src/popup/handlers/launch-panel-header-click-handler.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { IContextualMenuItem } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { LaunchPanelHeader } from '../components/launch-panel-header';

--- a/src/tests/unit/common/test-assessment-provider.tsx
+++ b/src/tests/unit/common/test-assessment-provider.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IColumn } from 'office-ui-fabric-react/lib/DetailsList';
+import { IColumn } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { AssessmentsProviderImpl } from 'assessments/assessments-provider';

--- a/src/tests/unit/jest-setup.ts
+++ b/src/tests/unit/jest-setup.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { configure } from 'enzyme';
 import * as Adapter from 'enzyme-adapter-react-16';
-import { setIconOptions } from 'office-ui-fabric-react/lib/Styling';
+import { setIconOptions } from 'office-ui-fabric-react';
 
 configure({ adapter: new Adapter() });
 setIconOptions({

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-details-column.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-details-column.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enzyme from 'enzyme';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { TooltipHost } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import {

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-edit-and-remove-control.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Icon } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-selected-button.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-selected-button.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IconButton } from 'office-ui-fabric-react/lib/Button';
+import { IconButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { It, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import { CheckboxVisibility, ConstrainMode, DetailsList, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react/lib/Spinner';
+import { ActionButton } from 'office-ui-fabric-react';
+import { CheckboxVisibility, ConstrainMode, DetailsList, IColumn } from 'office-ui-fabric-react';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { Mock, MockBehavior, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/assessment-table-column-config-handler.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-table-column-config-handler.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { forEach } from 'lodash';
-import { ColumnActionsMode, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
+import { ColumnActionsMode, IColumn } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/details-list-issues-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-list-issues-view.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/details-view-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-dropdown.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { DetailsViewDropDown, DetailsViewDropDownProps } from '../../../../../DetailsView/components/details-view-dropdown';

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
-import { Dialog } from 'office-ui-fabric-react/lib/Dialog';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { PrimaryButton } from 'office-ui-fabric-react';
+import { Dialog } from 'office-ui-fabric-react';
+import { TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
 import { FileURLProvider } from '../../../../../common/file-url-provider';

--- a/src/tests/unit/tests/DetailsView/components/failure-details.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-details.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { Icon } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { FailureDetails, FailureDetailsProps } from '../../../../../DetailsView/components/failure-details';

--- a/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/failure-instance-panel-control.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { ActionButton } from 'office-ui-fabric-react';
+import { TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/generic-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/generic-dialog.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react/lib/Button';
-import Dialog from 'office-ui-fabric-react/lib/Dialog';
+import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react';
+import Dialog from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { GenericDialog, GenericDialogProps } from '../../../../../DetailsView/components/generic-dialog';

--- a/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
+import { Panel, PanelType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { GenericPanel, GenericPanelProps } from '../../../../../DetailsView/components/generic-panel';

--- a/src/tests/unit/tests/DetailsView/components/issues-details-list.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-details-list.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection, Selection } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { Mock } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
@@ -8,7 +8,7 @@ import { IssuesTable, IssuesTableDeps, IssuesTableProps } from 'DetailsView/comp
 import { DetailsRowData, IssuesTableHandler } from 'DetailsView/components/issues-table-handler';
 import { shallow } from 'enzyme';
 import { DecoratedAxeNodeResult } from 'injected/scanner-utils';
-import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection, Selection } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { RuleResult } from 'scanner/iruleresults';

--- a/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/manual-test-step-view.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CheckboxVisibility, ConstrainMode, DetailsList } from 'office-ui-fabric-react/lib/DetailsList';
+import { CheckboxVisibility, ConstrainMode, DetailsList } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { Mock } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';

--- a/src/tests/unit/tests/DetailsView/components/scoping-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/scoping-panel.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { Mock } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/settings/high-contrast/high-contrast-settings.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/settings/high-contrast/high-contrast-settings.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
 import { EnableTelemetrySettingDescription } from '../../../../../../../../common/components/enable-telemetry-setting-description';

--- a/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
-import { ContextualMenu } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { ActionButton } from 'office-ui-fabric-react';
+import { ContextualMenu } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/switcher.test.tsx
@@ -4,7 +4,7 @@ import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { Switcher, SwitcherProps } from 'DetailsView/components/switcher';
 import { shallow } from 'enzyme';
-import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
+import { Dropdown, IDropdownOption } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/components/target-change-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/target-change-dialog.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enzyme from 'enzyme';
-import Dialog from 'office-ui-fabric-react/lib/Dialog';
-import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import Dialog from 'office-ui-fabric-react';
+import { TooltipHost } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { BlockingDialog } from '../../../../../common/components/blocking-dialog';

--- a/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-status-choice-group.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { ChoiceGroup, IChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
+import { ChoiceGroup, IChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as TestUtils from 'react-dom/test-utils';
 import { Mock, Times } from 'typemoq';

--- a/src/tests/unit/tests/DetailsView/components/test-steps-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-steps-nav.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { INavLink } from 'office-ui-fabric-react/lib/Nav';
+import { INavLink } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as TestUtils from 'react-dom/test-utils';
 import { Mock, Times } from 'typemoq';

--- a/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
+++ b/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { ISelection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection } from 'office-ui-fabric-react';
 import { BaseStore } from '../../../../common/base-store';
 import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
 import { DropdownClickHandler } from '../../../../common/dropdown-click-handler';

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -4,7 +4,7 @@ import { CardSelectionViewData, GetCardSelectionViewData } from 'common/get-card
 import { GetCardViewData } from 'common/rule-based-view-model-provider';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { shallow } from 'enzyme';
-import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection, Selection } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ISelection, Selection } from 'office-ui-fabric-react/lib/DetailsList';
+import { ISelection, Selection } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { IMock, It, Mock, MockBehavior } from 'typemoq';

--- a/src/tests/unit/tests/DetailsView/extensions/wait-for-all-requirements-to-complete.test.tsx
+++ b/src/tests/unit/tests/DetailsView/extensions/wait-for-all-requirements-to-complete.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { Spinner } from 'office-ui-fabric-react/lib/Spinner';
+import { Spinner } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { WithAssessmentTestResult } from '../../../../../DetailsView/components/assessment-view';

--- a/src/tests/unit/tests/common/components/blocking-dialog.test.tsx
+++ b/src/tests/unit/tests/common/components/blocking-dialog.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { Dialog, IDialogProps } from 'office-ui-fabric-react/lib/Dialog';
+import { Dialog, IDialogProps } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { BlockingDialog } from '../../../../../common/components/blocking-dialog';

--- a/src/tests/unit/tests/common/components/copy-issue-details-button.test.tsx
+++ b/src/tests/unit/tests/common/components/copy-issue-details-button.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enzyme from 'enzyme';
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/common/components/external-link.test.tsx
+++ b/src/tests/unit/tests/common/components/external-link.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { ExternalLink, ExternalLinkDeps } from '../../../../../common/components/external-link';

--- a/src/tests/unit/tests/common/components/new-tab-link.test.tsx
+++ b/src/tests/unit/tests/common/components/new-tab-link.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { ILinkProps } from 'office-ui-fabric-react/lib/Link';
+import { ILinkProps } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NewTabLink } from '../../../../../common/components/new-tab-link';

--- a/src/tests/unit/tests/common/components/selector-input-list.test.tsx
+++ b/src/tests/unit/tests/common/components/selector-input-list.test.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enzyme from 'enzyme';
-import { DefaultButton, IconButton } from 'office-ui-fabric-react/lib/Button';
-import { List } from 'office-ui-fabric-react/lib/List';
-import { ITextField, TextField } from 'office-ui-fabric-react/lib/TextField';
+import { DefaultButton, IconButton } from 'office-ui-fabric-react';
+import { List } from 'office-ui-fabric-react';
+import { ITextField, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/common/components/telemetry-permission-dialog.test.tsx
+++ b/src/tests/unit/tests/common/components/telemetry-permission-dialog.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enzyme from 'enzyme';
-import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
-import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
+import { PrimaryButton } from 'office-ui-fabric-react';
+import { Checkbox } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { NewTabLink } from '../../../../../common/components/new-tab-link';
 import { PrivacyStatementPopupText } from '../../../../../common/components/privacy-statement-text';

--- a/src/tests/unit/tests/common/components/visualization-toggle.test.tsx
+++ b/src/tests/unit/tests/common/components/visualization-toggle.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enzyme from 'enzyme';
-import { IToggleProps, Toggle } from 'office-ui-fabric-react/lib/Toggle';
+import { IToggleProps, Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 import { VisualizationToggle, VisualizationToggleProps } from '../../../../../common/components/visualization-toggle';

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -5,7 +5,7 @@ import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-crea
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { CommandBar, CommandBarProps } from 'electron/views/automated-checks/components/command-bar';
 import { mount, shallow } from 'enzyme';
-import { Button } from 'office-ui-fabric-react/lib/Button';
+import { Button } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { Mock, MockBehavior, Times } from 'typemoq';

--- a/src/tests/unit/tests/electron/views/automated-checks/components/maximize-restore-button.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/maximize-restore-button.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { Button } from 'office-ui-fabric-react/lib/Button';
+import { Button } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
@@ -7,7 +7,7 @@ import { MaximizeRestoreButtonProps } from 'electron/views/automated-checks/comp
 import { TitleBar, TitleBarProps } from 'electron/views/automated-checks/components/title-bar';
 import { PlatformInfo } from 'electron/window-management/platform-info';
 import { shallow } from 'enzyme';
-import { Button } from 'office-ui-fabric-react/lib/Button';
+import { Button } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-footer.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-footer.test.tsx
@@ -10,7 +10,7 @@ import {
 } from 'electron/views/device-connect-view/components/device-connect-footer';
 import { footerButtonCancel, footerButtonStart } from 'electron/views/device-connect-view/components/device-connect-footer.scss';
 import { shallow } from 'enzyme';
-import { Button } from 'office-ui-fabric-react/lib/Button';
+import { Button } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, Times } from 'typemoq';

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -11,8 +11,8 @@ import {
 } from 'electron/views/device-connect-view/components/device-connect-port-entry';
 import { portNumberField } from 'electron/views/device-connect-view/components/device-connect-port-entry.scss';
 import { shallow } from 'enzyme';
-import { Button } from 'office-ui-fabric-react/lib/Button';
-import { MaskedTextField } from 'office-ui-fabric-react/lib/TextField';
+import { Button } from 'office-ui-fabric-react';
+import { MaskedTextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/electron-external-link.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/electron-external-link.test.tsx
@@ -3,7 +3,7 @@
 import { Shell } from 'electron';
 import { ElectronExternalLink, ElectronExternalLinkProps } from 'electron/views/device-connect-view/components/electron-external-link';
 import { shallow } from 'enzyme';
-import { Button } from 'office-ui-fabric-react/lib/Button';
+import { Button } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { Mock, Times } from 'typemoq';

--- a/src/tests/unit/tests/issue-filing/components/issue-filing-option-choice-group.test.tsx
+++ b/src/tests/unit/tests/issue-filing/components/issue-filing-option-choice-group.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
+import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-settings-form.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-settings-form.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { Dropdown } from 'office-ui-fabric-react';
+import { TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { TextField } from 'office-ui-fabric-react/lib/TextField';
+import { TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
 

--- a/src/tests/unit/tests/popup/components/ad-hoc-tools-panel.test.tsx
+++ b/src/tests/unit/tests/popup/components/ad-hoc-tools-panel.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enzyme from 'enzyme';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Icon } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as TestUtils from 'react-dom/test-utils';
 import { Mock, Times } from 'typemoq';

--- a/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
+++ b/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { mount, shallow } from 'enzyme';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as TestUtils from 'react-dom/test-utils';
 import { IMock, It, Mock, Times } from 'typemoq';

--- a/src/tests/unit/tests/popup/components/header-contextual-menu.test.tsx
+++ b/src/tests/unit/tests/popup/components/header-contextual-menu.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { mount, ReactWrapper, shallow } from 'enzyme';
-import { ContextualMenu } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { ContextualMenu } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { It, Mock, Times } from 'typemoq';
 import { TelemetryEventSource } from '../../../../../common/extension-telemetry-events';

--- a/src/tests/unit/tests/popup/components/launch-pad-item-row.test.tsx
+++ b/src/tests/unit/tests/popup/components/launch-pad-item-row.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { LinkBase } from 'office-ui-fabric-react/lib/components/Link/Link.base';
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
-import { Link } from 'office-ui-fabric-react/lib/Link';
+import { LinkBase } from 'office-ui-fabric-react';
+import { Icon } from 'office-ui-fabric-react';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as TestUtils from 'react-dom/test-utils';
 import { Mock, Times } from 'typemoq';

--- a/src/tests/unit/tests/popup/components/launch-panel-header.test.tsx
+++ b/src/tests/unit/tests/popup/components/launch-panel-header.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { mount, shallow } from 'enzyme';
-import { IconButton } from 'office-ui-fabric-react/lib/Button';
+import { IconButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { It, Mock, Times } from 'typemoq';
 import { DropdownClickHandler } from '../../../../../common/dropdown-click-handler';

--- a/src/views/content/content-link.tsx
+++ b/src/views/content/content-link.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { Icon } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NewTabLink } from '../../common/components/new-tab-link';

--- a/src/views/content/content-panel-button.tsx
+++ b/src/views/content/content-panel-button.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ActionButton } from 'office-ui-fabric-react/lib/Button';
+import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { ContentActionMessageCreator } from '../../common/message-creators/content-action-message-creator';

--- a/src/views/content/content-panel.tsx
+++ b/src/views/content/content-panel.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
+import { Panel, PanelType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { ContentActionMessageCreator } from '../../common/message-creators/content-action-message-creator';


### PR DESCRIPTION
Shifted from path-based imports to module imports for all office fabric components. This has been causing problems with consuming exported packages.

For more information look here:
https://github.com/OfficeDev/office-ui-fabric-react/wiki/Advanced-Usage

#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
