### PR TITLE
fix: unblock linux signing by fixing AppImage name reference

### DIFF
--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -27,7 +27,7 @@ jobs:
             inputs:
                 SourceFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
                 contents: |
-                    Accessibility Insights for Android*.*
+                    Accessibility_Insights_for_Android*.*
                 TargetFolder: '$(System.DefaultWorkingDirectory)/detachedSignature'
 
           - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
@@ -56,7 +56,7 @@ jobs:
             inputs:
                 SourceFolder: $(System.DefaultWorkingDirectory)/detachedSignature
                 contents: |
-                    Accessibility Insights for Android*.*
+                    Accessibility_Insights_for_Android*.*
                 TargetFolder: '$(System.DefaultWorkingDirectory)/signing-in-progress/${{ parameters.signedArtifactName }}'
 
           - script: yarn update:electron-checksum signing-in-progress/${{ parameters.signedArtifactName }}


### PR DESCRIPTION
#### Description of changes

The previous PR #2113 replaced spaces w/ underscores in the Linux installer name. The signing task still references the old name. This PR updates the reference so it is correct.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
