### PR TITLE
fix: fixing missing wcag links in generated report via report package

### DIFF
--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -16,6 +16,7 @@ import { DocumentUtils } from 'scanner/document-utils';
 import { HelpUrlGetter } from 'scanner/help-url-getter';
 import { MessageDecorator } from 'scanner/message-decorator';
 import { ResultDecorator } from 'scanner/result-decorator';
+import { ruleToLinkConfiguration } from 'scanner/rule-to-links-mappings';
 import { FixInstructionProcessor } from '../../common/components/fix-instruction-processor';
 import { getPropertyConfiguration } from '../../common/configs/unified-result-property-configurations';
 import { DateProvider } from '../../common/date-provider';
@@ -70,6 +71,7 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
     const helpUrlGetter = new HelpUrlGetter(configuration);
     const resultDecorator = new ResultDecorator(titleProvider, messageDecorator, (ruleId, axeHelpUrl) =>
         helpUrlGetter.getHelpUrl(ruleId, axeHelpUrl),
+        ruleToLinkConfiguration,
     );
 
     const deps: AxeResultsReportDeps = {

--- a/src/reports/package/root/package.json
+++ b/src/reports/package/root/package.json
@@ -15,6 +15,7 @@
         "office-ui-fabric-react": "7.83.1",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",
+        "react-helmet": "^5.2.0",
         "uuid": "^3.4.0"
     }
 }

--- a/src/scanner/exposed-apis.ts
+++ b/src/scanner/exposed-apis.ts
@@ -36,6 +36,7 @@ export let scan = (
         documentUtils,
         messageDecorator,
         (ruleId, axeHelpUrl) => helpUrlGetter.getHelpUrl(ruleId, axeHelpUrl),
+        ruleToLinkConfiguration,
     );
     const launcher = new Launcher(axe, scanParameterGenerator, document, options);
     const axeResponseHandler = new AxeResponseHandler(
@@ -43,8 +44,6 @@ export let scan = (
         errorCallback,
         resultDecorator,
     );
-
-    resultDecorator.setRuleToLinksConfiguration(ruleToLinkConfiguration);
     launcher.runScan(axeResponseHandler);
 };
 

--- a/src/scanner/result-decorator.ts
+++ b/src/scanner/result-decorator.ts
@@ -13,7 +13,7 @@ export class ResultDecorator {
     constructor(
         private readonly documentUtils: DocumentUtils,
         private readonly messageDecorator: MessageDecorator,
-        private getHelpUrl: (ruleId: string, axeHelpUrl: string) => string,
+        private readonly getHelpUrl: (ruleId: string, axeHelpUrl: string) => string,
         private readonly ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]>,
     ) {}
 

--- a/src/scanner/result-decorator.ts
+++ b/src/scanner/result-decorator.ts
@@ -10,18 +10,12 @@ import { MessageDecorator } from './message-decorator';
 import { Processor } from './processor';
 
 export class ResultDecorator {
-    private ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]>;
-    private documentUtils: DocumentUtils;
-    private messageDecorator: MessageDecorator;
-
     constructor(
-        documentUtils: DocumentUtils,
-        messageDecorator: MessageDecorator,
+        private readonly documentUtils: DocumentUtils,
+        private readonly messageDecorator: MessageDecorator,
         private getHelpUrl: (ruleId: string, axeHelpUrl: string) => string,
-    ) {
-        this.documentUtils = documentUtils;
-        this.messageDecorator = messageDecorator;
-    }
+        private readonly ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]>,
+    ) {}
 
     public decorateResults(results: Axe.AxeResults): ScanResults {
         const scanResults: ScanResults = {
@@ -63,11 +57,5 @@ export class ResultDecorator {
         }
 
         return this.ruleToLinkConfiguration[ruleId];
-    }
-
-    public setRuleToLinksConfiguration(
-        configuration: DictionaryStringTo<HyperlinkDefinition[]>,
-    ): void {
-        this.ruleToLinkConfiguration = configuration;
     }
 }

--- a/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
@@ -670,7 +670,19 @@ exports[`report package integration with issues 1`] = `
                       More information about bypass
                     </a>
                   </span>
-                  <span />
+                  <span>
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks"
+                        target="_blank"
+                      >
+                        WCAG 2.4.1
+                      </a>
+                    </span>
+                  </span>
                 </div>
                 <ul
                   aria-label="failed instances with path, snippet and how to fix information"
@@ -875,7 +887,19 @@ exports[`report package integration with issues 1`] = `
                       More information about color-contrast
                     </a>
                   </span>
