### PR TITLE
fix: rule group header loses focus indicator while using AT

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -10,7 +10,7 @@ import { createDefaultLogger } from 'common/logging/default-logger';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { AllUrlsPermissionHandler } from 'DetailsView/handlers/allurls-permission-handler';
-import { loadTheme } from 'office-ui-fabric-react';
+import { loadTheme, setFocusVisibility } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
 import { AssessmentReportHtmlGenerator } from 'reports/assessment-report-html-generator';
 import { AssessmentReportModelBuilderFactory } from 'reports/assessment-report-model-builder-factory';
@@ -408,6 +408,7 @@ if (isNaN(tabId) === false) {
                     browserAdapter,
                     detailsViewActionMessageCreator,
                 ),
+                setFocusVisibility,
             };
 
             const renderer = new DetailsViewRenderer(

--- a/src/common/components/cards/collapsible-component-cards.tsx
+++ b/src/common/components/cards/collapsible-component-cards.tsx
@@ -5,13 +5,14 @@ import { CardSelectionMessageCreator } from 'common/message-creators/card-select
 import { NamedFC } from 'common/react/named-fc';
 import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
-
+import { SetFocusVisibility } from 'types/set-focus-visibility';
 import * as styles from './collapsible-component-cards.scss';
 
 export const collapsibleButtonAutomationId = 'collapsible-component-cards-button';
 
 export type CollapsibleComponentCardsDeps = {
     cardSelectionMessageCreator: CardSelectionMessageCreator;
+    setFocusVisibility: SetFocusVisibility;
 };
 
 export interface CollapsibleComponentCardsProps {
@@ -58,8 +59,14 @@ const CollapsibleComponentCards = NamedFC<CollapsibleComponentCardsProps>(
             collapsedCSSClassName = null;
         }
 
-        const onClick = (event: React.MouseEvent<HTMLDivElement>) =>
+        const onClick = (event: React.MouseEvent<HTMLDivElement>) => {
+            if (event.nativeEvent.detail === 0) {
+                // 0 => keyboard event
+                deps.setFocusVisibility(true);
+            }
+
             deps.cardSelectionMessageCreator.toggleRuleExpandCollapse(id, event);
+        };
 
         return (
             <div

--- a/src/common/components/cards/rules-with-instances.tsx
+++ b/src/common/components/cards/rules-with-instances.tsx
@@ -3,22 +3,25 @@
 import { FixInstructionProcessor } from 'common/components/fix-instruction-processor';
 import { NamedFC } from 'common/react/named-fc';
 import * as React from 'react';
-
 import { TargetAppData } from '../../../common/types/store-data/unified-data-interface';
 import { InstanceOutcomeType } from '../../../reports/components/instance-outcome-type';
 import { outcomeTypeSemantics } from '../../../reports/components/outcome-type';
 import { MinimalRuleHeader } from '../../../reports/components/report-sections/minimal-rule-header';
 import { CardRuleResult } from '../../types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../types/store-data/user-configuration-store';
-import { CollapsibleComponentCardsProps } from './collapsible-component-cards';
+import {
+    CollapsibleComponentCardsDeps,
+    CollapsibleComponentCardsProps,
+} from './collapsible-component-cards';
 import { RuleContent, RuleContentDeps } from './rule-content';
 import * as styles from './rules-with-instances.scss';
 
 export const ruleGroupAutomationId = 'cards-rule-group';
 
-export type RulesWithInstancesDeps = RuleContentDeps & {
-    collapsibleControl: (props: CollapsibleComponentCardsProps) => JSX.Element;
-};
+export type RulesWithInstancesDeps = RuleContentDeps &
+    CollapsibleComponentCardsDeps & {
+        collapsibleControl: (props: CollapsibleComponentCardsProps) => JSX.Element;
+    };
 
 export type RulesWithInstancesProps = {
     deps: RulesWithInstancesDeps;

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -46,6 +46,7 @@ import {
 import { PlatformInfo } from 'electron/window-management/platform-info';
 import { WindowFrameListener } from 'electron/window-management/window-frame-listener';
 import { WindowFrameUpdater } from 'electron/window-management/window-frame-updater';
+import { setFocusVisibility } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
@@ -237,6 +238,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             navigatorUtils: null,
             unifiedResultToIssueFilingDataConverter: null, // we don't support issue filing right now
             windowUtils: null,
+            setFocusVisibility,
         };
 
         const props: RootContainerProps = {

--- a/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/collapsible-component-cards.test.tsx
@@ -5,10 +5,23 @@ import { CardSelectionMessageCreator } from 'common/message-creators/card-select
 import { shallow } from 'enzyme';
 import { forOwn } from 'lodash';
 import * as React from 'react';
+import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, It, Mock, Times } from 'typemoq';
+import { SetFocusVisibility } from 'types/set-focus-visibility';
 
 describe('CollapsibleComponentCardsTest', () => {
+    const eventStubFactory = new EventStubFactory();
+
     let cardSelectionMessageCreatorMock: IMock<CardSelectionMessageCreator>;
+    let setFocusVisibilityMock: IMock<SetFocusVisibility>;
+
+    const partialProps: Partial<CollapsibleComponentCardsProps> = {
+        header: <div>Some header</div>,
+        content: <div>Some content</div>,
+        headingLevel: 5,
+        isExpanded: true,
+    };
+
     const optionalPropertiesObject = {
         contentClassName: [undefined, 'content-class-name-a'],
         containerClassName: [undefined, 'a-container'],
@@ -17,6 +30,11 @@ describe('CollapsibleComponentCardsTest', () => {
 
     beforeEach(() => {
         cardSelectionMessageCreatorMock = Mock.ofType(CardSelectionMessageCreator);
+        setFocusVisibilityMock = Mock.ofType<SetFocusVisibility>();
+        partialProps.deps = {
+            cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
+            setFocusVisibility: setFocusVisibilityMock.object,
+        };
     });
 
     forOwn(optionalPropertiesObject, (propertyValues, propertyName) => {
@@ -27,13 +45,10 @@ describe('CollapsibleComponentCardsTest', () => {
                     .verifiable(Times.never());
 
                 const props: CollapsibleComponentCardsProps = {
-                    header: <div>Some header</div>,
-                    content: <div>Some content</div>,
-                    headingLevel: 5,
+                    ...partialProps,
                     [propertyName]: value,
-                    deps: { cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object },
-                    isExpanded: true,
-                };
+                } as CollapsibleComponentCardsProps;
+
                 const control = CardsCollapsibleControl(props);
                 const result = shallow(control);
                 expect(result.getElement()).toMatchSnapshot();
@@ -43,19 +58,14 @@ describe('CollapsibleComponentCardsTest', () => {
     });
 
     test('toggle from expanded to collapsed', () => {
-        const eventStub = {} as React.SyntheticEvent;
+        const eventStub = eventStubFactory.createKeypressEvent() as any;
         cardSelectionMessageCreatorMock.setup(mock => mock.toggleRuleExpandCollapse(It.isAnyString(), eventStub)).verifiable(Times.once());
 
         const props: CollapsibleComponentCardsProps = {
-            header: <div>Some header</div>,
-            content: <div>Some content</div>,
-            headingLevel: 5,
-            deps: {
-                cardSelectionMessageCreator: cardSelectionMessageCreatorMock.object,
-            },
-            isExpanded: true,
+            ...partialProps,
             id: 'test-id',
-        };
+        } as CollapsibleComponentCardsProps;
+
         const control = CardsCollapsibleControl(props);
         const result = shallow(control);
         expect(result.getElement()).toMatchSnapshot('expanded');
@@ -65,5 +75,40 @@ describe('CollapsibleComponentCardsTest', () => {
         expect(result.getElement()).toMatchSnapshot('collapsed');
 
         cardSelectionMessageCreatorMock.verifyAll();
+    });
+
+    describe('set focus visibility when expanding/collapsing', () => {
+        let props: CollapsibleComponentCardsProps;
+
+        beforeEach(() => {
+            props = {
+                ...partialProps,
+                id: 'test-id',
+            } as CollapsibleComponentCardsProps;
+        });
+
+        it('should set focus visibility to true for keyboard event', () => {
+            const eventStub = eventStubFactory.createKeypressEvent();
+
+            const control = CardsCollapsibleControl(props);
+            const result = shallow(control);
+
+            const button = result.find('CustomizedActionButton');
+            button.simulate('click', eventStub);
+
+            setFocusVisibilityMock.verify(handler => handler(true, undefined), Times.once());
+        });
+
+        it('should not even call set focus visibility for mouse event', () => {
+            const eventStub = eventStubFactory.createMouseClickEvent();
+
+            const control = CardsCollapsibleControl(props);
+            const result = shallow(control);
+
+            const button = result.find('CustomizedActionButton');
+            button.simulate('click', eventStub);
+
+            setFocusVisibilityMock.verify(handler => handler(It.isAny(), It.isAny()), Times.never());
+        });
     });
 });

--- a/src/types/set-focus-visibility.ts
+++ b/src/types/set-focus-visibility.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { setFocusVisibility } from 'office-ui-fabric-react';
+
+export type SetFocusVisibility = typeof setFocusVisibility;


### PR DESCRIPTION
#### Description of changes

There is something about how Office Fabric handle focus visibility state when the user interacts with the webpage. There seems to be some rules around how to change that state base on the type of element and the type of interaction (basically, keyboard vs mouse).

In our case, when the user uses the keyboard to collapse/expand the rule header group, office fabric simply set the focus visibility state to hidden.

On the other hand, Office Fabric expose a `setFocusVisibility` utility function we can call to force the state. 

**Note** The report is not affected by this bug (only AI-Web and AI-Android). The main reason is the report is mostly static html, so there is no office fabric javascript running on the report.

#### Pull request checklist
- [x] Addresses an existing issue: #1568
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
