### PR TITLE
feat(permissions): add telemetry to set permission payload for url permissions

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -503,7 +503,11 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
     public setAllUrlsPermissionState = (event: SupportedMouseEvent, allUrlsPermissionState: boolean) => {
         const payload: SetAllUrlsPermissionStatePayload = {
             allUrlsPermissionState,
-            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, TelemetryEvents.TelemetryEventSource.DetailsView),
+            telemetry: this.telemetryFactory.forSetAllUrlPermissionState(
+                event,
+                TelemetryEvents.TelemetryEventSource.DetailsView,
+                allUrlsPermissionState,
+            ),
         };
 
         const message: Message = {

--- a/src/background/actions/permissions-state-actions.ts
+++ b/src/background/actions/permissions-state-actions.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Action } from 'common/flux/action';
 import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
+import { Action } from 'common/flux/action';
 
 export class PermissionsStateActions {
     public readonly getCurrentState = new Action<void>();

--- a/src/background/actions/permissions-state-actions.ts
+++ b/src/background/actions/permissions-state-actions.ts
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Action } from 'common/flux/action';
+import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 
 export class PermissionsStateActions {
     public readonly getCurrentState = new Action<void>();
-    public readonly setPermissionsState = new Action<boolean>();
+    public readonly setPermissionsState = new Action<SetAllUrlsPermissionStatePayload>();
 }

