### PR TITLE
feat(unified-channels): update unified app IDs and publish URLs to match reality

### DIFF
--- a/targets.config.js
+++ b/targets.config.js
@@ -120,9 +120,8 @@ module.exports = {
         },
         bundleFolder: 'electronBundle',
         mustExistFile: 'main.bundle.js',
-        // Note: this non-canary-looking appId is intentional for backcompat
-        appId: 'com.microsoft.accessibilityinsights',
-        publishUrl: 'https://a11yinsightsandroidblob.blob.core.windows.net/aimobile-canary',
+        appId: 'com.microsoft.accessibilityinsights.unified.canary',
+        publishUrl: 'https://a11yunifiedcanaryblob.blob.core.windows.net/a11yunified-canary',
         telemetryKeyIdentifier: 'unified-canary-instrumentation-key',
     },
     'unified-insider': {
@@ -138,7 +137,7 @@ module.exports = {
         bundleFolder: 'electronBundle',
         mustExistFile: 'main.bundle.js',
         appId: 'com.microsoft.accessibilityinsights.unified.insider',
-        publishUrl: 'https://a11yinsightsandroidblob-insiders.blob.core.windows.net/aimobile-insiders',
+        publishUrl: 'https://a11yunifiedinsiderblob.blob.core.windows.net/a11yunified-insider',
         telemetryKeyIdentifier: 'unified-insider-instrumentation-key',
     },
     'unified-production': {
@@ -154,7 +153,7 @@ module.exports = {
         bundleFolder: 'electronBundle',
         mustExistFile: 'main.bundle.js',
         appId: 'com.microsoft.accessibilityinsights.unified.production',
-        publishUrl: 'https://a11yinsightsandroidblob-production.blob.core.windows.net/aimobile-production',
+        publishUrl: 'https://a11yunifiedprodblob.blob.core.windows.net/a11yunified-prod',
         telemetryKeyIdentifier: 'unified-prod-instrumentation-key',
     },
 };


### PR DESCRIPTION
#### Description of changes

Updating the targets.config info on app ID and update URL to match how we've set up the publishing azure blob storage. Note, this intentionally sets canary up to use a new app ID and publish URL vs the "old" infrastructure's canary build

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1666342
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
