### PR TITLE
refactor: use css grid to layout diagnostic view toggle

### DIFF
--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -165,13 +165,6 @@ html {
     }
 }
 
-#popup-container .main-section .shortcut-label {
-    color: $secondary-text;
-    text-align: right;
-    padding-top: 3px;
-    padding-bottom: 0px;
-}
-
 #popup-container .main-section .ad-hoc-tools-panel-group-0 {
     padding-right: 15px;
 }
@@ -224,15 +217,6 @@ html {
 
 #popup-container .main-section .ms-Spinner {
     padding-top: 3px;
-}
-
-#popup-container .main-section .view-toggle-row {
-    height: 25px;
-}
-
-#popup-container .main-section .view-toggle-col {
-    padding-right: 0;
-    text-align: right;
 }
 
 #popup-container .main-section .ms-Checkbox-checkbox {

--- a/src/popup/components/diagnostic-view-toggle.scss
+++ b/src/popup/components/diagnostic-view-toggle.scss
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+
+.diagnostic-view-toggle {
+    display: grid;
+
+    grid-template-columns: auto auto;
+    grid-template-rows: 25px 25px;
+
+    align-items: center;
+
+    .title {
+        font-weight: 600;
+        font-size: 15px;
+    }
+
+    .toggle {
+        grid-row: 1;
+        grid-column: 2;
+        justify-self: end;
+
+        :global(.ms-Toggle-stateText) {
+            margin-right: 0;
+        }
+    }
+
+    .shortcut {
+        grid-row: 2;
+        grid-column: 2;
+        justify-self: end;
+
+        font-weight: 400;
+        font-size: 11px;
+        color: $secondary-text;
+    }
+}

