### PR TITLE
fix: window bar title text color

### DIFF
--- a/src/electron/views/automated-checks/components/title-bar.scss
+++ b/src/electron/views/automated-checks/components/title-bar.scss
@@ -5,7 +5,7 @@
 .title-bar {
     background: $ada-brand-color;
 
-    :global(.header-text) {
-        color: $always-white;
+    h1 {
+        color: $always-white !important;
     }
 }


### PR DESCRIPTION
#### Description of changes

Currently on master, AI-Android does not seem to have a title on the window bar when the user navigate to the automated checks result view.

On this PR, we use `$always-white` for the window bar title text color only (the device port entry view is not affected).

**Out of scope**
I'm guessing we may need to adjust this when we work on bringing high contrast theme but since I don't have details on the color palette and so, I'm leaving that for the future feature crew to do

**No title text on master**
![01 - no title on master](https://user-images.githubusercontent.com/2837582/73581807-581ac800-443f-11ea-99f8-c37c46fd1239.png)

**Fixed**
![02 - fixed](https://user-images.githubusercontent.com/2837582/73581808-59e48b80-443f-11ea-89d9-349f905ecfb6.png)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
