### PR TITLE
feat(office-fabric): update dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -12,12 +12,6 @@ update_configs:
       include_scope: true
     ignored_updates:
       - match:
-          # Major Office Fabric updates require enough extra validation
-          # that we schedule them as feature work, rather than having
-          # dependabot auto-update them like other deps.
-          dependency_name: "office-ui-fabric-react"
-          version_requirement: ">=7.0.0"
-      - match:
           # We use webdriverio only indirectly via spectron; our direct
           # dependency on the package is only for the sake of typings, so
           # we stick to the major version of webdriverio used by spectron.


### PR DESCRIPTION
#### Description of changes

Now that we updated office fabric to version 7, we want dependabot to create PR's to update office fabric.

We'll still may want to manually validate those PRs but it's nice to have dependabot checking for new versions and creating the resulting PRs.

#### Pull request checklist
- [x] Addresses an existing issue: completes WI # 1664294
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
