### PR TITLE
feat(android-settings): refactor how we assign class to the body

### DIFF
--- a/src/electron/views/common/body-class-modifier/body-class-modifier.tsx
+++ b/src/electron/views/common/body-class-modifier/body-class-modifier.tsx
@@ -1,12 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { PlatformInfo } from 'electron/window-management/platform-info';
+import { ClassAssigner } from 'electron/views/common/body-class-modifier/class-assigner';
+import { uniq } from 'lodash';
 import { css } from 'office-ui-fabric-react';
 import * as React from 'react';
 import Helmet from 'react-helmet';
 
 export type BodyClassModifierDeps = {
-    platformInfo: PlatformInfo;
+    classAssigners: ClassAssigner[];
 };
 
 export type BodyClassModifierProps = {
@@ -15,15 +16,11 @@ export type BodyClassModifierProps = {
 
 export class BodyClassModifier extends React.Component<BodyClassModifierProps> {
     public render(): JSX.Element {
-        const classNames = [];
-
-        if (this.props.deps.platformInfo.isMac()) {
-            classNames.push('is-mac-os');
-        }
+        const classNames = this.props.deps.classAssigners.map(assigner => assigner.assign());
 
         return (
             <Helmet>
-                <body className={css(...classNames)} />
+                <body className={css(...uniq(classNames))} />
             </Helmet>
         );
     }

--- a/src/electron/views/common/body-class-modifier/class-assigner.ts
+++ b/src/electron/views/common/body-class-modifier/class-assigner.ts
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export type ClassAssigner = {
+    assign(): string;
+};

--- a/src/electron/views/common/body-class-modifier/mac-os-class-assigner.ts
+++ b/src/electron/views/common/body-class-modifier/mac-os-class-assigner.ts
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ClassAssigner } from 'electron/views/common/body-class-modifier/class-assigner';
+import { PlatformInfo } from 'electron/window-management/platform-info';
+
+export const IsMacOsClassName = 'is-mac-os';
+
+export class MacOsClassAssigner implements ClassAssigner {
+    constructor(private readonly platformInfo: PlatformInfo) {}
+
+    public assign(): string {
+        if (this.platformInfo.isMac()) {
+            return IsMacOsClassName;
+        }
+
+        return null;
+    }
+}

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -51,10 +51,8 @@ import { createScanResultsFetcher } from 'electron/platform/android/fetch-scan-r
 import { ScanController } from 'electron/platform/android/scan-controller';
 import { createDefaultBuilder } from 'electron/platform/android/unified-result-builder';
 import { UnifiedSettingsProvider } from 'electron/settings/unified-settings-provider';
-import {
-    RootContainerDeps,
-    RootContainerState,
-} from 'electron/views/root-container/components/root-container';
+import { MacOsClassAssigner } from 'electron/views/common/body-class-modifier/mac-os-class-assigner';
+import { RootContainerState } from 'electron/views/root-container/components/root-container';
 import { PlatformInfo } from 'electron/window-management/platform-info';
 import { WindowFrameListener } from 'electron/window-management/window-frame-listener';
 import { WindowFrameUpdater } from 'electron/window-management/window-frame-updater';
@@ -82,7 +80,10 @@ import { DeviceActions } from '../flux/action/device-actions';
 import { DeviceStore } from '../flux/store/device-store';
 import { ElectronLink } from './device-connect-view/components/electron-link';
 import { sendAppInitializedTelemetryEvent } from './device-connect-view/send-app-initialized-telemetry';
-import { RootContainerRenderer } from './root-container/root-container-renderer';
+import {
+    RootContainerRenderer,
+    RootContainerRendererDeps,
+} from './root-container/root-container-renderer';
 import { screenshotViewModelProvider } from './screenshot/screenshot-view-model-provider';
 
 initializeFabricIcons();
@@ -267,6 +268,8 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
 
         const fixInstructionProcessor = new FixInstructionProcessor();
 
+        const classAssigners = [new MacOsClassAssigner(platformInfo)];
+
         const cardsViewDeps: CardsViewDeps = {
             LinkComponent: ElectronLink,
 
@@ -294,7 +297,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             setFocusVisibility,
         };
 
-        const deps: RootContainerDeps = {
+        const deps: RootContainerRendererDeps = {
             currentWindow,
             userConfigurationStore,
             deviceStore,
@@ -314,6 +317,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             ...cardsViewDeps,
             storeActionMessageCreator: new NullStoreActionMessageCreator(),
             settingsProvider: UnifiedSettingsProvider,
+            classAssigners,
         };
 
         const renderer = new RootContainerRenderer(ReactDOM.render, document, deps);

--- a/src/electron/views/root-container/root-container-renderer.tsx
+++ b/src/electron/views/root-container/root-container-renderer.tsx
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BodyClassModifier } from 'electron/views/common/body-class-modifier/body-class-modifier';
+import {
+    BodyClassModifier,
+    BodyClassModifierDeps,
+} from 'electron/views/common/body-class-modifier/body-class-modifier';
 import {
     RootContainer,
     RootContainerDeps,
@@ -8,11 +11,13 @@ import {
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
+export type RootContainerRendererDeps = RootContainerDeps & BodyClassModifierDeps;
+
 export class RootContainerRenderer {
     constructor(
         private readonly renderer: typeof ReactDOM.render,
         private readonly dom: ParentNode,
-        private readonly deps: RootContainerDeps,
+        private readonly deps: RootContainerRendererDeps,
     ) {}
 
     public render(): void {

--- a/src/tests/unit/tests/electron/views/common/body-class-modifier/__snapshots__/body-class-modifier.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/common/body-class-modifier/__snapshots__/body-class-modifier.test.tsx.snap
@@ -1,23 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BodyClassModifier renders with isMac = false 1`] = `
+exports[`BodyClassModifier renders 1`] = `
 <HelmetWrapper
   defer={true}
   encodeSpecialCharacters={true}
 >
   <body
-    className=""
-  />
-</HelmetWrapper>
-`;
-
-exports[`BodyClassModifier renders with isMac = true 1`] = `
-<HelmetWrapper
-  defer={true}
-  encodeSpecialCharacters={true}
->
-  <body
-    className="is-mac-os"
+    className="test-class-one test-class-two duplicated-class"
   />
 </HelmetWrapper>
 `;

--- a/src/tests/unit/tests/electron/views/common/body-class-modifier/body-class-modifier.test.tsx
+++ b/src/tests/unit/tests/electron/views/common/body-class-modifier/body-class-modifier.test.tsx
@@ -1,32 +1,46 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BodyClassModifier, BodyClassModifierProps } from 'electron/views/common/body-class-modifier/body-class-modifier';
-import { PlatformInfo } from 'electron/window-management/platform-info';
+import { ClassAssigner } from 'electron/views/common/body-class-modifier/class-assigner';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, Mock } from 'typemoq';
+import { Mock } from 'typemoq';
 
 describe('BodyClassModifier', () => {
-    describe('renders', () => {
-        let platformInfoMock: IMock<PlatformInfo>;
-        let props: BodyClassModifierProps;
+    let classAssigners: ClassAssigner[];
+    let props: BodyClassModifierProps;
 
-        beforeEach(() => {
-            platformInfoMock = Mock.ofType<PlatformInfo>();
+    beforeEach(() => {
+        classAssigners = [];
 
-            props = {
-                deps: {
-                    platformInfo: platformInfoMock.object,
-                },
-            };
-        });
+        classAssigners.push(createClassAssignerMock('test-class-one').object);
+        classAssigners.push(createClassAssignerMock('test-class-two').object);
+        classAssigners.push(createClassAssignerMock('duplicated-class').object);
+        classAssigners.push(createClassAssignerMock('duplicated-class').object);
+        classAssigners.push(createClassAssignerMock(null).object);
+        classAssigners.push(createClassAssignerMock(undefined).object);
 
-        it.each([true, false])('with isMac = %s', isMacOs => {
-            platformInfoMock.setup(info => info.isMac()).returns(() => isMacOs);
-
-            const wrapped = shallow(<BodyClassModifier {...props} />);
-
-            expect(wrapped.getElement()).toMatchSnapshot();
-        });
+        props = {
+            deps: {
+                classAssigners,
+                storeActionMessageCreator: null,
+                storesHub: null,
+            },
+            storeState: null,
+        };
     });
+
+    it('renders', () => {
+        const wrapped = shallow(<BodyClassModifier {...props} />);
+
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+
+    const createClassAssignerMock = (classToAssign: string) => {
+        const mock = Mock.ofType<ClassAssigner>();
+
+        mock.setup(assigner => assigner.assign()).returns(() => classToAssign);
+
+        return mock;
+    };
 });

--- a/src/tests/unit/tests/electron/views/common/body-class-modifier/mac-os-class-assigner.test.ts
+++ b/src/tests/unit/tests/electron/views/common/body-class-modifier/mac-os-class-assigner.test.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { IsMacOsClassName, MacOsClassAssigner } from 'electron/views/common/body-class-modifier/mac-os-class-assigner';
+import { PlatformInfo } from 'electron/window-management/platform-info';
+import { IMock, Mock } from 'typemoq';
+
+describe('MacOsClassAssigner', () => {
+    let platformInfoMock: IMock<PlatformInfo>;
+
+    let testSubject: MacOsClassAssigner;
+
+    beforeEach(() => {
+        platformInfoMock = Mock.ofType<PlatformInfo>();
+
+        testSubject = new MacOsClassAssigner(platformInfoMock.object);
+    });
+
+    describe('assigns', () => {
+        it('when platform is mac os', () => {
+            platformInfoMock.setup(info => info.isMac()).returns(() => true);
+
+            const result = testSubject.assign();
+
+            expect(result).toEqual(IsMacOsClassName);
+        });
+
+        it('when platform is NOT mac os', () => {
+            platformInfoMock.setup(info => info.isMac()).returns(() => false);
+
+            const result = testSubject.assign();
+
+            expect(result).toBeNull();
+        });
+    });
+});

--- a/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
@@ -3,8 +3,8 @@
 import { BrowserWindow } from 'electron';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { BodyClassModifier } from 'electron/views/common/body-class-modifier/body-class-modifier';
-import { RootContainer, RootContainerDeps } from 'electron/views/root-container/components/root-container';
-import { RootContainerRenderer } from 'electron/views/root-container/root-container-renderer';
+import { RootContainer } from 'electron/views/root-container/components/root-container';
+import { RootContainerRenderer, RootContainerRendererDeps } from 'electron/views/root-container/root-container-renderer';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -27,7 +27,7 @@ describe('RootContainerRendererTest', () => {
         const deps = {
             currentWindow: browserWindow,
             windowStateActionCreator: windowStateActionCreatorMock.object,
-        } as RootContainerDeps;
+        } as RootContainerRendererDeps;
 
         const expectedComponent = (
             <>


### PR DESCRIPTION
#### Description of changes

Currently, we have 2 different approach and 2 slightly different needs to assign a `class` to the body of an html page. On one side, we have the high contrast theme on AI-Web. On the other side, we have the `is-mac-os` on AI-Android. In both cases, we use `<Helmet>` for doing this.

As part of the android settings feature, we need to bring high contrast mode to AI-Android and it would be nice if both, AI-Web and AI-Android, use the same mechanism.

In this PR, I'm updating `BodyClassAssigner` to use the newly introduce `ClassAssigner` type. This will allow for:
- Separate concerns, as now the `BodyClassAssigner` does not know about the logic to apply each specific class (`is-mac-os` and `high-contrast-theme`) nor does it care
- It makes `BodyClassAssigner` open/close by accepting an array of `ClassAssigners` and calling them one by one to apply classes according to their own logic.
- It allows to instanciate the `BodyClassAssigner` with different `ClassAssigners` depending on the needs:
   - AI-Web will only use `HighContrastClassAssigner` (TBD, this will come in a future PR)
   - AI-Android will use both `MacOsClassAssigner` and `HighContrastClassAssigner`

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
