### PR TITLE
fix: unified screenshot view not being fully visible at small heights

### DIFF
--- a/src/electron/views/screenshot/screenshot-view.scss
+++ b/src/electron/views/screenshot/screenshot-view.scss
@@ -6,7 +6,6 @@
 .screenshot-view {
     overflow: auto;
     width: 23%;
-    height: 100%;
     padding-top: 16px;
     padding-bottom: 16px;
     padding-left: 24px;


### PR DESCRIPTION
#### Description of changes

Fixes #2121

Before:
![screenshot showing right pane overflowing off bottom of screen](https://user-images.githubusercontent.com/376284/73994301-ebee0780-4909-11ea-8865-4190fc4aa837.png)

After:
![screenshot showing right pane correctly scrollable all the way into view](https://user-images.githubusercontent.com/376284/73994294-e690bd00-4909-11ea-846d-28e4c05230ca.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2121
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
