### PR TITLE
chore: fix alphabetization of run scripts in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
         "yarn": "^1.17.3"
     },
     "scripts": {
-        "download:electron-mirror": "node ./pipeline/scripts/download-electron-mirror.js",
         "assessment": "npm-run-all --serial scss:clean fastpass build:all test test:e2e test:electron",
         "build": "grunt",
         "build:all": "grunt build-all",
@@ -23,13 +22,14 @@
         "build:prod": "grunt build-prod",
         "copyright:check": "license-check-and-add check -f copyright-header.config.json",
         "copyright:fix": "license-check-and-add add -f copyright-header.config.json",
-        "pack:electron": "electron-builder -p never",
+        "download:electron-mirror": "node ./pipeline/scripts/download-electron-mirror.js",
         "fastpass": "npm-run-all --print-label --parallel scss:clean copyright:check lint:check format:check",
         "fastpass:fix": "npm-run-all --print-label --serial scss:clean copyright:fix lint:fix format:fix",
         "format:check": "prettier --config prettier.config.js --check \"**/*\"",
         "format:fix": "prettier --config prettier.config.js --write \"**/*\"",
         "lint:check": "tslint -c ./tslint.json -p ./tsconfig.json",
         "lint:fix": "tslint --fix -c ./tslint.json -p ./tsconfig.json",
+        "pack:electron": "electron-builder -p never",
         "scss:build": "tsm \"src/**/*.scss\"",
         "scss:clean": "grunt clean:scss",
         "serve:mock-axe-android": "http-server -p 9051 -e json ./src/tests/miscellaneous/mock-axe-android",


### PR DESCRIPTION
#### Description of changes

Minor change, no functional impact; just cleans up formatting of package.json scripts

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
