### PR TITLE
feat(release-channels): add signing pipelines for canary/insider/production

### DIFF
--- a/pipeline/scripts/update-electron-checksum.js
+++ b/pipeline/scripts/update-electron-checksum.js
@@ -6,8 +6,10 @@ const YAML = require('js-yaml');
 const path = require('path');
 
 const getLatestYAMLPath = () => {
+    const parentDir = process.argv.length > 2 ? process.argv[2] : 'dist'; // TODO - use library or envvar?
+
     const platformModifier = process.platform == 'darwin' ? '-mac' : process.platform == 'linux' ? '-linux' : '';
-    const latestPath = path.join('dist', `latest${platformModifier}.yml`);
+    const latestPath = path.join(parentDir, `latest${platformModifier}.yml`);
     return latestPath;
 };
 

--- a/pipeline/scripts/update-electron-checksum.js
+++ b/pipeline/scripts/update-electron-checksum.js
@@ -5,9 +5,7 @@ const fs = require('fs');
 const YAML = require('js-yaml');
 const path = require('path');
 
-const getLatestYAMLPath = () => {
-    const parentDir = process.argv.length > 2 ? process.argv[2] : 'dist'; // TODO - use library or envvar?
-
+const getLatestYAMLPath = parentDir => {
     const platformModifier = process.platform == 'darwin' ? '-mac' : process.platform == 'linux' ? '-linux' : '';
     const latestPath = path.join(parentDir, `latest${platformModifier}.yml`);
     return latestPath;
@@ -19,8 +17,7 @@ const readLatestYAML = latestPath => {
     return latest;
 };
 
-const getSetupChecksum = async latest => {
-    const setupFilePath = path.join('dist', latest.path);
+const getSetupChecksum = async setupFilePath => {
     const setupChecksum = await hashUtil.hashFile(setupFilePath, 'sha512', 'base64');
     return setupChecksum;
 };
@@ -36,9 +33,10 @@ const writeLatestYAML = (latestPath, latest) => {
 };
 
 const updateElectronChecksum = async () => {
-    const latestPath = getLatestYAMLPath();
+    const parentDir = process.argv.length > 2 ? process.argv[2] : 'dist'; // TODO - refactor using library/envvar?
+    const latestPath = getLatestYAMLPath(parentDir);
     const latest = readLatestYAML(latestPath);
-    const setupChecksum = await getSetupChecksum(latest);
+    const setupChecksum = await getSetupChecksum(path.join(parentDir, latest.path));
 
     updateChecksumInLatest(latest, setupChecksum);
     writeLatestYAML(latestPath, latest);

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -10,7 +10,7 @@ jobs:
       pool:
           vmImage: 'ubuntu-16.04'
       steps:
-          - template: ../install-node-prerequisites.yaml
+          - template: ../../install-node-prerequisites.yaml
 
           - task: DownloadBuildArtifacts@0
             inputs:

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -62,7 +62,7 @@ jobs:
           - script: yarn update:electron-checksum
             displayName: update electron checksum after signing
 
-          - template: publish-packed-build-output.yaml
+          - template: ../publish-packed-build-output.yaml
             parameters:
                 packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
                 artifactName: $(signedArtifactName)

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -16,9 +16,9 @@ jobs:
             inputs:
                 source: 'specific'
                 runVersion: 'specific'
-                project: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).projectID
-                pipeline: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).pipelineID
-                runId: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).runID
+                project: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.projectID)
+                pipeline: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.pipelineID)
+                runId: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.runID)
                 artifact: ${{ parameters.unsignedArtifactName }}
                 path: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -59,7 +59,7 @@ jobs:
                     Accessibility Insights for Android*.*
                 TargetFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 
-          - script: yarn update:electron-checksum
+          - script: yarn update:electron-checksum signing-in-progress/${{ parameters.signedArtifactName }}
             displayName: update electron checksum after signing
 
           - template: ../publish-packed-build-output.yaml

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -63,5 +63,6 @@ jobs:
             displayName: update electron checksum after signing
 
           - template: publish-packed-build-output.yaml
-            packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
-            artifactName: $(signedArtifactName)
+            parameters:
+                packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                artifactName: $(signedArtifactName)

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -18,9 +18,9 @@ jobs:
                 downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
                 buildType: specific
                 buildVersionToDownload: specific
-                project: ${{ parameters.unsignedPipelineResource }}.projectID)
-                pipeline: ${{ parameters.unsignedPipelineResource }}.pipelineID)
-                buildId: ${{ parameters.unsignedPipelineResource }}.runID)
+                project: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.projectID)
+                pipeline: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.pipelineID)
+                buildId: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.runID)
 
           - task: CopyFiles@2
             displayName: 'Copy the AppImage file to detachedSignature'

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -48,7 +48,7 @@ jobs:
                         }
                     ]
 
