### PR TITLE
chore: remove unnecessary electron-builder dep from deploy/package.json

### DIFF
--- a/deploy/package.json
+++ b/deploy/package.json
@@ -8,7 +8,6 @@
         "url": "https://github.com/Microsoft/accessibility-insights-web"
     },
     "devDependencies": {
-        "electron-builder": "7.0.1",
         "grunt": "^1.0.4",
         "grunt-cli": "^1.3.1",
         "grunt-contrib-compress": "^1.4.3",


### PR DESCRIPTION
#### Description of changes

This dep was a leftover from when we were using `deploy/package.json` for unified packaging/release steps; now that we aren't doing that anymore, it can be removed.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
