### PR TITLE
test: increase coverage for assessment store

### DIFF
--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -2,30 +2,29 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
-import { forEach, isEmpty } from 'lodash';
-
-import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
-import { IndexedDBAPI } from '../../common/indexedDB/indexedDB';
-import { StoreNames } from '../../common/stores/store-names';
-import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
-import { ManualTestStatus } from '../../common/types/manual-test-status';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { StoreNames } from 'common/stores/store-names';
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { ManualTestStatus } from 'common/types/manual-test-status';
 import {
     AssessmentData,
     AssessmentStoreData,
     GeneratedAssessmentInstance,
     TestStepResult,
     UserCapturedInstance,
-} from '../../common/types/store-data/assessment-result-data';
+} from 'common/types/store-data/assessment-result-data';
+import { VisualizationType } from 'common/types/visualization-type';
 import {
     ScanBasePayload,
     ScanCompletedPayload,
     ScanUpdatePayload,
-} from '../../injected/analyzers/analyzer';
-import { DictionaryStringTo } from '../../types/common-types';
+} from 'injected/analyzers/analyzer';
+import { forEach, isEmpty } from 'lodash';
+import { DictionaryStringTo } from 'types/common-types';
 import { AddResultDescriptionPayload, SelectRequirementPayload } from '../actions/action-payloads';
 import { AssessmentDataConverter } from '../assessment-data-converter';
 import { InitialAssessmentStoreDataGenerator } from '../initial-assessment-store-data-generator';
