### PR TITLE
chore: update new line width for folder src/reports

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -16,6 +16,7 @@ module.exports = {
                 'src/electron/**/*',
                 'src/issue-filing/**/*',
                 'src/popup/**/*',
+                'src/reports/**/*',
                 'src/scanner/**/*',
                 'src/types/**/*',
             ],

--- a/src/reports/assessment-report-html-generator.tsx
+++ b/src/reports/assessment-report-html-generator.tsx
@@ -35,7 +35,10 @@ export class AssessmentReportHtmlGenerator {
         tabStoreData: TabStoreData,
         description: string,
     ): string {
-        const filteredProvider = assessmentsProviderWithFeaturesEnabled(assessmentsProvider, featureFlagStoreData);
+        const filteredProvider = assessmentsProviderWithFeaturesEnabled(
+            assessmentsProvider,
+            featureFlagStoreData,
+        );
 
         const modelBuilder = this.assessmentReportModelBuilderFactory.create(
             filteredProvider,

--- a/src/reports/assessment-report-model-builder.ts
+++ b/src/reports/assessment-report-model-builder.ts
@@ -1,10 +1,17 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentDefaultMessageGenerator, DefaultMessageInterface } from 'assessments/assessment-default-message-generator';
+import {
+    AssessmentDefaultMessageGenerator,
+    DefaultMessageInterface,
+} from 'assessments/assessment-default-message-generator';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
 import { ManualTestStatus } from 'common/types/manual-test-status';
-import { AssessmentData, AssessmentStoreData, TestStepInstance } from 'common/types/store-data/assessment-result-data';
+import {
+    AssessmentData,
+    AssessmentStoreData,
+    TestStepInstance,
+} from 'common/types/store-data/assessment-result-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { find, keys } from 'lodash';
 import { assessmentReportExtensionPoint } from '../DetailsView/extensions/assessment-report-extension-point';
@@ -49,8 +56,14 @@ export class AssessmentReportModelBuilder {
             incompleteDetailsData: getDetails(ManualTestStatus.UNKNOWN),
         } as ReportModel;
 
-        function getDefaultMessageComponent(getDefaultMessage, instancesMap, selectedStep): DefaultMessageInterface {
-            const defaultMessageGenerator = getDefaultMessage(assessmentDefaultMessageGeneratorInstance);
+        function getDefaultMessageComponent(
+            getDefaultMessage,
+            instancesMap,
+            selectedStep,
+        ): DefaultMessageInterface {
+            const defaultMessageGenerator = getDefaultMessage(
+                assessmentDefaultMessageGeneratorInstance,
+            );
             const defaultMessageComponent = defaultMessageGenerator(instancesMap, selectedStep);
             return defaultMessageComponent;
         }
@@ -63,10 +76,14 @@ export class AssessmentReportModelBuilder {
                         displayName: assessment.title,
                         steps: assessment.requirements
                             .filter(step => {
-                                return assessment.storeData.testStepStatus[step.key].stepFinalResult === status;
+                                return (
+                                    assessment.storeData.testStepStatus[step.key]
+                                        .stepFinalResult === status
+                                );
                             })
                             .map(step => {
-                                const generatedInstancesMap = assessment.storeData.generatedAssessmentInstancesMap;
+                                const generatedInstancesMap =
+                                    assessment.storeData.generatedAssessmentInstancesMap;
                                 const model: RequirementReportModel = {
                                     key: step.key,
                                     header: {
@@ -84,7 +101,9 @@ export class AssessmentReportModelBuilder {
                                     showPassingInstances: true,
                                 };
 
-                                assessmentReportExtensionPoint.apply(assessment.extensions).alterRequirementReportModel(model);
+                                assessmentReportExtensionPoint
+                                    .apply(assessment.extensions)
+                                    .alterRequirementReportModel(model);
 
                                 return model;
                             }),
@@ -95,11 +114,16 @@ export class AssessmentReportModelBuilder {
                 }) as AssessmentDetailsReportModel[];
         }
 
-        function getInstances(assessment: AssessmentResult, stepKey: string): InstanceReportModel[] {
+        function getInstances(
+            assessment: AssessmentResult,
+            stepKey: string,
+        ): InstanceReportModel[] {
             const { storeData } = assessment;
             const { reportInstanceFields } = find(assessment.requirements, s => s.key === stepKey);
 
-            function getInstanceReportModel(instance: Partial<TestStepInstance>): InstanceReportModel {
+            function getInstanceReportModel(
+                instance: Partial<TestStepInstance>,
+            ): InstanceReportModel {
                 const props = reportInstanceFields
                     .filter(element => {
                         if (element.getValue(instance)) {
@@ -107,13 +131,18 @@ export class AssessmentReportModelBuilder {
                         }
                         return false;
                     })
-                    .map(({ label, getValue }) => ({ key: label, value: getValue(instance) } as InstancePairReportModel));
+                    .map(
+                        ({ label, getValue }) =>
+                            ({ key: label, value: getValue(instance) } as InstancePairReportModel),
+                    );
 
                 return { props };
             }
 
             function getManualData(): InstanceReportModel[] {
-                return storeData.manualTestStepResultMap[stepKey].instances.map(instance => getInstanceReportModel(instance));
+                return storeData.manualTestStepResultMap[stepKey].instances.map(instance =>
+                    getInstanceReportModel(instance),
+                );
             }
 
             function getAssistedData(): InstanceReportModel[] {
@@ -123,10 +152,17 @@ export class AssessmentReportModelBuilder {
 
                 return keys(storeData.generatedAssessmentInstancesMap)
                     .filter(key => {
-                        const testStepResult = storeData.generatedAssessmentInstancesMap[key].testStepResults[stepKey];
-                        return testStepResult != undefined && testStepResult.status === storeData.testStepStatus[stepKey].stepFinalResult;
+                        const testStepResult =
+                            storeData.generatedAssessmentInstancesMap[key].testStepResults[stepKey];
+                        return (
+                            testStepResult != undefined &&
+                            testStepResult.status ===
+                                storeData.testStepStatus[stepKey].stepFinalResult
+                        );
                     })
-                    .map(key => getInstanceReportModel(storeData.generatedAssessmentInstancesMap[key]));
+                    .map(key =>
+                        getInstanceReportModel(storeData.generatedAssessmentInstancesMap[key]),
+                    );
             }
 
             if (

--- a/src/reports/automated-checks-report.scss
+++ b/src/reports/automated-checks-report.scss
@@ -79,8 +79,9 @@ $outcome-not-applicable-summary-color: $neutral-outcome;
     }
 
     .collapsible-control {
-        font-family: 'Segoe UI Web (West European)', 'Segoe UI', '-apple-system', BlinkMacSystemFont, Roboto, 'Helvetica Neue', Helvetica,
-            Ubuntu, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+        font-family: 'Segoe UI Web (West European)', 'Segoe UI', '-apple-system', BlinkMacSystemFont,
+            Roboto, 'Helvetica Neue', Helvetica, Ubuntu, Arial, sans-serif, 'Apple Color Emoji',
+            'Segoe UI Emoji', 'Segoe UI Symbol';
         background-color: transparent;
         cursor: pointer;
         border: none;

--- a/src/reports/components/assessment-report-assessment-list.tsx
+++ b/src/reports/components/assessment-report-assessment-list.tsx
@@ -4,7 +4,10 @@ import * as React from 'react';
 
 import { ManualTestStatus } from 'common/types/manual-test-status';
 import { AssessmentDetailsReportModel } from '../assessment-report-model';
-import { AssessmentReportStepList, AssessmentReportStepListDeps } from './assessment-report-step-list';
+import {
+    AssessmentReportStepList,
+    AssessmentReportStepListDeps,
+} from './assessment-report-step-list';
 import { OutcomeChip } from './outcome-chip';
 import { allRequirementOutcomeTypes } from './requirement-outcome-type';
 
@@ -21,7 +24,9 @@ export interface IconWithCountProps {
     count: number;
 }
 
-export class AssessmentReportAssessmentList extends React.Component<AssessmentReportAssessmentListProps> {
+export class AssessmentReportAssessmentList extends React.Component<
+    AssessmentReportAssessmentListProps
+> {
     public render(): JSX.Element {
         return <div>{this.renderAssessments()}</div>;
     }
@@ -31,7 +36,11 @@ export class AssessmentReportAssessmentList extends React.Component<AssessmentRe
             return (
                 <div className="assessment-details" key={assessment.key}>
                     {this.renderAssessmentHeader(assessment)}
-                    <AssessmentReportStepList deps={this.props.deps} status={this.props.status} steps={assessment.steps} />
+                    <AssessmentReportStepList
+                        deps={this.props.deps}
+                        status={this.props.status}
+                        steps={assessment.steps}
+                    />
                 </div>
             );
         });
@@ -41,7 +50,10 @@ export class AssessmentReportAssessmentList extends React.Component<AssessmentRe
         return (
             <h3 className="assessment-header">
                 {assessment.displayName}
-                <OutcomeChip count={assessment.steps.length} outcomeType={allRequirementOutcomeTypes[this.props.status]} />
+                <OutcomeChip
+                    count={assessment.steps.length}
+                    outcomeType={allRequirementOutcomeTypes[this.props.status]}
+                />
             </h3>
         );
     }

--- a/src/reports/components/assessment-report-body-header.tsx
+++ b/src/reports/components/assessment-report-body-header.tsx
@@ -8,8 +8,9 @@ export class AssessmentReportBodyHeader extends React.Component {
             <div className="assessment-report-body-header">
                 <h1>Assessment report</h1>
                 <p>
-                    This report shows the overall accessibility of the website or web app through a combination of automated and manual
-                    tests that cover all the WCAG 2.0 AA success criteria.
+                    This report shows the overall accessibility of the website or web app through a
+                    combination of automated and manual tests that cover all the WCAG 2.0 AA success
+                    criteria.
                 </p>
             </div>
         );

--- a/src/reports/components/assessment-report-body.tsx
+++ b/src/reports/components/assessment-report-body.tsx
@@ -4,7 +4,10 @@ import * as React from 'react';
 
 import { ManualTestStatus } from 'common/types/manual-test-status';
 import { AssessmentDetailsReportModel, ReportModel } from '../assessment-report-model';
-import { AssessmentReportAssessmentList, AssessmentReportAssessmentListDeps } from './assessment-report-assessment-list';
+import {
+    AssessmentReportAssessmentList,
+    AssessmentReportAssessmentListDeps,
+} from './assessment-report-assessment-list';
 import { AssessmentReportBodyHeader } from './assessment-report-body-header';
 import { AssessmentReportSummary } from './assessment-report-summary';
 import { AssessmentScanDetails } from './assessment-scan-details';
@@ -25,7 +28,10 @@ export class AssessmentReportBody extends React.Component<AssessmentReportBodyPr
             <div className="assessment-report-body" role="main">
                 <AssessmentReportBodyHeader />
                 <AssessmentReportSummary summary={this.props.data.summary} />
-                <AssessmentScanDetails details={this.props.data.scanDetails} description={this.props.description} />
+                <AssessmentScanDetails
+                    details={this.props.data.scanDetails}
+                    description={this.props.description}
+                />
 
                 {this.renderDetailsSection(
                     this.props.data.failedDetailsData,
@@ -60,11 +66,19 @@ export class AssessmentReportBody extends React.Component<AssessmentReportBodyPr
         return (
             <div className="details-section">
                 {this.renderDetailsSectionHeader(title, count, status)}
-                <AssessmentReportAssessmentList deps={this.props.deps} status={status} assessments={detailsData} />
+                <AssessmentReportAssessmentList
+                    deps={this.props.deps}
+                    status={status}
+                    assessments={detailsData}
+                />
             </div>
         );
     }
-    private renderDetailsSectionHeader(title: string, count: number, status: ManualTestStatus): JSX.Element {
+    private renderDetailsSectionHeader(
+        title: string,
+        count: number,
+        status: ManualTestStatus,
+    ): JSX.Element {
         return (
             <h2 className="details-section-header">
                 {title}

--- a/src/reports/components/assessment-report-footer.tsx
+++ b/src/reports/components/assessment-report-footer.tsx
@@ -15,7 +15,7 @@ export class AssessmentReportFooter extends React.Component<AssessmentReportFoot
             <footer className="report-footer">
                 This assessment report was generated using {title} {this.props.extensionVersion}{' '}
                 (Axe {this.props.axeVersion}), a tool that helps debug and find accessibility issues
-                earlier on {this.props.chromeVersion}. Get more information & download this tool at{' '}
+                earlier on {this.props.chromeVersion}. Get more information & download this tool at
                 <a
                     href="http://aka.ms/AccessibilityInsights"
                     className="link report-footer-link"

--- a/src/reports/components/assessment-report-footer.tsx
+++ b/src/reports/components/assessment-report-footer.tsx
@@ -13,10 +13,14 @@ export class AssessmentReportFooter extends React.Component<AssessmentReportFoot
     public render(): JSX.Element {
         return (
             <footer className="report-footer">
-                This assessment report was generated using {title} {this.props.extensionVersion} (Axe {this.props.axeVersion}), a tool that
-                helps debug and find accessibility issues earlier on {this.props.chromeVersion}. Get more information & download this tool
-                at{' '}
-                <a href="http://aka.ms/AccessibilityInsights" className="link report-footer-link" target="_blank">
+                This assessment report was generated using {title} {this.props.extensionVersion}{' '}
+                (Axe {this.props.axeVersion}), a tool that helps debug and find accessibility issues
+                earlier on {this.props.chromeVersion}. Get more information & download this tool at{' '}
+                <a
+                    href="http://aka.ms/AccessibilityInsights"
+                    className="link report-footer-link"
+                    target="_blank"
+                >
                     http://aka.ms/AccessibilityInsights
                 </a>
             </footer>

--- a/src/reports/components/assessment-report-instance-list.tsx
+++ b/src/reports/components/assessment-report-instance-list.tsx
@@ -4,78 +4,107 @@ import { flatten, toPairs } from 'lodash';
 import * as React from 'react';
 
 import { NamedFC } from 'common/react/named-fc';
-import { BagOf, isScalarColumnValue, ScalarColumnValue } from 'common/types/property-bag/column-value-bag';
+import {
+    BagOf,
+    isScalarColumnValue,
+    ScalarColumnValue,
+} from 'common/types/property-bag/column-value-bag';
 import { InstanceReportModel } from '../assessment-report-model';
 
 export interface AssessmentReportInstanceListProps {
     instances: InstanceReportModel[];
 }
 
-export const AssessmentReportInstanceList = NamedFC<AssessmentReportInstanceListProps>('AssessmentReportInstanceList', props => {
-    type Index = number | string;
-    type Row = React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableRowElement>, HTMLTableRowElement>;
-    type Cell = React.DetailedHTMLProps<React.HTMLAttributes<HTMLTableCellElement>, HTMLTableCellElement>;
+export const AssessmentReportInstanceList = NamedFC<AssessmentReportInstanceListProps>(
+    'AssessmentReportInstanceList',
+    props => {
+        type Index = number | string;
+        type Row = React.DetailedHTMLProps<
+            React.HTMLAttributes<HTMLTableRowElement>,
+            HTMLTableRowElement
+        >;
+        type Cell = React.DetailedHTMLProps<
+            React.HTMLAttributes<HTMLTableCellElement>,
+            HTMLTableCellElement
+        >;
 
-    return <div>{renderInstances()}</div>;
+        return <div>{renderInstances()}</div>;
 
-    function renderInstances(): JSX.Element[] {
-        return props.instances.map((instance, index) => {
-            return (
-                <table className="instance-details" key={`instance-row-${index}`}>
-                    <tbody>{renderInstanceRows(instance)}</tbody>
-                </table>
+        function renderInstances(): JSX.Element[] {
+            return props.instances.map((instance, index) => {
+                return (
+                    <table className="instance-details" key={`instance-row-${index}`}>
+                        <tbody>{renderInstanceRows(instance)}</tbody>
+                    </table>
+                );
+            });
+        }
+
+        function renderInstanceRows(instance: InstanceReportModel): Row[] {
+            const rowSets = instance.props.map(({ key, value }, index) =>
+                isScalarColumnValue(value)
+                    ? [renderScalarRow(key, value, index)]
+                    : renderPropertyBagRows(key, value, index),
             );
-        });
-    }
 
-    function renderInstanceRows(instance: InstanceReportModel): Row[] {
-        const rowSets = instance.props.map(({ key, value }, index) =>
-            isScalarColumnValue(value) ? [renderScalarRow(key, value, index)] : renderPropertyBagRows(key, value, index),
-        );
+            return flatten(rowSets);
+        }
 
-        return flatten(rowSets);
-    }
+        function renderPropertyBagRows(
+            key: string,
+            value: BagOf<ScalarColumnValue>,
+            index: Index,
+        ): Row[] {
+            const headerRow = renderPropertyBagHeaderRow(key);
+            const entryRows = renderProperyBagEntryRows(value, index);
+            return [headerRow, ...entryRows];
+        }
 
-    function renderPropertyBagRows(key: string, value: BagOf<ScalarColumnValue>, index: Index): Row[] {
-        const headerRow = renderPropertyBagHeaderRow(key);
-        const entryRows = renderProperyBagEntryRows(value, index);
-        return [headerRow, ...entryRows];
-    }
+        function renderPropertyBagHeaderRow(key: string): Row {
+            return renderRow(
+                [
+                    <th className={`instance-subsection-header`} colSpan={2} key={key}>
+                        {key + ':'}
+                    </th>,
+                ],
+                key,
+            );
+        }
 
-    function renderPropertyBagHeaderRow(key: string): Row {
-        return renderRow(
-            [
-                <th className={`instance-subsection-header`} colSpan={2} key={key}>
-                    {key + ':'}
-                </th>,
-            ],
-            key,
-        );
-    }
+        function renderProperyBagEntryRows(
+            bag: BagOf<ScalarColumnValue>,
+            outerIndex: Index,
+        ): Row[] {
+            return toPairs(bag).map(([key, value], index) =>
+                renderScalarRow(key, value, `${outerIndex}-${index}`, 'instance-key-indented'),
+            );
+        }
 
-    function renderProperyBagEntryRows(bag: BagOf<ScalarColumnValue>, outerIndex: Index): Row[] {
-        return toPairs(bag).map(([key, value], index) => renderScalarRow(key, value, `${outerIndex}-${index}`, 'instance-key-indented'));
-    }
+        function renderScalarRow(
+            key: string,
+            value: ScalarColumnValue,
+            index: Index,
+            keyClassName: string = 'instance-key',
+        ): Row {
+            return renderRow(
+                [
+                    <th className={keyClassName} key={key}>
+                        {key}
+                    </th>,
+                    <td className={'instance-value'} key={`${key}-${index}`}>
+                        {value ? value.toString() : '-'}
+                    </td>,
+                ],
+                index,
+            );
+        }
 
-    function renderScalarRow(key: string, value: ScalarColumnValue, index: Index, keyClassName: string = 'instance-key'): Row {
-        return renderRow(
-            [
-                <th className={keyClassName} key={key}>
-                    {key}
-                </th>,
-                <td className={'instance-value'} key={`${key}-${index}`}>
-                    {value ? value.toString() : '-'}
-                </td>,
-            ],
-            index,
-        );
-    }
-
-    function renderRow(cells: Cell[], index: Index): Row {
-        return (
-            <tr className="instance-pair-details" key={`instance-pair-row-${index}`}>
-                {cells}
-            </tr>
-        );
-    }
-});
+        function renderRow(cells: Cell[], index: Index): Row {
+            return (
+                <tr className="instance-pair-details" key={`instance-pair-row-${index}`}>
+                    {cells}
+                </tr>
+            );
+        }
+    },
+);

--- a/src/reports/components/assessment-report-step-header.tsx
+++ b/src/reports/components/assessment-report-step-header.tsx
@@ -24,34 +24,40 @@ export interface AssessmentReportStepHeaderProps {
     defaultMessageComponent: DefaultMessageInterface;
 }
 
-export const AssessmentReportStepHeader = NamedFC<AssessmentReportStepHeaderProps>('AssessmentReportStepHeader', props => {
-    const { deps, header, instanceCount, status, defaultMessageComponent } = props;
-    const { outcomeTypeSemanticsFromTestStatus } = deps;
+export const AssessmentReportStepHeader = NamedFC<AssessmentReportStepHeaderProps>(
+    'AssessmentReportStepHeader',
+    props => {
+        const { deps, header, instanceCount, status, defaultMessageComponent } = props;
+        const { outcomeTypeSemanticsFromTestStatus } = deps;
 
-    const outcomeType = allRequirementOutcomeTypes[status];
-    const minCount = header.requirementType === 'manual' && outcomeType === 'pass' ? 1 : 0;
-    let count = Math.max(minCount, instanceCount);
-    let message: JSX.Element = null;
+        const outcomeType = allRequirementOutcomeTypes[status];
+        const minCount = header.requirementType === 'manual' && outcomeType === 'pass' ? 1 : 0;
+        let count = Math.max(minCount, instanceCount);
+        let message: JSX.Element = null;
 
-    if (defaultMessageComponent && outcomeType === 'pass') {
-        count = defaultMessageComponent.instanceCount;
-        message = defaultMessageComponent.message;
-    }
+        if (defaultMessageComponent && outcomeType === 'pass') {
+            count = defaultMessageComponent.instanceCount;
+            message = defaultMessageComponent.message;
+        }
 
-    const outcomePastTense = outcomeTypeSemanticsFromTestStatus(status).pastTense;
-    const outcomeText = `${count} ${outcomePastTense}`;
+        const outcomePastTense = outcomeTypeSemanticsFromTestStatus(status).pastTense;
+        const outcomeText = `${count} ${outcomePastTense}`;
 
-    return (
-        <div className="step-header">
-            <h4 className="step-header-name">
-                {header.displayName}:<span className="screen-reader-only">{outcomeText}</span>
-            </h4>
-            <span className="step-header-description">{header.description}</span>
-            -
-            <GuidanceLinks classNameForDiv={`test-guidance-links-group`} links={header.guidanceLinks} />
-            <OutcomeChip count={count} outcomeType={outcomeType} />
-            <GuidanceTags deps={deps} links={header.guidanceLinks} />
-            {message && <span className="step-header-message">{message}</span>}
-        </div>
-    );
-});
+        return (
+            <div className="step-header">
+                <h4 className="step-header-name">
+                    {header.displayName}:<span className="screen-reader-only">{outcomeText}</span>
+                </h4>
+                <span className="step-header-description">{header.description}</span>
+                -
+                <GuidanceLinks
+                    classNameForDiv={`test-guidance-links-group`}
+                    links={header.guidanceLinks}
+                />
+                <OutcomeChip count={count} outcomeType={outcomeType} />
+                <GuidanceTags deps={deps} links={header.guidanceLinks} />
+                {message && <span className="step-header-message">{message}</span>}
+            </div>
+        );
+    },
+);

--- a/src/reports/components/assessment-report-step-list.tsx
+++ b/src/reports/components/assessment-report-step-list.tsx
@@ -6,7 +6,10 @@ import * as React from 'react';
 
 import { InstanceReportModel, RequirementReportModel } from '../assessment-report-model';
 import { AssessmentReportInstanceList } from './assessment-report-instance-list';
-import { AssessmentReportStepHeader, AssessmentReportStepHeaderDeps } from './assessment-report-step-header';
+import {
+    AssessmentReportStepHeader,
+    AssessmentReportStepHeaderDeps,
+} from './assessment-report-step-header';
 
 export type AssessmentReportStepListDeps = AssessmentReportStepHeaderDeps;
 
@@ -16,35 +19,40 @@ export interface AssessmentReportStepListProps {
     steps: RequirementReportModel[];
 }
 
-export const AssessmentReportStepList = NamedFC<AssessmentReportStepListProps>('AssessmentReportStepList', props => {
-    const { deps, status, steps } = props;
+export const AssessmentReportStepList = NamedFC<AssessmentReportStepListProps>(
+    'AssessmentReportStepList',
+    props => {
+        const { deps, status, steps } = props;
 
-    return <div>{renderSteps()}</div>;
+        return <div>{renderSteps()}</div>;
 
-    function renderSteps(): JSX.Element[] {
-        return steps.map(({ key, header, instances, defaultMessageComponent, showPassingInstances }) => {
-            const showInstances = status !== ManualTestStatus.PASS || showPassingInstances;
+        function renderSteps(): JSX.Element[] {
+            return steps.map(
+                ({ key, header, instances, defaultMessageComponent, showPassingInstances }) => {
+                    const showInstances = status !== ManualTestStatus.PASS || showPassingInstances;
 
-            return (
-                <div className="step-details" key={key}>
-                    <AssessmentReportStepHeader
-                        deps={deps}
-                        header={header}
-                        instanceCount={instances.length}
-                        status={status}
-                        defaultMessageComponent={defaultMessageComponent}
-                    />
-                    {showInstances && renderStepInstances(instances)}
-                </div>
+                    return (
+                        <div className="step-details" key={key}>
+                            <AssessmentReportStepHeader
+                                deps={deps}
+                                header={header}
+                                instanceCount={instances.length}
+                                status={status}
+                                defaultMessageComponent={defaultMessageComponent}
+                            />
+                            {showInstances && renderStepInstances(instances)}
+                        </div>
+                    );
+                },
             );
-        });
-    }
-
-    function renderStepInstances(instances: InstanceReportModel[]): JSX.Element {
-        if (status === ManualTestStatus.UNKNOWN) {
-            return;
         }
 
-        return <AssessmentReportInstanceList instances={instances} />;
-    }
-});
+        function renderStepInstances(instances: InstanceReportModel[]): JSX.Element {
+            if (status === ManualTestStatus.UNKNOWN) {
+                return;
+            }
+
+            return <AssessmentReportInstanceList instances={instances} />;
+        }
+    },
+);

--- a/src/reports/components/assessment-report-summary.tsx
+++ b/src/reports/components/assessment-report-summary.tsx
@@ -28,6 +28,8 @@ export class AssessmentReportSummary extends React.Component<AssessmentReportSum
     }
 
     private renderDetails(): JSX.Element {
-        return <AssessmentSummaryDetails testSummaries={this.props.summary.reportSummaryDetailsData} />;
+        return (
+            <AssessmentSummaryDetails testSummaries={this.props.summary.reportSummaryDetailsData} />
+        );
     }
 }

--- a/src/reports/components/assessment-report.tsx
+++ b/src/reports/components/assessment-report.tsx
@@ -22,8 +22,15 @@ export class AssessmentReport extends React.Component<AssessmentReportProps> {
     public render(): JSX.Element {
         return (
             <React.Fragment>
-                <HeaderSection pageTitle={this.props.data.scanDetails.targetPage} pageUrl={this.props.data.scanDetails.url} />
-                <AssessmentReportBody deps={this.props.deps} data={this.props.data} description={this.props.description} />
+                <HeaderSection
+                    pageTitle={this.props.data.scanDetails.targetPage}
+                    pageUrl={this.props.data.scanDetails.url}
+                />
+                <AssessmentReportBody
+                    deps={this.props.deps}
+                    data={this.props.data}
+                    description={this.props.description}
+                />
 
                 <AssessmentReportFooter
                     extensionVersion={this.props.extensionVersion}

--- a/src/reports/components/assessment-scan-details.tsx
+++ b/src/reports/components/assessment-scan-details.tsx
@@ -26,7 +26,10 @@ export class AssessmentScanDetails extends React.Component<AssessmentScanDetails
                                 <UrlIcon />
                             </td>
                             <td>
-                                <NewTabLink href={this.props.details.url} title="Navigate to target page">
+                                <NewTabLink
+                                    href={this.props.details.url}
+                                    title="Navigate to target page"
+                                >
                                     {this.props.details.url}
                                 </NewTabLink>
                             </td>
@@ -43,7 +46,9 @@ export class AssessmentScanDetails extends React.Component<AssessmentScanDetails
                             <td className="icon" aria-hidden="true">
                                 <CommentIcon />
                             </td>
-                            <td className="assessment-scan-details-description">{this.props.description}</td>
+                            <td className="assessment-scan-details-description">
+                                {this.props.description}
+                            </td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/reports/components/assessment-summary-details.tsx
+++ b/src/reports/components/assessment-summary-details.tsx
@@ -23,7 +23,11 @@ export class AssessmentSummaryDetails extends React.Component<AssessmentSummaryD
 
     private getTestDetailsList(summaries: AssessmentSummaryReportModel[]): JSX.Element[] {
         return summaries.map(testSummary => (
-            <div role="row" key={testSummary.displayName} className="assessment-summary-details-row">
+            <div
+                role="row"
+                key={testSummary.displayName}
+                className="assessment-summary-details-row"
+            >
                 <div className="test-summary">
                     <div role="cell" className="test-summary-display-name">
                         {testSummary.displayName}

--- a/src/reports/components/formatted-date.tsx
+++ b/src/reports/components/formatted-date.tsx
@@ -49,7 +49,9 @@ export class FormattedDate extends React.Component<FormattedDateProps> {
     }
 
     private getTimeZone(date: Date): string {
-        const timeString = date.toLocaleTimeString('en-us', { timeZoneName: 'short' }).replace(/\u200E/g, '');
+        const timeString = date
+            .toLocaleTimeString('en-us', { timeZoneName: 'short' })
+            .replace(/\u200E/g, '');
         return timeString.substr(timeString.lastIndexOf(' ') + 1);
     }
 

--- a/src/reports/components/outcome-chip-set.tsx
+++ b/src/reports/components/outcome-chip-set.tsx
@@ -9,7 +9,13 @@ import { allRequirementOutcomeTypes, RequirementOutcomeStats } from './requireme
 export const OutcomeChipSet = NamedFC<RequirementOutcomeStats>('OutcomeChipSet', props => (
     <div className="outcome-chip-set">
         {allRequirementOutcomeTypes.map(outcomeType =>
-            props[outcomeType] ? <OutcomeChip key={outcomeType} outcomeType={outcomeType} count={props[outcomeType]} /> : null,
+            props[outcomeType] ? (
+                <OutcomeChip
+                    key={outcomeType}
+                    outcomeType={outcomeType}
+                    count={props[outcomeType]}
+                />
+            ) : null,
         )}
     </div>
 ));

--- a/src/reports/components/outcome-chip.tsx
+++ b/src/reports/components/outcome-chip.tsx
@@ -24,7 +24,11 @@ export const OutcomeChip = NamedFC<OutcomeChipProps>('OutcomeChip', props => {
             <span className="icon">
                 <OutcomeIcon outcomeType={outcomeType} />
             </span>
-            <span data-automation-id={failureCountAutomationId} className="count" aria-hidden="true">
+            <span
+                data-automation-id={failureCountAutomationId}
+                className="count"
+                aria-hidden="true"
+            >
                 {' '}
                 {count}
             </span>

--- a/src/reports/components/outcome-icon-set.tsx
+++ b/src/reports/components/outcome-icon-set.tsx
@@ -24,7 +24,10 @@ export const OutcomeIconSet = NamedFC<RequirementOutcomeStats>('OutcomeIconSet',
         <div className="outcome-icon-set" title={text}>
             {allRequirementOutcomeTypes.map(outcomeType =>
                 times(props[outcomeType], index => (
-                    <span className={'outcome-icon outcome-icon-' + outcomeType} key={`outcome-icon-index-${index}`}>
+                    <span
+                        className={'outcome-icon outcome-icon-' + outcomeType}
+                        key={`outcome-icon-index-${index}`}
+                    >
                         <OutcomeIcon outcomeType={outcomeType} />
                     </span>
                 )),

--- a/src/reports/components/outcome-icon.tsx
+++ b/src/reports/components/outcome-icon.tsx
@@ -8,4 +8,7 @@ interface OutcomeIconProps {
     outcomeType: OutcomeType;
 }
 
-export const OutcomeIcon = NamedFC<OutcomeIconProps>('OutcomeIcon', props => outcomeIconMap[props.outcomeType]);
+export const OutcomeIcon = NamedFC<OutcomeIconProps>(
+    'OutcomeIcon',
+    props => outcomeIconMap[props.outcomeType],
+);

--- a/src/reports/components/outcome-summary-bar.scss
+++ b/src/reports/components/outcome-summary-bar.scss
@@ -66,7 +66,11 @@ $outcome-not-applicable-color: $neutral-outcome;
     }
     .inapplicable {
         @extend .block;
-        @include inapplicable-icon-styles($outcome-summary-icon-size, 0px, $outcome-not-applicable-color);
+        @include inapplicable-icon-styles(
+            $outcome-summary-icon-size,
+            0px,
+            $outcome-not-applicable-color
+        );
         border-radius: 0 2px 2px 0;
         .check-container {
             bottom: -1px;

--- a/src/reports/components/outcome-summary-bar.tsx
+++ b/src/reports/components/outcome-summary-bar.tsx
@@ -4,7 +4,13 @@ import { NamedFC } from 'common/react/named-fc';
 import { kebabCase } from 'lodash';
 import * as React from 'react';
 
-import { outcomeIconMap, outcomeIconMapInverted, OutcomeStats, OutcomeType, outcomeTypeSemantics } from './outcome-type';
+import {
+    outcomeIconMap,
+    outcomeIconMapInverted,
+    OutcomeStats,
+    OutcomeType,
+    outcomeTypeSemantics,
+} from './outcome-type';
 
 export type OutcomeSummaryBarProps = {
     outcomeStats: Partial<OutcomeStats>;
@@ -19,7 +25,8 @@ export const OutcomeSummaryBar = NamedFC<OutcomeSummaryBarProps>('OutcomeSummary
             {props.allOutcomeTypes.map(outcomeType => {
                 const { iconStyleInverted, countSuffix } = props;
                 const text = outcomeTypeSemantics[outcomeType].pastTense;
-                const iconMap = iconStyleInverted === true ? outcomeIconMapInverted : outcomeIconMap;
+                const iconMap =
+                    iconStyleInverted === true ? outcomeIconMapInverted : outcomeIconMap;
                 const outcomeIcon = iconMap[outcomeType];
                 const count = props.outcomeStats[outcomeType];
 

--- a/src/reports/components/report-sections/collapsible-result-section.tsx
+++ b/src/reports/components/report-sections/collapsible-result-section.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { CollapsibleComponentCardsProps } from 'common/components/cards/collapsible-component-cards';
-import { ResultSectionTitle, ResultSectionTitleProps } from 'common/components/cards/result-section-title';
+import {
+    ResultSectionTitle,
+    ResultSectionTitleProps,
+} from 'common/components/cards/result-section-title';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
@@ -18,15 +21,18 @@ export type CollapsibleResultSectionProps = RulesOnlyProps &
         containerClassName: string;
     };
 
-export const CollapsibleResultSection = NamedFC<CollapsibleResultSectionProps>('CollapsibleResultSection', props => {
-    const { containerClassName, containerId, deps } = props;
-    const CollapsibleContent = deps.collapsibleControl({
-        id: containerId,
-        header: <ResultSectionTitle {...props} />,
-        content: <RulesOnly {...props} />,
-        headingLevel: 2,
-        deps: null,
-    });
+export const CollapsibleResultSection = NamedFC<CollapsibleResultSectionProps>(
+    'CollapsibleResultSection',
+    props => {
+        const { containerClassName, containerId, deps } = props;
+        const CollapsibleContent = deps.collapsibleControl({
+            id: containerId,
+            header: <ResultSectionTitle {...props} />,
+            content: <RulesOnly {...props} />,
+            headingLevel: 2,
+            deps: null,
+        });
 
-    return <div className={containerClassName}>{CollapsibleContent}</div>;
-});
+        return <div className={containerClassName}>{CollapsibleContent}</div>;
+    },
+);

--- a/src/reports/components/report-sections/collapsible-script-provider.tsx
+++ b/src/reports/components/report-sections/collapsible-script-provider.tsx
@@ -8,7 +8,8 @@ export const addEventListenerForCollapsibleSection = (doc: Document) => {
         const button = container.querySelector('.collapsible-control');
         button.addEventListener('click', () => {
             const content = button.parentElement.nextElementSibling as HTMLElement;
-            const wasExpandedBefore = button.getAttribute('aria-expanded') === 'false' ? false : true;
+            const wasExpandedBefore =
+                button.getAttribute('aria-expanded') === 'false' ? false : true;
             const isExpandedAfter = !wasExpandedBefore;
 
             button.setAttribute('aria-expanded', isExpandedAfter + '');
@@ -23,7 +24,8 @@ export const addEventListenerForCollapsibleSection = (doc: Document) => {
     }
 };
 
-export const getAddListenerForCollapsibleSection = (code: string | Function): string => `(${String(code)})(document)`;
+export const getAddListenerForCollapsibleSection = (code: string | Function): string =>
+    `(${String(code)})(document)`;
 
 // untested line, having issues with snapshot testing and text representation.
 export const getDefaultAddListenerForCollapsibleSection = (): string =>

--- a/src/reports/components/report-sections/details-section.tsx
+++ b/src/reports/components/report-sections/details-section.tsx
@@ -10,12 +10,20 @@ import { UrlIcon } from 'common/icons/url-icon';
 import { NamedFC } from 'common/react/named-fc';
 import { SectionProps } from './report-section-factory';
 
-export type DetailsSectionProps = Pick<SectionProps, 'pageTitle' | 'pageUrl' | 'description' | 'scanDate' | 'toUtcString'>;
+export type DetailsSectionProps = Pick<
+    SectionProps,
+    'pageTitle' | 'pageUrl' | 'description' | 'scanDate' | 'toUtcString'
+>;
 
 export const DetailsSection = NamedFC<DetailsSectionProps>('DetailsSection', props => {
     const { pageTitle, pageUrl, description, scanDate, toUtcString } = props;
 
-    const createListItem = (icon: JSX.Element, label: string, content: string | JSX.Element, contentClassName?: string) => (
+    const createListItem = (
+        icon: JSX.Element,
+        label: string,
+        content: string | JSX.Element,
+        contentClassName?: string,
+    ) => (
         <li>
             <span className="icon" aria-hidden="true">
                 {icon}
@@ -40,7 +48,8 @@ export const DetailsSection = NamedFC<DetailsSectionProps>('DetailsSection', pro
                     </NewTabLink>,
                 )}
                 {createListItem(<DateIcon />, 'scan date:', scanDateUTC)}
-                {showCommentRow && createListItem(<CommentIcon />, 'comment:', description, 'description-text')}
+                {showCommentRow &&
+                    createListItem(<CommentIcon />, 'comment:', description, 'description-text')}
             </ul>
         </div>
     );

--- a/src/reports/components/report-sections/footer-section.tsx
+++ b/src/reports/components/report-sections/footer-section.tsx
@@ -12,8 +12,9 @@ export const FooterSection = NamedFC('FooterSection', () => {
     return (
         <div className={styles.reportFooterContainer}>
             <div className={styles.reportFooter} role="contentinfo">
-                This automated checks result was generated using <b id="tool-name">{toolName}</b>, a tool that helps debug and find
-                accessibility issues earlier. Get more information & download this tool at{' '}
+                This automated checks result was generated using <b id="tool-name">{toolName}</b>, a
+                tool that helps debug and find accessibility issues earlier. Get more information &
+                download this tool at{' '}
                 <NewTabLink
                     href="http://aka.ms/AccessibilityInsights"
                     aria-labelledby="tool-name"

--- a/src/reports/components/report-sections/footer-text.tsx
+++ b/src/reports/components/report-sections/footer-text.tsx
@@ -12,8 +12,10 @@ export const FooterText = NamedFC<FooterTextProps>(
     'FooterText',
     ({ environmentInfo: { axeCoreVersion, browserSpec, extensionVersion } }) => (
         <>
-            This automated checks result was generated using {`${toolName} ${extensionVersion} (Axe ${axeCoreVersion})`}, a tool that helps
-            debug and find accessibility issues earlier on {browserSpec}. Get more information & download this tool at <ToolLink />.
+            This automated checks result was generated using{' '}
+            {`${toolName} ${extensionVersion} (Axe ${axeCoreVersion})`}, a tool that helps debug and
+            find accessibility issues earlier on {browserSpec}. Get more information & download this
+            tool at <ToolLink />.
         </>
     ),
 );

--- a/src/reports/components/report-sections/full-rule-header.tsx
+++ b/src/reports/components/report-sections/full-rule-header.tsx
@@ -46,7 +46,11 @@ export const FullRuleHeader = NamedFC<FullRuleHeaderProps>('FullRuleHeader', pro
         const ruleUrl = cardResult.url;
         return (
             <span className="rule-details-id">
-                <NewTabLink href={ruleUrl} aria-label={`rule ${ruleId}`} aria-describedby={ariaDescribedBy}>
+                <NewTabLink
+                    href={ruleUrl}
+                    aria-label={`rule ${ruleId}`}
+                    aria-describedby={ariaDescribedBy}
+                >
                     {ruleId}
                 </NewTabLink>
             </span>
@@ -73,7 +77,8 @@ export const FullRuleHeader = NamedFC<FullRuleHeaderProps>('FullRuleHeader', pro
         <>
             <div className="rule-detail">
                 <div>
-                    {renderCountBadge()} {renderRuleLink()}: {renderDescription()} ({renderGuidanceLinks()}){renderGuidanceTags()}
+                    {renderCountBadge()} {renderRuleLink()}: {renderDescription()} (
+                    {renderGuidanceLinks()}){renderGuidanceTags()}
                 </div>
             </div>
         </>

--- a/src/reports/components/report-sections/header-section.tsx
+++ b/src/reports/components/report-sections/header-section.tsx
@@ -12,21 +12,26 @@ export interface HeaderSectionProps {
     pageUrl: string;
 }
 
-export const HeaderSection = NamedFC<HeaderSectionProps>('HeaderSection', ({ pageTitle, pageUrl }) => {
-    return (
-        <header>
-            <div className="report-header-bar">
-                <BrandWhite />
-                <div className="ms-font-m header-text ms-fontWeight-semibold">{productName}</div>
-            </div>
-            <div className="report-header-command-bar">
-                <div className="target-page">
-                    Target page:&nbsp;
-                    <NewTabLink href={pageUrl} title={pageTitle}>
-                        {pageTitle}
-                    </NewTabLink>
+export const HeaderSection = NamedFC<HeaderSectionProps>(
+    'HeaderSection',
+    ({ pageTitle, pageUrl }) => {
+        return (
+            <header>
+                <div className="report-header-bar">
+                    <BrandWhite />
+                    <div className="ms-font-m header-text ms-fontWeight-semibold">
+                        {productName}
+                    </div>
                 </div>
-            </div>
-        </header>
-    );
-});
+                <div className="report-header-command-bar">
+                    <div className="target-page">
+                        Target page:&nbsp;
+                        <NewTabLink href={pageUrl} title={pageTitle}>
+                            {pageTitle}
+                        </NewTabLink>
+                    </div>
+                </div>
+            </header>
+        );
+    },
+);

--- a/src/reports/components/report-sections/minimal-rule-header.tsx
+++ b/src/reports/components/report-sections/minimal-rule-header.tsx
@@ -40,7 +40,9 @@ export const MinimalRuleHeader = NamedFC<MinimalRuleHeaderProps>('MinimalRuleHea
         </span>
     );
 
-    const renderDescription = () => <span className="rule-details-description">{rule.description}</span>;
+    const renderDescription = () => (
+        <span className="rule-details-description">{rule.description}</span>
+    );
 
     return (
         <span data-automation-id={ruleDetailAutomationId} className="rule-detail">

--- a/src/reports/components/report-sections/not-applicable-checks-section.tsx
+++ b/src/reports/components/report-sections/not-applicable-checks-section.tsx
@@ -3,7 +3,10 @@
 import * as React from 'react';
 
 import { NamedFC } from 'common/react/named-fc';
-import { CollapsibleResultSection, CollapsibleResultSectionDeps } from './collapsible-result-section';
+import {
+    CollapsibleResultSection,
+    CollapsibleResultSectionDeps,
+} from './collapsible-result-section';
 import { SectionProps } from './report-section-factory';
 
 export type NotApplicableChecksSectionDeps = CollapsibleResultSectionDeps;

--- a/src/reports/components/report-sections/passed-checks-section.tsx
+++ b/src/reports/components/report-sections/passed-checks-section.tsx
@@ -3,25 +3,31 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { CollapsibleResultSection, CollapsibleResultSectionDeps } from './collapsible-result-section';
+import {
+    CollapsibleResultSection,
+    CollapsibleResultSectionDeps,
+} from './collapsible-result-section';
 import { SectionProps } from './report-section-factory';
 
 export type PassedChecksSectionDeps = CollapsibleResultSectionDeps;
 
 export type PassedChecksSectionProps = Pick<SectionProps, 'deps' | 'cardsViewData'>;
 
-export const PassedChecksSection = NamedFC<PassedChecksSectionProps>('PassedChecksSection', ({ deps, cardsViewData }) => {
-    const cardRuleResults = cardsViewData.cards.pass;
+export const PassedChecksSection = NamedFC<PassedChecksSectionProps>(
+    'PassedChecksSection',
+    ({ deps, cardsViewData }) => {
+        const cardRuleResults = cardsViewData.cards.pass;
 
-    return (
-        <CollapsibleResultSection
-            deps={deps}
-            title="Passed checks"
-            cardRuleResults={cardRuleResults}
-            containerClassName="result-section"
-            outcomeType="pass"
-            badgeCount={cardRuleResults.length}
-            containerId="passed-checks-section"
-        />
-    );
-});
+        return (
+            <CollapsibleResultSection
+                deps={deps}
+                title="Passed checks"
+                cardRuleResults={cardRuleResults}
+                containerClassName="result-section"
+                outcomeType="pass"
+                badgeCount={cardRuleResults.length}
+                containerId="passed-checks-section"
+            />
+        );
+    },
+);

--- a/src/reports/components/report-sections/report-collapsible-container.tsx
+++ b/src/reports/components/report-sections/report-collapsible-container.tsx
@@ -5,27 +5,35 @@ import { CollapsibleComponentCardsProps } from 'common/components/cards/collapsi
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-const ReportCollapsibleContainer = NamedFC<CollapsibleComponentCardsProps>('ReportCollapsibleContainer', props => {
-    const { id, header, headingLevel, content, containerClassName, buttonAriaLabel } = props;
+const ReportCollapsibleContainer = NamedFC<CollapsibleComponentCardsProps>(
+    'ReportCollapsibleContainer',
+    props => {
+        const { id, header, headingLevel, content, containerClassName, buttonAriaLabel } = props;
 
-    const contentId = `content-container-${id}`;
+        const contentId = `content-container-${id}`;
 
-    const outerDivClassName = css('collapsible-container', containerClassName, 'collapsed');
+        const outerDivClassName = css('collapsible-container', containerClassName, 'collapsed');
 
-    return (
-        <div className={outerDivClassName}>
-            <div className="title-container" role="heading" aria-level={headingLevel}>
-                <button className="collapsible-control" aria-expanded="false" aria-controls={contentId} aria-label={buttonAriaLabel}>
-                    {header}
-                </button>
+        return (
+            <div className={outerDivClassName}>
+                <div className="title-container" role="heading" aria-level={headingLevel}>
+                    <button
+                        className="collapsible-control"
+                        aria-expanded="false"
+                        aria-controls={contentId}
+                        aria-label={buttonAriaLabel}
+                    >
+                        {header}
+                    </button>
+                </div>
+                <div id={contentId} className="collapsible-content" aria-hidden="true">
+                    {content}
+                </div>
             </div>
-            <div id={contentId} className="collapsible-content" aria-hidden="true">
-                {content}
-            </div>
-        </div>
-    );
-});
-
-export const ReportCollapsibleContainerControl = (collapsibleControlProps: CollapsibleComponentCardsProps) => (
-    <ReportCollapsibleContainer {...collapsibleControlProps} />
+        );
+    },
 );
+
+export const ReportCollapsibleContainerControl = (
+    collapsibleControlProps: CollapsibleComponentCardsProps,
+) => <ReportCollapsibleContainer {...collapsibleControlProps} />;

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -12,7 +12,9 @@ import { UserConfigurationStoreData } from '../../../common/types/store-data/use
 import { NotApplicableChecksSectionDeps } from './not-applicable-checks-section';
 import { PassedChecksSectionDeps } from './passed-checks-section';
 
-export type SectionDeps = NotApplicableChecksSectionDeps & FailedInstancesSectionDeps & PassedChecksSectionDeps;
+export type SectionDeps = NotApplicableChecksSectionDeps &
+    FailedInstancesSectionDeps &
+    PassedChecksSectionDeps;
 
 export type SectionProps = {
     deps: SectionDeps;

--- a/src/reports/components/report-sections/results-container.tsx
+++ b/src/reports/components/report-sections/results-container.tsx
@@ -6,11 +6,14 @@ import { SectionProps } from './report-section-factory';
 
 export type ResultsContainerProps = Pick<SectionProps, 'getCollapsibleScript'>;
 
-export const ResultsContainer = NamedFC<ResultsContainerProps>('ResultsContainer', ({ children, getCollapsibleScript }) => {
-    return (
-        <>
-            <div className="results-container">{children}</div>
-            <script dangerouslySetInnerHTML={{ __html: getCollapsibleScript() }} />
-        </>
-    );
-});
+export const ResultsContainer = NamedFC<ResultsContainerProps>(
+    'ResultsContainer',
+    ({ children, getCollapsibleScript }) => {
+        return (
+            <>
+                <div className="results-container">{children}</div>
+                <script dangerouslySetInnerHTML={{ __html: getCollapsibleScript() }} />
+            </>
+        );
+    },
+);

--- a/src/reports/components/report-sections/rules-only.tsx
+++ b/src/reports/components/report-sections/rules-only.tsx
@@ -15,12 +15,20 @@ export type RulesOnlyProps = {
     outcomeType: InstanceOutcomeType;
 };
 
-export const RulesOnly = NamedFC<RulesOnlyProps>('RulesOnly', ({ outcomeType, deps, cardRuleResults: cardResults }) => {
-    return (
-        <div className={styles.ruleDetailsGroup}>
-            {cardResults.map(cardRuleResult => (
-                <FullRuleHeader deps={deps} key={cardRuleResult.id} cardRuleResult={cardRuleResult} outcomeType={outcomeType} />
-            ))}
-        </div>
-    );
-});
+export const RulesOnly = NamedFC<RulesOnlyProps>(
+    'RulesOnly',
+    ({ outcomeType, deps, cardRuleResults: cardResults }) => {
+        return (
+            <div className={styles.ruleDetailsGroup}>
+                {cardResults.map(cardRuleResult => (
+                    <FullRuleHeader
+                        deps={deps}
+                        key={cardRuleResult.id}
+                        cardRuleResult={cardRuleResult}
+                        outcomeType={outcomeType}
+                    />
+                ))}
+            </div>
+        );
+    },
+);

--- a/src/reports/components/report-sections/summary-section.tsx
+++ b/src/reports/components/report-sections/summary-section.tsx
@@ -23,7 +23,11 @@ export const SummarySection = NamedFC<SummarySectionProps>('SummarySection', pro
     return (
         <div className="summary-section">
             <h2>Summary</h2>
-            <OutcomeSummaryBar outcomeStats={countSummary} iconStyleInverted={true} allOutcomeTypes={allInstanceOutcomeTypes} />
+            <OutcomeSummaryBar
+                outcomeStats={countSummary}
+                iconStyleInverted={true}
+                allOutcomeTypes={allInstanceOutcomeTypes}
+            />
         </div>
     );
 });

--- a/src/reports/components/requirement-outcome-type.ts
+++ b/src/reports/components/requirement-outcome-type.ts
@@ -19,14 +19,20 @@ export function outcomeTypeFromTestStatus(testStatus: ManualTestStatus): Require
     return statusMap[testStatus];
 }
 
-export function outcomeTypeSemanticsFromTestStatus(testStatus: ManualTestStatus): OutcomeTypeSemantic {
+export function outcomeTypeSemanticsFromTestStatus(
+    testStatus: ManualTestStatus,
+): OutcomeTypeSemantic {
     return outcomeTypeSemantics[outcomeTypeFromTestStatus(testStatus)];
 }
 
 export type RequirementOutcomeStats = { [OT in RequirementOutcomeType]: number };
 
-export function outcomeStatsFromManualTestStatus(testStepStatus: ManualTestStatusData): RequirementOutcomeStats {
-    const outcomeTypeSet = values(testStepStatus).map(s => outcomeTypeFromTestStatus(s.stepFinalResult));
+export function outcomeStatsFromManualTestStatus(
+    testStepStatus: ManualTestStatusData,
+): RequirementOutcomeStats {
+    const outcomeTypeSet = values(testStepStatus).map(s =>
+        outcomeTypeFromTestStatus(s.stepFinalResult),
+    );
     const stats = countBy(outcomeTypeSet) as RequirementOutcomeStats;
     stats.pass = stats.pass || 0;
     stats.incomplete = stats.incomplete || 0;

--- a/src/reports/get-assessment-summary-model.ts
+++ b/src/reports/get-assessment-summary-model.ts
@@ -3,7 +3,10 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
 import { ManualTestStatusData } from 'common/types/manual-test-status';
-import { AssessmentData, AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import {
+    AssessmentData,
+    AssessmentStoreData,
+} from 'common/types/store-data/assessment-result-data';
 import { chain, zipObject } from 'lodash';
 
 import * as Model from './assessment-report-model';
@@ -15,7 +18,9 @@ import {
     RequirementOutcomeType,
 } from './components/requirement-outcome-type';
 
-export type AssessmentSummaryResult = Pick<Assessment, 'title'> & { storeData: Pick<AssessmentData, 'testStepStatus'> };
+export type AssessmentSummaryResult = Pick<Assessment, 'title'> & {
+    storeData: Pick<AssessmentData, 'testStepStatus'>;
+};
 export type AssessmentStatusData = { [key: string]: ManualTestStatusData };
 
 export type GetAssessmentSummaryModelFromProviderAndStoreData = (
@@ -58,7 +63,9 @@ export function getAssessmentSummaryModelFromProviderAndStatusData(
     return getAssessmentSummaryModelFromResults(assessmentResults);
 }
 
-export function getAssessmentSummaryModelFromResults(assessmentResults: AssessmentSummaryResult[]): Model.OverviewSummaryReportModel {
+export function getAssessmentSummaryModelFromResults(
+    assessmentResults: AssessmentSummaryResult[],
+): Model.OverviewSummaryReportModel {
     const reportSummaryDetailsData = assessmentResults.map(assessmentResult => ({
         displayName: assessmentResult.title,
         ...getCounts(assessmentResult),

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -27,7 +27,13 @@ export class ReportGenerator {
         cardsViewData: CardsViewModel,
         description: string,
     ): string {
-        return this.reportHtmlGenerator.generateHtml(scanDate, pageTitle, pageUrl, description, cardsViewData);
+        return this.reportHtmlGenerator.generateHtml(
+            scanDate,
+            pageTitle,
+            pageUrl,
+            description,
+            cardsViewData,
+        );
     }
 
     public generateAssessmentReport(

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -11,7 +11,11 @@ import * as React from 'react';
 import { ReportHead } from './components/report-head';
 import { ReportBody, ReportBodyProps } from './components/report-sections/report-body';
 import { ReportCollapsibleContainerControl } from './components/report-sections/report-collapsible-container';
-import { ReportSectionFactory, SectionDeps, SectionProps } from './components/report-sections/report-section-factory';
+import {
+    ReportSectionFactory,
+    SectionDeps,
+    SectionProps,
+} from './components/report-sections/report-section-factory';
 import { ReactStaticRenderer } from './react-static-renderer';
 
 export class ReportHtmlGenerator {
@@ -26,7 +30,13 @@ export class ReportHtmlGenerator {
         private readonly getPropertyConfiguration: (id: string) => Readonly<PropertyConfiguration>,
     ) {}
 
-    public generateHtml(scanDate: Date, pageTitle: string, pageUrl: string, description: string, cardsViewData: CardsViewModel): string {
+    public generateHtml(
+        scanDate: Date,
+        pageTitle: string,
+        pageUrl: string,
+        description: string,
+        cardsViewData: CardsViewModel,
+    ): string {
         const headElement: JSX.Element = <ReportHead />;
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(headElement);
 

--- a/src/reports/report-name-generator.ts
+++ b/src/reports/report-name-generator.ts
@@ -4,11 +4,22 @@ import { padStart } from 'lodash';
 
 export class ReportNameGenerator {
     public generateName(baseName: string, scanDate: Date, pageTitle: string): string {
-        return baseName + '_' + this.getDateSegment(scanDate) + '_' + this.getTitleSegment(pageTitle) + '.html';
+        return (
+            baseName +
+            '_' +
+            this.getDateSegment(scanDate) +
+            '_' +
+            this.getTitleSegment(pageTitle) +
+            '.html'
+        );
     }
 
     private getDateSegment(scanDate: Date): string {
-        return scanDate.getFullYear() + this.padStartWithZero(scanDate.getMonth() + 1, 2) + this.padStartWithZero(scanDate.getDate(), 2);
+        return (
+            scanDate.getFullYear() +
+            this.padStartWithZero(scanDate.getMonth() + 1, 2) +
+            this.padStartWithZero(scanDate.getDate(), 2)
+        );
     }
 
     private padStartWithZero(num: number, digits: number): string {

--- a/src/tests/unit/tests/reports/components/__snapshots__/assessment-report-footer.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/assessment-report-footer.test.tsx.snap
@@ -8,12 +8,12 @@ exports[`AssessmentReportFooter renders 1`] = `
   Accessibility Insights for Web
    
   test-extension-version
-   (Axe 
+   
+  (Axe 
   axeVersion
   ), a tool that helps debug and find accessibility issues earlier on 
   chromeVersion
   . Get more information & download this tool at
-   
   <a
     className="link report-footer-link"
     href="http://aka.ms/AccessibilityInsights"


### PR DESCRIPTION
#### Description of changes

This PR changes the files under `src/reports` to comply with our new prettier config of 100 line width.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
