### PR TITLE
fix: bring back confirmation dialog for unified electron client

### DIFF
--- a/copyright-header.config.json
+++ b/copyright-header.config.json
@@ -27,7 +27,7 @@
         "yarn.lock"
     ],
     "licenseFormats": {
-        "yaml|npmrc|yml|ps1|gitignore|dockerignore|prettierignore|yarnrc": {
+        "yaml|npmrc|yml|ps1|gitignore|dockerignore|prettierignore|yarnrc|nsh": {
             "eachLine": {
                 "prepend": "# "
             }

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -25,8 +25,10 @@ win:
     target: nsis
 
 nsis:
-    oneClick: true
+    oneClick: false
     perMachine: false
     deleteAppDataOnUninstall: true
+    include: src/electron/resources/installer.nsh
+
 publish:
     provider: generic

--- a/src/electron/resources/installer.nsh
+++ b/src/electron/resources/installer.nsh
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 !macro customInstallMode
   StrCpy $isForceCurrentInstall "1"
 !macroend

--- a/src/electron/resources/installer.nsh
+++ b/src/electron/resources/installer.nsh
@@ -1,0 +1,3 @@
+!macro customInstallMode
+  StrCpy $isForceCurrentInstall "1"
+!macroend


### PR DESCRIPTION
#### Description of changes

This PR helps with #1974 by leveraging a custom nsis installer script. Dan found this approch / references: 
- https://www.electron.build/configuration/nsis#custom-nsis-script
- https://github.com/electron-userland/electron-builder/blob/master/packages/app-builder-lib/templates/nsis/multiUserUi.nsh#L39

We had switched to the one-click installer to remove the per-user / per-machine configuration screen from the installer. This also removed the confirmation dialog as a side-effect. This installer script allows us to switch back to the assisted installer while avoiding the per-user / per-machine configuration screen.

With this PR the installer looks like:
- license agreement
- installing progress
- confirmation screen with checkbox to run the app

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
