### PR TITLE
feat(unified-channels): Add pipeline definitions for the new unsigned/signed builds

### DIFF
--- a/pipeline/electron/build-unsigned-release-packages.yaml
+++ b/pipeline/electron/build-unsigned-release-packages.yaml
@@ -8,6 +8,7 @@ variables:
     windowsVmImage: 'windows-latest'
     macVmImage: 'macOS-10.14'
     linuxVmImage: 'ubuntu-16.04'
+    AppInsightsInstrumentationKey: 'SET_THIS_IN_AZURE_DEVOPS'
 
 strategy:
     matrix:
@@ -23,7 +24,7 @@ steps:
 
     - template: download-electron-mirror.yaml
 
-    - script: yarn build:electron:all --unifiedVersion=$(Build.BuildNumber)
+    - script: yarn build:electron:all --unified-version=$(Build.BuildNumber) --app-insights-instrumentation-key=$(AppInsightsInstrumentationKey)
       displayName: yarn build:electron:all
 
     - template: publish-packed-build-output.yaml

--- a/pipeline/electron/build-unsigned-release-packages.yaml
+++ b/pipeline/electron/build-unsigned-release-packages.yaml
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Note: this will become the version of the released packages!
+name: $(Year:yyyy).$(Month)$(Day:dd).$(Rev:r)
+
+variables:
+    windowsVmImage: 'windows-latest'
+    macVmImage: 'macOS-10.14'
+    linuxVmImage: 'ubuntu-16.04'
+
+strategy:
+    matrix:
+        windows: { vmImage: $(windowsVmImage), platform: 'windows' }
+        mac: { vmImage: $(macVmImage), platform: 'mac' }
+        linux: { vmImage: $(linuxVmImage), platform: 'linux' }
+
+pool:
+    vmImage: $(vmImage)
+
+steps:
+    - template: ../install-node-prerequisites.yaml
+
+    - template: download-electron-mirror.yaml
+
+    - script: yarn build:electron:all --unifiedVersion=$(Build.BuildNumber)
+      displayName: yarn build:electron:all
+
+    - template: publish-packed-build-output.yaml
+      parameters:
+          packedOutputPath: '$(System.DefaultWorkingDirectory)/drop/electron/unified-canary/packed'
+          artifactName: unified-$(platform)-canary-unsigned
+
+    - template: publish-packed-build-output.yaml
+      parameters:
+          packedOutputPath: '$(System.DefaultWorkingDirectory)/drop/electron/unified-insider/packed'
+          artifactName: unified-$(platform)-insider-unsigned
+
+    - template: publish-packed-build-output.yaml
+      parameters:
+          packedOutputPath: '$(System.DefaultWorkingDirectory)/drop/electron/unified-production/packed'
+          artifactName: unified-$(platform)-production-unsigned
+
+    - template: electron-e2e-test-interactive.yaml
+    - template: electron-e2e-publish-results.yaml

--- a/pipeline/electron/publish-packed-build-output.yaml
+++ b/pipeline/electron/publish-packed-build-output.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    packedOutputPath: null
+    artifactName: null
+
+steps:
+    - task: CopyFiles@2
+      displayName: 'copy package files to upload'
+      inputs:
+          SourceFolder: $(packedOutputPath)
+          Contents: |
+              latest*.yml
+              Accessibility Insights for Android*.*
+          TargetFolder: '$(System.ArtifactStagingDirectory)/$(artifactName)'
+          CleanTargetFolder: true
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+          pathtoPublish: '$(System.ArtifactStagingDirectory)/$(artifactName)'
+          artifactName: $(artifactName)
+      displayName: publish artifact $(artifactName)

--- a/pipeline/electron/publish-signed-release-package.yaml
+++ b/pipeline/electron/publish-signed-release-package.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    artifactName: null
+
+steps:
+    - script: yarn update:electron-checksum
+      displayName: update electron checksum after signing
+
+    - task: PublishBuildArtifacts@1
+      inputs:
+          pathtoPublish: '$(System.DefaultWorkingDirectory)/dist'
+          artifactName: $(artifactName)
+      displayName: publish dist

--- a/pipeline/electron/sign-release-package-linux.yaml
+++ b/pipeline/electron/sign-release-package-linux.yaml
@@ -8,7 +8,7 @@ parameters:
 jobs:
     - job: $(signedArtifactName)
       pool:
-          vmImage: ubuntu-latest
+          vmImage: 'ubuntu-16.04'
       steps:
           - template: ../install-node-prerequisites.yaml
 

