### PR TITLE
fix: tab url change spamming telemetry event

### DIFF
--- a/src/background/target-page-controller.ts
+++ b/src/background/target-page-controller.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
-import { BaseTelemetryData, TriggeredByNotApplicable } from 'common/extension-telemetry-events';
 import { Logger } from 'common/logging/logger';
 import { Message } from 'common/message';
 import { Messages } from 'common/messages';
@@ -52,11 +51,7 @@ export class TargetPageController {
 
     private onTabUpdated = (tabId: number, changeInfo: chrome.tabs.TabChangeInfo): void => {
         if (changeInfo.url) {
-            const telemetry: BaseTelemetryData = {
-                source: null,
-                triggeredBy: TriggeredByNotApplicable,
-            };
-            this.handleTabUrlUpdate(tabId, telemetry);
+            this.handleTabUrlUpdate(tabId);
         }
     };
 
@@ -95,12 +90,12 @@ export class TargetPageController {
         });
     };
 
-    private handleTabUrlUpdate = (tabId: number, telemetry?: BaseTelemetryData): void => {
+    private handleTabUrlUpdate = (tabId: number): void => {
         if (!this.hasTabContext(tabId)) {
             this.addTabContext(tabId);
         }
 
-        this.sendTabUrlUpdatedAction(tabId, telemetry);
+        this.sendTabUrlUpdatedAction(tabId);
     };
 
     private hasTabContext(tabId: number): boolean {
@@ -116,7 +111,7 @@ export class TargetPageController {
         );
     }
 
-    private sendTabUrlUpdatedAction(tabId: number, telemetry?: BaseTelemetryData): void {
+    private sendTabUrlUpdatedAction(tabId: number): void {
         this.browserAdapter.getTab(
             tabId,
             (tab: chrome.tabs.Tab) => {
@@ -125,7 +120,7 @@ export class TargetPageController {
                     const interpreter = tabContext.interpreter;
                     interpreter.interpret({
                         messageType: Messages.Tab.ExistingTabUpdated,
-                        payload: { ...tab, telemetry },
+                        payload: tab,
                         tabId: tabId,
                     });
                 }

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -6,7 +6,6 @@ import { Interpreter } from 'background/interpreter';
 import { TabContext } from 'background/tab-context';
 import { TabContextFactory } from 'background/tab-context-factory';
 import { TargetPageController } from 'background/target-page-controller';
-import { TriggeredByNotApplicable } from 'common/extension-telemetry-events';
 import { Logger } from 'common/logging/logger';
 import { Messages } from 'common/messages';
 import { isFunction, values } from 'lodash';
@@ -143,7 +142,7 @@ describe('TargetPageController', () => {
 
                 const expectedMessage = {
                     messageType: Messages.Tab.ExistingTabUpdated,
-                    payload: { ...EXISTING_ACTIVE_TAB, telemetry: undefined },
+                    payload: { ...EXISTING_ACTIVE_TAB },
                     tabId: EXISTING_ACTIVE_TAB_ID,
                 };
                 mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(i => i.interpret(expectedMessage), Times.once());
@@ -317,10 +316,6 @@ describe('TargetPageController', () => {
                     payload: {
                         ...EXISTING_ACTIVE_TAB,
                         url: changeInfoWithUrl.url,
-                        telemetry: {
-                            source: null,
-                            triggeredBy: TriggeredByNotApplicable,
-                        },
                     },
                     tabId: EXISTING_ACTIVE_TAB_ID,
                 };


### PR DESCRIPTION
#### Description of changes

Currently on prod 2.13.1 (and master) the extension is sending a telemetry event every time the user navigates any tab to a different url. The original purpose of the telemetry event was to gather data to understand how often do our users reuse a tab they where scanning but the implementation did not account for this last part, i.e. we're not checking if the tab url change was trigger on a tab the user was actually scanning.

This missing check makes the extension to spam this event and we have seen an huge spike on telemetry events which may make us hit a limit on the amount of events/data we can send to app insights per unit of time.

Given the 2 paragraphs bellow, we are removing this event temporarily until we: 1) decide we actually need it; and 2) design a way to do this properly (i.e. no spamming, event sent only under the right circumstances)

#### Pull request checklist
- [x] Addresses an existing issue: #0000 this has not being file
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
