### PR TITLE
fix: simple typo information on the TouchSizeWcag rule for minwidth and minheight

### DIFF
--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -91,7 +91,7 @@ export class RuleInformationProvider {
         const logicalHeight = this.floorTo3Decimal(physicalHeight / dpi);
 
         return this.buildUnifiedFormattableResolution(
-            `The element has an insufficient target size (width: ${logicalWidth}dp, height: ${logicalHeight}dp). Set the element's minWidth and minHeight attributes to at least 48dp.`,
+            `The element has an insufficient target size (width: ${logicalWidth}dp, height: ${logicalHeight}dp). Set the element's minWidth and minHeight attributes to at least 44dp.`,
             ['minWidth', 'minHeight'],
         );
     };

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/rule-information-provider.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/rule-information-provider.test.ts.snap
@@ -67,8 +67,8 @@ Object {
       "minWidth",
       "minHeight",
     ],
-    "howToFix": "The element has an insufficient target size (width: 42.222dp, height: 38.222dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
+    "howToFix": "The element has an insufficient target size (width: 42.222dp, height: 38.222dp). Set the element's minWidth and minHeight attributes to at least 44dp.",
   },
-  "howToFixSummary": "The element has an insufficient target size (width: 42.222dp, height: 38.222dp). Set the element's minWidth and minHeight attributes to at least 48dp.",
+  "howToFixSummary": "The element has an insufficient target size (width: 42.222dp, height: 38.222dp). Set the element's minWidth and minHeight attributes to at least 44dp.",
 }
 `;


### PR DESCRIPTION
#### Description of changes
According to #1994, the text on `how to fix` info for `TouchSizeWcag` needs a change in the minwidth size recommended from 48dp to 44dp.
Making that change.
<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1994 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