-import { VisualizationType } from './../../common/types/visualization-type';
 import {
     AddFailureInstancePayload,
     AssessmentActionInstancePayload,

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -235,13 +235,13 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
             .forType(payload.test)
             .getVisualizationConfiguration();
         const assessmentData = config.getAssessmentData(this.state);
-        assessmentData.manualTestStepResultMap[
-            payload.requirement
-        ].instances = assessmentData.manualTestStepResultMap[payload.requirement].instances.filter(
-            instance => {
-                return instance.id !== payload.id;
-            },
+
+        const requirement = assessmentData.manualTestStepResultMap[payload.requirement];
+
+        requirement.instances = requirement.instances.filter(
+            instance => instance.id !== payload.id,
         );
+
         this.updateManualTestStepStatus(assessmentData, payload.requirement, payload.test);
 
         this.emitChanged();

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -215,16 +215,17 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         const config = this.assessmentsProvider
             .forType(payload.test)
             .getVisualizationConfiguration();
+
         const assessmentData = config.getAssessmentData(this.state);
-        const instances = assessmentData.manualTestStepResultMap[payload.requirement].instances;
-        for (let instanceIndex = 0; instanceIndex < instances.length; instanceIndex++) {
-            const instance = instances[instanceIndex];
-            if (instance.id === payload.id) {
-                instance.description = payload.instanceData.failureDescription;
-                instance.html = payload.instanceData.snippet;
-                instance.selector = payload.instanceData.path;
-                break;
-            }
+        const requirementInstances =
+            assessmentData.manualTestStepResultMap[payload.requirement].instances;
+
+        const instanceToEdit = requirementInstances.find(instance => instance.id === payload.id);
+
+        if (instanceToEdit) {
+            instanceToEdit.description = payload.instanceData.failureDescription;
+            instanceToEdit.html = payload.instanceData.snippet;
+            instanceToEdit.selector = payload.instanceData.path;
         }
 
         this.emitChanged();

--- a/src/tests/unit/tests/background/stores/__snapshots__/assessment-store.test.ts.snap
+++ b/src/tests/unit/tests/background/stores/__snapshots__/assessment-store.test.ts.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AssessmentStoreTest onContinuePreviousAssessment 1`] = `"tab with Id 1000 not found"`;
-
 exports[`AssessmentStoreTest onResetAllAssessmentsData 1`] = `"tab with Id 1000 not found"`;
 
 exports[`AssessmentStoreTest onUpdateTargetTabId 1`] = `"tab with Id 1000 not found"`;

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -12,6 +12,7 @@ import {
     SelectRequirementPayload,
     ToggleActionPayload,
     UpdateSelectedDetailsViewPayload,
+    AddResultDescriptionPayload,
 } from 'background/actions/action-payloads';
 import { AssessmentActions } from 'background/actions/assessment-actions';
 import { AssessmentDataConverter } from 'background/assessment-data-converter';
@@ -1398,6 +1399,22 @@ describe('AssessmentStoreTest', () => {
     test('verify the MaunalTestStatus Priorities', () => {
         expect(ManualTestStatus.PASS < ManualTestStatus.UNKNOWN).toBeTruthy();
         expect(ManualTestStatus.UNKNOWN < ManualTestStatus.FAIL).toBeTruthy();
+    });
+
+    test('onAddResultDescription', () => {
+        const payload: AddResultDescriptionPayload = {
+            description: 'new-test-description',
+        };
+
+        const initialState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object).build();
+
+        const finalState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+            .with('resultDescription', payload.description)
+            .build();
+
+        createStoreTesterForAssessmentActions('addResultDescription')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, finalState);
     });
 
     function setupDataGeneratorMock(persistedData: AssessmentStoreData, initialData: AssessmentStoreData): void {

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -4,6 +4,7 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
 import {
     AddFailureInstancePayload,
+    AddResultDescriptionPayload,
     ChangeInstanceSelectionPayload,
     ChangeInstanceStatusPayload,
     ChangeRequirementStatusPayload,
@@ -12,7 +13,6 @@ import {
     SelectRequirementPayload,
     ToggleActionPayload,
     UpdateSelectedDetailsViewPayload,
-    AddResultDescriptionPayload,
 } from 'background/actions/action-payloads';
 import { AssessmentActions } from 'background/actions/assessment-actions';
 import { AssessmentDataConverter } from 'background/assessment-data-converter';
@@ -236,7 +236,7 @@ describe('AssessmentStoreTest', () => {
         } as AssessmentVisualizationConfiguration;
 
         getVisualizationConfigurationMock
-            .setup(gvcm => gvcm())
+            .setup(configGetter => configGetter())
             .returns(() => {
                 return visualizationConfigStub;
             });
@@ -283,7 +283,7 @@ describe('AssessmentStoreTest', () => {
         } as AssessmentVisualizationConfiguration;
 
         getVisualizationConfigurationMock
-            .setup(gvcm => gvcm())
+            .setup(configGetter => configGetter())
             .returns(() => {
                 return visualizationConfigStub;
             });
@@ -333,7 +333,7 @@ describe('AssessmentStoreTest', () => {
         } as AssessmentVisualizationConfiguration;
 
         getVisualizationConfigurationMock
-            .setup(gvcm => gvcm())
+            .setup(configGetter => configGetter())
             .returns(() => {
                 return visualizationConfigStub;
             });
@@ -469,7 +469,7 @@ describe('AssessmentStoreTest', () => {
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
-        getInstanceIdentiferGeneratorMock.setup(giim => giim(requirementKey)).returns(() => instanceIdentifierGeneratorStub);
+        getInstanceIdentiferGeneratorMock.setup(idGetter => idGetter(requirementKey)).returns(() => instanceIdentifierGeneratorStub);
 
         assessmentDataConverterMock
             .setup(a =>
@@ -1396,7 +1396,7 @@ describe('AssessmentStoreTest', () => {
         assessmentsProviderMock.verifyAll();
     });
 
-    test('verify the MaunalTestStatus Priorities', () => {
+    test('verify the ManualTestStatus Priorities', () => {
         expect(ManualTestStatus.PASS < ManualTestStatus.UNKNOWN).toBeTruthy();
         expect(ManualTestStatus.UNKNOWN < ManualTestStatus.FAIL).toBeTruthy();
     });

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
 import {
@@ -19,15 +18,13 @@ import { AssessmentDataConverter } from 'background/assessment-data-converter';
 import { AssessmentDataRemover } from 'background/assessment-data-remover';
 import { InitialAssessmentStoreDataGenerator } from 'background/initial-assessment-store-data-generator';
 import { AssessmentStore } from 'background/stores/assessment-store';
-import { cloneDeep } from 'lodash';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
-import { AssessmentVisualizationConfiguration } from '../../../../../common/configs/assessment-visualization-configuration';
-import { IndexedDBAPI } from '../../../../../common/indexedDB/indexedDB';
-import { Tab } from '../../../../../common/itab';
-import { StoreNames } from '../../../../../common/stores/store-names';
-import { DetailsViewPivotType } from '../../../../../common/types/details-view-pivot-type';
-import { ManualTestStatus, ManualTestStatusData, TestStepData } from '../../../../../common/types/manual-test-status';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { AssessmentVisualizationConfiguration } from 'common/configs/assessment-visualization-configuration';
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { Tab } from 'common/itab';
+import { StoreNames } from 'common/stores/store-names';
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { ManualTestStatus, ManualTestStatusData, TestStepData } from 'common/types/manual-test-status';
 import {
     AssessmentData,
     AssessmentStoreData,
@@ -35,12 +32,14 @@ import {
     ManualTestStepResult,
     PersistedTabInfo,
     TestStepResult,
-} from '../../../../../common/types/store-data/assessment-result-data';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { ScanBasePayload, ScanCompletedPayload, ScanUpdatePayload } from '../../../../../injected/analyzers/analyzer';
-import { TabStopEvent } from '../../../../../injected/tab-stops-listener';
-import { ScanResults } from '../../../../../scanner/iruleresults';
-import { DictionaryStringTo } from '../../../../../types/common-types';
+} from 'common/types/store-data/assessment-result-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import { ScanBasePayload, ScanCompletedPayload, ScanUpdatePayload } from 'injected/analyzers/analyzer';
+import { TabStopEvent } from 'injected/tab-stops-listener';
+import { cloneDeep } from 'lodash';
+import { ScanResults } from 'scanner/iruleresults';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import { DictionaryStringTo } from 'types/common-types';
 import { AssessmentDataBuilder } from '../../../common/assessment-data-builder';
 import { AssessmentsStoreDataBuilder } from '../../../common/assessment-store-data-builder';
 import { AssessmentStoreTester } from '../../../common/assessment-store-tester';
@@ -76,23 +75,17 @@ describe('AssessmentStoreTest', () => {
         } as AssessmentVisualizationConfiguration;
 
         assessmentsProvider = CreateTestAssessmentProvider();
-        assessmentsProviderMock = Mock.ofType(AssessmentsProviderImpl, MockBehavior.Strict);
+        assessmentsProviderMock = Mock.ofType<AssessmentsProvider>(undefined, MockBehavior.Strict);
         assessmentMock = Mock.ofInstance({
             getVisualizationConfiguration: () => {
                 return null;
             },
         } as Assessment);
         assessmentDataConverterMock
-            .setup(adcm => adcm.getNewManualTestStepResult(It.isAny()))
+            .setup(dataConverter => dataConverter.getNewManualTestStepResult(It.isAny()))
             .returns(step => getDefaultManualTestStepResult(step));
 
-        indexDBInstanceMock = Mock.ofInstance(
-            {
-                setItem: (key, value) => null,
-                getItem: key => null,
-            } as IndexedDBAPI,
-            MockBehavior.Strict,
-        );
+        indexDBInstanceMock = Mock.ofType<IndexedDBAPI>(undefined, MockBehavior.Strict);
         initialAssessmentStoreDataGeneratorMock = Mock.ofType(InitialAssessmentStoreDataGenerator);
     });
 
@@ -472,13 +465,13 @@ describe('AssessmentStoreTest', () => {
 
         const finalState = getStateWithAssessment(assessmentData);
 
-        assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
+        assessmentsProviderMock.setup(provider => provider.all()).returns(() => assessmentsProvider.all());
 
-        assessmentsProviderMock.setup(apm => apm.getStepMap(assessmentType)).returns(() => stepMapStub);
+        assessmentsProviderMock.setup(provider => provider.getStepMap(assessmentType)).returns(() => stepMapStub);
 
-        assessmentsProviderMock.setup(apm => apm.getStep(assessmentType, 'assessment-1-step-1')).returns(() => stepConfig);
+        assessmentsProviderMock.setup(provider => provider.getStep(assessmentType, 'assessment-1-step-1')).returns(() => stepConfig);
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.testType)).returns(() => assessmentMock.object);
+        assessmentsProviderMock.setup(provider => provider.forType(payload.testType)).returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -523,19 +523,21 @@ describe('AssessmentStoreTest', () => {
 
         const finalState = getStateWithAssessment(assessmentData);
 
-        assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
-
-        assessmentsProviderMock.setup(apm => apm.getStepMap(assessmentType)).returns(() => assessmentsProvider.getStepMap(assessmentType));
+        assessmentsProviderMock.setup(provider => provider.all()).returns(() => assessmentsProvider.all());
 
         assessmentsProviderMock
-            .setup(apm => apm.getStep(assessmentType, requirementKey))
+            .setup(provider => provider.getStepMap(assessmentType))
+            .returns(() => assessmentsProvider.getStepMap(assessmentType));
+
+        assessmentsProviderMock
+            .setup(provider => provider.getStep(assessmentType, requirementKey))
             .returns(() => assessmentsProvider.getStep(assessmentType, requirementKey));
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.testType)).returns(() => assessmentMock.object);
+        assessmentsProviderMock.setup(provider => provider.forType(payload.testType)).returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
-        getInstanceIdentiferGeneratorMock.setup(giim => giim(requirementKey)).returns(() => instanceIdentifierGeneratorStub);
+        getInstanceIdentiferGeneratorMock.setup(getter => getter(requirementKey)).returns(() => instanceIdentifierGeneratorStub);
 
         assessmentDataConverterMock
             .setup(a =>


### PR DESCRIPTION
#### Description of changes

We have some missing tests for the assessment store, This PR add those tests and gets the coverage to 99.52% (statements)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