--- a/pipeline/electron/sign-release-package-linux.yaml
+++ b/pipeline/electron/sign-release-package-linux.yaml
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    unsignedPipelineResource: null
+    unsignedArtifactName: null
+    signedArtifactName: null
+
+jobs:
+    - job: $(signedArtifactName)
+      pool:
+          vmImage: ubuntu-latest
+      steps:
+          - template: ../install-node-prerequisites.yaml
+
+          - task: DownloadBuildArtifacts@0
+            inputs:
+                artifactName: $(unsignedArtifactName)
+                downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                buildType: specific
+                buildVersionToDownload: specific
+                project: $(unsignedPipelineResource.projectID)
+                pipeline: $(unsignedPipelineResource.pipelineID)
+                buildId: $(unsignedPipelineResource.runID)
+
+          - task: CopyFiles@2
+            displayName: 'Copy the AppImage file to detachedSignature'
+            inputs:
+                SourceFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                contents: |
+                    Accessibility Insights for Android*.*
+                TargetFolder: '$(System.DefaultWorkingDirectory)/detachedSignature'
+
+          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+            displayName: 'sign dist/detachedSignature'
+            inputs:
+                ConnectedServiceName: 'ESRP Code Signing'
+                FolderPath: '$(System.DefaultWorkingDirectory)/detachedSignature'
+                Pattern: '*.AppImage'
+                signConfigType: inlineSignParams
+                inlineOperation: |
+                    [
+                        {
+                            "keyCode": "CP-450779-Pgp",
+                            "operationSetCode": "LinuxSign",
+                            "parameters": [],
+                            "toolName": "sign",
+                            "toolVersion": "1.0"
+                        }
+                    ]
+
+          - script: 'mv "$(System.DefaultWorkingDirectory)/detachedSignature/Accessibility Insights for Android.AppImage" "$(System.DefaultWorkingDirectory)/detachedSignature/Accessibility Insights for Android.sig"'
+            displayName: 'Change signature file extension to sig'
+
+          - task: CopyFiles@2
+            displayName: 'Copy the detachedSignature file to working folder'
+            inputs:
+                SourceFolder: $(System.DefaultWorkingDirectory)/detachedSignature
+                contents: |
+                    Accessibility Insights for Android*.*
+                TargetFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+
+          - script: yarn update:electron-checksum
+            displayName: update electron checksum after signing
+
+          - template: publish-packed-build-output.yaml
+            packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+            artifactName: $(signedArtifactName)

--- a/pipeline/electron/sign-release-package-mac.yaml
+++ b/pipeline/electron/sign-release-package-mac.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    unsignedPipelineResource: null
+    unsignedArtifactName: null
+    signedArtifactName: null
+
+jobs:
+    - template: sign-release-package.yaml
+      parameters:
+          unsignedPipelineResource: $(unsignedPipelineResource)
+          unsignedArtifactName: $(unsignedArtifactName)
+          signedArtifactName: $(signedArtifactName)
+          vmImage: macOS-10.14
+          filePattern: '*.dmg, *.zip'
+          inlineSignParams: |
+              [
+                  {
+                      "keyCode": "CP-401337-Apple",
+                      "operationSetCode": "MacAppDeveloperSign",
+                      "parameters": [],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  }
+              ]