-                  <span />
+                  <span>
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html"
+                        target="_blank"
+                      >
+                        WCAG 1.4.3
+                      </a>
+                    </span>
+                  </span>
                 </div>
                 <ul
                   aria-label="failed instances with path, snippet and how to fix information"
@@ -1411,7 +1435,19 @@ exports[`report package integration with issues 1`] = `
                       More information about html-has-lang
                     </a>
                   </span>
-                  <span />
+                  <span>
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html"
+                        target="_blank"
+                      >
+                        WCAG 3.1.1
+                      </a>
+                    </span>
+                  </span>
                 </div>
                 <ul
                   aria-label="failed instances with path, snippet and how to fix information"
@@ -1610,7 +1646,19 @@ exports[`report package integration with issues 1`] = `
                       More information about image-alt
                     </a>
                   </span>
-                  <span />
+                  <span>
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
+                        target="_blank"
+                      >
+                        WCAG 1.1.1
+                      </a>
+                    </span>
+                  </span>
                 </div>
                 <ul
                   aria-label="failed instances with path, snippet and how to fix information"
@@ -2106,7 +2154,29 @@ exports[`report package integration with issues 1`] = `
                       More information about label
                     </a>
                   </span>
-                  <span />
+                  <span>
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html"
+                        target="_blank"
+                      >
+                        WCAG 3.3.2
+                      </a>
+                    </span>
+                  </span>
                 </div>
                 <ul
                   aria-label="failed instances with path, snippet and how to fix information"
@@ -3409,7 +3479,18 @@ exports[`report package integration with issues 1`] = `
                       More information about landmark-one-main
                     </a>
                   </span>
-                  <span />
+                  <span>
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                  </span>
                 </div>
                 <ul
                   aria-label="failed instances with path, snippet and how to fix information"
@@ -3608,7 +3689,18 @@ exports[`report package integration with issues 1`] = `
                       More information about page-has-heading-one
                     </a>
                   </span>
-                  <span />
+                  <span>
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                  </span>
                 </div>
                 <ul
                   aria-label="failed instances with path, snippet and how to fix information"
@@ -3807,7 +3899,18 @@ exports[`report package integration with issues 1`] = `
                       More information about region
                     </a>
                   </span>
-                  <span />
+                  <span>
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                  </span>
                 </div>
                 <ul
                   aria-label="failed instances with path, snippet and how to fix information"
@@ -4014,7 +4117,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures aria-hidden='true' is not present on the document body.
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4042,7 +4157,26 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensure that text spacing set through style attributes can be adjusted with custom stylesheets
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html"
+                        target="_blank"
+                      >
+                        WCAG 1.4.12
+                      </a>
+                    </span>
+                    )
+                    <span
+                      class="guidance-tags"
+                    >
+                      <span>
+                        New for WCAG 2.1
+                      </span>
+                    </span>
                   </div>
                 </div>
                 <div
@@ -4070,7 +4204,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures related &lt;input type="checkbox"&gt; elements have a group and that the group designation is consistent
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4098,7 +4243,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html"
+                        target="_blank"
+                      >
+                        WCAG 1.4.3
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4126,7 +4283,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures each HTML document contains a non-empty &lt;title&gt; element
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html"
+                        target="_blank"
+                      >
+                        WCAG 2.4.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4154,7 +4323,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures every id attribute value of active elements is unique
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4182,7 +4363,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures every id attribute value is unique
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4210,7 +4403,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures form field does not have multiple label elements
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4238,7 +4442,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;img&gt; elements have alternate text or a role of none or presentation
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
+                        target="_blank"
+                      >
+                        WCAG 1.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4266,7 +4482,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensure image alternative is not repeated as text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4294,7 +4521,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures input buttons have discernible text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4322,7 +4561,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures that every form element is not solely labeled using the title or aria-describedby attributes
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4350,7 +4600,28 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures the document has at most one banner landmark
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4378,7 +4649,28 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures the document has at most one contentinfo landmark
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4406,7 +4698,29 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures links have discernible text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html"
+                        target="_blank"
+                      >
+                        WCAG 2.4.4
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4434,7 +4748,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures that lists are structured correctly
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4462,7 +4788,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;li&gt; elements are used semantically
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4490,7 +4828,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensure that tables do not have the same summary and caption
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4518,7 +4867,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensure that each cell in a table using the headers refers to another cell in that table
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4546,7 +4907,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensure that each table header in a data table refers to data cells
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
               </div>
