### PR TITLE
fix: scanning spinner is not announced on assessment's automated checks

### DIFF
--- a/src/DetailsView/extensions/wait-for-all-requirements-to-complete.tsx
+++ b/src/DetailsView/extensions/wait-for-all-requirements-to-complete.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
+import { ScanningSpinner } from 'common/components/scanning-spinner/scanning-spinner';
 import * as React from 'react';
-
 import { OutcomeMath } from 'reports/components/outcome-math';
 import { AssessmentViewMainContentExtensionPoint } from '../components/assessment-view';
 
@@ -13,7 +12,7 @@ export const waitForAllRequirementsToComplete = AssessmentViewMainContentExtensi
     if (outcomeStats.incomplete > 0) {
         const percentage = OutcomeMath.percentageComplete(outcomeStats);
 
-        return <Spinner className="details-view-spinner" size={SpinnerSize.large} label={`Scanning ${percentage}%`} />;
+        return <ScanningSpinner isSpinning={true} label={`Scanning ${percentage}%`} />;
     }
 
     return <>{children}</>;

--- a/src/tests/unit/tests/DetailsView/extensions/__snapshots__/wait-for-all-requirements-to-complete.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/extensions/__snapshots__/wait-for-all-requirements-to-complete.test.tsx.snap
@@ -6,6 +6,6 @@ exports[`WaitForAllRequirementsToComplete renders children when oneHundredPercen
 </Fragment>"
 `;
 
-exports[`WaitForAllRequirementsToComplete renders spinner when fiftyPercent 1`] = `"<StyledSpinnerBase className=\\"details-view-spinner\\" size={3} label=\\"Scanning 50%\\" />"`;
+exports[`WaitForAllRequirementsToComplete renders spinner when fiftyPercent 1`] = `"<ScanningSpinner isSpinning={true} label=\\"Scanning 50%\\" />"`;
 
-exports[`WaitForAllRequirementsToComplete renders spinner when zeroPercent 1`] = `"<StyledSpinnerBase className=\\"details-view-spinner\\" size={3} label=\\"Scanning 0%\\" />"`;
+exports[`WaitForAllRequirementsToComplete renders spinner when zeroPercent 1`] = `"<ScanningSpinner isSpinning={true} label=\\"Scanning 0%\\" />"`;

--- a/src/tests/unit/tests/DetailsView/extensions/wait-for-all-requirements-to-complete.test.tsx
+++ b/src/tests/unit/tests/DetailsView/extensions/wait-for-all-requirements-to-complete.test.tsx
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ScanningSpinner } from 'common/components/scanning-spinner/scanning-spinner';
+import { WithAssessmentTestResult } from 'DetailsView/components/assessment-view';
+import { waitForAllRequirementsToComplete } from 'DetailsView/extensions/wait-for-all-requirements-to-complete';
 import { shallow } from 'enzyme';
-import { Spinner } from 'office-ui-fabric-react';
 import * as React from 'react';
-
-import { WithAssessmentTestResult } from '../../../../../DetailsView/components/assessment-view';
-import { waitForAllRequirementsToComplete } from '../../../../../DetailsView/extensions/wait-for-all-requirements-to-complete';
 
 describe('WaitForAllRequirementsToComplete', () => {
     const zeroPercent = {
@@ -30,21 +29,21 @@ describe('WaitForAllRequirementsToComplete', () => {
 
     it('renders spinner when zeroPercent', () => {
         const rendered = shallow(<Extension {...zeroPercent}>INSIDE</Extension>);
-        const spinner = rendered.find(Spinner);
+        const spinner = rendered.find(ScanningSpinner);
         expect(spinner.prop('label')).toEqual('Scanning 0%');
         expect(rendered.debug()).toMatchSnapshot();
     });
 
     it('renders spinner when fiftyPercent', () => {
         const rendered = shallow(<Extension {...fiftyPercent}>INSIDE</Extension>);
-        const spinner = rendered.find(Spinner);
+        const spinner = rendered.find(ScanningSpinner);
         expect(spinner.prop('label')).toEqual('Scanning 50%');
         expect(rendered.debug()).toMatchSnapshot();
     });
 
     it('renders children when oneHundredPercent', () => {
         const rendered = shallow(<Extension {...oneHundredPercent}>INSIDE</Extension>);
-        const spinner = rendered.find(Spinner);
+        const spinner = rendered.find(ScanningSpinner);
         expect(spinner.exists()).toEqual(false);
         expect(rendered.text()).toEqual('INSIDE');
         expect(rendered.debug()).toMatchSnapshot();


### PR DESCRIPTION
#### Description of changes

Currently, Assessment -> Automated checks shows a "scanning" spinner while we run axe. We are using Office Fabric `<Spinner>` which does not get properly announce (it does not get announced at all).

In this PR, we are switching to use `<ScanningSpinner>` to get a proper announcement. This is the same component we are already using in the new cards UI (so it's already being use on electron app and fast pass -> automated checks)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