--- a/src/background/browser-permissions-tracker.ts
+++ b/src/background/browser-permissions-tracker.ts
@@ -25,17 +25,21 @@ export class BrowserPermissionsTracker {
     }
 
     private updatePermissionState = async (): Promise<void> => {
-        let payload: boolean;
+        let permissionState: boolean;
 
         try {
-            payload = await this.browserAdapter.containsPermissions(allUrlAndFilePermissions);
+            permissionState = await this.browserAdapter.containsPermissions(
+                allUrlAndFilePermissions,
+            );
         } catch (error) {
-            payload = false;
+            permissionState = false;
             this.logger.log(permissionsCheckErrorMessage);
         } finally {
             const message: Message = {
                 messageType: Messages.PermissionsState.SetPermissionsState,
-                payload: payload,
+                payload: {
+                    allUrlAndFilePermissions: permissionState,
+                },
             };
 
             this.interpreter.interpret(message);

--- a/src/background/global-action-creators/permissions-state-action-creator.ts
+++ b/src/background/global-action-creators/permissions-state-action-creator.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 import { PermissionsStateActions } from 'background/actions/permissions-state-actions';
 import { Interpreter } from 'background/interpreter';
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { ALL_URLS_PERMISSION_UPDATED } from 'common/extension-telemetry-events';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 
@@ -9,6 +12,7 @@ export class PermissionsStateActionCreator {
     constructor(
         private readonly interpreter: Interpreter,
         private readonly permissionsStateActions: PermissionsStateActions,
+        private readonly telemetryEventHandler: TelemetryEventHandler,
     ) {}
 
     public registerCallbacks(): void {
@@ -26,7 +30,8 @@ export class PermissionsStateActionCreator {
         this.permissionsStateActions.getCurrentState.invoke(null);
     };
 
-    private onSetPermissionsState = (payload: boolean): void => {
+    private onSetPermissionsState = (payload: SetAllUrlsPermissionStatePayload): void => {
         this.permissionsStateActions.setPermissionsState.invoke(payload);
+        this.telemetryEventHandler.publishTelemetry(ALL_URLS_PERMISSION_UPDATED, payload);
     };
 }

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -108,6 +108,7 @@ export class GlobalContextFactory {
         const permissionsStateActionCreator = new PermissionsStateActionCreator(
             interpreter,
             globalActionsHub.permissionsStateActions,
+            telemetryEventHandler,
         );
 
         issueFilingActionCreator.registerCallbacks();

--- a/src/background/stores/global/permissions-state-store.ts
+++ b/src/background/stores/global/permissions-state-store.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 import { PermissionsStateActions } from 'background/actions/permissions-state-actions';
 import { BaseStoreImpl } from 'background/stores/base-store-impl';
 import { StoreNames } from 'common/stores/store-names';
@@ -23,9 +24,9 @@ export class PermissionsStateStore extends BaseStoreImpl<PermissionsStateStoreDa
         this.permissionsStateActions.setPermissionsState.addListener(this.onSetPermissionsState);
     }
 
-    private onSetPermissionsState = (hasAllUrlAndFilePermissions: boolean): void => {
-        if (hasAllUrlAndFilePermissions !== this.state.hasAllUrlAndFilePermissions) {
-            this.state.hasAllUrlAndFilePermissions = hasAllUrlAndFilePermissions;
+    private onSetPermissionsState = (payload: SetAllUrlsPermissionStatePayload): void => {
+        if (payload.allUrlsPermissionState !== this.state.hasAllUrlAndFilePermissions) {
+            this.state.hasAllUrlAndFilePermissions = payload.allUrlsPermissionState;
             this.emitChanged();
         }
     };

--- a/src/common/extension-telemetry-events.ts
+++ b/src/common/extension-telemetry-events.ts
@@ -63,6 +63,7 @@ export const ALL_RULES_COLLAPSED: string = 'allRulesCollapsed';
 export const RESCAN_VISUALIZATION: string = 'rescanVisualization';
 export const EXISTING_TAB_URL_UPDATED: string = 'existingTabUrlUpdated';
 export const SCAN_INCOMPLETE_WARNINGS: string = 'scanIncompleteWarnings';
+export const ALL_URLS_PERMISSION_UPDATED: string = 'allUrlsPermissionUpdated';
 
 export const TriggeredByNotApplicable: TriggeredBy = 'N/A';
 export type TriggeredBy = 'mouseclick' | 'keypress' | 'shortcut' | 'N/A';
@@ -202,6 +203,10 @@ export type AndroidScanFailedTelemetryData = {
     scanDuration: number;
 };
 
+export type SetAllUrlsPermissionTelemetryData = {
+    permissionState: boolean;
+} & BaseTelemetryData;
+
 export type ScanIncompleteWarningsTelemetryData = Pick<UnifiedScanCompletedPayload, 'scanIncompleteWarnings'>;
 
 export type TelemetryData =
@@ -227,4 +232,5 @@ export type TelemetryData =
     | ValidatePortTelemetryData
     | AndroidScanCompletedTelemetryData
     | AndroidScanFailedTelemetryData
-    | ScanIncompleteWarningsTelemetryData;
+    | ScanIncompleteWarningsTelemetryData
+    | SetAllUrlsPermissionTelemetryData;

--- a/src/common/telemetry-data-factory.ts
+++ b/src/common/telemetry-data-factory.ts
@@ -21,6 +21,7 @@ import {
     RequirementStatusTelemetryData,
     RuleAnalyzerScanTelemetryData,
     ScopingTelemetryData,
+    SetAllUrlsPermissionTelemetryData,
     SettingsOpenSourceItem,
     SettingsOpenTelemetryData,
     TelemetryEventSource,
@@ -299,5 +300,16 @@ export class TelemetryDataFactory {
             }
         });
         return ruleResults;
+    }
+
+    public forSetAllUrlPermissionState(
+        event: SupportedMouseEvent,
+        source: TelemetryEventSource,
+        permissionState: boolean,
+    ): SetAllUrlsPermissionTelemetryData {
+        return {
+            ...this.withTriggeredByAndSource(event, source),
+            permissionState,
+        };
     }
 }

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -27,9 +27,7 @@ import { SupportedMouseEvent, TelemetryDataFactory } from '../../../../../common
 import { DetailsViewPivotType } from '../../../../../common/types/details-view-pivot-type';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
-import {
-    DetailsViewRightContentPanelType,
-} from '../../../../../DetailsView/components/left-nav/details-view-right-content-panel-type';
+import { DetailsViewRightContentPanelType } from '../../../../../DetailsView/components/left-nav/details-view-right-content-panel-type';
 import { EventStubFactory } from '../../../common/event-stub-factory';
 
 describe('DetailsViewActionMessageCreatorTest', () => {

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -17,6 +17,7 @@ import {
     FeatureFlagToggleTelemetryData,
     RequirementActionTelemetryData,
     RequirementSelectTelemetryData,
+    SetAllUrlsPermissionTelemetryData,
     TelemetryEventSource,
     TriggeredByNotApplicable,
 } from '../../../../../common/extension-telemetry-events';
@@ -872,8 +873,8 @@ describe('DetailsViewActionMessageCreatorTest', () => {
     test('setAllUrlsPermissionState', () => {
         const eventStub = {} as SupportedMouseEvent;
         const telemetryStub = {
-            source: TelemetryEventSource.DetailsView,
-        } as BaseTelemetryData;
+            source: testSource,
+        } as SetAllUrlsPermissionTelemetryData;
         const permissionsState = true;
         const expectedMessage = {
             messageType: Messages.PermissionsState.SetPermissionsState,
@@ -884,7 +885,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         };
 
         telemetryFactoryMock
-            .setup(tf => tf.withTriggeredByAndSource(eventStub, TelemetryEventSource.DetailsView))
+            .setup(tf => tf.forSetAllUrlPermissionState(eventStub, TelemetryEventSource.DetailsView, permissionsState))
             .returns(() => telemetryStub);
 
         testSubject.setAllUrlsPermissionState(eventStub, permissionsState);

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -27,7 +27,9 @@ import { SupportedMouseEvent, TelemetryDataFactory } from '../../../../../common
 import { DetailsViewPivotType } from '../../../../../common/types/details-view-pivot-type';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
-import { DetailsViewRightContentPanelType } from '../../../../../DetailsView/components/left-nav/details-view-right-content-panel-type';
+import {
+    DetailsViewRightContentPanelType,
+} from '../../../../../DetailsView/components/left-nav/details-view-right-content-panel-type';
 import { EventStubFactory } from '../../../common/event-stub-factory';
 
 describe('DetailsViewActionMessageCreatorTest', () => {

--- a/src/tests/unit/tests/background/browser-permissions-tracker.test.ts
+++ b/src/tests/unit/tests/background/browser-permissions-tracker.test.ts
@@ -123,7 +123,9 @@ describe('BrowserPermissionsTracker', () => {
     function verifyInterpreterMessage(browserPermissions: boolean): void {
         const expectedMessage: Message = {
             messageType: Messages.PermissionsState.SetPermissionsState,
-            payload: browserPermissions,
+            payload: {
+                allUrlAndFilePermissions: browserPermissions,
+            },
         };
 
         interpreterMock.verify(i => i.interpret(expectedMessage), Times.once());

--- a/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 import { PermissionsStateActions } from 'background/actions/permissions-state-actions';
 import { PermissionsStateActionCreator } from 'background/global-action-creators/permissions-state-action-creator';
+import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { TelemetryData } from 'common/extension-telemetry-events';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { IMock, Mock } from 'typemoq';
@@ -20,19 +23,28 @@ describe('PermissionsStateActionCreator', () => {
         const interpreterMock = createInterpreterMock(expectedMessage, null);
         const getCurrentStateMock = createActionMock(null);
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
-        const testSubject = new PermissionsStateActionCreator(interpreterMock.object, permissionsStateActionsMock.object);
+        const testSubject = new PermissionsStateActionCreator(interpreterMock.object, permissionsStateActionsMock.object, null);
 
         testSubject.registerCallbacks();
 
         getCurrentStateMock.verifyAll();
     });
 
-    it.each([true, false])('handles SetPermissionsState message for payload %p', (payload: boolean) => {
+    it.each([true, false])('handles SetPermissionsState message for payload %p', (permissionState: boolean) => {
         const expectedMessage = Messages.PermissionsState.SetPermissionsState;
+        const payload: SetAllUrlsPermissionStatePayload = {
+            allUrlsPermissionState: permissionState,
+            telemetry: {} as TelemetryData,
+        };
         const interpreterMock = createInterpreterMock(expectedMessage, payload);
         const setPermissionsStateMock = createActionMock(payload);
+        const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
         setupActionsMock('setPermissionsState', setPermissionsStateMock.object);
-        const testSubject = new PermissionsStateActionCreator(interpreterMock.object, permissionsStateActionsMock.object);
+        const testSubject = new PermissionsStateActionCreator(
+            interpreterMock.object,
+            permissionsStateActionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 

--- a/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
@@ -5,6 +5,7 @@ import { PermissionsStateStore } from 'background/stores/global/permissions-stat
 import { StoreNames } from 'common/stores/store-names';
 import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { createStoreWithNullParams, StoreTester } from 'tests/unit/common/store-tester';
+import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 
 describe('PermissionsStateStoreTest', () => {
     test('constructor, no side effects', () => {
@@ -39,18 +40,24 @@ describe('PermissionsStateStoreTest', () => {
             const finalPermissionsValue = true;
             const initialState = { hasAllUrlAndFilePermissions: initialPermissionsValue };
             const finalState = { hasAllUrlAndFilePermissions: finalPermissionsValue };
+            const payload: SetAllUrlsPermissionStatePayload = {
+                allUrlsPermissionState: finalPermissionsValue,
+            };
 
             createStoreTesterForPermissionsStateActions('setPermissionsState')
-                .withActionParam(finalPermissionsValue)
+                .withActionParam(payload)
                 .testListenerToBeCalledOnce(initialState, finalState);
         });
 
         test.each([true, false])('does not update state when there is no change', hasPermissionsValue => {
             const initialState = { hasAllUrlAndFilePermissions: hasPermissionsValue };
             const finalState = { hasAllUrlAndFilePermissions: hasPermissionsValue };
+            const payload: SetAllUrlsPermissionStatePayload = {
+                allUrlsPermissionState: hasPermissionsValue,
+            };
 
             createStoreTesterForPermissionsStateActions('setPermissionsState')
-                .withActionParam(hasPermissionsValue)
+                .withActionParam(payload)
                 .testListenerToNeverBeCalled(initialState, finalState);
         });
     });

--- a/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 import { PermissionsStateActions } from 'background/actions/permissions-state-actions';
 import { PermissionsStateStore } from 'background/stores/global/permissions-state-store';
 import { StoreNames } from 'common/stores/store-names';
 import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { createStoreWithNullParams, StoreTester } from 'tests/unit/common/store-tester';
-import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 
 describe('PermissionsStateStoreTest', () => {
     test('constructor, no side effects', () => {

--- a/src/tests/unit/tests/common/telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/common/telemetry-data-factory.test.ts
@@ -13,6 +13,7 @@ import {
     RequirementActionTelemetryData,
     RequirementSelectTelemetryData,
     RuleAnalyzerScanTelemetryData,
+    SetAllUrlsPermissionTelemetryData,
     SettingsOpenSourceItem,
     SettingsOpenTelemetryData,
     TelemetryEventSource,
@@ -528,6 +529,20 @@ describe('TelemetryDataFactoryTest', () => {
 
         const expected: FileIssueClickTelemetryData = {
             service,
+            source: testSource,
+            triggeredBy: 'mouseclick',
+        };
+
+        expect(result).toEqual(expected);
+    });
+
+    test('forSetAllUrlPermissionState', () => {
+        const permissionState = true;
+
+        const result = testObject.forSetAllUrlPermissionState(mouseClickEvent, testSource, permissionState);
+
+        const expected: SetAllUrlsPermissionTelemetryData = {
+            permissionState,
             source: testSource,
             triggeredBy: 'mouseclick',
         };


### PR DESCRIPTION
#### Description of changes

This adds telemetry for when the setPermission action is called; since this requires a change in payload, there's lots to change. Additionally, we're currently **not** sending telemetry for when **the user changes their permissions from the settings**. If this needs to change, doing so would be easy.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
