### PR TITLE
refactor: root-container to use withStoreSubscription

### DIFF
--- a/src/electron/adapters/null-store-action-message-creator.ts
+++ b/src/electron/adapters/null-store-action-message-creator.ts
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { StoreActionMessageCreator } from 'common/message-creators/store-action-message-creator';
+
+export class NullStoreActionMessageCreator implements StoreActionMessageCreator {
+    public getAllStates(): void {}
+}

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -27,6 +27,7 @@ import { TelemetryDataFactory } from 'common/telemetry-data-factory';
 import { CardsViewDeps } from 'DetailsView/components/cards-view';
 import { remote } from 'electron';
 import { DirectActionMessageDispatcher } from 'electron/adapters/direct-action-message-dispatcher';
+import { NullStoreActionMessageCreator } from 'electron/adapters/null-store-action-message-creator';
 import { createGetToolDataDelegate } from 'electron/common/application-properties-provider';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
@@ -40,7 +41,7 @@ import { createScanResultsFetcher } from 'electron/platform/android/fetch-scan-r
 import { ScanController } from 'electron/platform/android/scan-controller';
 import { createDefaultBuilder } from 'electron/platform/android/unified-result-builder';
 import {
-    RootContainerProps,
+    RootContainerDeps,
     RootContainerState,
 } from 'electron/views/root-container/components/root-container';
 import { PlatformInfo } from 'electron/window-management/platform-info';
@@ -143,7 +144,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
         const windowFrameUpdater = new WindowFrameUpdater(windowFrameActions, currentWindow);
         windowFrameUpdater.initialize();
 
