### PR TITLE
fix: element snapshot formatter does not handle more than one class name value

### DIFF
--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -29,16 +29,17 @@ export function formatHtmlForSnapshot(htmlString: string): Node {
 
 // office fabric generates a random class & id name which changes every time.
 // We remove the random number before snapshot comparison to avoid flakiness
-function normalizeOfficeFabricGeneratedClassNames(htmlString: string): string {
+export function normalizeOfficeFabricGeneratedClassNames(htmlString: string): string {
     return htmlString.replace(/(class|id)="([\w\s-]+[\d]+|Panel\d+-\w+)"/g, (subString, args) => {
         return subString.replace(/[\d]+/g, '000');
     });
 }
 
+export const CSS_MODULE_HASH_REPLACEMENT = '{{CSS_MODULE_HASH}}';
 // Our webpack config adds generated suffixes of form "--abc12" to the end of class names defined in
 // CSS. This normalizes them to avoid causing E2Es to fail for unrelated style changes.
-function normalizeCssModuleClassNames(htmlString: string): string {
-    return htmlString.replace(/(class="[^"]+--)[A-Za-z0-9+\/=-]{5}(")/g, '$1{{CSS_MODULE_HASH}}$2');
+export function normalizeCssModuleClassNames(htmlString: string): string {
+    return htmlString.replace(/(class="[^"]+--)[A-Za-z0-9+\/=-]{5}(")/g, `$1${CSS_MODULE_HASH_REPLACEMENT}$2`);
 }
 
 // in some cases (eg, stylesheet links), HTML can contain absolute chrome-extension://{generated-id} paths

--- a/src/tests/common/element-snapshot-formatter.ts
+++ b/src/tests/common/element-snapshot-formatter.ts
@@ -14,8 +14,8 @@ export async function formatChildElementForSnapshot(rootElement: ElementHandle<E
 }
 
 export function formatHtmlForSnapshot(htmlString: string): Node {
-    htmlString = normalizeCssModuleClassNames(htmlString);
-    htmlString = normalizeOfficeFabricGeneratedClassNames(htmlString);
+    htmlString = normalizeClassName(htmlString);
+    htmlString = normalizeId(htmlString);
     htmlString = normalizeExtensionUrls(htmlString);
     htmlString = htmlString.trim();
 
@@ -27,19 +27,54 @@ export function formatHtmlForSnapshot(htmlString: string): Node {
     return template.content.cloneNode(true);
 }
 
-// office fabric generates a random class & id name which changes every time.
-// We remove the random number before snapshot comparison to avoid flakiness
-export function normalizeOfficeFabricGeneratedClassNames(htmlString: string): string {
-    return htmlString.replace(/(class|id)="([\w\s-]+[\d]+|Panel\d+-\w+)"/g, (subString, args) => {
-        return subString.replace(/[\d]+/g, '000');
+export function normalizeId(htmlString: string): string {
+    // matches a string like: id="*"
+    // we process only the string value on the right side
+    const idAttributeMatcher = /id="([^".]+)"/g;
+
+    return htmlString.replace(idAttributeMatcher, (_, idMatch: string) => {
+        const officeFabricIdMatcher = /^([a-zA-Z-_]+)(\d+)(-{0,1}\w+)?$/;
+
+        const idValue = idMatch.replace(officeFabricIdMatcher, `$1000$3`);
+
+        return `id="${idValue}"`;
     });
 }
 
+export function normalizeClassName(htmlString: string): string {
+    // matches a string like: class="*"
+    // we process only the string value on the right side
+    const classAttributeMatcher = /class="([^".]+)"/g;
+
+    return htmlString.replace(classAttributeMatcher, (_, classNamesMatch: string) => {
+        let classNames = classNamesMatch.split(' ');
+
+        classNames = classNames.map(className => {
+            let result = normalizeCssModuleClassName(className);
+            result = normalizeOfficeFabricClassName(result);
+            return result;
+        });
+
+        return `class="${classNames.join(' ')}"`;
+    });
+}
+
+// office fabric generates a "random" class & id name which changes every time.
+// We remove the "random" number before snapshot comparison to avoid flakiness
+export function normalizeOfficeFabricClassName(className: string): string {
+    const officeFabricClassNameMatcher = /^([a-zA-Z-_]+)(\d+)(-{0,1}\w+)?$/;
+
+    return className.replace(officeFabricClassNameMatcher, '$1000$3');
+}
+
 export const CSS_MODULE_HASH_REPLACEMENT = '{{CSS_MODULE_HASH}}';
+
 // Our webpack config adds generated suffixes of form "--abc12" to the end of class names defined in
 // CSS. This normalizes them to avoid causing E2Es to fail for unrelated style changes.
-export function normalizeCssModuleClassNames(htmlString: string): string {
-    return htmlString.replace(/(class="[^"]+--)[A-Za-z0-9+\/=-]{5}(")/g, `$1${CSS_MODULE_HASH_REPLACEMENT}$2`);
+export function normalizeCssModuleClassName(className: string): string {
+    const cssModuleClassNameMatcher = /^([\w-]+--)[A-Za-z0-9+\/=-]{5}$/;
+
+    return className.replace(cssModuleClassNameMatcher, `$1${CSS_MODULE_HASH_REPLACEMENT}`);
 }
 
 // in some cases (eg, stylesheet links), HTML can contain absolute chrome-extension://{generated-id} paths

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
 <DocumentFragment>
   <div
     aria-hidden="false"
-    class="ms-Panel is-open ms-Panel--hasCloseButton ms-Panel--custom generic-panel--000CjX000 preview-features-panel root-000"
+    class="ms-Panel is-open ms-Panel--hasCloseButton ms-Panel--custom generic-panel--{{CSS_MODULE_HASH}} preview-features-panel root-000"
   >
     <div
       class="ms-Overlay overlay-000"
@@ -58,7 +58,7 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
         >
           <p
             aria-level="2"
-            class="ms-Panel-headerText header-text--000nPhV headerText-000"
+            class="ms-Panel-headerText header-text--{{CSS_MODULE_HASH}} headerText-000"
             id="Panel000-headerText"
             role="heading"
           >

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -103,7 +103,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
               >
                 <div
                   aria-hidden="true"
-                  class="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle"
+                  class="ms-Grid-col ms-sm000 popup-start-dialog-icon-circle"
                 >
                   <i
                     aria-hidden="true"
@@ -151,7 +151,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
               >
                 <div
                   aria-hidden="true"
-                  class="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle"
+                  class="ms-Grid-col ms-sm000 popup-start-dialog-icon-circle"
                 >
                   <i
                     aria-hidden="true"
@@ -199,7 +199,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
               >
                 <div
                   aria-hidden="true"
-                  class="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle"
+                  class="ms-Grid-col ms-sm000 popup-start-dialog-icon-circle"
                 >
                   <i
                     aria-hidden="true"

--- a/src/tests/unit/common/__snapshots__/element-snapshot-formatter.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/element-snapshot-formatter.test.ts.snap
@@ -1,24 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`element-snapshot-formatter format html for snapshot normalizing ms-Panel-headerText header-text--0nPhV headerText-198 1`] = `
+exports[`element-snapshot-formatter format html for snapshot normalizing class = "ms-Panel is-open ms-Panel--hasCloseButton ms-Panel--custom generic-panel--4CjX1 preview-features-panel root-127" and id = "custom-id123" 1`] = `
 <DocumentFragment>
   <div>
-    <div
-      class="ms-Panel-headerText header-text--000nPhV headerText-000"
-    >
-      Hello world!
+    <div>
+      <div
+        class="ms-Panel is-open ms-Panel--hasCloseButton ms-Panel--custom generic-panel--{{CSS_MODULE_HASH}} preview-features-panel root-000"
+      >
+        Hello world!
+      </div>
+    </div>
+    <div>
+      <div
+        id="custom-id000"
+      >
+        Hello world!
+      </div>
     </div>
   </div>
 </DocumentFragment>
 `;
 
-exports[`element-snapshot-formatter format html for snapshot normalizing test-class-one test-class-two 1`] = `
+exports[`element-snapshot-formatter format html for snapshot normalizing class = "test-class-one test-class-two" and id = "custom-id" 1`] = `
 <DocumentFragment>
   <div>
-    <div
-      class="test-class-one test-class-two"
-    >
-      Hello world!
+    <div>
+      <div
+        class="test-class-one test-class-two"
+      >
+        Hello world!
+      </div>
+    </div>
+    <div>
+      <div
+        id="custom-id"
+      >
+        Hello world!
+      </div>
     </div>
   </div>
 </DocumentFragment>

--- a/src/tests/unit/common/__snapshots__/element-snapshot-formatter.test.ts.snap
+++ b/src/tests/unit/common/__snapshots__/element-snapshot-formatter.test.ts.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`element-snapshot-formatter format html for snapshot normalizing ms-Panel-headerText header-text--0nPhV headerText-198 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="ms-Panel-headerText header-text--000nPhV headerText-000"
+    >
+      Hello world!
+    </div>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`element-snapshot-formatter format html for snapshot normalizing test-class-one test-class-two 1`] = `
+<DocumentFragment>
+  <div>
+    <div
+      class="test-class-one test-class-two"
+    >
+      Hello world!
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/src/tests/unit/common/element-snapshot-formatter.test.ts
+++ b/src/tests/unit/common/element-snapshot-formatter.test.ts
@@ -1,56 +1,75 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import {
     CSS_MODULE_HASH_REPLACEMENT,
     formatHtmlForSnapshot,
-    normalizeCssModuleClassNames,
-    normalizeOfficeFabricGeneratedClassNames,
+    normalizeClassName,
+    normalizeCssModuleClassName,
+    normalizeId,
+    normalizeOfficeFabricClassName,
 } from 'tests/common/element-snapshot-formatter';
 
 describe('element-snapshot-formatter', () => {
-    describe('normalize office fabric generated class names', () => {
-        describe.each`
-            actualClassName              | expectedClassName
-            ${'thumb-123'}               | ${'thumb-000'}
-            ${'ms-Panel-234'}            | ${'ms-Panel-000'}
-            ${'thumb-321 ms-Panel-432'}  | ${'thumb-000 ms-Panel-000'}
-            ${'no-numbers'}              | ${'no-numbers'}
-            ${'no-numbers thumb-543'}    | ${'no-numbers thumb-000'}
-            ${'Panel765-word'}           | ${'Panel000-word'}
-            ${'Panel765-word thumb-123'} | ${'Panel000-word thumb-000'}
-        `('normalize $actualClassName to $expectedClassName', ({ actualClassName, expectedClassName }) => {
-            it('when in the class property', () => {
-                const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
+    describe('normalize office fabric id', () => {
+        it.each`
+            actualId               | expectedId
+            ${'custom-id'}         | ${'custom-id'}
+            ${'element1'}          | ${'element000'}
+            ${'element2-label'}    | ${'element000-label'}
+            ${'element-id3'}       | ${'element-id000'}
+            ${'element-id4-label'} | ${'element-id000-label'}
+        `('from "$actualId" to "${expectedId}"', ({ actualId, expectedId }) => {
+            const actualHtml = buildSimpleHtmlFragment('id', actualId);
 
-                const result = normalizeOfficeFabricGeneratedClassNames(actualHtml);
+            const result = normalizeId(actualHtml);
 
-                const expected = buildSimpleHtmlFragment('class', expectedClassName);
+            const expected = buildSimpleHtmlFragment('id', expectedId);
 
-                expect(result).toEqual(expected);
-            });
+            expect(result).toEqual(expected);
+        });
+    });
 
-            it('when in the id property', () => {
-                const actualHtml = buildSimpleHtmlFragment('id', actualClassName);
+    describe('normalize office fabric class names', () => {
+        it.each`
+            actualClassName                               | expectedClassName
+            ${'no-numbers'}                               | ${'no-numbers'}
+            ${'first'}                                    | ${'first'}
+            ${'thumb-123'}                                | ${'thumb-000'}
+            ${'ms-Panel-234'}                             | ${'ms-Panel-000'}
+            ${'Panel765-word'}                            | ${'Panel000-word'}
+            ${`my-class--${CSS_MODULE_HASH_REPLACEMENT}`} | ${`my-class--${CSS_MODULE_HASH_REPLACEMENT}`}
+        `('from "$actualClassName" to "$expectedClassName"', ({ actualClassName, expectedClassName }) => {
+            const result = normalizeOfficeFabricClassName(actualClassName);
 
-                const result = normalizeOfficeFabricGeneratedClassNames(actualHtml);
-
-                const expected = buildSimpleHtmlFragment('id', expectedClassName);
-
-                expect(result).toEqual(expected);
-            });
+            expect(result).toEqual(expectedClassName);
         });
     });
 
     describe('normalize css module class names', () => {
         it.each`
             actualClassName      | expectedClassName
+            ${'no-numbers'}      | ${'no-numbers'}
+            ${'first'}           | ${'first'}
             ${'my-class--Fs0Df'} | ${`my-class--${CSS_MODULE_HASH_REPLACEMENT}`}
-            ${'no-css-hash'}     | ${'no-css-hash'}
-        `('normalize $actualClassName to $expectedClassName', ({ actualClassName, expectedClassName }) => {
+            ${'my-class-Fs0Df'}  | ${'my-class-Fs0Df'}
+        `('from "$actualClassName" to "$expectedClassName"', ({ actualClassName, expectedClassName }) => {
+            const result = normalizeCssModuleClassName(actualClassName);
+
+            expect(result).toEqual(expectedClassName);
+        });
+    });
+
+    describe('normalize class names', () => {
+        it.each`
+            actualClassName                                     | expectedClassName
+            ${'first Panel765-word thumb-123 last'}             | ${`first Panel000-word thumb-000 last`}
+            ${'first Panel765-word css-module--Fs0Df last'}     | ${`first Panel000-word css-module--${CSS_MODULE_HASH_REPLACEMENT} last`}
+            ${'first css-module--Fs0Df last'}                   | ${`first css-module--${CSS_MODULE_HASH_REPLACEMENT} last`}
+            ${'first css-module--Fs0Df css-module--Ax9Ea last'} | ${`first css-module--${CSS_MODULE_HASH_REPLACEMENT} css-module--${CSS_MODULE_HASH_REPLACEMENT} last`}
+        `('from "$actualClassName" to "$expectedClassName"', ({ actualClassName, expectedClassName }) => {
             const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
 
-            const result = normalizeCssModuleClassNames(actualHtml);
+            const result = normalizeClassName(actualHtml);
 
             const expected = buildSimpleHtmlFragment('class', expectedClassName);
 
@@ -60,11 +79,14 @@ describe('element-snapshot-formatter', () => {
 
     describe('format html for snapshot', () => {
         it.each`
-            actualClassName
-            ${'test-class-one test-class-two'}
-            ${'ms-Panel-headerText header-text--0nPhV headerText-198'}
-        `('normalizing $actualClassName', ({ actualClassName }) => {
-            const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
+            actualClassName                                                                                                      | actualId
+            ${'test-class-one test-class-two'}                                                                                   | ${'custom-id'}
+            ${'ms-Panel is-open ms-Panel--hasCloseButton ms-Panel--custom generic-panel--4CjX1 preview-features-panel root-127'} | ${'custom-id123'}
+        `('normalizing class = "$actualClassName" and id = "$actualId"', ({ actualClassName, actualId }) => {
+            const htmlFragmentWithClass = buildSimpleHtmlFragment('class', actualClassName);
+            const htmlFragmentWithId = buildSimpleHtmlFragment('id', actualId);
+
+            const actualHtml = `<div>${htmlFragmentWithClass}${htmlFragmentWithId}</div>`;
 
             const result = formatHtmlForSnapshot(actualHtml);
 

--- a/src/tests/unit/common/element-snapshot-formatter.test.ts
+++ b/src/tests/unit/common/element-snapshot-formatter.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    CSS_MODULE_HASH_REPLACEMENT,
+    formatHtmlForSnapshot,
+    normalizeCssModuleClassNames,
+    normalizeOfficeFabricGeneratedClassNames,
+} from 'tests/common/element-snapshot-formatter';
+
+describe('element-snapshot-formatter', () => {
+    describe('normalize office fabric generated class names', () => {
+        describe.each`
+            actualClassName              | expectedClassName
+            ${'thumb-123'}               | ${'thumb-000'}
+            ${'ms-Panel-234'}            | ${'ms-Panel-000'}
+            ${'thumb-321 ms-Panel-432'}  | ${'thumb-000 ms-Panel-000'}
+            ${'no-numbers'}              | ${'no-numbers'}
+            ${'no-numbers thumb-543'}    | ${'no-numbers thumb-000'}
+            ${'Panel765-word'}           | ${'Panel000-word'}
+            ${'Panel765-word thumb-123'} | ${'Panel000-word thumb-000'}
+        `('normalize $actualClassName to $expectedClassName', ({ actualClassName, expectedClassName }) => {
+            it('when in the class property', () => {
+                const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
+
+                const result = normalizeOfficeFabricGeneratedClassNames(actualHtml);
+
+                const expected = buildSimpleHtmlFragment('class', expectedClassName);
+
+                expect(result).toEqual(expected);
+            });
+
+            it('when in the id property', () => {
+                const actualHtml = buildSimpleHtmlFragment('id', actualClassName);
+
+                const result = normalizeOfficeFabricGeneratedClassNames(actualHtml);
+
+                const expected = buildSimpleHtmlFragment('id', expectedClassName);
+
+                expect(result).toEqual(expected);
+            });
+        });
+    });
+
+    describe('normalize css module class names', () => {
+        it.each`
+            actualClassName      | expectedClassName
+            ${'my-class--Fs0Df'} | ${`my-class--${CSS_MODULE_HASH_REPLACEMENT}`}
+            ${'no-css-hash'}     | ${'no-css-hash'}
+        `('normalize $actualClassName to $expectedClassName', ({ actualClassName, expectedClassName }) => {
+            const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
+
+            const result = normalizeCssModuleClassNames(actualHtml);
+
+            const expected = buildSimpleHtmlFragment('class', expectedClassName);
+
+            expect(result).toEqual(expected);
+        });
+    });
+
+    describe('format html for snapshot', () => {
+        it.each`
+            actualClassName
+            ${'test-class-one test-class-two'}
+            ${'ms-Panel-headerText header-text--0nPhV headerText-198'}
+        `('normalizing $actualClassName', ({ actualClassName }) => {
+            const actualHtml = buildSimpleHtmlFragment('class', actualClassName);
+
+            const result = formatHtmlForSnapshot(actualHtml);
+
+            expect(result).toMatchSnapshot();
+        });
+    });
+
+    const buildSimpleHtmlFragment = (propertyName: string, propertyValue: string) => {
+        return `<div><div ${propertyName}="${propertyValue}">Hello world!</div></div>`;
+    };
+});

--- a/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
@@ -117,7 +117,7 @@ exports[`report package integration with issues 1`] = `
             color-interpolation-filters="sRGB"
             filterUnits="userSpaceOnUse"
             height="29.5269"
-            id="filter0_d"
+            id="filter000_d"
             width="29.5246"
             x="15.748"
             y="6.50654"
@@ -155,7 +155,7 @@ exports[`report package integration with issues 1`] = `
           </filter>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint0_linear"
+            id="paint000_linear"
             x1="14.3166"
             x2="5.92409"
             y1="16.8744"
@@ -174,7 +174,7 @@ exports[`report package integration with issues 1`] = `
           </lineargradient>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint1_linear"
+            id="paint000_linear"
             x1="14.3166"
             x2="5.92409"
             y1="16.8744"
@@ -193,7 +193,7 @@ exports[`report package integration with issues 1`] = `
           </lineargradient>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint2_linear"
+            id="paint000_linear"
             x1="11.3179"
             x2="11.0819"
             y1="20.1024"
@@ -6165,7 +6165,7 @@ exports[`report package integration with no issues 1`] = `
             color-interpolation-filters="sRGB"
             filterUnits="userSpaceOnUse"
             height="29.5269"
-            id="filter0_d"
+            id="filter000_d"
             width="29.5246"
             x="15.748"
             y="6.50654"
@@ -6203,7 +6203,7 @@ exports[`report package integration with no issues 1`] = `
           </filter>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint0_linear"
+            id="paint000_linear"
             x1="14.3166"
             x2="5.92409"
             y1="16.8744"
@@ -6222,7 +6222,7 @@ exports[`report package integration with no issues 1`] = `
           </lineargradient>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint1_linear"
+            id="paint000_linear"
             x1="14.3166"
             x2="5.92409"
             y1="16.8744"
@@ -6241,7 +6241,7 @@ exports[`report package integration with no issues 1`] = `
           </lineargradient>
           <lineargradient
             gradientUnits="userSpaceOnUse"
-            id="paint2_linear"
+            id="paint000_linear"
             x1="11.3179"
             x2="11.0819"
             y1="20.1024"


### PR DESCRIPTION
#### Description of changes

**NOTE** this is a second attempt to fix the element snapshot formatter logic. Original PR (#1981) has been abandoned.

While reviewing #1979, @dbjorge notice we are not properly handling a class attribute with more than one class value inside of it, like in this real case: `ms-Panel-headerText header-text--0nPhV headerText-000`.

The expected result from the example above is for the formater/normalizer to change `header-text--0nPhV` into `header-text--{{CSS_MODULE_HASH}}`. The position of the class name value should not matter; the same goes for the amount of class names the class attribute has.

Because we're using regex to do the replacement, I added unit tests for those functions (that way it was easier to found which of the functions was broken) and then updated the logic of the broken one to properly handle more than one class name value.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
