### PR TITLE
fix: high contrast menu icons fix

### DIFF
--- a/src/common/components/gear-options-button-component.scss
+++ b/src/common/components/gear-options-button-component.scss
@@ -28,4 +28,8 @@
         margin-right: 5px;
         margin-top: 10px;
     }
+
+    button {
+        color: $neutral-alpha-90;
+    }
 }

--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -10,6 +10,13 @@ body {
     font-family: $fontFamily;
 }
 
+.high-contrast-theme {
+    div.details-view-dropdown-callout {
+        box-shadow: $always-white 0px 0px 1px 0px !important;
+        border-radius: unset;
+    }
+}
+
 .telemetry-permission-dialog-modal {
     .ms-Overlay {
         background-color: $neutral-alpha-20;

--- a/src/popup/components/launch-panel-header.scss
+++ b/src/popup/components/launch-panel-header.scss
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+@import '../../common//styles/colors.scss';
 
 .feedback-collapseMenuButton-col {
     float: right;
+
+    > button {
+        color: $neutral-alpha-90;
+    }
 }

--- a/src/popup/components/launch-panel-header.scss
+++ b/src/popup/components/launch-panel-header.scss
@@ -9,3 +9,10 @@
         color: $neutral-alpha-90;
     }
 }
+
+:global(.high-contrast-theme) {
+    :global(.ms-Callout) {
+        box-shadow: $always-white 0px 0px 1px 0px !important;
+        border-radius: unset;
+    }
+}


### PR DESCRIPTION
#### Description of changes

This fix a regression on #1944.

Basically, make the icon buttons white-ish when high contrast theme is on.
Additionally, fix the contextual menu callout container border in high contrast theme.

**Notes**
- I'm abandoning #2047 in favor of this PR
- The way this buttons are implemented is inconsistent (2 buttons with contextual menu, 2 different ways of implementing them). This different approaches made it harder than it should be to convert the components to use CSS-Modules properly and I left that refactor out of the scope of this PR as it will take more time and we want to release Office Fabric 7 update to prod as soon as we can.

**Default theme buttons**
![01 - default theme](https://user-images.githubusercontent.com/2837582/73206302-86bf3880-40f7-11ea-8b27-88400720bd69.png)
**High contrast theme buttons**
![02 - high contrast theme](https://user-images.githubusercontent.com/2837582/73206303-86bf3880-40f7-11ea-898e-56fce53d104a.png)
**Default theme gear contextual menu**
![03 - default theme gear contextual menu](https://user-images.githubusercontent.com/2837582/73206304-86bf3880-40f7-11ea-91db-b000a5849ffb.png)
**High contrast theme gear contextual menu**
![04 - high contrast gear contextual menu](https://user-images.githubusercontent.com/2837582/73206305-86bf3880-40f7-11ea-91c3-6ccab94dd13c.png)
**Default theme hamburger contextual menu**
![05 - default hamburger contextual menu](https://user-images.githubusercontent.com/2837582/73206306-8757cf00-40f7-11ea-949c-fb6b1860d9cd.png)
**High contrast theme gear contextual menu**
![06 - high contrast hamburger contextual menu](https://user-images.githubusercontent.com/2837582/73206308-8757cf00-40f7-11ea-8a7c-c7e4b29b3a7f.png)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS 
   - no changes
