### PR TITLE
feat(permissions): send telemetry for iframe + no permissions

### DIFF
--- a/src/background/actions/unified-scan-result-action-creator.ts
+++ b/src/background/actions/unified-scan-result-action-creator.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { SCAN_INCOMPLETE_WARNINGS } from 'common/extension-telemetry-events';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
-
 import { Interpreter } from '../interpreter';
 import { UnifiedScanCompletedPayload } from './action-payloads';
 import { UnifiedScanResultActions } from './unified-scan-result-actions';
@@ -11,6 +12,7 @@ export class UnifiedScanResultActionCreator {
     constructor(
         private readonly interpreter: Interpreter,
         private readonly unifiedScanResultActions: UnifiedScanResultActions,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
     ) {}
 
     public registerCallbacks(): void {
@@ -26,6 +28,7 @@ export class UnifiedScanResultActionCreator {
 
     private onScanCompleted = (payload: UnifiedScanCompletedPayload): void => {
         this.unifiedScanResultActions.scanCompleted.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(SCAN_INCOMPLETE_WARNINGS, payload);
     };
 
     private onGetScanCurrentState = (): void => {

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -117,6 +117,7 @@ export class TabContextFactory {
         const scanResultActionCreator = new UnifiedScanResultActionCreator(
             interpreter,
             actionsHub.scanResultActions,
+            this.telemetryEventHandler,
         );
         const scopingPanelActionCreator = new ScopingPanelActionCreator(
             interpreter,

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
 import { SingleElementSelector } from './types/store-data/scoping-store-data';
 
 export const POPUP_INITIALIZED: string = 'PopupInitialized';
@@ -200,6 +201,8 @@ export type AndroidScanFailedTelemetryData = {
     scanDuration: number;
 };
 
+export type ScanIncompleteWarningsTelemetryData = Pick<UnifiedScanCompletedPayload, 'scanIncompleteWarnings'>;
+
 export type TelemetryData =
     | BaseTelemetryData
     | ToggleTelemetryData
@@ -222,4 +225,5 @@ export type TelemetryData =
     | RequirementStatusTelemetryData
     | ValidatePortTelemetryData
     | AndroidScanCompletedTelemetryData
-    | AndroidScanFailedTelemetryData;
+    | AndroidScanFailedTelemetryData
+    | ScanIncompleteWarningsTelemetryData;

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -62,6 +62,7 @@ export const ALL_RULES_EXPANDED: string = 'allRulesExpanded';
 export const ALL_RULES_COLLAPSED: string = 'allRulesCollapsed';
 export const RESCAN_VISUALIZATION: string = 'rescanVisualization';
 export const EXISTING_TAB_URL_UPDATED: string = 'existingTabUrlUpdated';
+export const SCAN_INCOMPLETE_WARNINGS: string = 'scanIncompleteWarnings';
 
 export const TriggeredByNotApplicable: TriggeredBy = 'N/A';
 export type TriggeredBy = 'mouseclick' | 'keypress' | 'shortcut' | 'N/A';

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -9,8 +9,7 @@ import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
-import { IMock, It, Mock, Times } from 'typemoq';
-
+import { IMock, Mock, Times } from 'typemoq';
 import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('UnifiedScanResultActionCreator', () => {

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -3,32 +3,51 @@
 import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
 import { UnifiedScanResultActionCreator } from 'background/actions/unified-scan-result-action-creator';
 import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { SCAN_INCOMPLETE_WARNINGS, ScanIncompleteWarningsTelemetryData } from 'common/extension-telemetry-events';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
-import { IMock, Mock } from 'typemoq';
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
+import { IMock, It, Mock, Times } from 'typemoq';
 
-import { ToolData } from '../../../../../common/types/store-data/unified-data-interface';
 import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('UnifiedScanResultActionCreator', () => {
+    let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+
+    beforeEach(() => {
+        telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+    });
+
     it('should handle ScanCompleted message', () => {
+        const scanIncompleteWarnings = ['test-warning-id' as ScanIncompleteWarningId];
+        const telemetry = {
+            scanIncompleteWarnings,
+        } as ScanIncompleteWarningsTelemetryData;
         const payload: UnifiedScanCompletedPayload = {
             scanResult: [],
             rules: [],
             toolInfo: {} as ToolData,
             targetAppInfo: { name: 'app name' },
-            scanIncompleteWarnings: [],
+            scanIncompleteWarnings,
+            telemetry,
         };
 
         const scanCompletedMock = createActionMock(payload);
         const actionsMock = createActionsMock('scanCompleted', scanCompletedMock.object);
         const interpreterMock = createInterpreterMock(Messages.UnifiedScan.ScanCompleted, payload);
 
-        const testSubject = new UnifiedScanResultActionCreator(interpreterMock.object, actionsMock.object);
+        const testSubject = new UnifiedScanResultActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         scanCompletedMock.verifyAll();
+        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(SCAN_INCOMPLETE_WARNINGS, payload), Times.once());
     });
 
     it('should handle GetState message', () => {
@@ -38,7 +57,11 @@ describe('UnifiedScanResultActionCreator', () => {
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
         const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.UnifiedScanResultStore), payload);
 
-        const testSubject = new UnifiedScanResultActionCreator(interpreterMock.object, actionsMock.object);
+        const testSubject = new UnifiedScanResultActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 

--- a/src/tests/unit/tests/injected/analyzers/unified-result-sender.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/unified-result-sender.test.ts
@@ -1,18 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads';
+import { EnvironmentInfoProvider } from 'common/environment-info-provider';
+import { Message } from 'common/message';
+import { Messages } from 'common/messages';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import { ToolData, UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
+import { ConvertScanResultsToUnifiedResultsDelegate } from 'injected/adapters/scan-results-to-unified-results';
+import { ConvertScanResultsToUnifiedRulesDelegate } from 'injected/adapters/scan-results-to-unified-rules';
+import { MessageDelegate } from 'injected/analyzers/rule-analyzer';
+import { UnifiedResultSender } from 'injected/analyzers/unified-result-sender';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
+import { ScanResults } from 'scanner/iruleresults';
 import { IMock, Mock, Times } from 'typemoq';
-import { UnifiedScanCompletedPayload } from '../../../../../background/actions/action-payloads';
-import { EnvironmentInfoProvider } from '../../../../../common/environment-info-provider';
-import { Message } from '../../../../../common/message';
-import { Messages } from '../../../../../common/messages';
-import { ToolData, UnifiedResult, UnifiedRule } from '../../../../../common/types/store-data/unified-data-interface';
-import { ConvertScanResultsToUnifiedResultsDelegate } from '../../../../../injected/adapters/scan-results-to-unified-results';
-import { ConvertScanResultsToUnifiedRulesDelegate } from '../../../../../injected/adapters/scan-results-to-unified-rules';
-import { MessageDelegate } from '../../../../../injected/analyzers/rule-analyzer';
-import { UnifiedResultSender } from '../../../../../injected/analyzers/unified-result-sender';
-import { ScanResults } from '../../../../../scanner/iruleresults';
 
 describe('sendConvertedResults', () => {
     it('should send a message with expected results', () => {
@@ -70,6 +70,9 @@ describe('sendConvertedResults', () => {
                 url: 'url',
             },
             scanIncompleteWarnings: stubScanIncompleteWarnings,
+            telemetry: {
+                scanIncompleteWarnings: stubScanIncompleteWarnings,
+            },
         };
         const expectedMessage: Message = {
             messageType: Messages.UnifiedScan.ScanCompleted,

--- a/src/tests/unit/tests/injected/analyzers/unified-result-sender.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/unified-result-sender.test.ts
@@ -4,44 +4,49 @@ import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads'
 import { EnvironmentInfoProvider } from 'common/environment-info-provider';
 import { Message } from 'common/message';
 import { Messages } from 'common/messages';
-import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { ToolData, UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
 import { ConvertScanResultsToUnifiedResultsDelegate } from 'injected/adapters/scan-results-to-unified-results';
 import { ConvertScanResultsToUnifiedRulesDelegate } from 'injected/adapters/scan-results-to-unified-rules';
 import { MessageDelegate } from 'injected/analyzers/rule-analyzer';
 import { UnifiedResultSender } from 'injected/analyzers/unified-result-sender';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
-import { ScanResults } from 'scanner/iruleresults';
 import { IMock, Mock, Times } from 'typemoq';
 
 describe('sendConvertedResults', () => {
-    it('should send a message with expected results', () => {
-        const axeInputResults = {
-            targetPageTitle: 'title',
-            targetPageUrl: 'url',
-        } as any;
-        const unifiedResults: UnifiedResult[] = [];
-        const unifiedRules: UnifiedRule[] = [];
-        const toolInfo = {} as ToolData;
+    const axeInputResults = {
+        targetPageTitle: 'title',
+        targetPageUrl: 'url',
+    } as any;
+    const unifiedResults: UnifiedResult[] = [];
+    const unifiedRules: UnifiedRule[] = [];
+    const toolInfo = {} as ToolData;
 
-        const uuidGeneratorStub = () => null;
+    const uuidGeneratorStub = () => null;
+    const testScanIncompleteWarningId = 'test-scan-incomplete-warning';
 
-        const sendDelegate: IMock<MessageDelegate> = Mock.ofInstance(message => null);
-        const convertToUnifiedMock: IMock<ConvertScanResultsToUnifiedResultsDelegate> = Mock.ofInstance(
-            (scanResults, uuidGenerator) => null,
-        );
-        const convertToUnifiedRulesMock: IMock<ConvertScanResultsToUnifiedRulesDelegate> = Mock.ofInstance(
-            (scanResults: ScanResults) => null,
-        );
-        const environmentInfoProviderMock: IMock<EnvironmentInfoProvider> = Mock.ofType(EnvironmentInfoProvider);
+    let sendDelegate: IMock<MessageDelegate>;
+    let convertToUnifiedMock: IMock<ConvertScanResultsToUnifiedResultsDelegate>;
+    let convertToUnifiedRulesMock: IMock<ConvertScanResultsToUnifiedRulesDelegate>;
+    let environmentInfoProviderMock: IMock<EnvironmentInfoProvider>;
+    let scanIncompleteWarningDetectorMock: IMock<ScanIncompleteWarningDetector>;
 
+    beforeEach(() => {
+        sendDelegate = Mock.ofType<MessageDelegate>();
+        convertToUnifiedMock = Mock.ofType<ConvertScanResultsToUnifiedResultsDelegate>();
+        convertToUnifiedRulesMock = Mock.ofType<ConvertScanResultsToUnifiedRulesDelegate>();
+        environmentInfoProviderMock = Mock.ofType<EnvironmentInfoProvider>();
+        scanIncompleteWarningDetectorMock = Mock.ofType<ScanIncompleteWarningDetector>();
+    });
+
+    it.each`
+        warnings                         | telemetry
+        ${[testScanIncompleteWarningId]} | ${{ scanIncompleteWarnings: [testScanIncompleteWarningId] }}
+        ${[]}                            | ${null}
+    `('it send results with warnings: $warnings and telemetry: $telemetry', ({ warnings, telemetry }) => {
         convertToUnifiedMock.setup(m => m(axeInputResults, uuidGeneratorStub)).returns(val => unifiedResults);
         convertToUnifiedRulesMock.setup(m => m(axeInputResults)).returns(val => unifiedRules);
         environmentInfoProviderMock.setup(provider => provider.getToolData()).returns(() => toolInfo);
-
-        const stubScanIncompleteWarnings = ['test-scan-incomplete-warning' as ScanIncompleteWarningId];
-        const scanIncompleteWarningDetectorMock = Mock.ofType<ScanIncompleteWarningDetector>();
-        scanIncompleteWarningDetectorMock.setup(m => m.detectScanIncompleteWarnings()).returns(() => stubScanIncompleteWarnings);
+        scanIncompleteWarningDetectorMock.setup(m => m.detectScanIncompleteWarnings()).returns(() => warnings);
 
         const testSubject = new UnifiedResultSender(
             sendDelegate.object,
@@ -69,11 +74,10 @@ describe('sendConvertedResults', () => {
                 name: 'title',
                 url: 'url',
             },
-            scanIncompleteWarnings: stubScanIncompleteWarnings,
-            telemetry: {
-                scanIncompleteWarnings: stubScanIncompleteWarnings,
-            },
+            scanIncompleteWarnings: warnings,
+            telemetry,
         };
+
         const expectedMessage: Message = {
             messageType: Messages.UnifiedScan.ScanCompleted,
             payload: expectedPayload,


### PR DESCRIPTION
#### Description of changes

Sending new telemetry event when we detect there are iframes in the target page and the extension has no all-origin permissions.

Decided to send the telemetry event as part of the scan complete message on the unified result side.

Still debating if sending the whole `'scanIncompleteWarnings'` array make sense or if we need to convert it or even discard it. Sending the warnings array (which is easier I think) coverts the scenario of having more than one type of warning while scanning, so if we add a new one, we don't need to change the telemetry part.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: completes WI # 1655390
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