-          - script: 'mv "$(System.DefaultWorkingDirectory)/detachedSignature/Accessibility Insights for Android.AppImage" "$(System.DefaultWorkingDirectory)/detachedSignature/Accessibility Insights for Android.sig"'
+          - script: 'rename "s/\.AppImage$/.sig/" $(System.DefaultWorkingDirectory)/detachedSignature/*.AppImage'
             displayName: 'Change signature file extension to sig'
 
           - task: CopyFiles@2

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -1,0 +1,67 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    unsignedPipelineResource: null
+    unsignedArtifactName: null
+    signedArtifactName: null
+
+jobs:
+    - job: $(signedArtifactName)
+      pool:
+          vmImage: 'ubuntu-16.04'
+      steps:
+          - template: ../install-node-prerequisites.yaml
+
+          - task: DownloadBuildArtifacts@0
+            inputs:
+                artifactName: $(unsignedArtifactName)
+                downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                buildType: specific
+                buildVersionToDownload: specific
+                project: $(unsignedPipelineResource.projectID)
+                pipeline: $(unsignedPipelineResource.pipelineID)
+                buildId: $(unsignedPipelineResource.runID)
+
+          - task: CopyFiles@2
+            displayName: 'Copy the AppImage file to detachedSignature'
+            inputs:
+                SourceFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                contents: |
+                    Accessibility Insights for Android*.*
+                TargetFolder: '$(System.DefaultWorkingDirectory)/detachedSignature'
+
+          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+            displayName: 'sign dist/detachedSignature'
+            inputs:
+                ConnectedServiceName: 'ESRP Code Signing'
+                FolderPath: '$(System.DefaultWorkingDirectory)/detachedSignature'
+                Pattern: '*.AppImage'
+                signConfigType: inlineSignParams
+                inlineOperation: |
+                    [
+                        {
+                            "keyCode": "CP-450779-Pgp",
+                            "operationSetCode": "LinuxSign",
+                            "parameters": [],
+                            "toolName": "sign",
+                            "toolVersion": "1.0"
+                        }
+                    ]
+
+          - script: 'mv "$(System.DefaultWorkingDirectory)/detachedSignature/Accessibility Insights for Android.AppImage" "$(System.DefaultWorkingDirectory)/detachedSignature/Accessibility Insights for Android.sig"'
+            displayName: 'Change signature file extension to sig'
+
+          - task: CopyFiles@2
+            displayName: 'Copy the detachedSignature file to working folder'
+            inputs:
+                SourceFolder: $(System.DefaultWorkingDirectory)/detachedSignature
+                contents: |
+                    Accessibility Insights for Android*.*
+                TargetFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+
+          - script: yarn update:electron-checksum
+            displayName: update electron checksum after signing
+
+          - template: publish-packed-build-output.yaml
+            packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+            artifactName: $(signedArtifactName)

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -6,7 +6,7 @@ parameters:
     signedArtifactName: null
 
 jobs:
-    - job: $(signedArtifactName)
+    - job: ${{ parameters.signedArtifactName }}
       pool:
           vmImage: 'ubuntu-16.04'
       steps:
@@ -14,18 +14,18 @@ jobs:
 
           - task: DownloadBuildArtifacts@0
             inputs:
-                artifactName: $(unsignedArtifactName)
-                downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                artifactName: ${{ parameters.unsignedArtifactName }}
+                downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
                 buildType: specific
                 buildVersionToDownload: specific
-                project: $(unsignedPipelineResource.projectID)
-                pipeline: $(unsignedPipelineResource.pipelineID)
-                buildId: $(unsignedPipelineResource.runID)
+                project: ${{ parameters.unsignedPipelineResource }}.projectID)
+                pipeline: ${{ parameters.unsignedPipelineResource }}.pipelineID)
+                buildId: ${{ parameters.unsignedPipelineResource }}.runID)
 
           - task: CopyFiles@2
             displayName: 'Copy the AppImage file to detachedSignature'
             inputs:
-                SourceFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                SourceFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
                 contents: |
                     Accessibility Insights for Android*.*
                 TargetFolder: '$(System.DefaultWorkingDirectory)/detachedSignature'
@@ -57,12 +57,12 @@ jobs:
                 SourceFolder: $(System.DefaultWorkingDirectory)/detachedSignature
                 contents: |
                     Accessibility Insights for Android*.*
-                TargetFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                TargetFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 
           - script: yarn update:electron-checksum
             displayName: update electron checksum after signing
 
           - template: ../publish-packed-build-output.yaml
             parameters:
-                packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
-                artifactName: $(signedArtifactName)
+                packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
+                artifactName: ${{ parameters.signedArtifactName }}

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -12,15 +12,15 @@ jobs:
       steps:
           - template: ../../install-node-prerequisites.yaml
 
