### PR TITLE
chore: log version when publishing ai-web

### DIFF
--- a/deploy/Gruntfile.js
+++ b/deploy/Gruntfile.js
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-const path = require('path');
 const YAML = require('js-yaml');
 
 module.exports = function(grunt) {

--- a/deploy/Gruntfile.js
+++ b/deploy/Gruntfile.js
@@ -102,6 +102,7 @@ module.exports = function(grunt) {
             version = versionFromDate();
         }
         manifest.version = version;
+        grunt.log.writeln(`publishing ai-web version ${version}`);
         grunt.file.write(manifestPath, JSON.stringify(manifest, undefined, 4));
     });
     grunt.registerTask('zip', ['update-config', 'update-manifest', 'compress:extension']);


### PR DESCRIPTION
#### Description of changes

While investigating longer-than-usual update times of our canary extension on the chrome web store, I noticed that our release do not log the version we're using when uploading to the store. 

This makes it harder to track which release run was the one that actually upload an updated version of the extension last, basically because our release does not fail if the store respond with an error, as in the case of uploading a new version while the extension is under "pending review"; in that case, we get this message:

```bash
Error on uploading (open) with message "Application error (6): hbcplehnakffdldhldncjlnbpfgogbem pending review so can't be edited". Raw response: {"kind":"chromewebstore#item","uploadState":"FAILURE","itemError":[{"error_code":"CLIENT_ERROR","error_detail":"Application error (6): hbcplehnakffdldhldncjlnbpfgogbem pending review so can't be edited"}]}
```

On this PR, just adding a log so we can actually see the version being used.

**Future work**: 
- we may want to change our logic to either fail when we get this message (that'll make it clear which release are actually successfully uploading an update)
- we may want to check extension status before uploading
- we may want to make sure the release has some sort of cooldown period (historically, we know that canary usually takes 15~20 minutes to update; it doesn't make sense to run a release if the last one was only 5 minutes ago)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
