### PR TITLE
feat(permissions): created different scan incomplete messages for assessment/fastpass

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -191,7 +191,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
-    public startOverTest(event: React.MouseEvent<any>, test: VisualizationType): void {
+    public startOverTest(event: SupportedMouseEvent, test: VisualizationType): void {
         const telemetry = this.telemetryFactory.forAssessmentActionFromDetailsView(test, event);
         const payload: ToggleActionPayload = {
             test,

--- a/src/DetailsView/components/iframe-warning.tsx
+++ b/src/DetailsView/components/iframe-warning.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NewTabLink } from 'common/components/new-tab-link';
 import { NamedFC } from 'common/react/named-fc';
 import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -16,7 +17,7 @@ export const IframeWarning = NamedFC<IframeWarningProps>('IframeWarning', props 
     <>
         There are iframes in the target page. To have complete results,{' '}
         <Link onClick={props.onAllowPermissionsClick}>give Accessibility Insights additional permissions</Link>; this will trigger a re-scan{' '}
-        of the test. <Link onClick={console.log}>Learn more here.</Link>
+        of the test. <NewTabLink href={'https://accessibilityinsights.io/docs/en/faq'}>Learn more here.</NewTabLink>
     </>
 ));
 

--- a/src/DetailsView/components/iframe-warning.tsx
+++ b/src/DetailsView/components/iframe-warning.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { SupportedMouseEvent } from 'common/telemetry-data-factory';
+import { VisualizationType } from 'common/types/visualization-type';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { AllUrlsPermissionHandler } from 'DetailsView/handlers/allurls-permission-handler';
+import { Link } from 'office-ui-fabric-react';
+import * as React from 'react';
+
+export type IframeWarningProps = {
+    onAllowPermissionsClick: (e: SupportedMouseEvent) => Promise<void>;
+};
+
+export const IframeWarning = NamedFC<IframeWarningProps>('IframeWarning', props => (
+    <>
+        There are iframes in the target page. To have complete results,{' '}
+        <Link onClick={props.onAllowPermissionsClick}>give Accessibility Insights additional permissions</Link>; this will trigger a re-scan{' '}
+        of the test. <Link onClick={console.log}>Learn more here.</Link>
+    </>
+));
+
+export type AssessmentIframeWarningDeps = {
+    allUrlsPermissionHandler: AllUrlsPermissionHandler;
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+};
+
+export type AssessmentIframeWarningProps = {
+    deps: AssessmentIframeWarningDeps;
+    test: VisualizationType;
+};
+
+export const AssessmentIframeWarning = NamedFC<AssessmentIframeWarningProps>('AssessmentIframeWarning', props => {
+    const { deps, test } = props;
+
+    const onAllowPermissionsClick = async (event: SupportedMouseEvent) => {
+        const rescanTest = () => {
+            deps.detailsViewActionMessageCreator.startOverTest(event, test);
+        };
+
+        await deps.allUrlsPermissionHandler.requestAllUrlsPermission(event, rescanTest);
+    };
+
+    return <IframeWarning onAllowPermissionsClick={onAllowPermissionsClick} />;
+});
+
+export type FastPassIframeWarningDeps = {
+    allUrlsPermissionHandler: AllUrlsPermissionHandler;
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+};
+
+export type FastPassIframeWarningProps = {
+    deps: FastPassIframeWarningDeps;
+    test: VisualizationType;
+};
+
+export const FastPassIframeWarning = NamedFC<FastPassIframeWarningProps>('FastPassIframeWarning', props => {
+    const { deps, test } = props;
+
+    const onAllowPermissionsClick = async (event: SupportedMouseEvent) => {
+        const rescanTest = () => {
+            deps.detailsViewActionMessageCreator.rescanVisualization(test, event);
+        };
+
+        await deps.allUrlsPermissionHandler.requestAllUrlsPermission(event, rescanTest);
+    };
+
+    return <IframeWarning onAllowPermissionsClick={onAllowPermissionsClick} />;
+});

--- a/src/DetailsView/components/scan-incomplete-warning.tsx
+++ b/src/DetailsView/components/scan-incomplete-warning.tsx
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import { VisualizationType } from 'common/types/visualization-type';
+import { ScanIncompleteWarningMessageBarDeps, WarningConfiguration } from 'DetailsView/components/warning-configuration';
 import { forOwn, isEmpty } from 'lodash';
 import { MessageBar, MessageBarType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
-export type ScanIncompleteWarningProps = {
-    warnings: ScanIncompleteWarningId[];
-};
+export type ScanIncompleteWarningDeps = ScanIncompleteWarningMessageBarDeps;
 
-const warningToMessage: { [key in ScanIncompleteWarningId]: (props: ScanIncompleteWarningProps) => JSX.Element } = {
-    'missing-required-cross-origin-permissions': () => (
-        <>We have detected iframes in the target page. To have complete results, please give us permissions. Learn more here.</>
-    ),
+export type ScanIncompleteWarningProps = {
+    deps: ScanIncompleteWarningDeps;
+    warnings: ScanIncompleteWarningId[];
+    warningConfiguration: WarningConfiguration;
+    test: VisualizationType;
 };
 
 export class ScanIncompleteWarning extends React.PureComponent<ScanIncompleteWarningProps> {
@@ -22,7 +23,7 @@ export class ScanIncompleteWarning extends React.PureComponent<ScanIncompleteWar
         }
 
         const messages = [];
-        forOwn(warningToMessage, (render, warningId: ScanIncompleteWarningId) => {
+        forOwn(this.props.warningConfiguration, (render, warningId: ScanIncompleteWarningId) => {
             if (!this.props.warnings.includes(warningId)) {
                 return;
             }

--- a/src/DetailsView/components/warning-configuration.tsx
+++ b/src/DetailsView/components/warning-configuration.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ReactFCWithDisplayName } from 'common/react/named-fc';
+import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
+import {
+    AssessmentIframeWarning,
+    AssessmentIframeWarningDeps,
+    AssessmentIframeWarningProps,
+    FastPassIframeWarning,
+    FastPassIframeWarningDeps,
+    FastPassIframeWarningProps,
+} from 'DetailsView/components/iframe-warning';
+import * as React from 'react';
+
+export type ScanIncompleteWarningMessageBarProps = FastPassIframeWarningProps | AssessmentIframeWarningProps;
+export type ScanIncompleteWarningMessageBarDeps = FastPassIframeWarningDeps | AssessmentIframeWarningDeps;
+
+export type WarningConfiguration = { [key in ScanIncompleteWarningId]: ReactFCWithDisplayName<ScanIncompleteWarningMessageBarProps> };
+
+export const assessmentWarningConfiguration: WarningConfiguration = {
+    'missing-required-cross-origin-permissions': AssessmentIframeWarning,
+};
+
+export const fastpassWarningConfiguration: WarningConfiguration = {
+    'missing-required-cross-origin-permissions': FastPassIframeWarning,
+};

--- a/src/DetailsView/components/warning-configuration.tsx
+++ b/src/DetailsView/components/warning-configuration.tsx
@@ -10,7 +10,6 @@ import {
     FastPassIframeWarningDeps,
     FastPassIframeWarningProps,
 } from 'DetailsView/components/iframe-warning';
-import * as React from 'react';
 
 export type ScanIncompleteWarningMessageBarProps = FastPassIframeWarningProps | AssessmentIframeWarningProps;
 export type ScanIncompleteWarningMessageBarDeps = FastPassIframeWarningDeps | AssessmentIframeWarningDeps;

--- a/src/DetailsView/handlers/allurls-permission-handler.ts
+++ b/src/DetailsView/handlers/allurls-permission-handler.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { allUrlAndFilePermissions } from 'background/browser-permissions-tracker';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
-
-export const allUrlAndFilePermissions = { origins: ['*://*/*'] };
 
 export class AllUrlsPermissionHandler {
     constructor(

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/iframe-warning.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/iframe-warning.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AssessmentIframeWarning render 1`] = `
+<IframeWarning
+  onAllowPermissionsClick={[Function]}
+/>
+`;
+
+exports[`FastPassIframeWarning render 1`] = `
+<IframeWarning
+  onAllowPermissionsClick={[Function]}
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/iframe-warning.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/iframe-warning.test.tsx.snap
@@ -11,3 +11,23 @@ exports[`FastPassIframeWarning render 1`] = `
   onAllowPermissionsClick={[Function]}
 />
 `;
+
+exports[`IframeWarning render 1`] = `
+<React.Fragment>
+  There are iframes in the target page. To have complete results,
+   
+  <StyledLinkBase
+    onClick={[Function]}
+  >
+    give Accessibility Insights additional permissions
+  </StyledLinkBase>
+  ; this will trigger a re-scan
+   
+  of the test. 
+  <NewTabLink
+    href="https://accessibilityinsights.io/docs/en/faq"
+  >
+    Learn more here.
+  </NewTabLink>
+</React.Fragment>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/scan-incomplete-warning.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/scan-incomplete-warning.test.tsx.snap
@@ -6,11 +6,7 @@ exports[`ScanIncompleteWarning rendered: where warnings were provided 1`] = `
 <React.Fragment>
   <StyledMessageBarBase
     messageBarType={5}
-  >
-    <React.Fragment>
-      We have detected iframes in the target page. To have complete results, please give us permissions. Learn more here.
-    </React.Fragment>
-  </StyledMessageBarBase>
+  />
 </React.Fragment>
 `;
 
@@ -18,10 +14,6 @@ exports[`ScanIncompleteWarning rendered: where warnings were provided, with one 
 <React.Fragment>
   <StyledMessageBarBase
     messageBarType={5}
-  >
-    <React.Fragment>
-      We have detected iframes in the target page. To have complete results, please give us permissions. Learn more here.
-    </React.Fragment>
-  </StyledMessageBarBase>
+  />
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/DetailsView/components/iframe-warning.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/iframe-warning.test.tsx
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { SupportedMouseEvent } from 'common/telemetry-data-factory';
+import { VisualizationType } from 'common/types/visualization-type';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import {
+    AssessmentIframeWarning,
+    AssessmentIframeWarningDeps,
+    AssessmentIframeWarningProps,
+    FastPassIframeWarning,
+    FastPassIframeWarningDeps,
+    FastPassIframeWarningProps,
+    IframeWarning,
+} from 'DetailsView/components/iframe-warning';
+import { AllUrlsPermissionHandler } from 'DetailsView/handlers/allurls-permission-handler';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+describe('AssessmentIframeWarning', () => {
+    let allUrlsPermissionHandlerMock: IMock<AllUrlsPermissionHandler>;
+    let detailsViewActionCreatorMock: IMock<DetailsViewActionMessageCreator>;
+    let testStub: VisualizationType;
+    let props: AssessmentIframeWarningProps;
+
+    beforeEach(() => {
+        allUrlsPermissionHandlerMock = Mock.ofType<AllUrlsPermissionHandler>();
+        detailsViewActionCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
+        testStub = -1;
+        props = {
+            deps: {
+                allUrlsPermissionHandler: allUrlsPermissionHandlerMock.object,
+                detailsViewActionMessageCreator: detailsViewActionCreatorMock.object,
+            } as AssessmentIframeWarningDeps,
+            test: testStub,
+        };
+    });
+
+    test('render', async () => {
+        const wrapper = shallow(<AssessmentIframeWarning {...props} />);
+        const eventStub = {} as SupportedMouseEvent;
+        const onAllowPermissionsClick = wrapper.find(IframeWarning).prop('onAllowPermissionsClick');
+
+        allUrlsPermissionHandlerMock
+            .setup(m => m.requestAllUrlsPermission(eventStub, It.isAny()))
+            .callback((_, successCallback) => {
+                successCallback();
+            });
+
+        await onAllowPermissionsClick(eventStub);
+
+        detailsViewActionCreatorMock.verify(m => m.startOverTest(eventStub, testStub), Times.once());
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});
+
+describe('FastPassIframeWarning', () => {
+    let allUrlsPermissionHandlerMock: IMock<AllUrlsPermissionHandler>;
+    let detailsViewActionCreatorMock: IMock<DetailsViewActionMessageCreator>;
+    let testStub: VisualizationType;
+    let props: FastPassIframeWarningProps;
+
+    beforeEach(() => {
+        allUrlsPermissionHandlerMock = Mock.ofType<AllUrlsPermissionHandler>();
+        detailsViewActionCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
+        testStub = -1;
+        props = {
+            deps: {
+                allUrlsPermissionHandler: allUrlsPermissionHandlerMock.object,
+                detailsViewActionMessageCreator: detailsViewActionCreatorMock.object,
+            } as FastPassIframeWarningDeps,
+            test: testStub,
+        };
+    });
+
+    test('render', async () => {
+        const wrapper = shallow(<FastPassIframeWarning {...props} />);
+        const eventStub = {} as SupportedMouseEvent;
+        const onAllowPermissionsClick = wrapper.find(IframeWarning).prop('onAllowPermissionsClick');
+
+        allUrlsPermissionHandlerMock
+            .setup(m => m.requestAllUrlsPermission(eventStub, It.isAny()))
+            .callback((_, successCallback) => {
+                successCallback();
+            });
+
+        await onAllowPermissionsClick(eventStub);
+
+        detailsViewActionCreatorMock.verify(m => m.rescanVisualization(testStub, eventStub), Times.once());
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/iframe-warning.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/iframe-warning.test.tsx
@@ -14,8 +14,24 @@ import {
 } from 'DetailsView/components/iframe-warning';
 import { AllUrlsPermissionHandler } from 'DetailsView/handlers/allurls-permission-handler';
 import { shallow } from 'enzyme';
+import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, It, Mock, Times } from 'typemoq';
+
+describe('IframeWarning', () => {
+    test('render', () => {
+        const onAllowPermissionsClickMock = Mock.ofInstance((e: SupportedMouseEvent): Promise<void> => null);
+        const eventStub = {} as any;
+
+        const wrapper = shallow(<IframeWarning onAllowPermissionsClick={onAllowPermissionsClickMock.object} />);
+        const onAllowPermissionsClick = wrapper.find(Link).prop('onClick');
+
+        onAllowPermissionsClick(eventStub);
+
+        onAllowPermissionsClickMock.verify(m => m(eventStub), Times.once());
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});
 
 describe('AssessmentIframeWarning', () => {
     let allUrlsPermissionHandlerMock: IMock<AllUrlsPermissionHandler>;

--- a/src/tests/unit/tests/DetailsView/components/scan-incomplete-warning.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/scan-incomplete-warning.test.tsx
@@ -1,15 +1,38 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
-import { ScanIncompleteWarning, ScanIncompleteWarningProps } from 'DetailsView/components/scan-incomplete-warning';
+import { VisualizationType } from 'common/types/visualization-type';
+import {
+    ScanIncompleteWarning,
+    ScanIncompleteWarningDeps,
+    ScanIncompleteWarningProps,
+} from 'DetailsView/components/scan-incomplete-warning';
+import { ScanIncompleteWarningMessageBarProps, WarningConfiguration } from 'DetailsView/components/warning-configuration';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('ScanIncompleteWarning', () => {
-    beforeEach(() => {});
+    let warningConfiguration: WarningConfiguration;
+    let testStub: VisualizationType;
+
+    beforeEach(() => {
+        testStub = -1;
+
+        const scanIncompleteWarningStub: ReactFCWithDisplayName<ScanIncompleteWarningMessageBarProps> = NamedFC<
+            ScanIncompleteWarningMessageBarProps
+        >('test', _ => null);
+        warningConfiguration = {
+            'missing-required-cross-origin-permissions': scanIncompleteWarningStub,
+        };
+    });
+
     test(`notRendered: where no warnings were provided`, () => {
         const componentProps: ScanIncompleteWarningProps = {
             warnings: [],
+            warningConfiguration,
+            test: testStub,
+            deps: {} as ScanIncompleteWarningDeps,
         };
 
         const testSubject = shallow(<ScanIncompleteWarning {...componentProps} />);
@@ -20,6 +43,9 @@ describe('ScanIncompleteWarning', () => {
     test(`rendered: where warnings were provided`, () => {
         const componentProps: ScanIncompleteWarningProps = {
             warnings: ['missing-required-cross-origin-permissions', 'missing-required-cross-origin-permissions'],
+            warningConfiguration,
+            test: testStub,
+            deps: {} as ScanIncompleteWarningDeps,
         };
 
         const testSubject = shallow(<ScanIncompleteWarning {...componentProps} />);
@@ -29,6 +55,9 @@ describe('ScanIncompleteWarning', () => {
     test(`rendered: where warnings were provided, with one warning not supported`, () => {
         const componentProps: ScanIncompleteWarningProps = {
             warnings: ['missing-required-cross-origin-permissions', 'not a real warning' as ScanIncompleteWarningId],
+            warningConfiguration,
+            test: testStub,
+            deps: {} as ScanIncompleteWarningDeps,
         };
 
         const testSubject = shallow(<ScanIncompleteWarning {...componentProps} />);

--- a/src/tests/unit/tests/DetailsView/handlers/allurls-permission-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/handlers/allurls-permission-handler.test.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { allUrlAndFilePermissions } from 'background/browser-permissions-tracker';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
-import { allUrlAndFilePermissions, AllUrlsPermissionHandler } from 'DetailsView/handlers/allurls-permission-handler';
+import { AllUrlsPermissionHandler } from 'DetailsView/handlers/allurls-permission-handler';
 import { SyntheticEvent } from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 


### PR DESCRIPTION
#### Description of changes

This creates different warning configurations for assessment and fastpass (to be used by switcher nav in the future). The different warning configurations can specify what is shown in the message bar per the different views (necessary for different behavior between the two views).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