--- a/src/popup/components/diagnostic-view-toggle.tsx
+++ b/src/popup/components/diagnostic-view-toggle.tsx
@@ -1,21 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Link } from 'office-ui-fabric-react';
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
-import { IToggle } from 'office-ui-fabric-react';
+import { VisualizationToggle } from 'common/components/visualization-toggle';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { KeyCodeConstants } from 'common/constants/keycode-constants';
+import { TelemetryEventSource } from 'common/extension-telemetry-events';
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
+import { IToggle, Link, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
+import { DictionaryStringTo } from 'types/common-types';
 import { ContentLink, ContentLinkDeps } from 'views/content/content-link';
-import { VisualizationToggle } from '../../common/components/visualization-toggle';
-import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
-import { VisualizationConfigurationFactory } from '../../common/configs/visualization-configuration-factory';
-import { KeyCodeConstants } from '../../common/constants/keycode-constants';
-import { TelemetryEventSource } from '../../common/extension-telemetry-events';
-import { DetailsViewPivotType } from '../../common/types/details-view-pivot-type';
-import { VisualizationStoreData } from '../../common/types/store-data/visualization-store-data';
-import { VisualizationType } from '../../common/types/visualization-type';
-import { DictionaryStringTo } from '../../types/common-types';
 import { PopupActionMessageCreator } from '../actions/popup-action-message-creator';
 import { DiagnosticViewClickHandler } from '../handlers/diagnostic-view-toggle-click-handler';
+import * as styles from './diagnostic-view-toggle.scss';
 
 export interface DiagnosticViewToggleProps {
     deps: DiagnosticViewToggleDeps;
@@ -65,26 +64,13 @@ export class DiagnosticViewToggle extends React.Component<
     public render(): JSX.Element {
         const displayableData = this.configuration.displayableData;
         const shortcut = this.getCommandShortcut();
+
         return (
-            <div>
-                <div className="ms-Grid-row view-toggle-row">
-                    <div className="ms-Grid-col ms-sm7">
-                        <div className="ms-fontColor-neutralPrimary ms-fontWeight-semibold ms-fontSize-mPlus">
-                            {displayableData.title}
-                        </div>
-                    </div>
-                    <div className="ms-Grid-col ms-sm5 view-toggle-col" style={{ float: 'right' }}>
-                        {this.renderToggleOrSpinner()}
-                    </div>
-                </div>
-                <div className="ms-Grid-row">
-                    <div className="ms-Grid-col ms-sm8">
-                        {this.renderLink(displayableData.linkToDetailsViewText)}
-                    </div>
-                    <div className="ms-Grid-col ms-sm4 shortcut-label" style={{ float: 'right' }}>
-                        <div className="ms-font-xs">{shortcut}</div>
-                    </div>
-                </div>
+            <div className={styles.diagnosticViewToggle}>
+                <div className={styles.title}>{displayableData.title}</div>
+                <div className={styles.toggle}>{this.renderToggleOrSpinner()}</div>
+                <div>{this.renderLink(displayableData.linkToDetailsViewText)}</div>
+                <div className={styles.shortcut}>{shortcut}</div>
             </div>
         );
     }

--- a/src/tests/unit/tests/popup/components/__snapshots__/diagnostic-view-toggle.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/diagnostic-view-toggle.test.tsx.snap
@@ -1,262 +1,158 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DiagnosticViewToggleTest renders details view link when the test does not have a guidance 1`] = `
-<div>
+<div
+  className="diagnosticViewToggle"
+>
   <div
-    className="ms-Grid-row view-toggle-row"
+    className="title"
   >
-    <div
-      className="ms-Grid-col ms-sm7"
-    >
-      <div
-        className="ms-fontColor-neutralPrimary ms-fontWeight-semibold ms-fontSize-mPlus"
-      >
-        Automated checks
-      </div>
-    </div>
-    <div
-      className="ms-Grid-col ms-sm5 view-toggle-col"
-      style={
-        Object {
-          "float": "right",
-        }
-      }
-    >
-      <VisualizationToggle
-        checked={false}
-        componentRef={
-          Object {
-            "current": null,
-          }
-        }
-        disabled={false}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        visualizationName="Automated checks"
-      />
-    </div>
+    Automated checks
   </div>
   <div
-    className="ms-Grid-row"
+    className="toggle"
   >
-    <div
-      className="ms-Grid-col ms-sm8"
-    >
-      <StyledLinkBase
-        className="insights-link"
-        href="#"
-        onClick={[Function]}
-      >
-        List view and filtering
-      </StyledLinkBase>
-    </div>
-    <div
-      className="ms-Grid-col ms-sm4 shortcut-label"
-      style={
+    <VisualizationToggle
+      checked={false}
+      componentRef={
         Object {
-          "float": "right",
+          "current": null,
         }
       }
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      visualizationName="Automated checks"
+    />
+  </div>
+  <div>
+    <StyledLinkBase
+      className="insights-link"
+      href="#"
+      onClick={[Function]}
     >
-      <div
-        className="ms-font-xs"
-      >
-        Ctrl+Shift+1
-      </div>
-    </div>
+      List view and filtering
+    </StyledLinkBase>
+  </div>
+  <div
+    className="shortcut"
+  >
+    Ctrl+Shift+1
   </div>
 </div>
 `;
 
 exports[`DiagnosticViewToggleTest renders spinner while scanning 1`] = `
-<div>
+<div
+  className="diagnosticViewToggle"
+>
   <div
-    className="ms-Grid-row view-toggle-row"
+    className="title"
   >
-    <div
-      className="ms-Grid-col ms-sm7"
-    >
-      <div
-        className="ms-fontColor-neutralPrimary ms-fontWeight-semibold ms-fontSize-mPlus"
-      >
-        Headings
-      </div>
-    </div>
-    <div
-      className="ms-Grid-col ms-sm5 view-toggle-col"
-      style={
-        Object {
-          "float": "right",
-        }
-      }
-    >
-      <StyledSpinnerBase
-        componentRef={[Function]}
-        size={1}
-      />
-    </div>
+    Headings
   </div>
   <div
-    className="ms-Grid-row"
+    className="toggle"
   >
-    <div
-      className="ms-Grid-col ms-sm8"
-    >
-      <ContentLink
-        deps={Object {}}
-        linkText="How to test headings"
-        reference={[Function]}
-      />
-    </div>
-    <div
-      className="ms-Grid-col ms-sm4 shortcut-label"
-      style={
-        Object {
-          "float": "right",
-        }
-      }
-    >
-      <div
-        className="ms-font-xs"
-      >
-        Ctrl+Shift+3
-      </div>
-    </div>
+    <StyledSpinnerBase
+      componentRef={[Function]}
+      size={1}
+    />
+  </div>
+  <div>
+    <ContentLink
+      deps={Object {}}
+      linkText="How to test headings"
+      reference={[Function]}
+    />
+  </div>
+  <div
+    className="shortcut"
+  >
+    Ctrl+Shift+3
   </div>
 </div>
 `;
 
 exports[`DiagnosticViewToggleTest renders toggle when not scanning 1`] = `
-<div>
+<div
+  className="diagnosticViewToggle"
+>
   <div
-    className="ms-Grid-row view-toggle-row"
+    className="title"
   >
-    <div
-      className="ms-Grid-col ms-sm7"
-    >
-      <div
-        className="ms-fontColor-neutralPrimary ms-fontWeight-semibold ms-fontSize-mPlus"
-      >
-        Headings
-      </div>
-    </div>
-    <div
-      className="ms-Grid-col ms-sm5 view-toggle-col"
-      style={
-        Object {
-          "float": "right",
-        }
-      }
-    >
-      <VisualizationToggle
-        checked={false}
-        componentRef={
-          Object {
-            "current": null,
-          }
-        }
-        disabled={false}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        visualizationName="Headings"
-      />
-    </div>
+    Headings
   </div>
   <div
-    className="ms-Grid-row"
+    className="toggle"
   >
-    <div
-      className="ms-Grid-col ms-sm8"
-    >
-      <ContentLink
-        deps={Object {}}
-        linkText="How to test headings"
-        reference={[Function]}
-      />
-    </div>
-    <div
-      className="ms-Grid-col ms-sm4 shortcut-label"
-      style={
+    <VisualizationToggle
+      checked={false}
+      componentRef={
         Object {
-          "float": "right",
+          "current": null,
         }
       }
-    >
-      <div
-        className="ms-font-xs"
-      >
-        Ctrl+Shift+3
-      </div>
-    </div>
+      disabled={false}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      visualizationName="Headings"
+    />
+  </div>
+  <div>
+    <ContentLink
+      deps={Object {}}
+      linkText="How to test headings"
+      reference={[Function]}
+    />
+  </div>
+  <div
+    className="shortcut"
+  >
+    Ctrl+Shift+3
   </div>
 </div>
 `;
 
 exports[`DiagnosticViewToggleTest renders toggle when scanning for a different visualization 1`] = `
-<div>
+<div
+  className="diagnosticViewToggle"
+>
   <div
-    className="ms-Grid-row view-toggle-row"
+    className="title"
   >
-    <div
-      className="ms-Grid-col ms-sm7"
-    >
-      <div
-        className="ms-fontColor-neutralPrimary ms-fontWeight-semibold ms-fontSize-mPlus"
-      >
-        Headings
-      </div>
-    </div>
-    <div
-      className="ms-Grid-col ms-sm5 view-toggle-col"
-      style={
-        Object {
-          "float": "right",
-        }
-      }
-    >
-      <VisualizationToggle
-        checked={false}
-        componentRef={
-          Object {
-            "current": null,
-          }
-        }
-        disabled={true}
-        onBlur={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        visualizationName="Headings"
-      />
-    </div>
+    Headings
   </div>
   <div
-    className="ms-Grid-row"
+    className="toggle"
   >
-    <div
-      className="ms-Grid-col ms-sm8"
-    >
-      <ContentLink
-        deps={Object {}}
-        linkText="How to test headings"
-        reference={[Function]}
-      />
-    </div>
-    <div
-      className="ms-Grid-col ms-sm4 shortcut-label"
-      style={
+    <VisualizationToggle
+      checked={false}
+      componentRef={
         Object {
-          "float": "right",
+          "current": null,
         }
       }
-    >
-      <div
-        className="ms-font-xs"
-      >
-        Ctrl+Shift+3
-      </div>
-    </div>
+      disabled={true}
+      onBlur={[Function]}
+      onClick={[Function]}
+      onFocus={[Function]}
+      visualizationName="Headings"
+    />
+  </div>
+  <div>
+    <ContentLink
+      deps={Object {}}
+      linkText="How to test headings"
+      reference={[Function]}
+    />
+  </div>
+  <div
+    className="shortcut"
+  >
+    Ctrl+Shift+3
   </div>
 </div>
 `;

--- a/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
+++ b/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
@@ -76,7 +76,7 @@ describe('DiagnosticViewToggleTest', () => {
     });
 
     describe('user interaction: ', () => {
-        it('handles click on details view link, it will open fast pass when Assessment enabled', () => {
+        it('handles click on details view link, it will open FastPass when Assessment enabled', () => {
             const visualizationType = VisualizationType.Issues;
             const event = eventStubFactory.createKeypressEvent();
             const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource);

--- a/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
+++ b/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
@@ -1,24 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { VisualizationToggle } from 'common/components/visualization-toggle';
+import { VisualizationConfiguration } from 'common/configs/visualization-configuration';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { TelemetryEventSource } from 'common/extension-telemetry-events';
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { VisualizationType } from 'common/types/visualization-type';
 import { mount, shallow } from 'enzyme';
 import { Link } from 'office-ui-fabric-react';
+import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-creator';
+import { DiagnosticViewToggle, DiagnosticViewToggleProps } from 'popup/components/diagnostic-view-toggle';
+import { DiagnosticViewClickHandler } from 'popup/handlers/diagnostic-view-toggle-click-handler';
 import * as React from 'react';
 import * as TestUtils from 'react-dom/test-utils';
 import { IMock, It, Mock, Times } from 'typemoq';
-
+import { DictionaryStringTo } from 'types/common-types';
 import { ContentLinkDeps } from 'views/content/content-link';
 import { ContentProvider } from 'views/content/content-page';
-import { VisualizationToggle } from '../../../../../common/components/visualization-toggle';
-import { VisualizationConfiguration } from '../../../../../common/configs/visualization-configuration';
-import { VisualizationConfigurationFactory } from '../../../../../common/configs/visualization-configuration-factory';
-import { TelemetryEventSource } from '../../../../../common/extension-telemetry-events';
-import { DetailsViewPivotType } from '../../../../../common/types/details-view-pivot-type';
-import { VisualizationStoreData } from '../../../../../common/types/store-data/visualization-store-data';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { PopupActionMessageCreator } from '../../../../../popup/actions/popup-action-message-creator';
-import { DiagnosticViewToggle, DiagnosticViewToggleProps } from '../../../../../popup/components/diagnostic-view-toggle';
-import { DiagnosticViewClickHandler } from '../../../../../popup/handlers/diagnostic-view-toggle-click-handler';
-import { DictionaryStringTo } from '../../../../../types/common-types';
 import { EventStubFactory } from '../../../common/event-stub-factory';
 import { ShortcutCommandsTestData } from '../../../common/sample-test-data';
 import { VisualizationStoreDataBuilder } from '../../../common/visualization-store-data-builder';
@@ -77,7 +76,7 @@ describe('DiagnosticViewToggleTest', () => {
     });
 
     describe('user interaction: ', () => {
-        it('hanldes click on details view link, it will open fastpass when Assessment enabled', () => {
+        it('handles click on details view link, it will open fast pass when Assessment enabled', () => {
             const visualizationType = VisualizationType.Issues;
             const event = eventStubFactory.createKeypressEvent();
             const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource);
@@ -128,7 +127,7 @@ describe('DiagnosticViewToggleTest', () => {
             propsBuilder.verifyAll();
         });
 
-        it('hanldes click on the link when toggle is present', () => {
+        it('handles click on the link when toggle is present', () => {
             const visualizationType = VisualizationType.Issues;
             const event = eventStubFactory.createKeypressEvent();
 
@@ -159,7 +158,7 @@ describe('DiagnosticViewToggleTest', () => {
         });
     });
 
-    describe('lifecycle events', () => {
+    describe('life cycle events', () => {
         it('sets focus when componentDidMount', () => {
             const visualizationType = VisualizationType.TabStops;
             const event = eventStubFactory.createKeypressEvent();


### PR DESCRIPTION
#### Description of changes

Currently, the composition between the ad-hoc tools panel and the 5 different diagnostic view toggles is based on office ui fabric react grid. This make for a lot of boiler plate `<div>` elements, which contains `ms-Grid`-related classes. This are the classes you need to use if you want to use OF grid but that's not really necessary as we can use css grid and move more of the layout details to scss.

As part of this PR:
- convert `DiagnosticViewToggle` to use css-module
- convert `DiagnosticViewToggle` to use css grid
- update snapshots

I tried to make the styles to match the original layout as much as I could but there may be small differences.

![image](https://user-images.githubusercontent.com/2837582/72178707-4d1ccc80-3398-11ea-97a7-ebbe21c6bf29.png)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