-          - task: DownloadBuildArtifacts@0
+          - task: DownloadPipelineArtifact@2
             inputs:
-                artifactName: ${{ parameters.unsignedArtifactName }}
-                downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
-                buildType: specific
-                buildVersionToDownload: specific
-                project: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.projectID)
-                pipeline: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.pipelineID)
-                buildId: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.runID)
+                source: 'specific'
+                runVersion: 'specific'
+                project: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).projectID
+                pipeline: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).pipelineID
+                runId: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).runID
+                artifact: ${{ parameters.unsignedArtifactName }}
+                path: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 
           - task: CopyFiles@2
             displayName: 'Copy the AppImage file to detachedSignature'

--- a/pipeline/unified/channel/sign-release-package-mac.yaml
+++ b/pipeline/unified/channel/sign-release-package-mac.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    unsignedPipelineResource: null
+    unsignedArtifactName: null
+    signedArtifactName: null
+
+jobs:
+    - template: sign-release-package.yaml
+      parameters:
+          unsignedPipelineResource: $(unsignedPipelineResource)
+          unsignedArtifactName: $(unsignedArtifactName)
+          signedArtifactName: $(signedArtifactName)
+          vmImage: macOS-10.14
+          filePattern: '*.dmg, *.zip'
+          inlineSignParams: |
+              [
+                  {
+                      "keyCode": "CP-401337-Apple",
+                      "operationSetCode": "MacAppDeveloperSign",
+                      "parameters": [],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  }
+              ]

--- a/pipeline/unified/channel/sign-release-package-mac.yaml
+++ b/pipeline/unified/channel/sign-release-package-mac.yaml
@@ -8,9 +8,9 @@ parameters:
 jobs:
     - template: sign-release-package.yaml
       parameters:
-          unsignedPipelineResource: $(unsignedPipelineResource)
-          unsignedArtifactName: $(unsignedArtifactName)
-          signedArtifactName: $(signedArtifactName)
+          unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
+          unsignedArtifactName: ${{ parameters.unsignedArtifactName }}
+          signedArtifactName: ${{ parameters.signedArtifactName }}
           vmImage: macOS-10.14
           filePattern: '*.dmg, *.zip'
           inlineSignParams: |

--- a/pipeline/unified/channel/sign-release-package-windows.yaml
+++ b/pipeline/unified/channel/sign-release-package-windows.yaml
@@ -1,0 +1,46 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    unsignedPipelineResource: null
+    unsignedArtifactName: null
+    signedArtifactName: null
+
+jobs:
+    - template: sign-release-package.yaml
+      parameters:
+          unsignedPipelineResource: $(unsignedPipelineResource)
+          unsignedArtifactName: $(unsignedArtifactName)
+          signedArtifactName: $(signedArtifactName)
+          vmImage: windows-latest
+          filePattern: '*.exe, *.dll'
+          inlineSignParams: |
+              [
+                  {
+                  "keyCode": "CP-230012",
+                  "operationSetCode": "SigntoolSign",
+                  "parameters": [
+                      {
+                      "parameterName": "OpusName",
+                      "parameterValue": "Microsoft"
+                      },
+                      {
+                      "parameterName": "OpusInfo",
+                      "parameterValue": "http://www.microsoft.com"
+                      },
+                      {
+                      "parameterName": "PageHash",
+                      "parameterValue": "/NPH"
+                      },
+                      {
+                      "parameterName": "FileDigest",
+                      "parameterValue": "/fd sha256"
+                      },
+                      {
+                      "parameterName": "TimeStamp",
+                      "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                      }
+                  ],
+                  "toolName": "signtool.exe",
+                  "toolVersion": "6.2.9304.0"
+                  }
+              ]

--- a/pipeline/unified/channel/sign-release-package-windows.yaml
+++ b/pipeline/unified/channel/sign-release-package-windows.yaml
@@ -8,9 +8,9 @@ parameters:
 jobs:
     - template: sign-release-package.yaml
       parameters:
-          unsignedPipelineResource: $(unsignedPipelineResource)
-          unsignedArtifactName: $(unsignedArtifactName)
-          signedArtifactName: $(signedArtifactName)
+          unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
+          unsignedArtifactName: ${{ parameters.unsignedArtifactName }}
+          signedArtifactName: ${{ parameters.signedArtifactName }}
           vmImage: windows-latest
           filePattern: '*.exe, *.dll'
           inlineSignParams: |

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -21,9 +21,9 @@ jobs:
             inputs:
                 source: 'specific'
                 runVersion: 'specific'
-                project: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).projectID
-                pipeline: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).pipelineID
-                runId: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).runID
+                project: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.projectID)
+                pipeline: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.pipelineID)
+                runId: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.runID)
                 artifact: ${{ parameters.unsignedArtifactName }}
                 path: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -13,7 +13,7 @@ jobs:
       pool:
           vmImage: $(vmImage)
       steps:
