### PR TITLE
refactor: assessment-default-message-generator uses css module

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -400,11 +400,6 @@ div.insights-file-issue-details-dialog-container {
                         color: $secondary-text;
                     }
                 }
-                .no-failure-view {
-                    font-size: 15px;
-                    font-weight: normal;
-                    padding: 15px 0px 0px 15px;
-                }
                 .instance-visibility-button {
                     color: $primary-text;
                     padding-bottom: 6px;

--- a/src/assessments/assessment-default-message-generator.scss
+++ b/src/assessments/assessment-default-message-generator.scss
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.no-failure-view {
+    font-size: 15px;
+    font-weight: normal;
+    padding: 15px 0px 0px 15px;
+}

--- a/src/assessments/assessment-default-message-generator.tsx
+++ b/src/assessments/assessment-default-message-generator.tsx
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isEmpty, size } from 'lodash';
-import * as React from 'react';
-
 import { ManualTestStatus } from 'common/types/manual-test-status';
 import {
     AssessmentInstancesMap,
     InstanceIdToInstanceDataMap,
     TestStepResult,
 } from 'common/types/store-data/assessment-result-data';
+import { isEmpty, size } from 'lodash';
+import * as React from 'react';
+import * as styles from './assessment-default-message-generator.scss';
 
 export type IMessageGenerator = (
     instancesMap: AssessmentInstancesMap,
@@ -77,7 +77,7 @@ export class AssessmentDefaultMessageGenerator {
 
     private getNoMatchingInstancesResult(): DefaultMessageInterface {
         return {
-            message: <div className="no-failure-view">No matching instances</div>,
+            message: <div className={styles.noFailureView}>No matching instances</div>,
             instanceCount: 0,
         };
     }
@@ -86,7 +86,7 @@ export class AssessmentDefaultMessageGenerator {
         passingInstanceKeys: TestStepResult[],
     ): DefaultMessageInterface {
         return {
-            message: <div className="no-failure-view">No failing instances</div>,
+            message: <div className={styles.noFailureView}>No failing instances</div>,
             instanceCount: size(passingInstanceKeys),
         };
     }

--- a/src/tests/unit/tests/assessments/assessment-default-message-generator.test.tsx
+++ b/src/tests/unit/tests/assessments/assessment-default-message-generator.test.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
-
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
-import { ManualTestStatus } from '../../../../common/types/manual-test-status';
-import { GeneratedAssessmentInstance } from '../../../../common/types/store-data/assessment-result-data';
-import { DictionaryStringTo } from '../../../../types/common-types';
+import * as styles from 'assessments/assessment-default-message-generator.scss';
+import { ManualTestStatus } from 'common/types/manual-test-status';
+import { GeneratedAssessmentInstance } from 'common/types/store-data/assessment-result-data';
+import * as React from 'react';
+import { DictionaryStringTo } from 'types/common-types';
 
 describe('AssessmentDefaultMessageGenerator', () => {
     const testSubject = new AssessmentDefaultMessageGenerator();
@@ -41,7 +41,7 @@ describe('AssessmentDefaultMessageGenerator', () => {
 
         expect(testSubject.getNoFailingInstanceMessage(instancesMap, 'step1')).not.toBeNull();
         const expected = {
-            message: <div className="no-failure-view">No matching instances</div>,
+            message: <div className={styles.noFailureView}>No matching instances</div>,
             instanceCount: 0,
         };
         expect(testSubject.getNoFailingInstanceMessage(instancesMap, 'step1')).toEqual(expected);
@@ -85,7 +85,7 @@ describe('AssessmentDefaultMessageGenerator', () => {
         expect(testSubject.getNoFailingInstanceMessage(instancesMap, 'step1')).not.toBeNull();
 
         const expected = {
-            message: <div className="no-failure-view">No matching instances</div>,
+            message: <div className={styles.noFailureView}>No matching instances</div>,
             instanceCount: 0,
         };
 
@@ -95,7 +95,7 @@ describe('AssessmentDefaultMessageGenerator', () => {
     test('no matching instance for empty instance map', () => {
         const instancesMap: DictionaryStringTo<GeneratedAssessmentInstance> = {};
         const expected = {
-            message: <div className="no-failure-view">No matching instances</div>,
+            message: <div className={styles.noFailureView}>No matching instances</div>,
             instanceCount: 0,
         };
         expect(testSubject.getNoMatchingInstanceMessage(instancesMap, 'step1')).not.toBeNull();
@@ -131,7 +131,7 @@ describe('AssessmentDefaultMessageGenerator', () => {
         };
 
         const expected = {
-            message: <div className="no-failure-view">No failing instances</div>,
+            message: <div className={styles.noFailureView}>No failing instances</div>,
             instanceCount: 1,
         };
 


### PR DESCRIPTION
#### Description of changes

- refactor assessment-default-message-generator to use css module
- remove now-dead css code from `detailsview.css`

**Notes** no changes on the UI or accessibility view.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
