### PR TITLE
feat(android-settings): telemetry settings product name

### DIFF
--- a/src/DetailsView/components/settings-panel/settings/settings-provider-impl.ts
+++ b/src/DetailsView/components/settings-panel/settings/settings-provider-impl.ts
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { title } from 'content/strings/application';
+import { createTelemetrySettings } from 'DetailsView/components/settings-panel/settings/telemetry/telemetry-settings';
 import { HighContrastSettings } from './high-contrast/high-contrast-settings';
 import { IssueFilingSettings } from './issue-filing/issue-filing-settings';
 import { createSettingsProvider } from './settings-provider';
-import { TelemetrySettings } from './telemetry/telemetry-settings';
 
 export const SettingsProviderImpl = createSettingsProvider([
-    TelemetrySettings,
+    createTelemetrySettings(title),
     HighContrastSettings,
     IssueFilingSettings,
 ]);

--- a/src/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.tsx
+++ b/src/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.tsx
@@ -5,27 +5,11 @@ import {
     EnableTelemetrySettingDescriptionProps,
 } from 'common/components/enable-telemetry-setting-description';
 import { NamedFC } from 'common/react/named-fc';
-import { enableTelemetrySettingsPanelTitle } from 'content/settings/improve-accessibility-insights';
 import * as React from 'react';
 import { GenericToggle } from '../../../generic-toggle';
 import { SettingsProps } from '../settings-props';
 
 export type TelemetrySettingsProps = SettingsProps & EnableTelemetrySettingDescriptionProps;
-
-export const TelemetrySettings = NamedFC<TelemetrySettingsProps>('TelemetrySettings', props => {
-    const { deps } = props;
-    const { userConfigMessageCreator } = deps;
-
-    return (
-        <GenericToggle
-            enabled={props.userConfigurationStoreState.enableTelemetry}
-            id="enable-telemetry"
-            name={enableTelemetrySettingsPanelTitle}
-            description={<EnableTelemetrySettingDescription deps={deps} />}
-            onClick={(id, state) => userConfigMessageCreator.setTelemetryState(state)}
-        />
-    );
-});
 
 export const createTelemetrySettings = (productName: string) => {
     return NamedFC<TelemetrySettingsProps>('TelemetrySettings', props => {

--- a/src/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.tsx
+++ b/src/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.tsx
@@ -26,3 +26,20 @@ export const TelemetrySettings = NamedFC<TelemetrySettingsProps>('TelemetrySetti
         />
     );
 });
+
+export const createTelemetrySettings = (productName: string) => {
+    return NamedFC<TelemetrySettingsProps>('TelemetrySettings', props => {
+        const { deps } = props;
+        const { userConfigMessageCreator } = deps;
+
+        return (
+            <GenericToggle
+                enabled={props.userConfigurationStoreState.enableTelemetry}
+                id="enable-telemetry"
+                name={`Help improve ${productName}`}
+                description={<EnableTelemetrySettingDescription deps={deps} />}
+                onClick={(id, state) => userConfigMessageCreator.setTelemetryState(state)}
+            />
+        );
+    });
+};

--- a/src/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.tsx
+++ b/src/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { enableTelemetrySettingsPanelTitle } from 'content/settings/improve-accessibility-insights';
-import * as React from 'react';
 import {
     EnableTelemetrySettingDescription,
     EnableTelemetrySettingDescriptionProps,
-} from '../../../../../common/components/enable-telemetry-setting-description';
-import { NamedFC } from '../../../../../common/react/named-fc';
+} from 'common/components/enable-telemetry-setting-description';
+import { NamedFC } from 'common/react/named-fc';
+import { enableTelemetrySettingsPanelTitle } from 'content/settings/improve-accessibility-insights';
+import * as React from 'react';
 import { GenericToggle } from '../../../generic-toggle';
 import { SettingsProps } from '../settings-props';
 

--- a/src/content/settings/improve-accessibility-insights.tsx
+++ b/src/content/settings/improve-accessibility-insights.tsx
@@ -1,9 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { title } from '../strings/application';
-
 export const telemetryPopupTitle = `We need your help`;
 
 export const telemetryPopupCheckboxTitle = `I agree to enable telemetry`;
-
-export const enableTelemetrySettingsPanelTitle = `Help improve ${title}`;

