### PR TITLE
fix: whitelist application insights telemetry endpoint in CSP

### DIFF
--- a/src/electron/views/index.html
+++ b/src/electron/views/index.html
@@ -6,7 +6,10 @@ Licensed under the MIT License.
 <html dir="ltr" lang="en">
     <head>
         <meta charset="utf-8" />
-        <meta http-equiv="Content-Security-Policy" content="script-src 'self';" />
+        <meta
+            http-equiv="Content-Security-Policy"
+            content="script-src 'self' https://az416426.vo.msecnd.net;"
+        />
         <link rel="stylesheet" type="text/css" href="../../common/styles/fabric.min.css" />
         <link
             rel="stylesheet"


### PR DESCRIPTION
#### Description of changes
This PR adds an application insights URL to the CSP to enable telemetry in the electron product. The telemetry error was masked by / confused with https://github.com/microsoft/accessibility-insights-web/issues/1758. That issue tracked the web product - an OfficeFabric empty "JavaScript:url" was being flagged. In electron the error `renderer.bundle.js:14000 Refused to load the script 'https://az416426.vo.msecnd.net/scripts/a/ai.0.js' because it violates the following Content Security Policy directive: "script-src 'self'". Note that 'script-src-elem' was not explicitly set, so 'script-src' is used as a fallback.` appears in the built product.

Apologies this isn't in my fork - I had a branch on the main repo for build changes and forgot to move back in between.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
