### PR TITLE
fix: element snapshot formatter does not handle more than one class name value

### DIFF
--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -30,7 +30,7 @@ export function formatHtmlForSnapshot(htmlString: string): Node {
 // office fabric generates a random class & id name which changes every time.
 // We remove the random number before snapshot comparison to avoid flakiness
 export function normalizeOfficeFabricGeneratedClassNames(htmlString: string): string {
-    return htmlString.replace(/(class|id)="([\w\s-]+[\d]+|Panel\d+-\w+)"/g, (subString, args) => {
+    return htmlString.replace(/(class|id)="([\w\s-]+[\d]+|Panel\d+-\w+)"/g, subString => {
         return subString.replace(/[\d]+/g, '000');
     });
 }
@@ -39,7 +39,15 @@ export const CSS_MODULE_HASH_REPLACEMENT = '{{CSS_MODULE_HASH}}';
 // Our webpack config adds generated suffixes of form "--abc12" to the end of class names defined in
 // CSS. This normalizes them to avoid causing E2Es to fail for unrelated style changes.
 export function normalizeCssModuleClassNames(htmlString: string): string {
-    return htmlString.replace(/(class="[^"]+--)[A-Za-z0-9+\/=-]{5}(")/g, `$1${CSS_MODULE_HASH_REPLACEMENT}$2`);
+    const classAttributeMatcher = /class="[\w- ]+"/g;
+
+    return htmlString.replace(classAttributeMatcher, classAttributeMatched => {
+        // only matches css module generated class name of the type:
+        // <original-class-name-string>--<5-chars-hash>
+        const cssModuleClassNameMatcher = /([\w-]+--)[A-Za-z0-9]{5}/g;
+
+        return classAttributeMatched.replace(cssModuleClassNameMatcher, `$1${CSS_MODULE_HASH_REPLACEMENT}`);
+    });
 }
 
 // in some cases (eg, stylesheet links), HTML can contain absolute chrome-extension://{generated-id} paths

--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -33,7 +33,7 @@ export function normalizeOfficeFabricGeneratedClassNames(htmlString: string): st
     const attributeMatcher = /(class|id)="([^".]+)"/g;
 
     return htmlString.replace(attributeMatcher, (match, attribute, value) => {
-        const classMatcher = /([a-zA-Z-]+)(\d+)(-{0,1}\w+)?/g;
+        const classMatcher = /([a-zA-Z-_]+)(\d+)(-{0,1}\w+)?/g;
 
         const normalizedValue = value.replace(classMatcher, '$1000$3');
 

--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -44,7 +44,7 @@ export function normalizeCssModuleClassNames(htmlString: string): string {
     return htmlString.replace(classAttributeMatcher, classAttributeMatched => {
         // only matches css module generated class name of the type:
         // <original-class-name-string>--<5-chars-hash>
-        const cssModuleClassNameMatcher = /([\w-]+--)[A-Za-z0-9]{5}/g;
+        const cssModuleClassNameMatcher = /([\w-]+--)[A-Za-z0-9+\/=-]{5}/g;
 
         return classAttributeMatched.replace(cssModuleClassNameMatcher, `$1${CSS_MODULE_HASH_REPLACEMENT}`);
     });

--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -30,7 +30,7 @@ export function formatHtmlForSnapshot(htmlString: string): Node {
 // office fabric generates a random class & id name which changes every time.
 // We remove the random number before snapshot comparison to avoid flakiness
 export function normalizeOfficeFabricGeneratedClassNames(htmlString: string): string {
-    const attributeMatcher = /(class|id)="(.+)"/g;
+    const attributeMatcher = /(class|id)="([^".]+)"/g;
 
     return htmlString.replace(attributeMatcher, (match, attribute, value) => {
         const classMatcher = /([a-zA-Z-]+)(\d+)(-{0,1}\w+)?/g;

--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -30,13 +30,14 @@ export function formatHtmlForSnapshot(htmlString: string): Node {
 // office fabric generates a random class & id name which changes every time.
 // We remove the random number before snapshot comparison to avoid flakiness
 export function normalizeOfficeFabricGeneratedClassNames(htmlString: string): string {
-    const attributeMatcher = /[class|id]="(.+)"/g;
+    const attributeMatcher = /(class|id)="(.+)"/g;
 
-    return htmlString.replace(attributeMatcher, attributeMatch => {
-        const classValueMatcher = /[\w-]+[\d]+|Panel\d+-\w+/g;
-        return attributeMatch.replace(classValueMatcher, valueMatch => {
-            return valueMatch.replace(/[\d]+/g, '000');
-        });
+    return htmlString.replace(attributeMatcher, (match, attribute, value) => {
+        const classMatcher = /([a-zA-Z-]+)(\d+)(-{0,1}\w+)?/g;
+
+        const normalizedValue = value.replace(classMatcher, '$1000$3');
+
+        return `${attribute}="${normalizedValue}"`;
     });
 }
 

--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -51,9 +51,9 @@ export function normalizeCssModuleClassNames(htmlString: string): string {
     return htmlString.replace(classAttributeMatcher, classAttributeMatched => {
         // only matches css module generated class name of the type:
         // <original-class-name-string>--<5-chars-hash>
-        const cssModuleClassNameMatcher = /([\w-]+--)[A-Za-z0-9+\/=-]{5}/g;
+        const cssModuleClassNameMatcher = /([\w-]+--)[A-Za-z0-9+\/=-]{5}([ "])/g;
 
-        return classAttributeMatched.replace(cssModuleClassNameMatcher, `$1${CSS_MODULE_HASH_REPLACEMENT}`);
+        return classAttributeMatched.replace(cssModuleClassNameMatcher, `$1${CSS_MODULE_HASH_REPLACEMENT}$2`);
     });
 }
 

--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -30,12 +30,18 @@ export function formatHtmlForSnapshot(htmlString: string): Node {
 // office fabric generates a random class & id name which changes every time.
 // We remove the random number before snapshot comparison to avoid flakiness
 export function normalizeOfficeFabricGeneratedClassNames(htmlString: string): string {
-    return htmlString.replace(/(class|id)="([\w\s-]+[\d]+|Panel\d+-\w+)"/g, subString => {
-        return subString.replace(/[\d]+/g, '000');
+    const attributeMatcher = /[class|id]="(.+)"/g;
+
+    return htmlString.replace(attributeMatcher, attributeMatch => {
+        const classValueMatcher = /[\w-]+[\d]+|Panel\d+-\w+/g;
+        return attributeMatch.replace(classValueMatcher, valueMatch => {
+            return valueMatch.replace(/[\d]+/g, '000');
+        });
     });
 }
 
 export const CSS_MODULE_HASH_REPLACEMENT = '{{CSS_MODULE_HASH}}';
+
 // Our webpack config adds generated suffixes of form "--abc12" to the end of class names defined in
 // CSS. This normalizes them to avoid causing E2Es to fail for unrelated style changes.
 export function normalizeCssModuleClassNames(htmlString: string): string {

--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -29,16 +29,17 @@ export function formatHtmlForSnapshot(htmlString: string): Node {
 
 // office fabric generates a random class & id name which changes every time.
 // We remove the random number before snapshot comparison to avoid flakiness
-function normalizeOfficeFabricGeneratedClassNames(htmlString: string): string {
+export function normalizeOfficeFabricGeneratedClassNames(htmlString: string): string {
     return htmlString.replace(/(class|id)="([\w\s-]+[\d]+|Panel\d+-\w+)"/g, (subString, args) => {
         return subString.replace(/[\d]+/g, '000');
     });
 }
 
+export const CSS_MODULE_HASH_REPLACEMENT = '{{CSS_MODULE_HASH}}';
 // Our webpack config adds generated suffixes of form "--abc12" to the end of class names defined in
 // CSS. This normalizes them to avoid causing E2Es to fail for unrelated style changes.
-function normalizeCssModuleClassNames(htmlString: string): string {
-    return htmlString.replace(/(class="[^"]+--)[A-Za-z0-9+\/=-]{5}(")/g, '$1{{CSS_MODULE_HASH}}$2');
+export function normalizeCssModuleClassNames(htmlString: string): string {
+    return htmlString.replace(/(class="[^"]+--)[A-Za-z0-9+\/=-]{5}(")/g, `$1${CSS_MODULE_HASH_REPLACEMENT}$2`);
 }
 
 // in some cases (eg, stylesheet links), HTML can contain absolute chrome-extension://{generated-id} paths

--- a/src/tests/end-to-end/tests/popup/__snapshots__/first-time-dialog.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/first-time-dialog.test.ts.snap
@@ -133,7 +133,7 @@ exports[`First time Dialog content should match snapshot 1`] = `
                       >
                         <span
                           class="ms-Button-label label-000"
-                          id="id__000"
+                          id="id__7"
                         >
                           OK
                         </span>

--- a/src/tests/end-to-end/tests/popup/__snapshots__/first-time-dialog.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/first-time-dialog.test.ts.snap
@@ -133,7 +133,7 @@ exports[`First time Dialog content should match snapshot 1`] = `
                       >
                         <span
                           class="ms-Button-label label-000"
-                          id="id__7"
+                          id="id__000"
                         >
                           OK
                         </span>

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -103,7 +103,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
               >
                 <div
                   aria-hidden="true"
-                  class="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle"
+                  class="ms-Grid-col ms-sm000 popup-start-dialog-icon-circle"
                 >
                   <i
                     aria-hidden="true"
@@ -151,7 +151,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
               >
                 <div
                   aria-hidden="true"
-                  class="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle"
+                  class="ms-Grid-col ms-sm000 popup-start-dialog-icon-circle"
                 >
                   <i
                     aria-hidden="true"
@@ -199,7 +199,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
               >
                 <div
                   aria-hidden="true"
-                  class="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle"
+                  class="ms-Grid-col ms-sm000 popup-start-dialog-icon-circle"
                 >
                   <i
                     aria-hidden="true"

--- a/src/tests/unit/common/__snapshots__/element-snapshot-formatter.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/element-snapshot-formatter.test.ts.snap
@@ -4,7 +4,7 @@ exports[`element-snapshot-formatter format html for snapshot normalizing ms-Pane
 <DocumentFragment>
   <div>
     <div
-      class="ms-Panel-headerText header-text--000nPhV headerText-000"
+      class="ms-Panel-headerText header-text--{{CSS_MODULE_HASH}} headerText-198"
     >
       Hello world!
     </div>

--- a/src/tests/unit/common/__snapshots__/element-snapshot-formatter.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/element-snapshot-formatter.test.ts.snap
@@ -4,7 +4,7 @@ exports[`element-snapshot-formatter format html for snapshot normalizing ms-Pane
 <DocumentFragment>
   <div>
     <div
-      class="ms-Panel-headerText header-text--{{CSS_MODULE_HASH}} headerText-198"
+      class="ms-Panel-headerText header-text--{{CSS_MODULE_HASH}} headerText-000"
     >
       Hello world!
     </div>

--- a/src/tests/unit/common/__snapshots__/element-snapshot-formatter.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/element-snapshot-formatter.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`element-snapshot-formatter format html for snapshot normalizing ms-Panel-headerText header-text--0nPhV headerText-198 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="ms-Panel-headerText header-text--000nPhV headerText-000"
+    >
+      Hello world!
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`element-snapshot-formatter format html for snapshot normalizing test-class-one test-class-two 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="test-class-one test-class-two"
+    >
+      Hello world!
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/tests/unit/common/element-snapshot-formatter.test.ts
+++ b/src/tests/unit/common/element-snapshot-formatter.test.ts
@@ -45,6 +45,7 @@ describe('element-snapshot-formatter', () => {
     describe('normalize css module class names', () => {
         it.each`
             actualClassName                                            | expectedClassName
+            ${'launch-panel-header--3-IL0'}                            | ${`launch-panel-header--${CSS_MODULE_HASH_REPLACEMENT}`}
             ${'my-class--Fs0Df'}                                       | ${`my-class--${CSS_MODULE_HASH_REPLACEMENT}`}
             ${'no-css-hash'}                                           | ${'no-css-hash'}
             ${'ms-Panel-headerText header-text--0nPhV headerText-198'} | ${`ms-Panel-headerText header-text--${CSS_MODULE_HASH_REPLACEMENT} headerText-198`}

--- a/src/tests/unit/common/element-snapshot-formatter.test.ts
+++ b/src/tests/unit/common/element-snapshot-formatter.test.ts
@@ -11,16 +11,17 @@ import {
 describe('element-snapshot-formatter', () => {
     describe('normalize office fabric generated class names', () => {
         describe.each`
-            actualClassName                                                                     | expectedClassName
-            ${'thumb-123'}                                                                      | ${'thumb-000'}
-            ${'ms-Panel-234'}                                                                   | ${'ms-Panel-000'}
-            ${'thumb-321 ms-Panel-432'}                                                         | ${'thumb-000 ms-Panel-000'}
-            ${'no-numbers'}                                                                     | ${'no-numbers'}
-            ${'no-numbers thumb-543'}                                                           | ${'no-numbers thumb-000'}
-            ${'Panel765-word'}                                                                  | ${'Panel000-word'}
-            ${'Panel765-word thumb-123'}                                                        | ${'Panel000-word thumb-000'}
-            ${'headerText-198'}                                                                 | ${'headerText-000'}
-            ${`ms-Panel-headerText header-text--${CSS_MODULE_HASH_REPLACEMENT} headerText-198`} | ${`ms-Panel-headerText header-text--${CSS_MODULE_HASH_REPLACEMENT} headerText-000`}
+            actualClassName                                                 | expectedClassName
+            ${'thumb-123'}                                                  | ${'thumb-000'}
+            ${'ms-Panel-234'}                                               | ${'ms-Panel-000'}
+            ${'thumb-321 ms-Panel-432'}                                     | ${'thumb-000 ms-Panel-000'}
+            ${'no-numbers'}                                                 | ${'no-numbers'}
+            ${'no-numbers thumb-543'}                                       | ${'no-numbers thumb-000'}
+            ${'Panel765-word'}                                              | ${'Panel000-word'}
+            ${'Panel765-word thumb-123'}                                    | ${'Panel000-word thumb-000'}
+            ${'headerText-198'}                                             | ${'headerText-000'}
+            ${`header-text--${CSS_MODULE_HASH_REPLACEMENT} headerText-198`} | ${`header-text--${CSS_MODULE_HASH_REPLACEMENT} headerText-000`}
+            ${'thumb-123 name-not-ending-in-digit'}                         | ${'thumb-000 name-not-ending-in-digit'}
         `('normalize "$actualClassName" to "$expectedClassName"', ({ actualClassName, expectedClassName }) => {
             it('when in the class property', () => {
                 const actualHtml = buildSimpleHtmlFragment('class', actualClassName);

--- a/src/tests/unit/common/element-snapshot-formatter.test.ts
+++ b/src/tests/unit/common/element-snapshot-formatter.test.ts
@@ -55,6 +55,7 @@ describe('element-snapshot-formatter', () => {
             ${'header-text--0nPhV headerText-198'}                     | ${`header-text--${CSS_MODULE_HASH_REPLACEMENT} headerText-198`}
             ${'ms-Panel-headerText header-text--0nPhV'}                | ${`ms-Panel-headerText header-text--${CSS_MODULE_HASH_REPLACEMENT}`}
             ${'header-text--0nPhV header-title--1mQiW'}                | ${`header-text--${CSS_MODULE_HASH_REPLACEMENT} header-title--${CSS_MODULE_HASH_REPLACEMENT}`}
+            ${'ms-Button--primary'}                                    | ${'ms-Button--primary'}
         `('normalize "$actualClassName" to "$expectedClassName"', ({ actualClassName, expectedClassName }) => {
             const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
 

--- a/src/tests/unit/common/element-snapshot-formatter.test.ts
+++ b/src/tests/unit/common/element-snapshot-formatter.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    CSS_MODULE_HASH_REPLACEMENT,
+    formatHtmlForSnapshot,
+    normalizeCssModuleClassNames,
+    normalizeOfficeFabricGeneratedClassNames,
+} from 'tests/common/element-snapshot-formatter';
+
+describe('element-snapshot-formatter', () => {
+    describe('normalize office fabric generated class names', () => {
+        describe.each`
+            actualClassName              | expectedClassName
+            ${'thumb-123'}               | ${'thumb-000'}
+            ${'ms-Panel-234'}            | ${'ms-Panel-000'}
+            ${'thumb-321 ms-Panel-432'}  | ${'thumb-000 ms-Panel-000'}
+            ${'no-numbers'}              | ${'no-numbers'}
+            ${'no-numbers thumb-543'}    | ${'no-numbers thumb-000'}
+            ${'Panel765-word'}           | ${'Panel000-word'}
+            ${'Panel765-word thumb-123'} | ${'Panel000-word thumb-000'}
+        `('normalize $actualClassName to $expectedClassName', ({ actualClassName, expectedClassName }) => {
+            it('when in the class property', () => {
+                const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
+
+                const result = normalizeOfficeFabricGeneratedClassNames(actualHtml);
+
+                const expected = buildSimpleHtmlFragment('class', expectedClassName);
+
+                expect(result).toEqual(expected);
+            });
+
+            it('when in the id property', () => {
+                const actualHtml = buildSimpleHtmlFragment('id', actualClassName);
+
+                const result = normalizeOfficeFabricGeneratedClassNames(actualHtml);
+
+                const expected = buildSimpleHtmlFragment('id', expectedClassName);
+
+                expect(result).toEqual(expected);
+            });
+        });
+    });
+
+    describe('normalize css module class names', () => {
+        it.each`
+            actualClassName      | expectedClassName
+            ${'my-class--Fs0Df'} | ${`my-class--${CSS_MODULE_HASH_REPLACEMENT}`}
+            ${'no-css-hash'}     | ${'no-css-hash'}
+        `('normalize $actualClassName to $expectedClassName', ({ actualClassName, expectedClassName }) => {
+            const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
+
+            const result = normalizeCssModuleClassNames(actualHtml);
+
+            const expected = buildSimpleHtmlFragment('class', expectedClassName);
+
+            expect(result).toEqual(expected);
+        });
+    });
+
+    describe('format html for snapshot', () => {
+        it.each`
+            actualClassName
+            ${'test-class-one test-class-two'}
+            ${'ms-Panel-headerText header-text--0nPhV headerText-198'}
+        `('normalizing $actualClassName', ({ actualClassName }) => {
+            const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
+
+            const result = formatHtmlForSnapshot(actualHtml);
+
+            expect(result).toMatchSnapshot();
+        });
+    });
+
+    const buildSimpleHtmlFragment = (propertyName: string, propertyValue: string) => {
+        return `<div><div ${propertyName}="${propertyValue}">Hello world!</div></div>`;
+    };
+});

--- a/src/tests/unit/common/element-snapshot-formatter.test.ts
+++ b/src/tests/unit/common/element-snapshot-formatter.test.ts
@@ -11,15 +11,17 @@ import {
 describe('element-snapshot-formatter', () => {
     describe('normalize office fabric generated class names', () => {
         describe.each`
-            actualClassName              | expectedClassName
-            ${'thumb-123'}               | ${'thumb-000'}
-            ${'ms-Panel-234'}            | ${'ms-Panel-000'}
-            ${'thumb-321 ms-Panel-432'}  | ${'thumb-000 ms-Panel-000'}
-            ${'no-numbers'}              | ${'no-numbers'}
-            ${'no-numbers thumb-543'}    | ${'no-numbers thumb-000'}
-            ${'Panel765-word'}           | ${'Panel000-word'}
-            ${'Panel765-word thumb-123'} | ${'Panel000-word thumb-000'}
-        `('normalize $actualClassName to $expectedClassName', ({ actualClassName, expectedClassName }) => {
+            actualClassName                                                                     | expectedClassName
+            ${'thumb-123'}                                                                      | ${'thumb-000'}
+            ${'ms-Panel-234'}                                                                   | ${'ms-Panel-000'}
+            ${'thumb-321 ms-Panel-432'}                                                         | ${'thumb-000 ms-Panel-000'}
+            ${'no-numbers'}                                                                     | ${'no-numbers'}
+            ${'no-numbers thumb-543'}                                                           | ${'no-numbers thumb-000'}
+            ${'Panel765-word'}                                                                  | ${'Panel000-word'}
+            ${'Panel765-word thumb-123'}                                                        | ${'Panel000-word thumb-000'}
+            ${'headerText-198'}                                                                 | ${'headerText-000'}
+            ${`ms-Panel-headerText header-text--${CSS_MODULE_HASH_REPLACEMENT} headerText-198`} | ${`ms-Panel-headerText header-text--${CSS_MODULE_HASH_REPLACEMENT} headerText-000`}
+        `('normalize "$actualClassName" to "$expectedClassName"', ({ actualClassName, expectedClassName }) => {
             it('when in the class property', () => {
                 const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
 

--- a/src/tests/unit/common/element-snapshot-formatter.test.ts
+++ b/src/tests/unit/common/element-snapshot-formatter.test.ts
@@ -44,10 +44,14 @@ describe('element-snapshot-formatter', () => {
 
     describe('normalize css module class names', () => {
         it.each`
-            actualClassName      | expectedClassName
-            ${'my-class--Fs0Df'} | ${`my-class--${CSS_MODULE_HASH_REPLACEMENT}`}
-            ${'no-css-hash'}     | ${'no-css-hash'}
-        `('normalize $actualClassName to $expectedClassName', ({ actualClassName, expectedClassName }) => {
+            actualClassName                                            | expectedClassName
+            ${'my-class--Fs0Df'}                                       | ${`my-class--${CSS_MODULE_HASH_REPLACEMENT}`}
+            ${'no-css-hash'}                                           | ${'no-css-hash'}
+            ${'ms-Panel-headerText header-text--0nPhV headerText-198'} | ${`ms-Panel-headerText header-text--${CSS_MODULE_HASH_REPLACEMENT} headerText-198`}
+            ${'header-text--0nPhV headerText-198'}                     | ${`header-text--${CSS_MODULE_HASH_REPLACEMENT} headerText-198`}
+            ${'ms-Panel-headerText header-text--0nPhV'}                | ${`ms-Panel-headerText header-text--${CSS_MODULE_HASH_REPLACEMENT}`}
+            ${'header-text--0nPhV header-title--1mQiW'}                | ${`header-text--${CSS_MODULE_HASH_REPLACEMENT} header-title--${CSS_MODULE_HASH_REPLACEMENT}`}
+        `('normalize "$actualClassName" to "$expectedClassName"', ({ actualClassName, expectedClassName }) => {
             const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
 
             const result = normalizeCssModuleClassNames(actualHtml);

--- a/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
@@ -117,7 +117,7 @@ exports[`report package integration with issues 1`] = `
             color-interpolation-filters="sRGB"
             filterUnits="userSpaceOnUse"
             height="29.5269"
-            id="filter0_d"
+            id="filter000_d"
             width="29.5246"
             x="15.748"
             y="6.50654"
@@ -155,7 +155,7 @@ exports[`report package integration with issues 1`] = `
           </filter>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint0_linear"
+            id="paint000_linear"
             x1="14.3166"
             x2="5.92409"
             y1="16.8744"
@@ -174,7 +174,7 @@ exports[`report package integration with issues 1`] = `
           </lineargradient>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint1_linear"
+            id="paint000_linear"
             x1="14.3166"
             x2="5.92409"
             y1="16.8744"
@@ -193,7 +193,7 @@ exports[`report package integration with issues 1`] = `
           </lineargradient>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint2_linear"
+            id="paint000_linear"
             x1="11.3179"
             x2="11.0819"
             y1="20.1024"
@@ -6165,7 +6165,7 @@ exports[`report package integration with no issues 1`] = `
             color-interpolation-filters="sRGB"
             filterUnits="userSpaceOnUse"
             height="29.5269"
-            id="filter0_d"
+            id="filter000_d"
             width="29.5246"
             x="15.748"
             y="6.50654"
@@ -6203,7 +6203,7 @@ exports[`report package integration with no issues 1`] = `
           </filter>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint0_linear"
+            id="paint000_linear"
             x1="14.3166"
             x2="5.92409"
             y1="16.8744"
@@ -6222,7 +6222,7 @@ exports[`report package integration with no issues 1`] = `
           </lineargradient>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint1_linear"
+            id="paint000_linear"
             x1="14.3166"
             x2="5.92409"
             y1="16.8744"
@@ -6241,7 +6241,7 @@ exports[`report package integration with no issues 1`] = `
           </lineargradient>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint2_linear"
+            id="paint000_linear"
             x1="11.3179"
             x2="11.0819"
             y1="20.1024"


### PR DESCRIPTION
#### Description of changes

While reviewing #1979, @dbjorge notice we are not properly handling a class attribute with more than one class value inside of it, like in this real case: `ms-Panel-headerText header-text--0nPhV headerText-000`.

The expected result from the example above is for the formater/normalizer to change `header-text--0nPhV` into `header-text--{{CSS_MODULE_HASH}}`. The position of the class name value should not matter; the same goes for the amount of class names the class attribute has.

Because we're using regex to do the replacement, I added unit tests for those functions (that way it was easier to found which of the functions was broken) and then updated the logic of the broken one to properly handle more than one class name value.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