-        const storeHub = new BaseClientStoresHub<RootContainerState>([
+        const storesHub = new BaseClientStoresHub<RootContainerState>([
             userConfigurationStore,
             deviceStore,
             windowStateStore,
@@ -241,28 +242,27 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             setFocusVisibility,
         };
 
-        const props: RootContainerProps = {
-            deps: {
-                currentWindow,
-                userConfigurationStore,
-                deviceStore,
-                userConfigMessageCreator,
-                windowStateActionCreator,
-                LinkComponent: ElectronLink,
-                fetchScanResults,
-                deviceConnectActionCreator,
-                storeHub,
-                scanActionCreator,
-                windowFrameActionCreator,
-                platformInfo: new PlatformInfo(process),
-                getCardsViewData: getCardViewData,
-                getCardSelectionViewData: getCardSelectionViewData,
-                screenshotViewModelProvider,
-                ...cardsViewDeps,
-            },
+        const deps: RootContainerDeps = {
+            currentWindow,
+            userConfigurationStore,
+            deviceStore,
+            userConfigMessageCreator,
+            windowStateActionCreator,
+            LinkComponent: ElectronLink,
+            fetchScanResults,
+            deviceConnectActionCreator,
+            storesHub,
+            scanActionCreator,
+            windowFrameActionCreator,
+            platformInfo: new PlatformInfo(process),
+            getCardsViewData: getCardViewData,
+            getCardSelectionViewData: getCardSelectionViewData,
+            screenshotViewModelProvider,
+            ...cardsViewDeps,
+            storeActionMessageCreator: new NullStoreActionMessageCreator(),
         };
 
-        const renderer = new RootContainerRenderer(ReactDOM.render, document, props);
+        const renderer = new RootContainerRenderer(ReactDOM.render, document, deps);
         renderer.render();
 
         sendAppInitializedTelemetryEvent(telemetryEventHandler, platformInfo);

--- a/src/electron/views/root-container/components/root-container.tsx
+++ b/src/electron/views/root-container/components/root-container.tsx
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ClientStoresHub } from 'common/stores/client-stores-hub';
+import {
+    withStoreSubscription,
+    WithStoreSubscriptionDeps,
+} from 'common/components/with-store-subscription';
+import { NamedFC } from 'common/react/named-fc';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
@@ -16,16 +20,15 @@ import {
     DeviceConnectViewContainerDeps,
 } from 'electron/views/device-connect-view/components/device-connect-view-container';
 import * as React from 'react';
-
 import './root-container.scss'; // Used for common <body>/etc styles
 
-export type RootContainerDeps = DeviceConnectViewContainerDeps &
-    AutomatedChecksViewDeps & {
-        storeHub: ClientStoresHub<RootContainerState>;
-    };
+export type RootContainerDeps = WithStoreSubscriptionDeps<RootContainerState> &
+    DeviceConnectViewContainerDeps &
+    AutomatedChecksViewDeps;
 
 export type RootContainerProps = {
     deps: RootContainerDeps;
+    storeState: RootContainerState;
 };
 
 export type RootContainerState = {
@@ -37,44 +40,16 @@ export type RootContainerState = {
     cardSelectionStoreData: CardSelectionStoreData;
 };
 
-export class RootContainer extends React.Component<RootContainerProps, RootContainerState> {
-    constructor(props: RootContainerProps) {
-        super(props);
+export const RootContainerInternal = NamedFC<RootContainerProps>('RootContainerInternal', props => {
+    const { storeState, ...rest } = props;
 
-        this.state = props.deps.storeHub.getAllStoreData();
+    if (storeState.windowStateStoreData.routeId === 'resultsView') {
+        return <AutomatedChecksView {...storeState} {...rest} />;
     }
 
-    public render(): JSX.Element {
-        if (this.state.windowStateStoreData.routeId === 'resultsView') {
-            return (
-                <AutomatedChecksView
-                    deviceStoreData={this.state.deviceStoreData}
-                    scanStoreData={this.state.scanStoreData}
-                    windowStateStoreData={this.state.windowStateStoreData}
-                    unifiedScanResultStoreData={this.state.unifiedScanResultStoreData}
-                    userConfigurationStoreData={this.state.userConfigurationStoreData}
-                    cardSelectionStoreData={this.state.cardSelectionStoreData}
-                    {...this.props}
-                />
-            );
-        }
-        return (
-            <DeviceConnectViewContainer
-                {...{
-                    userConfigurationStoreData: this.state.userConfigurationStoreData,
-                    deviceStoreData: this.state.deviceStoreData,
-                    windowStateStoreData: this.state.windowStateStoreData,
-                    ...this.props,
-                }}
-            />
-        );
-    }
+    return <DeviceConnectViewContainer {...storeState} {...rest} />;
+});
 
-    public componentDidMount(): void {
-        this.props.deps.storeHub.addChangedListenerToAllStores(this.onStoresChange);
-    }
-
-    private onStoresChange = () => {
-        this.setState(() => this.props.deps.storeHub.getAllStoreData());
-    };
-}
+export const RootContainer = withStoreSubscription<RootContainerProps, RootContainerState>(
+    RootContainerInternal,
+);

--- a/src/electron/views/root-container/root-container-renderer.tsx
+++ b/src/electron/views/root-container/root-container-renderer.tsx
@@ -3,7 +3,6 @@
 import {
     RootContainer,
     RootContainerDeps,
-    RootContainerProps,
 } from 'electron/views/root-container/components/root-container';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';

--- a/src/electron/views/root-container/root-container-renderer.tsx
+++ b/src/electron/views/root-container/root-container-renderer.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import {
     RootContainer,
+    RootContainerDeps,
     RootContainerProps,
 } from 'electron/views/root-container/components/root-container';
 import * as React from 'react';
@@ -11,13 +12,13 @@ export class RootContainerRenderer {
     constructor(
         private readonly renderer: typeof ReactDOM.render,
         private readonly dom: ParentNode,
-        private readonly props: RootContainerProps,
+        private readonly deps: RootContainerDeps,
     ) {}
 
     public render(): void {
-        this.props.deps.windowStateActionCreator.setRoute({ routeId: 'deviceConnectView' });
+        this.deps.windowStateActionCreator.setRoute({ routeId: 'deviceConnectView' });
 
         const rootContainer = this.dom.querySelector('#root-container');
-        this.renderer(<RootContainer {...this.props} />, rootContainer);
+        this.renderer(<RootContainer deps={this.deps} />, rootContainer);
     }
 }

--- a/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/root-container/components/__snapshots__/root-container.test.tsx.snap
@@ -1,10 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RootContainer renders device connect view container when route is deviceConnectView 1`] = `
+exports[`Component renders with routeId = deviceConnectView 1`] = `
 <DeviceConnectViewContainer
+  cardSelectionStoreData={
+    Object {
+      "rules": Object {},
+    }
+  }
   deps={
     Object {
-      "storeHub": proxy {
+      "storesHub": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
         "stores": undefined,
       },
@@ -12,12 +17,22 @@ exports[`RootContainer renders device connect view container when route is devic
   }
   deviceStoreData={
     Object {
-      "deviceConnectState": 2,
+      "port": 111,
+    }
+  }
+  scanStoreData={
+    Object {
+      "status": 2,
+    }
+  }
+  unifiedScanResultStoreData={
+    Object {
+      "rules": Array [],
     }
   }
   userConfigurationStoreData={
     Object {
-      "isFirstTime": true,
+      "isFirstTime": false,
     }
   }
   windowStateStoreData={
@@ -29,11 +44,16 @@ exports[`RootContainer renders device connect view container when route is devic
 />
 `;
 
-exports[`RootContainer renders results view container when route is resultsView 1`] = `
+exports[`Component renders with routeId = resultsView 1`] = `
 <AutomatedChecksView
+  cardSelectionStoreData={
+    Object {
+      "rules": Object {},
+    }
+  }
   deps={
     Object {
-      "storeHub": proxy {
+      "storesHub": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
         "stores": undefined,
       },
@@ -41,18 +61,22 @@ exports[`RootContainer renders results view container when route is resultsView 
   }
   deviceStoreData={
     Object {
-      "deviceConnectState": 2,
-      "port": 11111,
+      "port": 111,
     }
   }
   scanStoreData={
     Object {
-      "status": 0,
+      "status": 2,
+    }
+  }
+  unifiedScanResultStoreData={
+    Object {
+      "rules": Array [],
     }
   }
   userConfigurationStoreData={
     Object {
-      "isFirstTime": true,
+      "isFirstTime": false,
     }
   }
   windowStateStoreData={
@@ -62,34 +86,4 @@ exports[`RootContainer renders results view container when route is resultsView 
     }
   }
 />
-`;
-
-exports[`RootContainer store listening uses the store to update the state: initial state 1`] = `
-Object {
-  "deviceStoreData": Object {
-    "deviceConnectState": 2,
-  },
-  "userConfigurationStoreData": Object {
-    "isFirstTime": true,
-  },
-  "windowStateStoreData": Object {
-    "currentWindowState": "customSize",
-    "routeId": "deviceConnectView",
-  },
-}
-`;
-
-exports[`RootContainer store listening uses the store to update the state: updated state 1`] = `
-Object {
-  "deviceStoreData": Object {
-    "deviceConnectState": 2,
-  },
-  "userConfigurationStoreData": Object {
-    "isFirstTime": true,
-  },
-  "windowStateStoreData": Object {
-    "currentWindowState": "customSize",
-    "routeId": "resultsView",
-  },
-}
 `;

--- a/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { BrowserWindow } from 'electron';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
-import { RootContainer, RootContainerDeps, RootContainerProps } from 'electron/views/root-container/components/root-container';
+import { RootContainer, RootContainerDeps } from 'electron/views/root-container/components/root-container';
 import { RootContainerRenderer } from 'electron/views/root-container/root-container-renderer';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -27,12 +27,7 @@ describe('RootContainerRendererTest', () => {
             currentWindow: browserWindow,
             windowStateActionCreator: windowStateActionCreatorMock.object,
         } as RootContainerDeps;
-        const props = {
-            deps: {
-                currentWindow: browserWindow,
-                windowStateActionCreator: windowStateActionCreatorMock.object,
-            },
-        } as RootContainerProps;
+
         const expectedComponent = <RootContainer deps={deps} />;
 
         renderMock.setup(r => r(It.isValue(expectedComponent), containerDiv)).verifiable();

--- a/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { BrowserWindow } from 'electron';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
-import { RootContainer, RootContainerProps } from 'electron/views/root-container/components/root-container';
+import { RootContainer, RootContainerDeps, RootContainerProps } from 'electron/views/root-container/components/root-container';
 import { RootContainerRenderer } from 'electron/views/root-container/root-container-renderer';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
@@ -23,18 +23,22 @@ describe('RootContainerRendererTest', () => {
         containerDiv.setAttribute('id', 'root-container');
         dom.appendChild(containerDiv);
 
+        const deps = {
+            currentWindow: browserWindow,
+            windowStateActionCreator: windowStateActionCreatorMock.object,
+        } as RootContainerDeps;
         const props = {
             deps: {
                 currentWindow: browserWindow,
                 windowStateActionCreator: windowStateActionCreatorMock.object,
             },
         } as RootContainerProps;
-        const expectedComponent = <RootContainer {...props} />;
+        const expectedComponent = <RootContainer deps={deps} />;
 
         renderMock.setup(r => r(It.isValue(expectedComponent), containerDiv)).verifiable();
         windowStateActionCreatorMock.setup(w => w.setRoute({ routeId: 'deviceConnectView' })).verifiable(Times.once());
 
-        const renderer = new RootContainerRenderer(renderMock.object, dom, props);
+        const renderer = new RootContainerRenderer(renderMock.object, dom, deps);
 
         renderer.render();
 


### PR DESCRIPTION
#### Description of changes

Currently, AI-Web follows a pattern of wrapped the highest level component using `withStoreSubscription`. This way, all the store listening and reacting to updates is encapsulated on one component, leaving the high-level component free to take care of other responsibilities.

On AI-Android, this is not the case, as `<RootContainer>` explicitly handles listening to the stores (through an stores hub instance, but still).

On this PR: refactoring `<RootContainer>` to  use `withStoreSubscription` and get rid of all the store-listening-and-updating logic. This change will make all **"containers"** to be more alike and also -I think- it will help to enabling high contrast theme on AI-Android.

**NOTES** no UI/UX changes from this PR

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
