### PR TITLE
chore: update line width for folder scr/DetailsView (partial update)

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -21,7 +21,9 @@ module.exports = {
                 'src/scanner/**/*',
                 'src/types/**/*',
                 'src/views/**/*',
+                'src/DetailsView/**/*',
             ],
+            excludeFiles: ['src/DetailsView/components/**/*'],
             options: {
                 printWidth: 100,
             },

--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -282,7 +282,9 @@ div.insights-file-issue-details-dialog-container {
 
         .details-view-test-nav-area {
             box-sizing: border-box;
-            max-height: calc(100vh - #{detailsViewNavPivotsHeight} - #{$detailsViewHeaderBarHeight} - #{$detailsViewCommandBarHeight});
+            max-height: calc(
+                100vh - #{detailsViewNavPivotsHeight} - #{$detailsViewHeaderBarHeight} - #{$detailsViewCommandBarHeight}
+            );
             .ms-Nav-groupContent,
             .ms-Nav-navItems {
                 margin-bottom: 0px;
@@ -687,7 +689,9 @@ div.insights-file-issue-details-dialog-container {
                 }
                 .issues-table {
                     height: 100%;
-                    width: calc(100% - #{$fastPassRightPanelMarginRight} - #{$fastPassRightPanelMarginLeft});
+                    width: calc(
+                        100% - #{$fastPassRightPanelMarginRight} - #{$fastPassRightPanelMarginLeft}
+                    );
                     display: flex;
                     flex-direction: column;
                     margin-top: $fastPassRightPanelMarginTop;

--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -85,7 +85,11 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
-    public setFeatureFlag = (featureFlagId: string, enabled: boolean, event: React.MouseEvent<HTMLElement>): void => {
+    public setFeatureFlag = (
+        featureFlagId: string,
+        enabled: boolean,
+        event: React.MouseEvent<HTMLElement>,
+    ): void => {
         const messageType = Messages.FeatureFlags.SetFeatureFlag;
         const telemetry = this.telemetryFactory.forFeatureFlagToggle(
             event,
@@ -105,7 +109,11 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
-    public exportResultsClicked(exportResultsType: ExportResultType, exportedHtml: string, event: React.MouseEvent<HTMLElement>): void {
+    public exportResultsClicked(
+        exportResultsType: ExportResultType,
+        exportedHtml: string,
+        event: React.MouseEvent<HTMLElement>,
+    ): void {
         const telemetryData = this.telemetryFactory.forExportedHtml(
             exportResultsType,
             exportedHtml,
@@ -117,7 +125,10 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
     }
 
     public copyIssueDetailsClicked = (event: React.MouseEvent<any>): void => {
-        const telemetryData = this.telemetryFactory.withTriggeredByAndSource(event, TelemetryEvents.TelemetryEventSource.DetailsView);
+        const telemetryData = this.telemetryFactory.withTriggeredByAndSource(
+            event,
+            TelemetryEvents.TelemetryEventSource.DetailsView,
+        );
         this.dispatcher.sendTelemetry(TelemetryEvents.COPY_ISSUE_DETAILS, telemetryData);
     };
 
@@ -154,7 +165,11 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         visualizationType: VisualizationType,
     ): void {
         const payload: SelectRequirementPayload = {
-            telemetry: this.telemetryFactory.forSelectRequirement(event, visualizationType, selectedRequirement),
+            telemetry: this.telemetryFactory.forSelectRequirement(
+                event,
+                visualizationType,
+                selectedRequirement,
+            ),
             selectedRequirement: selectedRequirement,
             selectedTest: visualizationType,
         };
@@ -204,8 +219,15 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
-    public enableVisualHelper(test: VisualizationType, requirement: string, shouldScan = true, sendTelemetry = true): void {
-        const telemetry = sendTelemetry ? this.telemetryFactory.forAssessmentActionFromDetailsViewNoTriggeredBy(test) : null;
+    public enableVisualHelper(
+        test: VisualizationType,
+        requirement: string,
+        shouldScan = true,
+        sendTelemetry = true,
+    ): void {
+        const telemetry = sendTelemetry
+            ? this.telemetryFactory.forAssessmentActionFromDetailsViewNoTriggeredBy(test)
+            : null;
         const payload: AssessmentToggleActionPayload = {
             test,
             requirement,
@@ -213,7 +235,9 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: shouldScan ? Messages.Assessment.EnableVisualHelper : Messages.Assessment.EnableVisualHelperWithoutScan,
+            messageType: shouldScan
+                ? Messages.Assessment.EnableVisualHelper
+                : Messages.Assessment.EnableVisualHelperWithoutScan,
             payload,
         });
     }
@@ -242,7 +266,12 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
-    public changeManualTestStatus = (status: ManualTestStatus, test: VisualizationType, requirement: string, selector: string): void => {
+    public changeManualTestStatus = (
+        status: ManualTestStatus,
+        test: VisualizationType,
+        requirement: string,
+        selector: string,
+    ): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: ChangeInstanceStatusPayload = {
             test,
@@ -258,7 +287,11 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
-    public changeManualRequirementStatus = (status: ManualTestStatus, test: VisualizationType, requirement: string): void => {
+    public changeManualRequirementStatus = (
+        status: ManualTestStatus,
+        test: VisualizationType,
+        requirement: string,
+    ): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: ChangeRequirementStatusPayload = {
             test,
@@ -273,7 +306,11 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
-    public undoManualTestStatusChange = (test: VisualizationType, requirement: string, selector: string): void => {
+    public undoManualTestStatusChange = (
+        test: VisualizationType,
+        requirement: string,
+        selector: string,
+    ): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: AssessmentActionInstancePayload = {
             test,
@@ -288,7 +325,10 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
-    public undoManualRequirementStatusChange = (test: VisualizationType, requirement: string): void => {
+    public undoManualRequirementStatusChange = (
+        test: VisualizationType,
+        requirement: string,
+    ): void => {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: ChangeRequirementStatusPayload = {
             test: test,
@@ -349,7 +389,11 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
-    public addFailureInstance(instanceData: FailureInstanceData, test: VisualizationType, requirement: string): void {
+    public addFailureInstance(
+        instanceData: FailureInstanceData,
+        test: VisualizationType,
+        requirement: string,
+    ): void {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: AddFailureInstancePayload = {
             test,
@@ -364,7 +408,11 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
-    public removeFailureInstance = (test: VisualizationType, requirement: string, id: string): void => {
+    public removeFailureInstance = (
+        test: VisualizationType,
+        requirement: string,
+        id: string,
+    ): void => {
         const telemetry = this.telemetryFactory.forRequirementFromDetailsView(test, requirement);
         const payload: RemoveFailureInstancePayload = {
             test,
@@ -384,7 +432,12 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         this.dispatcher.sendTelemetry(TelemetryEvents.DETAILS_VIEW_OPEN, telemetryData);
     }
 
-    public editFailureInstance = (instanceData: FailureInstanceData, test: VisualizationType, requirement: string, id: string): void => {
+    public editFailureInstance = (
+        instanceData: FailureInstanceData,
+        test: VisualizationType,
+        requirement: string,
+        id: string,
+    ): void => {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: EditFailureInstancePayload = {
             test,
@@ -414,7 +467,11 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
-    public changeAssessmentVisualizationStateForAll(isVisualizationEnabled: boolean, test: VisualizationType, requirement: string): void {
+    public changeAssessmentVisualizationStateForAll(
+        isVisualizationEnabled: boolean,
+        test: VisualizationType,
+        requirement: string,
+    ): void {
         const telemetry = this.telemetryFactory.fromDetailsViewNoTriggeredBy();
         const payload: ChangeInstanceSelectionPayload = {
             test: test,
@@ -452,7 +509,11 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     };
 
-    public cancelStartOver = (event: React.MouseEvent<any>, test: VisualizationType, requirement: string): void => {
+    public cancelStartOver = (
+        event: React.MouseEvent<any>,
+        test: VisualizationType,
+        requirement: string,
+    ): void => {
         const telemetry = this.telemetryFactory.forCancelStartOver(event, test, requirement);
         const payload: BaseActionPayload = {
             telemetry: telemetry,
@@ -489,7 +550,10 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
     public rescanVisualization = (test: VisualizationType, event: SupportedMouseEvent) => {
         const payload: ToggleActionPayload = {
             test: test,
-            telemetry: this.telemetryFactory.withTriggeredByAndSource(event, TelemetryEvents.TelemetryEventSource.DetailsView),
+            telemetry: this.telemetryFactory.withTriggeredByAndSource(
+                event,
+                TelemetryEvents.TelemetryEventSource.DetailsView,
+            ),
         };
 
         const message: Message = {
@@ -500,7 +564,10 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         this.dispatcher.dispatchMessage(message);
     };
 
-    public setAllUrlsPermissionState = (event: SupportedMouseEvent, hasAllUrlAndFilePermissions: boolean) => {
+    public setAllUrlsPermissionState = (
+        event: SupportedMouseEvent,
+        hasAllUrlAndFilePermissions: boolean,
+    ) => {
         const payload: SetAllUrlsPermissionStatePayload = {
             hasAllUrlAndFilePermissions,
             telemetry: this.telemetryFactory.forSetAllUrlPermissionState(

--- a/src/DetailsView/actions/issues-selection-factory.ts
+++ b/src/DetailsView/actions/issues-selection-factory.ts
@@ -14,7 +14,9 @@ export class IssuesSelectionFactory {
                 const targets = items.map(item => '' + item.key);
                 messageCreator.updateIssuesSelectedTargets(targets);
                 const firstSelectedInstance = items[0];
-                messageCreator.updateFocusedInstanceTarget(firstSelectedInstance ? firstSelectedInstance.target : null);
+                messageCreator.updateFocusedInstanceTarget(
+                    firstSelectedInstance ? firstSelectedInstance.target : null,
+                );
             },
         });
         return selection;

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -20,15 +20,23 @@ import { VisualizationScanResultData } from '../common/types/store-data/visualiz
 import { VisualizationStoreData } from '../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../common/types/visualization-type';
 import { DetailsViewCommandBarDeps } from './components/details-view-command-bar';
-import { DetailsRightPanelConfiguration, DetailsViewContentDeps } from './components/details-view-right-panel';
+import {
+    DetailsRightPanelConfiguration,
+    DetailsViewContentDeps,
+} from './components/details-view-right-panel';
 import { DetailsViewSwitcherNavConfiguration } from './components/details-view-switcher-nav';
 import { IssuesTableHandler } from './components/issues-table-handler';
-import { DetailsViewLeftNav, DetailsViewLeftNavDeps } from './components/left-nav/details-view-left-nav';
+import {
+    DetailsViewLeftNav,
+    DetailsViewLeftNavDeps,
+} from './components/left-nav/details-view-left-nav';
 import { TargetPageHiddenBar } from './components/target-page-hidden-bar';
 import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-table-handler';
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
 
-export type DetailsViewBodyDeps = DetailsViewContentDeps & DetailsViewLeftNavDeps & DetailsViewCommandBarDeps;
+export type DetailsViewBodyDeps = DetailsViewContentDeps &
+    DetailsViewLeftNavDeps &
+    DetailsViewCommandBarDeps;
 
 export interface DetailsViewBodyProps {
     deps: DetailsViewBodyDeps;

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -8,7 +8,10 @@ import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { ThemeDeps } from '../common/components/theme';
-import { withStoreSubscription, WithStoreSubscriptionDeps } from '../common/components/with-store-subscription';
+import {
+    withStoreSubscription,
+    WithStoreSubscriptionDeps,
+} from '../common/components/with-store-subscription';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { DropdownClickHandler } from '../common/dropdown-click-handler';
 import { InspectActionMessageCreator } from '../common/message-creators/inspect-action-message-creator';
@@ -27,7 +30,10 @@ import { VisualizationStoreData } from '../common/types/store-data/visualization
 import { VisualizationType } from '../common/types/visualization-type';
 import { DetailsViewCommandBarDeps } from './components/details-view-command-bar';
 import { DetailsViewOverlay, DetailsViewOverlayDeps } from './components/details-view-overlay';
-import { DetailsRightPanelConfiguration, GetDetailsRightPanelConfiguration } from './components/details-view-right-panel';
+import {
+    DetailsRightPanelConfiguration,
+    GetDetailsRightPanelConfiguration,
+} from './components/details-view-right-panel';
 import { GetDetailsSwitcherNavConfiguration } from './components/details-view-switcher-nav';
 import { InteractiveHeader, InteractiveHeaderDeps } from './components/interactive-header';
 import { IssuesTableHandler } from './components/issues-table-handler';
@@ -111,11 +117,17 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
     }
 
     private isTargetPageClosed(): boolean {
-        return !this.hasStores() || (this.props.deps.storesHub.hasStoreData() && this.props.storeState.tabStoreData.isClosed);
+        return (
+            !this.hasStores() ||
+            (this.props.deps.storesHub.hasStoreData() &&
+                this.props.storeState.tabStoreData.isClosed)
+        );
     }
 
     private renderSpinner(): JSX.Element {
-        return <Spinner className="details-view-spinner" size={SpinnerSize.large} label="Loading..." />;
+        return (
+            <Spinner className="details-view-spinner" size={SpinnerSize.large} label="Loading..." />
+        );
     }
 
     private renderContent(): JSX.Element {
@@ -134,7 +146,9 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
         return (
             <InteractiveHeader
                 deps={this.props.deps}
-                selectedPivot={visualizationStoreData ? visualizationStoreData.selectedDetailsViewPivot : null}
+                selectedPivot={
+                    visualizationStoreData ? visualizationStoreData.selectedDetailsViewPivot : null
+                }
                 featureFlagStoreData={this.hasStores() ? storeState.featureFlagStoreData : null}
                 dropdownClickHandler={this.props.dropdownClickHandler}
                 tabClosed={this.hasStores() ? this.props.storeState.tabStoreData.isClosed : true}
@@ -160,14 +174,23 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
 
     private renderDetailsView(): JSX.Element {
         const { deps, storeState } = this.props;
-        const selectedDetailsRightPanelConfiguration = this.props.deps.getDetailsRightPanelConfiguration({
-            selectedDetailsViewPivot: storeState.visualizationStoreData.selectedDetailsViewPivot,
-            detailsViewRightContentPanel: storeState.detailsViewStoreData.detailsViewRightContentPanel,
-        });
-        const selectedDetailsViewSwitcherNavConfiguration = this.props.deps.getDetailsSwitcherNavConfiguration({
-            selectedDetailsViewPivot: storeState.visualizationStoreData.selectedDetailsViewPivot,
-        });
-        const selectedTest = selectedDetailsViewSwitcherNavConfiguration.getSelectedDetailsView(storeState);
+        const selectedDetailsRightPanelConfiguration = this.props.deps.getDetailsRightPanelConfiguration(
+            {
+                selectedDetailsViewPivot:
+                    storeState.visualizationStoreData.selectedDetailsViewPivot,
+                detailsViewRightContentPanel:
+                    storeState.detailsViewStoreData.detailsViewRightContentPanel,
+            },
+        );
+        const selectedDetailsViewSwitcherNavConfiguration = this.props.deps.getDetailsSwitcherNavConfiguration(
+            {
+                selectedDetailsViewPivot:
+                    storeState.visualizationStoreData.selectedDetailsViewPivot,
+            },
+        );
+        const selectedTest = selectedDetailsViewSwitcherNavConfiguration.getSelectedDetailsView(
+            storeState,
+        );
 
         const cardsViewData = this.props.deps.getCardViewData(
             this.props.storeState.unifiedScanResultStoreData.rules,
@@ -199,14 +222,23 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
                 cardsViewData={cardsViewData}
                 cardSelectionStoreData={storeState.cardSelectionStoreData}
                 targetAppInfo={storeState.unifiedScanResultStoreData.targetAppInfo}
-                scanIncompleteWarnings={storeState.unifiedScanResultStoreData.scanIncompleteWarnings}
+                scanIncompleteWarnings={
+                    storeState.unifiedScanResultStoreData.scanIncompleteWarnings
+                }
             />
         );
     }
 
     private hasStores(): boolean {
-        return this.props.deps !== null && this.props.deps.storesHub !== null && this.props.deps.storesHub.hasStores();
+        return (
+            this.props.deps !== null &&
+            this.props.deps.storesHub !== null &&
+            this.props.deps.storesHub.hasStores()
+        );
     }
 }
 
-export const DetailsView = withStoreSubscription<DetailsViewContainerProps, DetailsViewContainerState>(DetailsViewContainer);
+export const DetailsView = withStoreSubscription<
+    DetailsViewContainerProps,
+    DetailsViewContainerState
+>(DetailsViewContainer);

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -127,7 +127,11 @@ if (isNaN(tabId) === false) {
                 browserAdapter,
                 tab.id,
             );
-            const tabStore = new StoreProxy<TabStoreData>(StoreNames[StoreNames.TabStore], browserAdapter, tab.id);
+            const tabStore = new StoreProxy<TabStoreData>(
+                StoreNames[StoreNames.TabStore],
+                browserAdapter,
+                tab.id,
+            );
             const visualizationScanResultStore = new StoreProxy<VisualizationScanResultData>(
                 StoreNames[StoreNames.VisualizationScanResultStore],
                 browserAdapter,
@@ -138,15 +142,31 @@ if (isNaN(tabId) === false) {
                 browserAdapter,
                 tab.id,
             );
-            const pathSnippetStore = new StoreProxy<PathSnippetStoreData>(StoreNames[StoreNames.PathSnippetStore], browserAdapter, tab.id);
-            const detailsViewStore = new StoreProxy<DetailsViewData>(StoreNames[StoreNames.DetailsViewStore], browserAdapter, tab.id);
-            const assessmentStore = new StoreProxy<AssessmentStoreData>(StoreNames[StoreNames.AssessmentStore], browserAdapter, tab.id);
+            const pathSnippetStore = new StoreProxy<PathSnippetStoreData>(
+                StoreNames[StoreNames.PathSnippetStore],
+                browserAdapter,
+                tab.id,
+            );
+            const detailsViewStore = new StoreProxy<DetailsViewData>(
+                StoreNames[StoreNames.DetailsViewStore],
+                browserAdapter,
+                tab.id,
+            );
+            const assessmentStore = new StoreProxy<AssessmentStoreData>(
+                StoreNames[StoreNames.AssessmentStore],
+                browserAdapter,
+                tab.id,
+            );
             const featureFlagStore = new StoreProxy<DictionaryStringTo<boolean>>(
                 StoreNames[StoreNames.FeatureFlagStore],
                 browserAdapter,
                 tab.id,
             );
-            const scopingStore = new StoreProxy<ScopingStoreData>(StoreNames[StoreNames.ScopingPanelStateStore], browserAdapter, tab.id);
+            const scopingStore = new StoreProxy<ScopingStoreData>(
+                StoreNames[StoreNames.ScopingPanelStateStore],
+                browserAdapter,
+                tab.id,
+            );
             const userConfigStore = new StoreProxy<UserConfigurationStoreData>(
                 StoreNames[StoreNames.UserConfigurationStore],
                 browserAdapter,
@@ -173,9 +193,16 @@ if (isNaN(tabId) === false) {
             ]);
 
             const logger = createDefaultLogger();
-            const actionMessageDispatcher = new RemoteActionMessageDispatcher(browserAdapter.sendMessageToFrames, tab.id, logger);
+            const actionMessageDispatcher = new RemoteActionMessageDispatcher(
+                browserAdapter.sendMessageToFrames,
+                tab.id,
+                logger,
+            );
 
-            const detailsViewActionMessageCreator = new DetailsViewActionMessageCreator(telemetryFactory, actionMessageDispatcher);
+            const detailsViewActionMessageCreator = new DetailsViewActionMessageCreator(
+                telemetryFactory,
+                actionMessageDispatcher,
+            );
             const scopingActionMessageCreator = new ScopingActionMessageCreator(
                 telemetryFactory,
                 TelemetryEventSource.DetailsView,
@@ -186,7 +213,10 @@ if (isNaN(tabId) === false) {
                 TelemetryEventSource.DetailsView,
                 actionMessageDispatcher,
             );
-            const dropdownActionMessageCreator = new DropdownActionMessageCreator(telemetryFactory, actionMessageDispatcher);
+            const dropdownActionMessageCreator = new DropdownActionMessageCreator(
+                telemetryFactory,
+                actionMessageDispatcher,
+            );
 
             const issueFilingActionMessageCreator = new IssueFilingActionMessageCreator(
                 actionMessageDispatcher,
@@ -194,7 +224,9 @@ if (isNaN(tabId) === false) {
                 TelemetryEventSource.DetailsView,
             );
 
-            const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(actionMessageDispatcher);
+            const storeActionMessageCreatorFactory = new StoreActionMessageCreatorFactory(
+                actionMessageDispatcher,
+            );
 
             const contentActionMessageCreator = new ContentActionMessageCreator(
                 telemetryFactory,
@@ -203,30 +235,51 @@ if (isNaN(tabId) === false) {
             );
 
             const userConfigMessageCreator = new UserConfigMessageCreator(actionMessageDispatcher);
-            const storeActionMessageCreator = storeActionMessageCreatorFactory.fromStores(storesHub.stores);
+            const storeActionMessageCreator = storeActionMessageCreatorFactory.fromStores(
+                storesHub.stores,
+            );
 
-            const visualizationActionCreator = new VisualizationActionMessageCreator(actionMessageDispatcher);
+            const visualizationActionCreator = new VisualizationActionMessageCreator(
+                actionMessageDispatcher,
+            );
 
-            const issuesSelection = new IssuesSelectionFactory().createSelection(detailsViewActionMessageCreator);
-            const clickHandlerFactory = new DetailsViewToggleClickHandlerFactory(visualizationActionCreator, telemetryFactory);
+            const issuesSelection = new IssuesSelectionFactory().createSelection(
+                detailsViewActionMessageCreator,
+            );
+            const clickHandlerFactory = new DetailsViewToggleClickHandlerFactory(
+                visualizationActionCreator,
+                telemetryFactory,
+            );
             const visualizationConfigurationFactory = new VisualizationConfigurationFactory();
             const assessmentDefaultMessageGenerator = new AssessmentDefaultMessageGenerator();
             const assessmentInstanceTableHandler = new AssessmentInstanceTableHandler(
                 detailsViewActionMessageCreator,
-                new AssessmentTableColumnConfigHandler(new MasterCheckBoxConfigProvider(detailsViewActionMessageCreator), Assessments),
+                new AssessmentTableColumnConfigHandler(
+                    new MasterCheckBoxConfigProvider(detailsViewActionMessageCreator),
+                    Assessments,
+                ),
                 Assessments,
             );
             const issuesTableHandler = new IssuesTableHandler();
-            const previewFeatureFlagsHandler = new PreviewFeatureFlagsHandler(getAllFeatureFlagDetails());
+            const previewFeatureFlagsHandler = new PreviewFeatureFlagsHandler(
+                getAllFeatureFlagDetails(),
+            );
             const scopingFlagsHandler = new PreviewFeatureFlagsHandler(getAllFeatureFlagDetails());
-            const dropdownClickHandler = new DropdownClickHandler(dropdownActionMessageCreator, TelemetryEventSource.DetailsView);
+            const dropdownClickHandler = new DropdownClickHandler(
+                dropdownActionMessageCreator,
+                TelemetryEventSource.DetailsView,
+            );
 
             const navigatorUtils = new NavigatorUtils(window.navigator, logger);
             const extensionVersion = browserAdapter.getManifest().version;
             const axeVersion = getVersion();
             const browserSpec = navigatorUtils.getBrowserSpec();
 
-            const environmentInfoProvider = new EnvironmentInfoProvider(browserAdapter.getVersion(), browserSpec, AxeInfo.Default.version);
+            const environmentInfoProvider = new EnvironmentInfoProvider(
+                browserAdapter.getVersion(),
+                browserSpec,
+                AxeInfo.Default.version,
+            );
 
             const reactStaticRenderer = new ReactStaticRenderer();
             const reportNameGenerator = new ReportNameGenerator();
@@ -290,7 +343,11 @@ if (isNaN(tabId) === false) {
 
             const fileURLProvider = new FileURLProvider(windowUtils, provideBlob);
 
-            const reportGenerator = new ReportGenerator(reportNameGenerator, reportHtmlGenerator, assessmentReportHtmlGenerator);
+            const reportGenerator = new ReportGenerator(
+                reportNameGenerator,
+                reportHtmlGenerator,
+                assessmentReportHtmlGenerator,
+            );
 
             const axeResultToIssueFilingDataConverter = new AxeResultToIssueFilingDataConverter(
                 IssueFilingUrlStringUtils.getSelectorLastPart,
@@ -347,7 +404,10 @@ if (isNaN(tabId) === false) {
                 cardSelectionMessageCreator,
                 getCardSelectionViewData: getCardSelectionViewData,
                 cardsVisualizationModifierButtons: CardsVisualizationModifierButtons,
-                allUrlsPermissionHandler: new AllUrlsPermissionHandler(browserAdapter, detailsViewActionMessageCreator),
+                allUrlsPermissionHandler: new AllUrlsPermissionHandler(
+                    browserAdapter,
+                    detailsViewActionMessageCreator,
+                ),
             };
 
             const renderer = new DetailsViewRenderer(
@@ -369,7 +429,11 @@ if (isNaN(tabId) === false) {
             );
             renderer.render();
 
-            const a11ySelfValidator = new A11YSelfValidator(new ScannerUtils(scan, logger), new HTMLElementUtils(), logger);
+            const a11ySelfValidator = new A11YSelfValidator(
+                new ScannerUtils(scan, logger),
+                new HTMLElementUtils(),
+                logger,
+            );
             window.A11YSelfValidator = a11ySelfValidator;
         },
         () => {

--- a/src/DetailsView/detailsView.html
+++ b/src/DetailsView/detailsView.html
@@ -6,7 +6,11 @@ Licensed under the MIT License.
 <html dir="ltr" lang="en">
     <head>
         <meta charset="utf-8" />
-        <link rel="shortcut icon" type="image/x-icon" href="../icons/brand/blue/brand-blue-16px.png" />
+        <link
+            rel="shortcut icon"
+            type="image/x-icon"
+            href="../icons/brand/blue/brand-blue-16px.png"
+        />
         <link rel="stylesheet" type="text/css" href="../common/styles/fabric.min.css" />
         <link rel="stylesheet" type="text/css" href="./styles/default/detailsview.css" />
         <link rel="stylesheet" type="text/css" href="../bundle/detailsView.css" />

--- a/src/DetailsView/document-title-updater.ts
+++ b/src/DetailsView/document-title-updater.ts
@@ -65,8 +65,11 @@ export class DocumentTitleUpdater {
     }
 
     private hasAllStoreData(): boolean {
-        return [this.tabStore, this.detailsViewStore, this.visualizationStore, this.assessmentStore].every(
-            store => store.getState() != null,
-        );
+        return [
+            this.tabStore,
+            this.detailsViewStore,
+            this.visualizationStore,
+            this.assessmentStore,
+        ].every(store => store.getState() != null);
     }
 }

--- a/src/DetailsView/extensions/assessment-report-extension-point.ts
+++ b/src/DetailsView/extensions/assessment-report-extension-point.ts
@@ -7,4 +7,7 @@ const defaultComponent = {
     alterRequirementReportModel: (model: RequirementReportModel) => {},
 };
 
-export const assessmentReportExtensionPoint = createCallChainExtensionPoint('assessmentReportExtensionPoint', defaultComponent);
+export const assessmentReportExtensionPoint = createCallChainExtensionPoint(
+    'assessmentReportExtensionPoint',
+    defaultComponent,
+);

--- a/src/DetailsView/extensions/details-view-extension-point.ts
+++ b/src/DetailsView/extensions/details-view-extension-point.ts
@@ -7,4 +7,7 @@ const defaultComponent = {
     onAssessmentViewUpdate: (prevProps: AssessmentViewProps, curProps: AssessmentViewProps) => {},
 };
 
-export const detailsViewExtensionPoint = createCallChainExtensionPoint('detailsViewExtensionPoint', defaultComponent);
+export const detailsViewExtensionPoint = createCallChainExtensionPoint(
+    'detailsViewExtensionPoint',
+    defaultComponent,
+);

--- a/src/DetailsView/extensions/select-first-requirement-after-automated-checks.ts
+++ b/src/DetailsView/extensions/select-first-requirement-after-automated-checks.ts
@@ -9,7 +9,10 @@ function isRunning(props: AssessmentViewProps): boolean {
     return results.incomplete > 0;
 }
 
-function onAssessmentViewUpdate(prevProps: AssessmentViewProps, curProps: AssessmentViewProps): void {
+function onAssessmentViewUpdate(
+    prevProps: AssessmentViewProps,
+    curProps: AssessmentViewProps,
+): void {
     const { assessmentTestResult } = curProps;
     const prevIsRunning = isRunning(prevProps);
     const nowIsRunning = isRunning(curProps);

--- a/src/DetailsView/extensions/wait-for-all-requirements-to-complete.tsx
+++ b/src/DetailsView/extensions/wait-for-all-requirements-to-complete.tsx
@@ -5,15 +5,17 @@ import * as React from 'react';
 import { OutcomeMath } from 'reports/components/outcome-math';
 import { AssessmentViewMainContentExtensionPoint } from '../components/assessment-view';
 
-export const waitForAllRequirementsToComplete = AssessmentViewMainContentExtensionPoint.create(props => {
-    const { assessmentTestResult, children } = props;
+export const waitForAllRequirementsToComplete = AssessmentViewMainContentExtensionPoint.create(
+    props => {
+        const { assessmentTestResult, children } = props;
 
-    const outcomeStats = assessmentTestResult.getOutcomeStats();
-    if (outcomeStats.incomplete > 0) {
-        const percentage = OutcomeMath.percentageComplete(outcomeStats);
+        const outcomeStats = assessmentTestResult.getOutcomeStats();
+        if (outcomeStats.incomplete > 0) {
+            const percentage = OutcomeMath.percentageComplete(outcomeStats);
 
-        return <ScanningSpinner isSpinning={true} label={`Scanning ${percentage}%`} />;
-    }
+            return <ScanningSpinner isSpinning={true} label={`Scanning ${percentage}%`} />;
+        }
 
-    return <>{children}</>;
-});
+        return <>{children}</>;
+    },
+);

--- a/src/DetailsView/handlers/allurls-permission-handler.ts
+++ b/src/DetailsView/handlers/allurls-permission-handler.ts
@@ -8,11 +8,16 @@ import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-vie
 export class AllUrlsPermissionHandler {
     constructor(
         private readonly browserAdapter: BrowserAdapter,
-        private readonly actionMessageCreator: Pick<DetailsViewActionMessageCreator, 'setAllUrlsPermissionState'>,
+        private readonly actionMessageCreator: Pick<
+            DetailsViewActionMessageCreator,
+            'setAllUrlsPermissionState'
+        >,
     ) {}
 
     public requestAllUrlsPermission = async (e: SupportedMouseEvent, onSuccess: () => void) => {
-        const newAllUrlsPermissionState = await this.browserAdapter.requestPermissions(allUrlAndFilePermissions);
+        const newAllUrlsPermissionState = await this.browserAdapter.requestPermissions(
+            allUrlAndFilePermissions,
+        );
         this.actionMessageCreator.setAllUrlsPermissionState(e, newAllUrlsPermissionState);
 
         if (newAllUrlsPermissionState) {

--- a/src/DetailsView/handlers/assessment-instance-table-handler.tsx
+++ b/src/DetailsView/handlers/assessment-instance-table-handler.tsx
@@ -17,7 +17,10 @@ import { DictionaryStringTo } from '../../types/common-types';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { AssessmentInstanceEditAndRemoveControl } from '../components/assessment-instance-edit-and-remove-control';
 import { AssessmentInstanceSelectedButton } from '../components/assessment-instance-selected-button';
-import { AssessmentInstanceRowData, CapturedInstanceRowData } from '../components/assessment-instance-table';
+import {
+    AssessmentInstanceRowData,
+    CapturedInstanceRowData,
+} from '../components/assessment-instance-table';
 import { AssessmentTableColumnConfigHandler } from '../components/assessment-table-column-config-handler';
 import { FailureInstanceData } from '../components/failure-instance-panel-control';
 import { TestStatusChoiceGroup } from '../components/test-status-choice-group';
@@ -37,7 +40,11 @@ export class AssessmentInstanceTableHandler {
         this.assessmentsProvider = assessmentsProvider;
     }
 
-    public changeRequirementStatus = (status: ManualTestStatus, test: VisualizationType, step: string): void => {
+    public changeRequirementStatus = (
+        status: ManualTestStatus,
+        test: VisualizationType,
+        step: string,
+    ): void => {
         this.detailsViewActionMessageCreator.changeManualRequirementStatus(status, test, step);
     };
 
@@ -45,7 +52,11 @@ export class AssessmentInstanceTableHandler {
         this.detailsViewActionMessageCreator.undoManualRequirementStatusChange(test, step);
     };
 
-    public addFailureInstance = (instanceData: FailureInstanceData, test: VisualizationType, step: string): void => {
+    public addFailureInstance = (
+        instanceData: FailureInstanceData,
+        test: VisualizationType,
+        step: string,
+    ): void => {
         this.detailsViewActionMessageCreator.addFailureInstance(instanceData, test, step);
     };
 
@@ -70,15 +81,19 @@ export class AssessmentInstanceTableHandler {
         assessmentNavState: AssessmentNavState,
         hasVisualHelper: boolean,
     ): AssessmentInstanceRowData[] {
-        const assessmentInstances = this.getInstanceKeys(instancesMap, assessmentNavState).map(key => {
-            const instance = instancesMap[key];
-            return {
-                key: key,
-                statusChoiceGroup: this.renderChoiceGroup(instance, key, assessmentNavState),
-                visualizationButton: hasVisualHelper ? this.renderSelectedButton(instance, key, assessmentNavState) : null,
-                instance: instance,
-            } as AssessmentInstanceRowData;
-        });
+        const assessmentInstances = this.getInstanceKeys(instancesMap, assessmentNavState).map(
+            key => {
+                const instance = instancesMap[key];
+                return {
+                    key: key,
+                    statusChoiceGroup: this.renderChoiceGroup(instance, key, assessmentNavState),
+                    visualizationButton: hasVisualHelper
+                        ? this.renderSelectedButton(instance, key, assessmentNavState)
+                        : null,
+                    instance: instance,
+                } as AssessmentInstanceRowData;
+            },
+        );
         return assessmentInstances;
     }
 
@@ -92,13 +107,20 @@ export class AssessmentInstanceTableHandler {
         for (let keyIndex = 0; keyIndex < instanceKeys.length; keyIndex++) {
             const key = instanceKeys[keyIndex];
             const instance = instancesMap[key];
-            if (!instance.testStepResults[assessmentNavState.selectedTestStep].isVisualizationEnabled) {
+            if (
+                !instance.testStepResults[assessmentNavState.selectedTestStep]
+                    .isVisualizationEnabled
+            ) {
                 allEnabled = false;
                 break;
             }
         }
 
-        return this.assessmentTableColumnConfigHandler.getColumnConfigs(assessmentNavState, allEnabled, hasVisualHelper);
+        return this.assessmentTableColumnConfigHandler.getColumnConfigs(
+            assessmentNavState,
+            allEnabled,
+            hasVisualHelper,
+        );
     }
 
     public createCapturedInstanceTableItems(
@@ -111,7 +133,13 @@ export class AssessmentInstanceTableHandler {
         return instances.map((instance: UserCapturedInstance) => {
             return {
                 instance: instance,
-                instanceActionButtons: this.renderInstanceActionButtons(instance, test, step, featureFlagStoreData, pathSnippetStoreData),
+                instanceActionButtons: this.renderInstanceActionButtons(
+                    instance,
+                    test,
+                    step,
+                    featureFlagStoreData,
+                    pathSnippetStoreData,
+                ),
             };
         });
     }

--- a/src/DetailsView/handlers/details-view-toggle-click-handler-factory.ts
+++ b/src/DetailsView/handlers/details-view-toggle-click-handler-factory.ts
@@ -11,16 +11,26 @@ export class DetailsViewToggleClickHandlerFactory {
     private actionCreator: VisualizationActionMessageCreator;
     private telemetryFactory: TelemetryDataFactory;
 
-    constructor(actionCreator: VisualizationActionMessageCreator, telemetryFactory: TelemetryDataFactory) {
+    constructor(
+        actionCreator: VisualizationActionMessageCreator,
+        telemetryFactory: TelemetryDataFactory,
+    ) {
         this.actionCreator = actionCreator;
         this.telemetryFactory = telemetryFactory;
     }
 
-    public createClickHandler(visualizationType: VisualizationType, newValue: boolean): (event) => void {
+    public createClickHandler(
+        visualizationType: VisualizationType,
+        newValue: boolean,
+    ): (event) => void {
         return this.toggleVisualization.bind(this, visualizationType, newValue);
     }
 
-    private toggleVisualization(visualizationType: VisualizationType, newValue: boolean, event: React.MouseEvent<HTMLElement>): void {
+    private toggleVisualization(
+        visualizationType: VisualizationType,
+        newValue: boolean,
+        event: React.MouseEvent<HTMLElement>,
+    ): void {
         const source = TelemetryEventSource.DetailsView;
         const telementryInfo = this.telemetryFactory.forToggle(event, newValue, source);
         this.actionCreator.setVisualizationState(visualizationType, newValue, telementryInfo);

--- a/src/DetailsView/handlers/get-document-title.ts
+++ b/src/DetailsView/handlers/get-document-title.ts
@@ -9,7 +9,9 @@ export interface GetTestViewTitleProps {
 }
 
 export function getTestViewTitle(props: GetTestViewTitleProps): string {
-    const configuration = props.visualizationConfigurationFactory.getConfiguration(props.selectedDetailsView);
+    const configuration = props.visualizationConfigurationFactory.getConfiguration(
+        props.selectedDetailsView,
+    );
     const displayableData = configuration.displayableData;
 
     return displayableData.title;

--- a/src/DetailsView/handlers/master-checkbox-config-provider.ts
+++ b/src/DetailsView/handlers/master-checkbox-config-provider.ts
@@ -15,7 +15,10 @@ export class MasterCheckBoxConfigProvider {
         this.detailsViewActionMessageCreator = detailsViewActionMessageCreator;
     }
 
-    public getMasterCheckBoxProperty(assessmentNavState: AssessmentNavState, allEnabled: boolean): Partial<IColumn> {
+    public getMasterCheckBoxProperty(
+        assessmentNavState: AssessmentNavState,
+        allEnabled: boolean,
+    ): Partial<IColumn> {
         const iconName = allEnabled
             ? MasterCheckBoxConfigProvider.MASTER_CHECKBOX_ICON_NAME_ENABLED
             : MasterCheckBoxConfigProvider.MASTER_CHECKBOX_ICON_NAME_DISABLED;

--- a/src/DetailsView/handlers/preview-feature-flags-handler.ts
+++ b/src/DetailsView/handlers/preview-feature-flags-handler.ts
@@ -13,7 +13,9 @@ export class PreviewFeatureFlagsHandler {
         this.featureFlagDetails = featureFlagDetails;
     }
 
-    public getDisplayableFeatureFlags(featureFlagValues: FeatureFlagStoreData): DisplayableFeatureFlag[] {
+    public getDisplayableFeatureFlags(
+        featureFlagValues: FeatureFlagStoreData,
+    ): DisplayableFeatureFlag[] {
         const showAll = featureFlagValues[FeatureFlags.showAllFeatureFlags];
         const results: DisplayableFeatureFlag[] = [];
 


### PR DESCRIPTION
#### Description of changes

This PR changes the files under `src/DetailsView` to comply with our new prettier config of 100 line width.

Left out of this PR in order to keep it small: `src/DetailsView/components`. This folder will be gradually added in subsequent PR's

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
