### PR TITLE
fix: remove electron per-machine installer option & old data on uninstall

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -25,6 +25,8 @@ win:
     target: nsis
 
 nsis:
-    oneClick: false
+    oneClick: true
+    perMachine: false
+    deleteAppDataOnUninstall: true
 publish:
     provider: generic


### PR DESCRIPTION
#### Description of changes

This PR updates electron-builder.yml to achieve effects listed [here](https://www.electron.build/configuration/nsis#custom-nsis-script). The installer now deletes app data upon uninstall (addressing #1868) and removes the per-machine/per-user option. We don't plan to support per-machine installs - these require elevation and aren't updating correctly in electron-builder.

One side effect of this change is that the confirmation screen post-install goes away. This is due to the default options in electron-builder. To bring this back, we may need a custom NSIS script. This will be moved into a separate issue.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1868
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
