### PR TITLE
fix: telemetry settings toggle focus ring cut-off

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -124,29 +124,6 @@ div.insights-file-issue-details-dialog-container {
     }
 }
 
-.settings-panel {
-    .generic-toggle-component .toggle-description {
-        color: $secondary-text;
-    }
-
-    h3 {
-        font-size: 17px;
-        margin-block-end: 8px;
-    }
-
-    .issue-setting {
-        .ms-Label {
-            color: $neutral-100;
-            padding-top: 8px;
-            padding-bottom: 8px;
-        }
-
-        .ms-TextField-field {
-            color: $neutral-100;
-        }
-    }
-}
-
 .scoping-panel {
     .scoping-container {
         .scoping-description {

--- a/src/DetailsView/components/generic-panel.tsx
+++ b/src/DetailsView/components/generic-panel.tsx
@@ -12,12 +12,14 @@ export interface GenericPanelProps {
     closeButtonAriaLabel: string;
     hasCloseButton: boolean;
     onRenderFooterContent?: IRenderFunction<IPanelProps>;
+    innerPanelAutomationId?: string;
 }
 
 export class GenericPanel extends React.Component<GenericPanelProps> {
     public render(): JSX.Element {
         return (
             <Panel
+                data-automation-id={this.props.innerPanelAutomationId}
                 isOpen={this.props.isOpen}
                 type={PanelType.custom}
                 customWidth="550px"

--- a/src/DetailsView/components/settings-panel/settings-panel.scss
+++ b/src/DetailsView/components/settings-panel/settings-panel.scss
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../common/styles/colors.scss';
+
+.settings-panel {
+    .generic-toggle-component .toggle-description {
+        color: $secondary-text;
+    }
+
+    h3 {
+        font-size: 17px;
+        margin-block-end: 8px;
+    }
+
+    .issue-setting {
+        :global(.ms-Label) {
+            color: $neutral-100;
+            padding-top: 8px;
+            padding-bottom: 8px;
+        }
+
+        :global(.ms-TextField-field) {
+            color: $neutral-100;
+        }
+    }
+
+    :global(.ms-Panel-content) {
+        padding-top: 20px;
+    }
+}

--- a/src/DetailsView/components/settings-panel/settings-panel.tsx
+++ b/src/DetailsView/components/settings-panel/settings-panel.tsx
@@ -6,6 +6,7 @@ import { UserConfigurationStoreData } from 'common/types/store-data/user-configu
 import * as React from 'react';
 import { DetailsViewActionMessageCreator } from '../../actions/details-view-action-message-creator';
 import { GenericPanel } from '../generic-panel';
+import * as styles from './settings-panel.scss';
 import { SettingsDeps } from './settings/settings-props';
 import { SettingsComponent, SettingsProvider } from './settings/settings-provider';
 
@@ -28,7 +29,7 @@ export const SettingsPanel = NamedFC<SettingsPanelProps>('SettingsPanel', props 
     return (
         <GenericPanel
             isOpen={isOpen}
-            className="settings-panel"
+            className={styles.settingsPanel}
             onDismiss={detailsViewActionMessageCreator.closeSettingsPanel}
             closeButtonAriaLabel="Close settings panel"
             hasCloseButton={true}

--- a/src/DetailsView/components/settings-panel/settings-panel.tsx
+++ b/src/DetailsView/components/settings-panel/settings-panel.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import * as React from 'react';
-import { NamedFC } from '../../../common/react/named-fc';
-import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-flag-store-data';
-import { UserConfigurationStoreData } from '../../../common/types/store-data/user-configuration-store';
 import { DetailsViewActionMessageCreator } from '../../actions/details-view-action-message-creator';
 import { GenericPanel } from '../generic-panel';
 import { SettingsDeps } from './settings/settings-props';

--- a/src/DetailsView/components/settings-panel/settings-panel.tsx
+++ b/src/DetailsView/components/settings-panel/settings-panel.tsx
@@ -22,6 +22,8 @@ export interface SettingsPanelProps {
     featureFlagData: FeatureFlagStoreData;
 }
 
+export const settingsPanelAutomationId = 'settings-panel';
+
 export const SettingsPanel = NamedFC<SettingsPanelProps>('SettingsPanel', props => {
     const { deps, userConfigStoreState, featureFlagData, isOpen } = props;
     const { detailsViewActionMessageCreator, settingsProvider } = deps;
@@ -30,6 +32,7 @@ export const SettingsPanel = NamedFC<SettingsPanelProps>('SettingsPanel', props 
         <GenericPanel
             isOpen={isOpen}
             className={styles.settingsPanel}
+            innerPanelAutomationId={settingsPanelAutomationId}
             onDismiss={detailsViewActionMessageCreator.closeSettingsPanel}
             closeButtonAriaLabel="Close settings panel"
             hasCloseButton={true}

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -4,6 +4,7 @@ import { resultSectionAutomationId } from 'common/components/cards/result-sectio
 import { ruleDetailsGroupAutomationId } from 'common/components/cards/rules-with-instances';
 import { IframeWarningContainerAutomationId } from 'DetailsView/components/iframe-warning';
 import { overviewHeadingAutomationId } from 'DetailsView/components/overview-content/overview-heading';
+import { settingsPanelAutomationId } from 'DetailsView/components/settings-panel/settings-panel';
 import { startOverAutomationId } from 'DetailsView/components/start-over-component-factory';
 import { failureCountAutomationId } from 'reports/components/outcome-chip';
 import { cardsRuleIdAutomationId, ruleDetailAutomationId } from 'reports/components/report-sections/minimal-rule-header';
@@ -39,7 +40,7 @@ export const overviewSelectors = {
 };
 
 export const settingsPanelSelectors = {
-    settingsPanel: '.settings-panel',
+    settingsPanel: getAutomationIdSelector(settingsPanelAutomationId),
     closeButton: 'button[title="Close settings panel"]',
     highContrastModeToggle: 'button#enable-high-contrast-mode',
     telemetryStateToggle: 'button#enable-telemetry',

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/__snapshots__/settings-panel.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/__snapshots__/settings-panel.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`SettingsPanelTest render - isPanelOpen = false 1`] = `
 <GenericPanel
-  className="settings-panel"
+  className="settingsPanel"
   closeButtonAriaLabel="Close settings panel"
   hasCloseButton={true}
   isOpen={false}
@@ -71,7 +71,7 @@ exports[`SettingsPanelTest render - isPanelOpen = false 1`] = `
 
 exports[`SettingsPanelTest render - isPanelOpen = true 1`] = `
 <GenericPanel
-  className="settings-panel"
+  className="settingsPanel"
   closeButtonAriaLabel="Close settings panel"
   hasCloseButton={true}
   isOpen={true}

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/__snapshots__/settings-panel.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/__snapshots__/settings-panel.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`SettingsPanelTest render - isPanelOpen = false 1`] = `
   className="settingsPanel"
   closeButtonAriaLabel="Close settings panel"
   hasCloseButton={true}
+  innerPanelAutomationId="settings-panel"
   isOpen={false}
   onDismiss={[Function]}
   title="Settings"
@@ -74,6 +75,7 @@ exports[`SettingsPanelTest render - isPanelOpen = true 1`] = `
   className="settingsPanel"
   closeButtonAriaLabel="Close settings panel"
   hasCloseButton={true}
+  innerPanelAutomationId="settings-panel"
   isOpen={true}
   onDismiss={[Function]}
   title="Settings"

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/settings-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/settings-panel.test.tsx
@@ -1,19 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UserConfigMessageCreator } from 'common/message-creators/user-config-message-creator';
+import { NamedFC } from 'common/react/named-fc';
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { SettingsPanel, SettingsPanelDeps, SettingsPanelProps } from 'DetailsView/components/settings-panel/settings-panel';
+import { SettingsProps } from 'DetailsView/components/settings-panel/settings/settings-props';
+import { createSettingsProvider } from 'DetailsView/components/settings-panel/settings/settings-provider';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-
-import { UserConfigMessageCreator } from '../../../../../../common/message-creators/user-config-message-creator';
-import { NamedFC } from '../../../../../../common/react/named-fc';
-import { UserConfigurationStoreData } from '../../../../../../common/types/store-data/user-configuration-store';
-import { DetailsViewActionMessageCreator } from '../../../../../../DetailsView/actions/details-view-action-message-creator';
-import {
-    SettingsPanel,
-    SettingsPanelDeps,
-    SettingsPanelProps,
-} from '../../../../../../DetailsView/components/settings-panel/settings-panel';
-import { SettingsProps } from '../../../../../../DetailsView/components/settings-panel/settings/settings-props';
-import { createSettingsProvider } from '../../../../../../DetailsView/components/settings-panel/settings/settings-provider';
 
 describe('SettingsPanelTest', () => {
     let userConfigStoreData: UserConfigurationStoreData;


### PR DESCRIPTION
#### Description of changes

Fix by adding top padding (same value as current bottom padding)

Also convert the settings panel to use css-module.

**before**
![01 - before (cut-off)](https://user-images.githubusercontent.com/2837582/71602692-5c855580-2b0e-11ea-84b9-2a7e1b0eea51.png)

**after**
![02 - after (fixed)](https://user-images.githubusercontent.com/2837582/71602703-6313cd00-2b0e-11ea-8882-ce5adf8db7af.png)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
