### PR TITLE
feat(unified-channels): fix mac auto-update by building a zip side-by-side with dmg

### DIFF
--- a/src/electron/electron-builder/electron-builder.template.yaml
+++ b/src/electron/electron-builder/electron-builder.template.yaml
@@ -26,7 +26,7 @@ linux:
 mac:
     artifactName: ${productName}.${ext}
     icon: TARGET_SPECIFIC
-    target: dmg
+    target: [dmg, zip] # zip is required because of electron-userland/electron-builder#2199
     identity: null
 
 win:


### PR DESCRIPTION
#### Description of changes

This change is an attempt to work around https://github.com/electron-userland/electron-builder/issues/2199, where mac auto-update doesn't work if you produce only a .dmg file without a corresponding .zip file, even if the user installs using the .dmg file. Our signing pattern, artifact publishing patterns, and blob release patterns are all already dmg/zip agnostic, so I think no changes are required to cause the new zip file to be signed/released alongside the dmg.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
