### PR TITLE
fix: flooding error on background console

### DIFF
--- a/src/background/browser-message-broadcaster-factory.ts
+++ b/src/background/browser-message-broadcaster-factory.ts
@@ -6,6 +6,9 @@ import { inspect } from 'util';
 
 export type MessageBroadcaster = (message: any) => Promise<void>;
 
+export const connectionErrorMessage =
+    'Could not establish connection. Receiving end does not exist.';
+
 export class BrowserMessageBroadcasterFactory {
     constructor(private readonly browserAdapter: BrowserAdapter, private readonly logger: Logger) {}
 
@@ -48,6 +51,13 @@ export class BrowserMessageBroadcasterFactory {
         message: any,
         chromeError: chrome.runtime.LastError,
     ) => {
+        // We get this message when we have not yet injected our content script on the tab we are
+        // sending the message to.
+        // Filtering this out (not log it to the console) to avoid generating meaningless noise
+        if (chromeError.message === connectionErrorMessage) {
+            return;
+        }
+
         const msg = `${operationDescription} failed for message ${inspect(
             message,
         )} with browser error message: ${chromeError.message}`;

--- a/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
+++ b/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
@@ -146,5 +146,3 @@ describe('BrowserMessageBroadcasterFactory', () => {
         });
     });
 });
-
-//

--- a/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
+++ b/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserMessageBroadcasterFactory } from 'background/browser-message-broadcaster-factory';
+import { BrowserMessageBroadcasterFactory, connectionErrorMessage } from 'background/browser-message-broadcaster-factory';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { Logger } from 'common/logging/logger';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
@@ -76,6 +76,21 @@ describe('BrowserMessageBroadcasterFactory', () => {
 
             loggerMock.verifyAll();
         });
+
+        it('does not propagate know error message', async () => {
+            const testMessage = { someData: 'test data' } as any;
+            const testError = { message: connectionErrorMessage };
+
+            browserAdapterMock.setup(ba => ba.tabsQuery({})).returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
+            browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.resolve());
+            browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.reject(testError));
+
+            loggerMock.setup(m => m.error(It.isAny())).verifiable(Times.never());
+
+            await testSubject.allTabsBroadcaster(testMessage);
+
+            loggerMock.verifyAll();
+        });
     });
 
     describe('createTabSpecificBroadcaster', () => {
@@ -131,3 +146,5 @@ describe('BrowserMessageBroadcasterFactory', () => {
         });
     });
 });
+
+//


### PR DESCRIPTION
#### Description of changes

Currently, we are flooding the `background.html` console with errors from sending messages to tabs we have not yet injected our content scripts.

This make it really hard to see anything else on the console (including telemetry being log to the console).

In order to avoid this, filtering out the known error message we get on this scenario.

#### Pull request checklist
- [x] Addresses an existing issue: #1988
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
