### PR TITLE
refactor: rename payload property to match state property

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -500,13 +500,13 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         this.dispatcher.dispatchMessage(message);
     };
 
-    public setAllUrlsPermissionState = (event: SupportedMouseEvent, allUrlsPermissionState: boolean) => {
+    public setAllUrlsPermissionState = (event: SupportedMouseEvent, hasAllUrlAndFilePermissions: boolean) => {
         const payload: SetAllUrlsPermissionStatePayload = {
-            allUrlsPermissionState,
+            hasAllUrlAndFilePermissions,
             telemetry: this.telemetryFactory.forSetAllUrlPermissionState(
                 event,
                 TelemetryEvents.TelemetryEventSource.DetailsView,
-                allUrlsPermissionState,
+                hasAllUrlAndFilePermissions,
             ),
         };
 

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -181,7 +181,7 @@ export interface PopupInitializedPayload extends BaseActionPayload {
 }
 
 export interface SetAllUrlsPermissionStatePayload extends BaseActionPayload {
-    allUrlsPermissionState: boolean;
+    hasAllUrlAndFilePermissions: boolean;
 }
 
 export type ExistingTabUpdatedPayload = BaseActionPayload & Tab;

--- a/src/background/browser-permissions-tracker.ts
+++ b/src/background/browser-permissions-tracker.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 import { Interpreter } from 'background/interpreter';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { Logger } from 'common/logging/logger';
@@ -38,8 +39,8 @@ export class BrowserPermissionsTracker {
             const message: Message = {
                 messageType: Messages.PermissionsState.SetPermissionsState,
                 payload: {
-                    allUrlAndFilePermissions: permissionState,
-                },
+                    hasAllUrlAndFilePermissions: permissionState,
+                } as SetAllUrlsPermissionStatePayload,
             };
 
             this.interpreter.interpret(message);

--- a/src/background/stores/global/permissions-state-store.ts
+++ b/src/background/stores/global/permissions-state-store.ts
@@ -25,8 +25,8 @@ export class PermissionsStateStore extends BaseStoreImpl<PermissionsStateStoreDa
     }
 
     private onSetPermissionsState = (payload: SetAllUrlsPermissionStatePayload): void => {
-        if (payload.allUrlsPermissionState !== this.state.hasAllUrlAndFilePermissions) {
-            this.state.hasAllUrlAndFilePermissions = payload.allUrlsPermissionState;
+        if (this.state.hasAllUrlAndFilePermissions !== payload.hasAllUrlAndFilePermissions) {
+            this.state.hasAllUrlAndFilePermissions = payload.hasAllUrlAndFilePermissions;
             this.emitChanged();
         }
     };

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -1,19 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { HeadingsTestStep } from 'assessments/headings/test-steps/test-steps';
-import { OnDetailsViewPivotSelected } from 'background/actions/action-payloads';
+import { OnDetailsViewPivotSelected, SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { IMock, It, Mock, Times } from 'typemoq';
-
 import {
     AssessmentTelemetryData,
     BaseTelemetryData,
     COPY_ISSUE_DETAILS,
-    DETAILS_VIEW_OPEN,
     DetailsViewOpenTelemetryData,
     DetailsViewPivotSelectedTelemetryData,
-    EXPORT_RESULTS,
+    DETAILS_VIEW_OPEN,
     ExportResultsTelemetryData,
+    EXPORT_RESULTS,
     FeatureFlagToggleTelemetryData,
     RequirementActionTelemetryData,
     RequirementSelectTelemetryData,
@@ -880,8 +879,8 @@ describe('DetailsViewActionMessageCreatorTest', () => {
             messageType: Messages.PermissionsState.SetPermissionsState,
             payload: {
                 telemetry: telemetryStub,
-                allUrlsPermissionState: permissionsState,
-            },
+                hasAllUrlAndFilePermissions: permissionsState,
+            } as SetAllUrlsPermissionStatePayload,
         };
 
         telemetryFactoryMock

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -4,15 +4,16 @@ import { HeadingsTestStep } from 'assessments/headings/test-steps/test-steps';
 import { OnDetailsViewPivotSelected, SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { IMock, It, Mock, Times } from 'typemoq';
+
 import {
     AssessmentTelemetryData,
     BaseTelemetryData,
     COPY_ISSUE_DETAILS,
+    DETAILS_VIEW_OPEN,
     DetailsViewOpenTelemetryData,
     DetailsViewPivotSelectedTelemetryData,
-    DETAILS_VIEW_OPEN,
-    ExportResultsTelemetryData,
     EXPORT_RESULTS,
+    ExportResultsTelemetryData,
     FeatureFlagToggleTelemetryData,
     RequirementActionTelemetryData,
     RequirementSelectTelemetryData,

--- a/src/tests/unit/tests/background/browser-permissions-tracker.test.ts
+++ b/src/tests/unit/tests/background/browser-permissions-tracker.test.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
 import { allUrlAndFilePermissions, BrowserPermissionsTracker, permissionsCheckErrorMessage } from 'background/browser-permissions-tracker';
 import { Interpreter } from 'background/interpreter';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
@@ -27,8 +28,8 @@ describe('BrowserPermissionsTracker', () => {
         it('registers the expected listeners', async () => {
             await testSubject.initialize();
 
-            browserAdapterMock.verify(m => m.addListenerOnPermissionsAdded(It.is(isFunction)), Times.once());
-            browserAdapterMock.verify(m => m.addListenerOnPermissionsRemoved(It.is(isFunction)), Times.once());
+            browserAdapterMock.verify(adapter => adapter.addListenerOnPermissionsAdded(It.is(isFunction)), Times.once());
+            browserAdapterMock.verify(adapter => adapter.addListenerOnPermissionsRemoved(It.is(isFunction)), Times.once());
         });
     });
 
@@ -101,7 +102,9 @@ describe('BrowserPermissionsTracker', () => {
         mock.setup(m => m.addListenerOnPermissionsAdded(It.is(isFunction))).callback(c => {
             mock.notifyOnPermissionsAdded = c;
         });
-        mock.setup(m => m.addListenerOnPermissionsRemoved(It.is(isFunction))).callback(c => (mock.notifyOnPermissionsRemoved = c));
+        mock.setup(adapter => adapter.addListenerOnPermissionsRemoved(It.is(isFunction))).callback(
+            c => (mock.notifyOnPermissionsRemoved = c),
+        );
 
         mock.addPermissions = async () => {
             await mock.notifyOnPermissionsAdded();
@@ -124,10 +127,10 @@ describe('BrowserPermissionsTracker', () => {
         const expectedMessage: Message = {
             messageType: Messages.PermissionsState.SetPermissionsState,
             payload: {
-                allUrlAndFilePermissions: browserPermissions,
-            },
+                hasAllUrlAndFilePermissions: browserPermissions,
+            } as SetAllUrlsPermissionStatePayload,
         };
 
-        interpreterMock.verify(i => i.interpret(expectedMessage), Times.once());
+        interpreterMock.verify(interpreter => interpreter.interpret(expectedMessage), Times.once());
     }
 });

--- a/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
@@ -33,7 +33,7 @@ describe('PermissionsStateActionCreator', () => {
     it.each([true, false])('handles SetPermissionsState message for payload %p', (permissionState: boolean) => {
         const expectedMessage = Messages.PermissionsState.SetPermissionsState;
         const payload: SetAllUrlsPermissionStatePayload = {
-            allUrlsPermissionState: permissionState,
+            hasAllUrlAndFilePermissions: permissionState,
             telemetry: {} as TelemetryData,
         };
         const interpreterMock = createInterpreterMock(expectedMessage, payload);

--- a/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
@@ -41,7 +41,7 @@ describe('PermissionsStateStoreTest', () => {
             const initialState = { hasAllUrlAndFilePermissions: initialPermissionsValue };
             const finalState = { hasAllUrlAndFilePermissions: finalPermissionsValue };
             const payload: SetAllUrlsPermissionStatePayload = {
-                allUrlsPermissionState: finalPermissionsValue,
+                hasAllUrlAndFilePermissions: finalPermissionsValue,
             };
 
             createStoreTesterForPermissionsStateActions('setPermissionsState')
@@ -53,7 +53,7 @@ describe('PermissionsStateStoreTest', () => {
             const initialState = { hasAllUrlAndFilePermissions: hasPermissionsValue };
             const finalState = { hasAllUrlAndFilePermissions: hasPermissionsValue };
             const payload: SetAllUrlsPermissionStatePayload = {
-                allUrlsPermissionState: hasPermissionsValue,
+                hasAllUrlAndFilePermissions: hasPermissionsValue,
             };
 
             createStoreTesterForPermissionsStateActions('setPermissionsState')


### PR DESCRIPTION
#### Description of changes

While working on adding e2e test for the permissions feature (and debugging a nasty issue) I got confused by the 2 names we have for the same value, one on the payload side, one on the state side.

This PR normalize the names so they are both the same. I chose the name from the state as it seems a better one.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
