### PR TITLE
feat(office-fabric): udpate tooltip host content

### DIFF
--- a/src/DetailsView/components/target-change-dialog.tsx
+++ b/src/DetailsView/components/target-change-dialog.tsx
@@ -105,6 +105,7 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
                 calloutProps={{ gapSpace: 0 }}
             >
                 <Link
+                    as="a" // force Link to use an anchor tag in order have proper dom structure
                     role="link"
                     className={css('insights-link', 'target-page-link')}
                     onClick={this.props.deps.detailsViewActionMessageCreator.switchToTargetTab}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
@@ -46,6 +46,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         id="current-target-page-link"
       >
         <StyledLinkBase
+          as="a"
           className="insights-link target-page-link"
           onClick={[Function]}
           role="link"
@@ -141,6 +142,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         id="current-target-page-link"
       >
         <StyledLinkBase
+          as="a"
           className="insights-link target-page-link"
           onClick={[Function]}
           role="link"
@@ -236,6 +238,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         id="current-target-page-link"
       >
         <StyledLinkBase
+          as="a"
           className="insights-link target-page-link"
           onClick={[Function]}
           role="link"
@@ -331,6 +334,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         id="current-target-page-link"
       >
         <StyledLinkBase
+          as="a"
           className="insights-link target-page-link"
           onClick={[Function]}
           role="link"
@@ -426,6 +430,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
         id="current-target-page-link"
       >
         <StyledLinkBase
+          as="a"
           className="insights-link target-page-link"
           onClick={[Function]}
           role="link"


### PR DESCRIPTION
#### Description of changes

After updating to office fabric 7, the **Assessment in progress** dialog got a layout-changing behavior when the user hover over the second target page link (this user story has more details 1663263).

This happen because we're mixing inline and block elements inside the dialog content. In order to fix this, I forced the `<Link>` component to render as an anchor tag (which is an inline type of element).

#### Pull request checklist
- [x] Addresses an existing issue: completes WI # 1663263
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS