### PR TITLE
fix: assessment in progress dialog buttons have reverse tab order

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -40,10 +40,13 @@ div.insights-dialog-main-override.insights-file-issue-details-dialog-container {
         font-weight: $fontWeightSemiBold;
     }
     .target-change-dialog-button-container {
+        display: flex;
+        height: 40px;
+        justify-content: flex-end;
+
         .action-cancel-button-col {
             text-align: right;
             padding-left: 0px;
-            float: right;
             margin-top: 4px;
             margin-bottom: 24px;
         }

--- a/src/DetailsView/components/target-change-dialog.tsx
+++ b/src/DetailsView/components/target-change-dialog.tsx
@@ -1,19 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isEmpty } from 'lodash';
-import { DefaultButton } from 'office-ui-fabric-react';
-import { DialogFooter, DialogType } from 'office-ui-fabric-react';
-import { Link } from 'office-ui-fabric-react';
-import { TooltipHost } from 'office-ui-fabric-react';
-import * as React from 'react';
-
 import { css } from '@uifabric/utilities';
 import * as Markup from 'assessments/markup';
-import { BlockingDialog } from '../../common/components/blocking-dialog';
-import { NewTabLink } from '../../common/components/new-tab-link';
-import { Tab } from '../../common/itab';
-import { PersistedTabInfo } from '../../common/types/store-data/assessment-result-data';
-import { UrlParser } from '../../common/url-parser';
+import { BlockingDialog } from 'common/components/blocking-dialog';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { Tab } from 'common/itab';
+import { PersistedTabInfo } from 'common/types/store-data/assessment-result-data';
+import { UrlParser } from 'common/url-parser';
+import { isEmpty } from 'lodash';
+import { DefaultButton, DialogFooter, DialogType, Link, TooltipHost } from 'office-ui-fabric-react';
+import * as React from 'react';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 
 export type TargetChangeDialogDeps = {
@@ -62,18 +58,17 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
 
                 <DialogFooter>
                     <div className="target-change-dialog-button-container">
-                        <div className="button ms-Grid-col  action-cancel-button-col restart-button">
-                            <DefaultButton
-                                text="Start new"
-                                onClick={this.props.deps.detailsViewActionMessageCreator.startOverAllAssessments}
-                            />
-                        </div>
-
                         <div className="button ms-Grid-col  action-cancel-button-col continue-button">
                             <DefaultButton
                                 autoFocus={true}
                                 text="Continue previous"
                                 onClick={this.props.deps.detailsViewActionMessageCreator.continuePreviousAssessment}
+                            />
+                        </div>
+                        <div className="button ms-Grid-col  action-cancel-button-col restart-button">
+                            <DefaultButton
+                                text="Start new"
+                                onClick={this.props.deps.detailsViewActionMessageCreator.startOverAllAssessments}
                             />
                         </div>
                     </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
@@ -70,20 +70,20 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       className="target-change-dialog-button-container"
     >
       <div
-        className="button ms-Grid-col  action-cancel-button-col restart-button"
-      >
-        <CustomizedDefaultButton
-          onClick={[Function]}
-          text="Start new"
-        />
-      </div>
-      <div
         className="button ms-Grid-col  action-cancel-button-col continue-button"
       >
         <CustomizedDefaultButton
           autoFocus={true}
           onClick={[Function]}
           text="Continue previous"
+        />
+      </div>
+      <div
+        className="button ms-Grid-col  action-cancel-button-col restart-button"
+      >
+        <CustomizedDefaultButton
+          onClick={[Function]}
+          text="Start new"
         />
       </div>
     </div>
@@ -165,20 +165,20 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       className="target-change-dialog-button-container"
     >
       <div
-        className="button ms-Grid-col  action-cancel-button-col restart-button"
-      >
-        <CustomizedDefaultButton
-          onClick={[Function]}
-          text="Start new"
-        />
-      </div>
-      <div
         className="button ms-Grid-col  action-cancel-button-col continue-button"
       >
         <CustomizedDefaultButton
           autoFocus={true}
           onClick={[Function]}
           text="Continue previous"
+        />
+      </div>
+      <div
+        className="button ms-Grid-col  action-cancel-button-col restart-button"
+      >
+        <CustomizedDefaultButton
+          onClick={[Function]}
+          text="Start new"
         />
       </div>
     </div>
@@ -260,20 +260,20 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       className="target-change-dialog-button-container"
     >
       <div
-        className="button ms-Grid-col  action-cancel-button-col restart-button"
-      >
-        <CustomizedDefaultButton
-          onClick={[Function]}
-          text="Start new"
-        />
-      </div>
-      <div
         className="button ms-Grid-col  action-cancel-button-col continue-button"
       >
         <CustomizedDefaultButton
           autoFocus={true}
           onClick={[Function]}
           text="Continue previous"
+        />
+      </div>
+      <div
+        className="button ms-Grid-col  action-cancel-button-col restart-button"
+      >
+        <CustomizedDefaultButton
+          onClick={[Function]}
+          text="Start new"
         />
       </div>
     </div>
@@ -355,20 +355,20 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       className="target-change-dialog-button-container"
     >
       <div
-        className="button ms-Grid-col  action-cancel-button-col restart-button"
-      >
-        <CustomizedDefaultButton
-          onClick={[Function]}
-          text="Start new"
-        />
-      </div>
-      <div
         className="button ms-Grid-col  action-cancel-button-col continue-button"
       >
         <CustomizedDefaultButton
           autoFocus={true}
           onClick={[Function]}
           text="Continue previous"
+        />
+      </div>
+      <div
+        className="button ms-Grid-col  action-cancel-button-col restart-button"
+      >
+        <CustomizedDefaultButton
+          onClick={[Function]}
+          text="Start new"
         />
       </div>
     </div>
@@ -450,20 +450,20 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
       className="target-change-dialog-button-container"
     >
       <div
-        className="button ms-Grid-col  action-cancel-button-col restart-button"
-      >
-        <CustomizedDefaultButton
-          onClick={[Function]}
-          text="Start new"
-        />
-      </div>
-      <div
         className="button ms-Grid-col  action-cancel-button-col continue-button"
       >
         <CustomizedDefaultButton
           autoFocus={true}
           onClick={[Function]}
           text="Continue previous"
+        />
+      </div>
+      <div
+        className="button ms-Grid-col  action-cancel-button-col restart-button"
+      >
+        <CustomizedDefaultButton
+          onClick={[Function]}
+          text="Start new"
         />
       </div>
     </div>

--- a/src/tests/unit/tests/DetailsView/components/target-change-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/target-change-dialog.test.tsx
@@ -1,16 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BlockingDialog } from 'common/components/blocking-dialog';
+import { Tab } from 'common/itab';
+import { PersistedTabInfo } from 'common/types/store-data/assessment-result-data';
+import { UrlParser } from 'common/url-parser';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { TargetChangeDialog, TargetChangeDialogProps } from 'DetailsView/components/target-change-dialog';
 import * as Enzyme from 'enzyme';
-import Dialog from 'office-ui-fabric-react';
-import { TooltipHost } from 'office-ui-fabric-react';
+import Dialog, { TooltipHost } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { BlockingDialog } from '../../../../../common/components/blocking-dialog';
-import { Tab } from '../../../../../common/itab';
-import { PersistedTabInfo } from '../../../../../common/types/store-data/assessment-result-data';
-import { UrlParser } from '../../../../../common/url-parser';
-import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
-import { TargetChangeDialog, TargetChangeDialogProps } from '../../../../../DetailsView/components/target-change-dialog';
 
 describe('TargetChangeDialog test set for prev tab null', () => {
     const urlParserMock = Mock.ofType(UrlParser, MockBehavior.Strict);


### PR DESCRIPTION
#### Description of changes

Currently on the **Assessment in progress** dialog, we show 2 buttons: 1) **Continue previous**; and 2) **Start new** but we are using `float: right` in order to align the items to the right end. This make for a reverse tabbing order (even though, we are not using `tabIndex`).

In this PR, the buttons order on the html structure are trued-up and then aligned to the right end using **css flex box**.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
