### PR TITLE
fix: automated checks background color

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -688,16 +688,17 @@ div.insights-file-issue-details-dialog-container {
                     }
                 }
                 .issues-table {
+                    background-color: $neutral-2;
                     height: 100%;
                     width: calc(
                         100% - #{$fastPassRightPanelMarginRight} - #{$fastPassRightPanelMarginLeft}
                     );
                     display: flex;
                     flex-direction: column;
-                    margin-top: $fastPassRightPanelMarginTop;
-                    margin-right: $fastPassRightPanelMarginRight;
-                    margin-left: $fastPassRightPanelMarginLeft;
-                    margin-bottom: auto;
+                    padding-top: $fastPassRightPanelMarginTop;
+                    padding-right: $fastPassRightPanelMarginRight;
+                    padding-left: $fastPassRightPanelMarginLeft;
+                    padding-bottom: auto;
 
                     .issues-table-subtitle {
                         color: $secondary-text;


### PR DESCRIPTION
#### Description of changes

Update background color for Fast Pass > Automated checks view.

The color change:
- only affect the right side section (not the nav)
- only affects Fast Pass> Automated checks, not other views (Tab Stops nor Assessments)

![01 - default theme](https://user-images.githubusercontent.com/2837582/72116309-c7990e00-32fe-11ea-9a8a-0c9a6b6a178d.png)

#### Pull request checklist
- [x] Addresses an existing issue: #1962
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