@@ -4672,7 +5045,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures every accesskey attribute value is unique
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html"
+                        target="_blank"
+                      >
+                        WCAG 2.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4700,7 +5085,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;area&gt; elements of image maps have alternate text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
+                        target="_blank"
+                      >
+                        WCAG 1.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4728,7 +5125,29 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures ARIA attributes are allowed for an element's role
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4756,7 +5175,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures role attribute has an appropriate value for the element
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4784,7 +5214,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures unsupported DPUB roles are only used on elements with implicit fallback roles
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4812,7 +5253,29 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures aria-hidden elements do not contain focusable elements
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4840,7 +5303,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures every ARIA input field has an accessible name
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4868,7 +5343,29 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures elements with ARIA roles have all required ARIA attributes
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4896,7 +5393,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures elements with an ARIA role that require child roles contain them
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4924,7 +5433,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures elements with an ARIA role that require parent roles are contained by them
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4952,7 +5473,39 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures all elements with a role attribute use a valid value
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -4980,7 +5533,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures every ARIA toggle field has an accessible name
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5008,7 +5573,29 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures all ARIA attributes have valid values
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5036,7 +5623,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures attributes that begin with aria- are valid ARIA attributes
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5064,7 +5663,26 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensure the autocomplete attribute is correct and suitable for the form field
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html"
+                        target="_blank"
+                      >
+                        WCAG 1.3.5
+                      </a>
+                    </span>
+                    )
+                    <span
+                      class="guidance-tags"
+                    >
+                      <span>
+                        New for WCAG 2.1
+                      </span>
+                    </span>
                   </div>
                 </div>
                 <div
@@ -5092,7 +5710,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;blink&gt; elements are not used
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide"
+                        target="_blank"
+                      >
+                        WCAG 2.2.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5120,7 +5750,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures buttons have discernible text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5148,7 +5790,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;dl&gt; elements are structured correctly
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5176,7 +5830,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;dt&gt; and &lt;dd&gt; elements are contained by a &lt;dl&gt;
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5204,7 +5870,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures every id attribute value used in ARIA and in labels is unique
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5232,7 +5910,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures headings have discernible text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5260,7 +5949,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;iframe&gt; and &lt;frame&gt; elements contain the axe-core script
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5288,7 +5988,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;iframe&gt; and &lt;frame&gt; elements contain a unique title attribute
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5316,7 +6027,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;iframe&gt; and &lt;frame&gt; elements contain a non-empty title attribute
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks"
+                        target="_blank"
+                      >
+                        WCAG 2.4.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5344,7 +6067,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures the order of headings is semantically correct
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5372,7 +6106,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures the lang attribute of the &lt;html&gt; element has a valid value
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html"
+                        target="_blank"
+                      >
+                        WCAG 3.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5400,7 +6146,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html"
+                        target="_blank"
+                      >
+                        WCAG 3.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5428,7 +6186,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;input type="image"&gt; elements have alternate text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
+                        target="_blank"
+                      >
+                        WCAG 1.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5456,7 +6226,28 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures the banner landmark is at top level
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5484,7 +6275,28 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures the complementary landmark or aside is at top level
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5512,7 +6324,28 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures the contentinfo landmark is at top level
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5540,7 +6373,28 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures the main landmark is at top level
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5568,7 +6422,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Landmarks must have a unique role or role/label/title (i.e. accessible name) combination
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5596,7 +6461,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures presentational &lt;table&gt; elements do not use &lt;th&gt;, &lt;caption&gt; elements or the summary attribute
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5624,7 +6501,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;marquee&gt; elements are not used
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide"
+                        target="_blank"
+                      >
+                        WCAG 2.2.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5652,7 +6541,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;meta http-equiv="refresh"&gt; is not used
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html"
+                        target="_blank"
+                      >
+                        WCAG 2.2.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5680,7 +6581,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;meta name="viewport"&gt; can scale a significant amount
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5708,7 +6620,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;meta name="viewport"&gt; does not disable text scaling and zooming
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html"
+                        target="_blank"
+                      >
+                        WCAG 1.4.4
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5736,7 +6660,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;object&gt; elements have alternate text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
+                        target="_blank"
+                      >
+                        WCAG 1.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5764,7 +6700,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures related &lt;input type="radio"&gt; elements have a group and that the group designation is consistent
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5792,7 +6739,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures [role='img'] elements have alternate text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
+                        target="_blank"
+                      >
+                        WCAG 1.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5820,7 +6779,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures the scope attribute is used correctly on tables
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5848,7 +6818,28 @@ exports[`report package integration with issues 1`] = `
                     >
                       Elements that have scrollable content should be accessible by keyboard
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html"
+                        target="_blank"
+                      >
+                        WCAG 2.1.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5876,7 +6867,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures that server-side image maps are not used
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html"
+                        target="_blank"
+                      >
+                        WCAG 2.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5904,7 +6907,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensure all skip links have a focusable target
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5932,7 +6946,18 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures tabindex attribute values are not greater than 0
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5960,7 +6985,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures lang attributes have valid values
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html"
+                        target="_blank"
+                      >
+                        WCAG 3.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -5988,7 +7025,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;video&gt; elements have captions
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html"
+                        target="_blank"
+                      >
+                        WCAG 1.2.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -6016,7 +7065,19 @@ exports[`report package integration with issues 1`] = `
                     >
                       Ensures &lt;video&gt; elements have audio descriptions
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/audio-description-prerecorded"
+                        target="_blank"
+                      >
+                        WCAG 1.2.5
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
               </div>
