### PR TITLE
refactor: generic toggle to use css module

### DIFF
--- a/src/DetailsView/components/generic-toggle.scss
+++ b/src/DetailsView/components/generic-toggle.scss
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+
 .generic-toggle-component {
     margin-bottom: 4vh;
 
@@ -15,5 +17,9 @@
         .toggle {
             float: right;
         }
+    }
+
+    .toggle-description {
+        color: $secondary-text;
     }
 }

--- a/src/DetailsView/components/generic-toggle.scss
+++ b/src/DetailsView/components/generic-toggle.scss
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.generic-toggle-component {
+    margin-bottom: 4vh;
+
+    .toggle-container {
+        margin-bottom: 1vh;
+
+        .toggle-name {
+            display: inline-block;
+            font-size: 17px;
+            font-weight: bold;
+        }
+
+        .toggle {
+            float: right;
+        }
+    }
+}

--- a/src/DetailsView/components/generic-toggle.tsx
+++ b/src/DetailsView/components/generic-toggle.tsx
@@ -32,7 +32,7 @@ export const GenericToggle = NamedFC<GenericToggleProps>('GenericToggle', props 
                     ariaLabel={props.name}
                 />
             </div>
-            <div className={'toggle-description'}>{props.description}</div>
+            <div className={styles.toggleDescription}>{props.description}</div>
         </div>
     );
 });

