### PR TITLE
feat(office-fabric): fix switcher at announcement

### DIFF
--- a/src/DetailsView/components/issues-table.tsx
+++ b/src/DetailsView/components/issues-table.tsx
@@ -107,7 +107,7 @@ export class IssuesTable extends React.Component<IssuesTableProps> {
     private renderDisabledMessage(): JSX.Element {
         const disabledMessage = (
             <span>
-                Use the <Markup.Term>Start over</Markup.Term> button to scan the target page.
+                Use the <Markup.Term>Start over button</Markup.Term> to scan the target page.
             </span>
         );
 

--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -36,7 +36,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
 
     private onRenderOption = (option: IDropdownOption): JSX.Element => {
         return (
-            <span className={styles.switcherDropdownOption} aria-hidden="true">
+            <span className={styles.switcherDropdownOption}>
                 {option.data && option.data.icon && <Icon iconName={option.data.icon} />}
                 <span>{option.text}</span>
             </span>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/issues-table.test.tsx.snap
@@ -18,9 +18,9 @@ exports[`IssuesTableTest automated checks disabled 1`] = `
         <span>
           Use the 
           <Term>
-            Start over
+            Start over button
           </Term>
-           button to scan the target page.
+           to scan the target page.
         </span>
       </div>
     </React.Fragment>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`Switcher renders Switcher itself matches snapshot 1`] = `
 
 exports[`Switcher renders option renderer override matches snapshot  1`] = `
 <span
-  aria-hidden="true"
   className="switcherDropdownOption"
 >
   <StyledIconBase

--- a/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issues-table.test.tsx
@@ -12,7 +12,6 @@ import { ReportGenerator } from 'reports/report-generator';
 import { RuleResult } from 'scanner/iruleresults';
 import { IMock, Mock } from 'typemoq';
 import { DictionaryStringTo } from 'types/common-types';
-
 import { exampleUnifiedStatusResults } from '../../common/components/cards/sample-view-model-data';
 
 describe('IssuesTableTest', () => {


### PR DESCRIPTION
#### Description of changes

Several pieces of information to explain this change, bear with me:

The switcher AT announcement includes:
- tab-navigating to the dropdown.
- use arrow keys to change selection (with the dropdown to expand)
- expand the dropdown and use arrow keys to navigate the options.

Currently on **AI-Web prod 2.13.1** ATs announce the switcher **good enough** (there is just so much we can do to provide good aria values, after that, it's up to each AT to use that information and there are small and big differences between them.)

Currently on master, we have lost the proper announcement of the selection changes (by using arrow keys without expanding the dropdown). This is due to what we render for each option. We are using a wrapper `<span>` element so we can have icon + text. This wrapper has `aria-hidden="true"` which makes the ATs not to read it.

The fix then is as simple as remove this attribute from said element.

I have tested this change considering:
- browsers: (new) edge & chrome (they do behave different oddly enough)
- AT: Narrator (the best output), JAWS & NVDA

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: completes WI # 1665427
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