@@ -6735,7 +7796,29 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures ARIA attributes are allowed for an element's role
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -6763,7 +7846,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures role attribute has an appropriate value for the element
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -6791,7 +7885,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures aria-hidden='true' is not present on the document body.
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -6819,7 +7925,29 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures elements with ARIA roles have all required ARIA attributes
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -6847,7 +7975,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures elements with an ARIA role that require child roles contain them
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -6875,7 +8015,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures elements with an ARIA role that require parent roles are contained by them
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -6903,7 +8055,39 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures all elements with a role attribute use a valid value
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -6931,7 +8115,29 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures all ARIA attributes have valid values
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -6959,7 +8165,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures attributes that begin with aria- are valid ARIA attributes
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -6987,7 +8205,26 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensure that text spacing set through style attributes can be adjusted with custom stylesheets
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/text-spacing.html"
+                        target="_blank"
+                      >
+                        WCAG 1.4.12
+                      </a>
+                    </span>
+                    )
+                    <span
+                      class="guidance-tags"
+                    >
+                      <span>
+                        New for WCAG 2.1
+                      </span>
+                    </span>
                   </div>
                 </div>
                 <div
@@ -7015,7 +8252,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures buttons have discernible text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7043,7 +8292,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures each page has at least one mechanism for a user to bypass navigation and jump straight to the content
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks"
+                        target="_blank"
+                      >
+                        WCAG 2.4.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7071,7 +8332,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures related &lt;input type="checkbox"&gt; elements have a group and that the group designation is consistent
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7099,7 +8371,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures the contrast between foreground and background colors meets WCAG 2 AA contrast ratio thresholds
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html"
+                        target="_blank"
+                      >
+                        WCAG 1.4.3
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7127,7 +8411,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures each HTML document contains a non-empty &lt;title&gt; element
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html"
+                        target="_blank"
+                      >
+                        WCAG 2.4.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7155,7 +8451,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures every id attribute value of active elements is unique
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7183,7 +8491,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures every id attribute value used in ARIA and in labels is unique
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7211,7 +8531,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures every id attribute value is unique
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/parsing.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7239,7 +8571,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures headings have discernible text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7267,7 +8610,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures form field does not have multiple label elements
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7295,7 +8649,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures the order of headings is semantically correct
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7323,7 +8688,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures every HTML document has a lang attribute
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html"
+                        target="_blank"
+                      >
+                        WCAG 3.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7351,7 +8728,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures the lang attribute of the &lt;html&gt; element has a valid value
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html"
+                        target="_blank"
+                      >
+                        WCAG 3.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7379,7 +8768,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;img&gt; elements have alternate text or a role of none or presentation
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
+                        target="_blank"
+                      >
+                        WCAG 1.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7407,7 +8808,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensure image alternative is not repeated as text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7435,7 +8847,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures input buttons have discernible text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7463,7 +8887,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures that every form element is not solely labeled using the title or aria-describedby attributes
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7491,7 +8926,29 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures every form element has a label
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html"
+                        target="_blank"
+                      >
+                        WCAG 3.3.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7519,7 +8976,28 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures the banner landmark is at top level
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7547,7 +9025,28 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures the contentinfo landmark is at top level
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7575,7 +9074,28 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures the main landmark is at top level
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7603,7 +9123,28 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures the document has at most one banner landmark
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7631,7 +9172,28 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures the document has at most one contentinfo landmark
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7659,7 +9221,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures the document has only one main landmark and each iframe in the page has at most one main landmark
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7687,7 +9260,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Landmarks must have a unique role or role/label/title (i.e. accessible name) combination
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7715,7 +9299,29 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures links have discernible text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html"
+                        target="_blank"
+                      >
+                        WCAG 2.4.4
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7743,7 +9349,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures that lists are structured correctly
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7771,7 +9389,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;li&gt; elements are used semantically
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7799,7 +9429,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensure that the page, or at least one of its frames contains a level-one heading
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7827,7 +9468,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures all page content is contained by landmarks
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7855,7 +9507,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures the scope attribute is used correctly on tables
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7883,7 +9546,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensure that tables do not have the same summary and caption
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7911,7 +9585,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensure that each cell in a table using the headers refers to another cell in that table
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7939,7 +9625,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensure that each table header in a data table refers to data cells
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -7967,7 +9665,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures lang attributes have valid values
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html"
+                        target="_blank"
+                      >
+                        WCAG 3.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
               </div>
