### PR TITLE
refactor: popup header to use css grid

### DIFF
--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -89,10 +89,6 @@ html {
 #popup-container [role='heading'] {
     width: fit-content;
     padding-left: 0;
-
-    &.old {
-        padding-left: 8px;
-    }
 }
 
 #popup-container .launch-panel {

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -133,20 +133,6 @@ html {
     max-height: 30px;
 }
 
-#popup-container .launch-panel-header .feedback-collapseMenuButton-col {
-    padding-right: 0;
-    padding-left: 0;
-    float: right;
-
-    #feedback-collapse-menu-button {
-        color: $neutral-alpha-90;
-    }
-
-    .gear-button {
-        color: $neutral-alpha-90;
-    }
-}
-
 #popup-container .main-section .ad-hoc-tools-panel-group-0 {
     padding-right: 15px;
 }

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -133,22 +133,8 @@ html {
     color: $secondary-text;
 }
 
-#popup-container .launch-panel-header {
-    margin-bottom: 12px;
-    margin-left: 14px;
-    margin-right: 14px;
-}
-
 .popup-menu .ms-ContextualMenu-icon {
     max-height: 30px;
-}
-
-#popup-container .launch-panel-header .header-title {
-    height: 32px;
-}
-
-#popup-container .launch-panel-header .header-subtitle {
-    color: $neutral-60;
 }
 
 #popup-container .launch-panel-header .feedback-collapseMenuButton-col {

--- a/src/popup/components/header.scss
+++ b/src/popup/components/header.scss
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+
+.launch-panel-header {
+    margin-bottom: 12px;
+    margin-left: 14px;
+    margin-right: 14px;
+
+    padding: 0 8px;
+
+    .header-subtitle {
+        color: $neutral-60;
+    }
+}

--- a/src/popup/components/header.scss
+++ b/src/popup/components/header.scss
@@ -7,9 +7,24 @@
     margin-left: 14px;
     margin-right: 14px;
 
-    padding: 0 8px;
+    padding-left: 8px;
 
-    .header-subtitle {
+    display: grid;
+
+    grid-template-columns: auto auto;
+    grid-template-rows: auto auto;
+
+    .title {
+        margin-block-start: unset;
+        margin-block-end: unset;
+
+        color: $neutral-100;
+        font-size: 21px;
+        font-weight: 100;
+    }
+
+    .subtitle {
         color: $neutral-60;
+        font-size: 11px;
     }
 }

