### PR TITLE
refactor: generic panel more open/close-ish

### DIFF
--- a/src/DetailsView/components/failure-instance-panel-control.tsx
+++ b/src/DetailsView/components/failure-instance-panel-control.tsx
@@ -124,7 +124,7 @@ export class FailureInstancePanelControl extends React.Component<
             isOpen: this.state.isPanelOpen,
             className: styles.failureInstancePanel,
             onDismiss: this.closeFailureInstancePanel,
-            title:
+            headerText:
                 this.props.actionType === CapturedInstanceActionType.CREATE
                     ? FailureInstancePanelControl.addFailureInstanceLabel
                     : 'Edit failure instance',

--- a/src/DetailsView/components/generic-panel.tsx
+++ b/src/DetailsView/components/generic-panel.tsx
@@ -8,7 +8,7 @@ import * as styles from './generic-panel.scss';
 export interface GenericPanelProps {
     isOpen: boolean;
     onDismiss: () => void;
-    title: string;
+    headerText: string;
     className?: string;
     closeButtonAriaLabel: string;
     hasCloseButton: boolean;
@@ -29,7 +29,7 @@ export class GenericPanel extends React.Component<GenericPanelProps> {
                 onDismiss={this.props.onDismiss}
                 closeButtonAriaLabel={this.props.closeButtonAriaLabel}
                 hasCloseButton={this.props.hasCloseButton}
-                headerText={this.props.title}
+                headerText={this.props.headerText}
                 headerClassName={styles.headerText}
                 onRenderFooter={this.props.onRenderFooterContent}
             >

--- a/src/DetailsView/components/generic-panel.tsx
+++ b/src/DetailsView/components/generic-panel.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { css, IRenderFunction } from '@uifabric/utilities';
+import { NamedFC } from 'common/react/named-fc';
 import { IPanelProps, Panel, PanelType } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './generic-panel.scss';
@@ -16,25 +17,21 @@ export interface GenericPanelProps {
     innerPanelAutomationId?: string;
 }
 
-export class GenericPanel extends React.Component<GenericPanelProps> {
-    public render(): JSX.Element {
-        return (
-            <Panel
-                data-automation-id={this.props.innerPanelAutomationId}
-                isOpen={this.props.isOpen}
-                type={PanelType.custom}
-                customWidth="550px"
-                className={css(styles.genericPanel, this.props.className)}
-                isLightDismiss={true}
-                onDismiss={this.props.onDismiss}
-                closeButtonAriaLabel={this.props.closeButtonAriaLabel}
-                hasCloseButton={this.props.hasCloseButton}
-                headerText={this.props.headerText}
-                headerClassName={styles.headerText}
-                onRenderFooter={this.props.onRenderFooterContent}
-            >
-                {this.props.children}
-            </Panel>
-        );
-    }
-}
+export const GenericPanel = NamedFC<GenericPanelProps>('GenericPanel', props => (
+    <Panel
+        data-automation-id={props.innerPanelAutomationId}
+        isOpen={props.isOpen}
+        type={PanelType.custom}
+        customWidth="550px"
+        className={css(styles.genericPanel, props.className)}
+        isLightDismiss={true}
+        onDismiss={props.onDismiss}
+        closeButtonAriaLabel={props.closeButtonAriaLabel}
+        hasCloseButton={props.hasCloseButton}
+        headerText={props.headerText}
+        headerClassName={styles.headerText}
+        onRenderFooter={props.onRenderFooterContent}
+    >
+        {props.children}
+    </Panel>
+));

--- a/src/DetailsView/components/generic-panel.tsx
+++ b/src/DetailsView/components/generic-panel.tsx
@@ -1,36 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { css, IRenderFunction } from '@uifabric/utilities';
+import { css } from '@uifabric/utilities';
 import { NamedFC } from 'common/react/named-fc';
 import { IPanelProps, Panel, PanelType } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './generic-panel.scss';
 
-export interface GenericPanelProps {
-    isOpen: boolean;
-    onDismiss: () => void;
-    headerText: string;
-    className?: string;
-    closeButtonAriaLabel: string;
-    hasCloseButton: boolean;
-    onRenderFooterContent?: IRenderFunction<IPanelProps>;
+export type GenericPanelProps = IPanelProps & {
     innerPanelAutomationId?: string;
-}
+};
 
 export const GenericPanel = NamedFC<GenericPanelProps>('GenericPanel', props => (
     <Panel
+        {...props}
         data-automation-id={props.innerPanelAutomationId}
-        isOpen={props.isOpen}
         type={PanelType.custom}
         customWidth="550px"
         className={css(styles.genericPanel, props.className)}
         isLightDismiss={true}
-        onDismiss={props.onDismiss}
-        closeButtonAriaLabel={props.closeButtonAriaLabel}
-        hasCloseButton={props.hasCloseButton}
-        headerText={props.headerText}
         headerClassName={styles.headerText}
-        onRenderFooter={props.onRenderFooterContent}
     >
         {props.children}
     </Panel>

--- a/src/DetailsView/components/preview-features-panel.tsx
+++ b/src/DetailsView/components/preview-features-panel.tsx
@@ -23,7 +23,7 @@ export class PreviewFeaturesPanel extends React.Component<PreviewFeaturesPanelPr
     public render(): JSX.Element {
         return (
             <GenericPanel
-                title="Preview features"
+                headerText="Preview features"
                 isOpen={this.props.isOpen}
                 className="preview-features-panel"
                 onDismiss={

--- a/src/DetailsView/components/scoping-panel.tsx
+++ b/src/DetailsView/components/scoping-panel.tsx
@@ -28,7 +28,7 @@ export class ScopingPanel extends React.Component<ScopingPanelProps> {
     public render(): JSX.Element {
         return (
             <GenericPanel
-                title="Scoping"
+                headerText="Scoping"
                 isOpen={this.props.isOpen}
                 className="scoping-panel"
                 onDismiss={this.props.deps.detailsViewActionMessageCreator.closeScopingPanel}

--- a/src/DetailsView/components/settings-panel/settings-panel.tsx
+++ b/src/DetailsView/components/settings-panel/settings-panel.tsx
@@ -36,7 +36,7 @@ export const SettingsPanel = NamedFC<SettingsPanelProps>('SettingsPanel', props 
             onDismiss={detailsViewActionMessageCreator.closeSettingsPanel}
             closeButtonAriaLabel="Close settings panel"
             hasCloseButton={true}
-            title="Settings"
+            headerText="Settings"
         >
             {settingsProvider.all().map((TheComponent: SettingsComponent, index: number) => (
                 <TheComponent

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/failure-instance-panel-control.test.tsx.snap
@@ -18,9 +18,9 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: cre
     className="failureInstancePanel"
     closeButtonAriaLabel="Close failure instance panel"
     hasCloseButton={true}
+    headerText="Add a failure instance"
     isOpen={false}
     onDismiss={[Function]}
-    title="Add a failure instance"
   >
     <FlaggedComponent
       enableJSXElement={
@@ -73,9 +73,9 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: edi
     className="failureInstancePanel"
     closeButtonAriaLabel="Close failure instance panel"
     hasCloseButton={true}
+    headerText="Edit failure instance"
     isOpen={false}
     onDismiss={[Function]}
-    title="Edit failure instance"
   >
     <FlaggedComponent
       enableJSXElement={
@@ -131,9 +131,9 @@ exports[`FailureInstancePanelControlTest render FailureInstancePanelControl: par
     className="failureInstancePanel"
     closeButtonAriaLabel="Close failure instance panel"
     hasCloseButton={true}
+    headerText="Add a failure instance"
     isOpen={false}
     onDismiss={[Function]}
-    title="Add a failure instance"
   >
     <FlaggedComponent
       enableJSXElement={

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-panel.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-panel.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DetailsViewPanelTest render - isPanelOpen: false 1`] = `
+exports[`GenericPanel render - isPanelOpen: false 1`] = `
 <StyledPanelBase
   className="genericPanel panel-custom-class"
   closeButtonAriaLabel="close button label"
@@ -19,7 +19,7 @@ exports[`DetailsViewPanelTest render - isPanelOpen: false 1`] = `
 </StyledPanelBase>
 `;
 
-exports[`DetailsViewPanelTest render - isPanelOpen: true 1`] = `
+exports[`GenericPanel render - isPanelOpen: true 1`] = `
 <StyledPanelBase
   className="genericPanel panel-custom-class"
   closeButtonAriaLabel="close button label"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-panel.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-panel.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GenericPanel render - isPanelOpen: false 1`] = `
+exports[`GenericPanel renders isPanelOpen: false 1`] = `
 <StyledPanelBase
   className="genericPanel panel-custom-class"
   closeButtonAriaLabel="close button label"
@@ -19,7 +19,7 @@ exports[`GenericPanel render - isPanelOpen: false 1`] = `
 </StyledPanelBase>
 `;
 
-exports[`GenericPanel render - isPanelOpen: true 1`] = `
+exports[`GenericPanel renders isPanelOpen: true 1`] = `
 <StyledPanelBase
   className="genericPanel panel-custom-class"
   closeButtonAriaLabel="close button label"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-panel.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-panel.test.tsx.snap
@@ -37,3 +37,13 @@ exports[`GenericPanel renders isPanelOpen: true 1`] = `
   </div>
 </StyledPanelBase>
 `;
+
+exports[`GenericPanel renders minimal content 1`] = `
+<StyledPanelBase
+  className="genericPanel"
+  customWidth="550px"
+  headerClassName="headerText"
+  isLightDismiss={true}
+  type={7}
+/>
+`;

--- a/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
@@ -11,7 +11,7 @@ describe('DetailsViewPanelTest', () => {
         const props: GenericPanelProps = {
             isOpen: isPanelOpen,
             onDismiss: () => {},
-            title: 'panel title',
+            headerText: 'panel title',
             className: 'panel-custom-class',
             closeButtonAriaLabel: 'close button label',
             children: childContent,

--- a/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
@@ -22,5 +22,13 @@ describe('GenericPanel', () => {
 
             expect(wrapper.getElement()).toMatchSnapshot();
         });
+
+        it('minimal content', () => {
+            const props: GenericPanelProps = {};
+
+            const wrapper = shallow(<GenericPanel {...props} />);
+
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
@@ -4,7 +4,7 @@ import { GenericPanel, GenericPanelProps } from 'DetailsView/components/generic-
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-describe('DetailsViewPanelTest', () => {
+describe('GenericPanel', () => {
     test.each([true, false])('render - isPanelOpen: %s', (isPanelOpen: boolean) => {
         const childContent = <div>child content</div>;
 

--- a/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
@@ -5,20 +5,22 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('GenericPanel', () => {
-    test.each([true, false])('render - isPanelOpen: %s', (isPanelOpen: boolean) => {
-        const childContent = <div>child content</div>;
+    describe('renders', () => {
+        it.each([true, false])('isPanelOpen: %s', (isPanelOpen: boolean) => {
+            const childContent = <div>child content</div>;
 
-        const props: GenericPanelProps = {
-            isOpen: isPanelOpen,
-            onDismiss: () => {},
-            headerText: 'panel title',
-            className: 'panel-custom-class',
-            closeButtonAriaLabel: 'close button label',
-            hasCloseButton: true,
-        };
+            const props: GenericPanelProps = {
+                isOpen: isPanelOpen,
+                onDismiss: () => {},
+                headerText: 'panel title',
+                className: 'panel-custom-class',
+                closeButtonAriaLabel: 'close button label',
+                hasCloseButton: true,
+            };
 
-        const wrapper = shallow(<GenericPanel {...props}>{childContent}</GenericPanel>);
+            const wrapper = shallow(<GenericPanel {...props}>{childContent}</GenericPanel>);
 
-        expect(wrapper.getElement()).toMatchSnapshot();
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/generic-panel.test.tsx
@@ -14,11 +14,10 @@ describe('GenericPanel', () => {
             headerText: 'panel title',
             className: 'panel-custom-class',
             closeButtonAriaLabel: 'close button label',
-            children: childContent,
             hasCloseButton: true,
         };
 
-        const wrapper = shallow(<GenericPanel {...props} />);
+        const wrapper = shallow(<GenericPanel {...props}>{childContent}</GenericPanel>);
 
         expect(wrapper.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/DetailsView/components/preview-features-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/preview-features-panel.test.tsx
@@ -32,7 +32,7 @@ describe('PreviewFeaturesPanelTest', () => {
 
         const expected = (
             <GenericPanel
-                title="Preview features"
+                headerText="Preview features"
                 isOpen={true}
                 className={'preview-features-panel'}
                 onDismiss={testProps.deps.detailsViewActionMessageCreator.closePreviewFeaturesPanel}

--- a/src/tests/unit/tests/DetailsView/components/scoping-panel.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/scoping-panel.test.tsx
@@ -48,7 +48,7 @@ describe('ScopingPanelTest', () => {
                 onDismiss={testProps.deps.detailsViewActionMessageCreator.closeScopingPanel}
                 closeButtonAriaLabel={'Close scoping feature panel'}
                 hasCloseButton={true}
-                title="Scoping"
+                headerText="Scoping"
             >
                 <ScopingContainer
                     deps={testProps.deps}

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/__snapshots__/settings-panel.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/__snapshots__/settings-panel.test.tsx.snap
@@ -5,10 +5,10 @@ exports[`SettingsPanelTest render - isPanelOpen = false 1`] = `
   className="settingsPanel"
   closeButtonAriaLabel="Close settings panel"
   hasCloseButton={true}
+  headerText="Settings"
   innerPanelAutomationId="settings-panel"
   isOpen={false}
   onDismiss={[Function]}
-  title="Settings"
 >
   <TestSettings
     deps={
@@ -75,10 +75,10 @@ exports[`SettingsPanelTest render - isPanelOpen = true 1`] = `
   className="settingsPanel"
   closeButtonAriaLabel="Close settings panel"
   hasCloseButton={true}
+  headerText="Settings"
   innerPanelAutomationId="settings-panel"
   isOpen={true}
   onDismiss={[Function]}
-  title="Settings"
 >
   <TestSettings
     deps={


### PR DESCRIPTION
#### Description of changes

Doing some exploratory work to bring the settings panel to AI-Android, I found it would be useful to make the `<GenericPanel>` to accept all the properties from **Office Fabric** `<Panel>` and only have default values for some properties. This makes `<GenericPanel>` closer to **open/close** principle. 
 
**NOTE** there is a `prop` renaming so it could be easier to review this PR commit by commit.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
