### PR TITLE
feat(office-fabric): change the checkbox color to black instead of the blue (default)

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -406,6 +406,7 @@ div.insights-file-issue-details-dialog-container {
                     padding: 15px 0px 0px 15px;
                 }
                 .instance-visibility-button {
+                    color: $primary-text;
                     padding-bottom: 6px;
                 }
                 .test-step-choice-group-container {


### PR DESCRIPTION
#### Description of changes
After updating to office fabric 7, the instance-visibility-button color became blue, so we changed it back to black.

Before fix:
![image](https://user-images.githubusercontent.com/45858632/72488264-50afb980-37c5-11ea-8605-049fbea78a4b.png)


After fix:
![image](https://user-images.githubusercontent.com/45858632/72488622-522db180-37c6-11ea-91d6-47a6e33b9975.png)

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