-          - template: ../install-node-prerequisites.yaml
+          - template: ../../install-node-prerequisites.yaml
 
           - task: DownloadBuildArtifacts@0
             inputs:

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -17,20 +17,15 @@ jobs:
 
           - script: echo ${{ parameters.unsignedArtifactName }} ${{ parameters.unsignedPipelineResource }} $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.projectID)
 
-          - download: ${{ parameters.unsignedPipelineResource }}
-
-          - download: ${{ parameters.unsignedPipelineResource }}
-            artifact: ${{ parameters.unsignedArtifactName }}
-
-          - task: DownloadBuildArtifacts@0
+          - task: DownloadPipelineArtifact@2
             inputs:
-                artifactName: ${{ parameters.unsignedArtifactName }}
-                downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
-                buildType: specific
-                buildVersionToDownload: specific
+                source: 'specific'
+                runVersion: 'specific'
                 project: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).projectID
                 pipeline: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).pipelineID
-                buildId: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).runID
+                runId: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).runID
+                artifact: ${{ parameters.unsignedArtifactName }}
+                path: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 
           - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
             displayName: 'Send to ESRP Code Signing service'

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -17,6 +17,9 @@ jobs:
 
           - script: echo ${{ parameters.unsignedArtifactName }} ${{ parameters.unsignedPipelineResource }} $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.projectID)
 
+          - download: ${{ parameters.unsignedPipelineResource }}
+            artifact: ${{ parameters.unsignedArtifactName }}
+
           - task: DownloadBuildArtifacts@0
             inputs:
                 artifactName: ${{ parameters.unsignedArtifactName }}

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -23,9 +23,9 @@ jobs:
                 downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
                 buildType: specific
                 buildVersionToDownload: specific
-                project: ${{ parameters.unsignedPipelineResource }}.projectID
-                pipeline: ${{ parameters.unsignedPipelineResource }}.pipelineID
-                buildId: ${{ parameters.unsignedPipelineResource }}.runID
+                project: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).projectID
+                pipeline: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).pipelineID
+                buildId: $(resources.pipeline.${{ parameters.unsignedPipelineResource }}).runID
 
           - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
             displayName: 'Send to ESRP Code Signing service'

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -37,7 +37,7 @@ jobs:
           - script: yarn update:electron-checksum
             displayName: update electron checksum after signing
 
-          - template: publish-packed-build-output.yaml
+          - template: ../publish-packed-build-output.yaml
             parameters:
                 packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
                 artifactName: $(signedArtifactName)

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -18,6 +18,8 @@ jobs:
           - script: echo ${{ parameters.unsignedArtifactName }} ${{ parameters.unsignedPipelineResource }} $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.projectID)
 
           - download: ${{ parameters.unsignedPipelineResource }}
+
+          - download: ${{ parameters.unsignedPipelineResource }}
             artifact: ${{ parameters.unsignedArtifactName }}
 
           - task: DownloadBuildArtifacts@0

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -15,7 +15,7 @@ jobs:
       steps:
           - template: ../../install-node-prerequisites.yaml
 
-          - script: echo ${{ parameters.unsignedArtifactName }} ${{ parameters.unsignedPipelineResource }} ${{ parameters.unsignedPipelineResource }}.projectID
+          - script: echo ${{ parameters.unsignedArtifactName }} ${{ parameters.unsignedPipelineResource }} $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.projectID)
 
           - task: DownloadBuildArtifacts@0
             inputs:

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -38,5 +38,6 @@ jobs:
             displayName: update electron checksum after signing
 
           - template: publish-packed-build-output.yaml
-            packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
-            artifactName: $(signedArtifactName)
+            parameters:
+                packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                artifactName: $(signedArtifactName)

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -36,7 +36,7 @@ jobs:
                 signConfigType: inlineSignParams
                 inlineOperation: ${{ parameters.inlineSignParams }}
 
-          - script: yarn update:electron-checksum
+          - script: yarn update:electron-checksum --signing-in-progress/${{ parameters.signedArtifactName }}
             displayName: update electron checksum after signing
 
           - template: ../publish-packed-build-output.yaml

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -15,8 +15,6 @@ jobs:
       steps:
           - template: ../../install-node-prerequisites.yaml
 
-          - script: echo ${{ parameters.unsignedArtifactName }} ${{ parameters.unsignedPipelineResource }} $(resources.pipeline.${{ parameters.unsignedPipelineResource }}.projectID)
-
           - task: DownloadPipelineArtifact@2
             inputs:
                 source: 'specific'

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -9,35 +9,35 @@ parameters:
     signedArtifactName: null
 
 jobs:
-    - job: $(signedArtifactName)
+    - job: ${{ parameters.signedArtifactName }}
       pool:
