### PR TITLE
fix: popup hamburger menu aria label

### DIFF
--- a/src/popup/components/launch-panel-header.tsx
+++ b/src/popup/components/launch-panel-header.tsx
@@ -69,7 +69,7 @@ export class LaunchPanelHeader extends React.Component<
                     onClick={event =>
                         launchPanelHeaderClickHandler.onOpenContextualMenu(this, event)
                     }
-                    ariaLabel="Help and Feedback menu"
+                    ariaLabel="help menu"
                 />
                 {this.renderContextualMenu(this.state.isContextMenuVisible)}
             </div>

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -43,7 +43,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
             </div>
           </div>
           <button
-            aria-label="Help and Feedback menu"
+            aria-label="help menu"
             class="ms-Button ms-Button--icon root-000"
             data-is-focusable="true"
             id="feedback-collapse-menu-button"

--- a/src/tests/unit/tests/popup/components/__snapshots__/launch-panel-header.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/launch-panel-header.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`LaunchPanelHeaderTest render 1`] = `
       featureFlags={Object {}}
     />
     <CustomizedIconButton
-      ariaLabel="Help and Feedback menu"
+      ariaLabel="help menu"
       iconProps={
         Object {
           "iconName": "GlobalNavButton",
@@ -45,7 +45,7 @@ exports[`LaunchPanelHeaderTest render contextual menu renders with new assessmen
       }
     />
     <CustomizedIconButton
-      ariaLabel="Help and Feedback menu"
+      ariaLabel="help menu"
       iconProps={
         Object {
           "iconName": "GlobalNavButton",
@@ -159,7 +159,7 @@ exports[`LaunchPanelHeaderTest render contextual menu renders with new assessmen
                     }
                   />
                   <CustomizedIconButton
-                    ariaLabel="Help and Feedback menu"
+                    ariaLabel="help menu"
                     iconProps={
                       Object {
                         "iconName": "GlobalNavButton",
@@ -215,7 +215,7 @@ exports[`LaunchPanelHeaderTest render contextual menu renders without new assess
       featureFlags={Object {}}
     />
     <CustomizedIconButton
-      ariaLabel="Help and Feedback menu"
+      ariaLabel="help menu"
       iconProps={
         Object {
           "iconName": "GlobalNavButton",
@@ -315,7 +315,7 @@ exports[`LaunchPanelHeaderTest render contextual menu renders without new assess
                     featureFlags={Object {}}
                   />
                   <CustomizedIconButton
-                    ariaLabel="Help and Feedback menu"
+                    ariaLabel="help menu"
                     iconProps={
                       Object {
                         "iconName": "GlobalNavButton",

--- a/src/tests/unit/tests/popup/components/launch-panel-header.test.tsx
+++ b/src/tests/unit/tests/popup/components/launch-panel-header.test.tsx
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DropdownClickHandler } from 'common/dropdown-click-handler';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { mount, shallow } from 'enzyme';
 import { IconButton } from 'office-ui-fabric-react';
+import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-creator';
+import { LaunchPanelHeader, LaunchPanelHeaderDeps, LaunchPanelHeaderProps } from 'popup/components/launch-panel-header';
+import { LaunchPanelHeaderClickHandler } from 'popup/handlers/launch-panel-header-click-handler';
 import * as React from 'react';
+import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { It, Mock, Times } from 'typemoq';
-import { DropdownClickHandler } from '../../../../../common/dropdown-click-handler';
-import { FeatureFlagStoreData } from '../../../../../common/types/store-data/feature-flag-store-data';
-import { PopupActionMessageCreator } from '../../../../../popup/actions/popup-action-message-creator';
-import { LaunchPanelHeader, LaunchPanelHeaderDeps, LaunchPanelHeaderProps } from '../../../../../popup/components/launch-panel-header';
-import { LaunchPanelHeaderClickHandler } from '../../../../../popup/handlers/launch-panel-header-click-handler';
-import { EventStubFactory } from '../../../common/event-stub-factory';
 
 describe('LaunchPanelHeaderTest', () => {
     let props: LaunchPanelHeaderProps;


### PR DESCRIPTION
#### Description of changes

Originally (like eons ago) we had a **feedback** option on the popup's hamburger menu. The aria label of that button mentions this but since the option has been long gone, this PR update the label.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
