### PR TITLE
chore: refactor environment variables in electron build

### DIFF
--- a/pipeline/electron/distribute-publish-electron-linux.yaml
+++ b/pipeline/electron/distribute-publish-electron-linux.yaml
@@ -8,8 +8,8 @@ steps:
     - script: yarn pack:electron ${{ parameters.platforms }}
       displayName: pack electron distributables
       env:
-          ELECTRON_MIRROR: $(ELECTRON_MIRROR)
-          ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR)
+          ELECTRON_MIRROR: $(ELECTRON_MIRROR_VAR)
+          ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR_VAR)
 
     - task: CopyFiles@2
       displayName: 'Copy the AppImage file to detachedSignature'

--- a/pipeline/electron/distribute-sign-publish-electron-mac.yaml
+++ b/pipeline/electron/distribute-sign-publish-electron-mac.yaml
@@ -8,8 +8,8 @@ steps:
     - script: yarn pack:electron ${{ parameters.platforms }}
       displayName: create electron distributables
       env:
-          ELECTRON_MIRROR: $(ELECTRON_MIRROR)
-          ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR)
+          ELECTRON_MIRROR: $(ELECTRON_MIRROR_VAR)
+          ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR_VAR)
 
     - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
       displayName: 'sign dist'

--- a/pipeline/electron/distribute-sign-publish-electron-windows.yaml
+++ b/pipeline/electron/distribute-sign-publish-electron-windows.yaml
@@ -8,8 +8,8 @@ steps:
     - script: yarn pack:electron ${{ parameters.platforms }}
       displayName: create electron distributables
       env:
-          ELECTRON_MIRROR: $(ELECTRON_MIRROR)
-          ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR)
+          ELECTRON_MIRROR: $(ELECTRON_MIRROR_VAR)
+          ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR_VAR)
 
     - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
       displayName: 'sign dist'

--- a/pipeline/electron/download-electron-mirror.yaml
+++ b/pipeline/electron/download-electron-mirror.yaml
@@ -4,5 +4,5 @@ steps:
     - script: yarn download:electron-mirror
       displayName: download custom electron build
       env:
-          ELECTRON_MIRROR: $(ELECTRON_MIRROR)
-          ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR)
+          ELECTRON_MIRROR: $(ELECTRON_MIRROR_VAR)
+          ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR_VAR)


### PR DESCRIPTION
#### Description of changes

This PR renames the environment variables in the electron build from ELECTRON_MIRROR and ELECTRON_CUSTOM_DIR to ELECTRON_MIRROR_VAR and ELECTRON_CUSTOM_DIR_VAR. This helps ensure that only certain tasks are affected by the mirror variables. Previously, if the variable was non-secret and thus available to the pipeline, unrelated tasks (such as yarn install) were affected by the variable names due to name collisions (e.g. electron-chromedriver installation also respects ELECTRON_MIRROR). The associated build vars will be renamed upon completion of this PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