-          vmImage: $(vmImage)
+          vmImage: ${{ parameters.vmImage }}
       steps:
           - template: ../../install-node-prerequisites.yaml
 
           - task: DownloadBuildArtifacts@0
             inputs:
-                artifactName: $(unsignedArtifactName)
-                downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                artifactName: ${{ parameters.unsignedArtifactName }}
+                downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
                 buildType: specific
                 buildVersionToDownload: specific
-                project: $(unsignedPipelineResource.projectID)
-                pipeline: $(unsignedPipelineResource.pipelineID)
-                buildId: $(unsignedPipelineResource.runID)
+                project: ${{ parameters.unsignedPipelineResource }}.projectID
+                pipeline: ${{ parameters.unsignedPipelineResource }}.pipelineID
+                buildId: ${{ parameters.unsignedPipelineResource }}.runID
 
           - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
             displayName: 'Send to ESRP Code Signing service'
             inputs:
                 ConnectedServiceName: 'ESRP Code Signing'
-                FolderPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
-                Pattern: $(filePattern)
+                FolderPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
+                Pattern: ${{ parameters.filePattern }}
                 signConfigType: inlineSignParams
-                inlineOperation: $(inlineSignParams)
+                inlineOperation: ${{ parameters.inlineSignParams }}
 
           - script: yarn update:electron-checksum
             displayName: update electron checksum after signing
 
           - template: ../publish-packed-build-output.yaml
             parameters:
-                packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
-                artifactName: $(signedArtifactName)
+                packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
+                artifactName: ${{ parameters.signedArtifactName }}

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -15,6 +15,8 @@ jobs:
       steps:
           - template: ../../install-node-prerequisites.yaml
 
+          - script: echo ${{ parameters.unsignedArtifactName }} ${{ parameters.unsignedPipelineResource }} ${{ parameters.unsignedPipelineResource }}.projectID
+
           - task: DownloadBuildArtifacts@0
             inputs:
                 artifactName: ${{ parameters.unsignedArtifactName }}

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    vmImage: null
+    filePattern: null
+    inlineSignParams: null
+    unsignedPipelineResource: null
+    unsignedArtifactName: null
+    signedArtifactName: null
+
+jobs:
+    - job: $(signedArtifactName)
+      pool:
+          vmImage: $(vmImage)
+      steps:
+          - template: ../install-node-prerequisites.yaml
+
+          - task: DownloadBuildArtifacts@0
+            inputs:
+                artifactName: $(unsignedArtifactName)
+                downloadPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                buildType: specific
+                buildVersionToDownload: specific
+                project: $(unsignedPipelineResource.projectID)
+                pipeline: $(unsignedPipelineResource.pipelineID)
+                buildId: $(unsignedPipelineResource.runID)
+
+          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+            displayName: 'Send to ESRP Code Signing service'
+            inputs:
+                ConnectedServiceName: 'ESRP Code Signing'
+                FolderPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+                Pattern: $(filePattern)
+                signConfigType: inlineSignParams
+                inlineOperation: $(inlineSignParams)
+
+          - script: yarn update:electron-checksum
+            displayName: update electron checksum after signing
+
+          - template: publish-packed-build-output.yaml
+            packedOutputPath: '$(System.DefaultWorkingDirectory)/signing-in-progress/$(signedArtifactName)'
+            artifactName: $(signedArtifactName)

--- a/pipeline/unified/channel/sign-release-package.yaml
+++ b/pipeline/unified/channel/sign-release-package.yaml
@@ -36,7 +36,7 @@ jobs:
                 signConfigType: inlineSignParams
                 inlineOperation: ${{ parameters.inlineSignParams }}
 
-          - script: yarn update:electron-checksum --signing-in-progress/${{ parameters.signedArtifactName }}
+          - script: yarn update:electron-checksum signing-in-progress/${{ parameters.signedArtifactName }}
             displayName: update electron checksum after signing
 
           - template: ../publish-packed-build-output.yaml

--- a/pipeline/unified/channel/sign-release-packages-for-channel.yaml
+++ b/pipeline/unified/channel/sign-release-packages-for-channel.yaml
@@ -10,17 +10,17 @@ jobs:
     - template: sign-release-package-windows.yaml
       parameters:
           unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
-          unsignedArtifactName: unified-windows-${{ parameters.channel }}-unsigned
-          signedArtifactName: unified-windows-${{ parameters.channel }}-signed
+          unsignedArtifactName: unified_windows_${{ parameters.channel }}_unsigned
+          signedArtifactName: unified_windows_${{ parameters.channel }}_signed
 
     - template: sign-release-package-mac.yaml
       parameters:
           unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
