### PR TITLE
fix: css styling for color-contrast how to fix instructions

### DIFF
--- a/src/common/components/cards/fix-instruction-color-box.scss
+++ b/src/common/components/cards/fix-instruction-color-box.scss
@@ -2,22 +2,20 @@
 // Licensed under the MIT License.
 @import '../../../common/styles/colors.scss';
 
-.how-to-fix-card-row {
-    span.fix-instruction-color-box {
-        width: 14px;
-        height: 14px;
-        display: inline-block;
-        vertical-align: -5%;
-        margin: 0px 2px;
-        border: 1px solid $always-black;
-    }
+span.fix-instruction-color-box {
+    width: 14px;
+    height: 14px;
+    display: inline-block;
+    vertical-align: -5%;
+    margin: 0px 2px;
+    border: 1px solid $always-black;
+}
 
-    .screen-reader-only {
-        position: absolute;
-        left: -10000px;
-        top: auto;
-        width: 1px;
-        height: 1px;
-        overflow: hidden;
-    }
+.screen-reader-only {
+    position: absolute;
+    left: -10000px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
 }


### PR DESCRIPTION
#### Description of changes

The styling being removed is not being referenced anywhere else, so it is safe to remove.

![image](https://user-images.githubusercontent.com/32555133/71742993-39adb680-2e18-11ea-9c79-78b9adfbdac6.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1933
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
