### PR TITLE
fix: add default font-family to unified root container

### DIFF
--- a/src/electron/views/root-container/components/root-container.scss
+++ b/src/electron/views/root-container/components/root-container.scss
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../../../common/styles/colors.scss';
+@import '../../../../common/styles/fonts.scss';
 
 body {
     margin: 0px;
@@ -8,6 +9,7 @@ body {
     width: 100%;
     overflow: hidden;
     background-color: $neutral-0;
+    font-family: $fontFamily;
 }
 
 button {


### PR DESCRIPTION
#### Description of changes

This PR updates fonts in the unified client to match the default fonts in the Chrome extension.

![screenshot of font change](https://user-images.githubusercontent.com/7775527/74060516-00c8aa80-499f-11ea-8084-548290df0482.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
