### PR TITLE
feat(permissions): remove extra space in iframe warning

### DIFF
--- a/src/DetailsView/components/iframe-warning.tsx
+++ b/src/DetailsView/components/iframe-warning.tsx
@@ -19,7 +19,7 @@ export const IframeWarning = NamedFC<IframeWarningProps>('IframeWarning', props 
         <Link className="insights-link" onClick={props.onAllowPermissionsClick}>
             give Accessibility Insights additional permissions
         </Link>
-        ; this will trigger a rescan of the test.{' '}
+        ; this will trigger a rescan of the test.
         <NewTabLink href={'https://accessibilityinsights.io/docs/en/faq'}>Learn more here.</NewTabLink>
     </>
 ));

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/iframe-warning.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/iframe-warning.test.tsx.snap
@@ -23,7 +23,6 @@ exports[`IframeWarning render 1`] = `
     give Accessibility Insights additional permissions
   </StyledLinkBase>
   ; this will trigger a rescan of the test.
-   
   <NewTabLink
     href="https://accessibilityinsights.io/docs/en/faq"
   >


### PR DESCRIPTION
#### Description of changes

Just removing an extra space.

![image](https://user-images.githubusercontent.com/32555133/71298705-31487c80-233e-11ea-8eed-6958718ac04f.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
