### PR TITLE
chore: line width for src/tests/end-to-end folder

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -23,6 +23,7 @@ module.exports = {
                 'src/scanner/**/*',
                 'src/tests/common/**/*',
                 'src/tests/electron/**/*',
+                'src/tests/end-to-end/**/*',
                 'src/tests/miscellaneous/**/*',
                 'src/types/**/*',
                 'src/views/**/*',

--- a/src/tests/end-to-end/common/browser-factory.ts
+++ b/src/tests/end-to-end/common/browser-factory.ts
@@ -13,7 +13,8 @@ import { DEFAULT_BROWSER_LAUNCH_TIMEOUT_MS } from './timeouts';
 
 export const chromeLogsPath = path.join(__dirname, '../../../../test-results/e2e/chrome-logs/');
 
-export const browserLogPath = (browserInstanceId: string): string => path.join(chromeLogsPath, browserInstanceId);
+export const browserLogPath = (browserInstanceId: string): string =>
+    path.join(chromeLogsPath, browserInstanceId);
 
 const fileExists = util.promisify(fs.exists);
 
@@ -37,7 +38,11 @@ export async function launchBrowser(extensionOptions: ExtensionOptions): Promise
 
     const puppeteerBrowser = await launchNewBrowser(browserInstanceId, devExtensionPath);
 
-    const browser = new Browser(browserInstanceId, puppeteerBrowser, manifestOveride.restoreOriginalManifest);
+    const browser = new Browser(
+        browserInstanceId,
+        puppeteerBrowser,
+        manifestOveride.restoreOriginalManifest,
+    );
 
     const backgroundPage = await browser.backgroundPage();
     if (extensionOptions.suppressFirstTimeDialog) {
@@ -62,7 +67,10 @@ async function verifyExtensionIsBuilt(extensionPath: string): Promise<void> {
     }
 }
 
-const addPermissions = (extensionOptions: ExtensionOptions, manifestOveride: ManifestOveride): void => {
+const addPermissions = (
+    extensionOptions: ExtensionOptions,
+    manifestOveride: ManifestOveride,
+): void => {
     const { addExtraPermissionsToManifest } = extensionOptions;
 
     switch (addExtraPermissionsToManifest) {
@@ -71,7 +79,9 @@ const addPermissions = (extensionOptions: ExtensionOptions, manifestOveride: Man
             // the main reason is puppeteer lacks an API to activate the extension
             // via clicking the extenion icon (on the toolbar) or sending the extension shortcut
             // see https://github.com/puppeteer/puppeteer/issues/2486 for more details
-            manifestOveride.addTemporaryPermission(`http://localhost:${testResourceServerConfig.port}/*`);
+            manifestOveride.addTemporaryPermission(
+                `http://localhost:${testResourceServerConfig.port}/*`,
+            );
             break;
 
         case 'all-origins':
@@ -82,7 +92,10 @@ const addPermissions = (extensionOptions: ExtensionOptions, manifestOveride: Man
     }
 };
 
-async function launchNewBrowser(browserInstanceId: string, extensionPath: string): Promise<Puppeteer.Browser> {
+async function launchNewBrowser(
+    browserInstanceId: string,
+    extensionPath: string,
+): Promise<Puppeteer.Browser> {
     // It's important that we verify this before calling Puppeteer.launch because its behavior if the
     // extension can't be loaded is "the Chromium instance hangs with an alert and everything on Puppeteer's
     // end shows up as a generic timeout error with no meaningful logging".

--- a/src/tests/end-to-end/common/browser.ts
+++ b/src/tests/end-to-end/common/browser.ts
@@ -36,9 +36,13 @@ export class Browser {
             return this.memoizedBackgroundPage;
         }
 
-        const backgroundPageTarget = await this.underlyingBrowser.waitForTarget(isBackgroundPageTarget);
+        const backgroundPageTarget = await this.underlyingBrowser.waitForTarget(
+            isBackgroundPageTarget,
+        );
 
-        this.memoizedBackgroundPage = new BackgroundPage(await backgroundPageTarget.page(), { onPageCrash: this.onPageCrash });
+        this.memoizedBackgroundPage = new BackgroundPage(await backgroundPageTarget.page(), {
+            onPageCrash: this.onPageCrash,
+        });
 
         return this.memoizedBackgroundPage;
     }
@@ -81,7 +85,9 @@ export class Browser {
 
     public async waitForDetailsViewPage(targetPage: TargetPage): Promise<DetailsViewPage> {
         const expectedUrl = await this.getExtensionUrl(detailsViewRelativeUrl(targetPage.tabId));
-        const underlyingTarget = await this.underlyingBrowser.waitForTarget(t => t.url().toLowerCase() === expectedUrl.toLowerCase());
+        const underlyingTarget = await this.underlyingBrowser.waitForTarget(
+            t => t.url().toLowerCase() === expectedUrl.toLowerCase(),
+        );
         const underlyingPage = await underlyingTarget.page();
         const page = new DetailsViewPage(underlyingPage, { onPageCrash: this.onPageCrash });
         this.pages.push(page);
@@ -117,7 +123,9 @@ export class Browser {
         const backgroundPage = await this.backgroundPage();
         return await backgroundPage.evaluate(() => {
             return new Promise(resolve => {
-                chrome.tabs.query({ active: true, currentWindow: true }, tabs => resolve(tabs[0].id));
+                chrome.tabs.query({ active: true, currentWindow: true }, tabs =>
+                    resolve(tabs[0].id),
+                );
             });
         });
     }
@@ -131,7 +139,9 @@ export class Browser {
     }
 
     private onPageCrash = () => {
-        const errorMessage = `!!! Browser.onPageCrashed: see detailed chrome logs '${browserLogPath(this.browserInstanceId)}'`;
+        const errorMessage = `!!! Browser.onPageCrashed: see detailed chrome logs '${browserLogPath(
+            this.browserInstanceId,
+        )}'`;
         console.error(errorMessage);
     };
 }

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -7,7 +7,10 @@ import { overviewHeadingAutomationId } from 'DetailsView/components/overview-con
 import { settingsPanelAutomationId } from 'DetailsView/components/settings-panel/settings-panel';
 import { startOverAutomationId } from 'DetailsView/components/start-over-component-factory';
 import { failureCountAutomationId } from 'reports/components/outcome-chip';
-import { cardsRuleIdAutomationId, ruleDetailAutomationId } from 'reports/components/report-sections/minimal-rule-header';
+import {
+    cardsRuleIdAutomationId,
+    ruleDetailAutomationId,
+} from 'reports/components/report-sections/minimal-rule-header';
 
 const getAutomationIdSelector = (id: string) => `[data-automation-id="${id}"]`;
 

--- a/src/tests/end-to-end/common/manifest-overide.ts
+++ b/src/tests/end-to-end/common/manifest-overide.ts
@@ -35,5 +35,6 @@ export class ManifestOveride {
         await ManifestOveride.writeFile(this.manifestPath, content);
     }
 
-    public restoreOriginalManifest = async (): Promise<void> => await ManifestOveride.writeFile(this.manifestPath, this.originalManifest);
+    public restoreOriginalManifest = async (): Promise<void> =>
+        await ManifestOveride.writeFile(this.manifestPath, this.originalManifest);
 }

--- a/src/tests/end-to-end/common/page-controllers/details-view-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/details-view-page.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 import * as Puppeteer from 'puppeteer';
 import { CommonSelectors } from '../element-identifiers/common-selectors';
-import { detailsViewSelectors, settingsPanelSelectors } from '../element-identifiers/details-view-selectors';
+import {
+    detailsViewSelectors,
+    settingsPanelSelectors,
+} from '../element-identifiers/details-view-selectors';
 import { Page, PageOptions } from './page';
 
 export class DetailsViewPage extends Page {

--- a/src/tests/end-to-end/common/page-controllers/page.ts
+++ b/src/tests/end-to-end/common/page-controllers/page.ts
@@ -24,7 +24,9 @@ export type PageOptions = {
 export class Page {
     constructor(protected readonly underlyingPage: Puppeteer.Page, options?: PageOptions) {
         function forceEventFailure(eventDescription: string): void {
-            forceTestFailure(`Puppeteer.Page '${underlyingPage.url()}' emitted ${eventDescription}`);
+            forceTestFailure(
+                `Puppeteer.Page '${underlyingPage.url()}' emitted ${eventDescription}`,
+            );
         }
 
         function serializeError(error: Error): string {
@@ -32,7 +34,12 @@ export class Page {
         }
 
         underlyingPage.on('error', error => {
-            if (error.stack && error.stack.includes('Page crashed!') && options && options.onPageCrash) {
+            if (
+                error.stack &&
+                error.stack.includes('Page crashed!') &&
+                options &&
+                options.onPageCrash
+            ) {
                 options.onPageCrash();
             }
 
@@ -40,8 +47,12 @@ export class Page {
         });
         underlyingPage.on('pageerror', error => {
             if (
-                error.message.startsWith("TypeError: Cannot read property 'focusElement' of null") &&
-                error.message.includes('office-ui-fabric-react/lib/components/Dropdown/Dropdown.base.js')
+                error.message.startsWith(
+                    "TypeError: Cannot read property 'focusElement' of null",
+                ) &&
+                error.message.includes(
+                    'office-ui-fabric-react/lib/components/Dropdown/Dropdown.base.js',
+                )
             ) {
                 return; // benign; caused by https://github.com/OfficeDev/office-ui-fabric-react/issues/9715
             }
@@ -52,7 +63,9 @@ export class Page {
             const url = request.url();
             // Checking for 'fonts' and 'icons' in url as a workaround for #923
             if (!includes(url, 'fonts') && !includes(url, 'icons')) {
-                forceEventFailure(`'requestfailed' from '${url}' with errorText: ${request.failure().errorText}`);
+                forceEventFailure(
+                    `'requestfailed' from '${url}' with errorText: ${request.failure().errorText}`,
+                );
             }
         });
         underlyingPage.on('response', response => {
@@ -108,7 +121,10 @@ export class Page {
         return await promiseFactory.timeout(this.underlyingPage.evaluate(fn, ...args), timeout);
     }
 
-    public async getMatchingElements<T>(selector: string, elementProperty?: keyof Element): Promise<T[]> {
+    public async getMatchingElements<T>(
+        selector: string,
+        elementProperty?: keyof Element,
+    ): Promise<T[]> {
         return await this.screenshotOnError(
             async () =>
                 await this.evaluate(
@@ -126,15 +142,25 @@ export class Page {
         await this.screenshotOnError(async () => await this.underlyingPage.waitFor(durationMs));
     }
 
-    public async waitForSelector(selector: string, options?: Puppeteer.WaitForSelectorOptions): Promise<Puppeteer.ElementHandle<Element>> {
+    public async waitForSelector(
+        selector: string,
+        options?: Puppeteer.WaitForSelectorOptions,
+    ): Promise<Puppeteer.ElementHandle<Element>> {
         return await this.screenshotOnError(
-            async () => await this.underlyingPage.waitForSelector(selector, { timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS, ...options }),
+            async () =>
+                await this.underlyingPage.waitForSelector(selector, {
+                    timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS,
+                    ...options,
+                }),
         );
     }
 
     public async waitForSelectorXPath(xpath: string): Promise<Puppeteer.ElementHandle<Element>> {
         return await this.screenshotOnError(
-            async () => await this.underlyingPage.waitForXPath(xpath, { timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS }),
+            async () =>
+                await this.underlyingPage.waitForXPath(xpath, {
+                    timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS,
+                }),
         );
     }
 
@@ -183,7 +209,9 @@ export class Page {
         });
     }
 
-    public async waitForShadowRootOfSelector(selector: string): Promise<Puppeteer.ElementHandle<Element>> {
+    public async waitForShadowRootOfSelector(
+        selector: string,
+    ): Promise<Puppeteer.ElementHandle<Element>> {
         return await this.screenshotOnError(async () => {
             const shadowRootHandle = await this.underlyingPage.waitForFunction(
                 selectorInEval => {
@@ -199,7 +227,9 @@ export class Page {
 
     public async clickSelector(selector: string): Promise<void> {
         await this.screenshotOnError(async () => {
-            await this.underlyingPage.waitForSelector(selector, { timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS });
+            await this.underlyingPage.waitForSelector(selector, {
+                timeout: DEFAULT_PAGE_ELEMENT_WAIT_TIMEOUT_MS,
+            });
             await this.underlyingPage.hover(selector);
             await this.underlyingPage.waitFor(DEFAULT_CLICK_HOVER_DELAY_MS);
             await this.underlyingPage.click(selector, { delay: DEFAULT_CLICK_MOUSEUP_DELAY_MS });
@@ -237,7 +267,9 @@ export class Page {
         });
     }
 
-    public async getSelectorElements(selector: string): Promise<Puppeteer.ElementHandle<Element>[]> {
+    public async getSelectorElements(
+        selector: string,
+    ): Promise<Puppeteer.ElementHandle<Element>[]> {
         return await this.screenshotOnError(async () => {
             return await this.underlyingPage.$$(selector);
         });
@@ -285,6 +317,9 @@ export class Page {
     }
 
     private async screenshotOnError<T>(wrappedFunction: () => Promise<T>): Promise<T> {
-        return await screenshotOnError(path => this.underlyingPage.screenshot({ path, fullPage: true }), wrappedFunction);
+        return await screenshotOnError(
+            path => this.underlyingPage.screenshot({ path, fullPage: true }),
+            wrappedFunction,
+        );
     }
 }

--- a/src/tests/end-to-end/common/page-controllers/target-page.ts
+++ b/src/tests/end-to-end/common/page-controllers/target-page.ts
@@ -27,7 +27,11 @@ export function targetPageUrl(options?: TargetPageUrlOptions): string {
 }
 
 export class TargetPage extends Page {
-    constructor(underlyingPage: Puppeteer.Page, public readonly tabId: number, options?: PageOptions) {
+    constructor(
+        underlyingPage: Puppeteer.Page,
+        public readonly tabId: number,
+        options?: PageOptions,
+    ) {
         super(underlyingPage, options);
     }
 

--- a/src/tests/end-to-end/common/prepare-test-result-file-path.ts
+++ b/src/tests/end-to-end/common/prepare-test-result-file-path.ts
@@ -11,8 +11,15 @@ function sanitizeFilename(s: string): string {
 
 // Makes a directory for the fileType if one does not already exist.
 // Does *not* make the actual file.
-export async function prepareTestResultFilePath(resultsSubdirectoryName: string, fileExtension: string): Promise<string> {
-    const subdirectoryPath = path.resolve(__dirname, '../../../../test-results/e2e', resultsSubdirectoryName);
+export async function prepareTestResultFilePath(
+    resultsSubdirectoryName: string,
+    fileExtension: string,
+): Promise<string> {
+    const subdirectoryPath = path.resolve(
+        __dirname,
+        '../../../../test-results/e2e',
+        resultsSubdirectoryName,
+    );
     await makeDir(subdirectoryPath);
     const fileName = `${sanitizeFilename(generateUID())}.${fileExtension}`;
     const filePath = path.join(subdirectoryPath, fileName);

--- a/src/tests/end-to-end/common/scan-for-accessibility-issues.ts
+++ b/src/tests/end-to-end/common/scan-for-accessibility-issues.ts
@@ -9,13 +9,18 @@ import { prettyPrintAxeViolations, PrintableAxeResult } from './pretty-print-axe
 // we are using axe object in target page scope. so we shouldn't be importing axe object via axe-core
 declare var axe;
 
-export async function scanForAccessibilityIssues(page: Page, selector: string): Promise<PrintableAxeResult[]> {
+export async function scanForAccessibilityIssues(
+    page: Page,
+    selector: string,
+): Promise<PrintableAxeResult[]> {
     await injectAxeIfUndefined(page);
 
     const axeResults = (await page.evaluate(selectorInEvaluate => {
         return axe.run(
             { include: [selectorInEvaluate] } as ElementContext,
-            { runOnly: { type: 'tag', values: ['wcag2a', 'wcag21a', 'wcag2aa', 'wcag21aa'] } } as ElementContext,
+            {
+                runOnly: { type: 'tag', values: ['wcag2a', 'wcag21a', 'wcag2aa', 'wcag21aa'] },
+            } as ElementContext,
         );
     }, selector)) as AxeResults;
 
@@ -28,6 +33,8 @@ async function injectAxeIfUndefined(page: Page): Promise<void> {
     });
 
     if (axeIsUndefined) {
-        await page.injectScriptFile(path.join(__dirname, '../../../../node_modules/axe-core/axe.min.js'));
+        await page.injectScriptFile(
+            path.join(__dirname, '../../../../node_modules/axe-core/axe.min.js'),
+        );
     }
 }

--- a/src/tests/end-to-end/common/screenshot-on-error.ts
+++ b/src/tests/end-to-end/common/screenshot-on-error.ts
@@ -14,7 +14,10 @@ async function takeScreenshot(saveScreenshot: (path) => Promise<Buffer>): Promis
     console.log(`Screenshot file is located at: ${path}`);
 }
 
-export async function screenshotOnError<T>(saveScreenshot: (path) => Promise<Buffer>, wrappedFunction: () => Promise<T>): Promise<T> {
+export async function screenshotOnError<T>(
+    saveScreenshot: (path) => Promise<Buffer>,
+    wrappedFunction: () => Promise<T>,
+): Promise<T> {
     try {
         return await wrappedFunction();
     } catch (originalError) {

--- a/src/tests/end-to-end/common/with-tracing.ts
+++ b/src/tests/end-to-end/common/with-tracing.ts
@@ -9,14 +9,21 @@ async function startTracing(tracing: Puppeteer.Tracing): Promise<string> {
     return traceFilePath;
 }
 
-async function stopTracing(tracing: Puppeteer.Tracing, traceFilePath: string, logLabel: string): Promise<void> {
+async function stopTracing(
+    tracing: Puppeteer.Tracing,
+    traceFilePath: string,
+    logLabel: string,
+): Promise<void> {
     await tracing.stop();
 
     // Only log this after tracing.stop succeeds!
     console.log(`Trace file (${logLabel}) is located at: ${traceFilePath}`);
 }
 
-export async function withTracing<T>(tracing: Puppeteer.Tracing, wrappedFunction: () => Promise<T>): Promise<T> {
+export async function withTracing<T>(
+    tracing: Puppeteer.Tracing,
+    wrappedFunction: () => Promise<T>,
+): Promise<T> {
     const traceFilePath = await startTracing(tracing);
 
     let retVal: T;

--- a/src/tests/end-to-end/jest.config.js
+++ b/src/tests/end-to-end/jest.config.js
@@ -18,7 +18,13 @@ module.exports = {
     ],
     rootDir: rootDir,
     roots: [currentDir],
-    reporters: ['default', ['jest-junit', { outputDirectory: '.', outputName: '<rootDir>/test-results/e2e/junit-e2e.xml' }]],
+    reporters: [
+        'default',
+        [
+            'jest-junit',
+            { outputDirectory: '.', outputName: '<rootDir>/test-results/e2e/junit-e2e.xml' },
+        ],
+    ],
     setupFilesAfterEnv: [`${currentDir}/setup/test-setup.ts`],
     globals: {
         rootDir: path.resolve(__dirname, rootDir),

--- a/src/tests/end-to-end/test-resources/all-cross-origin-iframe.html
+++ b/src/tests/end-to-end/test-resources/all-cross-origin-iframe.html
@@ -11,8 +11,20 @@ Licensed under the MIT License.
 
     <body>
         <h1>Page with Images</h1>
-        <iframe name="image-text" src="http://localhost:9053/image/image-text.html" width="100%" height="50%"> </iframe>
+        <iframe
+            name="image-text"
+            src="http://localhost:9053/image/image-text.html"
+            width="100%"
+            height="50%"
+        >
+        </iframe>
         <h1>Page with Native Widgets</h1>
-        <iframe name="native-widgets" src="http://localhost:9053/native-widgets/input-type-radio.html" width="100%" height="50%"> </iframe>
+        <iframe
+            name="native-widgets"
+            src="http://localhost:9053/native-widgets/input-type-radio.html"
+            width="100%"
+            height="50%"
+        >
+        </iframe>
     </body>
 </html>

--- a/src/tests/end-to-end/test-resources/all.html
+++ b/src/tests/end-to-end/test-resources/all.html
@@ -13,6 +13,12 @@ Licensed under the MIT License.
         <h1>Page with Images</h1>
         <iframe name="image-text" src="./image/image-text.html" width="100%" height="50%"> </iframe>
         <h1>Page with Native Widgets</h1>
-        <iframe name="native-widgets" src="./native-widgets/input-type-radio.html" width="100%" height="50%"> </iframe>
+        <iframe
+            name="native-widgets"
+            src="./native-widgets/input-type-radio.html"
+            width="100%"
+            height="50%"
+        >
+        </iframe>
     </body>
 </html>

--- a/src/tests/end-to-end/test-resources/native-widgets/input-type-radio.html
+++ b/src/tests/end-to-end/test-resources/native-widgets/input-type-radio.html
@@ -28,7 +28,10 @@ Licensed under the MIT License.
             <form>
                 <fieldset>
                     <legend>Size</legend>
-                    <label> <input id="input-radio-2" type="radio" name="size" value="small" checked /> Small<br /> </label>
+                    <label>
+                        <input id="input-radio-2" type="radio" name="size" value="small" checked />
+                        Small<br />
+                    </label>
                     <label> <input type="radio" name="size" value="medium" /> Medium<br /> </label>
                     <label> <input type="radio" name="size" value="large" /> Large </label>
                 </fieldset>

--- a/src/tests/end-to-end/tests/common/settings-drop-down.test.ts
+++ b/src/tests/end-to-end/tests/common/settings-drop-down.test.ts
@@ -44,29 +44,41 @@ describe('Settings Dropdown', () => {
         expect(popupDropdownElement).toMatchSnapshot();
     });
 
-    it.each([true, false])('should pass accessibility validation in popup with highContrastMode=%s', async highContrastMode => {
-        await browser.setHighContrastMode(highContrastMode);
-        const popupPage = await browser.newPopupPage(targetPage);
-        await popupPage.waitForHighContrastMode(highContrastMode);
+    it.each([true, false])(
+        'should pass accessibility validation in popup with highContrastMode=%s',
+        async highContrastMode => {
+            await browser.setHighContrastMode(highContrastMode);
+            const popupPage = await browser.newPopupPage(targetPage);
+            await popupPage.waitForHighContrastMode(highContrastMode);
 
-        await popupPage.clickSelector(CommonSelectors.settingsGearButton);
+            await popupPage.clickSelector(CommonSelectors.settingsGearButton);
 
-        const results = await scanForAccessibilityIssues(popupPage, CommonSelectors.settingsDropdownMenu);
-        expect(results).toHaveLength(0);
-    });
+            const results = await scanForAccessibilityIssues(
+                popupPage,
+                CommonSelectors.settingsDropdownMenu,
+            );
+            expect(results).toHaveLength(0);
+        },
+    );
 
-    it.each([true, false])('should pass accessibility validation in details view with highContrastMode=%s', async highContrastMode => {
-        await browser.setHighContrastMode(highContrastMode);
-        await browser.newPopupPage(targetPage); // Required for the details view to register as having permissions/being open
+    it.each([true, false])(
+        'should pass accessibility validation in details view with highContrastMode=%s',
+        async highContrastMode => {
+            await browser.setHighContrastMode(highContrastMode);
+            await browser.newPopupPage(targetPage); // Required for the details view to register as having permissions/being open
 
-        const detailsViewPage = await browser.newDetailsViewPage(targetPage);
-        await detailsViewPage.waitForHighContrastMode(highContrastMode);
+            const detailsViewPage = await browser.newDetailsViewPage(targetPage);
+            await detailsViewPage.waitForHighContrastMode(highContrastMode);
 
-        await detailsViewPage.clickSelector(CommonSelectors.settingsGearButton);
+            await detailsViewPage.clickSelector(CommonSelectors.settingsGearButton);
 
-        const results = await scanForAccessibilityIssues(detailsViewPage, CommonSelectors.settingsDropdownMenu);
-        expect(results).toHaveLength(0);
-    });
+            const results = await scanForAccessibilityIssues(
+                detailsViewPage,
+                CommonSelectors.settingsDropdownMenu,
+            );
+            expect(results).toHaveLength(0);
+        },
+    );
 
     async function getDropdownPanelElement(page: Page): Promise<Node> {
         await page.clickSelector(CommonSelectors.settingsGearButton);

--- a/src/tests/end-to-end/tests/content/guidance-content.test.ts
+++ b/src/tests/end-to-end/tests/content/guidance-content.test.ts
@@ -35,17 +35,23 @@ describe('Guidance Content pages', () => {
         });
 
         it('matches the snapshot', async () => {
-            const mainContentContainer = await formatPageElementForSnapshot(contentPage, GuidanceContentSelectors.mainContentContainer);
+            const mainContentContainer = await formatPageElementForSnapshot(
+                contentPage,
+                GuidanceContentSelectors.mainContentContainer,
+            );
             expect(mainContentContainer).toMatchSnapshot();
         });
 
-        it.each([true, false])('has no accessibility issues with highContrastMode=%s', async highContrastMode => {
-            await browser.setHighContrastMode(highContrastMode);
-            await contentPage.bringToFront();
-            await contentPage.waitForHighContrastMode(highContrastMode);
+        it.each([true, false])(
+            'has no accessibility issues with highContrastMode=%s',
+            async highContrastMode => {
+                await browser.setHighContrastMode(highContrastMode);
+                await contentPage.bringToFront();
+                await contentPage.waitForHighContrastMode(highContrastMode);
 
-            const results = await scanForAccessibilityIssues(contentPage, '*');
-            expect(results).toHaveLength(0);
-        });
+                const results = await scanForAccessibilityIssues(contentPage, '*');
+                expect(results).toHaveLength(0);
+            },
+        );
     });
 });

--- a/src/tests/end-to-end/tests/details-view/cross-origin-iframe.test.ts
+++ b/src/tests/end-to-end/tests/details-view/cross-origin-iframe.test.ts
@@ -6,7 +6,10 @@ import * as testResourceServer from '../../../miscellaneous/test-resource-server
 import { ResourceServerConfig } from '../../../miscellaneous/test-resource-server/resource-server-config';
 import { Browser } from '../../common/browser';
 import { ExtraPermissions, launchBrowser } from '../../common/browser-factory';
-import { detailsViewSelectors, fastPassAutomatedChecksSelectors } from '../../common/element-identifiers/details-view-selectors';
+import {
+    detailsViewSelectors,
+    fastPassAutomatedChecksSelectors,
+} from '../../common/element-identifiers/details-view-selectors';
 import { DetailsViewPage } from '../../common/page-controllers/details-view-page';
 import { TargetPage } from '../../common/page-controllers/target-page';
 import { DEFAULT_TARGET_PAGE_SCAN_TIMEOUT_MS } from '../../common/timeouts';
@@ -43,7 +46,9 @@ describe('scanning', () => {
         });
 
         it('does not get results from inside cross-origin iframes', async () => {
-            const ruleDetails = await fastPassAutomatedChecks.getSelectorElements(fastPassAutomatedChecksSelectors.ruleDetail);
+            const ruleDetails = await fastPassAutomatedChecks.getSelectorElements(
+                fastPassAutomatedChecksSelectors.ruleDetail,
+            );
 
             expect(ruleDetails).toHaveLength(2);
 
@@ -56,7 +61,9 @@ describe('scanning', () => {
         });
 
         it('does show iframe detected warning', async () => {
-            const iframeWarning = await fastPassAutomatedChecks.getSelectorElement(fastPassAutomatedChecksSelectors.iframeWarning);
+            const iframeWarning = await fastPassAutomatedChecks.getSelectorElement(
+                fastPassAutomatedChecksSelectors.iframeWarning,
+            );
 
             expect(iframeWarning).not.toBeNull();
         });
@@ -75,7 +82,9 @@ describe('scanning', () => {
         });
 
         it('does find results from inside cross-origin iframes', async () => {
-            const ruleDetails = await fastPassAutomatedChecks.getSelectorElements(fastPassAutomatedChecksSelectors.ruleDetail);
+            const ruleDetails = await fastPassAutomatedChecks.getSelectorElements(
+                fastPassAutomatedChecksSelectors.ruleDetail,
+            );
 
             expect(ruleDetails).toHaveLength(5);
 
@@ -91,15 +100,24 @@ describe('scanning', () => {
         });
 
         it('does not show iframe detected warning', async () => {
-            const iframeWarning = await fastPassAutomatedChecks.getSelectorElement(fastPassAutomatedChecksSelectors.iframeWarning);
+            const iframeWarning = await fastPassAutomatedChecks.getSelectorElement(
+                fastPassAutomatedChecksSelectors.iframeWarning,
+            );
 
             expect(iframeWarning).toBeNull();
         });
     });
 
-    async function launchFastPassWithExtraPermissions(extraPermissions: ExtraPermissions): Promise<void> {
-        browser = await launchBrowser({ suppressFirstTimeDialog: true, addExtraPermissionsToManifest: extraPermissions });
-        targetPage = await browser.newTargetPage({ testResourcePath: 'all-cross-origin-iframe.html' });
+    async function launchFastPassWithExtraPermissions(
+        extraPermissions: ExtraPermissions,
+    ): Promise<void> {
+        browser = await launchBrowser({
+            suppressFirstTimeDialog: true,
+            addExtraPermissionsToManifest: extraPermissions,
+        });
+        targetPage = await browser.newTargetPage({
+            testResourcePath: 'all-cross-origin-iframe.html',
+        });
         await browser.newPopupPage(targetPage); // Required for the details view to register as having permissions/being open
 
         fastPassAutomatedChecks = await openAutomatedChecks();
@@ -123,15 +141,23 @@ describe('scanning', () => {
         expectedCounts: { [ruleName: string]: number },
     ): Promise<void> {
         for (const ruleDetail of actualRuleDetails) {
-            const ruleNameElement = await ruleDetail.$(fastPassAutomatedChecksSelectors.cardsRuleId);
-            const ruleName = await fastPassAutomatedChecks.evaluate(element => element.innerHTML, ruleNameElement);
+            const ruleNameElement = await ruleDetail.$(
+                fastPassAutomatedChecksSelectors.cardsRuleId,
+            );
+            const ruleName = await fastPassAutomatedChecks.evaluate(
+                element => element.innerHTML,
+                ruleNameElement,
+            );
 
             const expectedCount = expectedCounts[ruleName];
 
             expect(expectedCount).not.toBeNull();
 
             const countElement = await ruleDetail.$(fastPassAutomatedChecksSelectors.failureCount);
-            const count = await fastPassAutomatedChecks.evaluate(element => parseInt(element.innerHTML, 10), countElement);
+            const count = await fastPassAutomatedChecks.evaluate(
+                element => parseInt(element.innerHTML, 10),
+                countElement,
+            );
 
             expect(count).toBe(expectedCount);
         }

--- a/src/tests/end-to-end/tests/details-view/headings.test.ts
+++ b/src/tests/end-to-end/tests/details-view/headings.test.ts
@@ -14,7 +14,10 @@ describe('Details View -> Assessment -> Headings', () => {
     let headingsPage: DetailsViewPage;
 
     beforeAll(async () => {
-        browser = await launchBrowser({ suppressFirstTimeDialog: true, addExtraPermissionsToManifest: 'fake-activeTab' });
+        browser = await launchBrowser({
+            suppressFirstTimeDialog: true,
+            addExtraPermissionsToManifest: 'fake-activeTab',
+        });
         targetPage = await browser.newTargetPage();
         await browser.newPopupPage(targetPage); // Required for the details view to register as having permissions/being open
         headingsPage = await openHeadingsPage(browser, targetPage);
@@ -27,16 +30,25 @@ describe('Details View -> Assessment -> Headings', () => {
         }
     });
 
-    it.each([true, false])('should pass accessibility validation with highContrastMode=%s', async highContrastMode => {
-        await browser.setHighContrastMode(highContrastMode);
-        await headingsPage.waitForHighContrastMode(highContrastMode);
+    it.each([true, false])(
+        'should pass accessibility validation with highContrastMode=%s',
+        async highContrastMode => {
+            await browser.setHighContrastMode(highContrastMode);
+            await headingsPage.waitForHighContrastMode(highContrastMode);
 
-        const results = await scanForAccessibilityIssues(headingsPage, detailsViewSelectors.mainContent);
-        expect(results).toHaveLength(0);
-    });
+            const results = await scanForAccessibilityIssues(
+                headingsPage,
+                detailsViewSelectors.mainContent,
+            );
+            expect(results).toHaveLength(0);
+        },
+    );
 });
 
-async function openHeadingsPage(browser: Browser, targetPage: TargetPage): Promise<DetailsViewPage> {
+async function openHeadingsPage(
+    browser: Browser,
+    targetPage: TargetPage,
+): Promise<DetailsViewPage> {
     const detailsViewPage = await browser.newDetailsViewPage(targetPage);
     await detailsViewPage.switchToAssessment();
 

--- a/src/tests/end-to-end/tests/details-view/overview.test.ts
+++ b/src/tests/end-to-end/tests/details-view/overview.test.ts
@@ -26,16 +26,25 @@ describe('Details View -> Overview Page', () => {
         }
     });
 
-    it.each([true, false])('should pass accessibility validation with highContrastMode=%s', async highContrastMode => {
-        await browser.setHighContrastMode(highContrastMode);
-        await overviewPage.waitForHighContrastMode(highContrastMode);
+    it.each([true, false])(
+        'should pass accessibility validation with highContrastMode=%s',
+        async highContrastMode => {
+            await browser.setHighContrastMode(highContrastMode);
+            await overviewPage.waitForHighContrastMode(highContrastMode);
 
-        const results = await scanForAccessibilityIssues(overviewPage, overviewSelectors.overview);
-        expect(results).toHaveLength(0);
-    });
+            const results = await scanForAccessibilityIssues(
+                overviewPage,
+                overviewSelectors.overview,
+            );
+            expect(results).toHaveLength(0);
+        },
+    );
 });
 
-async function openOverviewPage(browser: Browser, targetPage: TargetPage): Promise<DetailsViewPage> {
+async function openOverviewPage(
+    browser: Browser,
+    targetPage: TargetPage,
+): Promise<DetailsViewPage> {
     const detailsViewPage = await browser.newDetailsViewPage(targetPage);
     await detailsViewPage.switchToAssessment();
     await detailsViewPage.waitForSelector(overviewSelectors.overviewHeading);

--- a/src/tests/end-to-end/tests/details-view/preview-features.test.ts
+++ b/src/tests/end-to-end/tests/details-view/preview-features.test.ts
@@ -30,25 +30,41 @@ describe('Details View -> Preview Features Panel', () => {
     });
 
     it('should match content in snapshot', async () => {
-        const previewFeaturesPanel = await formatPageElementForSnapshot(detailsViewPage, detailsViewSelectors.previewFeaturesPanel);
+        const previewFeaturesPanel = await formatPageElementForSnapshot(
+            detailsViewPage,
+            detailsViewSelectors.previewFeaturesPanel,
+        );
         expect(previewFeaturesPanel).toMatchSnapshot();
     });
 
-    it.each([true, false])('should pass accessibility validation with highContrastMode=%s', async highContrastMode => {
-        await browser.setHighContrastMode(highContrastMode);
-        await detailsViewPage.waitForHighContrastMode(highContrastMode);
+    it.each([true, false])(
+        'should pass accessibility validation with highContrastMode=%s',
+        async highContrastMode => {
+            await browser.setHighContrastMode(highContrastMode);
+            await detailsViewPage.waitForHighContrastMode(highContrastMode);
 
-        const results = await scanForAccessibilityIssues(detailsViewPage, detailsViewSelectors.previewFeaturesPanel);
-        expect(results).toHaveLength(0);
-    });
+            const results = await scanForAccessibilityIssues(
+                detailsViewPage,
+                detailsViewSelectors.previewFeaturesPanel,
+            );
+            expect(results).toHaveLength(0);
+        },
+    );
 });
 
-async function openPreviewFeaturesPanel(browser: Browser, targetPage: TargetPage): Promise<DetailsViewPage> {
+async function openPreviewFeaturesPanel(
+    browser: Browser,
+    targetPage: TargetPage,
+): Promise<DetailsViewPage> {
     const popupPage = await browser.newPopupPage(targetPage);
 
     await popupPage.clickSelector(CommonSelectors.settingsGearButton);
 
-    const detailsViewPage = await waitForDetailsViewWithPreviewFeaturesPanel(browser, popupPage, targetPage);
+    const detailsViewPage = await waitForDetailsViewWithPreviewFeaturesPanel(
+        browser,
+        popupPage,
+        targetPage,
+    );
 
     await detailsViewPage.waitForId(componentId);
 

--- a/src/tests/end-to-end/tests/details-view/settings-panel.test.ts
+++ b/src/tests/end-to-end/tests/details-view/settings-panel.test.ts
@@ -33,45 +33,77 @@ describe('Details View -> Settings Panel', () => {
 
     describe('Telemetry toggle', () => {
         it('should default to "off" in the usual configuration our E2E tests use', async () => {
-            await detailsViewPage.expectToggleState(settingsPanelSelectors.telemetryStateToggle, false);
+            await detailsViewPage.expectToggleState(
+                settingsPanelSelectors.telemetryStateToggle,
+                false,
+            );
         });
 
         it('should reflect the state applied via the background page insightsUserConfiguration controller all other tests use', async () => {
             await backgroundPage.setTelemetryState(true);
-            await detailsViewPage.expectToggleState(settingsPanelSelectors.telemetryStateToggle, true);
+            await detailsViewPage.expectToggleState(
+                settingsPanelSelectors.telemetryStateToggle,
+                true,
+            );
 
             await backgroundPage.setTelemetryState(false);
-            await detailsViewPage.expectToggleState(settingsPanelSelectors.telemetryStateToggle, false);
+            await detailsViewPage.expectToggleState(
+                settingsPanelSelectors.telemetryStateToggle,
+                false,
+            );
         });
     });
 
     describe('High Contrast Mode toggle', () => {
         it('should default to non-high-contrast mode', async () => {
-            await detailsViewPage.expectToggleState(settingsPanelSelectors.highContrastModeToggle, false);
+            await detailsViewPage.expectToggleState(
+                settingsPanelSelectors.highContrastModeToggle,
+                false,
+            );
         });
 
         it('should apply the appropriate CSS style when High Contrast Mode setting is toggled', async () => {
-            await detailsViewPage.setToggleState(settingsPanelSelectors.highContrastModeToggle, true);
+            await detailsViewPage.setToggleState(
+                settingsPanelSelectors.highContrastModeToggle,
+                true,
+            );
             await detailsViewPage.waitForSelector(CommonSelectors.highContrastThemeSelector);
 
-            await detailsViewPage.setToggleState(settingsPanelSelectors.highContrastModeToggle, false);
-            await detailsViewPage.waitForSelectorToDisappear(CommonSelectors.highContrastThemeSelector);
+            await detailsViewPage.setToggleState(
+                settingsPanelSelectors.highContrastModeToggle,
+                false,
+            );
+            await detailsViewPage.waitForSelectorToDisappear(
+                CommonSelectors.highContrastThemeSelector,
+            );
         });
 
         it('should reflect the state applied via the background page insightsUserConfiguration controller all other tests use', async () => {
             await backgroundPage.setHighContrastMode(true);
-            await detailsViewPage.expectToggleState(settingsPanelSelectors.highContrastModeToggle, true);
+            await detailsViewPage.expectToggleState(
+                settingsPanelSelectors.highContrastModeToggle,
+                true,
+            );
 
             await backgroundPage.setHighContrastMode(false);
-            await detailsViewPage.expectToggleState(settingsPanelSelectors.highContrastModeToggle, false);
+            await detailsViewPage.expectToggleState(
+                settingsPanelSelectors.highContrastModeToggle,
+                false,
+            );
         });
     });
 
-    it.each([true, false])('should pass accessibility validation with highContrastMode=%s', async highContrastMode => {
-        await backgroundPage.setHighContrastMode(highContrastMode);
-        await detailsViewPage.waitForHighContrastMode(highContrastMode);
+    it.each([true, false])(
+        'should pass accessibility validation with highContrastMode=%s',
+        async highContrastMode => {
+            await backgroundPage.setHighContrastMode(highContrastMode);
+            await detailsViewPage.waitForHighContrastMode(highContrastMode);
 
-        const results = await scanForAccessibilityIssues(detailsViewPage, settingsPanelSelectors.settingsPanel);
-        expect(results).toHaveLength(0);
-    });
+            const results = await scanForAccessibilityIssues(
+                detailsViewPage,
+                settingsPanelSelectors.settingsPanel,
+            );
+            expect(results).toHaveLength(0);
+        },
+    );
 });

--- a/src/tests/end-to-end/tests/popup/adhoc-panel.test.ts
+++ b/src/tests/end-to-end/tests/popup/adhoc-panel.test.ts
@@ -13,7 +13,10 @@ describe('Popup -> Ad-hoc tools', () => {
     let popupPage: PopupPage;
 
     beforeEach(async () => {
-        browser = await launchBrowser({ suppressFirstTimeDialog: true, addExtraPermissionsToManifest: 'fake-activeTab' });
+        browser = await launchBrowser({
+            suppressFirstTimeDialog: true,
+            addExtraPermissionsToManifest: 'fake-activeTab',
+        });
         targetPage = await browser.newTargetPage();
         popupPage = await browser.newPopupPage(targetPage);
         await popupPage.bringToFront();
@@ -47,15 +50,18 @@ describe('Popup -> Ad-hoc tools', () => {
         await popupPage.verifyLaunchPadLoaded();
     });
 
-    it.each([true, false])('should pass accessibility validation with highContrastMode=%s', async highContrastMode => {
-        await browser.setHighContrastMode(highContrastMode);
-        await popupPage.waitForHighContrastMode(highContrastMode);
+    it.each([true, false])(
+        'should pass accessibility validation with highContrastMode=%s',
+        async highContrastMode => {
+            await browser.setHighContrastMode(highContrastMode);
+            await popupPage.waitForHighContrastMode(highContrastMode);
 
-        await popupPage.gotoAdhocPanel();
+            await popupPage.gotoAdhocPanel();
 
-        const results = await scanForAccessibilityIssues(popupPage, '*');
-        expect(results).toHaveLength(0);
-    });
+            const results = await scanForAccessibilityIssues(popupPage, '*');
+            expect(results).toHaveLength(0);
+        },
+    );
 
     it.each(['Automated checks', 'Landmarks', 'Headings', 'Color'])(
         'should display the pinned target page visualizations when enabling the "%s" toggle',

--- a/src/tests/end-to-end/tests/popup/first-time-dialog.test.ts
+++ b/src/tests/end-to-end/tests/popup/first-time-dialog.test.ts
@@ -33,19 +33,26 @@ describe('First time Dialog', () => {
         await firstPopupPage.bringToFront();
 
         await firstPopupPage.clickSelector(popupPageElementIdentifiers.startUsingProductButton);
-        await firstPopupPage.waitForSelectorToDisappear(popupPageElementIdentifiers.telemetryDialog);
+        await firstPopupPage.waitForSelectorToDisappear(
+            popupPageElementIdentifiers.telemetryDialog,
+        );
         await firstPopupPage.close();
 
         const secondPopupPage = await newPopupPage();
         await secondPopupPage.waitForSelector(popupPageElementIdentifiers.launchPad);
-        await secondPopupPage.waitForSelectorToDisappear(popupPageElementIdentifiers.telemetryDialog);
+        await secondPopupPage.waitForSelectorToDisappear(
+            popupPageElementIdentifiers.telemetryDialog,
+        );
     });
 
     it('content should match snapshot', async () => {
         const popupPage = await newPopupPage();
         await popupPage.waitForSelector(popupPageElementIdentifiers.telemetryDialog);
 
-        const element = await formatPageElementForSnapshot(popupPage, popupPageElementIdentifiers.telemetryDialog);
+        const element = await formatPageElementForSnapshot(
+            popupPage,
+            popupPageElementIdentifiers.telemetryDialog,
+        );
         expect(element).toMatchSnapshot();
     });
 
@@ -53,7 +60,10 @@ describe('First time Dialog', () => {
         const popupPage = await newPopupPage();
         await popupPage.waitForSelector(popupPageElementIdentifiers.telemetryDialog);
 
-        const results = await scanForAccessibilityIssues(popupPage, popupPageElementIdentifiers.telemetryDialog);
+        const results = await scanForAccessibilityIssues(
+            popupPage,
+            popupPageElementIdentifiers.telemetryDialog,
+        );
         expect(results).toHaveLength(0);
     });
 });

--- a/src/tests/end-to-end/tests/popup/hamburger-menu.test.ts
+++ b/src/tests/end-to-end/tests/popup/hamburger-menu.test.ts
@@ -28,15 +28,24 @@ describe('Popup -> Hamburger menu', () => {
     });
 
     it('should have content matching snapshot', async () => {
-        const hamburgerMenu = await formatPageElementForSnapshot(popupPage, popupPageElementIdentifiers.hamburgerMenu);
+        const hamburgerMenu = await formatPageElementForSnapshot(
+            popupPage,
+            popupPageElementIdentifiers.hamburgerMenu,
+        );
         expect(hamburgerMenu).toMatchSnapshot();
     });
 
-    it.each([true, false])('should pass accessibility validation with highContrastMode=%s', async highContrastMode => {
-        await browser.setHighContrastMode(highContrastMode);
-        await popupPage.waitForHighContrastMode(highContrastMode);
+    it.each([true, false])(
+        'should pass accessibility validation with highContrastMode=%s',
+        async highContrastMode => {
+            await browser.setHighContrastMode(highContrastMode);
+            await popupPage.waitForHighContrastMode(highContrastMode);
 
-        const results = await scanForAccessibilityIssues(popupPage, popupPageElementIdentifiers.hamburgerMenu);
-        expect(results).toHaveLength(0);
-    });
+            const results = await scanForAccessibilityIssues(
+                popupPage,
+                popupPageElementIdentifiers.hamburgerMenu,
+            );
+            expect(results).toHaveLength(0);
+        },
+    );
 });

--- a/src/tests/end-to-end/tests/popup/launchpad.test.ts
+++ b/src/tests/end-to-end/tests/popup/launchpad.test.ts
@@ -29,15 +29,21 @@ describe('Popup -> Launch Pad', () => {
     });
 
     it('content should match snapshot', async () => {
-        const element = await formatPageElementForSnapshot(popupPage, popupPageElementIdentifiers.launchPad);
+        const element = await formatPageElementForSnapshot(
+            popupPage,
+            popupPageElementIdentifiers.launchPad,
+        );
         expect(element).toMatchSnapshot();
     });
 
-    it.each([true, false])('should pass accessibility validation with highContrastMode=%s', async highContrastMode => {
-        await browser.setHighContrastMode(highContrastMode);
-        await popupPage.waitForHighContrastMode(highContrastMode);
+    it.each([true, false])(
+        'should pass accessibility validation with highContrastMode=%s',
+        async highContrastMode => {
+            await browser.setHighContrastMode(highContrastMode);
+            await popupPage.waitForHighContrastMode(highContrastMode);
 
-        const results = await scanForAccessibilityIssues(popupPage, '*');
-        expect(results).toHaveLength(0);
-    });
+            const results = await scanForAccessibilityIssues(popupPage, '*');
+            expect(results).toHaveLength(0);
+        },
+    );
 });

--- a/src/tests/end-to-end/tests/target-page/issue-dialog.test.ts
+++ b/src/tests/end-to-end/tests/target-page/issue-dialog.test.ts
@@ -13,7 +13,10 @@ describe('Target Page issue dialog', () => {
     let popupPage: PopupPage;
 
     beforeAll(async () => {
-        browser = await launchBrowser({ suppressFirstTimeDialog: true, addExtraPermissionsToManifest: 'fake-activeTab' });
+        browser = await launchBrowser({
+            suppressFirstTimeDialog: true,
+            addExtraPermissionsToManifest: 'fake-activeTab',
+        });
         targetPage = await browser.newTargetPage();
         popupPage = await browser.newPopupPage(targetPage);
     });
@@ -31,10 +34,15 @@ describe('Target Page issue dialog', () => {
 
         await targetPage.bringToFront();
 
-        await targetPage.clickSelectorInShadowRoot(TargetPageInjectedComponentSelectors.failureLabel);
+        await targetPage.clickSelectorInShadowRoot(
+            TargetPageInjectedComponentSelectors.failureLabel,
+        );
         await targetPage.waitForSelector(TargetPageInjectedComponentSelectors.issueDialog);
 
-        const results = await scanForAccessibilityIssues(targetPage, TargetPageInjectedComponentSelectors.issueDialog);
+        const results = await scanForAccessibilityIssues(
+            targetPage,
+            TargetPageInjectedComponentSelectors.issueDialog,
+        );
         expect(results).toHaveLength(0);
     });
 });

--- a/src/tests/end-to-end/tests/target-page/tabstop.test.ts
+++ b/src/tests/end-to-end/tests/target-page/tabstop.test.ts
@@ -12,8 +12,13 @@ describe('Tab stops visualization', () => {
     let popupPage: PopupPage;
 
     beforeEach(async () => {
-        browser = await launchBrowser({ suppressFirstTimeDialog: true, addExtraPermissionsToManifest: 'fake-activeTab' });
-        targetPage = await browser.newTargetPage({ testResourcePath: 'native-widgets/input-type-radio.html' });
+        browser = await launchBrowser({
+            suppressFirstTimeDialog: true,
+            addExtraPermissionsToManifest: 'fake-activeTab',
+        });
+        targetPage = await browser.newTargetPage({
+            testResourcePath: 'native-widgets/input-type-radio.html',
+        });
     });
 
     afterEach(async () => {

--- a/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
+++ b/src/tests/end-to-end/tests/target-page/visualization-boxes.test.ts
@@ -13,7 +13,10 @@ describe('Target Page visualization boxes', () => {
     let popupPage: PopupPage;
 
     beforeEach(async () => {
-        browser = await launchBrowser({ suppressFirstTimeDialog: true, addExtraPermissionsToManifest: 'fake-activeTab' });
+        browser = await launchBrowser({
+            suppressFirstTimeDialog: true,
+            addExtraPermissionsToManifest: 'fake-activeTab',
+        });
         targetPage = await browser.newTargetPage();
         popupPage = await browser.newPopupPage(targetPage);
         await popupPage.gotoAdhocPanel();
@@ -28,12 +31,21 @@ describe('Target Page visualization boxes', () => {
 
     const adhocTools = ['Landmarks', 'Headings', 'Automated checks'];
 
-    it.each(adhocTools)('for adhoc tool "%s" should pass accessibility validation', async adhocTool => {
-        await popupPage.enableToggleByAriaLabel(adhocTool);
+    it.each(adhocTools)(
+        'for adhoc tool "%s" should pass accessibility validation',
+        async adhocTool => {
+            await popupPage.enableToggleByAriaLabel(adhocTool);
 
-        await targetPage.waitForSelectorInShadowRoot(TargetPageInjectedComponentSelectors.insightsVisualizationBox, { visible: true });
+            await targetPage.waitForSelectorInShadowRoot(
+                TargetPageInjectedComponentSelectors.insightsVisualizationBox,
+                { visible: true },
+            );
 
-        const results = await scanForAccessibilityIssues(targetPage, TargetPageInjectedComponentSelectors.insightsRootContainer);
-        expect(results).toHaveLength(0);
-    });
+            const results = await scanForAccessibilityIssues(
+                targetPage,
+                TargetPageInjectedComponentSelectors.insightsRootContainer,
+            );
+            expect(results).toHaveLength(0);
+        },
+    );
 });


### PR DESCRIPTION
#### Description of changes

This PR changes files under `src/tests/end-to-end` to comply with our new prettier config of 100 line width.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