-          unsignedArtifactName: unified-mac-${{ parameters.channel }}-unsigned
-          signedArtifactName: unified-mac-${{ parameters.channel }}-signed
+          unsignedArtifactName: unified_mac_${{ parameters.channel }}_unsigned
+          signedArtifactName: unified_mac_${{ parameters.channel }}_signed
 
     - template: sign-release-package-linux.yaml
       parameters:
           unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
-          unsignedArtifactName: unified-linux-${{ parameters.channel }}-unsigned
-          signedArtifactName: unified-linux-${{ parameters.channel }}-signed
+          unsignedArtifactName: unified_linux_${{ parameters.channel }}_unsigned
+          signedArtifactName: unified_linux_${{ parameters.channel }}_signed

--- a/pipeline/unified/channel/sign-release-packages-for-channel.yaml
+++ b/pipeline/unified/channel/sign-release-packages-for-channel.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+parameters:
+    # canary | insider | production
+    channel: null
+    # Should come from a pipeline resource based on build-unsigned-release-packages.yaml
+    unsignedPipelineResource: null
+
+jobs:
+    - template: sign-release-package-windows.yaml
+      parameters:
+          unsignedPipelineResource: $(unsignedPipelineResource)
+          unsignedArtifactName: unified-windows-$(channel)-unsigned
+          signedArtifactName: unified-windows-$(channel)-signed
+
+    - template: sign-release-package-mac.yaml
+      parameters:
+          unsignedPipelineResource: $(unsignedPipelineResource)
+          unsignedArtifactName: unified-mac-$(channel)-unsigned
+          signedArtifactName: unified-mac-$(channel)-signed
+
+    - template: sign-release-package-linux.yaml
+      parameters:
+          unsignedPipelineResource: $(unsignedPipelineResource)
+          unsignedArtifactName: unified-linux-$(channel)-unsigned
+          signedArtifactName: unified-linux-$(channel)-signed

--- a/pipeline/unified/channel/sign-release-packages-for-channel.yaml
+++ b/pipeline/unified/channel/sign-release-packages-for-channel.yaml
@@ -10,17 +10,17 @@ jobs:
     - template: sign-release-package-windows.yaml
       parameters:
           unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
-          unsignedArtifactName: unified_windows_${{ parameters.channel }}_unsigned
+          unsignedArtifactName: unified-windows-${{ parameters.channel }}-unsigned
           signedArtifactName: unified_windows_${{ parameters.channel }}_signed
 
     - template: sign-release-package-mac.yaml
       parameters:
           unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
-          unsignedArtifactName: unified_mac_${{ parameters.channel }}_unsigned
+          unsignedArtifactName: unified-mac-${{ parameters.channel }}-unsigned
           signedArtifactName: unified_mac_${{ parameters.channel }}_signed
 
     - template: sign-release-package-linux.yaml
       parameters:
           unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
-          unsignedArtifactName: unified_linux_${{ parameters.channel }}_unsigned
+          unsignedArtifactName: unified-linux-${{ parameters.channel }}-unsigned
           signedArtifactName: unified_linux_${{ parameters.channel }}_signed

--- a/pipeline/unified/channel/sign-release-packages-for-channel.yaml
+++ b/pipeline/unified/channel/sign-release-packages-for-channel.yaml
@@ -9,18 +9,18 @@ parameters:
 jobs:
     - template: sign-release-package-windows.yaml
       parameters:
-          unsignedPipelineResource: $(unsignedPipelineResource)
-          unsignedArtifactName: unified-windows-$(channel)-unsigned
-          signedArtifactName: unified-windows-$(channel)-signed
+          unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
+          unsignedArtifactName: unified-windows-${{ parameters.channel }}-unsigned
+          signedArtifactName: unified-windows-${{ parameters.channel }}-signed
 
     - template: sign-release-package-mac.yaml
       parameters:
-          unsignedPipelineResource: $(unsignedPipelineResource)
-          unsignedArtifactName: unified-mac-$(channel)-unsigned
-          signedArtifactName: unified-mac-$(channel)-signed
+          unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
+          unsignedArtifactName: unified-mac-${{ parameters.channel }}-unsigned
+          signedArtifactName: unified-mac-${{ parameters.channel }}-signed
 
     - template: sign-release-package-linux.yaml
       parameters:
-          unsignedPipelineResource: $(unsignedPipelineResource)
-          unsignedArtifactName: unified-linux-$(channel)-unsigned
-          signedArtifactName: unified-linux-$(channel)-signed
+          unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
+          unsignedArtifactName: unified-linux-${{ parameters.channel }}-unsigned
+          signedArtifactName: unified-linux-${{ parameters.channel }}-signed

