### PR TITLE
feat(unified-channels): Add grunt machinery for per-channel unified pkgs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -503,7 +503,7 @@ module.exports = function(grunt) {
         'build-assets',
         'drop:dev',
         'drop:electron',
-        'web-release-drops',
+        'extension-release-drops',
     ]);
 
     grunt.registerTask('default', ['build-dev']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,6 +4,7 @@ const sass = require('node-sass');
 const path = require('path');
 const targets = require('./targets.config');
 const merge = require('lodash/merge');
+const yaml = require('js-yaml');
 
 module.exports = function(grunt) {
     const extensionPath = 'extension';
@@ -188,6 +189,37 @@ module.exports = function(grunt) {
 
     const targetNames = Object.keys(targets);
     const releaseTargets = Object.keys(targets).filter(t => targets[t].release);
+    const extensionReleaseTargets = releaseTargets.filter(t => targets[t].config.options.productCategory === 'extension');
+    const unifiedReleaseTargets = releaseTargets.filter(t => targets[t].config.options.productCategory === 'electron');
+
+    unifiedReleaseTargets.forEach(targetName => {
+        const { config, appId, publishUrl } = targets[targetName];
+        const { icon512, fullName, productCategory } = config.options;
+        const dropPath = `drop/${productCategory}/${targetName}`;
+
+        grunt.config.merge({
+            'configure-electron-builder': {
+                [targetName]: {
+                    dropPath,
+                    icon512: `src/${icon512}`,
+                    fullName,
+                    appId,
+                    publishUrl,
+                },
+            },
+            'electron-builder-pack': {
+                [targetName]: {
+                    dropPath: dropPath,
+                },
+            },
+            'unified-release-drop': {
+                [targetName]: {
+                    // empty on purpose
+                },
+            },
+        });
+    });
+
     targetNames.forEach(targetName => {
         const { config, bundleFolder } = targets[targetName];
 
@@ -295,6 +327,14 @@ module.exports = function(grunt) {
 
     grunt.registerMultiTask('configure', function() {
         const { config, configJSONPath, configJSPath } = this.data;
+
+        // We pass this as an option from a build variable not because it is a secret
+        // (it can be found easily enough from released builds), but to make it harder
+        // to accidentally pollute release telemetry with data from local builds.
+        if (grunt.option('app-insights-instrumentation-key')) {
+            config.options.appInsightsInstrumentationKey = grunt.option('app-insights-instrumentation-key');
+        }
+
         const configJSON = JSON.stringify(config, undefined, 4);
         grunt.file.write(configJSONPath, configJSON);
         const copyrightHeader = '// Copyright (c) Microsoft Corporation. All rights reserved.\n// Licensed under the MIT License.\n';
@@ -344,6 +384,61 @@ module.exports = function(grunt) {
         console.log(`${targetName} extension is in ${dropExtensionPath}`);
     });
 
+    grunt.registerMultiTask('configure-electron-builder', function() {
+        grunt.task.requires('drop:' + this.target);
+        const { dropPath, icon512, fullName, appId, publishUrl } = this.data;
+
+        const outElectronBuilderConfigFile = path.join(dropPath, 'electron-builder.yml');
+        const srcElectronBuilderConfigFile = path.join('src', 'electron', 'electron-builder', `electron-builder.template.yaml`);
+
+        const version = grunt.option('unified-version') || '0.0.0';
+
+        const config = grunt.file.readYAML(srcElectronBuilderConfigFile);
+        config.appId = appId;
+        config.directories.app = dropPath;
+        config.directories.output = `${dropPath}/packed`;
+        config.extraMetadata.version = version;
+        config.publish.url = publishUrl;
+        config.productName = fullName;
+        config.extraMetadata.name = fullName;
+        config.win.icon = icon512;
+        config.mac.icon = icon512;
+
+        const configFileContent = yaml.safeDump(config);
+        grunt.file.write(outElectronBuilderConfigFile, configFileContent);
+        grunt.log.writeln(`generated ${outElectronBuilderConfigFile} from target config`);
+    });
+
+    grunt.registerMultiTask('electron-builder-pack', function() {
+        grunt.task.requires('drop:' + this.target);
+        grunt.task.requires('configure-electron-builder:' + this.target);
+
+        const { dropPath } = this.data;
+        const configFile = path.join(dropPath, 'electron-builder.yml');
+
+        const taskDoneCallback = this.async();
+
+        grunt.util.spawn(
+            {
+                cmd: 'node',
+                args: ['node_modules/electron-builder/out/cli/cli.js', '-p', 'never', '-c', configFile],
+            },
+            (error, result, code) => {
+                if (error) {
+                    grunt.fail.fatal(`electron-builder exited with error code ${code}:\n\n${result.stdout}`, code);
+                }
+
+                taskDoneCallback();
+            },
+        );
+    });
+
+    grunt.registerMultiTask('unified-release-drop', function() {
+        grunt.task.run(`drop:${this.target}`);
+        grunt.task.run(`configure-electron-builder:${this.target}`);
+        grunt.task.run(`electron-builder-pack:${this.target}`);
+    });
+
     grunt.registerTask('package-report', function() {
         const mustExistPath = path.join(packageReportBundlePath, 'report.bundle.js');
 
@@ -355,9 +450,15 @@ module.exports = function(grunt) {
         console.log(`package is in ${packageReportDropPath}`);
     });
 
-    grunt.registerTask('release-drops', function() {
-        releaseTargets.forEach(targetName => {
+    grunt.registerTask('extension-release-drops', function() {
+        extensionReleaseTargets.forEach(targetName => {
             grunt.task.run('drop:' + targetName);
+        });
+    });
+
+    grunt.registerTask('unified-release-drops', function() {
+        unifiedReleaseTargets.forEach(targetName => {
+            grunt.task.run('unified-release-drop:' + targetName);
         });
     });
 
@@ -377,16 +478,15 @@ module.exports = function(grunt) {
         'exec:generate-scss-typings',
         'exec:webpack-electron',
         'build-assets',
-        'drop:electron',
+        'drop:unifiedDev',
     ]);
     grunt.registerTask('build-electron-all', [
         'clean:intermediates',
         'exec:generate-scss-typings',
         'exec:webpack-electron',
         'build-assets',
-        'drop:electron',
-        'drop:electronInsider',
-        'drop:electronProduction',
+        'drop:unifiedDev',
+        'unified-release-drops',
     ]);
     grunt.registerTask('build-package-report', [
         'clean:intermediates',
@@ -402,8 +502,8 @@ module.exports = function(grunt) {
         'concurrent:webpack-all',
         'build-assets',
         'drop:dev',
-        'drop:electron',
-        'release-drops',
+        'drop:unifiedDev',
+        'web-release-drops',
     ]);
 
     grunt.registerTask('default', ['build-dev']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -478,14 +478,14 @@ module.exports = function(grunt) {
         'exec:generate-scss-typings',
         'exec:webpack-electron',
         'build-assets',
-        'drop:unifiedDev',
+        'drop:electron',
     ]);
     grunt.registerTask('build-electron-all', [
         'clean:intermediates',
         'exec:generate-scss-typings',
         'exec:webpack-electron',
         'build-assets',
-        'drop:unifiedDev',
+        'drop:electron',
         'unified-release-drops',
     ]);
     grunt.registerTask('build-package-report', [
@@ -502,7 +502,7 @@ module.exports = function(grunt) {
         'concurrent:webpack-all',
         'build-assets',
         'drop:dev',
-        'drop:unifiedDev',
+        'drop:electron',
         'web-release-drops',
     ]);
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 appId: com.microsoft.accessibilityinsights
 directories:
-    app: drop/electron/unifiedDev
+    app: drop/electron/electron
     buildResources: src/electron/resources
 extraMetadata:
     main: product/bundle/main.bundle.js

--- a/src/electron/electron-builder/electron-builder.template.yaml
+++ b/src/electron/electron-builder/electron-builder.template.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # The TARGET_SPECIFIC placeholders in this template are filled in from targets.config.js during
-# "yarn build:electron:all" by the grunt generate-electron-builder-config task
+# "yarn build:electron:all" by the grunt configure-electron-builder task
 
 appId: TARGET_SPECIFIC
 

--- a/src/electron/electron-builder/electron-builder.template.yaml
+++ b/src/electron/electron-builder/electron-builder.template.yaml
@@ -1,12 +1,20 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-appId: com.microsoft.accessibilityinsights
+
+# The TARGET_SPECIFIC placeholders in this template are filled in from targets.config.js during
+# "yarn build:electron:all" by the grunt generate-electron-builder-config task
+
+appId: TARGET_SPECIFIC
+
 directories:
-    app: drop/electron/unifiedDev
+    app: TARGET_SPECIFIC
+    output: TARGET_SPECIFIC
     buildResources: src/electron/resources
+
 extraMetadata:
     main: product/bundle/main.bundle.js
-    name: Accessibility Insights for Android
+    name: TARGET_SPECIFIC
+    version: TARGET_SPECIFIC
 
 linux:
     artifactName: ${productName}.${ext}
@@ -14,13 +22,13 @@ linux:
 
 mac:
     artifactName: ${productName}.${ext}
-    icon: extension/icons/brand/blue/brand-blue-512px.png
+    icon: TARGET_SPECIFIC
     target: dmg # can be changed to a zip, app or something else. ref: https://www.electron.build/configuration/mac
     identity: null
 
 win:
     artifactName: ${productName} setup.${ext}
-    icon: extension/icons/brand/blue/brand-blue-512px.png
+    icon: TARGET_SPECIFIC
     publisherName: 'Microsoft Corporation'
     target: nsis
 
@@ -28,5 +36,6 @@ nsis:
     oneClick: true
     perMachine: false
     deleteAppDataOnUninstall: true
+
 publish:
     provider: generic

--- a/targets.config.js
+++ b/targets.config.js
@@ -95,7 +95,8 @@ module.exports = {
         bundleFolder: 'prodBundle',
         mustExistFile: 'background.bundle.js',
     },
-    unifiedDev: {
+    // to be changed later to unified-dev
+    electron: {
         config: {
             options: {
                 ...commonUnifiedOptions,
@@ -107,7 +108,7 @@ module.exports = {
         bundleFolder: 'electronBundle',
         mustExistFile: 'main.bundle.js',
     },
-    unifiedCanary: {
+    'unified-canary': {
         release: true,
         config: {
             options: {
@@ -123,7 +124,7 @@ module.exports = {
         appId: 'com.microsoft.accessibilityinsights',
         publishUrl: 'https://a11yinsightsandroidblob.blob.core.windows.net/aimobile-canary',
     },
-    unifiedInsider: {
+    'unified-insider': {
         release: true,
         config: {
             options: {
@@ -138,7 +139,7 @@ module.exports = {
         appId: 'com.microsoft.accessibilityinsights.unified.insider',
         publishUrl: 'https://a11yinsightsandroidblob-insiders.blob.core.windows.net/aimobile-insiders',
     },
-    unifiedProduction: {
+    'unified-production': {
         release: true,
         config: {
             options: {

--- a/targets.config.js
+++ b/targets.config.js
@@ -6,6 +6,7 @@ function iconSet(key) {
         icon16: `icons/brand/${key}/brand-${key}-16px.png`,
         icon48: `icons/brand/${key}/brand-${key}-48px.png`,
         icon128: `icons/brand/${key}/brand-${key}-128px.png`,
+        icon512: `icons/brand/${key}/brand-${key}-512px.png`,
     };
 }
 
@@ -17,32 +18,27 @@ const icons = {
     production: iconSet('blue'),
 };
 
-const commonOptions = {
+const commonExtensionOptions = {
     fullName: 'Accessibility Insights for Web',
     extensionDescription: 'Accessibility Insights for Web helps developers quickly find and fix accessibility issues.',
-    ...icons.production,
     bundled: true,
+    productCategory: 'extension',
 };
 
-const publicOptions = {
-    ...commonOptions,
-    requireSignInForPreviewFeatures: false,
-};
-
-const internalOptions = {
-    ...commonOptions,
-    requireSignInForPreviewFeatures: true,
+const commonUnifiedOptions = {
+    fullName: 'Accessibility Insights for Android',
+    bundled: true,
+    productCategory: 'electron',
 };
 
 module.exports = {
     dev: {
         config: {
             options: {
-                ...internalOptions,
+                ...commonExtensionOptions,
                 ...icons.dev,
                 fullName: 'Accessibility Insights for Web - Dev',
                 telemetryBuildName: 'Dev',
-                productCategory: 'extension',
             },
         },
         bundleFolder: 'devBundle',
@@ -52,11 +48,10 @@ module.exports = {
         release: true,
         config: {
             options: {
-                ...publicOptions,
+                ...commonExtensionOptions,
                 ...icons.playground,
                 fullName: 'Accessibility Insights for Web - Playground',
                 telemetryBuildName: 'Playground',
-                productCategory: 'extension',
             },
         },
         bundleFolder: 'devBundle',
@@ -66,11 +61,10 @@ module.exports = {
         release: true,
         config: {
             options: {
-                ...internalOptions,
+                ...commonExtensionOptions,
                 ...icons.canary,
                 fullName: 'Accessibility Insights for Web - Canary',
                 telemetryBuildName: 'Canary',
-                productCategory: 'extension',
             },
         },
         bundleFolder: 'devBundle',
@@ -80,11 +74,10 @@ module.exports = {
         release: true,
         config: {
             options: {
-                ...internalOptions,
+                ...commonExtensionOptions,
                 ...icons.insider,
                 fullName: 'Accessibility Insights for Web - Insider',
                 telemetryBuildName: 'Insider',
-                productCategory: 'extension',
             },
         },
         bundleFolder: 'prodBundle',
@@ -94,52 +87,70 @@ module.exports = {
         release: true,
         config: {
             options: {
-                ...internalOptions,
+                ...commonExtensionOptions,
                 ...icons.production,
                 telemetryBuildName: 'Production',
-                productCategory: 'extension',
             },
         },
         bundleFolder: 'prodBundle',
         mustExistFile: 'background.bundle.js',
     },
-    electron: {
+    unifiedDev: {
         config: {
             options: {
-                ...internalOptions,
+                ...commonUnifiedOptions,
                 ...icons.dev,
                 fullName: 'Accessibility Insights for Android - Dev',
                 telemetryBuildName: 'AI Android - Dev',
-                productCategory: 'electron',
             },
         },
         bundleFolder: 'electronBundle',
         mustExistFile: 'main.bundle.js',
     },
-    electronInsider: {
+    unifiedCanary: {
+        release: true,
         config: {
             options: {
-                ...internalOptions,
-                ...icons.dev,
+                ...commonUnifiedOptions,
+                ...icons.canary,
+                fullName: 'Accessibility Insights for Android - Canary',
+                telemetryBuildName: 'AI Android - Canary',
+            },
+        },
+        bundleFolder: 'electronBundle',
+        mustExistFile: 'main.bundle.js',
+        // Note: this non-canary-looking appId is intentional for backcompat
+        appId: 'com.microsoft.accessibilityinsights',
+        publishUrl: 'https://a11yinsightsandroidblob.blob.core.windows.net/aimobile-canary',
+    },
+    unifiedInsider: {
+        release: true,
+        config: {
+            options: {
+                ...commonUnifiedOptions,
+                ...icons.insider,
                 fullName: 'Accessibility Insights for Android - Insider',
                 telemetryBuildName: 'AI Android - Insider',
-                productCategory: 'electron',
             },
         },
         bundleFolder: 'electronBundle',
         mustExistFile: 'main.bundle.js',
+        appId: 'com.microsoft.accessibilityinsights.unified.insider',
+        publishUrl: 'https://a11yinsightsandroidblob-insiders.blob.core.windows.net/aimobile-insiders',
     },
-    electronProduction: {
+    unifiedProduction: {
+        release: true,
         config: {
             options: {
-                ...internalOptions,
-                ...icons.dev,
+                ...commonUnifiedOptions,
+                ...icons.production,
                 fullName: 'Accessibility Insights for Android',
                 telemetryBuildName: 'AI Android - Production',
-                productCategory: 'electron',
             },
         },
         bundleFolder: 'electronBundle',
         mustExistFile: 'main.bundle.js',
+        appId: 'com.microsoft.accessibilityinsights.unified.production',
+        publishUrl: 'https://a11yinsightsandroidblob-production.blob.core.windows.net/aimobile-production',
     },
 };


### PR DESCRIPTION
#### Description of changes

This PR is part 1 of a series of PRs that will be updating the build machinery for our unified/electron/android releases to allow for multiple channels. This PR implements new behavior that will be used by unsigned release builds in future PRs:

```sh
yarn build:electron:all --unified-version=1.2.3 --app-insights-instrumentation-key=key`
```

This will produce a directory structure like the following:

```
drop/
    electron/
        electron/
            <unchanged; leaving rename of this to unified-dev for separate PR>
        unified-canary/
            packed/
                Accessibility Insights for Android - Canary setup.exe
                <or dmg/AppImage, depending on the build agent platform>
                latest.yml
        unified-insider/
            packed/
                Accessibility Insights for Android - Insider setup.exe
                latest.yml
        unified-production/
            packed/
                Accessibility Insights for Android setup.exe
                latest.yml
```

...with the version number and telemetry key from build number/variable injected in the appropriate places.

**Out of scope**/leaving for later PRs:
* renaming the existing `/drop/electron/electron/` folder or existing yarn commands
* removing grunt machinery for the existing form of canary build (will be done later after we switch builds over)
* adding pipelines to consume the new grunt machinery

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1662071
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