@@ -8093,7 +9803,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures every accesskey attribute value is unique
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html"
+                        target="_blank"
+                      >
+                        WCAG 2.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8121,7 +9843,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;area&gt; elements of image maps have alternate text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
+                        target="_blank"
+                      >
+                        WCAG 1.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8149,7 +9883,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures unsupported DPUB roles are only used on elements with implicit fallback roles
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8177,7 +9922,29 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures aria-hidden elements do not contain focusable elements
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8205,7 +9972,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures every ARIA input field has an accessible name
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8233,7 +10012,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures every ARIA toggle field has an accessible name
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html"
+                        target="_blank"
+                      >
+                        WCAG 4.1.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8261,7 +10052,26 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensure the autocomplete attribute is correct and suitable for the form field
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html"
+                        target="_blank"
+                      >
+                        WCAG 1.3.5
+                      </a>
+                    </span>
+                    )
+                    <span
+                      class="guidance-tags"
+                    >
+                      <span>
+                        New for WCAG 2.1
+                      </span>
+                    </span>
                   </div>
                 </div>
                 <div
@@ -8289,7 +10099,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;blink&gt; elements are not used
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide"
+                        target="_blank"
+                      >
+                        WCAG 2.2.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8317,7 +10139,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;dl&gt; elements are structured correctly
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8345,7 +10179,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;dt&gt; and &lt;dd&gt; elements are contained by a &lt;dl&gt;
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8373,7 +10219,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;iframe&gt; and &lt;frame&gt; elements contain the axe-core script
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8401,7 +10258,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;iframe&gt; and &lt;frame&gt; elements contain a unique title attribute
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8429,7 +10297,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;iframe&gt; and &lt;frame&gt; elements contain a non-empty title attribute
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks"
+                        target="_blank"
+                      >
+                        WCAG 2.4.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8457,7 +10337,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensure that HTML elements with both valid lang and xml:lang attributes agree on the base language of the page
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html"
+                        target="_blank"
+                      >
+                        WCAG 3.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8485,7 +10377,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;input type="image"&gt; elements have alternate text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
+                        target="_blank"
+                      >
+                        WCAG 1.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8513,7 +10417,28 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures the complementary landmark or aside is at top level
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8541,7 +10466,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures presentational &lt;table&gt; elements do not use &lt;th&gt;, &lt;caption&gt; elements or the summary attribute
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
+                        target="_blank"
+                      >
+                        WCAG 1.3.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8569,7 +10506,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;marquee&gt; elements are not used
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/pause-stop-hide"
+                        target="_blank"
+                      >
+                        WCAG 2.2.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8597,7 +10546,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;meta http-equiv="refresh"&gt; is not used
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable.html"
+                        target="_blank"
+                      >
+                        WCAG 2.2.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8625,7 +10586,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;meta name="viewport"&gt; can scale a significant amount
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8653,7 +10625,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;meta name="viewport"&gt; does not disable text scaling and zooming
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html"
+                        target="_blank"
+                      >
+                        WCAG 1.4.4
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8681,7 +10665,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;object&gt; elements have alternate text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
+                        target="_blank"
+                      >
+                        WCAG 1.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8709,7 +10705,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures related &lt;input type="radio"&gt; elements have a group and that the group designation is consistent
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8737,7 +10744,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures [role='img'] elements have alternate text
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
+                        target="_blank"
+                      >
+                        WCAG 1.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8765,7 +10784,28 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Elements that have scrollable content should be accessible by keyboard
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html"
+                        target="_blank"
+                      >
+                        WCAG 2.1.1
+                      </a>
+                      <span>
+                        , 
+                      </span>
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8793,7 +10833,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures that server-side image maps are not used
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/keyboard.html"
+                        target="_blank"
+                      >
+                        WCAG 2.1.1
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8821,7 +10873,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensure all skip links have a focusable target
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8849,7 +10912,18 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures tabindex attribute values are not greater than 0
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <button
+                        class="ms-Link insights-link root-000"
+                        type="button"
+                      >
+                        BEST PRACTICE
+                      </button>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8877,7 +10951,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;video&gt; elements have captions
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html"
+                        target="_blank"
+                      >
+                        WCAG 1.2.2
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
                 <div
