### PR TITLE
chore: make scss:clean run before the checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "copyright:check": "license-check-and-add check -f copyright-header.config.json",
         "copyright:fix": "license-check-and-add add -f copyright-header.config.json",
         "download:electron-mirror": "node ./pipeline/scripts/download-electron-mirror.js",
-        "fastpass": "npm-run-all --print-label --parallel scss:clean copyright:check lint:check format:check",
+        "fastpass": "npm-run-all --print-label scss:clean --parallel copyright:check lint:check format:check",
         "fastpass:fix": "npm-run-all --print-label --serial scss:clean copyright:fix lint:fix format:fix",
         "format:check": "prettier --config prettier.config.js --check \"**/*\"",
         "format:fix": "prettier --config prettier.config.js --write \"**/*\"",


### PR DESCRIPTION
#### Description of changes

Currently, running `yarn fastpass` is failing for `format:check` command with:
```
[error] Unable to read file: <some scss.d.ts file path here>
[error] ENOENT: no such file or directory, open <some scss.d.ts file path here>
```

This seems related to the recent addition of `scss:clean` command to the `fastpass` one after the `--parallel` flag, which cause the cleaning task to run in parallel with the checking task.

Making the clean step run before all the check tasks fix the issue.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
