### PR TITLE
fix: high contrast menu icons fix

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -113,10 +113,6 @@ div.insights-file-issue-details-dialog-container {
     padding-left: 5px !important;
 }
 
-.details-view-dropdown-callout {
-    right: 0 !important;
-}
-
 .scoping-panel {
     .scoping-container {
         .scoping-description {

--- a/src/DetailsView/components/details-view-dropdown.scss
+++ b/src/DetailsView/components/details-view-dropdown.scss
@@ -10,3 +10,18 @@
     margin-right: 5px;
     margin-top: 10px;
 }
+
+.details-view-dropdown-callout {
+    right: 43px !important;
+}
+
+:global(.high-contrast-theme) {
+    .details-view-dropdown-callout {
+        box-sizing: border-box;
+        box-shadow: rgba(0, 0, 0, 0.4) 0px 0px 5px 0px;
+        border-width: 1px;
+        border-style: solid;
+        border-color: rgb(57, 57, 57);
+        outline: transparent;
+    }
+}

--- a/src/DetailsView/components/details-view-dropdown.scss
+++ b/src/DetailsView/components/details-view-dropdown.scss
@@ -5,6 +5,7 @@
 .gear-button {
     .gear-options-icon {
         color: $neutral-alpha-90;
+        padding-right: 5px;
     }
 
     margin-right: 5px;
@@ -12,7 +13,7 @@
 }
 
 .details-view-dropdown-callout {
-    right: 43px !important;
+    right: 48px !important;
 }
 
 :global(.high-contrast-theme) {

--- a/src/DetailsView/components/details-view-dropdown.scss
+++ b/src/DetailsView/components/details-view-dropdown.scss
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+
+.gear-button {
+    .gear-options-icon {
+        color: $neutral-alpha-90;
+    }
+
+    margin-right: 5px;
+    margin-top: 10px;
+}

--- a/src/DetailsView/components/details-view-dropdown.tsx
+++ b/src/DetailsView/components/details-view-dropdown.tsx
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IPoint } from '@uifabric/utilities';
-import { DirectionalHint } from 'office-ui-fabric-react';
-import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react';
-import { Icon } from 'office-ui-fabric-react';
-import { Link } from 'office-ui-fabric-react';
+import {
+    ContextualMenu,
+    DirectionalHint,
+    Icon,
+    IContextualMenuItem,
+    Link,
+} from 'office-ui-fabric-react';
 import * as React from 'react';
+import * as styles from './details-view-dropdown.scss';
 
 export interface DetailsViewDropDownProps {
     menuItems: IContextualMenuItem[];
@@ -31,11 +35,11 @@ export class DetailsViewDropDown extends React.Component<
     public render(): JSX.Element {
         return (
             <div className="details-view-dropdown">
-                <Link className={'gear-button'} onClick={this.openDropdown}>
+                <Link className={styles.gearButton} onClick={this.openDropdown}>
                     <Icon
-                        className="gear-options-icon"
+                        className={styles.gearOptionsIcon}
                         iconName="Gear"
-                        ariaLabel={'Manage Settings'}
+                        ariaLabel="Manage Settings"
                     />
                 </Link>
                 {this.renderContextMenu()}

--- a/src/DetailsView/components/details-view-dropdown.tsx
+++ b/src/DetailsView/components/details-view-dropdown.tsx
@@ -20,6 +20,9 @@ export interface DetailsViewDropDownState {
     target?: HTMLElement | string | MouseEvent | IPoint | null;
 }
 
+export const gearButtonAutomationId = 'gear-button';
+export const gearOptionsIconAutomationId = 'gear-options-icon';
+
 export class DetailsViewDropDown extends React.Component<
     DetailsViewDropDownProps,
     DetailsViewDropDownState
@@ -34,9 +37,10 @@ export class DetailsViewDropDown extends React.Component<
 
     public render(): JSX.Element {
         return (
-            <div className="details-view-dropdown">
+            <div data-automation-id={gearButtonAutomationId} className="details-view-dropdown">
                 <Link className={styles.gearButton} onClick={this.openDropdown}>
                     <Icon
+                        data-automation-id={gearOptionsIconAutomationId}
                         className={styles.gearOptionsIcon}
                         iconName="Gear"
                         ariaLabel="Manage Settings"

--- a/src/DetailsView/components/details-view-dropdown.tsx
+++ b/src/DetailsView/components/details-view-dropdown.tsx
@@ -54,7 +54,7 @@ export class DetailsViewDropDown extends React.Component<
         return (
             <ContextualMenu
                 calloutProps={{
-                    className: 'details-view-dropdown-callout',
+                    className: styles.detailsViewDropdownCallout,
                 }}
                 gapSpace={12}
                 shouldFocusOnMount={true}

--- a/src/common/components/gear-options-button-component.scss
+++ b/src/common/components/gear-options-button-component.scss
@@ -23,9 +23,4 @@
 
 :global(#popup-container) .gear-options-button-component {
     display: inline-block;
-
-    button:global(.gear-button) {
-        margin-right: 5px;
-        margin-top: 10px;
-    }
 }

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -325,7 +325,3 @@ button[disabled]:focus:not(.ms-ContextualMenu-link) {
         font-style: italic;
     }
 }
-
-.gear-options-icon {
-    padding-right: 5px;
-}

--- a/src/popup/components/launch-panel-header.scss
+++ b/src/popup/components/launch-panel-header.scss
@@ -1,5 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+
+.feedback-collapse-menu-button {
+    color: $neutral-alpha-90;
+}
 
 .feedback-collapseMenuButton-col {
     float: right;

--- a/src/popup/components/launch-panel-header.tsx
+++ b/src/popup/components/launch-panel-header.tsx
@@ -62,6 +62,7 @@ export class LaunchPanelHeader extends React.Component<
                 <IconButton
                     iconProps={{ iconName: 'GlobalNavButton' }}
                     id="feedback-collapse-menu-button"
+                    className={styles.feedbackCollapseMenuButton}
                     onClick={event =>
                         launchPanelHeaderClickHandler.onOpenContextualMenu(this, event)
                     }

--- a/src/tests/end-to-end/common/element-identifiers/common-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/common-selectors.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { gearButtonAutomationId } from 'DetailsView/components/details-view-dropdown';
+import { getAutomationIdSelector } from 'tests/end-to-end/common/element-identifiers/get-automation-id-selector';
+
 export const CommonSelectors = {
-    settingsGearButton: '.gear-button',
+    settingsGearButton: getAutomationIdSelector(gearButtonAutomationId),
     settingsDropdownMenu: '#settings-dropdown-menu',
     previewFeaturesDropdownButton: '.preview-features-drop-down-button',
     highContrastThemeSelector: 'body.high-contrast-theme',

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -2,14 +2,14 @@
 // Licensed under the MIT License.
 import { resultSectionAutomationId } from 'common/components/cards/result-section';
 import { ruleDetailsGroupAutomationId } from 'common/components/cards/rules-with-instances';
+import { gearOptionsIconAutomationId } from 'DetailsView/components/details-view-dropdown';
 import { IframeWarningContainerAutomationId } from 'DetailsView/components/iframe-warning';
 import { overviewHeadingAutomationId } from 'DetailsView/components/overview-content/overview-heading';
 import { settingsPanelAutomationId } from 'DetailsView/components/settings-panel/settings-panel';
 import { startOverAutomationId } from 'DetailsView/components/start-over-component-factory';
 import { failureCountAutomationId } from 'reports/components/outcome-chip';
 import { cardsRuleIdAutomationId, ruleDetailAutomationId } from 'reports/components/report-sections/minimal-rule-header';
-
-const getAutomationIdSelector = (id: string) => `[data-automation-id="${id}"]`;
+import { getAutomationIdSelector } from 'tests/end-to-end/common/element-identifiers/get-automation-id-selector';
 
 export const detailsViewSelectors = {
     previewFeaturesPanel: '.preview-features-panel',
@@ -19,7 +19,7 @@ export const detailsViewSelectors = {
     mainContent: '[role=main]',
     instanceTableTextContent: '.assessment-instance-textContent',
 
-    gearButton: '.gear-options-icon',
+    gearButton: getAutomationIdSelector(gearOptionsIconAutomationId),
     settingsButton: 'button[name="Settings"]',
 
     automatedChecksResultSection: getAutomationIdSelector(resultSectionAutomationId),

--- a/src/tests/end-to-end/common/element-identifiers/get-automation-id-selector.ts
+++ b/src/tests/end-to-end/common/element-identifiers/get-automation-id-selector.ts
@@ -1,0 +1,3 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export const getAutomationIdSelector = (id: string) => `[data-automation-id="${id}"]`;

--- a/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/launchpad.test.ts.snap
@@ -23,14 +23,16 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
           >
             <div
               class="details-view-dropdown"
+              data-automation-id="gear-button"
             >
               <button
-                class="ms-Link gear-button root-000"
+                class="ms-Link gear-button--{{CSS_MODULE_HASH}} root-000"
                 type="button"
               >
                 <i
                   aria-label="Manage Settings"
-                  class="gear-options-icon root-000"
+                  class="gear-options-icon--{{CSS_MODULE_HASH}} root-000"
+                  data-automation-id="gear-options-icon"
                   data-icon-name="Gear"
                 >
                   
@@ -40,7 +42,7 @@ exports[`Popup -> Launch Pad content should match snapshot 1`] = `
           </div>
           <button
             aria-label="help menu"
-            class="ms-Button ms-Button--icon root-000"
+            class="ms-Button ms-Button--icon feedback-collapse-menu-button--{{CSS_MODULE_HASH}} root-000"
             data-is-focusable="true"
             id="feedback-collapse-menu-button"
             type="button"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-dropdown.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`DetailsViewDropDownTest renders with isContextMenuVisible = false 1`] =
   className="details-view-dropdown"
 >
   <StyledLinkBase
-    className="gear-button"
+    className="gearButton"
     onClick={[Function]}
   >
     <StyledIconBase
@@ -22,7 +22,7 @@ exports[`DetailsViewDropDownTest renders with isContextMenuVisible = true 1`] = 
   className="details-view-dropdown"
 >
   <StyledLinkBase
-    className="gear-button"
+    className="gearButton"
     onClick={[Function]}
   >
     <StyledIconBase

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-dropdown.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`DetailsViewDropDownTest renders with isContextMenuVisible = false 1`] = `
 <div
   className="details-view-dropdown"
+  data-automation-id="gear-button"
 >
   <StyledLinkBase
     className="gearButton"
@@ -11,6 +12,7 @@ exports[`DetailsViewDropDownTest renders with isContextMenuVisible = false 1`] =
     <StyledIconBase
       ariaLabel="Manage Settings"
       className="gearOptionsIcon"
+      data-automation-id="gear-options-icon"
       iconName="Gear"
     />
   </StyledLinkBase>
@@ -20,6 +22,7 @@ exports[`DetailsViewDropDownTest renders with isContextMenuVisible = false 1`] =
 exports[`DetailsViewDropDownTest renders with isContextMenuVisible = true 1`] = `
 <div
   className="details-view-dropdown"
+  data-automation-id="gear-button"
 >
   <StyledLinkBase
     className="gearButton"
@@ -28,6 +31,7 @@ exports[`DetailsViewDropDownTest renders with isContextMenuVisible = true 1`] = 
     <StyledIconBase
       ariaLabel="Manage Settings"
       className="gearOptionsIcon"
+      data-automation-id="gear-options-icon"
       iconName="Gear"
     />
   </StyledLinkBase>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/details-view-dropdown.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`DetailsViewDropDownTest renders with isContextMenuVisible = false 1`] =
   >
     <StyledIconBase
       ariaLabel="Manage Settings"
-      className="gear-options-icon"
+      className="gearOptionsIcon"
       iconName="Gear"
     />
   </StyledLinkBase>
@@ -27,14 +27,14 @@ exports[`DetailsViewDropDownTest renders with isContextMenuVisible = true 1`] = 
   >
     <StyledIconBase
       ariaLabel="Manage Settings"
-      className="gear-options-icon"
+      className="gearOptionsIcon"
       iconName="Gear"
     />
   </StyledLinkBase>
   <StyledWithResponsiveMode
     calloutProps={
       Object {
-        "className": "details-view-dropdown-callout",
+        "className": "detailsViewDropdownCallout",
       }
     }
     directionalHint={6}

--- a/src/tests/unit/tests/DetailsView/components/details-view-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-dropdown.test.tsx
@@ -5,7 +5,7 @@ import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react';
 import { Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 
-import { DetailsViewDropDown, DetailsViewDropDownProps } from '../../../../../DetailsView/components/details-view-dropdown';
+import { DetailsViewDropDown, DetailsViewDropDownProps } from 'DetailsView/components/details-view-dropdown';
 
 describe('DetailsViewDropDownTest', () => {
     describe('renders', () => {

--- a/src/tests/unit/tests/popup/components/__snapshots__/launch-panel-header.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/launch-panel-header.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`LaunchPanelHeaderTest render 1`] = `
     />
     <CustomizedIconButton
       ariaLabel="help menu"
+      className="feedbackCollapseMenuButton"
       iconProps={
         Object {
           "iconName": "GlobalNavButton",
@@ -44,6 +45,7 @@ exports[`LaunchPanelHeaderTest render contextual menu renders with new assessmen
     />
     <CustomizedIconButton
       ariaLabel="help menu"
+      className="feedbackCollapseMenuButton"
       iconProps={
         Object {
           "iconName": "GlobalNavButton",
@@ -157,6 +159,7 @@ exports[`LaunchPanelHeaderTest render contextual menu renders with new assessmen
                   />
                   <CustomizedIconButton
                     ariaLabel="help menu"
+                    className="feedbackCollapseMenuButton"
                     iconProps={
                       Object {
                         "iconName": "GlobalNavButton",
@@ -212,6 +215,7 @@ exports[`LaunchPanelHeaderTest render contextual menu renders without new assess
     />
     <CustomizedIconButton
       ariaLabel="help menu"
+      className="feedbackCollapseMenuButton"
       iconProps={
         Object {
           "iconName": "GlobalNavButton",
@@ -311,6 +315,7 @@ exports[`LaunchPanelHeaderTest render contextual menu renders without new assess
                   />
                   <CustomizedIconButton
                     ariaLabel="help menu"
+                    className="feedbackCollapseMenuButton"
                     iconProps={
                       Object {
                         "iconName": "GlobalNavButton",


### PR DESCRIPTION
#### Description of changes

This fix a regression on #1944.

Basically, make the icon buttons white-ish when high contrast theme is on.
Additionally, fix the contextual menu callout container border in high contrast theme.

![01 - normal theme button color](https://user-images.githubusercontent.com/2837582/73112549-a706b180-3ec3-11ea-9e82-c4baa9adf843.png)
![02 - high contrast theme button color](https://user-images.githubusercontent.com/2837582/73112550-a706b180-3ec3-11ea-9d29-d46913e10de7.png)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
