### PR TITLE
chore: make prettier ignore icns image format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@
 **/*.dockerignore
 **/*.gitattributes
 **/*.gitignore
+**/*.icns
 **/*.ico
 **/*.nsh
 **/*.png


### PR DESCRIPTION
#### Description of changes

We recently added a new type of image file to the repo (`.icns`, a mac-specific icon format). This PR updates our `.prettierignore` to avoid complaining about not knowing how to parse those during `yarn fastpass`

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
