### PR TITLE
refactor: promisify tabs query

### DIFF
--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -160,7 +160,7 @@ async function initialize(): Promise<void> {
         logger,
     );
 
-    const clientHandler = new TargetPageController(
+    const targetPageController = new TargetPageController(
         tabToContextMap,
         messageBroadcasterFactory,
         browserAdapter,
@@ -169,7 +169,7 @@ async function initialize(): Promise<void> {
         logger,
     );
 
-    clientHandler.initialize();
+    await targetPageController.initialize();
 
     const devToolsBackgroundListener = new DevToolsListener(tabToContextMap, browserAdapter);
     devToolsBackgroundListener.initialize();

--- a/src/background/browser-message-broadcaster-factory.ts
+++ b/src/background/browser-message-broadcaster-factory.ts
@@ -14,9 +14,7 @@ export class BrowserMessageBroadcasterFactory {
         // condition described by #1816
         await this.sendMessageToFrames(message);
 
-        const allTabs: chrome.tabs.Tab[] = await new Promise(resolve => {
-            this.browserAdapter.tabsQuery({}, resolve);
-        });
+        const allTabs = await this.browserAdapter.tabsQueryP({});
 
         await Promise.all(allTabs.map(tab => this.sendMessageToTab(tab.id, message)));
     };

--- a/src/background/browser-message-broadcaster-factory.ts
+++ b/src/background/browser-message-broadcaster-factory.ts
@@ -14,7 +14,7 @@ export class BrowserMessageBroadcasterFactory {
         // condition described by #1816
         await this.sendMessageToFrames(message);
 
-        const allTabs = await this.browserAdapter.tabsQueryP({});
+        const allTabs = await this.browserAdapter.tabsQuery({});
 
         await Promise.all(allTabs.map(tab => this.sendMessageToTab(tab.id, message)));
     };

--- a/src/background/chrome-command-handler.ts
+++ b/src/background/chrome-command-handler.ts
@@ -104,7 +104,7 @@ export class ChromeCommandHandler {
 
     private async queryCurrentActiveTab(): Promise<Tabs.Tab> {
         const tabQueryParams: chrome.tabs.QueryInfo = { active: true, currentWindow: true };
-        const currentActiveTabs = await this.browserAdapter.tabsQueryP(tabQueryParams);
+        const currentActiveTabs = await this.browserAdapter.tabsQuery(tabQueryParams);
 
         if (currentActiveTabs && currentActiveTabs[0]) {
             return currentActiveTabs[0];

--- a/src/background/chrome-command-handler.ts
+++ b/src/background/chrome-command-handler.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Tabs } from 'webextension-polyfill-ts';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { CommandsAdapter } from '../common/browser-adapters/commands-adapter';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
@@ -101,13 +102,9 @@ export class ChromeCommandHandler {
         return await this.urlValidator.isSupportedUrl(this.targetTabUrl);
     }
 
-    private queryTabs(tabQueryParams: chrome.tabs.QueryInfo): Promise<chrome.tabs.Tab[]> {
-        return new Promise(resolve => this.browserAdapter.tabsQuery(tabQueryParams, resolve));
-    }
-
-    private async queryCurrentActiveTab(): Promise<chrome.tabs.Tab> {
+    private async queryCurrentActiveTab(): Promise<Tabs.Tab> {
         const tabQueryParams: chrome.tabs.QueryInfo = { active: true, currentWindow: true };
-        const currentActiveTabs = await this.queryTabs(tabQueryParams);
+        const currentActiveTabs = await this.browserAdapter.tabsQueryP(tabQueryParams);
 
         if (currentActiveTabs && currentActiveTabs[0]) {
             return currentActiveTabs[0];

--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -22,7 +22,7 @@ export class TargetPageController {
     ) {}
 
     public async initialize(): Promise<void> {
-        const tabs = await this.browserAdapter.tabsQueryP({});
+        const tabs = await this.browserAdapter.tabsQuery({});
         if (tabs) {
             tabs.forEach(tab => {
                 this.handleTabUrlUpdate(tab.id);
@@ -66,7 +66,7 @@ export class TargetPageController {
 
         this.sendTabVisibilityChangeAction(activeTabId, false);
 
-        const tabs = await this.browserAdapter.tabsQueryP({ windowId });
+        const tabs = await this.browserAdapter.tabsQuery({ windowId });
         tabs.forEach(tab => {
             if (!tab.active) {
                 this.sendTabVisibilityChangeAction(tab.id, true);
@@ -81,7 +81,7 @@ export class TargetPageController {
         });
 
         chromeWindows.forEach(async chromeWindow => {
-            const activeTabs = await this.browserAdapter.tabsQueryP({
+            const activeTabs = await this.browserAdapter.tabsQuery({
                 active: true,
                 windowId: chromeWindow.id,
             });

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -10,7 +10,6 @@ export interface BrowserAdapter {
     addListenerToWebNavigationUpdated(callback: (details: chrome.webNavigation.WebNavigationFramedCallbackDetails) => void): void;
     addListenerOnWindowsFocusChanged(callback: (windowId: number) => void): void;
     tabsQueryP(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]>;
-    tabsQuery(query: chrome.tabs.QueryInfo, callback: (result: chrome.tabs.Tab[]) => void): void;
     createActiveTab(url: string): Promise<Tabs.Tab>;
     createTabInNewWindow(url: string): Promise<Tabs.Tab>;
     switchToTab(tabId: number): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -9,6 +9,7 @@ export interface BrowserAdapter {
     addListenerToTabsOnRemoved(callback: (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo) => void): void;
     addListenerToWebNavigationUpdated(callback: (details: chrome.webNavigation.WebNavigationFramedCallbackDetails) => void): void;
     addListenerOnWindowsFocusChanged(callback: (windowId: number) => void): void;
+    tabsQueryP(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]>;
     tabsQuery(query: chrome.tabs.QueryInfo, callback: (result: chrome.tabs.Tab[]) => void): void;
     createActiveTab(url: string): Promise<Tabs.Tab>;
     createTabInNewWindow(url: string): Promise<Tabs.Tab>;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -9,7 +9,7 @@ export interface BrowserAdapter {
     addListenerToTabsOnRemoved(callback: (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo) => void): void;
     addListenerToWebNavigationUpdated(callback: (details: chrome.webNavigation.WebNavigationFramedCallbackDetails) => void): void;
     addListenerOnWindowsFocusChanged(callback: (windowId: number) => void): void;
-    tabsQueryP(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]>;
+    tabsQuery(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]>;
     createActiveTab(url: string): Promise<Tabs.Tab>;
     createTabInNewWindow(url: string): Promise<Tabs.Tab>;
     switchToTab(tabId: number): void;

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -45,10 +45,6 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return browser.tabs.query(query);
     }
 
-    public tabsQuery(query: chrome.tabs.QueryInfo, callback: (result: chrome.tabs.Tab[]) => void): void {
-        chrome.tabs.query(query, callback);
-    }
-
     public getTab(tabId: number, onResolve: (tab: chrome.tabs.Tab) => void, onReject?: () => void): void {
         chrome.tabs.get(tabId, tab => {
             if (tab) {

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -40,6 +40,11 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
     public getRunTimeId(): string {
         return chrome.runtime.id;
     }
+
+    public tabsQueryP(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]> {
+        return browser.tabs.query(query);
+    }
+
     public tabsQuery(query: chrome.tabs.QueryInfo, callback: (result: chrome.tabs.Tab[]) => void): void {
         chrome.tabs.query(query, callback);
     }

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -41,7 +41,7 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return chrome.runtime.id;
     }
 
-    public tabsQueryP(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]> {
+    public tabsQuery(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]> {
         return browser.tabs.query(query);
     }
 

--- a/src/popup/target-tab-finder.ts
+++ b/src/popup/target-tab-finder.ts
@@ -24,20 +24,14 @@ export class TargetTabFinder {
     }
 
     private getTabInfo = (): Promise<Tab> => {
-        return new Promise((resolve, reject) => {
-            const tabIdInUrl = this.urlParser.getIntParam(this.win.location.href, 'tabId');
+        const tabIdInUrl = this.urlParser.getIntParam(this.win.location.href, 'tabId');
 
-            if (isNaN(tabIdInUrl)) {
-                this.browserAdapter.tabsQuery(
-                    {
-                        active: true,
-                        currentWindow: true,
-                    },
-                    (tabs: Tab[]): void => {
-                        resolve(tabs.pop());
-                    },
-                );
-            } else {
+        if (isNaN(tabIdInUrl)) {
+            return this.browserAdapter
+                .tabsQueryP({ active: true, currentWindow: true })
+                .then(tabs => tabs.pop());
+        } else {
+            return new Promise((resolve, reject) => {
                 this.browserAdapter.getTab(
                     tabIdInUrl,
                     (tab: Tab) => {
@@ -47,8 +41,8 @@ export class TargetTabFinder {
                         reject(`Tab with Id ${tabIdInUrl} not found`);
                     },
                 );
-            }
-        });
+            });
+        }
     };
 
     private createTargetTabInfo = async (tab: Tab): Promise<TargetTabInfo> => {

--- a/src/popup/target-tab-finder.ts
+++ b/src/popup/target-tab-finder.ts
@@ -28,7 +28,7 @@ export class TargetTabFinder {
 
         if (isNaN(tabIdInUrl)) {
             return this.browserAdapter
-                .tabsQueryP({ active: true, currentWindow: true })
+                .tabsQuery({ active: true, currentWindow: true })
                 .then(tabs => tabs.pop());
         } else {
             return new Promise((resolve, reject) => {

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -3,7 +3,7 @@
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { isFunction } from 'lodash';
 import { IMock, It, Mock } from 'typemoq';
-import { Windows } from 'webextension-polyfill-ts';
+import { Tabs, Windows } from 'webextension-polyfill-ts';
 
 // This is a mock BrowserAdapter that maintains simulated state about which "windows" and "tabs"
 // exist and which listeners have been registered, and provides a few helper functions to simulate
@@ -52,15 +52,16 @@ export function createSimulatedBrowserAdapter(tabs: chrome.tabs.Tab[], windows: 
             reject();
         }
     });
-    mock.setup(m => m.tabsQuery(It.isAny(), It.isAny())).callback((query, c) =>
-        c(
-            mock.tabs.filter(
-                candidateTab =>
-                    (query.active == null || query.active === candidateTab.active) &&
-                    (query.windowId == null || query.windowId === candidateTab.windowId),
-            ),
-        ),
-    );
+
+    mock.setup(m => m.tabsQueryP(It.isAny())).returns(query => {
+        const result = mock.tabs.filter(
+            candidateTab =>
+                (query.active == null || query.active === candidateTab.active) &&
+                (query.windowId == null || query.windowId === candidateTab.windowId),
+        );
+
+        return Promise.resolve(result as Tabs.Tab[]);
+    });
 
     mock.updateTab = (tabId, changeInfo) => {
         mock.tabs

--- a/src/tests/unit/common/simulated-browser-adapter.ts
+++ b/src/tests/unit/common/simulated-browser-adapter.ts
@@ -53,7 +53,7 @@ export function createSimulatedBrowserAdapter(tabs: chrome.tabs.Tab[], windows: 
         }
     });
 
-    mock.setup(m => m.tabsQueryP(It.isAny())).returns(query => {
+    mock.setup(m => m.tabsQuery(It.isAny())).returns(query => {
         const result = mock.tabs.filter(
             candidateTab =>
                 (query.active == null || query.active === candidateTab.active) &&

--- a/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
+++ b/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
@@ -3,8 +3,8 @@
 import { BrowserMessageBroadcasterFactory } from 'background/browser-message-broadcaster-factory';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { Logger } from 'common/logging/logger';
-import { isFunction } from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { Tabs } from 'webextension-polyfill-ts';
 
 describe('BrowserMessageBroadcasterFactory', () => {
     let loggerMock: IMock<Logger>;
@@ -26,8 +26,8 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const expectedMessage = testMessage;
 
             browserAdapterMock
-                .setup(ba => ba.tabsQuery({}, It.is(isFunction)))
-                .callback((_, cb) => cb([{ id: testTabId }]))
+                .setup(ba => ba.tabsQueryP({}))
+                .returns(() => Promise.resolve([{ id: testTabId } as Tabs.Tab]))
                 .verifiable(Times.once());
             browserAdapterMock
                 .setup(ba => ba.sendMessageToFrames(expectedMessage))
@@ -49,7 +49,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const expectedMessage =
                 "sendMessageToFrames failed for message { someData: 'test data' } with browser error message: test error";
 
-            browserAdapterMock.setup(ba => ba.tabsQuery({}, It.is(isFunction))).callback((_, cb) => cb([{ id: 1 }]));
+            browserAdapterMock.setup(ba => ba.tabsQueryP({})).returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
             browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.reject(testError));
             browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.resolve());
 
@@ -66,7 +66,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const expectedMessage =
                 "sendMessageToTab(1) failed for message { someData: 'test data' } with browser error message: test error";
 
-            browserAdapterMock.setup(ba => ba.tabsQuery({}, It.is(isFunction))).callback((_, cb) => cb([{ id: 1 }]));
+            browserAdapterMock.setup(ba => ba.tabsQueryP({})).returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
             browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.resolve());
             browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.reject(testError));
 

--- a/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
+++ b/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
@@ -26,7 +26,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const expectedMessage = testMessage;
 
             browserAdapterMock
-                .setup(ba => ba.tabsQueryP({}))
+                .setup(ba => ba.tabsQuery({}))
                 .returns(() => Promise.resolve([{ id: testTabId } as Tabs.Tab]))
                 .verifiable(Times.once());
             browserAdapterMock
@@ -49,7 +49,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const expectedMessage =
                 "sendMessageToFrames failed for message { someData: 'test data' } with browser error message: test error";
 
-            browserAdapterMock.setup(ba => ba.tabsQueryP({})).returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
+            browserAdapterMock.setup(ba => ba.tabsQuery({})).returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
             browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.reject(testError));
             browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.resolve());
 
@@ -66,7 +66,7 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const expectedMessage =
                 "sendMessageToTab(1) failed for message { someData: 'test data' } with browser error message: test error";
 
-            browserAdapterMock.setup(ba => ba.tabsQueryP({})).returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
+            browserAdapterMock.setup(ba => ba.tabsQuery({})).returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
             browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.resolve());
             browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.reject(testError));
 

--- a/src/tests/unit/tests/background/chrome-command-handler.test.ts
+++ b/src/tests/unit/tests/background/chrome-command-handler.test.ts
@@ -62,7 +62,7 @@ describe('ChromeCommandHandlerTest', () => {
 
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         browserAdapterMock
-            .setup(adapter => adapter.tabsQueryP(It.isValue({ active: true, currentWindow: true })))
+            .setup(adapter => adapter.tabsQuery(It.isValue({ active: true, currentWindow: true })))
             .returns(() => Promise.resolve([{ id: simulatedActiveTabId, url: simulatedActiveTabUrl } as Tabs.Tab]))
             .verifiable();
 

--- a/src/tests/unit/tests/background/chrome-command-handler.test.ts
+++ b/src/tests/unit/tests/background/chrome-command-handler.test.ts
@@ -6,22 +6,22 @@ import { UserConfigurationStore } from 'background/stores/global/user-configurat
 import { TabContextStoreHub } from 'background/stores/tab-context-store-hub';
 import { VisualizationStore } from 'background/stores/visualization-store';
 import { TabContext, TabToContextMap } from 'background/tab-context';
+import { BaseStore } from 'common/base-store';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { CommandsAdapter } from 'common/browser-adapters/commands-adapter';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { DisplayableStrings } from 'common/constants/displayable-strings';
+import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { Logger } from 'common/logging/logger';
+import { Message } from 'common/message';
+import { Messages } from 'common/messages';
+import { NotificationCreator } from 'common/notification-creator';
+import { TelemetryDataFactory } from 'common/telemetry-data-factory';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import { UrlValidator } from 'common/url-validator';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
-import { BaseStore } from '../../../../common/base-store';
-import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
-import { CommandsAdapter } from '../../../../common/browser-adapters/commands-adapter';
-import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
-import { DisplayableStrings } from '../../../../common/constants/displayable-strings';
-import { TelemetryEventSource } from '../../../../common/extension-telemetry-events';
-import { Message } from '../../../../common/message';
-import { Messages } from '../../../../common/messages';
-import { NotificationCreator } from '../../../../common/notification-creator';
-import { TelemetryDataFactory } from '../../../../common/telemetry-data-factory';
-import { VisualizationStoreData } from '../../../../common/types/store-data/visualization-store-data';
-import { VisualizationType } from '../../../../common/types/visualization-type';
-import { UrlValidator } from '../../../../common/url-validator';
+import { Tabs } from 'webextension-polyfill-ts';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 
 describe('ChromeCommandHandlerTest', () => {
@@ -62,10 +62,8 @@ describe('ChromeCommandHandlerTest', () => {
 
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         browserAdapterMock
-            .setup(ca => ca.tabsQuery(It.isValue({ active: true, currentWindow: true }), It.isAny()))
-            .returns((_, callback) => {
-                callback([{ id: simulatedActiveTabId, url: simulatedActiveTabUrl } as chrome.tabs.Tab]);
-            })
+            .setup(adapter => adapter.tabsQueryP(It.isValue({ active: true, currentWindow: true })))
+            .returns(() => Promise.resolve([{ id: simulatedActiveTabId, url: simulatedActiveTabUrl } as Tabs.Tab]))
             .verifiable();
 
         commandsAdapterMock = Mock.ofType<CommandsAdapter>();

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -63,8 +63,8 @@ describe('TargetPageController', () => {
     });
 
     describe('initialize', () => {
-        it('should register the expected listeners', () => {
-            testSubject.initialize();
+        it('should register the expected listeners', async () => {
+            await testSubject.initialize();
 
             mockBrowserAdapter.verify(m => m.addListenerOnConnect(It.isAny()), Times.once());
             mockBrowserAdapter.verify(m => m.addListenerOnWindowsFocusChanged(It.isAny()), Times.once());
@@ -76,8 +76,8 @@ describe('TargetPageController', () => {
             mockDetailsViewController.verify(m => m.setupDetailsViewTabRemovedHandler(It.isAny()), Times.once());
         });
 
-        it('should create a tab context for each pre-existing tab', () => {
-            testSubject.initialize();
+        it('should create a tab context for each pre-existing tab', async () => {
+            await testSubject.initialize();
 
             mockTabContextFactory.verify(f => f.createTabContext(It.isAny(), It.isAny(), It.isAny(), EXISTING_ACTIVE_TAB_ID), Times.once());
             expect(tabToContextMap[EXISTING_ACTIVE_TAB_ID]).toHaveProperty(
@@ -100,8 +100,8 @@ describe('TargetPageController', () => {
     });
 
     describe('in initialized state', () => {
-        beforeEach(() => {
-            testSubject.initialize();
+        beforeEach(async () => {
+            await testSubject.initialize();
             resetInterpreterMocks(mockTabInterpreters);
         });
 
@@ -257,8 +257,9 @@ describe('TargetPageController', () => {
                 mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].verify(i => i.interpret(expectedMessage), Times.once());
             });
 
-            it('should send a Tab.VisibilityChange message with isHidden=true for other known tabs in the same window when a known tab is activated', () => {
+            it('should send a Tab.VisibilityChange message with isHidden=true for other known tabs in the same window when a known tab is activated', async () => {
                 mockBrowserAdapter.activateTab(EXISTING_INACTIVE_TAB);
+                await tick();
 
                 const expectedMessage = {
                     messageType: Messages.Tab.VisibilityChange,
@@ -268,8 +269,9 @@ describe('TargetPageController', () => {
                 mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(i => i.interpret(expectedMessage), Times.once());
             });
 
-            it('should send a Tab.VisibilityChange message with isHidden=true for other known tabs in the same window when an untracked tab is activated', () => {
+            it('should send a Tab.VisibilityChange message with isHidden=true for other known tabs in the same window when an untracked tab is activated', async () => {
                 mockBrowserAdapter.activateTab(NEW_TAB);
+                await tick();
 
                 const expectedMessage = {
                     messageType: Messages.Tab.VisibilityChange,

--- a/src/tests/unit/tests/popup/target-tab-finder.test.ts
+++ b/src/tests/unit/tests/popup/target-tab-finder.test.ts
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { Tab } from 'common/itab';
+import { UrlParser } from 'common/url-parser';
+import { UrlValidator } from 'common/url-validator';
+import { TargetTabFinder } from 'popup/target-tab-finder';
 import { IMock, It, Mock } from 'typemoq';
-
-import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
-import { Tab } from '../../../../common/itab';
-import { UrlParser } from '../../../../common/url-parser';
-import { UrlValidator } from '../../../../common/url-validator';
-import { TargetTabFinder } from '../../../../popup/target-tab-finder';
+import { Tabs } from 'webextension-polyfill-ts';
 
 describe('TargetTabFinderTest', () => {
     let testSubject: TargetTabFinder;
@@ -104,18 +104,8 @@ describe('TargetTabFinderTest', () => {
 
     function setupTabQueryCall(): void {
         browserAdapterMock
-            .setup(b =>
-                b.tabsQuery(
-                    {
-                        active: true,
-                        currentWindow: true,
-                    },
-                    It.isAny(),
-                ),
-            )
-            .callback((id, cb) => {
-                cb([tabStub]);
-            });
+            .setup(adapter => adapter.tabsQueryP({ active: true, currentWindow: true }))
+            .returns(() => Promise.resolve([tabStub as Tabs.Tab]));
     }
 
     function setupIsSupportedCall(isSupported: boolean): void {

--- a/src/tests/unit/tests/popup/target-tab-finder.test.ts
+++ b/src/tests/unit/tests/popup/target-tab-finder.test.ts
@@ -104,7 +104,7 @@ describe('TargetTabFinderTest', () => {
 
     function setupTabQueryCall(): void {
         browserAdapterMock
-            .setup(adapter => adapter.tabsQueryP({ active: true, currentWindow: true }))
+            .setup(adapter => adapter.tabsQuery({ active: true, currentWindow: true }))
             .returns(() => Promise.resolve([tabStub as Tabs.Tab]));
     }
 


### PR DESCRIPTION
#### Description of changes

This is part of a long-run refactor to promisify all (possible) `chrome.*` calls.

In this case, promisifying `tabsQuery`.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
