### PR TITLE
fix: avoid invalid div/span nesting in left nav items

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -543,6 +543,8 @@ div.insights-file-issue-details-dialog-container {
                 text-align: left;
                 margin-top: 6px;
                 margin-bottom: 6px;
+                display: flex;
+                flex-direction: column;
             }
             .overview-name {
                 line-height: 20px;

--- a/src/DetailsView/components/left-nav/left-nav-icon.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-icon.tsx
@@ -12,11 +12,7 @@ export type LeftNavIconProps = {
 export const LeftNavStatusIcon = NamedFC<LeftNavIconProps>('LeftNavStatusIcon', props => {
     const { item } = props;
 
-    return (
-        <span>
-            <StatusIcon status={item.status} className={'dark-gray'} level="test" />
-        </span>
-    );
+    return <StatusIcon status={item.status} className={'dark-gray'} level="test" />;
 });
 
 export const LeftNavIndexIcon = NamedFC<LeftNavIconProps>('LeftNavIndexIcon', props => {

--- a/src/DetailsView/components/left-nav/left-nav-icon.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-icon.tsx
@@ -13,14 +13,14 @@ export const LeftNavStatusIcon = NamedFC<LeftNavIconProps>('LeftNavStatusIcon', 
     const { item } = props;
 
     return (
-        <div>
+        <span>
             <StatusIcon status={item.status} className={'dark-gray'} level="test" />
-        </div>
+        </span>
     );
 });
 
 export const LeftNavIndexIcon = NamedFC<LeftNavIconProps>('LeftNavIndexIcon', props => {
     const { item } = props;
 
-    return <div className={'index-circle'}>{item.index}</div>;
+    return <span className={'index-circle'}>{item.index}</span>;
 });

--- a/src/DetailsView/components/left-nav/overview-left-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/overview-left-nav-link.tsx
@@ -11,15 +11,15 @@ export const OverviewLeftNavLink = NamedFC<BaseLeftNavLinkProps>(
     'OverviewLeftNavLink',
     ({ link }) => {
         return (
-            <div className={'button-flex-container'} aria-hidden="true">
-                <div>
+            <span className={'button-flex-container'} aria-hidden="true">
+                <span>
                     <Icon iconName="home" className={css('status-icon', 'dark-gray')} />
-                </div>
-                <div className="ms-Button-label overview-label">
-                    <div className="overview-name">{link.name}</div>
-                    <div className="overview-percent">{link.percentComplete}% Completed</div>
-                </div>
-            </div>
+                </span>
+                <span className="ms-Button-label overview-label">
+                    <span className="overview-name">{link.name}</span>
+                    <span className="overview-percent">{link.percentComplete}% Completed</span>
+                </span>
+            </span>
         );
     },
 );

--- a/src/DetailsView/components/left-nav/test-view-left-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/test-view-left-nav-link.tsx
@@ -9,10 +9,10 @@ export const TestViewLeftNavLink = NamedFC<BaseLeftNavLinkProps>(
     'TestViewLeftNavLink',
     ({ link, renderIcon }) => {
         return (
-            <div className={'button-flex-container'} aria-hidden="true">
+            <span className={'button-flex-container'} aria-hidden="true">
                 {renderIcon(link)}
-                <div className={'ms-Button-label test-name'}>{link.name}</div>
-            </div>
+                <span className={'ms-Button-label test-name'}>{link.name}</span>
+            </span>
         );
     },
 );

--- a/src/DetailsView/components/requirement-link.tsx
+++ b/src/DetailsView/components/requirement-link.tsx
@@ -17,29 +17,29 @@ export interface RequirementLinkProps {
 export class RequirementLink extends React.Component<RequirementLinkProps> {
     public render(): JSX.Element {
         return (
-            <div className={'button-flex-container'} aria-hidden="true">
+            <span className={'button-flex-container'} aria-hidden="true">
                 {this.props.renderRequirementDescription(this)}
                 <StatusIcon status={this.props.status} level="requirement" />
-            </div>
+            </span>
         );
     }
 
     public renderRequirementDescriptionWithIndex(): JSX.Element {
         return (
-            <div className={css('ms-Button-label', styles.reqDescription)}>
+            <span className={css('ms-Button-label', styles.reqDescription)}>
                 <span className={styles.reqIndex}>{this.props.link.index}</span>
                 <span className={styles.reqName}>{this.props.link.name}.</span>
                 {this.props.link.description}
-            </div>
+            </span>
         );
     }
 
     public renderRequirementDescriptionWithoutIndex(): JSX.Element {
         return (
-            <div className={css('ms-Button-label', styles.reqDescription)}>
+            <span className={css('ms-Button-label', styles.reqDescription)}>
                 <span className={styles.reqName}>{this.props.link.name}.</span>
                 {this.props.link.description}
-            </div>
+            </span>
         );
     }
 }

--- a/src/injected/components/details-dialog.tsx
+++ b/src/injected/components/details-dialog.tsx
@@ -276,9 +276,9 @@ export class DetailsDialog extends React.Component<DetailsDialogProps, DetailsDi
                                 aria-label="Close"
                                 data-is-focusable="true"
                             >
-                                <div className="ms-button-flex-container">
+                                <span className="ms-button-flex-container">
                                     <CancelIcon />
-                                </div>
+                                </span>
                             </button>
                         </div>
                     </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-link.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/requirement-link.test.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RequirementLink renders with index 1`] = `
-<div
+<span
   aria-hidden="true"
   className="button-flex-container"
 >
-  <div
+  <span
     className="ms-Button-label reqDescription"
   >
     <span
@@ -22,20 +22,20 @@ exports[`RequirementLink renders with index 1`] = `
     <span>
       Link with index description
     </span>
-  </div>
+  </span>
   <StatusIcon
     level="requirement"
     status={0}
   />
-</div>
+</span>
 `;
 
 exports[`RequirementLink renders without index 1`] = `
-<div
+<span
   aria-hidden="true"
   className="button-flex-container"
 >
-  <div
+  <span
     className="ms-Button-label reqDescription"
   >
     <span
@@ -47,10 +47,10 @@ exports[`RequirementLink renders without index 1`] = `
     <span>
       Link without index description
     </span>
-  </div>
+  </span>
   <StatusIcon
     level="requirement"
     status={0}
   />
-</div>
+</span>
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/assessment-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/assessment-left-nav.test.tsx.snap
@@ -41,11 +41,9 @@ exports[`AssessmentLeftNav render with status icon 1`] = `
 `;
 
 exports[`AssessmentLeftNav render with status icon 2`] = `
-<span>
-  <StatusIcon
-    className="dark-gray"
-    level="test"
-    status={-1}
-  />
-</span>
+<StatusIcon
+  className="dark-gray"
+  level="test"
+  status={-1}
+/>
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/assessment-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/assessment-left-nav.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`AssessmentLeftNav render with index icon 1`] = `
 `;
 
 exports[`AssessmentLeftNav render with index icon 2`] = `
-<div
+<span
   className="index-circle"
 />
 `;
@@ -41,11 +41,11 @@ exports[`AssessmentLeftNav render with status icon 1`] = `
 `;
 
 exports[`AssessmentLeftNav render with status icon 2`] = `
-<div>
+<span>
   <StatusIcon
     className="dark-gray"
     level="test"
     status={-1}
   />
-</div>
+</span>
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-icon.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-icon.test.tsx.snap
@@ -9,11 +9,9 @@ exports[`LeftNavIndexIcon render 1`] = `
 `;
 
 exports[`LeftNavStatusIcon render 1`] = `
-<span>
-  <StatusIcon
-    className="dark-gray"
-    level="test"
-    status={0}
-  />
-</span>
+<StatusIcon
+  className="dark-gray"
+  level="test"
+  status={0}
+/>
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-icon.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-icon.test.tsx.snap
@@ -1,19 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`LeftNavIndexIcon render 1`] = `
-<div
+<span
   className="index-circle"
 >
   1
-</div>
+</span>
 `;
 
 exports[`LeftNavStatusIcon render 1`] = `
-<div>
+<span>
   <StatusIcon
     className="dark-gray"
     level="test"
     status={0}
   />
-</div>
+</span>
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/overview-left-nav-link.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/overview-left-nav-link.test.tsx.snap
@@ -1,30 +1,30 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`OverviewLeftNavLink renders 1`] = `
-<div
+<span
   aria-hidden="true"
   className="button-flex-container"
 >
-  <div>
+  <span>
     <StyledIconBase
       className="status-icon dark-gray"
       iconName="home"
     />
-  </div>
-  <div
+  </span>
+  <span
     className="ms-Button-label overview-label"
   >
-    <div
+    <span
       className="overview-name"
     >
       test-props-link-name
-    </div>
-    <div
+    </span>
+    <span
       className="overview-percent"
     >
       42
       % Completed
-    </div>
-  </div>
-</div>
+    </span>
+  </span>
+</span>
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/test-view-left-nav-link.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/test-view-left-nav-link.test.tsx.snap
@@ -1,17 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TestViewLeftNavLink renders 1`] = `
-<div
+<span
   aria-hidden="true"
   className="button-flex-container"
 >
   <i>
     test-props-renderIcon
   </i>
-  <div
+  <span
     className="ms-Button-label test-name"
   >
     test-props-link-name
-  </div>
-</div>
+  </span>
+</span>
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/visualization-based-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/visualization-based-left-nav.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`VisualizationBasedLeftNav renders with index icon 1`] = `
 `;
 
 exports[`VisualizationBasedLeftNav renders with index icon 2`] = `
-<div
+<span
   className="index-circle"
 />
 `;

--- a/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/details-dialog.test.tsx.snap
@@ -1159,11 +1159,11 @@ exports[`DetailsDialog renders with: {"isDevToolsOpen": false, "shadowDialog": t
           data-is-focusable="true"
           type="button"
         >
-          <div
+          <span
             className="ms-button-flex-container"
           >
             <CancelIcon />
-          </div>
+          </span>
         </button>
       </div>
     </div>
@@ -1499,11 +1499,11 @@ exports[`DetailsDialog renders with: {"isDevToolsOpen": false, "shadowDialog": t
                           data-is-focusable="true"
                           type="button"
                         >
-                          <div
+                          <span
                             className="ms-button-flex-container"
                           >
                             <CancelIcon />
-                          </div>
+                          </span>
                         </button>
                       </div>
                     </div>
@@ -2299,11 +2299,11 @@ exports[`DetailsDialog renders with: {"isDevToolsOpen": true, "shadowDialog": tr
           data-is-focusable="true"
           type="button"
         >
-          <div
+          <span
             className="ms-button-flex-container"
           >
             <CancelIcon />
-          </div>
+          </span>
         </button>
       </div>
     </div>
@@ -2639,11 +2639,11 @@ exports[`DetailsDialog renders with: {"isDevToolsOpen": true, "shadowDialog": tr
                           data-is-focusable="true"
                           type="button"
                         >
-                          <div
+                          <span
                             className="ms-button-flex-container"
                           >
                             <CancelIcon />
-                          </div>
+                          </span>
                         </button>
                       </div>
                     </div>


### PR DESCRIPTION
#### Description of changes

This fixes the last subitem of #1801, where our left nav items were failing the WCAG 4.1.1 parsing test due to us nesting `<div>`-based content for our left nav items inside of span/button elements. The outer `<span>` is controlled by office fabric in this case, so this updates all the inner elements to use `<span>` rather than `<div>`. This was a noop in most cases since almost all of the nav item content rendered inline/with overridden display styles anyway.

The sole exception was the overview button's layout where it has the label on one line then the percentage complete on the next line, which relied on the implicit block display; the style update in `detailsview.scss` is there to prevent this impact.

There is no visual or AT change as part of this update. After this update, the only remaining nu validator WCAG violations are false positives (see #1801 for more info)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: fixes #1801
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a, no change] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
