### PR TITLE
chore: line width for src/tests/unit/tests/scanner folder

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -33,6 +33,7 @@ module.exports = {
                 'src/tests/unit/tests/assessments/**/*',
                 'src/tests/unit/tests/content/**/*',
                 'src/tests/unit/tests/DevTools/**/*',
+                'src/tests/unit/tests/scanner/**/*',
                 'src/types/**/*',
                 'src/views/**/*',
             ],

--- a/src/tests/unit/tests/scanner/axe-configurator.test.ts
+++ b/src/tests/unit/tests/scanner/axe-configurator.test.ts
@@ -74,7 +74,9 @@ describe('AxeConfigurator', () => {
 
             configureMock.setup(cm => cm(It.isValue({ locale: localeConfiguration }))).verifiable();
 
-            configureMock.setup(cm => cm(It.isValue({ branding: { brand: 'axe', application: 'msftAI' } }))).verifiable();
+            configureMock
+                .setup(cm => cm(It.isValue({ branding: { brand: 'axe', application: 'msftAI' } })))
+                .verifiable();
 
             const axeStub = {
                 configure: configureMock.object,

--- a/src/tests/unit/tests/scanner/axe-response-handler.test.ts
+++ b/src/tests/unit/tests/scanner/axe-response-handler.test.ts
@@ -22,7 +22,11 @@ describe('AxeResponseHandler', () => {
 
             errorCallbackMock.setup(scb => scb(errorStub)).verifiable();
 
-            const testSubject = new AxeResponseHandler(successCallbackMock.object, errorCallbackMock.object, null);
+            const testSubject = new AxeResponseHandler(
+                successCallbackMock.object,
+                errorCallbackMock.object,
+                null,
+            );
 
             const failingFunction = () => {
                 testSubject.handleResponse(errorStub, null);
@@ -47,7 +51,11 @@ describe('AxeResponseHandler', () => {
 
             successCallbackMock.setup(scm => scm(scanResultsStub)).verifiable();
 
-            const testSubject = new AxeResponseHandler(successCallbackMock.object, null, resultDecoratorMock.object);
+            const testSubject = new AxeResponseHandler(
+                successCallbackMock.object,
+                null,
+                resultDecoratorMock.object,
+            );
 
             testSubject.handleResponse(null, axeResultStub as any);
 

--- a/src/tests/unit/tests/scanner/axe-rule-overrides.test.ts
+++ b/src/tests/unit/tests/scanner/axe-rule-overrides.test.ts
@@ -10,7 +10,9 @@ describe('AriaAllowedAttrOverride', () => {
         it('should call configure with the configuration', () => {
             const axeMock = Mock.ofInstance({ configure: config => null }, MockBehavior.Strict);
 
-            axeMock.setup(am => am.configure(AxeRuleOverrides.overrideConfiguration)).verifiable(Times.once());
+            axeMock
+                .setup(am => am.configure(AxeRuleOverrides.overrideConfiguration))
+                .verifiable(Times.once());
 
             AxeRuleOverrides.override(axeMock.object as typeof Axe);
             axeMock.verifyAll();

--- a/src/tests/unit/tests/scanner/axe-utils.test.ts
+++ b/src/tests/unit/tests/scanner/axe-utils.test.ts
@@ -28,12 +28,18 @@ describe('AxeUtils', () => {
     });
 
     describe('getAccessibleText', () => {
-        const accessibleTextMock = GlobalMock.ofInstance(axe.commons.text.accessibleText, 'accessibleText', axe.commons.text);
+        const accessibleTextMock = GlobalMock.ofInstance(
+            axe.commons.text.accessibleText,
+            'accessibleText',
+            axe.commons.text,
+        );
         it('should call mock when labelledbycontext true', () => {
             GlobalScope.using(accessibleTextMock).with(() => {
                 const elementStub = {} as HTMLElement;
                 const isLabelledByContext = true;
-                accessibleTextMock.setup(m => m(It.isValue(elementStub), isLabelledByContext)).verifiable(Times.once());
+                accessibleTextMock
+                    .setup(m => m(It.isValue(elementStub), isLabelledByContext))
+                    .verifiable(Times.once());
                 AxeUtils.getAccessibleText(elementStub, isLabelledByContext);
             });
             accessibleTextMock.verifyAll();
@@ -43,7 +49,9 @@ describe('AxeUtils', () => {
             GlobalScope.using(accessibleTextMock).with(() => {
                 const elementStub = {} as HTMLElement;
                 const isLabelledByContext = false;
-                accessibleTextMock.setup(m => m(It.isValue(elementStub), isLabelledByContext)).verifiable(Times.once());
+                accessibleTextMock
+                    .setup(m => m(It.isValue(elementStub), isLabelledByContext))
+                    .verifiable(Times.once());
                 AxeUtils.getAccessibleText(elementStub, isLabelledByContext);
             });
             accessibleTextMock.verifyAll();
@@ -229,7 +237,12 @@ describe('AxeUtils', () => {
 
         beforeEach(() => {
             fixture = createTestFixture('test-fixture', '');
-            windowMock = GlobalMock.ofInstance(window.getComputedStyle, 'getComputedStyle', window, MockBehavior.Strict);
+            windowMock = GlobalMock.ofInstance(
+                window.getComputedStyle,
+                'getComputedStyle',
+                window,
+                MockBehavior.Strict,
+            );
         });
 
         afterEach(() => {
@@ -241,7 +254,11 @@ describe('AxeUtils', () => {
                 <img id="el1" alt="" />
             `;
             const element1 = fixture.querySelector('#el1');
-            windowMock.setup(m => m(It.isAny())).returns(node => ({ getPropertyValue: property => 'some-value' } as CSSStyleDeclaration));
+            windowMock
+                .setup(m => m(It.isAny()))
+                .returns(
+                    node => ({ getPropertyValue: property => 'some-value' } as CSSStyleDeclaration),
+                );
             let result;
             GlobalScope.using(windowMock).with(() => {
                 result = AxeUtils.hasBackgoundImage(element1 as HTMLElement);
@@ -254,7 +271,9 @@ describe('AxeUtils', () => {
                 <img id="el1" alt="" />
             `;
             const element1 = fixture.querySelector('#el1');
-            windowMock.setup(m => m(It.isAny())).returns(node => ({ getPropertyValue: property => 'none' } as CSSStyleDeclaration));
+            windowMock
+                .setup(m => m(It.isAny()))
+                .returns(node => ({ getPropertyValue: property => 'none' } as CSSStyleDeclaration));
             let result;
             GlobalScope.using(windowMock).with(() => {
                 result = AxeUtils.hasBackgoundImage(element1 as HTMLElement);
@@ -269,7 +288,12 @@ describe('AxeUtils', () => {
 
         beforeEach(() => {
             fixture = createTestFixture('test-fixture', '');
-            windowMock = GlobalMock.ofInstance(window.getComputedStyle, 'getComputedStyle', window, MockBehavior.Strict);
+            windowMock = GlobalMock.ofInstance(
+                window.getComputedStyle,
+                'getComputedStyle',
+                window,
+                MockBehavior.Strict,
+            );
         });
 
         afterEach(() => {
@@ -281,7 +305,9 @@ describe('AxeUtils', () => {
                 <img id="el1"/>
             `;
             const element1 = fixture.querySelector('#el1');
-            windowMock.setup(m => m(It.isAny())).returns(node => ({ getPropertyValue: property => 'none' } as CSSStyleDeclaration));
+            windowMock
+                .setup(m => m(It.isAny()))
+                .returns(node => ({ getPropertyValue: property => 'none' } as CSSStyleDeclaration));
             let result;
             GlobalScope.using(windowMock).with(() => {
                 result = AxeUtils.getImageType(element1 as HTMLElement);
@@ -294,7 +320,9 @@ describe('AxeUtils', () => {
                 <i id="el1" />
             `;
             const element1 = fixture.querySelector('#el1');
-            windowMock.setup(m => m(It.isAny())).returns(node => ({ getPropertyValue: property => 'none' } as CSSStyleDeclaration));
+            windowMock
+                .setup(m => m(It.isAny()))
+                .returns(node => ({ getPropertyValue: property => 'none' } as CSSStyleDeclaration));
             let result;
             GlobalScope.using(windowMock).with(() => {
                 result = AxeUtils.getImageType(element1 as HTMLElement);
@@ -307,7 +335,9 @@ describe('AxeUtils', () => {
                 <div id="el1" role='img'/> <div>
             `;
             const element1 = fixture.querySelector('#el1');
-            windowMock.setup(m => m(It.isAny())).returns(node => ({ getPropertyValue: property => 'none' } as CSSStyleDeclaration));
+            windowMock
+                .setup(m => m(It.isAny()))
+                .returns(node => ({ getPropertyValue: property => 'none' } as CSSStyleDeclaration));
             let result;
             GlobalScope.using(windowMock).with(() => {
                 result = AxeUtils.getImageType(element1 as HTMLElement);
@@ -320,7 +350,11 @@ describe('AxeUtils', () => {
                 <div id="el1"/> <div>
             `;
             const element1 = fixture.querySelector('#el1');
-            windowMock.setup(m => m(It.isAny())).returns(node => ({ getPropertyValue: property => 'imgUrl' } as CSSStyleDeclaration));
+            windowMock
+                .setup(m => m(It.isAny()))
+                .returns(
+                    node => ({ getPropertyValue: property => 'imgUrl' } as CSSStyleDeclaration),
+                );
             let result;
             GlobalScope.using(windowMock).with(() => {
                 result = AxeUtils.getImageType(element1 as HTMLElement);

--- a/src/tests/unit/tests/scanner/custom-rules/autocomplete-rule.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/autocomplete-rule.test.ts
@@ -50,30 +50,49 @@ input[type="color"]',
             dataSetterMock = Mock.ofInstance(data => {});
         });
 
-        it.each(['text', 'search', 'url', 'tel', 'email', 'password', 'date', 'date-time', 'date-time-local', 'range', 'color'])(
-            'validate input with type %s is collected by rule',
-            (inputType: string) => {
-                testDom = TestDocumentCreator.createTestDocument(`<input type="${inputType}" id="test-node">`);
-                const node = testDom.querySelector('#test-node');
-                const expectedData = {
-                    inputType,
-                    autocomplete: null,
-                };
-                dataSetterMock.setup(d => d(It.isValue(expectedData))).verifiable(Times.once());
-                const result = autocompleteRuleConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, node);
-                expect(result).toBe(true);
-            },
-        );
+        it.each([
+            'text',
+            'search',
+            'url',
+            'tel',
+            'email',
+            'password',
+            'date',
+            'date-time',
+            'date-time-local',
+            'range',
+            'color',
+        ])('validate input with type %s is collected by rule', (inputType: string) => {
+            testDom = TestDocumentCreator.createTestDocument(
+                `<input type="${inputType}" id="test-node">`,
+            );
+            const node = testDom.querySelector('#test-node');
+            const expectedData = {
+                inputType,
+                autocomplete: null,
+            };
+            dataSetterMock.setup(d => d(It.isValue(expectedData))).verifiable(Times.once());
+            const result = autocompleteRuleConfiguration.checks[0].evaluate.call(
+                { data: dataSetterMock.object },
+                node,
+            );
+            expect(result).toBe(true);
+        });
 
         it.each(['on', 'off'])('should pick autocomplete value', (autocomplete: string) => {
-            testDom = TestDocumentCreator.createTestDocument(`<input type="text" autocomplete="${autocomplete}" id="test-node">`);
+            testDom = TestDocumentCreator.createTestDocument(
+                `<input type="text" autocomplete="${autocomplete}" id="test-node">`,
+            );
             const node = testDom.querySelector('#test-node');
             const expectedData = {
                 inputType: 'text',
                 autocomplete,
             };
             dataSetterMock.setup(d => d(It.isValue(expectedData))).verifiable(Times.once());
-            const result = autocompleteRuleConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, node);
+            const result = autocompleteRuleConfiguration.checks[0].evaluate.call(
+                { data: dataSetterMock.object },
+                node,
+            );
             expect(result).toBe(true);
         });
     });

--- a/src/tests/unit/tests/scanner/custom-rules/css-content-rule.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/css-content-rule.test.ts
@@ -20,8 +20,18 @@ describe('verify matches', () => {
     let divElementFixture: HTMLDivElement;
     let headingElementFixture: HTMLHeadingElement;
 
-    const getComputedStyleMock = GlobalMock.ofInstance(window.getComputedStyle, 'getComputedStyle', window, MockBehavior.Strict);
-    const axeVisibilityMock = GlobalMock.ofInstance(axe.commons.dom.isVisible, 'isVisible', axe.commons.dom, MockBehavior.Strict);
+    const getComputedStyleMock = GlobalMock.ofInstance(
+        window.getComputedStyle,
+        'getComputedStyle',
+        window,
+        MockBehavior.Strict,
+    );
+    const axeVisibilityMock = GlobalMock.ofInstance(
+        axe.commons.dom.isVisible,
+        'isVisible',
+        axe.commons.dom,
+        MockBehavior.Strict,
+    );
 
     beforeEach(() => {
         divElementFixture = document.createElement('div');
@@ -45,37 +55,52 @@ describe('verify matches', () => {
 
     const isElementVisible = [true, false];
 
-    test.each(isElementVisible)('element has pseudo selector but isVisible is toggled: %s', isVisibleParam => {
-        axeVisibilityMock
-            .setup(isVisible => isVisible(headingElementFixture))
-            .returns(() => isVisibleParam)
-            .verifiable();
+    test.each(isElementVisible)(
+        'element has pseudo selector but isVisible is toggled: %s',
+        isVisibleParam => {
+            axeVisibilityMock
+                .setup(isVisible => isVisible(headingElementFixture))
+                .returns(() => isVisibleParam)
+                .verifiable();
 
-        getComputedStyleMock
-            .setup(getComputedStyle => getComputedStyle(headingElementFixture, It.is(checkIfSelectorIsValid)))
-            .returns(style => ({ content: 'test' } as CSSStyleDeclaration))
-            .verifiable(Times.atLeastOnce());
+            getComputedStyleMock
+                .setup(getComputedStyle =>
+                    getComputedStyle(headingElementFixture, It.is(checkIfSelectorIsValid)),
+                )
+                .returns(style => ({ content: 'test' } as CSSStyleDeclaration))
+                .verifiable(Times.atLeastOnce());
 
-        testSemantics(divElementFixture, isVisibleParam);
-    });
+            testSemantics(divElementFixture, isVisibleParam);
+        },
+    );
 
     const contentSwitchParameters = [
         { pseudoSelectorContent: 'none', testExpectation: false },
         { pseudoSelectorContent: 'non-none', testExpectation: true },
     ];
-    test.each(contentSwitchParameters)('element isVisible but pseudo selector content is toggled: %p', testCaseParameters => {
-        axeVisibilityMock
-            .setup(isVisible => isVisible(headingElementFixture))
-            .returns(() => true)
-            .verifiable();
+    test.each(contentSwitchParameters)(
+        'element isVisible but pseudo selector content is toggled: %p',
+        testCaseParameters => {
+            axeVisibilityMock
+                .setup(isVisible => isVisible(headingElementFixture))
+                .returns(() => true)
+                .verifiable();
 
-        getComputedStyleMock
-            .setup(getComputedStyle => getComputedStyle(headingElementFixture, It.is(checkIfSelectorIsValid)))
-            .returns(style => ({ content: testCaseParameters.pseudoSelectorContent } as CSSStyleDeclaration))
-            .verifiable(Times.atLeastOnce());
+            getComputedStyleMock
+                .setup(getComputedStyle =>
+                    getComputedStyle(headingElementFixture, It.is(checkIfSelectorIsValid)),
+                )
+                .returns(
+                    style =>
+                        ({
+                            content: testCaseParameters.pseudoSelectorContent,
+                        } as CSSStyleDeclaration),
+                )
+                .verifiable(Times.atLeastOnce());
 
-        testSemantics(divElementFixture, testCaseParameters.testExpectation);
-    });
+            testSemantics(divElementFixture, testCaseParameters.testExpectation);
+        },
+    );
 
     function testSemantics(elements: HTMLElement, expectedResult: boolean): void {
         let result: boolean;

--- a/src/tests/unit/tests/scanner/custom-rules/css-positioning-rule.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/css-positioning-rule.test.ts
@@ -18,8 +18,18 @@ describe('verify meaningful sequence configs', () => {
 });
 
 describe('verify evaluate', () => {
-    const getComputedStyleMock = GlobalMock.ofInstance(window.getComputedStyle, 'getComputedStyle', window, MockBehavior.Strict);
-    const axeVisibilityMock = GlobalMock.ofInstance(axe.commons.dom.isVisible, 'isVisible', axe.commons.dom, MockBehavior.Strict);
+    const getComputedStyleMock = GlobalMock.ofInstance(
+        window.getComputedStyle,
+        'getComputedStyle',
+        window,
+        MockBehavior.Strict,
+    );
+    const axeVisibilityMock = GlobalMock.ofInstance(
+        axe.commons.dom.isVisible,
+        'isVisible',
+        axe.commons.dom,
+        MockBehavior.Strict,
+    );
 
     beforeEach(() => {
         getComputedStyleMock.reset();
@@ -74,18 +84,31 @@ describe('verify evaluate', () => {
         },
     ];
 
-    it.each(testFixture)('check for different combinations of nodeStyleStub and visibility %p', testStub => {
-        testMeaningfulSequence(testStub.nodeStyleStub, testStub.isVisible, testStub.expectedResult);
-    });
+    it.each(testFixture)(
+        'check for different combinations of nodeStyleStub and visibility %p',
+        testStub => {
+            testMeaningfulSequence(
+                testStub.nodeStyleStub,
+                testStub.isVisible,
+                testStub.expectedResult,
+            );
+        },
+    );
 
-    function testMeaningfulSequence(nodeStyleStub: DictionaryStringTo<string>, isVisibleParam: boolean, expectedResult: boolean): void {
+    function testMeaningfulSequence(
+        nodeStyleStub: DictionaryStringTo<string>,
+        isVisibleParam: boolean,
+        expectedResult: boolean,
+    ): void {
         axeVisibilityMock
             .setup(isVisible => isVisible(nodeStyleStub))
             .returns(() => isVisibleParam)
             .verifiable();
         getComputedStyleMock
             .setup(m => m(It.isAny()))
-            .returns(style => ({ getPropertyValue: property => style[property] } as CSSStyleDeclaration))
+            .returns(
+                style => ({ getPropertyValue: property => style[property] } as CSSStyleDeclaration),
+            )
             .verifiable(Times.once());
 
         let result: boolean;

--- a/src/tests/unit/tests/scanner/custom-rules/cues-rule.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/cues-rule.test.ts
@@ -82,7 +82,12 @@ describe('cues rule', () => {
 
 function testCuesEvaluateWithData(expectedData, nodeData): void {
     const nodeStub = createNodeStub(expectedData.element, nodeData);
-    const getAccessibleTextMock = GlobalMock.ofInstance(AxeUtils.getAccessibleText, 'getAccessibleText', AxeUtils, MockBehavior.Strict);
+    const getAccessibleTextMock = GlobalMock.ofInstance(
+        AxeUtils.getAccessibleText,
+        'getAccessibleText',
+        AxeUtils,
+        MockBehavior.Strict,
+    );
 
     const dataSetterMock = Mock.ofInstance(data => {});
 
@@ -91,7 +96,10 @@ function testCuesEvaluateWithData(expectedData, nodeData): void {
 
     let result;
     GlobalScope.using(getAccessibleTextMock).with(() => {
-        result = cuesConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, nodeStub);
+        result = cuesConfiguration.checks[0].evaluate.call(
+            { data: dataSetterMock.object },
+            nodeStub,
+        );
     });
 
     expect(result).toBe(true);

--- a/src/tests/unit/tests/scanner/custom-rules/frame-title.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/frame-title.test.ts
@@ -26,7 +26,10 @@ describe('FrameTitleRule', () => {
             dataSetterMock.setup(d => d(It.isValue(expectedData))).verifiable(Times.once());
 
             expect(iframe.matches(selector)).toBeTruthy();
-            frameTitleConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, elementStub);
+            frameTitleConfiguration.checks[0].evaluate.call(
+                { data: dataSetterMock.object },
+                elementStub,
+            );
             dataSetterMock.verifyAll();
         });
     });
@@ -54,7 +57,10 @@ describe('FrameTitleRule', () => {
             dataSetterMock.setup(d => d(It.isValue(expectedData))).verifiable(Times.once());
 
             expect(frame.matches(selector)).toBeTruthy();
-            frameTitleConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, elementStub);
+            frameTitleConfiguration.checks[0].evaluate.call(
+                { data: dataSetterMock.object },
+                elementStub,
+            );
             dataSetterMock.verifyAll();
         });
     });

--- a/src/tests/unit/tests/scanner/custom-rules/heading-rule.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/heading-rule.test.ts
@@ -17,7 +17,10 @@ describe('HeadingRule', () => {
             };
             const dataSetterMock = Mock.ofInstance(data => {});
             dataSetterMock.setup(d => d(It.isValue(expectedData))).verifiable(Times.once());
-            headingConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, elementStub);
+            headingConfiguration.checks[0].evaluate.call(
+                { data: dataSetterMock.object },
+                elementStub,
+            );
             dataSetterMock.verifyAll();
         });
     });
@@ -37,7 +40,10 @@ describe('HeadingRule', () => {
             };
             const dataSetterMock = Mock.ofInstance(data => {});
             dataSetterMock.setup(d => d(It.isValue(expectedData))).verifiable(Times.once());
-            headingConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, elementStub);
+            headingConfiguration.checks[0].evaluate.call(
+                { data: dataSetterMock.object },
+                elementStub,
+            );
             dataSetterMock.verifyAll();
         });
     });

--- a/src/tests/unit/tests/scanner/custom-rules/image-rule.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/image-rule.test.ts
@@ -62,8 +62,15 @@ describe('imageRule', () => {
         });
 
         it('should not match', () => {
-            const windowMock = GlobalMock.ofInstance(window.getComputedStyle, 'getComputedStyle', window, MockBehavior.Strict);
-            windowMock.setup(m => m(It.isAny())).returns(() => ({ getPropertyValue: property => 'none' } as CSSStyleDeclaration));
+            const windowMock = GlobalMock.ofInstance(
+                window.getComputedStyle,
+                'getComputedStyle',
+                window,
+                MockBehavior.Strict,
+            );
+            windowMock
+                .setup(m => m(It.isAny()))
+                .returns(() => ({ getPropertyValue: property => 'none' } as CSSStyleDeclaration));
             let result;
             const node = document.createElement('div');
             GlobalScope.using(windowMock).with(() => {

--- a/src/tests/unit/tests/scanner/custom-rules/link-function.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/link-function.test.ts
@@ -70,12 +70,29 @@ describe('link function', () => {
             AxeUtils,
             MockBehavior.Strict,
         );
-        const getAccessibleTextMock = GlobalMock.ofInstance(AxeUtils.getAccessibleText, 'getAccessibleText', AxeUtils, MockBehavior.Strict);
+        const getAccessibleTextMock = GlobalMock.ofInstance(
+            AxeUtils.getAccessibleText,
+            'getAccessibleText',
+            AxeUtils,
+            MockBehavior.Strict,
+        );
         it('evaluates when both accessible-name and url are specified (node html as snippet)', () => {
-            testEvaluate('accessible-name', 'url', getPropertyValuesMock, getAccessibleTextMock, true);
+            testEvaluate(
+                'accessible-name',
+                'url',
+                getPropertyValuesMock,
+                getAccessibleTextMock,
+                true,
+            );
         });
         it('evaluates when url is unspecified (parent html as snippet)', () => {
-            testEvaluate('accessible-name', null, getPropertyValuesMock, getAccessibleTextMock, false);
+            testEvaluate(
+                'accessible-name',
+                null,
+                getPropertyValuesMock,
+                getAccessibleTextMock,
+                false,
+            );
         });
         it('evaluates when accessible-name is unspecified (parent html as snippet)', () => {
             testEvaluate(null, 'url', getPropertyValuesMock, getAccessibleTextMock, false);
@@ -105,18 +122,27 @@ function testEvaluate(
     const nodeStub = getNodeStub(expectedData.url, expectedData.role, expectedData.tabIndex);
 
     dataSetterMock.setup(m => m(It.isValue(expectedData))).verifiable(Times.once());
-    getPropertyValuesMock.setup(m => m(It.isValue(nodeStub), It.isAny())).returns(v => expectedData.ariaAttributes);
+    getPropertyValuesMock
+        .setup(m => m(It.isValue(nodeStub), It.isAny()))
+        .returns(v => expectedData.ariaAttributes);
     getAccessibleTextMock.setup(m => m(nodeStub, false)).returns(n => expectedData.accessibleName);
 
     let result;
     GlobalScope.using(getPropertyValuesMock, getAccessibleTextMock).with(() => {
-        result = linkFunctionConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, nodeStub);
+        result = linkFunctionConfiguration.checks[0].evaluate.call(
+            { data: dataSetterMock.object },
+            nodeStub,
+        );
     });
     expect(result).toBe(true);
     dataSetterMock.verifyAll();
 }
 
-function testMatches(href: string, expectedHasCustomWidgetMarkup: boolean, expectedResult: boolean): void {
+function testMatches(
+    href: string,
+    expectedHasCustomWidgetMarkup: boolean,
+    expectedResult: boolean,
+): void {
     const nodeStub = getNodeStub(href, null, null);
     const hasCustomWidgetMarkupMock = GlobalMock.ofInstance(
         AxeUtils.hasCustomWidgetMarkup,
@@ -124,7 +150,9 @@ function testMatches(href: string, expectedHasCustomWidgetMarkup: boolean, expec
         AxeUtils,
         MockBehavior.Strict,
     );
-    hasCustomWidgetMarkupMock.setup(m => m(It.isValue(nodeStub))).returns(v => expectedHasCustomWidgetMarkup);
+    hasCustomWidgetMarkupMock
+        .setup(m => m(It.isValue(nodeStub)))
+        .returns(v => expectedHasCustomWidgetMarkup);
     let result;
     GlobalScope.using(hasCustomWidgetMarkupMock).with(() => {
         result = linkFunctionConfiguration.rule.matches(nodeStub, null);

--- a/src/tests/unit/tests/scanner/custom-rules/link-purpose.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/link-purpose.test.ts
@@ -24,7 +24,12 @@ describe('link purpose', () => {
 
     describe('verify evaluate', () => {
         let dataSetterMock: IMock<(data) => void>;
-        const getAccessibleTextMock = GlobalMock.ofInstance(AxeUtils.getAccessibleText, 'getAccessibleText', AxeUtils, MockBehavior.Strict);
+        const getAccessibleTextMock = GlobalMock.ofInstance(
+            AxeUtils.getAccessibleText,
+            'getAccessibleText',
+            AxeUtils,
+            MockBehavior.Strict,
+        );
         const getAccessibleDescriptionMock = GlobalMock.ofInstance(
             AxeUtils.getAccessibleDescription,
             'getAccessibleDescription',
@@ -35,7 +40,9 @@ describe('link purpose', () => {
         beforeEach(() => {
             dataSetterMock = Mock.ofInstance(data => {});
             getAccessibleTextMock.setup(m => m(It.isAny(), false)).returns(_ => 'accessible-text');
-            getAccessibleDescriptionMock.setup(m => m(It.isAny())).returns(_ => 'accessible-description');
+            getAccessibleDescriptionMock
+                .setup(m => m(It.isAny()))
+                .returns(_ => 'accessible-description');
         });
 
         it('get the right data', () => {
@@ -55,7 +62,10 @@ describe('link purpose', () => {
 
             let result;
             GlobalScope.using(getAccessibleTextMock, getAccessibleDescriptionMock).with(() => {
-                result = linkPurposeConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, nodeStub);
+                result = linkPurposeConfiguration.checks[0].evaluate.call(
+                    { data: dataSetterMock.object },
+                    nodeStub,
+                );
             });
             expect(result).toBe(true);
             dataSetterMock.verifyAll();

--- a/src/tests/unit/tests/scanner/custom-rules/native-widgets-default.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/native-widgets-default.test.ts
@@ -13,8 +13,13 @@ import { createNodeStub, testNativeWidgetConfiguration } from '../helpers';
 describe('native widgets default', () => {
     describe('verify native widgets default configs', () => {
         it('should have correct props', () => {
-            testNativeWidgetConfiguration('native-widgets-default', 'native-widgets-default-collector');
-            expect(nativeWidgetSelector).toBe('button, input[list], input[type]:not([type="hidden"]), select, textarea');
+            testNativeWidgetConfiguration(
+                'native-widgets-default',
+                'native-widgets-default-collector',
+            );
+            expect(nativeWidgetSelector).toBe(
+                'button, input[list], input[type]:not([type="hidden"]), select, textarea',
+            );
         });
     });
 
@@ -68,12 +73,19 @@ describe('native widgets default', () => {
             const nodeStub = createNodeStub(expectedData.element, {});
 
             dataSetterMock.setup(m => m(It.isValue(expectedData))).verifiable(Times.once());
-            getAccessibleDescriptionMock.setup(m => m(nodeStub)).returns(v => expectedData.accessibleDescription);
-            getAccessibleTextMock.setup(m => m(nodeStub, false)).returns(n => expectedData.accessibleName);
+            getAccessibleDescriptionMock
+                .setup(m => m(nodeStub))
+                .returns(v => expectedData.accessibleDescription);
+            getAccessibleTextMock
+                .setup(m => m(nodeStub, false))
+                .returns(n => expectedData.accessibleName);
 
             let result;
             GlobalScope.using(getAccessibleDescriptionMock, getAccessibleTextMock).with(() => {
-                result = nativeWidgetsDefaultConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, nodeStub);
+                result = nativeWidgetsDefaultConfiguration.checks[0].evaluate.call(
+                    { data: dataSetterMock.object },
+                    nodeStub,
+                );
             });
 
             expect(result).toBe(true);

--- a/src/tests/unit/tests/scanner/custom-rules/text-alternative.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/text-alternative.test.ts
@@ -11,11 +11,15 @@ describe('text alternative', () => {
         it('should have correct props', () => {
             expect(textAlternativeConfiguration.rule.id).toBe('accessible-image');
             expect(textAlternativeConfiguration.rule.selector).toBe('*');
-            expect(textAlternativeConfiguration.rule.any[0]).toBe('text-alternative-data-collector');
+            expect(textAlternativeConfiguration.rule.any[0]).toBe(
+                'text-alternative-data-collector',
+            );
             expect(textAlternativeConfiguration.rule.all).toEqual([]);
             expect(textAlternativeConfiguration.rule.all.length).toBe(0);
             expect(textAlternativeConfiguration.rule.any.length).toBe(1);
-            expect(textAlternativeConfiguration.checks[0].id).toBe('text-alternative-data-collector');
+            expect(textAlternativeConfiguration.checks[0].id).toBe(
+                'text-alternative-data-collector',
+            );
         });
     });
 
@@ -106,7 +110,10 @@ describe('text alternative', () => {
             dataSetterMock.setup(d => d(It.isAny()));
             let result;
             GlobalScope.using(getAccessibleDescriptionMock).with(() => {
-                result = textAlternativeConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, element1);
+                result = textAlternativeConfiguration.checks[0].evaluate.call(
+                    { data: dataSetterMock.object },
+                    element1,
+                );
             });
             expect(result).toBe(true);
         });
@@ -131,7 +138,10 @@ describe('text alternative', () => {
             dataSetterMock.setup(d => d(It.isValue(expectedData))).verifiable(Times.once());
             let result;
             GlobalScope.using(getAccessibleDescriptionMock).with(() => {
-                result = textAlternativeConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, element1);
+                result = textAlternativeConfiguration.checks[0].evaluate.call(
+                    { data: dataSetterMock.object },
+                    element1,
+                );
             });
             expect(result).toBe(true);
             dataSetterMock.verifyAll();

--- a/src/tests/unit/tests/scanner/custom-rules/text-contrast.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/text-contrast.test.ts
@@ -15,13 +15,19 @@ function testTextContrast(
 ): void {
     windowMock
         .setup(m => m(It.isAny()))
-        .returns(currentNode => ({ getPropertyValue: property => currentNode[property] } as CSSStyleDeclaration));
+        .returns(
+            currentNode =>
+                ({ getPropertyValue: property => currentNode[property] } as CSSStyleDeclaration),
+        );
 
     dataSetterMock.setup(d => d(expectedData));
 
     let result;
     GlobalScope.using(windowMock, axeUtilsMock).with(() => {
-        result = textContrastConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, node);
+        result = textContrastConfiguration.checks[0].evaluate.call(
+            { data: dataSetterMock.object },
+            node,
+        );
     });
     expect(result).toBe(false);
 
@@ -43,12 +49,24 @@ describe('text contrast', () => {
 
     describe('verify evaluate', () => {
         let dataSetterMock: IMock<(data) => void>;
-        const axeUtilsMock = GlobalMock.ofInstance(AxeUtils.getEvaluateFromCheck, 'getEvaluateFromCheck', AxeUtils, MockBehavior.Strict);
-        const windowMock = GlobalMock.ofInstance(window.getComputedStyle, 'getComputedStyle', window, MockBehavior.Strict);
+        const axeUtilsMock = GlobalMock.ofInstance(
+            AxeUtils.getEvaluateFromCheck,
+            'getEvaluateFromCheck',
+            AxeUtils,
+            MockBehavior.Strict,
+        );
+        const windowMock = GlobalMock.ofInstance(
+            window.getComputedStyle,
+            'getComputedStyle',
+            window,
+            MockBehavior.Strict,
+        );
 
         beforeEach(() => {
             dataSetterMock = Mock.ofInstance(data => {});
-            axeUtilsMock.setup(m => m(It.isAnyString())).returns(_ => (node, options, virtualNode, context) => false);
+            axeUtilsMock
+                .setup(m => m(It.isAnyString()))
+                .returns(_ => (node, options, virtualNode, context) => false);
         });
 
         it('large font size / regular font weight', () => {

--- a/src/tests/unit/tests/scanner/custom-rules/unique-landmark-check.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/unique-landmark-check.test.ts
@@ -83,7 +83,9 @@ describe('axe.Check: unique-landmark', () => {
         const expectedNode: Element = fixture.querySelector('#landmark1');
 
         labelFunctionMock.setup(lfm => lfm(node)).returns(() => null);
-        labelFunctionMock.setup(lfm => lfm(It.isObjectWith(expectedNode))).returns(() => 'header landmark');
+        labelFunctionMock
+            .setup(lfm => lfm(It.isObjectWith(expectedNode)))
+            .returns(() => 'header landmark');
 
         expectCheckTrue(node);
     });
@@ -105,9 +107,15 @@ describe('axe.Check: unique-landmark', () => {
             duplicateLandmark2 = fixture.querySelector('#landmark2');
             uniqueLandmark = fixture.querySelector('#landmark3');
 
-            labelFunctionMock.setup(lfm => lfm(duplicateLandmark1)).returns(() => duplicateLandmarkLabel);
-            labelFunctionMock.setup(lfm => lfm(duplicateLandmark2)).returns(() => duplicateLandmarkLabel);
-            labelFunctionMock.setup(lfm => lfm(uniqueLandmark)).returns(() => 'some other landmark');
+            labelFunctionMock
+                .setup(lfm => lfm(duplicateLandmark1))
+                .returns(() => duplicateLandmarkLabel);
+            labelFunctionMock
+                .setup(lfm => lfm(duplicateLandmark2))
+                .returns(() => duplicateLandmarkLabel);
+            labelFunctionMock
+                .setup(lfm => lfm(uniqueLandmark))
+                .returns(() => 'some other landmark');
         });
 
         it('false for duplicate landmark', () => {

--- a/src/tests/unit/tests/scanner/custom-rules/unique-landmark.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/unique-landmark.test.ts
@@ -19,7 +19,9 @@ describe('unique-landmark', () => {
     });
 
     it('returns correct url', () => {
-        expect(uniqueLandmarkConfiguration.rule.helpUrl).toBe('/insights.html#/content/rules/uniqueLandmark');
+        expect(uniqueLandmarkConfiguration.rule.helpUrl).toBe(
+            '/insights.html#/content/rules/uniqueLandmark',
+        );
     });
 
     it('should not match because not a landmark', () => {

--- a/src/tests/unit/tests/scanner/custom-rules/widget-function.test.ts
+++ b/src/tests/unit/tests/scanner/custom-rules/widget-function.test.ts
@@ -4,7 +4,10 @@ import { difference, map } from 'lodash';
 import { GlobalMock, GlobalScope, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import * as AxeUtils from '../../../../../scanner/axe-utils';
-import { evaluateWidgetFunction, widgetFunctionConfiguration } from '../../../../../scanner/custom-rules/widget-function';
+import {
+    evaluateWidgetFunction,
+    widgetFunctionConfiguration,
+} from '../../../../../scanner/custom-rules/widget-function';
 import { createNodeStub, testNativeWidgetConfiguration } from '../helpers';
 
 declare let axe;
@@ -23,7 +26,12 @@ describe('widget function', () => {
 
     describe('evaluate', () => {
         it('sets correct data and returns true', () => {
-            const getAttributesMock = GlobalMock.ofInstance(AxeUtils.getAttributes, 'getAttributes', AxeUtils, MockBehavior.Strict);
+            const getAttributesMock = GlobalMock.ofInstance(
+                AxeUtils.getAttributes,
+                'getAttributes',
+                AxeUtils,
+                MockBehavior.Strict,
+            );
             const getAccessibleTextMock = GlobalMock.ofInstance(
                 AxeUtils.getAccessibleText,
                 'getAccessibleText',
@@ -49,12 +57,19 @@ describe('widget function', () => {
             });
 
             dataSetterMock.setup(m => m(It.isValue(expectedData))).verifiable(Times.once());
-            getAttributesMock.setup(m => m(It.isValue(nodeStub), It.isAny())).returns(v => expectedData.ariaAttributes);
-            getAccessibleTextMock.setup(m => m(nodeStub, false)).returns(n => expectedData.accessibleName);
+            getAttributesMock
+                .setup(m => m(It.isValue(nodeStub), It.isAny()))
+                .returns(v => expectedData.ariaAttributes);
+            getAccessibleTextMock
+                .setup(m => m(nodeStub, false))
+                .returns(n => expectedData.accessibleName);
 
             let result;
             GlobalScope.using(getAttributesMock, getAccessibleTextMock).with(() => {
-                result = widgetFunctionConfiguration.checks[0].evaluate.call({ data: dataSetterMock.object }, nodeStub);
+                result = widgetFunctionConfiguration.checks[0].evaluate.call(
+                    { data: dataSetterMock.object },
+                    nodeStub,
+                );
             });
             expect(result).toBe(true);
             dataSetterMock.verifyAll();
@@ -63,7 +78,12 @@ describe('widget function', () => {
 });
 
 describe('verify widget function data', () => {
-    const getAccessibleTextMock = GlobalMock.ofInstance(AxeUtils.getAccessibleText, 'getAccessibleText', AxeUtils, MockBehavior.Loose);
+    const getAccessibleTextMock = GlobalMock.ofInstance(
+        AxeUtils.getAccessibleText,
+        'getAccessibleText',
+        AxeUtils,
+        MockBehavior.Loose,
+    );
 
     const fixture = createTestFixture('test_fixture', '');
 

--- a/src/tests/unit/tests/scanner/helpers.ts
+++ b/src/tests/unit/tests/scanner/helpers.ts
@@ -27,7 +27,12 @@ export function testNativeWidgetConfiguration(
     expectedEvaluate?: (node: any, options: any, virtualNode: any, context: any) => boolean,
     expectedMatches?: (node: any, virtualNode: any) => boolean,
 ): void {
-    const result = createNativeWidgetConfiguration(ruleId, checkId, expectedEvaluate, expectedMatches);
+    const result = createNativeWidgetConfiguration(
+        ruleId,
+        checkId,
+        expectedEvaluate,
+        expectedMatches,
+    );
     expect(result.rule.id).toEqual(ruleId);
     expect(result.rule.any).toHaveLength(1);
     expect(result.rule.any[0]).toEqual(checkId);

--- a/src/tests/unit/tests/scanner/launcher.test.ts
+++ b/src/tests/unit/tests/scanner/launcher.test.ts
@@ -29,18 +29,29 @@ describe('Launcher', () => {
             const optionsStub = {};
             const errorMock = Mock.ofType(Error);
 
-            scanParameterGeneratorMock.setup(spgm => spgm.getAxeEngineOptions(optionsStub)).returns(() => defaultOptions);
+            scanParameterGeneratorMock
+                .setup(spgm => spgm.getAxeEngineOptions(optionsStub))
+                .returns(() => defaultOptions);
 
-            scanParameterGeneratorMock.setup(spgm => spgm.getContext(domMock.object, optionsStub)).returns(() => domMock.object);
+            scanParameterGeneratorMock
+                .setup(spgm => spgm.getContext(domMock.object, optionsStub))
+                .returns(() => domMock.object);
 
-            axeResponseHandlerMock.setup(arhm => arhm.handleResponse(errorMock.object, emptyResultsStub)).verifiable(Times.once());
+            axeResponseHandlerMock
+                .setup(arhm => arhm.handleResponse(errorMock.object, emptyResultsStub))
+                .verifiable(Times.once());
 
             axeMock
                 .setup(axe => axe.run(domMock.object as any, defaultOptions, It.is(isFunction)))
                 .callback((dom, options, callback) => callback(errorMock.object, emptyResultsStub))
                 .verifiable(Times.once());
 
-            const testObject = new Launcher(axeMock.object, scanParameterGeneratorMock.object, domMock.object, optionsStub);
+            const testObject = new Launcher(
+                axeMock.object,
+                scanParameterGeneratorMock.object,
+                domMock.object,
+                optionsStub,
+            );
             testObject.runScan(axeResponseHandlerMock.object);
 
             axeResponseHandlerMock.verifyAll();

--- a/src/tests/unit/tests/scanner/message-decorator.test.ts
+++ b/src/tests/unit/tests/scanner/message-decorator.test.ts
@@ -30,14 +30,20 @@ describe('MessageDecorator', () => {
             configuration[0].rule.decorateNode = node => (node.snippet = 'test snippet');
             const expectedResult = generateAxeResultStubWithStatus(configuration[0]);
             expectedResult.nodes[0].snippet = 'test snippet';
-            const testSubject = new MessageDecorator(configuration, checkMessageTransformerMock.object);
+            const testSubject = new MessageDecorator(
+                configuration,
+                checkMessageTransformerMock.object,
+            );
             testBasicDecorateMessage(expectedResult, testSubject);
         });
 
         it('should add messages to all checks via check message creator (no decorateNode in config)', () => {
             configuration[0].rule.decorateNode = null;
             const expectedResult = generateAxeResultStubWithStatus(configuration[0]);
-            const testSubject = new MessageDecorator(configuration, checkMessageTransformerMock.object);
+            const testSubject = new MessageDecorator(
+                configuration,
+                checkMessageTransformerMock.object,
+            );
             testBasicDecorateMessage(expectedResult, testSubject);
         });
 
@@ -50,17 +56,26 @@ describe('MessageDecorator', () => {
         });
     });
 
-    function testBasicDecorateMessage(expectedResult: AxeRule, testSubject: MessageDecorator): void {
+    function testBasicDecorateMessage(
+        expectedResult: AxeRule,
+        testSubject: MessageDecorator,
+    ): void {
         checkMessageTransformerMock
-            .setup(cmcm => cmcm.addMessagesToChecks(axeResultStub.nodes[0].any, configuration[0].checks))
+            .setup(cmcm =>
+                cmcm.addMessagesToChecks(axeResultStub.nodes[0].any, configuration[0].checks),
+            )
             .verifiable(Times.once());
 
         checkMessageTransformerMock
-            .setup(cmcm => cmcm.addMessagesToChecks(axeResultStub.nodes[0].none, configuration[0].checks))
+            .setup(cmcm =>
+                cmcm.addMessagesToChecks(axeResultStub.nodes[0].none, configuration[0].checks),
+            )
             .verifiable(Times.once());
 
         checkMessageTransformerMock
-            .setup(cmcm => cmcm.addMessagesToChecks(axeResultStub.nodes[0].all, configuration[0].checks))
+            .setup(cmcm =>
+                cmcm.addMessagesToChecks(axeResultStub.nodes[0].all, configuration[0].checks),
+            )
             .verifiable(Times.once());
 
         expectedResult.description = configuration[0].rule.description;

--- a/src/tests/unit/tests/scanner/processor.test.ts
+++ b/src/tests/unit/tests/scanner/processor.test.ts
@@ -37,7 +37,11 @@ describe('getDefaultAxeRules', () => {
 
     it('suppressChecksByMessages: removes only suppressed checks.', () => {
         const initialRuleResult: AxeNodeResult = {
-            any: [suppressedChecks.requiredChildrenListbox, suppressedChecks.requiredChildrenTextbox, nonSuppressedCheck],
+            any: [
+                suppressedChecks.requiredChildrenListbox,
+                suppressedChecks.requiredChildrenTextbox,
+                nonSuppressedCheck,
+            ],
             none: [],
             all: [],
             html: null,

--- a/src/tests/unit/tests/scanner/result-decorator.test.ts
+++ b/src/tests/unit/tests/scanner/result-decorator.test.ts
@@ -85,7 +85,9 @@ describe('ResultDecorator', () => {
                 MockBehavior.Strict,
             );
 
-            messageDecoratorMock.setup(mdm => mdm.decorateResultWithMessages(instanceStub)).verifiable(Times.once());
+            messageDecoratorMock
+                .setup(mdm => mdm.decorateResultWithMessages(instanceStub))
+                .verifiable(Times.once());
 
             getHelpUrlMock.setup(gchm => gchm(instanceStub.id, It.isAny())).returns(() => urlStub);
 
@@ -144,7 +146,9 @@ describe('ResultDecorator', () => {
                 MockBehavior.Strict,
             );
 
-            messageDecoratorMock.setup(mdm => mdm.decorateResultWithMessages(instanceStub)).verifiable(Times.once());
+            messageDecoratorMock
+                .setup(mdm => mdm.decorateResultWithMessages(instanceStub))
+                .verifiable(Times.once());
 
             getHelpUrlMock.setup(gchm => gchm(instanceStub.id, It.isAny())).returns(() => urlStub);
 
@@ -224,13 +228,19 @@ describe('ResultDecorator', () => {
                 MockBehavior.Strict,
             );
 
-            messageDecoratorMock.setup(mdm => mdm.decorateResultWithMessages(instanceStub)).verifiable(Times.once());
+            messageDecoratorMock
+                .setup(mdm => mdm.decorateResultWithMessages(instanceStub))
+                .verifiable(Times.once());
 
-            messageDecoratorMock.setup(mdm => mdm.decorateResultWithMessages(inapplicableInstance)).verifiable(Times.once());
+            messageDecoratorMock
+                .setup(mdm => mdm.decorateResultWithMessages(inapplicableInstance))
+                .verifiable(Times.once());
 
             getHelpUrlMock.setup(gchm => gchm(instanceStub.id, It.isAny())).returns(() => urlStub);
 
-            getHelpUrlMock.setup(gchm => gchm(inapplicableInstance.id, It.isAny())).returns(() => urlStub);
+            getHelpUrlMock
+                .setup(gchm => gchm(inapplicableInstance.id, It.isAny()))
+                .returns(() => urlStub);
 
             suppressChecksByMessagesMock
                 .setup(scbmm => scbmm(instanceStub, true))
@@ -254,7 +264,9 @@ describe('ResultDecorator', () => {
             );
             let decoratedResult;
             GlobalScope.using(suppressChecksByMessagesMock).with(() => {
-                decoratedResult = testSubject.decorateResults(nonEmptyResultWithInapplicable as any);
+                decoratedResult = testSubject.decorateResults(
+                    nonEmptyResultWithInapplicable as any,
+                );
             });
 
             expect(decoratedResult).toEqual(resultStubWithGuidanceLinks);
@@ -288,7 +300,9 @@ describe('ResultDecorator', () => {
 
             instanceStub.nodes = [];
 
-            messageDecoratorMock.setup(mdm => mdm.decorateResultWithMessages(instanceStub)).verifiable(Times.once());
+            messageDecoratorMock
+                .setup(mdm => mdm.decorateResultWithMessages(instanceStub))
+                .verifiable(Times.once());
 
             suppressChecksByMessagesMock
                 .setup(scbmm => scbmm(instanceStub, true))

--- a/src/tests/unit/tests/scanner/scan-parameter-generator.test.ts
+++ b/src/tests/unit/tests/scanner/scan-parameter-generator.test.ts
@@ -157,7 +157,9 @@ describe('ScanParameterGenerator', () => {
             const selectorFirstReturnedContext = 'test-selector';
 
             expect(generator.getContext(null, domFirstOptions)).toEqual(domFirstReturnedContext);
-            expect(generator.getContext(null, selectorFirstOptions)).toEqual(selectorFirstReturnedContext);
+            expect(generator.getContext(null, selectorFirstOptions)).toEqual(
+                selectorFirstReturnedContext,
+            );
         });
     });
 });


### PR DESCRIPTION
#### Description of changes

Add `src/tests/unit/tests/scanner` folder to prettier override for the line width value.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