@@ -8905,7 +10991,19 @@ exports[`report package integration with no issues 1`] = `
                     >
                       Ensures &lt;video&gt; elements have audio descriptions
                     </span>
-                     ()
+                     (
+                    <span
+                      class="guidance-links"
+                    >
+                      <a
+                        class="ms-Link insights-link root-000"
+                        href="https://www.w3.org/WAI/WCAG21/Understanding/audio-description-prerecorded"
+                        target="_blank"
+                      >
+                        WCAG 1.2.5
+                      </a>
+                    </span>
+                    )
                   </div>
                 </div>
               </div>

--- a/src/tests/unit/tests/scanner/result-decorator.test.ts
+++ b/src/tests/unit/tests/scanner/result-decorator.test.ts
@@ -48,13 +48,22 @@ describe('ResultDecorator', () => {
 
     describe('constructor', () => {
         it('should construct the generator', () => {
-            const resultDecorator = new ResultDecorator(documentUtilsMock.object, messageDecoratorMock.object, getHelpUrlMock.object);
+            const guidanceLink = {} as any;
+            const configuration = {
+                'test-rule': [guidanceLink],
+            };
+            const resultDecorator = new ResultDecorator(
+                documentUtilsMock.object,
+                messageDecoratorMock.object,
+                getHelpUrlMock.object,
+                configuration,
+            );
             expect(resultDecorator).not.toBeNull();
         });
     });
 
     describe('decorateResults: w/ no configuration', () => {
-        it('should return without guidace links', () => {
+        it('should return without guidance links', () => {
             const scanResultInstance: RuleResult = {
                 ...instanceStub,
                 guidanceLinks: null,
@@ -87,7 +96,12 @@ describe('ResultDecorator', () => {
                 })
                 .verifiable();
 
-            const testSubject = new ResultDecorator(documentUtilsMock.object, messageDecoratorMock.object, getHelpUrlMock.object);
+            const testSubject = new ResultDecorator(
+                documentUtilsMock.object,
+                messageDecoratorMock.object,
+                getHelpUrlMock.object,
+                undefined,
+            );
             let decoratedResult;
             GlobalScope.using(suppressChecksByMessagesMock).with(() => {
                 decoratedResult = testSubject.decorateResults(nonEmptyResultStub);
@@ -100,13 +114,13 @@ describe('ResultDecorator', () => {
         });
     });
 
-    describe('decorateResults: w/ setRuleToLinksConfiguration', () => {
+    describe('decorateResults: with ruleToLinksConfiguration', () => {
         it('should call success callback with correct result', () => {
             const guidanceLink = {} as any;
             const configuration = {
                 'test-rule': [guidanceLink],
             };
-            const resultStubWithGuidacenLinks = {
+            const resultStubWithGuidanceLinks = {
                 passes: [],
                 violations: [
                     {
@@ -141,14 +155,18 @@ describe('ResultDecorator', () => {
                 })
                 .verifiable();
 
-            const testSubject = new ResultDecorator(documentUtilsMock.object, messageDecoratorMock.object, getHelpUrlMock.object);
+            const testSubject = new ResultDecorator(
+                documentUtilsMock.object,
+                messageDecoratorMock.object,
+                getHelpUrlMock.object,
+                configuration,
+            );
             let decoratedResult;
-            testSubject.setRuleToLinksConfiguration(configuration);
             GlobalScope.using(suppressChecksByMessagesMock).with(() => {
                 decoratedResult = testSubject.decorateResults(nonEmptyResultStub);
             });
 
-            expect(decoratedResult).toEqual(resultStubWithGuidacenLinks);
+            expect(decoratedResult).toEqual(resultStubWithGuidanceLinks);
             suppressChecksByMessagesMock.verifyAll();
             documentUtilsMock.verifyAll();
             messageDecoratorMock.verifyAll();
@@ -171,26 +189,26 @@ describe('ResultDecorator', () => {
                 targetPageTitle: 'test title',
                 url: 'https://test_url',
             };
-            const guidaceLinkStub = {} as any;
+            const guidanceLinkStub = {} as any;
             const configuration = {
-                'test-rule': [guidaceLinkStub],
-                'test-inapplicable-rule': [guidaceLinkStub],
+                'test-rule': [guidanceLinkStub],
+                'test-inapplicable-rule': [guidanceLinkStub],
             };
-            const resultStubWithGuidacenLinks = {
+            const resultStubWithGuidanceLinks = {
                 passes: [],
                 violations: [
                     {
                         id: 'test-rule',
                         nodes: [nodeStub],
                         description: null,
-                        guidanceLinks: [guidaceLinkStub],
+                        guidanceLinks: [guidanceLinkStub],
                         helpUrl: urlStub,
                     },
                 ],
                 inapplicable: [
                     {
                         ...inapplicableInstance,
-                        guidanceLinks: [guidaceLinkStub],
+                        guidanceLinks: [guidanceLinkStub],
                         helpUrl: urlStub,
                     },
                 ],
@@ -228,14 +246,18 @@ describe('ResultDecorator', () => {
                 })
                 .verifiable();
 
-            const testSubject = new ResultDecorator(documentUtilsMock.object, messageDecoratorMock.object, getHelpUrlMock.object);
+            const testSubject = new ResultDecorator(
+                documentUtilsMock.object,
+                messageDecoratorMock.object,
+                getHelpUrlMock.object,
+                configuration,
+            );
             let decoratedResult;
-            testSubject.setRuleToLinksConfiguration(configuration);
             GlobalScope.using(suppressChecksByMessagesMock).with(() => {
                 decoratedResult = testSubject.decorateResults(nonEmptyResultWithInapplicable as any);
             });
 
-            expect(decoratedResult).toEqual(resultStubWithGuidacenLinks);
+            expect(decoratedResult).toEqual(resultStubWithGuidanceLinks);
             suppressChecksByMessagesMock.verifyAll();
             documentUtilsMock.verifyAll();
             messageDecoratorMock.verifyAll();
@@ -275,9 +297,13 @@ describe('ResultDecorator', () => {
                 })
                 .verifiable();
 
-            const testSubject = new ResultDecorator(documentUtilsMock.object, messageDecoratorMock.object, getHelpUrlMock.object);
+            const testSubject = new ResultDecorator(
+                documentUtilsMock.object,
+                messageDecoratorMock.object,
+                getHelpUrlMock.object,
+                configuration,
+            );
             let decoratedResult;
-            testSubject.setRuleToLinksConfiguration(configuration);
             GlobalScope.using(suppressChecksByMessagesMock).with(() => {
                 decoratedResult = testSubject.decorateResults(nonEmptyResultStub);
             });


### PR DESCRIPTION
#### Description of changes
This PR fixes a bug in html report generation using the npm report package. The WCAG links were missing.

(ruleToLinkConfiguration in resultDecorator object was undefined when using it in report package)

Added react-helmet as a dependency for report package, since this change made the output js file to take dependency on react-helmet.
 
![image](https://user-images.githubusercontent.com/29855291/72654151-1f5cf800-3943-11ea-8ff3-b0bd47730c63.png)

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
