### PR TITLE
fix: assessment in progress dialog, new target page link not tab navigable

### DIFF
--- a/src/DetailsView/components/target-change-dialog.tsx
+++ b/src/DetailsView/components/target-change-dialog.tsx
@@ -106,6 +106,7 @@ export class TargetChangeDialog extends React.Component<TargetChangeDialogProps>
             >
                 <Link
                     as="a" // force Link to use an anchor tag in order have proper dom structure
+                    tabIndex={0}
                     role="link"
                     className={css('insights-link', 'target-page-link')}
                     onClick={this.props.deps.detailsViewActionMessageCreator.switchToTargetTab}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/target-change-dialog.test.tsx.snap
@@ -50,6 +50,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
           className="insights-link target-page-link"
           onClick={[Function]}
           role="link"
+          tabIndex={0}
         >
           test title 2
         </StyledLinkBase>
@@ -146,6 +147,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
           className="insights-link target-page-link"
           onClick={[Function]}
           role="link"
+          tabIndex={0}
         >
           test title 2
         </StyledLinkBase>
@@ -242,6 +244,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
           className="insights-link target-page-link"
           onClick={[Function]}
           role="link"
+          tabIndex={0}
         >
           test title 2
         </StyledLinkBase>
@@ -338,6 +341,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
           className="insights-link target-page-link"
           onClick={[Function]}
           role="link"
+          tabIndex={0}
         >
           test title 2
         </StyledLinkBase>
@@ -434,6 +438,7 @@ exports[`TargetChangeDialog test sets for same prev tab and newTab values snapsh
           className="insights-link target-page-link"
           onClick={[Function]}
           role="link"
+          tabIndex={0}
         >
           test title 2
         </StyledLinkBase>


### PR DESCRIPTION
#### Description of changes

Currently on master, the **Assessment in progress** dialog contains the following tabbable elements:
1. old target page link
1. new target page link
1. continue previous button
1. start new button

The second item in the list, new target page link, is not reachable using only tabs navigation.

This PR fix this by explicitly adding `tabIndex={0}` to the link properties.

#### Pull request checklist
- [x] Addresses an existing issue: not filed
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS: check on chrome with Narrator, JAWS & NVDA