--- a/src/DetailsView/components/generic-toggle.tsx
+++ b/src/DetailsView/components/generic-toggle.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
 import { Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
-
-import { NamedFC } from '../../common/react/named-fc';
+import * as styles from './generic-toggle.scss';
 
 export interface GenericToggleProps {
     enabled: boolean;
@@ -19,12 +19,12 @@ export const GenericToggle = NamedFC<GenericToggleProps>('GenericToggle', props 
     };
 
     return (
-        <div className={'generic-toggle-component'}>
-            <div className={'toggle-container'}>
-                <div className={'toggle-name'}>{props.name}</div>
+        <div className={styles.genericToggleComponent}>
+            <div className={styles.toggleContainer}>
+                <div className={styles.toggleName}>{props.name}</div>
                 <Toggle
                     id={props.id}
-                    className={'toggle'}
+                    className={styles.toggle}
                     checked={props.enabled}
                     onClick={onClick}
                     onText={'On'}

--- a/src/DetailsView/components/settings-panel/settings-panel.scss
+++ b/src/DetailsView/components/settings-panel/settings-panel.scss
@@ -3,10 +3,6 @@
 @import '../../../common/styles/colors.scss';
 
 .settings-panel {
-    :global(.toggle-description) {
-        color: $secondary-text;
-    }
-
     h3 {
         font-size: 17px;
         margin-block-end: 8px;

--- a/src/DetailsView/components/settings-panel/settings-panel.scss
+++ b/src/DetailsView/components/settings-panel/settings-panel.scss
@@ -3,7 +3,7 @@
 @import '../../../common/styles/colors.scss';
 
 .settings-panel {
-    .generic-toggle-component .toggle-description {
+    :global(.toggle-description) {
         color: $secondary-text;
     }
 

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -39,22 +39,6 @@ button::after {
     color: $neutral-100;
 }
 
-.generic-toggle-component {
-    margin-bottom: 4vh;
-    .toggle-container {
-        margin-bottom: 1vh;
-        .toggle-name {
-            display: inline-block;
-            font-size: 17px;
-            font-weight: bold;
-        }
-
-        .toggle {
-            float: right;
-        }
-    }
-}
-
 .high-contrast-theme {
     .insights-link {
         &:hover {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-toggle.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-toggle.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`GenericToggleTest render with jsx content 1`] = `
+exports[`GenericToggleTest renders description content is JSX.Element 1`] = `
 <div
   className="genericToggleComponent"
 >
@@ -32,7 +32,37 @@ exports[`GenericToggleTest render with jsx content 1`] = `
 </div>
 `;
 
-exports[`GenericToggleTest render with string content - toggleState : false 1`] = `
+exports[`GenericToggleTest renders description content is string 1`] = `
+<div
+  className="genericToggleComponent"
+>
+  <div
+    className="toggleContainer"
+  >
+    <div
+      className="toggleName"
+    >
+      test name
+    </div>
+    <StyledToggleBase
+      ariaLabel="test name"
+      checked={true}
+      className="toggle"
+      id="test-id-1"
+      offText="Off"
+      onClick={[Function]}
+      onText="On"
+    />
+  </div>
+  <div
+    className="toggle-description"
+  >
+    test string description
+  </div>
+</div>
+`;
+
+exports[`GenericToggleTest renders toggle enable = false 1`] = `
 <div
   className="genericToggleComponent"
 >
@@ -62,7 +92,7 @@ exports[`GenericToggleTest render with string content - toggleState : false 1`] 
 </div>
 `;
 
-exports[`GenericToggleTest render with string content - toggleState : true 1`] = `
+exports[`GenericToggleTest renders toggle enable = true 1`] = `
 <div
   className="genericToggleComponent"
 >

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-toggle.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-toggle.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`GenericToggleTest render with jsx content 1`] = `
 <div
-  className="generic-toggle-component"
+  className="genericToggleComponent"
 >
   <div
-    className="toggle-container"
+    className="toggleContainer"
   >
     <div
-      className="toggle-name"
+      className="toggleName"
     >
       test name
     </div>
@@ -34,13 +34,13 @@ exports[`GenericToggleTest render with jsx content 1`] = `
 
 exports[`GenericToggleTest render with string content - toggleState : false 1`] = `
 <div
-  className="generic-toggle-component"
+  className="genericToggleComponent"
 >
   <div
-    className="toggle-container"
+    className="toggleContainer"
   >
     <div
-      className="toggle-name"
+      className="toggleName"
     >
       test name
     </div>
@@ -64,43 +64,13 @@ exports[`GenericToggleTest render with string content - toggleState : false 1`] 
 
 exports[`GenericToggleTest render with string content - toggleState : true 1`] = `
 <div
-  className="generic-toggle-component"
+  className="genericToggleComponent"
 >
   <div
-    className="toggle-container"
+    className="toggleContainer"
   >
     <div
-      className="toggle-name"
-    >
-      test name
-    </div>
-    <StyledToggleBase
-      ariaLabel="test name"
-      checked={true}
-      className="toggle"
-      id="test-id-1"
-      offText="Off"
-      onClick={[Function]}
-      onText="On"
-    />
-  </div>
-  <div
-    className="toggle-description"
-  >
-    test description
-  </div>
-</div>
-`;
-
-exports[`GenericToggleTest verify if the classname passed from prop is added properly 1`] = `
-<div
-  className="generic-toggle-component"
->
-  <div
-    className="toggle-container"
-  >
-    <div
-      className="toggle-name"
+      className="toggleName"
     >
       test name
     </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-toggle.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-toggle.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`GenericToggleTest renders description content is JSX.Element 1`] = `
     />
   </div>
   <div
-    className="toggle-description"
+    className="toggleDescription"
   >
     <h1>
       hello
@@ -55,7 +55,7 @@ exports[`GenericToggleTest renders description content is string 1`] = `
     />
   </div>
   <div
-    className="toggle-description"
+    className="toggleDescription"
   >
     test string description
   </div>
@@ -85,7 +85,7 @@ exports[`GenericToggleTest renders toggle enable = false 1`] = `
     />
   </div>
   <div
-    className="toggle-description"
+    className="toggleDescription"
   >
     test description
   </div>
@@ -115,7 +115,7 @@ exports[`GenericToggleTest renders toggle enable = true 1`] = `
     />
   </div>
   <div
-    className="toggle-description"
+    className="toggleDescription"
   >
     test description
   </div>

--- a/src/tests/unit/tests/DetailsView/components/generic-toggle.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/generic-toggle.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
-import { GenericToggle, GenericToggleProps } from '../../../../../DetailsView/components/generic-toggle';
+import { GenericToggle, GenericToggleProps } from 'DetailsView/components/generic-toggle';
 
 describe('GenericToggleTest', () => {
     let onClickMock: IMock<(id: string, enabled: boolean, event: React.MouseEvent<HTMLElement>) => void>;
@@ -55,18 +55,5 @@ describe('GenericToggleTest', () => {
         toggle.simulate('click', eventStub);
 
         onClickMock.verify(ocm => ocm(props.id, !props.enabled, eventStub), Times.once());
-    });
-
-    test('verify if the classname passed from prop is added properly', () => {
-        const props: GenericToggleProps = {
-            name: 'test name',
-            description: 'test description',
-            enabled: true,
-            onClick: onClickMock.object,
-            id: 'test-id-1',
-        };
-
-        const wrapper = shallow(<GenericToggle {...props} />);
-        expect(wrapper.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/generic-toggle.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/generic-toggle.test.tsx
@@ -1,59 +1,67 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { GenericToggle, GenericToggleProps } from 'DetailsView/components/generic-toggle';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
-import { GenericToggle, GenericToggleProps } from 'DetailsView/components/generic-toggle';
-
 describe('GenericToggleTest', () => {
-    let onClickMock: IMock<(id: string, enabled: boolean, event: React.MouseEvent<HTMLElement>) => void>;
+    type OnClick = GenericToggleProps['onClick'];
+    let onClickMock: IMock<OnClick>;
 
     beforeEach(() => {
-        onClickMock = Mock.ofInstance((id: string, enabled: boolean, event: React.MouseEvent<HTMLElement>) => {});
+        onClickMock = Mock.ofType<OnClick>();
     });
 
-    test.each([true, false])('render with string content - toggleState : %s', (toggleState: boolean) => {
-        const props: GenericToggleProps = {
-            name: 'test name',
-            description: 'test description',
-            enabled: toggleState,
-            onClick: onClickMock.object,
-            id: 'test-id-1',
-        };
+    describe('renders', () => {
+        it.each([true, false])('toggle enable = %s', enabled => {
+            const props: GenericToggleProps = {
+                name: 'test name',
+                description: 'test description',
+                enabled,
+                onClick: onClickMock.object,
+                id: 'test-id-1',
+            };
 
-        const wrapped = shallow(<GenericToggle {...props} />);
-        expect(wrapped.getElement()).toMatchSnapshot();
+            const wrapped = shallow(<GenericToggle {...props} />);
+            expect(wrapped.getElement()).toMatchSnapshot();
+        });
+
+        it.each`
+            testDescription     | descriptionContent
+            ${'is string'}      | ${'test string description'}
+            ${'is JSX.Element'} | ${(<h1>hello</h1>)}
+        `('description content $testDescription', ({ descriptionContent }) => {
+            const props: GenericToggleProps = {
+                name: 'test name',
+                description: descriptionContent,
+                enabled: true,
+                onClick: onClickMock.object,
+                id: 'test-id-1',
+            };
+
+            const wrapped = shallow(<GenericToggle {...props} />);
+            expect(wrapped.getElement()).toMatchSnapshot();
+        });
     });
 
-    test('render with jsx content', () => {
-        const props: GenericToggleProps = {
-            name: 'test name',
-            description: <h1>hello</h1>,
-            enabled: true,
-            onClick: onClickMock.object,
-            id: 'test-id-1',
-        };
+    describe('user interaction', () => {
+        it('handles toggle click', () => {
+            const props: GenericToggleProps = {
+                name: 'test name',
+                description: 'test description',
+                enabled: true,
+                onClick: onClickMock.object,
+                id: 'test-id-1',
+            };
 
-        const wrapped = shallow(<GenericToggle {...props} />);
-        expect(wrapped.getElement()).toMatchSnapshot();
-    });
+            const wrapped = shallow(<GenericToggle {...props} />);
 
-    test('verify onclick call', () => {
-        const props: GenericToggleProps = {
-            name: 'test name',
-            description: 'test description',
-            enabled: true,
-            onClick: onClickMock.object,
-            id: 'test-id-1',
-        };
+            const toggle = wrapped.find(`#${props.id}`);
+            const eventStub: any = {};
+            toggle.simulate('click', eventStub);
 
-        const wrapped = shallow(<GenericToggle {...props} />);
-
-        const toggle = wrapped.find(`#${props.id}`);
-        const eventStub: any = {};
-        toggle.simulate('click', eventStub);
-
-        onClickMock.verify(ocm => ocm(props.id, !props.enabled, eventStub), Times.once());
+            onClickMock.verify(handler => handler(props.id, !props.enabled, eventStub), Times.once());
+        });
     });
 });


### PR DESCRIPTION
#### Description of changes

Convert `<GenericToggle>` to use css module.

This will help to have the correct stylings on both **AI-Web** and **AI-Android** (the latter will come up as part as an upcoming feature to bring the settings panel to AI-Android).

Additionally, fixed the description text color which was missed from a previous CSS-Module refactor on the `<SettingsPanel>` 

**Wrong color (on prod 2.14.1)**
![01 - incorrect color from prod 2 14 1](https://user-images.githubusercontent.com/2837582/73580757-99a97400-443b-11ea-9e7d-2fa68f427e16.png)

**Fixed color**
![02 - fixed color on this PR](https://user-images.githubusercontent.com/2837582/73580760-9e6e2800-443b-11ea-8641-3c8ad715b24a.png)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
