### PR TITLE
fix: remove operation.name from telemetry

### DIFF
--- a/src/background/telemetry/app-insights-telemetry-client.ts
+++ b/src/background/telemetry/app-insights-telemetry-client.ts
@@ -78,6 +78,7 @@ export class AppInsightsTelemetryClient implements TelemetryClient {
     }
 
     private initializeInternal(): void {
+        this.appInsights.context.operation.name = '';
         this.appInsights.context.addTelemetryInitializer((envelope: ExtendedEnvelop) => {
             const baseData = envelope.data.baseData;
             baseData.properties = {


### PR DESCRIPTION
#### Description of changes

Application Insights logs [operation name](https://docs.microsoft.com/en-us/azure/azure-monitor/app/data-model-context#operation-name) which can include user paths. We don't need this information and would rather not have user paths in our telemetry, so this PR overwrites it to an empty string. This follows the example [here](https://docs.microsoft.com/en-us/azure/azure-monitor/app/api-custom-events-metrics#telemetrycontext).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
