### PR TITLE
refactor: promisify switch to tab

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -224,10 +224,10 @@ export class ActionCreator {
         this.visualizationActions.disableAssessmentVisualizations.invoke(null);
     };
 
-    private onAssessmentScanCompleted = (
+    private onAssessmentScanCompleted = async (
         payload: ScanCompletedPayload<any>,
         tabId: number,
-    ): void => {
+    ): Promise<void> => {
         const eventName = TelemetryEvents.ASSESSMENT_SCAN_COMPLETED;
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
         this.visualizationActions.scanCompleted.invoke(null);
@@ -236,7 +236,7 @@ export class ActionCreator {
             payload.key,
             payload.testType,
         );
-        this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
+        await this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
     };
 
     private onOpenPreviewFeaturesPanel = async (
@@ -281,7 +281,10 @@ export class ActionCreator {
         this.visualizationActions.updateFocusedInstance.invoke(payload);
     };
 
-    private onScanCompleted = (payload: ScanCompletedPayload<any>, tabId: number): void => {
+    private onScanCompleted = async (
+        payload: ScanCompletedPayload<any>,
+        tabId: number,
+    ): Promise<void> => {
         const telemetryEventName = TelemetryEvents.ADHOC_SCAN_COMPLETED;
         this.telemetryEventHandler.publishTelemetry(telemetryEventName, payload);
         this.visualizationScanResultActions.scanCompleted.invoke(payload);
@@ -291,7 +294,7 @@ export class ActionCreator {
             payload.key,
             payload.testType,
         );
-        this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
+        await this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
     };
 
     private onScrollRequested = (payload: BaseActionPayload): void => {

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -69,7 +69,7 @@ export class ActionCreator {
         );
         this.interpreter.registerTypeToPayloadCallback(
             visualizationMessages.Common.ScanCompleted,
-            this.onScanCompleted,
+            this.onAdHocScanCompleted,
         );
         this.interpreter.registerTypeToPayloadCallback(
             visualizationMessages.Common.ScrollRequested,
@@ -281,7 +281,7 @@ export class ActionCreator {
         this.visualizationActions.updateFocusedInstance.invoke(payload);
     };
 
-    private onScanCompleted = async (
+    private onAdHocScanCompleted = async (
         payload: ScanCompletedPayload<any>,
         tabId: number,
     ): Promise<void> => {

--- a/src/background/actions/inspect-action-creator.ts
+++ b/src/background/actions/inspect-action-creator.ts
@@ -32,7 +32,7 @@ export class InspectActionCreator {
     private onChangeInspectMode = async (payload: InspectPayload, tabId: number): Promise<void> => {
         this.telemetryEventHandler.publishTelemetry(CHANGE_INSPECT_MODE, payload);
         await this.browserAdapter
-            .switchToTabP(tabId)
+            .switchToTab(tabId)
             .catch(error => this.logger.error(`switchToTab failed: ${error}`));
         this.inspectActions.changeInspectMode.invoke(payload);
     };

--- a/src/background/actions/inspect-action-creator.ts
+++ b/src/background/actions/inspect-action-creator.ts
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import * as TelemetryEvents from 'common/extension-telemetry-events';
+import { CHANGE_INSPECT_MODE } from 'common/extension-telemetry-events';
+import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
-
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { InspectActions, InspectPayload } from './inspect-actions';
@@ -15,27 +15,29 @@ export class InspectActionCreator {
         private readonly inspectActions: InspectActions,
         private readonly telemetryEventHandler: TelemetryEventHandler,
         private readonly browserAdapter: BrowserAdapter,
+        private readonly logger: Logger,
     ) {}
 
     public registerCallbacks(): void {
         this.interpreter.registerTypeToPayloadCallback(
             Messages.Inspect.ChangeInspectMode,
-            (payload: InspectPayload, tabId: number) => this.onChangeInspectMode(payload, tabId),
+            this.onChangeInspectMode,
         );
         this.interpreter.registerTypeToPayloadCallback(
             getStoreStateMessage(StoreNames.InspectStore),
-            () => this.onGetInspectCurrentState(),
+            this.onGetInspectCurrentState,
         );
     }
 
-    private onChangeInspectMode(payload: InspectPayload, tabId: number): void {
-        const eventName = TelemetryEvents.CHANGE_INSPECT_MODE;
-        this.telemetryEventHandler.publishTelemetry(eventName, payload);
-        this.browserAdapter.switchToTab(tabId);
+    private onChangeInspectMode = async (payload: InspectPayload, tabId: number): Promise<void> => {
+        this.telemetryEventHandler.publishTelemetry(CHANGE_INSPECT_MODE, payload);
+        await this.browserAdapter
+            .switchToTabP(tabId)
+            .catch(error => this.logger.error(`switchToTab failed: ${error}`));
         this.inspectActions.changeInspectMode.invoke(payload);
-    }
+    };
 
-    private onGetInspectCurrentState(): void {
+    private onGetInspectCurrentState = (): void => {
         this.inspectActions.getCurrentState.invoke(null);
-    }
+    };
 }

--- a/src/background/actions/tab-action-creator.ts
+++ b/src/background/actions/tab-action-creator.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { EXISTING_TAB_URL_UPDATED, SWITCH_BACK_TO_TARGET } from 'common/extension-telemetry-events';
+import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { Interpreter } from '../interpreter';
@@ -19,6 +20,7 @@ export class TabActionCreator {
         private readonly tabActions: TabActions,
         private readonly browserAdapter: BrowserAdapter,
         private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly logger: Logger,
     ) {}
 
     public registerCallbacks(): void {
@@ -47,8 +49,13 @@ export class TabActionCreator {
         );
     }
 
-    private onSwitchToTargetTab = (payload: SwitchToTargetTabPayload, tabId: number): void => {
-        this.browserAdapter.switchToTab(tabId);
+    private onSwitchToTargetTab = async (
+        payload: SwitchToTargetTabPayload,
+        tabId: number,
+    ): Promise<void> => {
+        await this.browserAdapter
+            .switchToTabP(tabId)
+            .catch(error => this.logger.error(`switchToTab failed: ${error}`));
         this.telemetryEventHandler.publishTelemetry(SWITCH_BACK_TO_TARGET, payload);
     };
 

--- a/src/background/actions/tab-action-creator.ts
+++ b/src/background/actions/tab-action-creator.ts
@@ -54,7 +54,7 @@ export class TabActionCreator {
         tabId: number,
     ): Promise<void> => {
         await this.browserAdapter
-            .switchToTabP(tabId)
+            .switchToTab(tabId)
             .catch(error => this.logger.error(`switchToTab failed: ${error}`));
         this.telemetryEventHandler.publishTelemetry(SWITCH_BACK_TO_TARGET, payload);
     };

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Logger } from 'common/logging/logger';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { DictionaryStringTo } from '../types/common-types';
 
 export class DetailsViewController {
     private tabIdToDetailsViewMap: DictionaryStringTo<number> = {};
-    private browserAdapter: BrowserAdapter;
     private detailsViewRemovedHandler: (tabId: number) => void;
 
-    constructor(adapter: BrowserAdapter) {
-        this.browserAdapter = adapter;
+    constructor(private readonly browserAdapter: BrowserAdapter) {
         this.browserAdapter.addListenerToTabsOnRemoved(this.onRemoveTab);
         this.browserAdapter.addListenerToTabsOnUpdated(this.onUpdateTab);
     }
@@ -22,7 +21,7 @@ export class DetailsViewController {
         const detailsViewTabId = this.tabIdToDetailsViewMap[targetTabId];
 
         if (detailsViewTabId != null) {
-            this.browserAdapter.switchToTab(detailsViewTabId);
+            await this.browserAdapter.switchToTabP(detailsViewTabId);
             return;
         }
 

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Logger } from 'common/logging/logger';
 import { BrowserAdapter } from '../common/browser-adapters/browser-adapter';
 import { DictionaryStringTo } from '../types/common-types';
 

--- a/src/background/details-view-controller.ts
+++ b/src/background/details-view-controller.ts
@@ -21,7 +21,7 @@ export class DetailsViewController {
         const detailsViewTabId = this.tabIdToDetailsViewMap[targetTabId];
 
         if (detailsViewTabId != null) {
-            await this.browserAdapter.switchToTabP(detailsViewTabId);
+            await this.browserAdapter.switchToTab(detailsViewTabId);
             return;
         }
 

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -109,6 +109,7 @@ export class TabContextFactory {
             actionsHub.inspectActions,
             this.telemetryEventHandler,
             browserAdapter,
+            this.logger,
         );
         const pathSnippetActionCreator = new PathSnippetActionCreator(
             interpreter,

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -93,6 +93,7 @@ export class TabContextFactory {
             actionsHub.tabActions,
             browserAdapter,
             this.telemetryEventHandler,
+            this.logger,
         );
         const popupActionCreator = new PopupActionCreator(
             interpreter,

--- a/src/background/target-tab-controller.ts
+++ b/src/background/target-tab-controller.ts
@@ -13,16 +13,16 @@ export class TargetTabController {
         this.configurationFactory = configurationFactory;
     }
 
-    public showTargetTab(
+    public async showTargetTab(
         targetTabId: number,
         testType: VisualizationType,
         testStep: string = null,
-    ): void {
+    ): Promise<void> {
         const config = this.configurationFactory.getConfiguration(testType);
         const switchToTargetTab = config.getSwitchToTargetTabOnScan(testStep);
 
         if (switchToTargetTab) {
-            this.browserAdapter.switchToTab(targetTabId);
+            await this.browserAdapter.switchToTabP(targetTabId);
         }
     }
 }

--- a/src/background/target-tab-controller.ts
+++ b/src/background/target-tab-controller.ts
@@ -22,7 +22,7 @@ export class TargetTabController {
         const switchToTargetTab = config.getSwitchToTargetTabOnScan(testStep);
 
         if (switchToTargetTab) {
-            await this.browserAdapter.switchToTabP(targetTabId);
+            await this.browserAdapter.switchToTab(targetTabId);
         }
     }
 }

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -12,7 +12,6 @@ export interface BrowserAdapter {
     tabsQuery(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]>;
     createActiveTab(url: string): Promise<Tabs.Tab>;
     createTabInNewWindow(url: string): Promise<Tabs.Tab>;
-    switchToTab(tabId: number): void;
     switchToTabP(tabId: number): Promise<void>;
     updateTab(tabId: number, updateProperties: Tabs.UpdateUpdatePropertiesType): Promise<Tabs.Tab>;
     getTab(tabId: number, onResolve: (tab: chrome.tabs.Tab) => void, onReject?: () => void): void;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -13,6 +13,7 @@ export interface BrowserAdapter {
     createActiveTab(url: string): Promise<Tabs.Tab>;
     createTabInNewWindow(url: string): Promise<Tabs.Tab>;
     switchToTab(tabId: number): void;
+    switchToTabP(tabId: number): Promise<void>;
     updateTab(tabId: number, updateProperties: Tabs.UpdateUpdatePropertiesType): Promise<Tabs.Tab>;
     getTab(tabId: number, onResolve: (tab: chrome.tabs.Tab) => void, onReject?: () => void): void;
     updateWindow(windowId: number, updateProperties: Windows.UpdateUpdateInfoType): Promise<Windows.Window>;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -12,7 +12,7 @@ export interface BrowserAdapter {
     tabsQuery(query: Tabs.QueryQueryInfoType): Promise<Tabs.Tab[]>;
     createActiveTab(url: string): Promise<Tabs.Tab>;
     createTabInNewWindow(url: string): Promise<Tabs.Tab>;
-    switchToTabP(tabId: number): Promise<void>;
+    switchToTab(tabId: number): Promise<void>;
     updateTab(tabId: number, updateProperties: Tabs.UpdateUpdatePropertiesType): Promise<Tabs.Tab>;
     getTab(tabId: number, onResolve: (tab: chrome.tabs.Tab) => void, onReject?: () => void): void;
     updateWindow(windowId: number, updateProperties: Windows.UpdateUpdateInfoType): Promise<Windows.Window>;

--- a/src/common/browser-adapters/browser-adapter.ts
+++ b/src/common/browser-adapters/browser-adapter.ts
@@ -13,7 +13,9 @@ export interface BrowserAdapter {
     createActiveTab(url: string): Promise<Tabs.Tab>;
     createTabInNewWindow(url: string): Promise<Tabs.Tab>;
     switchToTab(tabId: number): void;
+    updateTab(tabId: number, updateProperties: Tabs.UpdateUpdatePropertiesType): Promise<Tabs.Tab>;
     getTab(tabId: number, onResolve: (tab: chrome.tabs.Tab) => void, onReject?: () => void): void;
+    updateWindow(windowId: number, updateProperties: Windows.UpdateUpdateInfoType): Promise<Windows.Window>;
     sendMessageToTab(tabId: number, message: any): Promise<void>;
     sendMessageToFrames(message: any): Promise<void>;
     executeScriptInTab(tabId: number, details: ExtensionTypes.InjectDetails): Promise<any[]>;

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -79,7 +79,7 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return browser.windows.update(windowId, updateProperties);
     }
 
-    public async switchToTabP(tabId: number): Promise<void> {
+    public async switchToTab(tabId: number): Promise<void> {
         const tab = await this.updateTab(tabId, { active: true });
         await this.updateWindow(tab.windowId, { focused: true });
     }

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -84,16 +84,6 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         await this.updateWindow(tab.windowId, { focused: true });
     }
 
-    public switchToTab(tabId: number): void {
-        const props = {
-            active: true,
-        };
-
-        chrome.tabs.update(tabId, props, tab => {
-            chrome.windows.update(tab.windowId, { focused: true });
-        });
-    }
-
     public sendMessageToTab(tabId: number, message: any): Promise<void> {
         return browser.tabs.sendMessage(tabId, message);
     }

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -71,6 +71,14 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return browser.windows.create({ url, focused: true }).then(window => window.tabs[0]);
     }
 
+    public updateTab(tabId: number, updateProperties: Tabs.UpdateUpdatePropertiesType): Promise<Tabs.Tab> {
+        return browser.tabs.update(tabId, updateProperties);
+    }
+
+    public updateWindow(windowId: number, updateProperties: Windows.UpdateUpdateInfoType): Promise<Windows.Window> {
+        return browser.windows.update(windowId, updateProperties);
+    }
+
     public switchToTab(tabId: number): void {
         const props = {
             active: true,

--- a/src/common/browser-adapters/chrome-adapter.ts
+++ b/src/common/browser-adapters/chrome-adapter.ts
@@ -79,6 +79,11 @@ export class ChromeAdapter implements BrowserAdapter, StorageAdapter, CommandsAd
         return browser.windows.update(windowId, updateProperties);
     }
 
+    public async switchToTabP(tabId: number): Promise<void> {
+        const tab = await this.updateTab(tabId, { active: true });
+        await this.updateWindow(tab.windowId, { focused: true });
+    }
+
     public switchToTab(tabId: number): void {
         const props = {
             active: true,

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -48,6 +48,8 @@ import { tick } from 'tests/unit/common/tick';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DictionaryStringTo } from 'types/common-types';
 
+//
+
 const VisualizationMessage = Messages.Visualizations;
 const PreviewFeaturesMessage = Messages.PreviewFeatures;
 

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -48,8 +48,6 @@ import { tick } from 'tests/unit/common/tick';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DictionaryStringTo } from 'types/common-types';
 
-//
-
 const VisualizationMessage = Messages.Visualizations;
 const PreviewFeaturesMessage = Messages.PreviewFeatures;
 
@@ -407,7 +405,7 @@ describe('ActionCreatorTest', () => {
         builder.verifyAll();
     });
 
-    test('registerCallback for onScanCompleted', () => {
+    test('registerCallback for onAdHocScanCompleted', () => {
         const key = 'Key should not matter';
         const actionName = 'scanCompleted';
         const message = VisualizationMessage.Common.ScanCompleted;

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -74,7 +74,7 @@ describe('InspectActionCreator', () => {
         });
 
         it('switch to tab succeed', async () => {
-            browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.resolve());
+            browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.resolve());
 
             testSubject.registerCallbacks();
 
@@ -85,7 +85,7 @@ describe('InspectActionCreator', () => {
 
         it('logs error when switch to tab fails', async () => {
             const dummyError = 'test-dummy-error';
-            browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.reject(dummyError));
+            browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.reject(dummyError));
 
             testSubject.registerCallbacks();
 

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -3,22 +3,27 @@
 import { InspectActionCreator } from 'background/actions/inspect-action-creator';
 import { InspectActions, InspectPayload } from 'background/actions/inspect-actions';
 import { InspectMode } from 'background/inspect-modes';
+import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import * as TelemetryEvents from 'common/extension-telemetry-events';
+import { CHANGE_INSPECT_MODE } from 'common/extension-telemetry-events';
+import { Action } from 'common/flux/action';
+import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
+import { tick } from 'tests/unit/common/tick';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-
 import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('InspectActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
     let browserAdapterMock: IMock<BrowserAdapter>;
+    let loggerMock: IMock<Logger>;
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
         browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
+        loggerMock = Mock.ofType<Logger>();
     });
 
     it('handles GetState message', () => {
@@ -31,6 +36,7 @@ describe('InspectActionCreator', () => {
             actionsMock.object,
             telemetryEventHandlerMock.object,
             browserAdapterMock.object,
+            loggerMock.object,
         );
 
         testSubject.registerCallbacks();
@@ -38,33 +44,56 @@ describe('InspectActionCreator', () => {
         getCurrentStateMock.verifyAll();
     });
 
-    it('handles ChangeInspectMode message', () => {
+    describe('handles ChangeInspectMode message', () => {
         const payload: InspectPayload = {
             inspectMode: InspectMode.scopingAddInclude,
         };
 
         const tabId: number = -1;
 
-        telemetryEventHandlerMock
-            .setup(publisher => publisher.publishTelemetry(TelemetryEvents.CHANGE_INSPECT_MODE, payload))
-            .verifiable(Times.once());
+        let changeInspectModeMock: IMock<Action<InspectPayload>>;
+        let actionsMock: IMock<InspectActions>;
+        let interpreterMock: IMock<Interpreter>;
 
-        browserAdapterMock.setup(ba => ba.switchToTab(tabId)).verifiable(Times.once());
+        let testSubject: InspectActionCreator;
 
-        const changeInspectModeMock = createActionMock(payload);
-        const actionsMock = createActionsMock('changeInspectMode', changeInspectModeMock.object);
-        const interpreterMock = createInterpreterMock(Messages.Inspect.ChangeInspectMode, payload, tabId);
+        beforeEach(() => {
+            telemetryEventHandlerMock.setup(publisher => publisher.publishTelemetry(CHANGE_INSPECT_MODE, payload)).verifiable(Times.once());
 
-        const testSubject = new InspectActionCreator(
-            interpreterMock.object,
-            actionsMock.object,
-            telemetryEventHandlerMock.object,
-            browserAdapterMock.object,
-        );
+            changeInspectModeMock = createActionMock(payload);
+            actionsMock = createActionsMock('changeInspectMode', changeInspectModeMock.object);
+            interpreterMock = createInterpreterMock(Messages.Inspect.ChangeInspectMode, payload, tabId);
 
-        testSubject.registerCallbacks();
+            testSubject = new InspectActionCreator(
+                interpreterMock.object,
+                actionsMock.object,
+                telemetryEventHandlerMock.object,
+                browserAdapterMock.object,
+                loggerMock.object,
+            );
+        });
 
-        changeInspectModeMock.verifyAll();
+        it('switch to tab succeed', async () => {
+            browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.resolve());
+
+            testSubject.registerCallbacks();
+
+            await tick();
+
+            changeInspectModeMock.verifyAll();
+        });
+
+        it('logs error when switch to tab fails', async () => {
+            const dummyError = 'test-dummy-error';
+            browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.reject(dummyError));
+
+            testSubject.registerCallbacks();
+
+            await tick();
+
+            changeInspectModeMock.verifyAll();
+            loggerMock.verify(logger => logger.error(`switchToTab failed: ${dummyError}`), Times.once());
+        });
     });
 
     function createActionsMock<ActionName extends keyof InspectActions>(

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -136,7 +136,7 @@ describe('TestActionCreatorTest', () => {
         });
 
         it('switch to tab succeed', async () => {
-            browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.resolve());
+            browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.resolve());
 
             testSubject.registerCallbacks();
 
@@ -147,7 +147,7 @@ describe('TestActionCreatorTest', () => {
 
         it('logs error when switch to tab fails', async () => {
             const dummyError = 'switch to tab dummy error';
-            browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.reject(dummyError));
+            browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.reject(dummyError));
 
             testSubject.registerCallbacks();
 

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -3,6 +3,7 @@
 import { ExistingTabUpdatedPayload, PageVisibilityChangeTabPayload, SwitchToTargetTabPayload } from 'background/actions/action-payloads';
 import { TabActionCreator } from 'background/actions/tab-action-creator';
 import { TabActions } from 'background/actions/tab-actions';
+import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import {
@@ -12,18 +13,22 @@ import {
     TriggeredBy,
     TriggeredByNotApplicable,
 } from 'common/extension-telemetry-events';
+import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
+import { tick } from 'tests/unit/common/tick';
 import { IMock, Mock, Times } from 'typemoq';
 import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
 
 describe('TestActionCreatorTest', () => {
     let browserAdapterMock: IMock<BrowserAdapter>;
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
+    let loggerMock: IMock<Logger>;
 
     beforeEach(() => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        loggerMock = Mock.ofType<Logger>();
     });
 
     it('handles Tab.NewTabCreated message', () => {
@@ -38,7 +43,13 @@ describe('TestActionCreatorTest', () => {
         const actionsMock = createActionsMock('newTabCreated', actionMock.object);
         const interpreterMock = createInterpreterMock(Messages.Tab.NewTabCreated, payload);
 
-        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, telemetryEventHandlerMock.object);
+        const testSubject = new TabActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            null,
+            telemetryEventHandlerMock.object,
+            loggerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -51,7 +62,7 @@ describe('TestActionCreatorTest', () => {
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
         const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.TabStore), null);
 
-        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null);
+        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null, loggerMock.object);
 
         testSubject.registerCallbacks();
 
@@ -63,7 +74,7 @@ describe('TestActionCreatorTest', () => {
         const actionsMock = createActionsMock('tabRemove', tabRemoveMock.object);
         const interpreterMock = createInterpreterMock(Messages.Tab.Remove, null);
 
-        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null);
+        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null, loggerMock.object);
 
         testSubject.registerCallbacks();
 
@@ -85,7 +96,13 @@ describe('TestActionCreatorTest', () => {
         const actionsMock = createActionsMock('existingTabUpdated', actionMock.object);
         const interpreterMock = createInterpreterMock(Messages.Tab.ExistingTabUpdated, payload);
 
-        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, telemetryEventHandlerMock.object);
+        const testSubject = new TabActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            null,
+            telemetryEventHandlerMock.object,
+            loggerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -93,7 +110,7 @@ describe('TestActionCreatorTest', () => {
         telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(EXISTING_TAB_URL_UPDATED, payload), Times.once());
     });
 
-    it('handles Tab.Switch message', () => {
+    describe('handles Tab.Switch message', () => {
         const payload: SwitchToTargetTabPayload = {
             telemetry: {
                 triggeredBy: 'test' as TriggeredBy,
@@ -103,14 +120,42 @@ describe('TestActionCreatorTest', () => {
 
         const tabId: number = -1;
 
-        const interpreterMock = createInterpreterMock(Messages.Tab.Switch, payload, tabId);
+        let interpreterMock: IMock<Interpreter>;
+        let testSubject: TabActionCreator;
 
-        const testSubject = new TabActionCreator(interpreterMock.object, null, browserAdapterMock.object, telemetryEventHandlerMock.object);
+        beforeEach(() => {
+            interpreterMock = createInterpreterMock(Messages.Tab.Switch, payload, tabId);
 
-        testSubject.registerCallbacks();
+            testSubject = new TabActionCreator(
+                interpreterMock.object,
+                null,
+                browserAdapterMock.object,
+                telemetryEventHandlerMock.object,
+                loggerMock.object,
+            );
+        });
 
-        browserAdapterMock.verify(ba => ba.switchToTab(tabId), Times.once());
-        telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(SWITCH_BACK_TO_TARGET, payload), Times.once());
+        it('switch to tab succeed', async () => {
+            browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.resolve());
+
+            testSubject.registerCallbacks();
+
+            await tick();
+
+            telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(SWITCH_BACK_TO_TARGET, payload), Times.once());
+        });
+
+        it('logs error when switch to tab fails', async () => {
+            const dummyError = 'switch to tab dummy error';
+            browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.reject(dummyError));
+
+            testSubject.registerCallbacks();
+
+            await tick();
+
+            telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(SWITCH_BACK_TO_TARGET, payload), Times.once());
+            loggerMock.verify(logger => logger.error(`switchToTab failed: ${dummyError}`), Times.once());
+        });
     });
 
     it('handles Tab.VisibilityChange message', () => {
@@ -122,7 +167,7 @@ describe('TestActionCreatorTest', () => {
         const actionsMock = createActionsMock('tabVisibilityChange', tabVisibilityChangeMock.object);
         const interpreterMock = createInterpreterMock(Messages.Tab.VisibilityChange, payload);
 
-        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null);
+        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null, loggerMock.object);
 
         testSubject.registerCallbacks();
 

--- a/src/tests/unit/tests/background/details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/details-view-controller.test.ts
@@ -2,33 +2,33 @@
 // Licensed under the MIT License.
 import { DetailsViewController } from 'background/details-view-controller';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { IMock, It, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { Tabs } from 'webextension-polyfill-ts';
 
 describe('DetailsViewControllerTest', () => {
-    let mockBrowserAdapter: IMock<BrowserAdapter>;
+    let browserAdapterMock: IMock<BrowserAdapter>;
     let testSubject: DetailsViewController;
     let onTabRemoveCallback: (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo) => void;
     let onUpdateTabCallback: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => void;
 
     beforeEach(() => {
-        mockBrowserAdapter = Mock.ofType<BrowserAdapter>();
+        browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
 
-        mockBrowserAdapter
+        browserAdapterMock
             .setup(adapter => adapter.addListenerToTabsOnRemoved(It.isAny()))
             .callback(callback => {
                 onTabRemoveCallback = callback;
             })
             .verifiable();
 
-        mockBrowserAdapter
+        browserAdapterMock
             .setup(adapter => adapter.addListenerToTabsOnUpdated(It.isAny()))
             .callback(callback => {
                 onUpdateTabCallback = callback;
             })
             .verifiable();
 
-        testSubject = new DetailsViewController(mockBrowserAdapter.object);
+        testSubject = new DetailsViewController(browserAdapterMock.object);
     });
 
     describe('showDetailsView', () => {
@@ -36,45 +36,62 @@ describe('DetailsViewControllerTest', () => {
             const targetTabId = 12;
             const detailsViewTabId = 10;
 
-            setupCreateDetailsViewP(targetTabId, detailsViewTabId).verifiable(Times.once());
+            setupCreateDetailsView(targetTabId, detailsViewTabId).verifiable(Times.once());
 
             await testSubject.showDetailsView(targetTabId);
 
-            mockBrowserAdapter.verifyAll();
+            browserAdapterMock.verifyAll();
         });
 
         it('switch to existing tab the second time', async () => {
             const targetTabId = 5;
             const detailsViewTabId = 10;
 
-            setupCreateDetailsViewP(targetTabId, detailsViewTabId).verifiable(Times.once());
+            setupCreateDetailsView(targetTabId, detailsViewTabId).verifiable(Times.once());
 
             await testSubject.showDetailsView(targetTabId);
 
-            mockBrowserAdapter.reset();
+            browserAdapterMock.reset();
 
-            setupCreateDetailsViewPForAnyUrl(Times.never());
-
-            mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
+            setupCreateDetailsViewForAnyUrl(Times.never());
+            setupSwitchToTab(detailsViewTabId);
 
             // call show details second time
             await testSubject.showDetailsView(targetTabId);
 
-            mockBrowserAdapter.verifyAll();
+            browserAdapterMock.verifyAll();
         });
 
-        it('propagates error from failing browser adapter call', async () => {
+        it('propagates error from failing browser adapter call to switch to tab', async () => {
+            const targetTabId = 5;
+            const detailsViewTabId = 10;
+
+            setupCreateDetailsView(targetTabId, detailsViewTabId).verifiable(Times.once());
+
+            await testSubject.showDetailsView(targetTabId);
+
+            browserAdapterMock.reset();
+
+            const errorMessage = 'switchToTab failed with dummy error';
+            browserAdapterMock.setup(adapter => adapter.switchToTabP(detailsViewTabId)).returns(() => Promise.reject(errorMessage));
+
+            await expect(testSubject.showDetailsView(targetTabId)).rejects.toEqual(errorMessage);
+
+            browserAdapterMock.verifyAll();
+        });
+
+        it('propagates error from failing browser adapter call to create tab', async () => {
             const targetTabId = 5;
             const errorMessage = 'error creating new window (from browser adapter)';
 
-            mockBrowserAdapter
+            browserAdapterMock
                 .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId))
                 .returns(() => Promise.reject(errorMessage))
                 .verifiable(Times.once());
 
             await expect(testSubject.showDetailsView(targetTabId)).rejects.toEqual(errorMessage);
 
-            mockBrowserAdapter.verifyAll();
+            browserAdapterMock.verifyAll();
         });
     });
 
@@ -82,24 +99,23 @@ describe('DetailsViewControllerTest', () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
 
-        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+        setupCreateDetailsView(targetTabId, detailsViewTabId);
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.reset();
+        browserAdapterMock.reset();
 
         // update target tab
         onUpdateTabCallback(targetTabId, null, null);
 
-        setupCreateDetailsViewPForAnyUrl(Times.never());
-
-        mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
+        setupCreateDetailsViewForAnyUrl(Times.never());
+        setupSwitchToTab(detailsViewTabId);
 
         // call show details second time
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.verifyAll();
+        browserAdapterMock.verifyAll();
     });
 
     test('showDetailsView after details tab navigated to another page', async () => {
@@ -111,26 +127,24 @@ describe('DetailsViewControllerTest', () => {
 
         testSubject.setupDetailsViewTabRemovedHandler(detailsViewRemovedHandlerMock.object);
 
-        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+        setupCreateDetailsView(targetTabId, detailsViewTabId);
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.reset();
+        browserAdapterMock.reset();
 
         // update details tab
-        mockBrowserAdapter.setup(adapter => adapter.getRunTimeId()).returns(() => 'ext_id');
+        browserAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => 'ext_id');
 
         onUpdateTabCallback(detailsViewTabId, { url: 'www.bing.com/DetailsView/detailsView.html?tabId=' + targetTabId }, null);
 
-        setupCreateDetailsViewPForAnyUrl(Times.once());
-
-        mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
+        setupCreateDetailsViewForAnyUrl(Times.once());
 
         // call show details second time
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.verifyAll();
+        browserAdapterMock.verifyAll();
         detailsViewRemovedHandlerMock.verifyAll();
     });
 
@@ -138,135 +152,124 @@ describe('DetailsViewControllerTest', () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
 
-        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+        setupCreateDetailsView(targetTabId, detailsViewTabId);
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.reset();
+        browserAdapterMock.reset();
 
         // update details tab
         const extensionId = 'ext_id';
-        mockBrowserAdapter.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
+        browserAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
         onUpdateTabCallback(detailsViewTabId, { url: 'chromeExt://ext_id/DetailsView/detailsView.html?tabId=90' }, null);
 
-        setupCreateDetailsViewPForAnyUrl(Times.once());
-
-        mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
+        setupCreateDetailsViewForAnyUrl(Times.once());
 
         // call show details second time
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.verifyAll();
+        browserAdapterMock.verifyAll();
     });
 
     test('showDetailsView after details tab refresh', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
 
-        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+        setupCreateDetailsView(targetTabId, detailsViewTabId);
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.reset();
+        browserAdapterMock.reset();
 
         // update details tab
         const extensionId = 'ext_id';
-        mockBrowserAdapter.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
+        browserAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
         onUpdateTabCallback(detailsViewTabId, { url: 'chromeExt://ext_Id/detailsView/detailsView.html?tabId=' + targetTabId }, null);
 
-        setupCreateDetailsViewPForAnyUrl(Times.never());
-
-        mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
+        setupCreateDetailsViewForAnyUrl(Times.never());
+        setupSwitchToTab(detailsViewTabId);
 
         // call show details second time
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.verifyAll();
+        browserAdapterMock.verifyAll();
     });
 
     test('showDetailsView after details tab title update', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
 
-        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+        setupCreateDetailsView(targetTabId, detailsViewTabId);
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.reset();
+        browserAdapterMock.reset();
 
         // update details tab
-        const extensionId = 'ext_id';
-        mockBrowserAdapter.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
         onUpdateTabCallback(detailsViewTabId, { title: 'issues' }, null);
 
-        setupCreateDetailsViewPForAnyUrl(Times.never());
-
-        mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
+        setupCreateDetailsViewForAnyUrl(Times.never());
+        setupSwitchToTab(detailsViewTabId);
 
         // call show details second time
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.verifyAll();
+        browserAdapterMock.verifyAll();
     });
 
     test('showDetailsView after random tab updated', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
 
-        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+        setupCreateDetailsView(targetTabId, detailsViewTabId);
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.reset();
+        browserAdapterMock.reset();
 
         // remove details tab
-        const extensionId = 'ext_id';
-        mockBrowserAdapter.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
         onUpdateTabCallback(123, { title: 'issues' }, null);
 
-        setupCreateDetailsViewPForAnyUrl(Times.never());
-
-        mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
+        setupCreateDetailsViewForAnyUrl(Times.never());
+        setupSwitchToTab(detailsViewTabId);
 
         // call show details second time
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.verifyAll();
+        browserAdapterMock.verifyAll();
     });
 
     test('showDetailsView after target tab removed', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
 
-        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+        setupCreateDetailsView(targetTabId, detailsViewTabId);
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.reset();
+        browserAdapterMock.reset();
 
         // remove target tab
         onTabRemoveCallback(targetTabId, null);
 
-        setupCreateDetailsViewPForAnyUrl(Times.once());
-
-        mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
+        setupCreateDetailsViewForAnyUrl(Times.once());
 
         // call show details second time
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.verifyAll();
+        browserAdapterMock.verifyAll();
     });
 
     test('showDetailsView after details tab removed', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
 
-        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+        setupCreateDetailsView(targetTabId, detailsViewTabId);
 
         const detailsViewRemovedHandlerMock = Mock.ofInstance((tabId: number) => {});
         detailsViewRemovedHandlerMock.setup(handler => handler(targetTabId)).verifiable(Times.once());
@@ -275,19 +278,17 @@ describe('DetailsViewControllerTest', () => {
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.reset();
+        browserAdapterMock.reset();
 
         // remove details tab
         onTabRemoveCallback(detailsViewTabId, null);
 
-        setupCreateDetailsViewPForAnyUrl(Times.once());
-
-        mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
+        setupCreateDetailsViewForAnyUrl(Times.once());
 
         // call show details second time
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.verifyAll();
+        browserAdapterMock.verifyAll();
         detailsViewRemovedHandlerMock.verifyAll();
     });
 
@@ -295,58 +296,59 @@ describe('DetailsViewControllerTest', () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
 
-        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+        setupCreateDetailsView(targetTabId, detailsViewTabId);
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.reset();
+        browserAdapterMock.reset();
 
         // remove details tab
         onTabRemoveCallback(detailsViewTabId, null);
 
-        setupCreateDetailsViewPForAnyUrl(Times.once());
-
-        mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.never());
+        setupCreateDetailsViewForAnyUrl(Times.once());
 
         // call show details second time
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.verifyAll();
+        browserAdapterMock.verifyAll();
     });
 
     test('showDetailsView after random tab removed', async () => {
         const targetTabId = 5;
         const detailsViewTabId = 10;
 
-        setupCreateDetailsViewP(targetTabId, detailsViewTabId);
+        setupCreateDetailsView(targetTabId, detailsViewTabId);
 
         // call show details once
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.reset();
+        browserAdapterMock.reset();
 
         // remove details tab
         onTabRemoveCallback(100, null);
 
-        setupCreateDetailsViewPForAnyUrl(Times.never());
-
-        mockBrowserAdapter.setup(adapter => adapter.switchToTab(detailsViewTabId)).verifiable(Times.once());
+        setupCreateDetailsViewForAnyUrl(Times.never());
+        setupSwitchToTab(detailsViewTabId);
 
         // call show details second time
         await testSubject.showDetailsView(targetTabId);
 
-        mockBrowserAdapter.verifyAll();
+        browserAdapterMock.verifyAll();
     });
 
-    const setupCreateDetailsViewP = (targetTabId: number, resultingDetailsViewTabId: number) => {
-        return mockBrowserAdapter
+    const setupSwitchToTab = (tabId: number) => {
+        return browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.resolve());
+    };
+
+    const setupCreateDetailsView = (targetTabId: number, resultingDetailsViewTabId: number) => {
+        return browserAdapterMock
             .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId))
             .returns(() => Promise.resolve({ id: resultingDetailsViewTabId } as Tabs.Tab));
     };
 
-    const setupCreateDetailsViewPForAnyUrl = (times: Times) => {
-        mockBrowserAdapter
+    const setupCreateDetailsViewForAnyUrl = (times: Times) => {
+        browserAdapterMock
             .setup(adapter => adapter.createTabInNewWindow(It.isAny()))
             .returns(() => Promise.resolve({ id: -1 } as Tabs.Tab))
             .verifiable(times);

--- a/src/tests/unit/tests/background/details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/details-view-controller.test.ts
@@ -73,7 +73,7 @@ describe('DetailsViewControllerTest', () => {
             browserAdapterMock.reset();
 
             const errorMessage = 'switchToTab failed with dummy error';
-            browserAdapterMock.setup(adapter => adapter.switchToTabP(detailsViewTabId)).returns(() => Promise.reject(errorMessage));
+            browserAdapterMock.setup(adapter => adapter.switchToTab(detailsViewTabId)).returns(() => Promise.reject(errorMessage));
 
             await expect(testSubject.showDetailsView(targetTabId)).rejects.toEqual(errorMessage);
 
@@ -338,7 +338,7 @@ describe('DetailsViewControllerTest', () => {
     });
 
     const setupSwitchToTab = (tabId: number) => {
-        return browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.resolve());
+        return browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.resolve());
     };
 
     const setupCreateDetailsView = (targetTabId: number, resultingDetailsViewTabId: number) => {

--- a/src/tests/unit/tests/background/target-tab-controller.test.ts
+++ b/src/tests/unit/tests/background/target-tab-controller.test.ts
@@ -57,7 +57,7 @@ describe('TargetTabControllerTest', () => {
             browserAdapterMock.verifyAll();
         });
 
-        it('propagates error from swith to tab', async () => {
+        it('propagates error from switch to tab', async () => {
             getSwitchToTargetTabCallbackMock
                 .setup(cm => cm(step))
                 .returns(() => true)

--- a/src/tests/unit/tests/background/target-tab-controller.test.ts
+++ b/src/tests/unit/tests/background/target-tab-controller.test.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, Mock, Times } from 'typemoq';
-
 import { TargetTabController } from 'background/target-tab-controller';
+import { IMock, Mock, Times } from 'typemoq';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
@@ -14,9 +13,9 @@ describe('TargetTabControllerTest', () => {
     let testSubject: TargetTabController;
     let configStub: VisualizationConfiguration;
     let getSwitchToTargetTabCallbackMock: IMock<(step: string) => boolean>;
-    let test: VisualizationType;
-    let tabId: number;
-    let step: string;
+    const test: VisualizationType = -2;
+    const tabId: number = -1;
+    const step: string = 'some step';
 
     beforeEach(() => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
@@ -25,46 +24,53 @@ describe('TargetTabControllerTest', () => {
         configStub = {
             getSwitchToTargetTabOnScan: getSwitchToTargetTabCallbackMock.object,
         } as VisualizationConfiguration;
-        tabId = -1;
-        test = -2;
-        step = 'some step';
 
         configurationFactoryMock.setup(cfm => cfm.getConfiguration(test)).returns(() => configStub);
 
         testSubject = new TargetTabController(browserAdapterMock.object, configurationFactoryMock.object);
     });
 
-    it('tests the constructor', () => {
-        expect(testSubject).toBeDefined();
-    });
+    describe('showTargetTab', () => {
+        it("test doesn't switch to target tab", async () => {
+            configurationFactoryMock.setup(cfm => cfm.getConfiguration(test)).returns(() => configStub);
 
-    it("showTargetTab: test doesn't switch to target tab", () => {
-        configurationFactoryMock.setup(cfm => cfm.getConfiguration(test)).returns(() => configStub);
+            getSwitchToTargetTabCallbackMock
+                .setup(cm => cm(null))
+                .returns(() => false)
+                .verifiable(Times.once());
 
-        getSwitchToTargetTabCallbackMock
-            .setup(cm => cm(null))
-            .returns(() => false)
-            .verifiable(Times.once());
+            setupSwitchToTabBrowserCall(Times.never());
 
-        setupSwitchToTabBrowserCall(Times.never());
+            await testSubject.showTargetTab(tabId, test);
+            browserAdapterMock.verifyAll();
+        });
 
-        testSubject.showTargetTab(tabId, test);
-        browserAdapterMock.verifyAll();
-    });
+        it('test does switch to target tab', async () => {
+            getSwitchToTargetTabCallbackMock
+                .setup(cm => cm(step))
+                .returns(() => true)
+                .verifiable(Times.once());
 
-    it('showTargetTab: test does switch to target tab', () => {
-        getSwitchToTargetTabCallbackMock
-            .setup(cm => cm(step))
-            .returns(() => true)
-            .verifiable(Times.once());
+            setupSwitchToTabBrowserCall(Times.once());
 
-        setupSwitchToTabBrowserCall(Times.once());
+            await testSubject.showTargetTab(tabId, test, step);
+            browserAdapterMock.verifyAll();
+        });
 
-        testSubject.showTargetTab(tabId, test, step);
-        browserAdapterMock.verifyAll();
+        it('propagates error from swith to tab', async () => {
+            getSwitchToTargetTabCallbackMock
+                .setup(cm => cm(step))
+                .returns(() => true)
+                .verifiable(Times.once());
+
+            const errorMessage = 'switchToTab failed error message';
+            browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.reject(errorMessage));
+
+            await expect(testSubject.showTargetTab(tabId, test, step)).rejects.toEqual(errorMessage);
+        });
     });
 
     function setupSwitchToTabBrowserCall(times: Times): void {
-        browserAdapterMock.setup(bam => bam.switchToTab(tabId)).verifiable(times);
+        browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).verifiable(times);
     }
 });

--- a/src/tests/unit/tests/background/target-tab-controller.test.ts
+++ b/src/tests/unit/tests/background/target-tab-controller.test.ts
@@ -64,13 +64,13 @@ describe('TargetTabControllerTest', () => {
                 .verifiable(Times.once());
 
             const errorMessage = 'switchToTab failed error message';
-            browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).returns(() => Promise.reject(errorMessage));
+            browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.reject(errorMessage));
 
             await expect(testSubject.showTargetTab(tabId, test, step)).rejects.toEqual(errorMessage);
         });
     });
 
     function setupSwitchToTabBrowserCall(times: Times): void {
-        browserAdapterMock.setup(adapter => adapter.switchToTabP(tabId)).verifiable(times);
+        browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).verifiable(times);
     }
 });


### PR DESCRIPTION
#### Description of changes

This is part of a long-run refactor to promisify all (possible) `chrome.*` calls.

In this case, promisifying `switchToTab`.

`switchToTab` actually have a little logic inside (so not strictly an adapter function): 1) set the tab to active; 2) set the window to focused. Simple enough but doesn't really match the Adapter Pattern. As a future work (so out of scope for this PR) we may want to extract that bit of logic to, says, `TabSwitcher` class (or plainly a function).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
