### PR TITLE
chore: update line width for folder src/common/components/cards

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -15,6 +15,7 @@ module.exports = {
                 'src/common/action/**/*',
                 'src/common/assessment/**/*',
                 'src/common/browser-adapters/**/*',
+                'src/common/components/cards/**/*',
                 'src/common/configs/**/*',
                 'src/common/configuration/**/*',
                 'src/common/constants/**/*',

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -12,7 +12,10 @@ import { IssueFilingService } from '../../../issue-filing/types/issue-filing-ser
 import { NavigatorUtils } from '../../navigator-utils';
 import { CreateIssueDetailsTextData } from '../../types/create-issue-details-text-data';
 import { IssueFilingNeedsSettingsContentProps } from '../../types/issue-filing-needs-setting-content';
-import { IssueFilingServiceProperties, UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
+import {
+    IssueFilingServiceProperties,
+    UserConfigurationStoreData,
+} from '../../types/store-data/user-configuration-store';
 import { IssueFilingButtonDeps } from '../issue-filing-button';
 import { Toast, ToastDeps } from '../toast';
 import { CardInteractionSupport } from './card-interaction-support';
@@ -37,7 +40,10 @@ export interface CardKebabMenuButtonProps {
     kebabMenuAriaLabel?: string;
 }
 
-export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProps, CardKebabMenuButtonState> {
+export class CardKebabMenuButton extends React.Component<
+    CardKebabMenuButtonProps,
+    CardKebabMenuButtonState
+> {
     private toastRef: React.RefObject<Toast>;
     constructor(props: CardKebabMenuButtonProps) {
         super(props);
@@ -125,14 +131,22 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
         const { issueDetailsData, userConfigurationStoreData, deps } = this.props;
         const { issueFilingServiceProvider, issueFilingActionMessageCreator } = deps;
 
-        const selectedBugFilingService = issueFilingServiceProvider.forKey(userConfigurationStoreData.bugService);
+        const selectedBugFilingService = issueFilingServiceProvider.forKey(
+            userConfigurationStoreData.bugService,
+        );
         const selectedBugFilingServiceData = selectedBugFilingService.getSettingsFromStoreData(
             userConfigurationStoreData.bugServicePropertiesMap,
         );
-        const isSettingValid = selectedBugFilingService.isSettingsValid(selectedBugFilingServiceData);
+        const isSettingValid = selectedBugFilingService.isSettingsValid(
+            selectedBugFilingServiceData,
+        );
 
         if (isSettingValid) {
-            issueFilingActionMessageCreator.fileIssue(event, userConfigurationStoreData.bugService, issueDetailsData);
+            issueFilingActionMessageCreator.fileIssue(
+                event,
+                userConfigurationStoreData.bugService,
+                issueDetailsData,
+            );
             this.closeNeedsSettingsContent();
         } else {
             this.openNeedsSettingsContent();
@@ -140,7 +154,9 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
     };
 
     private copyFailureDetails = async (event: React.MouseEvent<any>): Promise<void> => {
-        const text = this.props.deps.issueDetailsTextGenerator.buildText(this.props.issueDetailsData);
+        const text = this.props.deps.issueDetailsTextGenerator.buildText(
+            this.props.issueDetailsData,
+        );
         this.props.deps.detailsViewActionMessageCreator.copyIssueDetailsClicked(event);
 
         try {
@@ -160,7 +176,9 @@ export class CardKebabMenuButton extends React.Component<CardKebabMenuButtonProp
             return null;
         }
 
-        const selectedIssueFilingService: IssueFilingService = issueFilingServiceProvider.forKey(userConfigurationStoreData.bugService);
+        const selectedIssueFilingService: IssueFilingService = issueFilingServiceProvider.forKey(
+            userConfigurationStoreData.bugService,
+        );
         const selectedIssueFilingServiceData: IssueFilingServiceProperties = selectedIssueFilingService.getSettingsFromStoreData(
             userConfigurationStoreData.bugServicePropertiesMap,
         );

--- a/src/common/components/cards/collapsible-component-cards.scss
+++ b/src/common/components/cards/collapsible-component-cards.scss
@@ -23,8 +23,9 @@
     }
 
     .collapsible-control {
-        font-family: 'Segoe UI Web (West European)', 'Segoe UI', '-apple-system', BlinkMacSystemFont, Roboto, 'Helvetica Neue', Helvetica,
-            Ubuntu, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+        font-family: 'Segoe UI Web (West European)', 'Segoe UI', '-apple-system', BlinkMacSystemFont,
+            Roboto, 'Helvetica Neue', Helvetica, Ubuntu, Arial, sans-serif, 'Apple Color Emoji',
+            'Segoe UI Emoji', 'Segoe UI Symbol';
         background-color: transparent;
         cursor: pointer;
         border: none;

--- a/src/common/components/cards/collapsible-component-cards.tsx
+++ b/src/common/components/cards/collapsible-component-cards.tsx
@@ -50,16 +50,25 @@ const CollapsibleComponentCards = NamedFC<CollapsibleComponentCardsProps>(
         const showContent = isExpanded || false;
 
         if (showContent) {
-            contentWrapper = <div className={css(contentClassName, styles.collapsibleContainerContent)}>{content}</div>;
+            contentWrapper = (
+                <div className={css(contentClassName, styles.collapsibleContainerContent)}>
+                    {content}
+                </div>
+            );
             collapsedCSSClassName = null;
         }
 
-        const onClick = (event: React.MouseEvent<HTMLDivElement>) => deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(id, event);
+        const onClick = (event: React.MouseEvent<HTMLDivElement>) =>
+            deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(id, event);
 
         return (
             <div
                 data-automation-id={containerAutomationId}
-                className={css(containerClassName, styles.collapsibleContainer, collapsedCSSClassName)}
+                className={css(
+                    containerClassName,
+                    styles.collapsibleContainer,
+                    collapsedCSSClassName,
+                )}
             >
                 <div {...containerProps}>
                     <ActionButton
@@ -78,6 +87,6 @@ const CollapsibleComponentCards = NamedFC<CollapsibleComponentCardsProps>(
     },
 );
 
-export const CardsCollapsibleControl = (collapsibleControlProps: CollapsibleComponentCardsProps) => (
-    <CollapsibleComponentCards {...collapsibleControlProps} />
-);
+export const CardsCollapsibleControl = (
+    collapsibleControlProps: CollapsibleComponentCardsProps,
+) => <CollapsibleComponentCards {...collapsibleControlProps} />;

--- a/src/common/components/cards/failed-instances-section.tsx
+++ b/src/common/components/cards/failed-instances-section.tsx
@@ -19,7 +19,13 @@ export type FailedInstancesSectionProps = {
 
 export const FailedInstancesSection = NamedFC<FailedInstancesSectionProps>(
     'FailedInstancesSection',
-    ({ cardsViewData, deps, userConfigurationStoreData, targetAppInfo, shouldAlertFailuresCount }) => {
+    ({
+        cardsViewData,
+        deps,
+        userConfigurationStoreData,
+        targetAppInfo,
+        shouldAlertFailuresCount,
+    }) => {
         if (cardsViewData == null || cardsViewData.cards == null) {
             return null;
         }

--- a/src/common/components/cards/how-to-fix-android-card-row.tsx
+++ b/src/common/components/cards/how-to-fix-android-card-row.tsx
@@ -13,16 +13,19 @@ export interface HowToFixAndroidCardRowProps extends CardRowProps {
     propertyData: FormattableResolution;
 }
 
-export const HowToFixAndroidCardRow = NamedFC<HowToFixAndroidCardRowProps>('HowToFixAndroidCardRow', props => {
-    return (
-        <SimpleCardRow
-            label="How to fix"
-            content={<span>{getHowToFixContent(props)}</span>}
-            rowKey={`how-to-fix-row-${props.index}`}
-            contentClassName="how-to-fix-card-row"
-        />
-    );
-});
+export const HowToFixAndroidCardRow = NamedFC<HowToFixAndroidCardRowProps>(
+    'HowToFixAndroidCardRow',
+    props => {
+        return (
+            <SimpleCardRow
+                label="How to fix"
+                content={<span>{getHowToFixContent(props)}</span>}
+                rowKey={`how-to-fix-row-${props.index}`}
+                contentClassName="how-to-fix-card-row"
+            />
+        );
+    },
+);
 
 type HowToFixSplit = {
     str?: string;
@@ -63,7 +66,10 @@ function getHowToFixContent(props: HowToFixAndroidCardRowProps): (JSX.Element | 
     return result;
 }
 
-function getHowToFixSplitsForPattern(pattern: string, previousHowToFixSplit: HowToFixSplit[]): HowToFixSplit[] {
+function getHowToFixSplitsForPattern(
+    pattern: string,
+    previousHowToFixSplit: HowToFixSplit[],
+): HowToFixSplit[] {
     const newHowToFixSplit: HowToFixSplit[] = [];
 
     previousHowToFixSplit.forEach(prop => {

--- a/src/common/components/cards/how-to-fix-card-row.tsx
+++ b/src/common/components/cards/how-to-fix-card-row.tsx
@@ -20,35 +20,44 @@ export interface HowToFixWebCardRowProps extends CardRowProps {
     propertyData: HowToFixWebPropertyData;
 }
 
-export const HowToFixWebCardRow = NamedFC<HowToFixWebCardRowProps>('HowToFixWebCardRow', ({ deps, ...props }) => {
-    const { any: anyOf, all, none } = props.propertyData;
+export const HowToFixWebCardRow = NamedFC<HowToFixWebCardRowProps>(
+    'HowToFixWebCardRow',
+    ({ deps, ...props }) => {
+        const { any: anyOf, all, none } = props.propertyData;
 
-    const renderFixInstructionsContent = () => {
+        const renderFixInstructionsContent = () => {
+            return (
+                <div className={styles.howToFixContent}>
+                    <FixInstructionPanel
+                        deps={deps}
+                        checkType={CheckType.All}
+                        checks={all.concat(none).map(turnStringToMessageObject)}
+                        renderTitleElement={renderFixInstructionsTitleElement}
+                    />
+                    <FixInstructionPanel
+                        deps={deps}
+                        checkType={CheckType.Any}
+                        checks={anyOf.map(turnStringToMessageObject)}
+                        renderTitleElement={renderFixInstructionsTitleElement}
+                    />
+                </div>
+            );
+        };
+
+        const turnStringToMessageObject = (s: string) => {
+            return { message: s };
+        };
+
+        const renderFixInstructionsTitleElement = (titleText: string) => {
+            return <div>{titleText}</div>;
+        };
+
         return (
-            <div className={styles.howToFixContent}>
-                <FixInstructionPanel
-                    deps={deps}
-                    checkType={CheckType.All}
-                    checks={all.concat(none).map(turnStringToMessageObject)}
-                    renderTitleElement={renderFixInstructionsTitleElement}
-                />
-                <FixInstructionPanel
-                    deps={deps}
-                    checkType={CheckType.Any}
-                    checks={anyOf.map(turnStringToMessageObject)}
-                    renderTitleElement={renderFixInstructionsTitleElement}
-                />
-            </div>
+            <SimpleCardRow
+                label="How to fix"
+                content={renderFixInstructionsContent()}
+                rowKey={`how-to-fix-row-${props.index}`}
+            />
         );
-    };
-
-    const turnStringToMessageObject = (s: string) => {
-        return { message: s };
-    };
-
-    const renderFixInstructionsTitleElement = (titleText: string) => {
-        return <div>{titleText}</div>;
-    };
-
-    return <SimpleCardRow label="How to fix" content={renderFixInstructionsContent()} rowKey={`how-to-fix-row-${props.index}`} />;
-});
+    },
+);

--- a/src/common/components/cards/instance-details-footer.tsx
+++ b/src/common/components/cards/instance-details-footer.tsx
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { HighlightHiddenIcon, HighlightUnavailableIcon, HighlightVisibleIcon } from 'common/icons/highlight-status-icons';
+import {
+    HighlightHiddenIcon,
+    HighlightUnavailableIcon,
+    HighlightVisibleIcon,
+} from 'common/icons/highlight-status-icons';
 import { NamedFC } from 'common/react/named-fc';
 import { CreateIssueDetailsTextData } from 'common/types/create-issue-details-text-data';
 import { CardResult } from 'common/types/store-data/card-view-model';
@@ -29,65 +33,70 @@ export type InstanceDetailsFooterProps = {
     rule: UnifiedRule;
 };
 
-export const InstanceDetailsFooter = NamedFC<InstanceDetailsFooterProps>('InstanceDetailsFooter', props => {
-    const { deps, userConfigurationStoreData, result, rule, targetAppInfo } = props;
-    const { cardInteractionSupport } = deps;
+export const InstanceDetailsFooter = NamedFC<InstanceDetailsFooterProps>(
+    'InstanceDetailsFooter',
+    props => {
+        const { deps, userConfigurationStoreData, result, rule, targetAppInfo } = props;
+        const { cardInteractionSupport } = deps;
 
-    const supportsAnyActions = cardInteractionSupport.supportsIssueFiling || cardInteractionSupport.supportsCopyFailureDetails;
-    const { supportsHighlighting } = cardInteractionSupport;
+        const supportsAnyActions =
+            cardInteractionSupport.supportsIssueFiling ||
+            cardInteractionSupport.supportsCopyFailureDetails;
+        const { supportsHighlighting } = cardInteractionSupport;
 
-    if (!supportsHighlighting && !supportsAnyActions) {
-        return null;
-    }
-
-    const renderKebabMenu = () => {
-        if (!supportsAnyActions) {
+        if (!supportsHighlighting && !supportsAnyActions) {
             return null;
         }
 
-        const issueDetailsData: CreateIssueDetailsTextData = deps.unifiedResultToIssueFilingDataConverter.convert(
-            result,
-            rule,
-            targetAppInfo,
-        );
+        const renderKebabMenu = () => {
+            if (!supportsAnyActions) {
+                return null;
+            }
 
-        const kebabMenuAriaLabel: string = `More Actions for card ${result.identifiers.identifier} in rule ${rule.id}`;
+            const issueDetailsData: CreateIssueDetailsTextData = deps.unifiedResultToIssueFilingDataConverter.convert(
+                result,
+                rule,
+                targetAppInfo,
+            );
+
+            const kebabMenuAriaLabel: string = `More Actions for card ${result.identifiers.identifier} in rule ${rule.id}`;
+            return (
+                <CardKebabMenuButton
+                    deps={deps}
+                    userConfigurationStoreData={userConfigurationStoreData}
+                    issueDetailsData={issueDetailsData}
+                    kebabMenuAriaLabel={kebabMenuAriaLabel}
+                />
+            );
+        };
+
+        const renderHighlightStatus = () => {
+            if (!supportsHighlighting) {
+                return null;
+            }
+
+            const highlightState = result.highlightStatus;
+
+            const label = 'Highlight ' + highlightState;
+            const icon = {
+                unavailable: <HighlightUnavailableIcon />,
+                visible: <HighlightVisibleIcon />,
+                hidden: <HighlightHiddenIcon />,
+            }[highlightState];
+
+            return (
+                <div className={styles.highlightStatus}>
+                    {icon}
+                    <Label>{label}</Label>
+                </div>
+            );
+        };
+
         return (
-            <CardKebabMenuButton
-                deps={deps}
-                userConfigurationStoreData={userConfigurationStoreData}
-                issueDetailsData={issueDetailsData}
-                kebabMenuAriaLabel={kebabMenuAriaLabel}
-            />
-        );
-    };
-
-    const renderHighlightStatus = () => {
-        if (!supportsHighlighting) {
-            return null;
-        }
-
-        const highlightState = result.highlightStatus;
-
-        const label = 'Highlight ' + highlightState;
-        const icon = {
-            unavailable: <HighlightUnavailableIcon />,
-            visible: <HighlightVisibleIcon />,
-            hidden: <HighlightHiddenIcon />,
-        }[highlightState];
-
-        return (
-            <div className={styles.highlightStatus}>
-                {icon}
-                <Label>{label}</Label>
+            <div className={styles.foot}>
+                {renderHighlightStatus()}
+                {renderKebabMenu()}
             </div>
         );
-    };
-
-    return (
-        <div className={styles.foot}>
-            {renderHighlightStatus()}
-            {renderKebabMenu()}
-        </div>
-    );
-});
+    },
+);

--- a/src/common/components/cards/instance-details-group.tsx
+++ b/src/common/components/cards/instance-details-group.tsx
@@ -5,7 +5,10 @@ import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
 import { getPropertyConfiguration } from '../../../common/configs/unified-result-property-configurations';
-import { TargetAppData, UnifiedRule } from '../../../common/types/store-data/unified-data-interface';
+import {
+    TargetAppData,
+    UnifiedRule,
+} from '../../../common/types/store-data/unified-data-interface';
 import { CardRuleResult } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { InstanceDetails, InstanceDetailsDeps } from './instance-details';
@@ -24,35 +27,38 @@ export type InstanceDetailsGroupProps = {
     targetAppInfo: TargetAppData;
 };
 
-export const InstanceDetailsGroup = NamedFC<InstanceDetailsGroupProps>('InstanceDetailsGroup', props => {
-    const { deps, rule, userConfigurationStoreData, targetAppInfo } = props;
-    const { nodes } = rule;
-    const unifiedRule: UnifiedRule = {
-        id: rule.id,
-        description: rule.description,
-        url: rule.url,
-        guidance: rule.guidance,
-    };
+export const InstanceDetailsGroup = NamedFC<InstanceDetailsGroupProps>(
+    'InstanceDetailsGroup',
+    props => {
+        const { deps, rule, userConfigurationStoreData, targetAppInfo } = props;
+        const { nodes } = rule;
+        const unifiedRule: UnifiedRule = {
+            id: rule.id,
+            description: rule.description,
+            url: rule.url,
+            guidance: rule.guidance,
+        };
 
-    return (
-        <ul
-            data-automation-id={ruleContentAutomationId}
-            className={styles.instanceDetailsList}
-            aria-label="failed instances with path, snippet and how to fix information"
-        >
-            {nodes.map((node, index) => (
-                <li key={`instance-details-${index}`}>
-                    <InstanceDetails
-                        {...{ index }}
-                        deps={deps}
-                        result={node}
-                        getPropertyConfigById={getPropertyConfiguration}
-                        userConfigurationStoreData={userConfigurationStoreData}
-                        rule={unifiedRule}
-                        targetAppInfo={targetAppInfo}
-                    />
-                </li>
-            ))}
-        </ul>
-    );
-});
+        return (
+            <ul
+                data-automation-id={ruleContentAutomationId}
+                className={styles.instanceDetailsList}
+                aria-label="failed instances with path, snippet and how to fix information"
+            >
+                {nodes.map((node, index) => (
+                    <li key={`instance-details-${index}`}>
+                        <InstanceDetails
+                            {...{ index }}
+                            deps={deps}
+                            result={node}
+                            getPropertyConfigById={getPropertyConfiguration}
+                            userConfigurationStoreData={userConfigurationStoreData}
+                            rule={unifiedRule}
+                            targetAppInfo={targetAppInfo}
+                        />
+                    </li>
+                ))}
+            </ul>
+        );
+    },
+);

--- a/src/common/components/cards/instance-details.tsx
+++ b/src/common/components/cards/instance-details.tsx
@@ -6,11 +6,23 @@ import { NamedFC } from 'common/react/named-fc';
 import { CardResult } from 'common/types/store-data/card-view-model';
 import { forOwn, isEmpty } from 'lodash';
 import * as React from 'react';
-import { instanceDetailsCard, instanceDetailsCardContainer, reportInstanceTable, selected } from 'reports/components/instance-details.scss';
+import {
+    instanceDetailsCard,
+    instanceDetailsCardContainer,
+    reportInstanceTable,
+    selected,
+} from 'reports/components/instance-details.scss';
 
-import { CardRowDeps, PropertyConfiguration } from '../../../common/configs/unified-result-property-configurations';
+import {
+    CardRowDeps,
+    PropertyConfiguration,
+} from '../../../common/configs/unified-result-property-configurations';
 import { CardSelectionMessageCreator } from '../../../common/message-creators/card-selection-message-creator';
-import { StoredInstancePropertyBag, TargetAppData, UnifiedRule } from '../../../common/types/store-data/unified-data-interface';
+import {
+    StoredInstancePropertyBag,
+    TargetAppData,
+    UnifiedRule,
+} from '../../../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
 import { InstanceDetailsFooter, InstanceDetailsFooterDeps } from './instance-details-footer';
 
@@ -44,7 +56,14 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
             if (!isEmpty(propertyConfig)) {
                 const CardRow = propertyConfig.cardRow;
                 ++propertyIndex;
-                cardRows.push(<CardRow deps={deps} propertyData={propertyData} index={index} key={`${propertyName}-${propertyIndex}`} />);
+                cardRows.push(
+                    <CardRow
+                        deps={deps}
+                        propertyData={propertyData}
+                        index={index}
+                        key={`${propertyName}-${propertyIndex}`}
+                    />,
+                );
             }
         });
         return <>{cardRows}</>;
@@ -57,7 +76,10 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
     };
 
     const cardKeyPressHandler = (event: React.KeyboardEvent<any>): void => {
-        if (event.keyCode === KeyCodeConstants.ENTER || event.keyCode === KeyCodeConstants.SPACEBAR) {
+        if (
+            event.keyCode === KeyCodeConstants.ENTER ||
+            event.keyCode === KeyCodeConstants.SPACEBAR
+        ) {
             event.preventDefault();
             cardClickHandler(event);
         }
@@ -73,10 +95,16 @@ export const InstanceDetails = NamedFC<InstanceDetailsProps>('InstanceDetails', 
         [selected]: isHighlightSupported ? result.isSelected : false,
     });
 
-    const cardAriaLabel = `${result.identifiers && result.identifiers.identifier ? result.identifiers.identifier : ''} card`;
+    const cardAriaLabel = `${
+        result.identifiers && result.identifiers.identifier ? result.identifiers.identifier : ''
+    } card`;
 
     return (
-        <div data-automation-id={instanceCardAutomationId} className={instanceDetailsCardContainerStyling} role="table">
+        <div
+            data-automation-id={instanceCardAutomationId}
+            className={instanceDetailsCardContainerStyling}
+            role="table"
+        >
             <div
                 className={instanceDetailsCardStyling}
                 tabIndex={0}

--- a/src/common/components/cards/result-section-content.tsx
+++ b/src/common/components/cards/result-section-content.tsx
@@ -13,7 +13,9 @@ import { UserConfigurationStoreData } from '../../types/store-data/user-configur
 import { RulesWithInstances, RulesWithInstancesDeps } from './rules-with-instances';
 
 export type ResultSectionContentDeps = RulesWithInstancesDeps & {
-    cardsVisualizationModifierButtons: ReactFCWithDisplayName<CardsVisualizationModifierButtonsProps>;
+    cardsVisualizationModifierButtons: ReactFCWithDisplayName<
+        CardsVisualizationModifierButtonsProps
+    >;
 };
 
 export type ResultSectionContentProps = {
@@ -27,23 +29,33 @@ export type ResultSectionContentProps = {
     allCardsCollapsed: boolean;
 };
 
-export const ResultSectionContent = NamedFC<ResultSectionContentProps>('ResultSectionContent', props => {
-    const { results, outcomeType, fixInstructionProcessor, deps, userConfigurationStoreData, targetAppInfo } = props;
-    if (results.length === 0) {
-        return <NoFailedInstancesCongrats />;
-    }
+export const ResultSectionContent = NamedFC<ResultSectionContentProps>(
+    'ResultSectionContent',
+    props => {
+        const {
+            results,
+            outcomeType,
+            fixInstructionProcessor,
+            deps,
+            userConfigurationStoreData,
+            targetAppInfo,
+        } = props;
+        if (results.length === 0) {
+            return <NoFailedInstancesCongrats />;
+        }
 
-    return (
-        <>
-            <deps.cardsVisualizationModifierButtons {...props} />
-            <RulesWithInstances
-                deps={deps}
-                rules={results}
-                outcomeType={outcomeType}
-                fixInstructionProcessor={fixInstructionProcessor}
-                userConfigurationStoreData={userConfigurationStoreData}
-                targetAppInfo={targetAppInfo}
-            />
-        </>
-    );
-});
+        return (
+            <>
+                <deps.cardsVisualizationModifierButtons {...props} />
+                <RulesWithInstances
+                    deps={deps}
+                    rules={results}
+                    outcomeType={outcomeType}
+                    fixInstructionProcessor={fixInstructionProcessor}
+                    userConfigurationStoreData={userConfigurationStoreData}
+                    targetAppInfo={targetAppInfo}
+                />
+            </>
+        );
+    },
+);

--- a/src/common/components/cards/result-section-title.tsx
+++ b/src/common/components/cards/result-section-title.tsx
@@ -25,7 +25,8 @@ export const ResultSectionTitle = NamedFC<ResultSectionTitleProps>('ResultSectio
     return (
         <span className={styles.resultSectionTitle}>
             <span className="screen-reader-only">
-                {props.title} {props.shouldAlertFailuresCount ? alertingFailuresCount : props.badgeCount}
+                {props.title}{' '}
+                {props.shouldAlertFailuresCount ? alertingFailuresCount : props.badgeCount}
             </span>
             <span className={styles.title} aria-hidden="true">
                 {props.title}

--- a/src/common/components/cards/result-section.tsx
+++ b/src/common/components/cards/result-section.tsx
@@ -4,7 +4,11 @@ import { css } from '@uifabric/utilities';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
 
-import { ResultSectionContent, ResultSectionContentDeps, ResultSectionContentProps } from './result-section-content';
+import {
+    ResultSectionContent,
+    ResultSectionContentDeps,
+    ResultSectionContentProps,
+} from './result-section-content';
 import { ResultSectionTitle, ResultSectionTitleProps } from './result-section-title';
 import * as styles from './result-section.scss';
 
@@ -22,7 +26,10 @@ export const ResultSection = NamedFC<ResultSectionProps>('ResultSection', props 
     const { containerClassName } = props;
 
     return (
-        <div className={css(containerClassName, styles.resultSection)} data-automation-id={resultSectionAutomationId}>
+        <div
+            className={css(containerClassName, styles.resultSection)}
+            data-automation-id={resultSectionAutomationId}
+        >
             <h2>
                 <ResultSectionTitle {...props} />
             </h2>

--- a/src/common/components/cards/rule-resources.tsx
+++ b/src/common/components/cards/rule-resources.tsx
@@ -22,7 +22,9 @@ export const RuleResources = NamedFC<RuleResourcesProps>('RuleResources', ({ dep
         return null;
     }
 
-    const renderTitle = () => <div className={styles.moreResourcesTitle}>Resources for this rule</div>;
+    const renderTitle = () => (
+        <div className={styles.moreResourcesTitle}>Resources for this rule</div>
+    );
 
     const renderRuleLink = () => {
         if (rule.url == null) {

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -33,8 +33,19 @@ export const ruleDetailsGroupAutomationId = 'rule-details-group';
 
 export const RulesWithInstances = NamedFC<RulesWithInstancesProps>(
     'RulesWithInstances',
-    ({ rules, outcomeType, fixInstructionProcessor, deps, userConfigurationStoreData, targetAppInfo }) => {
-        const getCollapsibleComponentProps = (rule: CardRuleResult, idx: number, buttonAriaLabel: string) => {
+    ({
+        rules,
+        outcomeType,
+        fixInstructionProcessor,
+        deps,
+        userConfigurationStoreData,
+        targetAppInfo,
+    }) => {
+        const getCollapsibleComponentProps = (
+            rule: CardRuleResult,
+            idx: number,
+            buttonAriaLabel: string,
+        ) => {
             return {
                 id: rule.id,
                 key: `summary-details-${idx + 1}`,
@@ -59,11 +70,16 @@ export const RulesWithInstances = NamedFC<RulesWithInstancesProps>(
         };
 
         return (
-            <div className={styles.ruleDetailsGroup} data-automation-id={ruleDetailsGroupAutomationId}>
+            <div
+                className={styles.ruleDetailsGroup}
+                data-automation-id={ruleDetailsGroupAutomationId}
+            >
                 {rules.map((rule, idx) => {
                     const { pastTense } = outcomeTypeSemantics[outcomeType];
                     const buttonAriaLabel = `${rule.id} ${rule.nodes.length} ${pastTense} ${rule.description}`;
-                    const CollapsibleComponent = deps.collapsibleControl(getCollapsibleComponentProps(rule, idx, buttonAriaLabel));
+                    const CollapsibleComponent = deps.collapsibleControl(
+                        getCollapsibleComponentProps(rule, idx, buttonAriaLabel),
+                    );
                     return CollapsibleComponent;
                 })}
             </div>

--- a/src/common/components/cards/simple-card-row.tsx
+++ b/src/common/components/cards/simple-card-row.tsx
@@ -13,13 +13,18 @@ export interface SimpleCardRowProps {
     contentClassName?: string;
 }
 
-export const SimpleCardRow = NamedFC<SimpleCardRowProps>('SimpleCardRow', ({ label: givenLabel, content, rowKey, contentClassName }) => {
-    const contentStyling = css(styles.instanceListRowContent, contentClassName);
+export const SimpleCardRow = NamedFC<SimpleCardRowProps>(
+    'SimpleCardRow',
+    ({ label: givenLabel, content, rowKey, contentClassName }) => {
+        const contentStyling = css(styles.instanceListRowContent, contentClassName);
 
-    return (
-        <tr className={styles.row} key={rowKey}>
-            <th className={css(styles.label, 'report-instance-table-label-overrides')}>{givenLabel}</th>
-            <td className={contentStyling}>{content}</td>
-        </tr>
-    );
-});
+        return (
+            <tr className={styles.row} key={rowKey}>
+                <th className={css(styles.label, 'report-instance-table-label-overrides')}>
+                    {givenLabel}
+                </th>
+                <td className={contentStyling}>{content}</td>
+            </tr>
+        );
+    },
+);


### PR DESCRIPTION
#### Description of changes

This PR changes files under folder `src/common/components/cards` to comply with our new prettier config of 100 line width.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
