### PR TITLE
feat(office-fabric): restore activity switcher focus ring

### DIFF
--- a/src/DetailsView/components/switcher.scss
+++ b/src/DetailsView/components/switcher.scss
@@ -30,11 +30,9 @@
         }
     }
 
-    &:focus {
-        :global(.ms-Dropdown-title) {
-            border: 2px $switcher-focus-border solid;
-            border-style: dotted;
-        }
+    :global(.ms-Dropdown):focus::after {
+        border: 2px $switcher-focus-border solid;
+        border-style: dotted;
     }
 }
 


### PR DESCRIPTION
#### Description of changes

Looks like in Office Fabric 7 they change the way they "draw" the focus ring.

When the dropdown gets focus there is an `::after` element getting added to the dom. It's this element the one that gets the visible focus ring but we were adding the styles on a different place.

This PR moves the original styles to the proper selector so we can get the proper focus ring.

**Notes** there are no actual visible changes from this css update.

#### Pull request checklist
- [x] Addresses an existing issue: completes WI # 1662930
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
