### PR TITLE
fix: add keyboard shortcut icon to hamburger menu

### DIFF
--- a/src/common/components/hamburger-menu-button.tsx
+++ b/src/common/components/hamburger-menu-button.tsx
@@ -73,6 +73,9 @@ export const HamburgerMenuButton = NamedFC<HamburgerMenuButtonProps>(
             },
             {
                 key: 'modify-shortcuts',
+                iconProps: {
+                    iconName: 'KeyboardClassic',
+                },
                 name: 'Keyboard shortcuts',
                 onClick: event => popupActionMessageCreator.openShortcutConfigureTab(event),
             },

--- a/src/common/fabric-icons.ts
+++ b/src/common/fabric-icons.ts
@@ -44,6 +44,7 @@ export function initializeFabricIcons(): void {
             home: '\uE80F',
             incidentTriangle: '\uE814',
             info: '\uE946',
+            keyboardClassic: '\uE765',
             ladybugSolid: '\uF44A',
             mail: '\uE715',
             medical: '\uEAD4',

--- a/src/tests/end-to-end/tests/popup/__snapshots__/hamburger-menu.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/hamburger-menu.test.ts.snap
@@ -132,7 +132,10 @@ exports[`Popup -> Hamburger menu should have content matching snapshot 1`] = `
               <i
                 aria-hidden="true"
                 class="ms-ContextualMenu-icon icon-000"
-              />
+                data-icon-name="KeyboardClassic"
+              >
+                
+              </i>
               <span
                 class="ms-ContextualMenu-itemText label-000"
               >

--- a/src/tests/unit/tests/common/components/__snapshots__/hamburger-menu-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/hamburger-menu-button.test.tsx.snap
@@ -44,6 +44,9 @@ exports[`HamburgerMenuButton renders proper button and menu item props 1`] = `
           "key": "divider_1",
         },
         Object {
+          "iconProps": Object {
+            "iconName": "KeyboardClassic",
+          },
           "key": "modify-shortcuts",
           "name": "Keyboard shortcuts",
           "onClick": [Function],


### PR DESCRIPTION
#### Description of changes

This PR adds an icon in the hamburger menu for keyboard shortcuts.

![keyboard shortcut screenshot](https://user-images.githubusercontent.com/7775527/74067499-43de4a00-49ae-11ea-8566-ccd889257d5b.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
