### PR TITLE
fix: gear button's top margin

### DIFF
--- a/src/common/components/gear-options-button-component.scss
+++ b/src/common/components/gear-options-button-component.scss
@@ -24,7 +24,7 @@
 :global(#popup-container) .gear-options-button-component {
     display: inline-block;
 
-    button.gear-button {
+    button:global(.gear-button) {
         margin-right: 5px;
         margin-top: 10px;
     }


### PR DESCRIPTION
#### Description of changes

The gear-button class name is not being modified by css modules and hence needs the global qualifier.

![image](https://user-images.githubusercontent.com/32555133/71217026-3be91000-2271-11ea-986d-e898c9105627.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