--- a/pipeline/unified/sign-release-packages-canary.yaml
+++ b/pipeline/unified/sign-release-packages-canary.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+name: $(resources.pipeline.build-unsigned-release-packages.runName)-CanarySigning-$(Rev:r)
+
+trigger: null
+
+resources:
+    pipelines:
+        - pipeline: build-unsigned-release-packages
+          source: build-unsigned-release-packages
+          trigger:
+              branches: [master]
+
+jobs:
+    - template: sign-release-packages-for-channel.yaml
+      parameters:
+          unsignedPipelineResource: $(resources.pipeline.build-unsigned-release-packages)
+          channel: canary

--- a/pipeline/unified/sign-release-packages-canary.yaml
+++ b/pipeline/unified/sign-release-packages-canary.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-name: $(resources.pipeline.build-unsigned-release-packages.runName)-CanarySigning-$(Rev:r)
+name: CanarySigning-$(Rev:r)
 
 trigger: null
 
@@ -14,5 +14,5 @@ resources:
 jobs:
     - template: channel/sign-release-packages-for-channel.yaml
       parameters:
-          unsignedPipelineResource: $(resources.pipeline.build-unsigned-release-packages)
+          unsignedPipelineResource: build-unsigned-release-packages
           channel: canary

--- a/pipeline/unified/sign-release-packages-canary.yaml
+++ b/pipeline/unified/sign-release-packages-canary.yaml
@@ -12,7 +12,7 @@ resources:
               branches: [master]
 
 jobs:
-    - template: sign-release-packages-for-channel.yaml
+    - template: channel/sign-release-packages-for-channel.yaml
       parameters:
           unsignedPipelineResource: $(resources.pipeline.build-unsigned-release-packages)
           channel: canary

--- a/pipeline/unified/sign-release-packages-canary.yaml
+++ b/pipeline/unified/sign-release-packages-canary.yaml
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 name: CanarySigning-$(Rev:r)
 
-trigger: null
+trigger: none
 
 resources:
     pipelines:

--- a/pipeline/unified/sign-release-packages-insider-production.yaml
+++ b/pipeline/unified/sign-release-packages-insider-production.yaml
@@ -11,6 +11,8 @@ resources:
           trigger: none # manual
 
 jobs:
+    - script: echo $(resources.pipeline.build-unsigned-release-packages.projectID) $(resources.pipeline.build-unsigned-release-packages.pipelineID) $(resources.pipeline.build-unsigned-release-packages.runID)
+
     - template: channel/sign-release-packages-for-channel.yaml
       parameters:
           unsignedProjectID: $(resources.pipeline.build-unsigned-release-packages.projectID)

--- a/pipeline/unified/sign-release-packages-insider-production.yaml
+++ b/pipeline/unified/sign-release-packages-insider-production.yaml
@@ -6,7 +6,7 @@ trigger: none
 
 resources:
     pipelines:
-        - pipeline: build-unsigned-release-packages
+        - pipeline: [dev] build unified unsigned installers
           source: build-unsigned-release-packages
           trigger: none # manual
 

--- a/pipeline/unified/sign-release-packages-insider-production.yaml
+++ b/pipeline/unified/sign-release-packages-insider-production.yaml
@@ -11,14 +11,14 @@ resources:
           trigger: none # manual
 
 jobs:
-    - template: sign-release-packages-for-channel.yaml
+    - template: channel/sign-release-packages-for-channel.yaml
       parameters:
           unsignedProjectID: $(resources.pipeline.build-unsigned-release-packages.projectID)
           unsignedPipelineID: $(resources.pipeline.build-unsigned-release-packages.pipelineID)
           unsignedRunID: $(resources.pipeline.build-unsigned-release-packages.runID)
           channel: insider
 
-    - template: sign-release-packages-for-channel.yaml
+    - template: channel/sign-release-packages-for-channel.yaml
       parameters:
           unsignedPipelineResource: $(resources.pipeline.build-unsigned-release-packages)
           channel: production

--- a/pipeline/unified/sign-release-packages-insider-production.yaml
+++ b/pipeline/unified/sign-release-packages-insider-production.yaml
@@ -11,7 +11,9 @@ resources:
           trigger: none # manual
 
 jobs:
-    - script: echo $(resources.pipeline.build-unsigned-release-packages.projectID) $(resources.pipeline.build-unsigned-release-packages.pipelineID) $(resources.pipeline.build-unsigned-release-packages.runID)
+    - job: echo
+      steps:
+          - script: echo $(resources.pipeline.build-unsigned-release-packages.projectID) $(resources.pipeline.build-unsigned-release-packages.pipelineID) $(resources.pipeline.build-unsigned-release-packages.runID)
 
     - template: channel/sign-release-packages-for-channel.yaml
       parameters:

--- a/pipeline/unified/sign-release-packages-insider-production.yaml
+++ b/pipeline/unified/sign-release-packages-insider-production.yaml
@@ -12,6 +12,7 @@ resources:
 
 jobs:
     - template: channel/sign-release-packages-for-channel.yaml