--- a/src/electron/settings/unified-settings-provider.ts
+++ b/src/electron/settings/unified-settings-provider.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { androidAppTitle } from 'content/strings/application';
 import { createSettingsProvider } from 'DetailsView/components/settings-panel/settings/settings-provider';
-import { TelemetrySettings } from 'DetailsView/components/settings-panel/settings/telemetry/telemetry-settings';
+import { createTelemetrySettings } from 'DetailsView/components/settings-panel/settings/telemetry/telemetry-settings';
 
-export const UnifiedSettingsProvider = createSettingsProvider([TelemetrySettings]);
+export const UnifiedSettingsProvider = createSettingsProvider([
+    createTelemetrySettings(androidAppTitle),
+]);

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/settings/telemetry/__snapshots__/telemetry-settings.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/settings/telemetry/__snapshots__/telemetry-settings.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`TelemetrySettings renders with enabled = false 1`] = `
   }
   enabled={false}
   id="enable-telemetry"
-  name="Help improve Accessibility Insights for Web"
+  name="Help improve test-product-name"
   onClick={[Function]}
 />
 `;
@@ -31,7 +31,7 @@ exports[`TelemetrySettings renders with enabled = true 1`] = `
   }
   enabled={true}
   id="enable-telemetry"
-  name="Help improve Accessibility Insights for Web"
+  name="Help improve test-product-name"
   onClick={[Function]}
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.test.tsx
@@ -1,18 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { EnableTelemetrySettingDescription } from 'common/components/enable-telemetry-setting-description';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { UserConfigMessageCreator } from 'common/message-creators/user-config-message-creator';
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { GenericToggle } from 'DetailsView/components/generic-toggle';
+import { TelemetrySettings, TelemetrySettingsProps } from 'DetailsView/components/settings-panel/settings/telemetry/telemetry-settings';
 import { shallow } from 'enzyme';
 import { Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
-import { EnableTelemetrySettingDescription } from '../../../../../../../../common/components/enable-telemetry-setting-description';
-import { NewTabLink } from '../../../../../../../../common/components/new-tab-link';
-import { UserConfigMessageCreator } from '../../../../../../../../common/message-creators/user-config-message-creator';
-import { UserConfigurationStoreData } from '../../../../../../../../common/types/store-data/user-configuration-store';
-import { GenericToggle } from '../../../../../../../../DetailsView/components/generic-toggle';
-import {
-    TelemetrySettings,
-    TelemetrySettingsProps,
-} from '../../../../../../../../DetailsView/components/settings-panel/settings/telemetry/telemetry-settings';
 
 describe('TelemetrySettings', () => {
     const enableStates = [true, false];

--- a/src/tests/unit/tests/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/settings-panel/settings/telemetry/telemetry-settings.test.tsx
@@ -5,7 +5,10 @@ import { NewTabLink } from 'common/components/new-tab-link';
 import { UserConfigMessageCreator } from 'common/message-creators/user-config-message-creator';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { GenericToggle } from 'DetailsView/components/generic-toggle';
-import { TelemetrySettings, TelemetrySettingsProps } from 'DetailsView/components/settings-panel/settings/telemetry/telemetry-settings';
+import {
+    createTelemetrySettings,
+    TelemetrySettingsProps,
+} from 'DetailsView/components/settings-panel/settings/telemetry/telemetry-settings';
 import { shallow } from 'enzyme';
 import { Toggle } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -13,6 +16,8 @@ import { Mock, Times } from 'typemoq';
 
 describe('TelemetrySettings', () => {
     const enableStates = [true, false];
+
+    const TelemetrySettings = createTelemetrySettings('test-product-name');
 
     describe('renders', () => {
         it.each(enableStates)('with enabled = %s', enabled => {


### PR DESCRIPTION
#### Description of changes

Currently, the telemetry opt-in settings on android is being reuse from ai-web and thus the product name is wrong (it shows **Accessibility Insights for Web** even on AI-Android).

In this PR, allow for the telemetry settings component be created with a different product name so it can be properly reused on AI-web and AI-Android.

![01 - telemetry settings on ai-android](https://user-images.githubusercontent.com/2837582/74204626-cf630f80-4c28-11ea-8328-f289a2b9f259.png)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
