### PR TITLE
feat(release-channels): reduce installer size and add confirmation dialog

### DIFF
--- a/src/electron/electron-builder/electron-builder.template.yaml
+++ b/src/electron/electron-builder/electron-builder.template.yaml
@@ -11,6 +11,9 @@ directories:
     output: TARGET_SPECIFIC
     buildResources: src/electron/resources
 
+files:
+    - '!packed${/*}'
+
 extraMetadata:
     main: product/bundle/main.bundle.js
     name: TARGET_SPECIFIC
@@ -33,9 +36,9 @@ win:
     target: nsis
 
 nsis:
-    oneClick: true
+    oneClick: false
     perMachine: false
     deleteAppDataOnUninstall: true
-
+    include: src/electron/resources/installer.nsh
 publish:
     provider: generic


### PR DESCRIPTION
#### Description of changes

This PR includes two changes to the unified electron client installer:
- restore a confirmation dialog (this was already done in #2060 but the changes weren't brought over to the **template** file)
- reduce the installer size by removing the 'packed' folder from the asar archive. Because we provide a custom output path, the intermediate files are created in a new folder called 'packed'. electron-builder has no way to understand whether 'packed' should be included or not in the asar archive. We exclude it via the file glob (see https://www.electron.build/configuration/contents#files) so that our asar archive only includes source code.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