--- a/pipeline/electron/sign-release-package-windows.yaml
+++ b/pipeline/electron/sign-release-package-windows.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    unsignedPipelineResource: null
+    unsignedArtifactName: null
+    signedArtifactName: null
+
+jobs:
+    - template: sign-release-package.yaml
+      parameters:
+          unsignedPipelineResource: $(unsignedPipelineResource)
+          unsignedArtifactName: $(unsignedArtifactName)
+          signedArtifactName: $(signedArtifactName)
+          vmImage: windows-latest
+          filePattern: '*.exe, *.dll'
+          inlineSignParams: |
+              [
+                  {
+                  "keyCode": "CP-230012",
+                  "operationSetCode": "SigntoolSign",
+                  "parameters": [
+                      {
+                      "parameterName": "OpusName",
+                      "parameterValue": "Microsoft"
+                      },
+                      {
+                      "parameterName": "OpusInfo",
+                      "parameterValue": "http://www.microsoft.com"
+                      },
+                      {
+                      "parameterName": "PageHash",
+                      "parameterValue": "/NPH"
+                      },
+                      {
+                      "parameterName": "FileDigest",
+                      "parameterValue": "/fd sha256"
+                      },
+                      {
+                      "parameterName": "TimeStamp",
+                      "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                      }
+                  ],
+                  "toolName": "signtool.exe",
+                  "toolVersion": "6.2.9304.0"
+                  }
+              ]

--- a/pipeline/electron/sign-release-package.yaml
+++ b/pipeline/electron/sign-release-package.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    vmImage: null
+    filePattern: null
+    inlineSignParams: null
+    unsignedPipelineResource: null
+    unsignedArtifactName: null
+    signedArtifactName: null
+
+jobs:
+    - job: $(signedArtifactName)
+      pool:
+          vmImage: $(vmImage)
+      steps:
+          - template: ../install-node-prerequisites.yaml
+
+          - task: DownloadBuildArtifacts@0
+            inputs:
+                artifactName: $(unsignedArtifactName)
+                downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                buildType: specific
+                buildVersionToDownload: specific
+                project: $(unsignedPipelineResource.projectID)
+                pipeline: $(unsignedPipelineResource.pipelineID)
+                buildId: $(unsignedPipelineResource.runID)
+
+          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+            displayName: 'Send to ESRP Code Signing service'
+            inputs:
+                ConnectedServiceName: 'ESRP Code Signing'
+                FolderPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                Pattern: $(filePattern)
+                signConfigType: inlineSignParams
+                inlineOperation: $(inlineSignParams)
+
+          - script: yarn update:electron-checksum
+            displayName: update electron checksum after signing
+
+          - template: publish-packed-build-output.yaml
+            packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+            artifactName: $(signedArtifactName)

--- a/pipeline/electron/sign-release-packages-canary.yaml
+++ b/pipeline/electron/sign-release-packages-canary.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+name: $(resources.pipeline.build-unsigned-release-packages.runName)-CanarySigning-$(Rev:r)
+
+trigger: null
+
+resources:
+    pipelines:
+        - pipeline: build-unsigned-release-packages
+          source: build-unsigned-release-packages
+          trigger:
+              branches: [master]
+
+jobs:
+    - template: sign-release-packages-for-channel.yaml
+      parameters:
+          unsignedPipelineResource: $(resources.pipeline.build-unsigned-release-packages)
+          channel: canary

--- a/pipeline/electron/sign-release-packages-for-channel.yaml
+++ b/pipeline/electron/sign-release-packages-for-channel.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    # canary | insider | production
+    channel: null
+    # Should come from a pipeline resource based on build-unsigned-release-packages.yaml
+    unsignedPipelineResource: null
+
+jobs:
+    - template: sign-release-package-windows.yaml
+      parameters:
+          unsignedPipelineResource: $(unsignedPipelineResource)
+          unsignedArtifactName: unified-windows-$(channel)-unsigned
+          signedArtifactName: unified-windows-$(channel)-signed
+
+    - template: sign-release-package-mac.yaml
+      parameters:
+          unsignedPipelineResource: $(unsignedPipelineResource)
+          unsignedArtifactName: unified-mac-$(channel)-unsigned
+          signedArtifactName: unified-mac-$(channel)-signed
+
+    - template: sign-release-package-linux.yaml
+      parameters:
+          unsignedPipelineResource: $(unsignedPipelineResource)
+          unsignedArtifactName: unified-linux-$(channel)-unsigned
+          signedArtifactName: unified-linux-$(channel)-signed

--- a/pipeline/electron/sign-release-packages-insider-production.yaml
+++ b/pipeline/electron/sign-release-packages-insider-production.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+name: $(resources.pipeline.build-unsigned-release-packages.runName)-InsiderProductionSigning-$(Rev:r)
+
+trigger: null
+
+resources:
+    pipelines:
+        - pipeline: build-unsigned-release-packages
+          source: build-unsigned-release-packages
+          trigger: null # manual
+
+jobs:
+    - template: sign-release-packages-for-channel.yaml
+      parameters:
+          unsignedProjectID: $(resources.pipeline.build-unsigned-release-packages.projectID)
+          unsignedPipelineID: $(resources.pipeline.build-unsigned-release-packages.pipelineID)
+          unsignedRunID: $(resources.pipeline.build-unsigned-release-packages.runID)
+          channel: insider
+
+    - template: sign-release-packages-for-channel.yaml
+      parameters:
+          unsignedPipelineResource: $(resources.pipeline.build-unsigned-release-packages)
+          channel: production


### PR DESCRIPTION
#### Description of changes

Note: this PR is a draft because it hasn't yet been tested at all in azure devops, and still has a few todos:
* [ ] update checksum step needs an update to account for modified working directory layout

This PR implements the new signed/unsigned build machinery we'll be using to produce signed builds across all channel+platform combinations we want to support. In particular, the expectation for setting up the pipelines will be:

* `build-unsigned-release-packages.yaml` will trigger automatically with each passing build of our internal security/compliance check build
    - it will need a non-secret build variable set for the shared app insights instrumentation key
* `sign-release-packages-canary.yaml` will trigger automatically with each passing build of the first unsigned build
* `sign-release-packages-insider-production.yaml` will trigger manually as the first step in a release driver kicking off a new insider release

Later, we'll add release pipelines configured in azure devops that work exactly like the current canary one (download signed artifact, upload to appropriate azure blob, done)

**Out of scope**:
* This PR intentionally avoids removing the old canary build infrastructure; we'll do that separately once we've switched over the canary releases to the new format

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1666342
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