+      displayName: test
       parameters:
           unsignedProjectID: $(resources.pipeline.build-unsigned-release-packages.projectID)
           unsignedPipelineID: $(resources.pipeline.build-unsigned-release-packages.pipelineID)

--- a/pipeline/unified/sign-release-packages-insider-production.yaml
+++ b/pipeline/unified/sign-release-packages-insider-production.yaml
@@ -12,7 +12,6 @@ resources:
 
 jobs:
     - template: channel/sign-release-packages-for-channel.yaml
-      displayName: test
       parameters:
           unsignedProjectID: $(resources.pipeline.build-unsigned-release-packages.projectID)
           unsignedPipelineID: $(resources.pipeline.build-unsigned-release-packages.pipelineID)

--- a/pipeline/unified/sign-release-packages-insider-production.yaml
+++ b/pipeline/unified/sign-release-packages-insider-production.yaml
@@ -6,7 +6,7 @@ trigger: none
 
 resources:
     pipelines:
-        - pipeline: [dev] build unified unsigned installers
+        - pipeline: build-unsigned-release-packages
           source: build-unsigned-release-packages
           trigger: none # manual
 

--- a/pipeline/unified/sign-release-packages-insider-production.yaml
+++ b/pipeline/unified/sign-release-packages-insider-production.yaml
@@ -17,12 +17,10 @@ jobs:
 
     - template: channel/sign-release-packages-for-channel.yaml
       parameters:
-          unsignedProjectID: $(resources.pipeline.build-unsigned-release-packages.projectID)
-          unsignedPipelineID: $(resources.pipeline.build-unsigned-release-packages.pipelineID)
-          unsignedRunID: $(resources.pipeline.build-unsigned-release-packages.runID)
+          unsignedPipelineResource: build-unsigned-release-packages
           channel: insider
 
     - template: channel/sign-release-packages-for-channel.yaml
       parameters:
-          unsignedPipelineResource: $(resources.pipeline.build-unsigned-release-packages)
+          unsignedPipelineResource: build-unsigned-release-packages
           channel: production

--- a/pipeline/unified/sign-release-packages-insider-production.yaml
+++ b/pipeline/unified/sign-release-packages-insider-production.yaml
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-name: $(resources.pipeline.build-unsigned-release-packages.runName)-InsiderProductionSigning-$(Rev:r)
+name: InsiderProductionSigning-$(Rev:r)
 
 trigger: none
 
@@ -11,10 +11,6 @@ resources:
           trigger: none # manual
 
 jobs:
-    - job: echo
-      steps:
-          - script: echo $(resources.pipeline.build-unsigned-release-packages.projectID) $(resources.pipeline.build-unsigned-release-packages.pipelineID) $(resources.pipeline.build-unsigned-release-packages.runID)
-
     - template: channel/sign-release-packages-for-channel.yaml
       parameters:
           unsignedPipelineResource: build-unsigned-release-packages

--- a/pipeline/unified/sign-release-packages-insider-production.yaml
+++ b/pipeline/unified/sign-release-packages-insider-production.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+name: $(resources.pipeline.build-unsigned-release-packages.runName)-InsiderProductionSigning-$(Rev:r)
+
+trigger: null
+
+resources:
+    pipelines:
+        - pipeline: build-unsigned-release-packages
+          source: build-unsigned-release-packages
+          trigger: null # manual
+
+jobs:
+    - template: sign-release-packages-for-channel.yaml
+      parameters:
+          unsignedProjectID: $(resources.pipeline.build-unsigned-release-packages.projectID)
+          unsignedPipelineID: $(resources.pipeline.build-unsigned-release-packages.pipelineID)
+          unsignedRunID: $(resources.pipeline.build-unsigned-release-packages.runID)
+          channel: insider
+
+    - template: sign-release-packages-for-channel.yaml
+      parameters:
+          unsignedPipelineResource: $(resources.pipeline.build-unsigned-release-packages)
+          channel: production

--- a/pipeline/unified/sign-release-packages-insider-production.yaml
+++ b/pipeline/unified/sign-release-packages-insider-production.yaml
@@ -2,13 +2,13 @@
 # Licensed under the MIT License.
 name: $(resources.pipeline.build-unsigned-release-packages.runName)-InsiderProductionSigning-$(Rev:r)
 
-trigger: null
+trigger: none
 
 resources:
     pipelines:
         - pipeline: build-unsigned-release-packages
           source: build-unsigned-release-packages
-          trigger: null # manual
+          trigger: none # manual
 
 jobs:
     - template: sign-release-packages-for-channel.yaml


### PR DESCRIPTION
#### Description of changes

This set of pipelines is responsible for signing the unsigned-release packages created by `build-unsigned-release-packages.yaml`. Separate release pipelines will consume the signed installers and upload them to Azure blob storage.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
