### PR TITLE
fix: high contrast menu icons fix

### DIFF
--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -156,6 +156,14 @@ html {
     padding-right: 0;
     padding-left: 0;
     float: right;
+
+    #feedback-collapse-menu-button {
+        color: $neutral-alpha-90;
+    }
+
+    .gear-button {
+        color: $neutral-alpha-90;
+    }
 }
 
 #popup-container .main-section .shortcut-label {

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -140,7 +140,6 @@ html {
 }
 
 .popup-menu .ms-ContextualMenu-icon {
-    color: $communication-primary;
     max-height: 30px;
 }
 


### PR DESCRIPTION
#### Description of changes

Fix the high contrast mode colors for the popup gear and hamburger menu icons and their contextual menu icons too.

I decided to not use any custom colors (i.e. use office fabric colors directly) for 2 reasons: 1) simplify (by removing custom styles from our code base) and; 2) match what we're doing with the gear icon on the details view (which have no custom color already)

**Gear & Hamburger menu buttons**
_before_
![01 - before - gear and hamburger menu buttons](https://user-images.githubusercontent.com/2837582/71856461-e72efd00-3098-11ea-8596-d95ee317b298.png)
_after_
![04 - after - gear and hamburger menu buttons](https://user-images.githubusercontent.com/2837582/71856475-f150fb80-3098-11ea-86b6-b58534c4a0f7.png)

**Hamburger contextual menu icons**
_before_
![02 - before - hamburger contextual menu](https://user-images.githubusercontent.com/2837582/71856539-23625d80-3099-11ea-8741-33398ba24a35.png)
_after_
![05 - after - hamburger contextual menu](https://user-images.githubusercontent.com/2837582/71856544-29583e80-3099-11ea-9623-094d67efcb2e.png)


#### Pull request checklist
- [x] Addresses an existing issue: not filed
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
