### PR TITLE
chore: avoid spurious prettier error with .nsh files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@
 **/*.gitattributes
 **/*.gitignore
 **/*.ico
+**/*.nsh
 **/*.png
 **/*.snap
 **/Dockerfile


### PR DESCRIPTION
#### Description of changes

We recently added a new type of file to the repo (a `.nsh` file for customizing how unified's nsis installer works), which prettier doesn't understand how to format. This causes a spurious `[error]` line of stdout during `yarn format:check`.

This PR updates `.prettierignore` to ignore `.nsh` files to avoid the spurious error.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
