### PR TITLE
fix: darken text secondary color

### DIFF
--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -15,7 +15,7 @@
 
     // Text colors
     --primary-text: rgba(0, 0, 0, 0.9);
-    --secondary-text: rgba(0, 0, 0, 0.55);
+    --secondary-text: rgba(0, 0, 0, 0.7);
     --disabled-text: rgba(0, 0, 0, 0.38);
     --primary-text-invert: rgba(255, 255, 255, 1);
     --secondary-text-invert: rgba(255, 255, 255, 0.65);


### PR DESCRIPTION
#### Description of changes

This PR darkens the text secondary color as requested in issue #2064 

example:
![before / after of text color](https://user-images.githubusercontent.com/7775527/73396871-2404a300-4297-11ea-8d7b-c4235511ebfa.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2064
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