--- a/src/popup/components/header.tsx
+++ b/src/popup/components/header.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { css } from '@uifabric/utilities';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 import * as styles from './header.scss';
@@ -14,19 +13,9 @@ export interface HeaderProps {
 export const Header = NamedFC<HeaderProps>('Header', props => {
     return (
         <header className={styles.launchPanelHeader}>
-            <div className="ms-Grid-row">
-                <div
-                    role="heading"
-                    aria-level={1}
-                    className="ms-Grid-col ms-u-sm10 ms-fontColor-neutralPrimary ms-font-xl old"
-                >
-                    {props.title}
-                </div>
-                {props.children}
-            </div>
-            <div className={css(styles.headerSubtitle, 'ms-fontWeight-semilight ms-fontSize-xs')}>
-                {props.subtitle}
-            </div>
+            <h1 className={styles.title}>{props.title}</h1>
+            <div>{props.children}</div>
+            <div className={styles.subtitle}>{props.subtitle}</div>
         </header>
     );
 });

--- a/src/popup/components/header.tsx
+++ b/src/popup/components/header.tsx
@@ -8,14 +8,13 @@ import * as styles from './header.scss';
 export interface HeaderProps {
     title: string;
     subtitle?: React.ReactChild;
-    rowExtraClassName?: string;
     children?: JSX.Element;
 }
 
 export const Header = NamedFC<HeaderProps>('Header', props => {
     return (
         <header className={styles.launchPanelHeader}>
-            <div className={css('ms-Grid-row', props.rowExtraClassName)}>
+            <div className="ms-Grid-row">
                 <div
                     role="heading"
                     aria-level={1}

--- a/src/popup/components/header.tsx
+++ b/src/popup/components/header.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
+import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-import { NamedFC } from '../../common/react/named-fc';
+import * as styles from './header.scss';
 
 export interface HeaderProps {
     title: string;
@@ -13,7 +14,7 @@ export interface HeaderProps {
 
 export const Header = NamedFC<HeaderProps>('Header', props => {
     return (
-        <header className="ms-Grid launch-panel-header">
+        <header className={styles.launchPanelHeader}>
             <div className={css('ms-Grid-row', props.rowExtraClassName)}>
                 <div
                     role="heading"
@@ -24,7 +25,7 @@ export const Header = NamedFC<HeaderProps>('Header', props => {
                 </div>
                 {props.children}
             </div>
-            <div className="header-subtitle ms-fontWeight-semilight ms-fontSize-xs">
+            <div className={css(styles.headerSubtitle, 'ms-fontWeight-semilight ms-fontSize-xs')}>
                 {props.subtitle}
             </div>
         </header>

--- a/src/popup/components/launch-panel-header.scss
+++ b/src/popup/components/launch-panel-header.scss
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+.feedback-collapseMenuButton-col {
+    float: right;
+}

--- a/src/popup/components/launch-panel-header.tsx
+++ b/src/popup/components/launch-panel-header.tsx
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IconButton } from 'office-ui-fabric-react';
-import { IContextualMenuItem } from 'office-ui-fabric-react';
+import { GearOptionsButtonComponent } from 'common/components/gear-options-button-component';
+import { DropdownClickHandler } from 'common/dropdown-click-handler';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { IconButton, IContextualMenuItem } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { GearOptionsButtonComponent } from '../../common/components/gear-options-button-component';
-import { DropdownClickHandler } from '../../common/dropdown-click-handler';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { PopupActionMessageCreator } from '../actions/popup-action-message-creator';
 import { LaunchPanelHeaderClickHandler } from '../handlers/launch-panel-header-click-handler';
 import { Header } from './header';
 import { HeaderContextualMenu, HeaderContextualMenuDeps } from './header-contextual-menu';
+import * as styles from './launch-panel-header.scss';
 
 export type LaunchPanelHeaderDeps = {
     popupActionMessageCreator: PopupActionMessageCreator;
@@ -44,11 +44,7 @@ export class LaunchPanelHeader extends React.Component<
 
     public render(): JSX.Element {
         return (
-            <Header
-                title={this.props.title}
-                subtitle={this.props.subtitle}
-                rowExtraClassName="header-title"
-            >
+            <Header title={this.props.title} subtitle={this.props.subtitle}>
                 {this.renderGearOptionsButton()}
             </Header>
         );
@@ -58,7 +54,7 @@ export class LaunchPanelHeader extends React.Component<
         const { dropdownClickHandler, launchPanelHeaderClickHandler } = this.props.deps;
 
         return (
-            <div className="ms-Grid-col ms-u-sm2 feedback-collapseMenuButton-col">
+            <div className={styles.feedbackCollapseMenuButtonCol}>
                 <GearOptionsButtonComponent
                     dropdownClickHandler={dropdownClickHandler}
                     featureFlags={this.props.featureFlags}

--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -38,7 +38,7 @@ function normalizeOfficeFabricGeneratedClassNames(htmlString: string): string {
 // Our webpack config adds generated suffixes of form "--abc12" to the end of class names defined in
 // CSS. This normalizes them to avoid causing E2Es to fail for unrelated style changes.
 function normalizeCssModuleClassNames(htmlString: string): string {
-    return htmlString.replace(/(class="[^"]+--)[A-Za-z0-9+\/=]{5}(")/g, '$1{{CSS_MODULE_HASH}}$2');
+    return htmlString.replace(/(class="[^"]+--)[A-Za-z0-9+\/=-]{5}(")/g, '$1{{CSS_MODULE_HASH}}$2');
 }
 
 // in some cases (eg, stylesheet links), HTML can contain absolute chrome-extension://{generated-id} paths

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -7,20 +7,16 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
     id="new-launch-pad"
   >
     <header
-      class="ms-Grid launch-panel-header"
+      class="launch-panel-header--{{CSS_MODULE_HASH}}"
     >
-      <div
-        class="ms-Grid-row header-title"
+      <h1
+        class="title--{{CSS_MODULE_HASH}}"
       >
+        Accessibility Insights for Web
+      </h1>
+      <div>
         <div
-          aria-level="1"
-          class="ms-Grid-col ms-u-sm10 ms-fontColor-neutralPrimary ms-font-xl old"
-          role="heading"
-        >
-          Accessibility Insights for Web
-        </div>
-        <div
-          class="ms-Grid-col ms-u-sm2 feedback-collapseMenuButton-col"
+          class="feedback-collapseMenuButton-col--{{CSS_MODULE_HASH}}"
         >
           <div
             class="gear-options-button-component--{{CSS_MODULE_HASH}}"
@@ -65,7 +61,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
         </div>
       </div>
       <div
-        class="header-subtitle ms-fontWeight-semilight ms-fontSize-xs"
+        class="subtitle--{{CSS_MODULE_HASH}}"
       >
         <a
           aria-label="demo video"

--- a/src/tests/unit/tests/popup/components/__snapshots__/header.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/header.test.tsx.snap
@@ -1,35 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HeaderTest render 1`] = `
-"<header className=\\"ms-Grid launch-panel-header\\">
+"<header className=\\"launchPanelHeader\\">
   <div className=\\"ms-Grid-row\\">
     <div role=\\"heading\\" aria-level={1} className=\\"ms-Grid-col ms-u-sm10 ms-fontColor-neutralPrimary ms-font-xl old\\">
       title
     </div>
   </div>
-  <div className=\\"header-subtitle ms-fontWeight-semilight ms-fontSize-xs\\">
+  <div className=\\"headerSubtitle ms-fontWeight-semilight ms-fontSize-xs\\">
     sub-title
   </div>
 </header>"
 `;
 
 exports[`HeaderTest render with children prop 1`] = `
-"<header className=\\"ms-Grid launch-panel-header\\">
+"<header className=\\"launchPanelHeader\\">
   <div className=\\"ms-Grid-row\\">
     <div role=\\"heading\\" aria-level={1} className=\\"ms-Grid-col ms-u-sm10 ms-fontColor-neutralPrimary ms-font-xl old\\" />
     <div>
       my content
     </div>
   </div>
-  <div className=\\"header-subtitle ms-fontWeight-semilight ms-fontSize-xs\\" />
+  <div className=\\"headerSubtitle ms-fontWeight-semilight ms-fontSize-xs\\" />
 </header>"
 `;
 
 exports[`HeaderTest render with rowExtraClassName prop 1`] = `
-"<header className=\\"ms-Grid launch-panel-header\\">
+"<header className=\\"launchPanelHeader\\">
   <div className=\\"ms-Grid-row extra-class\\">
     <div role=\\"heading\\" aria-level={1} className=\\"ms-Grid-col ms-u-sm10 ms-fontColor-neutralPrimary ms-font-xl old\\" />
   </div>
-  <div className=\\"header-subtitle ms-fontWeight-semilight ms-fontSize-xs\\" />
+  <div className=\\"headerSubtitle ms-fontWeight-semilight ms-fontSize-xs\\" />
 </header>"
 `;

--- a/src/tests/unit/tests/popup/components/__snapshots__/header.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/header.test.tsx.snap
@@ -1,25 +1,71 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Header render 1`] = `
-"<header className=\\"launchPanelHeader\\">
-  <h1 className=\\"title\\">
-    title
+exports[`Header render with children: non-empty children 1`] = `
+<header
+  className="launchPanelHeader"
+>
+  <h1
+    className="title"
+  >
+    test-title
   </h1>
-  <div />
-  <div className=\\"subtitle\\">
-    sub-title
+  <div>
+    <span>
+      test children
+    </span>
   </div>
-</header>"
+  <div
+    className="subtitle"
+  />
+</header>
 `;
 
-exports[`Header render with children prop 1`] = `
-"<header className=\\"launchPanelHeader\\">
-  <h1 className=\\"title\\" />
-  <div>
-    <div>
-      my content
-    </div>
+exports[`Header render with children: null children 1`] = `
+<header
+  className="launchPanelHeader"
+>
+  <h1
+    className="title"
+  >
+    test-title
+  </h1>
+  <div />
+  <div
+    className="subtitle"
+  />
+</header>
+`;
+
+exports[`Header render with subtitle <test-sub-title> 1`] = `
+<header
+  className="launchPanelHeader"
+>
+  <h1
+    className="title"
+  >
+    test-title
+  </h1>
+  <div />
+  <div
+    className="subtitle"
+  >
+    test-sub-title
   </div>
-  <div className=\\"subtitle\\" />
-</header>"
+</header>
+`;
+
+exports[`Header render with subtitle <undefined> 1`] = `
+<header
+  className="launchPanelHeader"
+>
+  <h1
+    className="title"
+  >
+    test-title
+  </h1>
+  <div />
+  <div
+    className="subtitle"
+  />
+</header>
 `;

--- a/src/tests/unit/tests/popup/components/__snapshots__/header.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/header.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HeaderTest render 1`] = `
+exports[`Header render 1`] = `
 "<header className=\\"launchPanelHeader\\">
   <div className=\\"ms-Grid-row\\">
     <div role=\\"heading\\" aria-level={1} className=\\"ms-Grid-col ms-u-sm10 ms-fontColor-neutralPrimary ms-font-xl old\\">
@@ -13,22 +13,13 @@ exports[`HeaderTest render 1`] = `
 </header>"
 `;
 
-exports[`HeaderTest render with children prop 1`] = `
+exports[`Header render with children prop 1`] = `
 "<header className=\\"launchPanelHeader\\">
   <div className=\\"ms-Grid-row\\">
     <div role=\\"heading\\" aria-level={1} className=\\"ms-Grid-col ms-u-sm10 ms-fontColor-neutralPrimary ms-font-xl old\\" />
     <div>
       my content
     </div>
-  </div>
-  <div className=\\"headerSubtitle ms-fontWeight-semilight ms-fontSize-xs\\" />
-</header>"
-`;
-
-exports[`HeaderTest render with rowExtraClassName prop 1`] = `
-"<header className=\\"launchPanelHeader\\">
-  <div className=\\"ms-Grid-row extra-class\\">
-    <div role=\\"heading\\" aria-level={1} className=\\"ms-Grid-col ms-u-sm10 ms-fontColor-neutralPrimary ms-font-xl old\\" />
   </div>
   <div className=\\"headerSubtitle ms-fontWeight-semilight ms-fontSize-xs\\" />
 </header>"

--- a/src/tests/unit/tests/popup/components/__snapshots__/header.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/header.test.tsx.snap
@@ -2,12 +2,11 @@
 
 exports[`Header render 1`] = `
 "<header className=\\"launchPanelHeader\\">
-  <div className=\\"ms-Grid-row\\">
-    <div role=\\"heading\\" aria-level={1} className=\\"ms-Grid-col ms-u-sm10 ms-fontColor-neutralPrimary ms-font-xl old\\">
-      title
-    </div>
-  </div>
-  <div className=\\"headerSubtitle ms-fontWeight-semilight ms-fontSize-xs\\">
+  <h1 className=\\"title\\">
+    title
+  </h1>
+  <div />
+  <div className=\\"subtitle\\">
     sub-title
   </div>
 </header>"
@@ -15,12 +14,12 @@ exports[`Header render 1`] = `
 
 exports[`Header render with children prop 1`] = `
 "<header className=\\"launchPanelHeader\\">
-  <div className=\\"ms-Grid-row\\">
-    <div role=\\"heading\\" aria-level={1} className=\\"ms-Grid-col ms-u-sm10 ms-fontColor-neutralPrimary ms-font-xl old\\" />
+  <h1 className=\\"title\\" />
+  <div>
     <div>
       my content
     </div>
   </div>
-  <div className=\\"headerSubtitle ms-fontWeight-semilight ms-fontSize-xs\\" />
+  <div className=\\"subtitle\\" />
 </header>"
 `;

--- a/src/tests/unit/tests/popup/components/__snapshots__/launch-panel-header.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/launch-panel-header.test.tsx.snap
@@ -2,12 +2,11 @@
 
 exports[`LaunchPanelHeaderTest render 1`] = `
 <Header
-  rowExtraClassName="header-title"
   subtitle="test subtitle"
   title="test title"
 >
   <div
-    className="ms-Grid-col ms-u-sm2 feedback-collapseMenuButton-col"
+    className="feedbackCollapseMenuButtonCol"
   >
     <GearOptionsButtonComponent
       dropdownClickHandler={Object {}}
@@ -29,12 +28,11 @@ exports[`LaunchPanelHeaderTest render 1`] = `
 
 exports[`LaunchPanelHeaderTest render contextual menu renders with new assessment experience 1`] = `
 <Header
-  rowExtraClassName="header-title"
   subtitle="test subtitle"
   title="test title"
 >
   <div
-    className="ms-Grid-col ms-u-sm2 feedback-collapseMenuButton-col"
+    className="feedbackCollapseMenuButtonCol"
   >
     <GearOptionsButtonComponent
       dropdownClickHandler={Object {}}
@@ -143,12 +141,11 @@ exports[`LaunchPanelHeaderTest render contextual menu renders with new assessmen
               "_numberOfReRenders": 0,
               "_renderPhaseUpdates": null,
               "_rendered": <Header
-                rowExtraClassName="header-title"
                 subtitle="test subtitle"
                 title="test title"
               >
                 <div
-                  className="ms-Grid-col ms-u-sm2 feedback-collapseMenuButton-col"
+                  className="feedbackCollapseMenuButtonCol"
                 >
                   <GearOptionsButtonComponent
                     dropdownClickHandler={Object {}}
@@ -203,12 +200,11 @@ exports[`LaunchPanelHeaderTest render contextual menu renders with new assessmen
 
 exports[`LaunchPanelHeaderTest render contextual menu renders without new assessment experience 1`] = `
 <Header
-  rowExtraClassName="header-title"
   subtitle="test subtitle"
   title="test title"
 >
   <div
-    className="ms-Grid-col ms-u-sm2 feedback-collapseMenuButton-col"
+    className="feedbackCollapseMenuButtonCol"
   >
     <GearOptionsButtonComponent
       dropdownClickHandler={Object {}}
@@ -303,12 +299,11 @@ exports[`LaunchPanelHeaderTest render contextual menu renders without new assess
               "_numberOfReRenders": 0,
               "_renderPhaseUpdates": null,
               "_rendered": <Header
-                rowExtraClassName="header-title"
                 subtitle="test subtitle"
                 title="test title"
               >
                 <div
-                  className="ms-Grid-col ms-u-sm2 feedback-collapseMenuButton-col"
+                  className="feedbackCollapseMenuButtonCol"
                 >
                   <GearOptionsButtonComponent
                     dropdownClickHandler={Object {}}

--- a/src/tests/unit/tests/popup/components/header.test.tsx
+++ b/src/tests/unit/tests/popup/components/header.test.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
+import { Header, HeaderProps } from 'popup/components/header';
 import * as React from 'react';
-import { Header, HeaderProps } from '../../../../../popup/components/header';
 
 describe('HeaderTest', () => {
     test('render', () => {

--- a/src/tests/unit/tests/popup/components/header.test.tsx
+++ b/src/tests/unit/tests/popup/components/header.test.tsx
@@ -4,23 +4,11 @@ import { shallow } from 'enzyme';
 import { Header, HeaderProps } from 'popup/components/header';
 import * as React from 'react';
 
-describe('HeaderTest', () => {
+describe('Header', () => {
     test('render', () => {
         const props: HeaderProps = {
             title: 'title',
             subtitle: 'sub-title',
-        };
-
-        const wrapper = shallow(<Header {...props} />);
-
-        expect(wrapper.debug()).toMatchSnapshot();
-    });
-
-    test('render with rowExtraClassName prop', () => {
-        const props: HeaderProps = {
-            title: null,
-            subtitle: null,
-            rowExtraClassName: 'extra-class',
         };
 
         const wrapper = shallow(<Header {...props} />);

--- a/src/tests/unit/tests/popup/components/header.test.tsx
+++ b/src/tests/unit/tests/popup/components/header.test.tsx
@@ -5,27 +5,33 @@ import { Header, HeaderProps } from 'popup/components/header';
 import * as React from 'react';
 
 describe('Header', () => {
-    test('render', () => {
-        const props: HeaderProps = {
-            title: 'title',
-            subtitle: 'sub-title',
-        };
+    describe('render', () => {
+        const title = 'test-title';
 
-        const wrapper = shallow(<Header {...props} />);
+        it.each(['test-sub-title', undefined])('with subtitle <%s>', subtitle => {
+            const props: HeaderProps = {
+                title,
+                subtitle,
+            };
 
-        expect(wrapper.debug()).toMatchSnapshot();
-    });
+            const wrapper = shallow(<Header {...props} />);
 
-    test('render with children prop', () => {
-        const children: JSX.Element = <div>my content</div>;
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
 
-        const props: HeaderProps = {
-            title: null,
-            subtitle: null,
-        };
+        it.each`
+            description             | children
+            ${'non-empty children'} | ${(<span>test children</span>)}
+            ${'null children'}      | ${null}
+        `('with children: $description', ({ children }) => {
+            const props: HeaderProps = {
+                title,
+                children,
+            };
 
-        const wrapper = shallow(<Header {...props}>{children}</Header>);
+            const wrapper = shallow(<Header {...props} />);
 
-        expect(wrapper.debug()).toMatchSnapshot();
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
     });
 });


### PR DESCRIPTION
#### Description of changes

Currently, the popup header component is using office fabric grid, which is base on adding classes to `<div>`/`<span>` elements.

This PR changes that to use css grid, which simplify the component code as it moves the layout "logic" to the scss files.

There should be no differences in how the UI is presented (either to the AT -there is a H1 on the header- or visually)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
