### PR TITLE
chore: line width for src/tests/unit/tests/background folder

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -32,6 +32,7 @@ module.exports = {
                 'src/tests/unit/stubs/**/*',
                 'src/tests/unit/tests/ad-hoc-visualizations/**/*',
                 'src/tests/unit/tests/assessments/**/*',
+                'src/tests/unit/tests/background/**/*',
                 'src/tests/unit/tests/content/**/*',
                 'src/tests/unit/tests/DevTools/**/*',
                 'src/tests/unit/tests/scanner/**/*',

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -203,7 +203,10 @@ describe('ActionCreatorTest', () => {
         const updateViewActionName = 'updateSelectedPivotChild';
 
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(VisualizationMessage.DetailsView.Open, [actionCreatorPayload, tabId])
+            .setupRegistrationCallback(VisualizationMessage.DetailsView.Open, [
+                actionCreatorPayload,
+                tabId,
+            ])
             .setupActionOnVisualizationActions(updateViewActionName)
             .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
@@ -237,7 +240,10 @@ describe('ActionCreatorTest', () => {
         const updateViewActionName = 'updateSelectedPivotChild';
 
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(VisualizationMessage.DetailsView.Open, [actionCreatorPayload, tabId])
+            .setupRegistrationCallback(VisualizationMessage.DetailsView.Open, [
+                actionCreatorPayload,
+                tabId,
+            ])
             .setupActionOnVisualizationActions(updateViewActionName)
             .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
@@ -277,13 +283,23 @@ describe('ActionCreatorTest', () => {
         };
 
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(VisualizationMessage.DetailsView.Open, [actionCreatorPayload, tabId])
+            .setupRegistrationCallback(VisualizationMessage.DetailsView.Open, [
+                actionCreatorPayload,
+                tabId,
+            ])
             .setupActionOnVisualizationActions(updateViewActionName)
             .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
             .setupActionOnVisualizationActions(enablingIssuesActionName)
-            .setupVisualizationActionWithInvokeParameter(enablingIssuesActionName, enableVisualizationTelemetryPayload)
+            .setupVisualizationActionWithInvokeParameter(
+                enablingIssuesActionName,
+                enableVisualizationTelemetryPayload,
+            )
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
-            .setupTelemetrySend(TelemetryEvents.AUTOMATED_CHECKS_TOGGLE, enableVisualizationTelemetryPayload, tabId)
+            .setupTelemetrySend(
+                TelemetryEvents.AUTOMATED_CHECKS_TOGGLE,
+                enableVisualizationTelemetryPayload,
+                tabId,
+            )
             .setupShowDetailsView(tabId, Promise.resolve());
 
         const actionCreator = validator.buildActionCreator();
@@ -313,7 +329,10 @@ describe('ActionCreatorTest', () => {
 
         const updateViewActionName = 'updateSelectedPivotChild';
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(VisualizationMessage.DetailsView.Open, [actionCreatorPayload, tabId])
+            .setupRegistrationCallback(VisualizationMessage.DetailsView.Open, [
+                actionCreatorPayload,
+                tabId,
+            ])
             .setupActionOnVisualizationActions(updateViewActionName)
             .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
             .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, tabId)
@@ -335,7 +354,10 @@ describe('ActionCreatorTest', () => {
         const validator = new ActionCreatorValidator()
             .setupRegistrationCallback(VisualizationMessage.DetailsView.Close, [null, tabId])
             .setupActionOnVisualizationActions(disableAssessmentVisualizationActionName)
-            .setupVisualizationActionWithInvokeParameter(disableAssessmentVisualizationActionName, null);
+            .setupVisualizationActionWithInvokeParameter(
+                disableAssessmentVisualizationActionName,
+                null,
+            );
 
         const actionCreator = validator.buildActionCreator();
         actionCreator.registerCallbacks();
@@ -457,7 +479,10 @@ describe('ActionCreatorTest', () => {
         const args = [];
         const actionName = 'getCurrentState';
         const builder = new ActionCreatorValidator()
-            .setupRegistrationCallback(getStoreStateMessage(StoreNames.VisualizationScanResultStore), args)
+            .setupRegistrationCallback(
+                getStoreStateMessage(StoreNames.VisualizationScanResultStore),
+                args,
+            )
             .setupActionOnVisualizationScanResultActions(actionName)
             .setupVisualizationScanResultActionWithInvokeParameter(actionName, null);
 
@@ -486,9 +511,15 @@ describe('ActionCreatorTest', () => {
 
         it('updates details view state and sends telemetry', async () => {
             const builder = new ActionCreatorValidator()
-                .setupRegistrationCallback(VisualizationMessage.DetailsView.Select, [actionCreatorPayload, tabId])
+                .setupRegistrationCallback(VisualizationMessage.DetailsView.Select, [
+                    actionCreatorPayload,
+                    tabId,
+                ])
                 .setupActionOnVisualizationActions(updateViewActionName)
-                .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
+                .setupVisualizationActionWithInvokeParameter(
+                    updateViewActionName,
+                    actionCreatorPayload,
+                )
                 .setupActionOnPreviewFeaturesActions(closePreviewFeaturesActionName)
                 .setupPreviewFeaturesActionWithInvokeParameter(closePreviewFeaturesActionName, null)
                 .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, 1)
@@ -507,13 +538,22 @@ describe('ActionCreatorTest', () => {
             const showDetailsViewErrorMessage = 'error on showDetailsView';
 
             const builder = new ActionCreatorValidator()
-                .setupRegistrationCallback(VisualizationMessage.DetailsView.Select, [actionCreatorPayload, tabId])
+                .setupRegistrationCallback(VisualizationMessage.DetailsView.Select, [
+                    actionCreatorPayload,
+                    tabId,
+                ])
                 .setupActionOnVisualizationActions(updateViewActionName)
-                .setupVisualizationActionWithInvokeParameter(updateViewActionName, actionCreatorPayload)
+                .setupVisualizationActionWithInvokeParameter(
+                    updateViewActionName,
+                    actionCreatorPayload,
+                )
                 .setupActionOnPreviewFeaturesActions(closePreviewFeaturesActionName)
                 .setupPreviewFeaturesActionWithInvokeParameter(closePreviewFeaturesActionName, null)
                 .setupTelemetrySend(TelemetryEvents.PIVOT_CHILD_SELECTED, actionCreatorPayload, 1)
-                .setupShowDetailsView(tabId, Promise.reject({ message: showDetailsViewErrorMessage }))
+                .setupShowDetailsView(
+                    tabId,
+                    Promise.reject({ message: showDetailsViewErrorMessage }),
+                )
                 .setupLogError(showDetailsViewErrorMessage);
 
             const actionCreator = builder.buildActionCreator();
@@ -533,8 +573,15 @@ describe('ActionCreatorTest', () => {
         };
 
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(VisualizationMessage.TabStops.RecordingCompleted, [actionCreatorPayload, tabId])
-            .setupTelemetrySend(TelemetryEvents.TABSTOPS_RECORDING_COMPLETE, actionCreatorPayload, tabId);
+            .setupRegistrationCallback(VisualizationMessage.TabStops.RecordingCompleted, [
+                actionCreatorPayload,
+                tabId,
+            ])
+            .setupTelemetrySend(
+                TelemetryEvents.TABSTOPS_RECORDING_COMPLETE,
+                actionCreatorPayload,
+                tabId,
+            );
         const actionCreator = validator.buildActionCreator();
 
         actionCreator.registerCallbacks();
@@ -599,9 +646,17 @@ describe('ActionCreatorTest', () => {
         };
 
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Assessment.AssessmentScanCompleted, [payload, tabId])
+            .setupRegistrationCallback(Messages.Assessment.AssessmentScanCompleted, [
+                payload,
+                tabId,
+            ])
             .setupTelemetrySend(TelemetryEvents.ASSESSMENT_SCAN_COMPLETED, payload, tabId)
-            .setupCreateNotificationByVisualizationKey(payload.selectorMap, payload.key, payload.testType, payload.scanIncompleteWarnings)
+            .setupCreateNotificationByVisualizationKey(
+                payload.selectorMap,
+                payload.key,
+                payload.testType,
+                payload.scanIncompleteWarnings,
+            )
             .setupShowTargetTab(tabId, payload.testType, payload.key);
 
         const actionCreator = validator.buildActionCreator();
@@ -659,7 +714,10 @@ describe('ActionCreatorTest', () => {
         const disableActionName = 'disableAssessmentVisualizations';
 
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Assessment.StartOverAllAssessments, [payload, tabId])
+            .setupRegistrationCallback(Messages.Assessment.StartOverAllAssessments, [
+                payload,
+                tabId,
+            ])
             .setupActionOnVisualizationActions(disableActionName)
             .setupVisualizationActionWithInvokeParameter(disableActionName, null)
             .setupTelemetrySend(TelemetryEvents.START_OVER_ASSESSMENT, payload, 1);
@@ -675,7 +733,10 @@ describe('ActionCreatorTest', () => {
         const payload: BaseActionPayload = {};
 
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Assessment.CancelStartOverAllAssessments, [payload, tabId])
+            .setupRegistrationCallback(Messages.Assessment.CancelStartOverAllAssessments, [
+                payload,
+                tabId,
+            ])
             .setupTelemetrySend(TelemetryEvents.CANCEL_START_OVER_ASSESSMENT, payload, tabId);
 
         const actionCreator = validator.buildActionCreator();
@@ -694,7 +755,10 @@ describe('ActionCreatorTest', () => {
         const enableActionName = 'enableVisualization';
 
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Visualizations.Common.RescanVisualization, [payload, tabId])
+            .setupRegistrationCallback(Messages.Visualizations.Common.RescanVisualization, [
+                payload,
+                tabId,
+            ])
             .setupActionOnVisualizationActions(disableActionName)
             .setupActionOnVisualizationActions(enableActionName)
             .setupVisualizationActionWithInvokeParameter(disableActionName, payload.test)
@@ -733,7 +797,10 @@ describe('ActionCreatorTest', () => {
         const actionName = 'enableVisualizationWithoutScan';
 
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Assessment.EnableVisualHelperWithoutScan, [payload, tabId])
+            .setupRegistrationCallback(Messages.Assessment.EnableVisualHelperWithoutScan, [
+                payload,
+                tabId,
+            ])
             .setupActionOnVisualizationActions(actionName)
             .setupVisualizationActionWithInvokeParameter(actionName, payload);
         const actionCreator = validator.buildActionCreator();
@@ -771,7 +838,10 @@ describe('ActionCreatorTest', () => {
         const actionName = 'disableVisualization';
 
         const validator = new ActionCreatorValidator()
-            .setupRegistrationCallback(Messages.Assessment.DisableVisualHelperForTest, [payload, tabId])
+            .setupRegistrationCallback(Messages.Assessment.DisableVisualHelperForTest, [
+                payload,
+                tabId,
+            ])
             .setupActionOnVisualizationActions(actionName)
             .setupVisualizationActionWithInvokeParameter(actionName, payload.test);
         const actionCreator = validator.buildActionCreator();
@@ -817,7 +887,10 @@ describe('ActionCreatorTest', () => {
                 .setupRegistrationCallback(PreviewFeaturesMessage.OpenPanel, [telemetryInfo, tabId])
                 .setupActionOnPreviewFeaturesActions(actionName)
                 .setupTelemetrySend(TelemetryEvents.PREVIEW_FEATURES_OPEN, telemetryInfo, tabId)
-                .setupShowDetailsView(tabId, Promise.reject({ message: showDetailsViewErrorMessage }))
+                .setupShowDetailsView(
+                    tabId,
+                    Promise.reject({ message: showDetailsViewErrorMessage }),
+                )
                 .setupLogError(showDetailsViewErrorMessage)
                 .setupPreviewFeaturesActionWithInvokeParameter(actionName, null);
 
@@ -848,10 +921,20 @@ describe('ActionCreatorTest', () => {
         };
 
         const builder = new ActionCreatorValidator()
-            .setupRegistrationCallback(VisualizationMessage.DetailsView.PivotSelect, [actionCreatorPayload, tabId])
+            .setupRegistrationCallback(VisualizationMessage.DetailsView.PivotSelect, [
+                actionCreatorPayload,
+                tabId,
+            ])
             .setupActionOnVisualizationActions(updatePivotActionName)
-            .setupTelemetrySend(TelemetryEvents.DETAILS_VIEW_PIVOT_ACTIVATED, actionCreatorPayload, tabId)
-            .setupVisualizationActionWithInvokeParameter(updatePivotActionName, actionCreatorPayload);
+            .setupTelemetrySend(
+                TelemetryEvents.DETAILS_VIEW_PIVOT_ACTIVATED,
+                actionCreatorPayload,
+                tabId,
+            )
+            .setupVisualizationActionWithInvokeParameter(
+                updatePivotActionName,
+                actionCreatorPayload,
+            );
 
         const actionCreator = builder.buildActionCreator();
 
@@ -885,7 +968,12 @@ describe('ActionCreatorTest', () => {
             .setupVisualizationScanResultActionWithInvokeParameter(scanResultActionName, payload)
             .setupManifest({ name: 'testname', icons: { 128: 'iconUrl' } })
             .setupTelemetrySend(telemetryName, payload, tabId)
-            .setupCreateNotificationByVisualizationKey(payload.selectorMap, key, payload.testType, payload.scanIncompleteWarnings)
+            .setupCreateNotificationByVisualizationKey(
+                payload.selectorMap,
+                key,
+                payload.testType,
+                payload.scanIncompleteWarnings,
+            )
             .setupShowTargetTab(tabId, payload.testType, key);
 
         const actionCreator = validator.buildActionCreator();
@@ -901,7 +989,9 @@ class ActionCreatorValidator {
     private visualizationActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
     private devToolsActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
 
-    private visualizationScanResultActionsContainerMock = Mock.ofType(VisualizationScanResultActions);
+    private visualizationScanResultActionsContainerMock = Mock.ofType(
+        VisualizationScanResultActions,
+    );
     private visualizationScanResultActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
 
     private detailsViewActionsContainerMock = Mock.ofType(DetailsViewActions);
@@ -917,7 +1007,10 @@ class ActionCreatorValidator {
 
     private devToolActionsContainerMock = Mock.ofType(DevToolActions);
 
-    private contentScriptInjectorStrictMock = Mock.ofType<ContentScriptInjector>(null, MockBehavior.Strict);
+    private contentScriptInjectorStrictMock = Mock.ofType<ContentScriptInjector>(
+        null,
+        MockBehavior.Strict,
+    );
     private interpreterMock = Mock.ofType<Interpreter>();
     private getManifestMock = Mock.ofInstance(() => {
         return null;
@@ -942,13 +1035,21 @@ class ActionCreatorValidator {
         injectionActions: null,
     };
 
-    private telemetryEventHandlerStrictMock = Mock.ofType<TelemetryEventHandler>(null, MockBehavior.Strict);
-    private notificationCreatorStrictMock = Mock.ofType<NotificationCreator>(null, MockBehavior.Strict);
-    private targetTabControllerStrictMock = Mock.ofType<TargetTabController>(null, MockBehavior.Strict);
-    private detailsViewControllerStrictMock: IMock<ExtensionDetailsViewController> = Mock.ofType<ExtensionDetailsViewController>(
+    private telemetryEventHandlerStrictMock = Mock.ofType<TelemetryEventHandler>(
         null,
         MockBehavior.Strict,
     );
+    private notificationCreatorStrictMock = Mock.ofType<NotificationCreator>(
+        null,
+        MockBehavior.Strict,
+    );
+    private targetTabControllerStrictMock = Mock.ofType<TargetTabController>(
+        null,
+        MockBehavior.Strict,
+    );
+    private detailsViewControllerStrictMock: IMock<ExtensionDetailsViewController> = Mock.ofType<
+        ExtensionDetailsViewController
+    >(null, MockBehavior.Strict);
 
     private loggerMock = Mock.ofType<Logger>();
 
@@ -979,7 +1080,11 @@ class ActionCreatorValidator {
         actionName: keyof VisualizationActions,
         expectedInvokeParam: any,
     ): ActionCreatorValidator {
-        this.setupActionWithInvokeParameter(actionName, expectedInvokeParam, this.visualizationActionMocks);
+        this.setupActionWithInvokeParameter(
+            actionName,
+            expectedInvokeParam,
+            this.visualizationActionMocks,
+        );
         return this;
     }
 
@@ -993,7 +1098,11 @@ class ActionCreatorValidator {
         actionName: keyof PreviewFeaturesActions,
         expectedInvokeParam: any,
     ): ActionCreatorValidator {
-        this.setupActionWithInvokeParameter(actionName, expectedInvokeParam, this.previewFeaturesActionMocks);
+        this.setupActionWithInvokeParameter(
+            actionName,
+            expectedInvokeParam,
+            this.previewFeaturesActionMocks,
+        );
         return this;
     }
 
@@ -1001,12 +1110,23 @@ class ActionCreatorValidator {
         actionName: keyof VisualizationScanResultActions,
         expectedInvokeParam: any,
     ): ActionCreatorValidator {
-        this.setupActionWithInvokeParameter(actionName, expectedInvokeParam, this.visualizationScanResultActionMocks);
+        this.setupActionWithInvokeParameter(
+            actionName,
+            expectedInvokeParam,
+            this.visualizationScanResultActionMocks,
+        );
         return this;
     }
 
-    public setupInspectActionWithInvokeParameter(actionName: keyof InspectActions, expectedInvokeParam: any): ActionCreatorValidator {
-        this.setupActionWithInvokeParameter(actionName, expectedInvokeParam, this.inspectActionsMock);
+    public setupInspectActionWithInvokeParameter(
+        actionName: keyof InspectActions,
+        expectedInvokeParam: any,
+    ): ActionCreatorValidator {
+        this.setupActionWithInvokeParameter(
+            actionName,
+            expectedInvokeParam,
+            this.inspectActionsMock,
+        );
         return this;
     }
 
@@ -1017,14 +1137,27 @@ class ActionCreatorValidator {
         warnings: ScanIncompleteWarningId[],
     ): ActionCreatorValidator {
         this.notificationCreatorStrictMock
-            .setup(x => x.createNotificationByVisualizationKey(selectorMap, key, visualizationType, warnings))
+            .setup(x =>
+                x.createNotificationByVisualizationKey(
+                    selectorMap,
+                    key,
+                    visualizationType,
+                    warnings,
+                ),
+            )
             .verifiable(Times.once());
 
         return this;
     }
 
-    public setupShowTargetTab(tabId: number, testType: VisualizationType, step: string): ActionCreatorValidator {
-        this.targetTabControllerStrictMock.setup(controller => controller.showTargetTab(tabId, testType, step)).verifiable();
+    public setupShowTargetTab(
+        tabId: number,
+        testType: VisualizationType,
+        step: string,
+    ): ActionCreatorValidator {
+        this.targetTabControllerStrictMock
+            .setup(controller => controller.showTargetTab(tabId, testType, step))
+            .verifiable();
 
         return this;
     }
@@ -1035,7 +1168,11 @@ class ActionCreatorValidator {
         return this;
     }
 
-    public setupTelemetrySend(eventName: string, telemetryInfo: any, tabId: number): ActionCreatorValidator {
+    public setupTelemetrySend(
+        eventName: string,
+        telemetryInfo: any,
+        tabId: number,
+    ): ActionCreatorValidator {
         this.telemetryEventHandlerStrictMock
             .setup(tsm => tsm.publishTelemetry(It.isValue(eventName), It.isValue(telemetryInfo)))
             .verifiable(Times.once());
@@ -1060,18 +1197,36 @@ class ActionCreatorValidator {
         return this;
     }
 
-    public setupActionOnVisualizationActions(actionName: keyof VisualizationActions): ActionCreatorValidator {
-        this.setupAction(actionName, this.visualizationActionMocks, this.visualizationActionsContainerMock);
+    public setupActionOnVisualizationActions(
+        actionName: keyof VisualizationActions,
+    ): ActionCreatorValidator {
+        this.setupAction(
+            actionName,
+            this.visualizationActionMocks,
+            this.visualizationActionsContainerMock,
+        );
         return this;
     }
 
-    public setupActionOnPreviewFeaturesActions(actionName: keyof PreviewFeaturesActions): ActionCreatorValidator {
-        this.setupAction(actionName, this.previewFeaturesActionMocks, this.previewFeaturesActionsContainerMock);
+    public setupActionOnPreviewFeaturesActions(
+        actionName: keyof PreviewFeaturesActions,
+    ): ActionCreatorValidator {
+        this.setupAction(
+            actionName,
+            this.previewFeaturesActionMocks,
+            this.previewFeaturesActionsContainerMock,
+        );
         return this;
     }
 
-    public setupActionOnVisualizationScanResultActions(actionName: keyof VisualizationScanResultActions): ActionCreatorValidator {
-        this.setupAction(actionName, this.visualizationScanResultActionMocks, this.visualizationScanResultActionsContainerMock);
+    public setupActionOnVisualizationScanResultActions(
+        actionName: keyof VisualizationScanResultActions,
+    ): ActionCreatorValidator {
+        this.setupAction(
+            actionName,
+            this.visualizationScanResultActionMocks,
+            this.visualizationScanResultActionsContainerMock,
+        );
         return this;
     }
 
@@ -1080,9 +1235,14 @@ class ActionCreatorValidator {
         return this;
     }
 
-    public setupRegistrationCallback(expectedType: string, callbackParams?: any[]): ActionCreatorValidator {
+    public setupRegistrationCallback(
+        expectedType: string,
+        callbackParams?: any[],
+    ): ActionCreatorValidator {
         this.interpreterMock
-            .setup(interpreter => interpreter.registerTypeToPayloadCallback(It.isValue(expectedType), It.isAny()))
+            .setup(interpreter =>
+                interpreter.registerTypeToPayloadCallback(It.isValue(expectedType), It.isAny()),
+            )
             .callback((messageType, callback) => {
                 if (callbackParams) {
                     callback.apply(null, callbackParams);

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -23,10 +23,17 @@ import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { VisualizationType } from 'common/types/visualization-type';
-import { ScanBasePayload, ScanCompletedPayload, ScanUpdatePayload } from 'injected/analyzers/analyzer';
+import {
+    ScanBasePayload,
+    ScanCompletedPayload,
+    ScanUpdatePayload,
+} from 'injected/analyzers/analyzer';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('AssessmentActionCreatorTest', () => {
     let assessmentActionsMock: IMock<AssessmentActions>;
@@ -53,7 +60,11 @@ describe('AssessmentActionCreatorTest', () => {
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('passUnmarkedInstance', passUnmarkedInstanceActionMock);
 
-        const interpreterMock = createInterpreterMock(AssessmentMessages.PassUnmarkedInstances, telemetryOnlyPayload, testTabId);
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.PassUnmarkedInstances,
+            telemetryOnlyPayload,
+            testTabId,
+        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -66,23 +77,42 @@ describe('AssessmentActionCreatorTest', () => {
         updateTabIdActionMock.verifyAll();
         passUnmarkedInstanceActionMock.verifyAll();
         telemetryEventHandlerMock.verify(
-            handler => handler.publishTelemetry(TelemetryEvents.PASS_UNMARKED_INSTANCES, telemetryOnlyPayload),
+            handler =>
+                handler.publishTelemetry(
+                    TelemetryEvents.PASS_UNMARKED_INSTANCES,
+                    telemetryOnlyPayload,
+                ),
             Times.once(),
         );
     });
 
     it('handles ContinuePreviousAssessment message', () => {
         const continuePreviousAssessmentMock = createActionMock(testTabId);
-        const actionsMock = createActionsMock('continuePreviousAssessment', continuePreviousAssessmentMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.ContinuePreviousAssessment, telemetryOnlyPayload, testTabId);
+        const actionsMock = createActionsMock(
+            'continuePreviousAssessment',
+            continuePreviousAssessmentMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.ContinuePreviousAssessment,
+            telemetryOnlyPayload,
+            testTabId,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         continuePreviousAssessmentMock.verifyAll();
         telemetryEventHandlerMock.verify(
-            handler => handler.publishTelemetry(TelemetryEvents.CONTINUE_PREVIOUS_ASSESSMENT, telemetryOnlyPayload),
+            handler =>
+                handler.publishTelemetry(
+                    TelemetryEvents.CONTINUE_PREVIOUS_ASSESSMENT,
+                    telemetryOnlyPayload,
+                ),
             Times.once(),
         );
     });
@@ -94,15 +124,29 @@ describe('AssessmentActionCreatorTest', () => {
         } as EditFailureInstancePayload;
 
         const editFailureInstanceMock = createActionMock(payload);
-        const actionsMock = createActionsMock('editFailureInstance', editFailureInstanceMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.EditFailureInstance, payload, testTabId);
+        const actionsMock = createActionsMock(
+            'editFailureInstance',
+            editFailureInstanceMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.EditFailureInstance,
+            payload,
+            testTabId,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         editFailureInstanceMock.verifyAll();
-        telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(TelemetryEvents.EDIT_FAILURE_INSTANCE, payload), Times.once());
+        telemetryEventHandlerMock.verify(
+            tp => tp.publishTelemetry(TelemetryEvents.EDIT_FAILURE_INSTANCE, payload),
+            Times.once(),
+        );
     });
 
     it('handles RemoveFailureInstance message', () => {
@@ -112,15 +156,28 @@ describe('AssessmentActionCreatorTest', () => {
         } as RemoveFailureInstancePayload;
 
         const removeFailureInstanceMock = createActionMock(payload);
-        const actionsMock = createActionsMock('removeFailureInstance', removeFailureInstanceMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.RemoveFailureInstance, payload);
+        const actionsMock = createActionsMock(
+            'removeFailureInstance',
+            removeFailureInstanceMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.RemoveFailureInstance,
+            payload,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         removeFailureInstanceMock.verifyAll();
-        telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(TelemetryEvents.REMOVE_FAILURE_INSTANCE, payload), Times.once());
+        telemetryEventHandlerMock.verify(
+            tp => tp.publishTelemetry(TelemetryEvents.REMOVE_FAILURE_INSTANCE, payload),
+            Times.once(),
+        );
     });
 
     it('handles AddFailureInstance message', () => {
@@ -131,14 +188,24 @@ describe('AssessmentActionCreatorTest', () => {
 
         const addFailureInstanceMock = createActionMock(payload);
         const actionsMock = createActionsMock('addFailureInstance', addFailureInstanceMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.AddFailureInstance, payload);
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.AddFailureInstance,
+            payload,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         addFailureInstanceMock.verifyAll();
-        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(TelemetryEvents.ADD_FAILURE_INSTANCE, payload), Times.once());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(TelemetryEvents.ADD_FAILURE_INSTANCE, payload),
+            Times.once(),
+        );
     });
 
     it('handles AddResultDescription message', () => {
@@ -147,10 +214,20 @@ describe('AssessmentActionCreatorTest', () => {
         };
 
         const addResultDescriptionMock = createActionMock(payload);
-        const actionsMock = createActionsMock('addResultDescription', addResultDescriptionMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.AddResultDescription, payload);
+        const actionsMock = createActionsMock(
+            'addResultDescription',
+            addResultDescriptionMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.AddResultDescription,
+            payload,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -169,7 +246,11 @@ describe('AssessmentActionCreatorTest', () => {
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('changeRequirementStatus', changeRequirementStatusMock);
 
-        const interpreterMock = createInterpreterMock(AssessmentMessages.ChangeRequirementStatus, payload, testTabId);
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.ChangeRequirementStatus,
+            payload,
+            testTabId,
+        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -194,16 +275,28 @@ describe('AssessmentActionCreatorTest', () => {
         } as ChangeRequirementStatusPayload;
 
         const undoRequirementStatusChange = createActionMock(payload);
-        const actionsMock = createActionsMock('undoRequirementStatusChange', undoRequirementStatusChange.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.UndoChangeRequirementStatus, payload, testTabId);
+        const actionsMock = createActionsMock(
+            'undoRequirementStatusChange',
+            undoRequirementStatusChange.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.UndoChangeRequirementStatus,
+            payload,
+            testTabId,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         undoRequirementStatusChange.verifyAll();
         telemetryEventHandlerMock.verify(
-            handler => handler.publishTelemetry(TelemetryEvents.UNDO_REQUIREMENT_STATUS_CHANGE, payload),
+            handler =>
+                handler.publishTelemetry(TelemetryEvents.UNDO_REQUIREMENT_STATUS_CHANGE, payload),
             Times.once(),
         );
     });
@@ -215,10 +308,17 @@ describe('AssessmentActionCreatorTest', () => {
         } as AssessmentActionInstancePayload;
 
         const undoInstanceStatusChangeMock = createActionMock(payload);
-        const actionsMock = createActionsMock('undoInstanceStatusChange', undoInstanceStatusChangeMock.object);
+        const actionsMock = createActionsMock(
+            'undoInstanceStatusChange',
+            undoInstanceStatusChangeMock.object,
+        );
         const interpreterMock = createInterpreterMock(AssessmentMessages.Undo, payload);
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -241,7 +341,11 @@ describe('AssessmentActionCreatorTest', () => {
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
         setupAssessmentActionsMock('changeInstanceStatus', changeInstanceStatusMock);
 
-        const interpreterMock = createInterpreterMock(AssessmentMessages.ChangeStatus, payload, testTabId);
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.ChangeStatus,
+            payload,
+            testTabId,
+        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -266,16 +370,30 @@ describe('AssessmentActionCreatorTest', () => {
         } as ChangeInstanceSelectionPayload;
 
         const changeAssessmentVisualizationStateMock = createActionMock(payload);
-        const actionsMock = createActionsMock('changeAssessmentVisualizationState', changeAssessmentVisualizationStateMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.ChangeVisualizationState, payload);
+        const actionsMock = createActionsMock(
+            'changeAssessmentVisualizationState',
+            changeAssessmentVisualizationStateMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.ChangeVisualizationState,
+            payload,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         changeAssessmentVisualizationStateMock.verifyAll();
         telemetryEventHandlerMock.verify(
-            handler => handler.publishTelemetry(TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS, payload),
+            handler =>
+                handler.publishTelemetry(
+                    TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS,
+                    payload,
+                ),
             Times.once(),
         );
     });
@@ -291,15 +409,27 @@ describe('AssessmentActionCreatorTest', () => {
             'changeAssessmentVisualizationStateForAll',
             changeAssessmentVisualizationStateForAllMock.object,
         );
-        const interpreterMock = createInterpreterMock(AssessmentMessages.ChangeVisualizationStateForAll, payload, testTabId);
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.ChangeVisualizationStateForAll,
+            payload,
+            testTabId,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         changeAssessmentVisualizationStateForAllMock.verifyAll();
         telemetryEventHandlerMock.verify(
-            handler => handler.publishTelemetry(TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS_FOR_ALL, payload),
+            handler =>
+                handler.publishTelemetry(
+                    TelemetryEvents.CHANGE_ASSESSMENT_VISUALIZATION_STATUS_FOR_ALL,
+                    payload,
+                ),
             Times.once(),
         );
     });
@@ -313,7 +443,11 @@ describe('AssessmentActionCreatorTest', () => {
         const actionsMock = createActionsMock('resetData', resetDataMock.object);
         const interpreterMock = createInterpreterMock(AssessmentMessages.StartOverTest, payload);
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -324,10 +458,21 @@ describe('AssessmentActionCreatorTest', () => {
         const payload = {};
 
         const resetAllAssessmentsData = createActionMock(testTabId);
-        const actionsMock = createActionsMock('resetAllAssessmentsData', resetAllAssessmentsData.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.StartOverAllAssessments, payload, testTabId);
+        const actionsMock = createActionsMock(
+            'resetAllAssessmentsData',
+            resetAllAssessmentsData.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.StartOverAllAssessments,
+            payload,
+            testTabId,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -345,7 +490,11 @@ describe('AssessmentActionCreatorTest', () => {
         setupAssessmentActionsMock('scanCompleted', scanCompleteMock);
         setupAssessmentActionsMock('updateTargetTabId', updateTabIdActionMock);
 
-        const interpreterMock = createInterpreterMock(AssessmentMessages.AssessmentScanCompleted, payload, testTabId);
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.AssessmentScanCompleted,
+            payload,
+            testTabId,
+        );
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -361,9 +510,16 @@ describe('AssessmentActionCreatorTest', () => {
     it('handles GetCurrentState message', () => {
         const getCurrentStateMock = createActionMock<void>(null);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.AssessmentStore), null);
+        const interpreterMock = createInterpreterMock(
+            getStoreStateMessage(StoreNames.AssessmentStore),
+            null,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -378,14 +534,24 @@ describe('AssessmentActionCreatorTest', () => {
 
         const selectRequirementMock = createActionMock(payload);
         const actionsMock = createActionsMock('selectRequirement', selectRequirementMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.SelectTestRequirement, payload);
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.SelectTestRequirement,
+            payload,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         selectRequirementMock.verifyAll();
-        telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(TelemetryEvents.SELECT_REQUIREMENT, payload), Times.once());
+        telemetryEventHandlerMock.verify(
+            tp => tp.publishTelemetry(TelemetryEvents.SELECT_REQUIREMENT, payload),
+            Times.once(),
+        );
     });
 
     it('handles ScanUpdate message', () => {
@@ -398,7 +564,11 @@ describe('AssessmentActionCreatorTest', () => {
         const actionsMock = createActionsMock('scanUpdate', scanUpdateMock.object);
         const interpreterMock = createInterpreterMock(AssessmentMessages.ScanUpdate, payload);
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -416,14 +586,24 @@ describe('AssessmentActionCreatorTest', () => {
 
         const trackingCompletedMock = createActionMock(payload);
         const actionsMock = createActionsMock('trackingCompleted', trackingCompletedMock.object);
-        const interpreterMock = createInterpreterMock(AssessmentMessages.TrackingCompleted, payload);
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.TrackingCompleted,
+            payload,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         trackingCompletedMock.verifyAll();
-        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry('TrackingCompletedHello', payload), Times.once());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry('TrackingCompletedHello', payload),
+            Times.once(),
+        );
     });
 
     it('handles PivotChildSelected message', () => {
@@ -432,18 +612,33 @@ describe('AssessmentActionCreatorTest', () => {
         } as OnDetailsViewOpenPayload;
 
         const updateSelectedPivotChildMock = createActionMock(payload);
-        const actionsMock = createActionsMock('updateSelectedPivotChild', updateSelectedPivotChildMock.object);
-        const interpreterMock = createInterpreterMock(Messages.Visualizations.DetailsView.Select, payload);
+        const actionsMock = createActionsMock(
+            'updateSelectedPivotChild',
+            updateSelectedPivotChildMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            Messages.Visualizations.DetailsView.Select,
+            payload,
+        );
 
-        const testSubject = new AssessmentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         updateSelectedPivotChildMock.verifyAll();
     });
 
-    function setupAssessmentActionsMock(actionName: keyof AssessmentActions, actionMock: IMock<Action<any>>): void {
-        assessmentActionsMock.setup(actions => actions[actionName]).returns(() => actionMock.object);
+    function setupAssessmentActionsMock(
+        actionName: keyof AssessmentActions,
+        actionMock: IMock<Action<any>>,
+    ): void {
+        assessmentActionsMock
+            .setup(actions => actions[actionName])
+            .returns(() => actionMock.object);
     }
 
     function createActionsMock<ActionName extends keyof AssessmentActions>(

--- a/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/card-selection-action-creator.test.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseActionPayload, CardSelectionPayload, RuleExpandCollapsePayload } from 'background/actions/action-payloads';
+import {
+    BaseActionPayload,
+    CardSelectionPayload,
+    RuleExpandCollapsePayload,
+} from 'background/actions/action-payloads';
 import { CardSelectionActionCreator } from 'background/actions/card-selection-action-creator';
 import { CardSelectionActions } from 'background/actions/card-selection-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
@@ -8,7 +12,10 @@ import * as TelemetryEvents from 'common/extension-telemetry-events';
 import { Messages } from 'common/messages';
 import { IMock, Mock, Times } from 'typemoq';
 
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('CardSelectionActionCreator', () => {
     const tabId = -2;
@@ -24,10 +31,21 @@ describe('CardSelectionActionCreator', () => {
             ruleId: 'test-rule-id',
         };
         const toggleCardSelectionMock = createActionMock(payload);
-        const actionsMock = createActionsMock('toggleCardSelection', toggleCardSelectionMock.object);
-        const interpreterMock = createInterpreterMock(Messages.CardSelection.CardSelectionToggled, payload, tabId);
+        const actionsMock = createActionsMock(
+            'toggleCardSelection',
+            toggleCardSelectionMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            Messages.CardSelection.CardSelectionToggled,
+            payload,
+            tabId,
+        );
 
-        const testSubject = new CardSelectionActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new CardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -43,10 +61,21 @@ describe('CardSelectionActionCreator', () => {
             ruleId: 'test-rule-id',
         };
         const ruleExpansionToggleMock = createActionMock(payload);
-        const actionsMock = createActionsMock('toggleRuleExpandCollapse', ruleExpansionToggleMock.object);
-        const interpreterMock = createInterpreterMock(Messages.CardSelection.RuleExpansionToggled, payload, tabId);
+        const actionsMock = createActionsMock(
+            'toggleRuleExpandCollapse',
+            ruleExpansionToggleMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            Messages.CardSelection.RuleExpansionToggled,
+            payload,
+            tabId,
+        );
 
-        const testSubject = new CardSelectionActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new CardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -61,9 +90,17 @@ describe('CardSelectionActionCreator', () => {
         const payloadStub: BaseActionPayload = {};
         const toggleVisualHelperMock = createActionMock(null);
         const actionsMock = createActionsMock('toggleVisualHelper', toggleVisualHelperMock.object);
-        const interpreterMock = createInterpreterMock(Messages.CardSelection.ToggleVisualHelper, payloadStub, tabId);
+        const interpreterMock = createInterpreterMock(
+            Messages.CardSelection.ToggleVisualHelper,
+            payloadStub,
+            tabId,
+        );
 
-        const testSubject = new CardSelectionActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new CardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -77,10 +114,21 @@ describe('CardSelectionActionCreator', () => {
     test('onCollapseAllRules', () => {
         const payloadStub: BaseActionPayload = {};
         const collapseAllRulesActionMock = createActionMock(null);
-        const actionsMock = createActionsMock('collapseAllRules', collapseAllRulesActionMock.object);
-        const interpreterMock = createInterpreterMock(Messages.CardSelection.CollapseAllRules, payloadStub, tabId);
+        const actionsMock = createActionsMock(
+            'collapseAllRules',
+            collapseAllRulesActionMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            Messages.CardSelection.CollapseAllRules,
+            payloadStub,
+            tabId,
+        );
 
-        const testSubject = new CardSelectionActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new CardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -95,9 +143,17 @@ describe('CardSelectionActionCreator', () => {
         const payloadStub: BaseActionPayload = {};
         const expandAllRulesActionMock = createActionMock(null);
         const actionsMock = createActionsMock('expandAllRules', expandAllRulesActionMock.object);
-        const interpreterMock = createInterpreterMock(Messages.CardSelection.ExpandAllRules, payloadStub, tabId);
+        const interpreterMock = createInterpreterMock(
+            Messages.CardSelection.ExpandAllRules,
+            payloadStub,
+            tabId,
+        );
 
-        const testSubject = new CardSelectionActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new CardSelectionActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 

--- a/src/tests/unit/tests/background/actions/content-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/content-action-creator.test.ts
@@ -6,13 +6,20 @@ import { ContentActions, ContentPayload } from 'background/actions/content-actio
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
 import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { CONTENT_PANEL_CLOSED, CONTENT_PANEL_OPENED, TelemetryEventSource } from 'common/extension-telemetry-events';
+import {
+    CONTENT_PANEL_CLOSED,
+    CONTENT_PANEL_OPENED,
+    TelemetryEventSource,
+} from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
 import { Logger } from 'common/logging/logger';
 import { Messages } from 'common/messages';
 import { tick } from 'tests/unit/common/tick';
 import { IMock, Mock, Times } from 'typemoq';
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('ContentActionMessageCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -42,7 +49,11 @@ describe('ContentActionMessageCreator', () => {
         beforeEach(() => {
             openContentPanelMock = createActionMock(payload);
             actionsMock = createActionsMock('openContentPanel', openContentPanelMock.object);
-            interpreterMock = createInterpreterMock(Messages.ContentPanel.OpenPanel, payload, tabId);
+            interpreterMock = createInterpreterMock(
+                Messages.ContentPanel.OpenPanel,
+                payload,
+                tabId,
+            );
             detailsViewControllerMock = Mock.ofType<ExtensionDetailsViewController>();
             loggerMock = Mock.ofType<Logger>();
             testSubject = new ContentActionCreator(
@@ -67,7 +78,10 @@ describe('ContentActionMessageCreator', () => {
 
             openContentPanelMock.verifyAll();
             detailsViewControllerMock.verifyAll();
-            telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(CONTENT_PANEL_OPENED, payload), Times.once());
+            telemetryEventHandlerMock.verify(
+                handler => handler.publishTelemetry(CONTENT_PANEL_OPENED, payload),
+                Times.once(),
+            );
             loggerMock.verify(logger => logger.error(errorMessage), Times.once());
         });
 
@@ -83,7 +97,10 @@ describe('ContentActionMessageCreator', () => {
 
             openContentPanelMock.verifyAll();
             detailsViewControllerMock.verifyAll();
-            telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(CONTENT_PANEL_OPENED, payload), Times.once());
+            telemetryEventHandlerMock.verify(
+                handler => handler.publishTelemetry(CONTENT_PANEL_OPENED, payload),
+                Times.once(),
+            );
         });
     });
 
@@ -99,12 +116,20 @@ describe('ContentActionMessageCreator', () => {
         actionsMock = createActionsMock('closeContentPanel', closeContentPanelMock.object);
         interpreterMock = createInterpreterMock(Messages.ContentPanel.ClosePanel, payload);
 
-        testSubject = new ContentActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object, null);
+        testSubject = new ContentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+            null,
+        );
 
         testSubject.registerCallbacks();
 
         closeContentPanelMock.verifyAll();
-        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(CONTENT_PANEL_CLOSED, payload), Times.once());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(CONTENT_PANEL_CLOSED, payload),
+            Times.once(),
+        );
     });
 
     function createActionsMock<ActionName extends keyof ContentActions>(

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -6,7 +6,12 @@ import { DetailsViewActions } from 'background/actions/details-view-actions';
 import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
 import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { SETTINGS_PANEL_CLOSE, SETTINGS_PANEL_OPEN, TelemetryEventSource, TriggeredBy } from 'common/extension-telemetry-events';
+import {
+    SETTINGS_PANEL_CLOSE,
+    SETTINGS_PANEL_OPEN,
+    TelemetryEventSource,
+    TriggeredBy,
+} from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
 import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
@@ -14,7 +19,10 @@ import { StoreNames } from 'common/stores/store-names';
 import { DetailsViewRightContentPanelType } from 'DetailsView/components/left-nav/details-view-right-content-panel-type';
 import { tick } from 'tests/unit/common/tick';
 import { IMock, Mock, Times } from 'typemoq';
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('DetailsViewActionCreatorTest', () => {
     let detailsViewControllerMock: IMock<ExtensionDetailsViewController>;
@@ -42,7 +50,11 @@ describe('DetailsViewActionCreatorTest', () => {
         beforeEach(() => {
             openSettingsPanelMock = createActionMock<void>(null);
             actionsMock = createActionsMock('openSettingsPanel', openSettingsPanelMock.object);
-            interpreterMock = createInterpreterMock(Messages.SettingsPanel.OpenPanel, defaultBasePayload, tabId);
+            interpreterMock = createInterpreterMock(
+                Messages.SettingsPanel.OpenPanel,
+                defaultBasePayload,
+                tabId,
+            );
         });
 
         it('when showDetailsView fails', async () => {
@@ -69,7 +81,10 @@ describe('DetailsViewActionCreatorTest', () => {
 
             openSettingsPanelMock.verifyAll();
             detailsViewControllerMock.verifyAll();
-            telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(SETTINGS_PANEL_OPEN, defaultBasePayload), Times.once());
+            telemetryEventHandlerMock.verify(
+                handler => handler.publishTelemetry(SETTINGS_PANEL_OPEN, defaultBasePayload),
+                Times.once(),
+            );
             loggerMock.verify(logger => logger.error(errorMessage), Times.once());
         });
 
@@ -92,13 +107,19 @@ describe('DetailsViewActionCreatorTest', () => {
 
             openSettingsPanelMock.verifyAll();
             detailsViewControllerMock.verifyAll();
-            telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(SETTINGS_PANEL_OPEN, defaultBasePayload), Times.once());
+            telemetryEventHandlerMock.verify(
+                handler => handler.publishTelemetry(SETTINGS_PANEL_OPEN, defaultBasePayload),
+                Times.once(),
+            );
         });
     });
     it('handles SettingsPanel.ClosePanel message', () => {
         const closeSettingsPanelMock = createActionMock<void>(null);
         const actionsMock = createActionsMock('closeSettingsPanel', closeSettingsPanelMock.object);
-        const interpreterMock = createInterpreterMock(Messages.SettingsPanel.ClosePanel, defaultBasePayload);
+        const interpreterMock = createInterpreterMock(
+            Messages.SettingsPanel.ClosePanel,
+            defaultBasePayload,
+        );
 
         const testObject = new DetailsViewActionCreator(
             interpreterMock.object,
@@ -110,7 +131,10 @@ describe('DetailsViewActionCreatorTest', () => {
         testObject.registerCallback();
 
         closeSettingsPanelMock.verifyAll();
-        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(SETTINGS_PANEL_CLOSE, defaultBasePayload), Times.once());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(SETTINGS_PANEL_CLOSE, defaultBasePayload),
+            Times.once(),
+        );
     });
 
     it('handles Visualization.DetailsView.SetDetailsViewRightContentPanel message', () => {
@@ -121,7 +145,10 @@ describe('DetailsViewActionCreatorTest', () => {
             'setSelectedDetailsViewRightContentPanel',
             setSelectedDetailsViewRightContentPanelMock.object,
         );
-        const interpreterMock = createInterpreterMock(Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel, payload);
+        const interpreterMock = createInterpreterMock(
+            Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
+            payload,
+        );
 
         const testObject = new DetailsViewActionCreator(
             interpreterMock.object,
@@ -138,7 +165,10 @@ describe('DetailsViewActionCreatorTest', () => {
     it('handles Visualization.DetailsView.GetState message', () => {
         const getCurrentStateMock = createActionMock<void>(null);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.DetailsViewStore), null);
+        const interpreterMock = createInterpreterMock(
+            getStoreStateMessage(StoreNames.DetailsViewStore),
+            null,
+        );
 
         const testObject = new DetailsViewActionCreator(
             interpreterMock.object,

--- a/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/dev-tools-action-creator.test.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { InspectElementPayload, InspectFrameUrlPayload, OnDevToolOpenPayload } from 'background/actions/action-payloads';
+import {
+    InspectElementPayload,
+    InspectFrameUrlPayload,
+    OnDevToolOpenPayload,
+} from 'background/actions/action-payloads';
 import { DevToolsActionCreator } from 'background/actions/dev-tools-action-creator';
 import { DevToolActions } from 'background/actions/dev-tools-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
@@ -9,7 +13,10 @@ import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('DevToolsActionCreatorTest', () => {
     const tabId: number = -1;
@@ -26,9 +33,17 @@ describe('DevToolsActionCreatorTest', () => {
 
         const setDevToolsStateMock = createActionMock(payload.status);
         const actionsMock = createActionsMock('setDevToolState', setDevToolsStateMock.object);
-        const interpreterMock = createInterpreterMock(Messages.DevTools.DevtoolStatus, payload, tabId);
+        const interpreterMock = createInterpreterMock(
+            Messages.DevTools.DevtoolStatus,
+            payload,
+            tabId,
+        );
 
-        const newTestObject = new DevToolsActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const newTestObject = new DevToolsActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         newTestObject.registerCallbacks();
 
@@ -38,9 +53,17 @@ describe('DevToolsActionCreatorTest', () => {
     it('handles GetState message', () => {
         const getCurrentStateMock = createActionMock(null);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.DevToolsStore), null, tabId);
+        const interpreterMock = createInterpreterMock(
+            getStoreStateMessage(StoreNames.DevToolsStore),
+            null,
+            tabId,
+        );
 
-        const newTestObject = new DevToolsActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const newTestObject = new DevToolsActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         newTestObject.registerCallbacks();
 
@@ -54,9 +77,17 @@ describe('DevToolsActionCreatorTest', () => {
 
         const setFrameUrlMock = createActionMock(payload.frameUrl);
         const actionsMock = createActionsMock('setFrameUrl', setFrameUrlMock.object);
-        const interpreterMock = createInterpreterMock(Messages.DevTools.InspectFrameUrl, payload, tabId);
+        const interpreterMock = createInterpreterMock(
+            Messages.DevTools.InspectFrameUrl,
+            payload,
+            tabId,
+        );
 
-        const newTestObject = new DevToolsActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const newTestObject = new DevToolsActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         newTestObject.registerCallbacks();
 
@@ -74,9 +105,17 @@ describe('DevToolsActionCreatorTest', () => {
 
         const setInspectElementMock = createActionMock(payload.target);
         const actionsMock = createActionsMock('setInspectElement', setInspectElementMock.object);
-        const interpreterMock = createInterpreterMock(Messages.DevTools.InspectElement, payload, tabId);
+        const interpreterMock = createInterpreterMock(
+            Messages.DevTools.InspectElement,
+            payload,
+            tabId,
+        );
 
-        const newTestObject = new DevToolsActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const newTestObject = new DevToolsActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         newTestObject.registerCallbacks();
 

--- a/src/tests/unit/tests/background/actions/injection-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/injection-action-creator.test.ts
@@ -3,14 +3,20 @@
 import { InjectionActionCreator } from 'background/actions/injection-action-creator';
 import { InjectionActions } from 'background/actions/injection-actions';
 import { Messages } from 'common/messages';
-import { createActionMock, createInterpreterMock } from 'tests/unit/tests/background/global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from 'tests/unit/tests/background/global-action-creators/action-creator-test-helpers';
 import { IMock, Mock } from 'typemoq';
 
 describe('InjectionActionCreator', () => {
     it('handles InjectionStarted message', () => {
         const injectionStartedMock = createActionMock(null);
         const actionsMock = createActionsMock('injectionStarted', injectionStartedMock.object);
-        const interpreterMock = createInterpreterMock(Messages.Visualizations.State.InjectionStarted, null);
+        const interpreterMock = createInterpreterMock(
+            Messages.Visualizations.State.InjectionStarted,
+            null,
+        );
 
         const testSubject = new InjectionActionCreator(interpreterMock.object, actionsMock.object);
 
@@ -22,7 +28,10 @@ describe('InjectionActionCreator', () => {
     it.only('handles InjectionCompleted message', () => {
         const injectionCompletedMock = createActionMock<void>(null);
         const actionsMock = createActionsMock('injectionCompleted', injectionCompletedMock.object);
-        const interpreterMock = createInterpreterMock(Messages.Visualizations.State.InjectionCompleted, null);
+        const interpreterMock = createInterpreterMock(
+            Messages.Visualizations.State.InjectionCompleted,
+            null,
+        );
 
         const testSubject = new InjectionActionCreator(interpreterMock.object, actionsMock.object);
 

--- a/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/inspect-action-creator.test.ts
@@ -13,7 +13,10 @@ import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { tick } from 'tests/unit/common/tick';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('InspectActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -29,7 +32,10 @@ describe('InspectActionCreator', () => {
     it('handles GetState message', () => {
         const getCurrentStateMock = createActionMock(null);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.InspectStore), null);
+        const interpreterMock = createInterpreterMock(
+            getStoreStateMessage(StoreNames.InspectStore),
+            null,
+        );
 
         const testSubject = new InspectActionCreator(
             interpreterMock.object,
@@ -58,11 +64,17 @@ describe('InspectActionCreator', () => {
         let testSubject: InspectActionCreator;
 
         beforeEach(() => {
-            telemetryEventHandlerMock.setup(publisher => publisher.publishTelemetry(CHANGE_INSPECT_MODE, payload)).verifiable(Times.once());
+            telemetryEventHandlerMock
+                .setup(publisher => publisher.publishTelemetry(CHANGE_INSPECT_MODE, payload))
+                .verifiable(Times.once());
 
             changeInspectModeMock = createActionMock(payload);
             actionsMock = createActionsMock('changeInspectMode', changeInspectModeMock.object);
-            interpreterMock = createInterpreterMock(Messages.Inspect.ChangeInspectMode, payload, tabId);
+            interpreterMock = createInterpreterMock(
+                Messages.Inspect.ChangeInspectMode,
+                payload,
+                tabId,
+            );
 
             testSubject = new InspectActionCreator(
                 interpreterMock.object,
@@ -74,7 +86,9 @@ describe('InspectActionCreator', () => {
         });
 
         it('switch to tab succeed', async () => {
-            browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.resolve());
+            browserAdapterMock
+                .setup(adapter => adapter.switchToTab(tabId))
+                .returns(() => Promise.resolve());
 
             testSubject.registerCallbacks();
 
@@ -85,14 +99,19 @@ describe('InspectActionCreator', () => {
 
         it('logs error when switch to tab fails', async () => {
             const dummyError = 'test-dummy-error';
-            browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.reject(dummyError));
+            browserAdapterMock
+                .setup(adapter => adapter.switchToTab(tabId))
+                .returns(() => Promise.reject(dummyError));
 
             testSubject.registerCallbacks();
 
             await tick();
 
             changeInspectModeMock.verifyAll();
-            loggerMock.verify(logger => logger.error(`switchToTab failed: ${dummyError}`), Times.once());
+            loggerMock.verify(
+                logger => logger.error(`switchToTab failed: ${dummyError}`),
+                Times.once(),
+            );
         });
     });
 

--- a/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/path-snippet-action-creator.test.ts
@@ -6,7 +6,10 @@ import { IMock, Mock } from 'typemoq';
 
 import { getStoreStateMessage, Messages } from '../../../../../common/messages';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('PathSnippetActionCreatorTest', () => {
     it('handles AddPathForValidation message', () => {
@@ -14,9 +17,15 @@ describe('PathSnippetActionCreatorTest', () => {
 
         const onAddPathMock = createActionMock(payload);
         const actionsMock = createActionsMock('onAddPath', onAddPathMock.object);
-        const interpreterMock = createInterpreterMock(Messages.PathSnippet.AddPathForValidation, payload);
+        const interpreterMock = createInterpreterMock(
+            Messages.PathSnippet.AddPathForValidation,
+            payload,
+        );
 
-        const newTestObject = new PathSnippetActionCreator(interpreterMock.object, actionsMock.object);
+        const newTestObject = new PathSnippetActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+        );
 
         newTestObject.registerCallbacks();
 
@@ -28,9 +37,15 @@ describe('PathSnippetActionCreatorTest', () => {
 
         const onAddSnippetMock = createActionMock(payload);
         const actionsMock = createActionsMock('onAddSnippet', onAddSnippetMock.object);
-        const interpreterMock = createInterpreterMock(Messages.PathSnippet.AddCorrespondingSnippet, payload);
+        const interpreterMock = createInterpreterMock(
+            Messages.PathSnippet.AddCorrespondingSnippet,
+            payload,
+        );
 
-        const newTestObject = new PathSnippetActionCreator(interpreterMock.object, actionsMock.object);
+        const newTestObject = new PathSnippetActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+        );
 
         newTestObject.registerCallbacks();
 
@@ -40,9 +55,15 @@ describe('PathSnippetActionCreatorTest', () => {
     it('handles GetPathSnippetCurrentState message', () => {
         const getCurrentStateMock = createActionMock(null);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.PathSnippetStore), null);
+        const interpreterMock = createInterpreterMock(
+            getStoreStateMessage(StoreNames.PathSnippetStore),
+            null,
+        );
 
-        const newTestObject = new PathSnippetActionCreator(interpreterMock.object, actionsMock.object);
+        const newTestObject = new PathSnippetActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+        );
 
         newTestObject.registerCallbacks();
 
@@ -52,9 +73,15 @@ describe('PathSnippetActionCreatorTest', () => {
     it('handles ClearPathSnippetData message', () => {
         const onClearDataMock = createActionMock(null);
         const actionsMock = createActionsMock('onClearData', onClearDataMock.object);
-        const interpreterMock = createInterpreterMock(Messages.PathSnippet.ClearPathSnippetData, null);
+        const interpreterMock = createInterpreterMock(
+            Messages.PathSnippet.ClearPathSnippetData,
+            null,
+        );
 
-        const newTestObject = new PathSnippetActionCreator(interpreterMock.object, actionsMock.object);
+        const newTestObject = new PathSnippetActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+        );
 
         newTestObject.registerCallbacks();
 

--- a/src/tests/unit/tests/background/actions/popup-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/popup-action-creator.test.ts
@@ -4,11 +4,18 @@ import { PopupInitializedPayload } from 'background/actions/action-payloads';
 import { PopupActionCreator } from 'background/actions/popup-action-creator';
 import { TabActions } from 'background/actions/tab-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { POPUP_INITIALIZED, TelemetryEventSource, TriggeredBy } from 'common/extension-telemetry-events';
+import {
+    POPUP_INITIALIZED,
+    TelemetryEventSource,
+    TriggeredBy,
+} from 'common/extension-telemetry-events';
 import { Messages } from 'common/messages';
 import { IMock, Mock, Times } from 'typemoq';
 
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('PopupActionCreator', () => {
     it('handles Messages.Popup.Initialized', () => {
@@ -28,12 +35,19 @@ describe('PopupActionCreator', () => {
         const actionsMock = createTabActionsMock('newTabCreated', actionMock.object);
         const interpreterMock = createInterpreterMock(Messages.Popup.Initialized, payload);
         const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
-        const testSubject = new PopupActionCreator(interpreterMock.object, actionsMock.object, telemetryEventHandlerMock.object);
+        const testSubject = new PopupActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
         actionMock.verifyAll();
-        telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(POPUP_INITIALIZED, payload), Times.once());
+        telemetryEventHandlerMock.verify(
+            tp => tp.publishTelemetry(POPUP_INITIALIZED, payload),
+            Times.once(),
+        );
     });
 
     function createTabActionsMock<ActionName extends keyof TabActions>(

--- a/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
@@ -12,7 +12,10 @@ import { Logger } from 'common/logging/logger';
 import { Messages } from 'common/messages';
 import { tick } from 'tests/unit/common/tick';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('ScopingPanelActionCreatorTest', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -24,7 +27,10 @@ describe('ScopingPanelActionCreatorTest', () => {
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
-        detailsViewControllerStrictMock = Mock.ofType<ExtensionDetailsViewController>(undefined, MockBehavior.Strict);
+        detailsViewControllerStrictMock = Mock.ofType<ExtensionDetailsViewController>(
+            undefined,
+            MockBehavior.Strict,
+        );
     });
 
     describe('handles OpenPanel message', () => {
@@ -38,7 +44,9 @@ describe('ScopingPanelActionCreatorTest', () => {
             openScopingPanelMock = createActionMock(null);
             actionsMocks = createActionsMock('openScopingPanel', openScopingPanelMock.object);
             interpreterMock = createInterpreterMock(Messages.Scoping.OpenPanel, payload, tabId);
-            telemetryEventHandlerMock.setup(handler => handler.publishTelemetry(SCOPING_OPEN, payload)).verifiable(Times.once());
+            telemetryEventHandlerMock
+                .setup(handler => handler.publishTelemetry(SCOPING_OPEN, payload))
+                .verifiable(Times.once());
             loggerMock = Mock.ofType<Logger>();
 
             testObject = new ScopingPanelActionCreator(
@@ -87,7 +95,9 @@ describe('ScopingPanelActionCreatorTest', () => {
     test('handles ClosePanel message', () => {
         const payload: BaseActionPayload = {};
 
-        telemetryEventHandlerMock.setup(tp => tp.publishTelemetry(SCOPING_CLOSE, payload)).verifiable(Times.once());
+        telemetryEventHandlerMock
+            .setup(tp => tp.publishTelemetry(SCOPING_CLOSE, payload))
+            .verifiable(Times.once());
 
         const closeScopingPanelActionMock = createActionMock(null);
         actionsMocks = createActionsMock('closeScopingPanel', closeScopingPanelActionMock.object);

--- a/src/tests/unit/tests/background/actions/shortcuts-page-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/shortcuts-page-action-creator.test.ts
@@ -28,7 +28,9 @@ describe('ShortcutsPageActionCreator', () => {
         interpreterMock = Mock.ofType<Interpreter>();
 
         interpreterMock
-            .setup(interpreter => interpreter.registerTypeToPayloadCallback(expectedMessage, It.is(isFunction)))
+            .setup(interpreter =>
+                interpreter.registerTypeToPayloadCallback(expectedMessage, It.is(isFunction)),
+            )
             .callback((message, handler) => {
                 handler(payload);
             });
@@ -47,35 +49,50 @@ describe('ShortcutsPageActionCreator', () => {
 
     describe('handles ConfigureShortcuts message', () => {
         it('opens the shortcuts tab', async () => {
-            shortcutsPageControllerMock.setup(controller => controller.openShortcutsTab()).returns(() => Promise.resolve());
+            shortcutsPageControllerMock
+                .setup(controller => controller.openShortcutsTab())
+                .returns(() => Promise.resolve());
 
             testSubject.registerCallbacks();
 
             await tick();
 
-            shortcutsPageControllerMock.verify(controller => controller.openShortcutsTab(), Times.once());
+            shortcutsPageControllerMock.verify(
+                controller => controller.openShortcutsTab(),
+                Times.once(),
+            );
         });
 
         describe('sends telemetry', () => {
             it('when opening shortcuts tab succeeds', async () => {
-                shortcutsPageControllerMock.setup(controller => controller.openShortcutsTab()).returns(() => Promise.resolve());
+                shortcutsPageControllerMock
+                    .setup(controller => controller.openShortcutsTab())
+                    .returns(() => Promise.resolve());
 
                 testSubject.registerCallbacks();
 
                 await tick();
 
-                telemetryHandlerMock.verify(handler => handler.publishTelemetry(SHORTCUT_CONFIGURE_OPEN, payload), Times.once());
+                telemetryHandlerMock.verify(
+                    handler => handler.publishTelemetry(SHORTCUT_CONFIGURE_OPEN, payload),
+                    Times.once(),
+                );
             });
 
             it('when opening shortcuts tab fails', async () => {
                 const errorMessage = 'dummy error';
-                shortcutsPageControllerMock.setup(controller => controller.openShortcutsTab()).returns(() => Promise.reject(errorMessage));
+                shortcutsPageControllerMock
+                    .setup(controller => controller.openShortcutsTab())
+                    .returns(() => Promise.reject(errorMessage));
 
                 testSubject.registerCallbacks();
 
                 await tick();
 
-                telemetryHandlerMock.verify(handler => handler.publishTelemetry(SHORTCUT_CONFIGURE_OPEN, payload), Times.once());
+                telemetryHandlerMock.verify(
+                    handler => handler.publishTelemetry(SHORTCUT_CONFIGURE_OPEN, payload),
+                    Times.once(),
+                );
                 loggerMock.verify(logger => logger.error(errorMessage), Times.once());
             });
         });

--- a/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/tab-action-creator.test.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ExistingTabUpdatedPayload, PageVisibilityChangeTabPayload, SwitchToTargetTabPayload } from 'background/actions/action-payloads';
+import {
+    ExistingTabUpdatedPayload,
+    PageVisibilityChangeTabPayload,
+    SwitchToTargetTabPayload,
+} from 'background/actions/action-payloads';
 import { TabActionCreator } from 'background/actions/tab-action-creator';
 import { TabActions } from 'background/actions/tab-actions';
 import { Interpreter } from 'background/interpreter';
@@ -18,7 +22,10 @@ import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { tick } from 'tests/unit/common/tick';
 import { IMock, Mock, Times } from 'typemoq';
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('TestActionCreatorTest', () => {
     let browserAdapterMock: IMock<BrowserAdapter>;
@@ -54,15 +61,27 @@ describe('TestActionCreatorTest', () => {
         testSubject.registerCallbacks();
 
         actionMock.verifyAll();
-        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(null, payload), Times.never());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(null, payload),
+            Times.never(),
+        );
     });
 
     it('handles Tab.GetCurrent message', () => {
         const getCurrentStateMock = createActionMock<void>(null);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.TabStore), null);
+        const interpreterMock = createInterpreterMock(
+            getStoreStateMessage(StoreNames.TabStore),
+            null,
+        );
 
-        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null, loggerMock.object);
+        const testSubject = new TabActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            null,
+            null,
+            loggerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -74,7 +93,13 @@ describe('TestActionCreatorTest', () => {
         const actionsMock = createActionsMock('tabRemove', tabRemoveMock.object);
         const interpreterMock = createInterpreterMock(Messages.Tab.Remove, null);
 
-        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null, loggerMock.object);
+        const testSubject = new TabActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            null,
+            null,
+            loggerMock.object,
+        );
 
         testSubject.registerCallbacks();
 
@@ -107,7 +132,10 @@ describe('TestActionCreatorTest', () => {
         testSubject.registerCallbacks();
 
         actionMock.verifyAll();
-        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(EXISTING_TAB_URL_UPDATED, payload), Times.once());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(EXISTING_TAB_URL_UPDATED, payload),
+            Times.once(),
+        );
     });
 
     describe('handles Tab.Switch message', () => {
@@ -136,25 +164,38 @@ describe('TestActionCreatorTest', () => {
         });
 
         it('switch to tab succeed', async () => {
-            browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.resolve());
+            browserAdapterMock
+                .setup(adapter => adapter.switchToTab(tabId))
+                .returns(() => Promise.resolve());
 
             testSubject.registerCallbacks();
 
             await tick();
 
-            telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(SWITCH_BACK_TO_TARGET, payload), Times.once());
+            telemetryEventHandlerMock.verify(
+                tp => tp.publishTelemetry(SWITCH_BACK_TO_TARGET, payload),
+                Times.once(),
+            );
         });
 
         it('logs error when switch to tab fails', async () => {
             const dummyError = 'switch to tab dummy error';
-            browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.reject(dummyError));
+            browserAdapterMock
+                .setup(adapter => adapter.switchToTab(tabId))
+                .returns(() => Promise.reject(dummyError));
 
             testSubject.registerCallbacks();
 
             await tick();
 
-            telemetryEventHandlerMock.verify(tp => tp.publishTelemetry(SWITCH_BACK_TO_TARGET, payload), Times.once());
-            loggerMock.verify(logger => logger.error(`switchToTab failed: ${dummyError}`), Times.once());
+            telemetryEventHandlerMock.verify(
+                tp => tp.publishTelemetry(SWITCH_BACK_TO_TARGET, payload),
+                Times.once(),
+            );
+            loggerMock.verify(
+                logger => logger.error(`switchToTab failed: ${dummyError}`),
+                Times.once(),
+            );
         });
     });
 
@@ -164,10 +205,19 @@ describe('TestActionCreatorTest', () => {
         };
 
         const tabVisibilityChangeMock = createActionMock(payload.hidden);
-        const actionsMock = createActionsMock('tabVisibilityChange', tabVisibilityChangeMock.object);
+        const actionsMock = createActionsMock(
+            'tabVisibilityChange',
+            tabVisibilityChangeMock.object,
+        );
         const interpreterMock = createInterpreterMock(Messages.Tab.VisibilityChange, payload);
 
-        const testSubject = new TabActionCreator(interpreterMock.object, actionsMock.object, null, null, loggerMock.object);
+        const testSubject = new TabActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            null,
+            null,
+            loggerMock.object,
+        );
 
         testSubject.registerCallbacks();
 

--- a/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/unified-scan-result-action-creator.test.ts
@@ -4,13 +4,19 @@ import { UnifiedScanCompletedPayload } from 'background/actions/action-payloads'
 import { UnifiedScanResultActionCreator } from 'background/actions/unified-scan-result-action-creator';
 import { UnifiedScanResultActions } from 'background/actions/unified-scan-result-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { SCAN_INCOMPLETE_WARNINGS, ScanIncompleteWarningsTelemetryData } from 'common/extension-telemetry-events';
+import {
+    SCAN_INCOMPLETE_WARNINGS,
+    ScanIncompleteWarningsTelemetryData,
+} from 'common/extension-telemetry-events';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { IMock, Mock, Times } from 'typemoq';
-import { createActionMock, createInterpreterMock } from '../global-action-creators/action-creator-test-helpers';
+import {
+    createActionMock,
+    createInterpreterMock,
+} from '../global-action-creators/action-creator-test-helpers';
 
 describe('UnifiedScanResultActionCreator', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
@@ -46,7 +52,10 @@ describe('UnifiedScanResultActionCreator', () => {
         testSubject.registerCallbacks();
 
         scanCompletedMock.verifyAll();
-        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(SCAN_INCOMPLETE_WARNINGS, payload), Times.once());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(SCAN_INCOMPLETE_WARNINGS, payload),
+            Times.once(),
+        );
     });
 
     it('should handle GetState message', () => {
@@ -54,7 +63,10 @@ describe('UnifiedScanResultActionCreator', () => {
 
         const getCurrentStateMock = createActionMock<null>(payload);
         const actionsMock = createActionsMock('getCurrentState', getCurrentStateMock.object);
-        const interpreterMock = createInterpreterMock(getStoreStateMessage(StoreNames.UnifiedScanResultStore), payload);
+        const interpreterMock = createInterpreterMock(
+            getStoreStateMessage(StoreNames.UnifiedScanResultStore),
+            payload,
+        );
 
         const testSubject = new UnifiedScanResultActionCreator(
             interpreterMock.object,

--- a/src/tests/unit/tests/background/assessment-data-converter.test.ts
+++ b/src/tests/unit/tests/background/assessment-data-converter.test.ts
@@ -5,7 +5,10 @@ import { IMock, It, Mock } from 'typemoq';
 import { AssessmentDataConverter } from 'background/assessment-data-converter';
 import { UniquelyIdentifiableInstances } from 'background/instance-identifier-generator';
 import { ManualTestStatus } from '../../../../common/types/manual-test-status';
-import { AssessmentInstancesMap, TestStepResult } from '../../../../common/types/store-data/assessment-result-data';
+import {
+    AssessmentInstancesMap,
+    TestStepResult,
+} from '../../../../common/types/store-data/assessment-result-data';
 import { DecoratedAxeNodeResult, HtmlElementAxeResults } from '../../../../injected/scanner-utils';
 import { TabStopEvent } from '../../../../injected/tab-stops-listener';
 import { DictionaryStringTo } from '../../../../types/common-types';
@@ -60,7 +63,10 @@ describe('AssessmentDataConverterTest', () => {
             },
         };
 
-        setupGenerateInstanceIdentifierMock({ target: [selectorStub], html: htmlStub }, identifierStub);
+        setupGenerateInstanceIdentifierMock(
+            { target: [selectorStub], html: htmlStub },
+            identifierStub,
+        );
         const instanceMap = testSubject.generateAssessmentInstancesMap(
             null,
             selectorMap,
@@ -110,7 +116,10 @@ describe('AssessmentDataConverterTest', () => {
             },
         };
 
-        setupGenerateInstanceIdentifierMock({ target: [selectorStub], html: htmlStub }, identifierStub);
+        setupGenerateInstanceIdentifierMock(
+            { target: [selectorStub], html: htmlStub },
+            identifierStub,
+        );
         const instanceMap = testSubject.generateAssessmentInstancesMap(
             null,
             selectorMap,
@@ -131,7 +140,13 @@ describe('AssessmentDataConverterTest', () => {
             },
         };
         const expectedResult = {};
-        const instanceMap = testSubject.generateAssessmentInstancesMap(null, selectorMap, testStep, undefined, null);
+        const instanceMap = testSubject.generateAssessmentInstancesMap(
+            null,
+            selectorMap,
+            testStep,
+            undefined,
+            null,
+        );
 
         expect(instanceMap).toEqual(expectedResult);
     });
@@ -187,7 +202,10 @@ describe('AssessmentDataConverterTest', () => {
                 },
             },
         };
-        setupGenerateInstanceIdentifierMock({ target: [selectorStub], html: htmlStub }, identifierStub);
+        setupGenerateInstanceIdentifierMock(
+            { target: [selectorStub], html: htmlStub },
+            identifierStub,
+        );
         const instanceMap = testSubject.generateAssessmentInstancesMap(
             {},
             selectorMap,
@@ -229,7 +247,10 @@ describe('AssessmentDataConverterTest', () => {
                 },
             },
         };
-        setupGenerateInstanceIdentifierMock({ target: [selectorStub], html: htmlStub }, identifierStub);
+        setupGenerateInstanceIdentifierMock(
+            { target: [selectorStub], html: htmlStub },
+            identifierStub,
+        );
         const instanceMap = testSubject.generateAssessmentInstancesMap(
             {},
             selectorMap,
@@ -304,7 +325,10 @@ describe('AssessmentDataConverterTest', () => {
             },
         };
 
-        setupGenerateInstanceIdentifierMock({ target: [selectorStub], html: htmlStub }, identifierStub);
+        setupGenerateInstanceIdentifierMock(
+            { target: [selectorStub], html: htmlStub },
+            identifierStub,
+        );
         const instanceMap = testSubject.generateAssessmentInstancesMap(
             previouslyGeneratedInstances,
             selectorMap,
@@ -451,7 +475,9 @@ describe('AssessmentDataConverterTest', () => {
             selector: path,
         };
 
-        expect(testSubject.generateFailureInstance(description, path, snippet)).toEqual(expectedResult);
+        expect(testSubject.generateFailureInstance(description, path, snippet)).toEqual(
+            expectedResult,
+        );
     });
 
     test('generateFailureInstance with description and path', () => {
@@ -465,10 +491,17 @@ describe('AssessmentDataConverterTest', () => {
             html: snippet,
         };
 
-        expect(testSubject.generateFailureInstance(description, path, snippet)).toEqual(expectedResult);
+        expect(testSubject.generateFailureInstance(description, path, snippet)).toEqual(
+            expectedResult,
+        );
     });
 
-    function setupGenerateInstanceIdentifierMock(instance: UniquelyIdentifiableInstances, identifier: string): void {
-        generateInstanceIdentifierMock.setup(giim => giim(It.isValue(instance))).returns(() => identifier);
+    function setupGenerateInstanceIdentifierMock(
+        instance: UniquelyIdentifiableInstances,
+        identifier: string,
+    ): void {
+        generateInstanceIdentifierMock
+            .setup(giim => giim(It.isValue(instance)))
+            .returns(() => identifier);
     }
 });

--- a/src/tests/unit/tests/background/assessment-data-remover.test.ts
+++ b/src/tests/unit/tests/background/assessment-data-remover.test.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentDataRemover } from 'background/assessment-data-remover';
-import { GeneratedAssessmentInstance, TestStepResult } from '../../../../common/types/store-data/assessment-result-data';
+import {
+    GeneratedAssessmentInstance,
+    TestStepResult,
+} from '../../../../common/types/store-data/assessment-result-data';
 import { DictionaryStringTo } from '../../../../types/common-types';
 
 describe('AssessmentDataRemoverTest', () => {
@@ -11,17 +14,25 @@ describe('AssessmentDataRemoverTest', () => {
 
     test('deleteDataFromGeneratedMapWithStepKey: only delete one test step result entry', () => {
         const instanceMap = getInstanceMapWitMultipleTestStepResults();
-        new AssessmentDataRemover().deleteDataFromGeneratedMapWithStepKey(instanceMap, selectedStep);
+        new AssessmentDataRemover().deleteDataFromGeneratedMapWithStepKey(
+            instanceMap,
+            selectedStep,
+        );
         expect(instanceMap[instanceKey].testStepResults[anotherStep]).toBeDefined();
     });
 
     test('deleteDataFromGeneratedMapWithStepKey: delete the instance in the instance map', () => {
         const instanceMap = getInstanceMapWithOnlyOneTestStepResult();
-        new AssessmentDataRemover().deleteDataFromGeneratedMapWithStepKey(instanceMap, selectedStep);
+        new AssessmentDataRemover().deleteDataFromGeneratedMapWithStepKey(
+            instanceMap,
+            selectedStep,
+        );
         expect(instanceMap[instanceKey]).toBeUndefined();
     });
 
-    function getInstanceMapWithOnlyOneTestStepResult(): DictionaryStringTo<GeneratedAssessmentInstance> {
+    function getInstanceMapWithOnlyOneTestStepResult(): DictionaryStringTo<
+        GeneratedAssessmentInstance
+    > {
         return {
             [instanceKey]: {
                 testStepResults: {
@@ -36,7 +47,9 @@ describe('AssessmentDataRemoverTest', () => {
         };
     }
 
-    function getInstanceMapWitMultipleTestStepResults(): DictionaryStringTo<GeneratedAssessmentInstance> {
+    function getInstanceMapWitMultipleTestStepResults(): DictionaryStringTo<
+        GeneratedAssessmentInstance
+    > {
         return {
             [instanceKey]: {
                 testStepResults: {

--- a/src/tests/unit/tests/background/assessment-scan-policy-runner.test.ts
+++ b/src/tests/unit/tests/background/assessment-scan-policy-runner.test.ts
@@ -4,18 +4,30 @@ import { IMock, It, Mock, MockBehavior } from 'typemoq';
 
 import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
-import { AssessmentScanPolicyRunner, IIsAnAssessmentSelected, IScheduleScan } from 'background/assessment-scan-policy-runner';
+import {
+    AssessmentScanPolicyRunner,
+    IIsAnAssessmentSelected,
+    IScheduleScan,
+} from 'background/assessment-scan-policy-runner';
 import { AssessmentStore } from 'background/stores/assessment-store';
 import { VisualizationStore } from 'background/stores/visualization-store';
 import { BaseStore } from '../../../../common/base-store';
-import { AssessmentData, AssessmentStoreData } from '../../../../common/types/store-data/assessment-result-data';
-import { TestsEnabledState, VisualizationStoreData } from '../../../../common/types/store-data/visualization-store-data';
+import {
+    AssessmentData,
+    AssessmentStoreData,
+} from '../../../../common/types/store-data/assessment-result-data';
+import {
+    TestsEnabledState,
+    VisualizationStoreData,
+} from '../../../../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../../../../common/types/visualization-type';
 
 describe('AssessmentScanPolicyRunner', () => {
     describe('constructor', () => {
         it('exists', () => {
-            expect(new AssessmentScanPolicyRunner(null, null, null, null, null, null)).toBeDefined();
+            expect(
+                new AssessmentScanPolicyRunner(null, null, null, null, null, null),
+            ).toBeDefined();
         });
     });
 
@@ -39,8 +51,14 @@ describe('AssessmentScanPolicyRunner', () => {
             assessmentStoreMock = Mock.ofType(AssessmentStore, MockBehavior.Strict);
             visualizationStore = Mock.ofType(VisualizationStore, MockBehavior.Strict);
             assessmentProviderMock = Mock.ofType(AssessmentsProviderImpl, MockBehavior.Strict);
-            getSelectedAssessmentTestMock = Mock.ofInstance((testTestData: TestsEnabledState) => null, MockBehavior.Strict);
-            scheduleScanMock = Mock.ofInstance((test: VisualizationType, step: string, tabId: number) => null, MockBehavior.Strict);
+            getSelectedAssessmentTestMock = Mock.ofInstance(
+                (testTestData: TestsEnabledState) => null,
+                MockBehavior.Strict,
+            );
+            scheduleScanMock = Mock.ofInstance(
+                (test: VisualizationType, step: string, tabId: number) => null,
+                MockBehavior.Strict,
+            );
             testSubject = new AssessmentScanPolicyRunner(
                 assessmentStoreMock.object,
                 visualizationStore.object,
@@ -66,7 +84,9 @@ describe('AssessmentScanPolicyRunner', () => {
             setupStoreMockForCallback(assessmentStoreMock);
             setupStoreMockForCallback(visualizationStore);
             setupGetSelectedAssessmentTest(false);
-            setupStoreGetState<VisualizationStoreData>(visualizationStore, { tests: testData } as VisualizationStoreData);
+            setupStoreGetState<VisualizationStoreData>(visualizationStore, {
+                tests: testData,
+            } as VisualizationStoreData);
             setupStoreGetState<AssessmentStoreData>(assessmentStoreMock, {
                 persistedTabInfo: { id: currentTabId },
             } as AssessmentStoreData);
@@ -81,8 +101,12 @@ describe('AssessmentScanPolicyRunner', () => {
         it('should not do anything, current tab is not the assessment tab', () => {
             setupStoreMockForCallback(assessmentStoreMock);
             setupStoreMockForCallback(visualizationStore);
-            setupStoreGetState<VisualizationStoreData>(visualizationStore, { tests: testData } as VisualizationStoreData);
-            setupStoreGetState<AssessmentStoreData>(assessmentStoreMock, { persistedTabInfo: { id: 1 } } as AssessmentStoreData);
+            setupStoreGetState<VisualizationStoreData>(visualizationStore, {
+                tests: testData,
+            } as VisualizationStoreData);
+            setupStoreGetState<AssessmentStoreData>(assessmentStoreMock, {
+                persistedTabInfo: { id: 1 },
+            } as AssessmentStoreData);
             setupGetSelectedAssessmentTest(true);
 
             testSubject.beginListeningToStores();
@@ -95,8 +119,12 @@ describe('AssessmentScanPolicyRunner', () => {
         it('should not do anything, assessment target tab is null', () => {
             setupStoreMockForCallback(assessmentStoreMock);
             setupStoreMockForCallback(visualizationStore);
-            setupStoreGetState<VisualizationStoreData>(visualizationStore, { tests: testData } as VisualizationStoreData);
-            setupStoreGetState<AssessmentStoreData>(assessmentStoreMock, { persistedTabInfo: null } as AssessmentStoreData);
+            setupStoreGetState<VisualizationStoreData>(visualizationStore, {
+                tests: testData,
+            } as VisualizationStoreData);
+            setupStoreGetState<AssessmentStoreData>(assessmentStoreMock, {
+                persistedTabInfo: null,
+            } as AssessmentStoreData);
             setupGetSelectedAssessmentTest(true);
 
             testSubject.beginListeningToStores();
@@ -107,11 +135,17 @@ describe('AssessmentScanPolicyRunner', () => {
         });
 
         it('should not do anything, as something is already being scanned', () => {
-            const visualizationStateStub: Partial<VisualizationStoreData> = { tests: testData, scanning: 'something' };
+            const visualizationStateStub: Partial<VisualizationStoreData> = {
+                tests: testData,
+                scanning: 'something',
+            };
             setupStoreMockForCallback(assessmentStoreMock);
             setupStoreMockForCallback(visualizationStore);
             setupGetSelectedAssessmentTest(true);
-            setupStoreGetState<VisualizationStoreData>(visualizationStore, visualizationStateStub as VisualizationStoreData);
+            setupStoreGetState<VisualizationStoreData>(
+                visualizationStore,
+                visualizationStateStub as VisualizationStoreData,
+            );
             setupStoreGetState<AssessmentStoreData>(assessmentStoreMock, {
                 persistedTabInfo: { id: currentTabId },
             } as AssessmentStoreData);
@@ -148,8 +182,13 @@ describe('AssessmentScanPolicyRunner', () => {
             setupStoreMockForCallback(assessmentStoreMock);
             setupStoreMockForCallback(visualizationStore);
             setupGetSelectedAssessmentTest(true);
-            setupStoreGetState<VisualizationStoreData>(visualizationStore, { tests: testData } as VisualizationStoreData);
-            setupStoreGetState<AssessmentStoreData>(assessmentStoreMock, assessmentStoreDataStub as AssessmentStoreData);
+            setupStoreGetState<VisualizationStoreData>(visualizationStore, {
+                tests: testData,
+            } as VisualizationStoreData);
+            setupStoreGetState<AssessmentStoreData>(
+                assessmentStoreMock,
+                assessmentStoreDataStub as AssessmentStoreData,
+            );
             setupAssessmentsProvider(assessmentProviderMock, assessmentConfig);
 
             let scanStepCallback: (step: string) => void;
@@ -204,7 +243,10 @@ describe('AssessmentScanPolicyRunner', () => {
                 .verifiable();
         }
 
-        function setupAssessmentsProvider(mock: IMock<AssessmentsProviderImpl>, config: Assessment): void {
+        function setupAssessmentsProvider(
+            mock: IMock<AssessmentsProviderImpl>,
+            config: Assessment,
+        ): void {
             mock.setup(m => m.forType(testType))
                 .returns(() => config)
                 .verifiable();

--- a/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
+++ b/src/tests/unit/tests/background/browser-message-broadcaster-factory.test.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserMessageBroadcasterFactory, connectionErrorMessage } from 'background/browser-message-broadcaster-factory';
+import {
+    BrowserMessageBroadcasterFactory,
+    connectionErrorMessage,
+} from 'background/browser-message-broadcaster-factory';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { Logger } from 'common/logging/logger';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
@@ -16,7 +19,10 @@ describe('BrowserMessageBroadcasterFactory', () => {
         loggerMock = Mock.ofType<Logger>();
         browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
 
-        testSubject = new BrowserMessageBroadcasterFactory(browserAdapterMock.object, loggerMock.object);
+        testSubject = new BrowserMessageBroadcasterFactory(
+            browserAdapterMock.object,
+            loggerMock.object,
+        );
     });
 
     describe('allTabsBroadcaster', () => {
@@ -49,9 +55,15 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const expectedMessage =
                 "sendMessageToFrames failed for message { someData: 'test data' } with browser error message: test error";
 
-            browserAdapterMock.setup(ba => ba.tabsQuery({})).returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
-            browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.reject(testError));
-            browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.resolve());
+            browserAdapterMock
+                .setup(ba => ba.tabsQuery({}))
+                .returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToFrames(It.isAny()))
+                .returns(() => Promise.reject(testError));
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny()))
+                .returns(() => Promise.resolve());
 
             loggerMock.setup(m => m.error(expectedMessage)).verifiable(Times.once());
 
@@ -66,9 +78,15 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const expectedMessage =
                 "sendMessageToTab(1) failed for message { someData: 'test data' } with browser error message: test error";
 
-            browserAdapterMock.setup(ba => ba.tabsQuery({})).returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
-            browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.resolve());
-            browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.reject(testError));
+            browserAdapterMock
+                .setup(ba => ba.tabsQuery({}))
+                .returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToFrames(It.isAny()))
+                .returns(() => Promise.resolve());
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny()))
+                .returns(() => Promise.reject(testError));
 
             loggerMock.setup(m => m.error(expectedMessage)).verifiable(Times.once());
 
@@ -81,9 +99,15 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const testMessage = { someData: 'test data' } as any;
             const testError = { message: connectionErrorMessage };
 
-            browserAdapterMock.setup(ba => ba.tabsQuery({})).returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
-            browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.resolve());
-            browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.reject(testError));
+            browserAdapterMock
+                .setup(ba => ba.tabsQuery({}))
+                .returns(() => Promise.resolve([{ id: 1 } as Tabs.Tab]));
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToFrames(It.isAny()))
+                .returns(() => Promise.resolve());
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny()))
+                .returns(() => Promise.reject(testError));
 
             loggerMock.setup(m => m.error(It.isAny())).verifiable(Times.never());
 
@@ -119,8 +143,12 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const expectedMessage =
                 "sendMessageToFrames failed for message { someData: 'test data', tabId: 1 } with browser error message: test error";
 
-            browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.reject(testError));
-            browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.resolve());
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToFrames(It.isAny()))
+                .returns(() => Promise.reject(testError));
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny()))
+                .returns(() => Promise.resolve());
 
             loggerMock.setup(m => m.error(expectedMessage)).verifiable(Times.once());
 
@@ -135,8 +163,12 @@ describe('BrowserMessageBroadcasterFactory', () => {
             const expectedMessage =
                 "sendMessageToTab(1) failed for message { someData: 'test data', tabId: 1 } with browser error message: test error";
 
-            browserAdapterMock.setup(ba => ba.sendMessageToFrames(It.isAny())).returns(() => Promise.resolve());
-            browserAdapterMock.setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.reject(testError));
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToFrames(It.isAny()))
+                .returns(() => Promise.resolve());
+            browserAdapterMock
+                .setup(ba => ba.sendMessageToTab(It.isAny(), It.isAny()))
+                .returns(() => Promise.reject(testError));
 
             loggerMock.setup(m => m.error(expectedMessage)).verifiable(Times.once());
 

--- a/src/tests/unit/tests/background/browser-permissions-tracker.test.ts
+++ b/src/tests/unit/tests/background/browser-permissions-tracker.test.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { SetAllUrlsPermissionStatePayload } from 'background/actions/action-payloads';
-import { allUrlAndFilePermissions, BrowserPermissionsTracker, permissionsCheckErrorMessage } from 'background/browser-permissions-tracker';
+import {
+    allUrlAndFilePermissions,
+    BrowserPermissionsTracker,
+    permissionsCheckErrorMessage,
+} from 'background/browser-permissions-tracker';
 import { Interpreter } from 'background/interpreter';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { Logger } from 'common/logging/logger';
@@ -21,15 +25,25 @@ describe('BrowserPermissionsTracker', () => {
         loggerMock = Mock.ofType<Logger>();
         browserAdapterMock = createBrowserAdapterMock();
 
-        testSubject = new BrowserPermissionsTracker(browserAdapterMock.object, interpreterMock.object, loggerMock.object);
+        testSubject = new BrowserPermissionsTracker(
+            browserAdapterMock.object,
+            interpreterMock.object,
+            loggerMock.object,
+        );
     });
 
     describe('initialize', () => {
         it('registers the expected listeners', async () => {
             await testSubject.initialize();
 
-            browserAdapterMock.verify(adapter => adapter.addListenerOnPermissionsAdded(It.is(isFunction)), Times.once());
-            browserAdapterMock.verify(adapter => adapter.addListenerOnPermissionsRemoved(It.is(isFunction)), Times.once());
+            browserAdapterMock.verify(
+                adapter => adapter.addListenerOnPermissionsAdded(It.is(isFunction)),
+                Times.once(),
+            );
+            browserAdapterMock.verify(
+                adapter => adapter.addListenerOnPermissionsRemoved(It.is(isFunction)),
+                Times.once(),
+            );
         });
     });
 

--- a/src/tests/unit/tests/background/completed-test-step-telemetry-creator.test.ts
+++ b/src/tests/unit/tests/background/completed-test-step-telemetry-creator.test.ts
@@ -15,7 +15,10 @@ import { Message } from '../../../../common/message';
 import { Messages } from '../../../../common/messages';
 import { TelemetryDataFactory } from '../../../../common/telemetry-data-factory';
 import { ManualTestStatus } from '../../../../common/types/manual-test-status';
-import { AssessmentData, AssessmentStoreData } from '../../../../common/types/store-data/assessment-result-data';
+import {
+    AssessmentData,
+    AssessmentStoreData,
+} from '../../../../common/types/store-data/assessment-result-data';
 import { TabStoreData } from '../../../../common/types/store-data/tab-store-data';
 import { CreateTestAssessmentProvider } from '../../common/test-assessment-provider';
 
@@ -49,7 +52,9 @@ function testBeforeAfterAssessmentData(
 
     telemetryFactoryMock
         .setup(m => m.forRequirementStatus(It.isAny(), It.isAny(), It.isAny(), It.isAny()))
-        .returns((viz, step, passed, instances) => getMockTelemetryData(viz, step, passed, instances))
+        .returns((viz, step, passed, instances) =>
+            getMockTelemetryData(viz, step, passed, instances),
+        )
         .verifiable(Times.atLeastOnce());
 
     let callback;
@@ -87,7 +92,8 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
     test('initialize: onAssessmentChange, telemetry sent because one test step switches to PASS', () => {
         const before = getMockAssessmentStoreDataUnknowns();
         const after = getMockAssessmentStoreDataUnknowns();
-        after.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult = ManualTestStatus.PASS;
+        after.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult =
+            ManualTestStatus.PASS;
 
         const expectedTelemetry = getMockTelemetryData(-1, 'assessment-1-step-1', true, 1);
         testBeforeAfterAssessmentData(expectedTelemetry, Times.once(), before, after);
@@ -96,7 +102,8 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
     test('initialize: onAssessmentChange, no telemetry sent because tabId is null', () => {
         const before = getMockAssessmentStoreDataUnknowns();
         const after = getMockAssessmentStoreDataUnknowns();
-        after.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult = ManualTestStatus.PASS;
+        after.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult =
+            ManualTestStatus.PASS;
         after.persistedTabInfo = null;
 
         const expectedTelemetry = getMockTelemetryData(-1, 'assessment-1-step-1', true, 1);
@@ -106,7 +113,8 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
     test('initialize: onAssessmentChange, telemetry sent because one manual test step switches to FAIL with failure instance', () => {
         const before = getMockAssessmentStoreDataUnknowns();
         const after = getMockAssessmentStoreDataUnknowns();
-        after.assessments['assessment-1'].testStepStatus['assessment-1-step-2'].stepFinalResult = ManualTestStatus.FAIL;
+        after.assessments['assessment-1'].testStepStatus['assessment-1-step-2'].stepFinalResult =
+            ManualTestStatus.FAIL;
 
         const expectedTelemetry = getMockTelemetryData(-1, 'assessment-1-step-2', false, 1);
         testBeforeAfterAssessmentData(expectedTelemetry, Times.once(), before, after);
@@ -114,7 +122,8 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
 
     test('initialize: onAssessmentChange, no telemetry sent because one test step switches from PASS to UNKNOWN', () => {
         const before = getMockAssessmentStoreDataUnknowns();
-        before.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult = ManualTestStatus.PASS;
+        before.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult =
+            ManualTestStatus.PASS;
         const after = getMockAssessmentStoreDataUnknowns();
 
         const expectedTelemetry = getMockTelemetryData(-1, 'assessment-1-step-1', true, 1);
@@ -124,7 +133,8 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
     test('initialize: onAssessmentChange, telemetry sent because one test step switches from UNKNOWN to FAIL', () => {
         const before = getMockAssessmentStoreDataUnknowns();
         const after = getMockAssessmentStoreDataUnknowns();
-        after.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult = ManualTestStatus.FAIL;
+        after.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult =
+            ManualTestStatus.FAIL;
 
         const expectedTelemetry = getMockTelemetryData(-1, 'assessment-1-step-1', false, 1);
         testBeforeAfterAssessmentData(expectedTelemetry, Times.once(), before, after);
@@ -132,7 +142,8 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
 
     test('initialize: onAssessmentChange, no telemetry sent because one test step switches from FAIL to UNKNOWN', () => {
         const before = getMockAssessmentStoreDataUnknowns();
-        before.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult = ManualTestStatus.FAIL;
+        before.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult =
+            ManualTestStatus.FAIL;
         const after = getMockAssessmentStoreDataUnknowns();
 
         const expectedTelemetry = getMockTelemetryData(-1, 'assessment-1-step-1', false, 1);
@@ -141,9 +152,11 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
 
     test('initialize: onAssessmentChange, no telemetry sent because one test step remains PASS and PASS', () => {
         const before = getMockAssessmentStoreDataUnknowns();
-        before.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult = ManualTestStatus.PASS;
+        before.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult =
+            ManualTestStatus.PASS;
         const after = getMockAssessmentStoreDataUnknowns();
-        after.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult = ManualTestStatus.PASS;
+        after.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult =
+            ManualTestStatus.PASS;
 
         const expectedTelemetry = getMockTelemetryData(-1, 'assessment-1-step-1', true, 1);
         testBeforeAfterAssessmentData(expectedTelemetry, Times.never(), before, after);
@@ -152,8 +165,10 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
     test('initialize: onAssessmentChange, single telemetry sent because two test steps switch from UNKNOWN to PASS', () => {
         const before = getMockAssessmentStoreDataUnknowns();
         const after = getMockAssessmentStoreDataUnknowns();
-        after.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult = ManualTestStatus.PASS;
-        after.assessments['assessment-1'].testStepStatus['assessment-1-step-2'].stepFinalResult = ManualTestStatus.PASS;
+        after.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult =
+            ManualTestStatus.PASS;
+        after.assessments['assessment-1'].testStepStatus['assessment-1-step-2'].stepFinalResult =
+            ManualTestStatus.PASS;
 
         const expectedTelemetry = getMockTelemetryData(-1, 'assessment-1-step-1', true, 1);
         testBeforeAfterAssessmentData(expectedTelemetry, Times.once(), before, after);
@@ -187,7 +202,9 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
         const expectedMessage: Message = {
             messageType: Messages.Telemetry.Send,
         };
-        interpreterMock.setup(im => im.interpret(It.isValue(expectedMessage))).verifiable(Times.never());
+        interpreterMock
+            .setup(im => im.interpret(It.isValue(expectedMessage)))
+            .verifiable(Times.never());
 
         testSubject.initialize();
         callback();
@@ -232,7 +249,9 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
 
         telemetryFactoryMock
             .setup(m => m.forRequirementStatus(It.isAny(), It.isAny(), It.isAny(), It.isAny()))
-            .returns((viz, step, passed, instances) => getMockTelemetryData(viz, step, passed, instances))
+            .returns((viz, step, passed, instances) =>
+                getMockTelemetryData(viz, step, passed, instances),
+            )
             .verifiable();
 
         assessmentStoreMock
@@ -247,10 +266,13 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
             .returns(() => data)
             .verifiable(Times.atLeastOnce());
 
-        interpreterMock.setup(im => im.interpret(It.isValue(expectedMessage))).verifiable(Times.once());
+        interpreterMock
+            .setup(im => im.interpret(It.isValue(expectedMessage)))
+            .verifiable(Times.once());
 
         testSubject.initialize();
-        data.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult = ManualTestStatus.PASS;
+        data.assessments['assessment-1'].testStepStatus['assessment-1-step-1'].stepFinalResult =
+            ManualTestStatus.PASS;
         callback();
 
         assessmentStoreMock.verifyAll();
@@ -258,7 +280,12 @@ describe('CompletedTestStepTelemetryCreatorTest', () => {
     });
 });
 
-function getMockTelemetryData(test: number, requirement: string, passed: boolean, instances: number): RequirementStatusTelemetryData {
+function getMockTelemetryData(
+    test: number,
+    requirement: string,
+    passed: boolean,
+    instances: number,
+): RequirementStatusTelemetryData {
     return {
         selectedRequirement: requirement,
         selectedTest: test.toString(),
@@ -274,9 +301,18 @@ function getMockAssessmentStoreDataUnknowns(): AssessmentStoreData {
         'assessment-1': {
             fullAxeResultsMap: null,
             testStepStatus: {
-                'assessment-1-step-1': { stepFinalResult: ManualTestStatus.UNKNOWN, isStepScanned: false },
-                'assessment-1-step-2': { stepFinalResult: ManualTestStatus.UNKNOWN, isStepScanned: false },
-                'assessment-1-step-3': { stepFinalResult: ManualTestStatus.UNKNOWN, isStepScanned: false },
+                'assessment-1-step-1': {
+                    stepFinalResult: ManualTestStatus.UNKNOWN,
+                    isStepScanned: false,
+                },
+                'assessment-1-step-2': {
+                    stepFinalResult: ManualTestStatus.UNKNOWN,
+                    isStepScanned: false,
+                },
+                'assessment-1-step-3': {
+                    stepFinalResult: ManualTestStatus.UNKNOWN,
+                    isStepScanned: false,
+                },
             },
             generatedAssessmentInstancesMap: {
                 h1: {
@@ -318,8 +354,14 @@ function getMockAssessmentStoreDataUnknowns(): AssessmentStoreData {
         'assessment-2': {
             fullAxeResultsMap: null,
             testStepStatus: {
-                'assessment-2-step-1': { stepFinalResult: ManualTestStatus.UNKNOWN, isStepScanned: false },
-                'assessment-2-step-2': { stepFinalResult: ManualTestStatus.UNKNOWN, isStepScanned: false },
+                'assessment-2-step-1': {
+                    stepFinalResult: ManualTestStatus.UNKNOWN,
+                    isStepScanned: false,
+                },
+                'assessment-2-step-2': {
+                    stepFinalResult: ManualTestStatus.UNKNOWN,
+                    isStepScanned: false,
+                },
             },
             generatedAssessmentInstancesMap: {
                 h1: {

--- a/src/tests/unit/tests/background/content-script-injector.test.ts
+++ b/src/tests/unit/tests/background/content-script-injector.test.ts
@@ -17,7 +17,10 @@ describe('ContentScriptInjector', () => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         promiseFactoryMock = Mock.ofType<PromiseFactory>();
 
-        testSubject = new ContentScriptInjector(browserAdapterMock.object, promiseFactoryMock.object);
+        testSubject = new ContentScriptInjector(
+            browserAdapterMock.object,
+            promiseFactoryMock.object,
+        );
     });
 
     it('uses a timeout promise with the expected timeout constant', async () => {
@@ -32,14 +35,18 @@ describe('ContentScriptInjector', () => {
     });
 
     it('rejects if a timeout occurs', async () => {
-        promiseFactoryMock.setup(factory => factory.timeout(It.isAny(), It.isAny())).returns(() => Promise.reject('artificial timeout'));
+        promiseFactoryMock
+            .setup(factory => factory.timeout(It.isAny(), It.isAny()))
+            .returns(() => Promise.reject('artificial timeout'));
 
         await expect(testSubject.injectScripts(testTabId)).rejects.toBe('artificial timeout');
     });
 
     describe('when no timeout occurs', () => {
         beforeEach(() => {
-            promiseFactoryMock.setup(factory => factory.timeout(It.isAny(), It.isAny())).returns(originalPromise => originalPromise);
+            promiseFactoryMock
+                .setup(factory => factory.timeout(It.isAny(), It.isAny()))
+                .returns(originalPromise => originalPromise);
         });
 
         it('injects each CSS file once with the expected parameters', async () => {
@@ -47,7 +54,9 @@ describe('ContentScriptInjector', () => {
 
             ContentScriptInjector.cssFiles.forEach(cssFile => {
                 const expectedDetails = { allFrames: true, file: cssFile };
-                browserAdapterMock.setup(adapter => adapter.insertCSSInTab(testTabId, expectedDetails)).returns(() => Promise.resolve());
+                browserAdapterMock
+                    .setup(adapter => adapter.insertCSSInTab(testTabId, expectedDetails))
+                    .returns(() => Promise.resolve());
             });
 
             await testSubject.injectScripts(testTabId);
@@ -59,7 +68,11 @@ describe('ContentScriptInjector', () => {
             setupInsertCSSToSucceedImmediately();
 
             ContentScriptInjector.jsFiles.forEach(jsFile => {
-                const expectedDetails: ExtensionTypes.InjectDetails = { allFrames: true, file: jsFile, runAt: 'document_start' };
+                const expectedDetails: ExtensionTypes.InjectDetails = {
+                    allFrames: true,
+                    file: jsFile,
+                    runAt: 'document_start',
+                };
                 browserAdapterMock
                     .setup(adapter => adapter.executeScriptInTab(testTabId, expectedDetails))
                     .returns(() => Promise.resolve([]));
@@ -78,7 +91,12 @@ describe('ContentScriptInjector', () => {
             // simulate JS injection taking a while,
             // only completing asynchronously when we explicitly invoke the resolve function from the returned promise
             browserAdapterMock
-                .setup(adapter => adapter.executeScriptInTab(It.isAny(), It.isObjectWith({ file: ContentScriptInjector.jsFiles[0] })))
+                .setup(adapter =>
+                    adapter.executeScriptInTab(
+                        It.isAny(),
+                        It.isObjectWith({ file: ContentScriptInjector.jsFiles[0] }),
+                    ),
+                )
                 .returns(
                     () =>
                         new Promise(resolve => {
@@ -110,11 +128,15 @@ describe('ContentScriptInjector', () => {
         });
 
         function setupInsertCSSToSucceedImmediately(): void {
-            browserAdapterMock.setup(adapter => adapter.insertCSSInTab(It.isAny(), It.isAny())).returns(() => Promise.resolve());
+            browserAdapterMock
+                .setup(adapter => adapter.insertCSSInTab(It.isAny(), It.isAny()))
+                .returns(() => Promise.resolve());
         }
 
         function setupExecuteScriptToSucceedImmediately(): void {
-            browserAdapterMock.setup(adapter => adapter.executeScriptInTab(It.isAny(), It.isAny())).returns(() => Promise.resolve([]));
+            browserAdapterMock
+                .setup(adapter => adapter.executeScriptInTab(It.isAny(), It.isAny()))
+                .returns(() => Promise.resolve([]));
         }
     });
 });

--- a/src/tests/unit/tests/background/create-initial-assessment-test-data.test.ts
+++ b/src/tests/unit/tests/background/create-initial-assessment-test-data.test.ts
@@ -7,13 +7,18 @@ import {
     createInitialAssessmentTestData,
 } from 'background/create-initial-assessment-test-data';
 import { ManualTestStatus, TestStepData } from '../../../../common/types/manual-test-status';
-import { GeneratedAssessmentInstance, ManualTestStepResult } from '../../../../common/types/store-data/assessment-result-data';
+import {
+    GeneratedAssessmentInstance,
+    ManualTestStepResult,
+} from '../../../../common/types/store-data/assessment-result-data';
 import { CreateTestAssessmentProvider } from '../../common/test-assessment-provider';
 
 describe('createInitialAssessmentTestData', () => {
     const assessmentsProvider = CreateTestAssessmentProvider();
     const knownTestIds = assessmentsProvider.all().map(test => test.key);
-    const knownRequirementIds = flatMap(assessmentsProvider.all(), test => test.requirements.map(step => step.key));
+    const knownRequirementIds = flatMap(assessmentsProvider.all(), test =>
+        test.requirements.map(step => step.key),
+    );
     const knownRequirement1 = knownRequirementIds[0];
     const knownRequirement2 = knownRequirementIds[1];
     const knownRequirement3 = knownRequirementIds[2];
@@ -28,33 +33,54 @@ describe('createInitialAssessmentTestData', () => {
             id1: createGeneratedAssessmentInstance('id1', [knownRequirement1]),
         };
 
-        const actual = createInitialAssessmentTestData(assessmentsProvider.forKey(knownTestIds[0]), {
-            fullAxeResultsMap: null,
-            generatedAssessmentInstancesMap: persistedMap,
-            manualTestStepResultMap: {},
-            testStepStatus: {},
-        });
+        const actual = createInitialAssessmentTestData(
+            assessmentsProvider.forKey(knownTestIds[0]),
+            {
+                fullAxeResultsMap: null,
+                generatedAssessmentInstancesMap: persistedMap,
+                manualTestStepResultMap: {},
+                testStepStatus: {},
+            },
+        );
 
         expect(actual.generatedAssessmentInstancesMap).toEqual(expectedMap);
     });
 
     it('outputs manualTestStepResultMap entries for only known assessments, propagating results for the persisted ones', () => {
         const persistedMap = {
-            [knownRequirement1]: createManualRequirementResult(knownRequirement1, ManualTestStatus.FAIL),
-            [unknownRequirement]: createManualRequirementResult(unknownRequirement, ManualTestStatus.FAIL),
+            [knownRequirement1]: createManualRequirementResult(
+                knownRequirement1,
+                ManualTestStatus.FAIL,
+            ),
+            [unknownRequirement]: createManualRequirementResult(
+                unknownRequirement,
+                ManualTestStatus.FAIL,
+            ),
         };
         const expectedMap = {
-            [knownRequirement1]: createManualRequirementResult(knownRequirement1, ManualTestStatus.FAIL),
-            [knownRequirement2]: createManualRequirementResult(knownRequirement2, ManualTestStatus.UNKNOWN),
-            [knownRequirement3]: createManualRequirementResult(knownRequirement3, ManualTestStatus.UNKNOWN),
+            [knownRequirement1]: createManualRequirementResult(
+                knownRequirement1,
+                ManualTestStatus.FAIL,
+            ),
+            [knownRequirement2]: createManualRequirementResult(
+                knownRequirement2,
+                ManualTestStatus.UNKNOWN,
+            ),
+            [knownRequirement3]: createManualRequirementResult(
+                knownRequirement3,
+                ManualTestStatus.UNKNOWN,
+            ),
         };
 
-        const actual = createInitialAssessmentTestData(assessmentsProvider.forKey(knownTestIds[0]), {
-            fullAxeResultsMap: null,
-            generatedAssessmentInstancesMap: {},
-            manualTestStepResultMap: persistedMap,
-            testStepStatus: {},
-        });
+        const actual = createInitialAssessmentTestData(
+            assessmentsProvider.forKey(knownTestIds[0]),
+            {
+                fullAxeResultsMap: null,
+                generatedAssessmentInstancesMap: {},
+                manualTestStepResultMap: persistedMap,
+                testStepStatus: {},
+            },
+        );
 
         expect(actual.manualTestStepResultMap).toEqual(expectedMap);
     });
@@ -70,12 +96,15 @@ describe('createInitialAssessmentTestData', () => {
             [knownRequirement3]: createDefaultRequirementResult(),
         };
 
-        const actual = createInitialAssessmentTestData(assessmentsProvider.forKey(knownTestIds[0]), {
-            fullAxeResultsMap: null,
-            generatedAssessmentInstancesMap: {},
-            manualTestStepResultMap: {},
-            testStepStatus: persistedTestStepStatus,
-        });
+        const actual = createInitialAssessmentTestData(
+            assessmentsProvider.forKey(knownTestIds[0]),
+            {
+                fullAxeResultsMap: null,
+                generatedAssessmentInstancesMap: {},
+                manualTestStepResultMap: {},
+                testStepStatus: persistedTestStepStatus,
+            },
+        );
 
         expect(actual.testStepStatus).toEqual(expectedTestStepStatus);
     });
@@ -84,7 +113,9 @@ describe('createInitialAssessmentTestData', () => {
 describe('createAutomatedChecksInitialAssessmentTestData', () => {
     const assessmentsProvider = CreateTestAssessmentProvider();
     const knownTestIds = assessmentsProvider.all().map(test => test.key);
-    const knownRequirementIds = flatMap(assessmentsProvider.all(), test => test.requirements.map(step => step.key));
+    const knownRequirementIds = flatMap(assessmentsProvider.all(), test =>
+        test.requirements.map(step => step.key),
+    );
     const knownRequirement1 = knownRequirementIds[0];
     const knownRequirement2 = knownRequirementIds[1];
     const knownRequirement3 = knownRequirementIds[2];
@@ -98,16 +129,28 @@ describe('createAutomatedChecksInitialAssessmentTestData', () => {
             [knownRequirement3]: createDefaultRequirementResult(),
         };
         const expectedManual = {
-            [knownRequirement1]: createManualRequirementResult(knownRequirement1, ManualTestStatus.UNKNOWN),
-            [knownRequirement2]: createManualRequirementResult(knownRequirement2, ManualTestStatus.UNKNOWN),
-            [knownRequirement3]: createManualRequirementResult(knownRequirement3, ManualTestStatus.UNKNOWN),
+            [knownRequirement1]: createManualRequirementResult(
+                knownRequirement1,
+                ManualTestStatus.UNKNOWN,
+            ),
+            [knownRequirement2]: createManualRequirementResult(
+                knownRequirement2,
+                ManualTestStatus.UNKNOWN,
+            ),
+            [knownRequirement3]: createManualRequirementResult(
+                knownRequirement3,
+                ManualTestStatus.UNKNOWN,
+            ),
         };
-        const actual = createAutomatedChecksInitialAssessmentTestData(assessmentsProvider.forKey(knownTestIds[0]), {
-            fullAxeResultsMap: null,
-            generatedAssessmentInstancesMap: persistedMap,
-            manualTestStepResultMap: {},
-            testStepStatus: {},
-        });
+        const actual = createAutomatedChecksInitialAssessmentTestData(
+            assessmentsProvider.forKey(knownTestIds[0]),
+            {
+                fullAxeResultsMap: null,
+                generatedAssessmentInstancesMap: persistedMap,
+                manualTestStepResultMap: {},
+                testStepStatus: {},
+            },
+        );
 
         expect(actual.generatedAssessmentInstancesMap).toEqual(null);
         expect(actual.manualTestStepResultMap).toEqual(expectedManual);
@@ -126,12 +169,24 @@ describe('createAutomatedChecksInitialAssessmentTestData', () => {
             [knownRequirement3]: createRequirementResult(true, ManualTestStatus.PASS),
         };
         const persistedManual = {
-            [knownRequirement1]: createManualRequirementResult(knownRequirement1, ManualTestStatus.FAIL),
+            [knownRequirement1]: createManualRequirementResult(
+                knownRequirement1,
+                ManualTestStatus.FAIL,
+            ),
         };
         const expectedManual = {
-            [knownRequirement1]: createManualRequirementResult(knownRequirement1, ManualTestStatus.FAIL),
-            [knownRequirement2]: createManualRequirementResult(knownRequirement2, ManualTestStatus.UNKNOWN),
-            [knownRequirement3]: createManualRequirementResult(knownRequirement3, ManualTestStatus.UNKNOWN),
+            [knownRequirement1]: createManualRequirementResult(
+                knownRequirement1,
+                ManualTestStatus.FAIL,
+            ),
+            [knownRequirement2]: createManualRequirementResult(
+                knownRequirement2,
+                ManualTestStatus.UNKNOWN,
+            ),
+            [knownRequirement3]: createManualRequirementResult(
+                knownRequirement3,
+                ManualTestStatus.UNKNOWN,
+            ),
         };
         const persistedGenerated = {
             id1: createGeneratedAssessmentInstance('id1', [knownRequirement1, unknownRequirement]),
@@ -140,12 +195,15 @@ describe('createAutomatedChecksInitialAssessmentTestData', () => {
             id1: createGeneratedAssessmentInstance('id1', [knownRequirement1]),
         };
 
-        const actual = createAutomatedChecksInitialAssessmentTestData(assessmentsProvider.forKey(knownTestIds[0]), {
-            fullAxeResultsMap: null,
-            generatedAssessmentInstancesMap: persistedGenerated,
-            manualTestStepResultMap: persistedManual,
-            testStepStatus: persistedTestStepStatus,
-        });
+        const actual = createAutomatedChecksInitialAssessmentTestData(
+            assessmentsProvider.forKey(knownTestIds[0]),
+            {
+                fullAxeResultsMap: null,
+                generatedAssessmentInstancesMap: persistedGenerated,
+                manualTestStepResultMap: persistedManual,
+                testStepStatus: persistedTestStepStatus,
+            },
+        );
 
         expect(actual.manualTestStepResultMap).toEqual(expectedManual);
         expect(actual.generatedAssessmentInstancesMap).toEqual(expectedGenerated);
@@ -164,24 +222,39 @@ describe('createAutomatedChecksInitialAssessmentTestData', () => {
             [knownRequirement3]: createDefaultRequirementResult(),
         };
         const persistedManual = {
-            [knownRequirement1]: createManualRequirementResult(knownRequirement1, ManualTestStatus.FAIL),
+            [knownRequirement1]: createManualRequirementResult(
+                knownRequirement1,
+                ManualTestStatus.FAIL,
+            ),
         };
         const expectedManual = {
-            [knownRequirement1]: createManualRequirementResult(knownRequirement1, ManualTestStatus.UNKNOWN),
-            [knownRequirement2]: createManualRequirementResult(knownRequirement2, ManualTestStatus.UNKNOWN),
-            [knownRequirement3]: createManualRequirementResult(knownRequirement3, ManualTestStatus.UNKNOWN),
+            [knownRequirement1]: createManualRequirementResult(
+                knownRequirement1,
+                ManualTestStatus.UNKNOWN,
+            ),
+            [knownRequirement2]: createManualRequirementResult(
+                knownRequirement2,
+                ManualTestStatus.UNKNOWN,
+            ),
+            [knownRequirement3]: createManualRequirementResult(
+                knownRequirement3,
+                ManualTestStatus.UNKNOWN,
+            ),
         };
         const persistedGenerated = {
             id1: createGeneratedAssessmentInstance('id1', [knownRequirement1, unknownRequirement]),
         };
         const expectedGenerated = null;
 
-        const actual = createAutomatedChecksInitialAssessmentTestData(assessmentsProvider.forKey(knownTestIds[0]), {
-            fullAxeResultsMap: null,
-            generatedAssessmentInstancesMap: persistedGenerated,
-            manualTestStepResultMap: persistedManual,
-            testStepStatus: persistedTestStepStatus,
-        });
+        const actual = createAutomatedChecksInitialAssessmentTestData(
+            assessmentsProvider.forKey(knownTestIds[0]),
+            {
+                fullAxeResultsMap: null,
+                generatedAssessmentInstancesMap: persistedGenerated,
+                manualTestStepResultMap: persistedManual,
+                testStepStatus: persistedTestStepStatus,
+            },
+        );
 
         expect(actual.manualTestStepResultMap).toEqual(expectedManual);
         expect(actual.generatedAssessmentInstancesMap).toEqual(expectedGenerated);
@@ -200,7 +273,10 @@ function createDefaultRequirementResult(): TestStepData {
     return createRequirementResult(false, ManualTestStatus.UNKNOWN);
 }
 
-function createManualRequirementResult(requirementId: string, status: number): ManualTestStepResult {
+function createManualRequirementResult(
+    requirementId: string,
+    status: number,
+): ManualTestStepResult {
     return {
         id: requirementId,
         instances: [],
@@ -208,7 +284,10 @@ function createManualRequirementResult(requirementId: string, status: number): M
     };
 }
 
-function createGeneratedAssessmentInstance(instanceId: string, requirementIds: string[]): GeneratedAssessmentInstance {
+function createGeneratedAssessmentInstance(
+    instanceId: string,
+    requirementIds: string[],
+): GeneratedAssessmentInstance {
     const instanceData = {
         target: [],
         html: 'html',

--- a/src/tests/unit/tests/background/dev-tools-listener.test.ts
+++ b/src/tests/unit/tests/background/dev-tools-listener.test.ts
@@ -7,7 +7,10 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { ConnectionNames } from '../../../../common/constants/connection-names';
 import { Messages } from '../../../../common/messages';
 import { DevToolsOpenMessage } from '../../../../common/types/dev-tools-open-message';
-import { DevToolsChromeAdapterMock, PortWithTabTabIdStub } from '../../mock-helpers/dev-tools-chrome-adapter-mock';
+import {
+    DevToolsChromeAdapterMock,
+    PortWithTabTabIdStub,
+} from '../../mock-helpers/dev-tools-chrome-adapter-mock';
 import { PortOnDisconnectMock } from '../../mock-helpers/port-on-disconnect-mock';
 import { PortOnMessageMock } from '../../mock-helpers/port-on-message-mock';
 
@@ -26,7 +29,10 @@ describe('DevToolsListenerTests', () => {
             2: new TabContext(tabId2InterpreterMock.object, null),
         };
         devToolsChromeAdapterMock = new DevToolsChromeAdapterMock();
-        testSubject = new DevToolsListener(tabIdToContextMap, devToolsChromeAdapterMock.getObject());
+        testSubject = new DevToolsListener(
+            tabIdToContextMap,
+            devToolsChromeAdapterMock.getObject(),
+        );
     });
 
     test('initialize - ignore non-dev tools connections', () => {

--- a/src/tests/unit/tests/background/extension-details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/extension-details-view-controller.test.ts
@@ -9,7 +9,11 @@ describe('ExtensionDetailsViewController', () => {
     let browserAdapterMock: IMock<BrowserAdapter>;
     let testSubject: ExtensionDetailsViewController;
     let onTabRemoveCallback: (tabId: number, removeInfo: chrome.tabs.TabRemoveInfo) => void;
-    let onUpdateTabCallback: (tabId: number, changeInfo: chrome.tabs.TabChangeInfo, tab: chrome.tabs.Tab) => void;
+    let onUpdateTabCallback: (
+        tabId: number,
+        changeInfo: chrome.tabs.TabChangeInfo,
+        tab: chrome.tabs.Tab,
+    ) => void;
 
     beforeEach(() => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
@@ -73,7 +77,9 @@ describe('ExtensionDetailsViewController', () => {
             browserAdapterMock.reset();
 
             const errorMessage = 'switchToTab failed with dummy error';
-            browserAdapterMock.setup(adapter => adapter.switchToTab(detailsViewTabId)).returns(() => Promise.reject(errorMessage));
+            browserAdapterMock
+                .setup(adapter => adapter.switchToTab(detailsViewTabId))
+                .returns(() => Promise.reject(errorMessage));
 
             await expect(testSubject.showDetailsView(targetTabId)).rejects.toEqual(errorMessage);
 
@@ -85,7 +91,11 @@ describe('ExtensionDetailsViewController', () => {
             const errorMessage = 'error creating new window (from browser adapter)';
 
             browserAdapterMock
-                .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId))
+                .setup(adapter =>
+                    adapter.createTabInNewWindow(
+                        'DetailsView/detailsView.html?tabId=' + targetTabId,
+                    ),
+                )
                 .returns(() => Promise.reject(errorMessage))
                 .verifiable(Times.once());
 
@@ -123,7 +133,9 @@ describe('ExtensionDetailsViewController', () => {
         const detailsViewTabId = 10;
 
         const detailsViewRemovedHandlerMock = Mock.ofInstance((tabId: number) => {});
-        detailsViewRemovedHandlerMock.setup(handler => handler(targetTabId)).verifiable(Times.once());
+        detailsViewRemovedHandlerMock
+            .setup(handler => handler(targetTabId))
+            .verifiable(Times.once());
 
         testSubject.setupDetailsViewTabRemovedHandler(detailsViewRemovedHandlerMock.object);
 
@@ -137,7 +149,11 @@ describe('ExtensionDetailsViewController', () => {
         // update details tab
         browserAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => 'ext_id');
 
-        onUpdateTabCallback(detailsViewTabId, { url: 'www.bing.com/DetailsView/detailsView.html?tabId=' + targetTabId }, null);
+        onUpdateTabCallback(
+            detailsViewTabId,
+            { url: 'www.bing.com/DetailsView/detailsView.html?tabId=' + targetTabId },
+            null,
+        );
 
         setupCreateDetailsViewForAnyUrl(Times.once());
 
@@ -162,7 +178,11 @@ describe('ExtensionDetailsViewController', () => {
         // update details tab
         const extensionId = 'ext_id';
         browserAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
-        onUpdateTabCallback(detailsViewTabId, { url: 'chromeExt://ext_id/DetailsView/detailsView.html?tabId=90' }, null);
+        onUpdateTabCallback(
+            detailsViewTabId,
+            { url: 'chromeExt://ext_id/DetailsView/detailsView.html?tabId=90' },
+            null,
+        );
 
         setupCreateDetailsViewForAnyUrl(Times.once());
 
@@ -186,7 +206,11 @@ describe('ExtensionDetailsViewController', () => {
         // update details tab
         const extensionId = 'ext_id';
         browserAdapterMock.setup(adapter => adapter.getRunTimeId()).returns(() => extensionId);
-        onUpdateTabCallback(detailsViewTabId, { url: 'chromeExt://ext_Id/detailsView/detailsView.html?tabId=' + targetTabId }, null);
+        onUpdateTabCallback(
+            detailsViewTabId,
+            { url: 'chromeExt://ext_Id/detailsView/detailsView.html?tabId=' + targetTabId },
+            null,
+        );
 
         setupCreateDetailsViewForAnyUrl(Times.never());
         setupSwitchToTab(detailsViewTabId);
@@ -272,7 +296,9 @@ describe('ExtensionDetailsViewController', () => {
         setupCreateDetailsView(targetTabId, detailsViewTabId);
 
         const detailsViewRemovedHandlerMock = Mock.ofInstance((tabId: number) => {});
-        detailsViewRemovedHandlerMock.setup(handler => handler(targetTabId)).verifiable(Times.once());
+        detailsViewRemovedHandlerMock
+            .setup(handler => handler(targetTabId))
+            .verifiable(Times.once());
         testSubject.setupDetailsViewTabRemovedHandler(detailsViewRemovedHandlerMock.object);
 
         // call show details once
@@ -338,12 +364,16 @@ describe('ExtensionDetailsViewController', () => {
     });
 
     const setupSwitchToTab = (tabId: number) => {
-        return browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.resolve());
+        return browserAdapterMock
+            .setup(adapter => adapter.switchToTab(tabId))
+            .returns(() => Promise.resolve());
     };
 
     const setupCreateDetailsView = (targetTabId: number, resultingDetailsViewTabId: number) => {
         return browserAdapterMock
-            .setup(adapter => adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId))
+            .setup(adapter =>
+                adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId),
+            )
             .returns(() => Promise.resolve({ id: resultingDetailsViewTabId } as Tabs.Tab));
     };
 

--- a/src/tests/unit/tests/background/feature-flags-controller.test.ts
+++ b/src/tests/unit/tests/background/feature-flags-controller.test.ts
@@ -32,7 +32,10 @@ describe('FeatureFlagsControllerTest', () => {
             .returns(() => storeDataStub)
             .verifiable(Times.exactly(3));
 
-        testObject = new FeatureFlagsController(featureFlagStoreMock.object, interpreterMock.object);
+        testObject = new FeatureFlagsController(
+            featureFlagStoreMock.object,
+            interpreterMock.object,
+        );
 
         expect(testObject.isEnabled(FeatureFlags.logTelemetryToConsole)).toBeFalsy();
         expect(testObject.isEnabled('testFeatureFlag')).toBeTruthy();
@@ -53,7 +56,10 @@ describe('FeatureFlagsControllerTest', () => {
             })
             .verifiable();
 
-        testObject = new FeatureFlagsController(featureFlagStoreMock.object, interpreterMock.object);
+        testObject = new FeatureFlagsController(
+            featureFlagStoreMock.object,
+            interpreterMock.object,
+        );
         expect(testObject.listFeatureFlags()).toEqual(storeDataStub);
         featureFlagStoreMock.verifyAll();
     });
@@ -78,8 +84,13 @@ describe('FeatureFlagsControllerTest', () => {
             .setup(f => f.getState())
             .returns(() => storeDataStub)
             .verifiable();
-        testObject = new FeatureFlagsController(featureFlagStoreMock.object, interpreterMock.object);
-        const storeState = enabled ? testObject.enableFeature(feature) : testObject.disableFeature(feature);
+        testObject = new FeatureFlagsController(
+            featureFlagStoreMock.object,
+            interpreterMock.object,
+        );
+        const storeState = enabled
+            ? testObject.enableFeature(feature)
+            : testObject.disableFeature(feature);
         expect(storeState).toEqual(storeDataStub);
         interpreterMock.verifyAll();
         featureFlagStoreMock.verifyAll();
@@ -92,7 +103,10 @@ describe('FeatureFlagsControllerTest', () => {
         };
         interpreterMock.setup(i => i.interpret(It.isObjectWith(message))).verifiable();
 
-        testObject = new FeatureFlagsController(featureFlagStoreMock.object, interpreterMock.object);
+        testObject = new FeatureFlagsController(
+            featureFlagStoreMock.object,
+            interpreterMock.object,
+        );
         testObject.resetFeatureFlags();
         interpreterMock.verifyAll();
     });

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FeatureFlags, getAllFeatureFlagDetails, getDefaultFeatureFlagValues } from 'common/feature-flags';
+import {
+    FeatureFlags,
+    getAllFeatureFlagDetails,
+    getDefaultFeatureFlagValues,
+} from 'common/feature-flags';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { findIndex, forEach, indexOf, keys } from 'lodash';
 

--- a/src/tests/unit/tests/background/get-persisted-data.test.ts
+++ b/src/tests/unit/tests/background/get-persisted-data.test.ts
@@ -6,7 +6,10 @@ import { IMock, Mock } from 'typemoq';
 
 import { InstallationData } from '../../../../background/installation-data';
 import { IndexedDBAPI } from '../../../../common/indexedDB/indexedDB';
-import { AssessmentStoreData, PersistedTabInfo } from '../../../../common/types/store-data/assessment-result-data';
+import {
+    AssessmentStoreData,
+    PersistedTabInfo,
+} from '../../../../common/types/store-data/assessment-result-data';
 import { UserConfigurationStoreData } from '../../../../common/types/store-data/user-configuration-store';
 
 describe('GetPersistedDataTest', () => {
@@ -38,12 +41,22 @@ describe('GetPersistedDataTest', () => {
     });
 
     it('propagates the results of IndexedDBAPI.getItem for the appropriate keys', async () => {
-        const indexedDataKeysToFetch = [IndexedDBDataKeys.assessmentStore, IndexedDBDataKeys.userConfiguration];
+        const indexedDataKeysToFetch = [
+            IndexedDBDataKeys.assessmentStore,
+            IndexedDBDataKeys.userConfiguration,
+        ];
 
-        indexedDBInstanceStrictMock.setup(i => i.getItem(IndexedDBDataKeys.assessmentStore)).returns(async () => assessmentStoreData);
-        indexedDBInstanceStrictMock.setup(i => i.getItem(IndexedDBDataKeys.userConfiguration)).returns(async () => userConfigurationData);
+        indexedDBInstanceStrictMock
+            .setup(i => i.getItem(IndexedDBDataKeys.assessmentStore))
+            .returns(async () => assessmentStoreData);
+        indexedDBInstanceStrictMock
+            .setup(i => i.getItem(IndexedDBDataKeys.userConfiguration))
+            .returns(async () => userConfigurationData);
 
-        const data = await getPersistedData(indexedDBInstanceStrictMock.object, indexedDataKeysToFetch);
+        const data = await getPersistedData(
+            indexedDBInstanceStrictMock.object,
+            indexedDataKeysToFetch,
+        );
 
         expect(data).toEqual({
             assessmentStoreData: assessmentStoreData,
@@ -52,12 +65,22 @@ describe('GetPersistedDataTest', () => {
     });
 
     it('uses specified data keys to read persisted data', async () => {
-        const indexedDataKeysToFetch = [IndexedDBDataKeys.userConfiguration, IndexedDBDataKeys.installation];
+        const indexedDataKeysToFetch = [
+            IndexedDBDataKeys.userConfiguration,
+            IndexedDBDataKeys.installation,
+        ];
 
-        indexedDBInstanceStrictMock.setup(i => i.getItem(IndexedDBDataKeys.userConfiguration)).returns(async () => userConfigurationData);
-        indexedDBInstanceStrictMock.setup(i => i.getItem(IndexedDBDataKeys.installation)).returns(async () => installationData);
+        indexedDBInstanceStrictMock
+            .setup(i => i.getItem(IndexedDBDataKeys.userConfiguration))
+            .returns(async () => userConfigurationData);
+        indexedDBInstanceStrictMock
+            .setup(i => i.getItem(IndexedDBDataKeys.installation))
+            .returns(async () => installationData);
 
-        const data = await getPersistedData(indexedDBInstanceStrictMock.object, indexedDataKeysToFetch);
+        const data = await getPersistedData(
+            indexedDBInstanceStrictMock.object,
+            indexedDataKeysToFetch,
+        );
 
         expect(data).toEqual({
             userConfigurationData: userConfigurationData,

--- a/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
+++ b/src/tests/unit/tests/background/global-action-creators/action-creator-test-helpers.ts
@@ -11,7 +11,11 @@ export const createActionMock = <Payload>(payload: Payload): IMock<Action<Payloa
     return actionMock;
 };
 
-export const createInterpreterMock = <Payload>(message: string, payload: Payload, tabId?: number): IMock<Interpreter> => {
+export const createInterpreterMock = <Payload>(
+    message: string,
+    payload: Payload,
+    tabId?: number,
+): IMock<Interpreter> => {
     const interpreterMock = Mock.ofType<Interpreter>();
     interpreterMock
         .setup(interpreter => interpreter.registerTypeToPayloadCallback(message, It.is(isFunction)))

--- a/src/tests/unit/tests/background/global-action-creators/feature-flags-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/feature-flags-action-creator.test.ts
@@ -23,7 +23,11 @@ describe('FeatureFlagsActionCreator', () => {
         telemetryHandlerMock = Mock.ofType<TelemetryEventHandler>();
         featureFlagActionsMock = Mock.ofType<FeatureFlagActions>();
 
-        testSubject = new FeatureFlagsActionCreator(interpreterMock.object, featureFlagActionsMock.object, telemetryHandlerMock.object);
+        testSubject = new FeatureFlagsActionCreator(
+            interpreterMock.object,
+            featureFlagActionsMock.object,
+            telemetryHandlerMock.object,
+        );
     });
 
     it('handles GetFeatureFlags message', () => {
@@ -75,7 +79,9 @@ describe('FeatureFlagsActionCreator', () => {
 
     const setupInterpreterMock = <Payload>(expectedMessage: string, payload?: Payload): void => {
         interpreterMock
-            .setup(interpreter => interpreter.registerTypeToPayloadCallback(expectedMessage, It.is(isFunction)))
+            .setup(interpreter =>
+                interpreter.registerTypeToPayloadCallback(expectedMessage, It.is(isFunction)),
+            )
             .callback((message, handler) => {
                 if (payload) {
                     handler(payload);

--- a/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/global-action-creator.test.ts
@@ -126,39 +126,68 @@ class GlobalActionCreatorValidator {
     private actionsSetup: boolean = false;
 
     public setupActionOnCommandActions(actionName: string): GlobalActionCreatorValidator {
-        return this.setupAction(actionName, this.commandActionsContainerMock, this.commandActionMocksMap);
+        return this.setupAction(
+            actionName,
+            this.commandActionsContainerMock,
+            this.commandActionMocksMap,
+        );
     }
 
     public setupActionOnFeatureFlagActions(actionName: string): GlobalActionCreatorValidator {
-        return this.setupAction(actionName, this.featureFlagActionsContainerMock, this.featureFlagActionsMockMap);
+        return this.setupAction(
+            actionName,
+            this.featureFlagActionsContainerMock,
+            this.featureFlagActionsMockMap,
+        );
     }
 
     public setupActionOnLaunchPanelActions(actionName: string): GlobalActionCreatorValidator {
-        return this.setupAction(actionName, this.launchPanelStateActionsContainerMock, this.launchPanelActionsMockMap);
+        return this.setupAction(
+            actionName,
+            this.launchPanelStateActionsContainerMock,
+            this.launchPanelActionsMockMap,
+        );
     }
 
-    public setupGetCommandsFromAdapter(commands: chrome.commands.Command[]): GlobalActionCreatorValidator {
+    public setupGetCommandsFromAdapter(
+        commands: chrome.commands.Command[],
+    ): GlobalActionCreatorValidator {
         this.commandsAdapterMock.setup(x => x.getCommands(It.isAny())).callback(cb => cb(commands));
 
         return this;
     }
 
-    public setupCommandActionWithInvokeParameter(actionName: keyof CommandActions, expectedInvokeParam: any): GlobalActionCreatorValidator {
-        return this.setupActionWithInvokeParameter(actionName, expectedInvokeParam, this.commandActionMocksMap);
+    public setupCommandActionWithInvokeParameter(
+        actionName: keyof CommandActions,
+        expectedInvokeParam: any,
+    ): GlobalActionCreatorValidator {
+        return this.setupActionWithInvokeParameter(
+            actionName,
+            expectedInvokeParam,
+            this.commandActionMocksMap,
+        );
     }
 
     public setupFeatureFlagActionWithInvokeParameter(
         actionName: keyof FeatureFlagActions,
         expectedInvokeParam: any,
     ): GlobalActionCreatorValidator {
-        return this.setupActionWithInvokeParameter(actionName, expectedInvokeParam, this.featureFlagActionsMockMap);
+        return this.setupActionWithInvokeParameter(
+            actionName,
+            expectedInvokeParam,
+            this.featureFlagActionsMockMap,
+        );
     }
 
     public setupLaunchPanelActionWithInvokeParameter(
         actionName: keyof LaunchPanelStateActions,
         expectedInvokeParam: any,
     ): GlobalActionCreatorValidator {
-        return this.setupActionWithInvokeParameter(actionName, expectedInvokeParam, this.launchPanelActionsMockMap);
+        return this.setupActionWithInvokeParameter(
+            actionName,
+            expectedInvokeParam,
+            this.launchPanelActionsMockMap,
+        );
     }
 
     private setupActionWithInvokeParameter(
@@ -173,7 +202,10 @@ class GlobalActionCreatorValidator {
         return this;
     }
 
-    private getOrCreateAction(actionName: string, actionsMockMap: DictionaryStringTo<IMock<Action<any>>>): IMock<Action<any>> {
+    private getOrCreateAction(
+        actionName: string,
+        actionsMockMap: DictionaryStringTo<IMock<Action<any>>>,
+    ): IMock<Action<any>> {
         let action = actionsMockMap[actionName];
 
         if (action == null) {
@@ -199,7 +231,10 @@ class GlobalActionCreatorValidator {
         return this;
     }
 
-    public setupRegistrationCallback(expectedType: string, callbackParams?: any[]): GlobalActionCreatorValidator {
+    public setupRegistrationCallback(
+        expectedType: string,
+        callbackParams?: any[],
+    ): GlobalActionCreatorValidator {
         this.interpreterMock
             .setup(x => x.registerTypeToPayloadCallback(It.isValue(expectedType), It.isAny()))
             .callback((messageType, callback) => {
@@ -214,7 +249,9 @@ class GlobalActionCreatorValidator {
     }
 
     public setupTelemetrySend(eventName: string): GlobalActionCreatorValidator {
-        this.telemetryEventHandlerMock.setup(tsm => tsm.publishTelemetry(It.isValue(eventName), It.isAny())).verifiable(Times.once());
+        this.telemetryEventHandlerMock
+            .setup(tsm => tsm.publishTelemetry(It.isValue(eventName), It.isAny()))
+            .verifiable(Times.once());
 
         return this;
     }

--- a/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
@@ -6,7 +6,11 @@ import { FileIssuePayload } from 'background/actions/action-payloads';
 import { IssueFilingActionCreator } from 'background/global-action-creators/issue-filing-action-creator';
 import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { FILE_ISSUE_CLICK, TelemetryEventSource, TriggeredBy } from '../../../../../common/extension-telemetry-events';
+import {
+    FILE_ISSUE_CLICK,
+    TelemetryEventSource,
+    TriggeredBy,
+} from '../../../../../common/extension-telemetry-events';
 import { CreateIssueDetailsTextData } from '../../../../../common/types/create-issue-details-text-data';
 import { IssueFilingController } from '../../../../../issue-filing/common/issue-filing-controller-impl';
 
@@ -29,10 +33,17 @@ describe('IssueFilingActionCreator', () => {
             .callback((message, handler) => handler(payload));
 
         const telemetryHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
-        telemetryHandlerMock.setup(handler => handler.publishTelemetry(FILE_ISSUE_CLICK, payload)).verifiable(Times.once());
+        telemetryHandlerMock
+            .setup(handler => handler.publishTelemetry(FILE_ISSUE_CLICK, payload))
+            .verifiable(Times.once());
 
-        const issueFilingControllerMock = Mock.ofType<IssueFilingController>(null, MockBehavior.Strict);
-        issueFilingControllerMock.setup(controller => controller.fileIssue(payload.service, payload.issueData)).verifiable(Times.once());
+        const issueFilingControllerMock = Mock.ofType<IssueFilingController>(
+            null,
+            MockBehavior.Strict,
+        );
+        issueFilingControllerMock
+            .setup(controller => controller.fileIssue(payload.service, payload.issueData))
+            .verifiable(Times.once());
 
         const testSubject = new IssueFilingActionCreator(
             interpreterMock.object,

--- a/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/permissions-state-action-creator.test.ts
@@ -23,33 +23,40 @@ describe('PermissionsStateActionCreator', () => {
         const interpreterMock = createInterpreterMock(expectedMessage, null);
         const getCurrentStateMock = createActionMock(null);
         setupActionsMock('getCurrentState', getCurrentStateMock.object);
-        const testSubject = new PermissionsStateActionCreator(interpreterMock.object, permissionsStateActionsMock.object, null);
+        const testSubject = new PermissionsStateActionCreator(
+            interpreterMock.object,
+            permissionsStateActionsMock.object,
+            null,
+        );
 
         testSubject.registerCallbacks();
 
         getCurrentStateMock.verifyAll();
     });
 
-    it.each([true, false])('handles SetPermissionsState message for payload %p', (permissionState: boolean) => {
-        const expectedMessage = Messages.PermissionsState.SetPermissionsState;
-        const payload: SetAllUrlsPermissionStatePayload = {
-            hasAllUrlAndFilePermissions: permissionState,
-            telemetry: {} as TelemetryData,
-        };
-        const interpreterMock = createInterpreterMock(expectedMessage, payload);
-        const setPermissionsStateMock = createActionMock(payload);
-        const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
-        setupActionsMock('setPermissionsState', setPermissionsStateMock.object);
-        const testSubject = new PermissionsStateActionCreator(
-            interpreterMock.object,
-            permissionsStateActionsMock.object,
-            telemetryEventHandlerMock.object,
-        );
+    it.each([true, false])(
+        'handles SetPermissionsState message for payload %p',
+        (permissionState: boolean) => {
+            const expectedMessage = Messages.PermissionsState.SetPermissionsState;
+            const payload: SetAllUrlsPermissionStatePayload = {
+                hasAllUrlAndFilePermissions: permissionState,
+                telemetry: {} as TelemetryData,
+            };
+            const interpreterMock = createInterpreterMock(expectedMessage, payload);
+            const setPermissionsStateMock = createActionMock(payload);
+            const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+            setupActionsMock('setPermissionsState', setPermissionsStateMock.object);
+            const testSubject = new PermissionsStateActionCreator(
+                interpreterMock.object,
+                permissionsStateActionsMock.object,
+                telemetryEventHandlerMock.object,
+            );
 
-        testSubject.registerCallbacks();
+            testSubject.registerCallbacks();
 
-        setPermissionsStateMock.verifyAll();
-    });
+            setPermissionsStateMock.verifyAll();
+        },
+    );
 
     const setupActionsMock = <ActionName extends keyof PermissionsStateActions>(
         actionName: ActionName,

--- a/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/scoping-action-creator.test.ts
@@ -77,7 +77,9 @@ describe('ScopingActionCreator', () => {
 
     const setupInterpreterMock = <Payload>(expectedMessage: string, payload?: Payload): void => {
         interpreterMock
-            .setup(interpreter => interpreter.registerTypeToPayloadCallback(expectedMessage, It.is(isFunction)))
+            .setup(interpreter =>
+                interpreter.registerTypeToPayloadCallback(expectedMessage, It.is(isFunction)),
+            )
             .callback((message, handler) => {
                 if (payload) {
                     handler(payload);
@@ -87,7 +89,10 @@ describe('ScopingActionCreator', () => {
             });
     };
 
-    const setupActionsMock = <ActionName extends keyof ScopingActions>(actionName: ActionName, action: ScopingActions[ActionName]) => {
+    const setupActionsMock = <ActionName extends keyof ScopingActions>(
+        actionName: ActionName,
+        action: ScopingActions[ActionName],
+    ) => {
         scopingActionsMock.setup(actions => actions[actionName]).returns(() => action);
     };
 });

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -41,7 +41,10 @@ describe('UserConfigurationActionCreator', () => {
             enableHighContrast: true,
         };
         const setHighContrastConfigMock = createActionMock(payload);
-        const actionsMock = createActionsMock('setHighContrastMode', setHighContrastConfigMock.object);
+        const actionsMock = createActionsMock(
+            'setHighContrastMode',
+            setHighContrastConfigMock.object,
+        );
         const testSubject = new UserConfigurationActionCreator(actionsMock.object);
 
         testSubject.setHighContrastMode(payload);
@@ -69,7 +72,10 @@ describe('UserConfigurationActionCreator', () => {
             propertyValue: 'property-value',
         };
         const setIssueFilingServicePropertyMock = createActionMock(payload);
-        const actionsMock = createActionsMock('setIssueFilingServiceProperty', setIssueFilingServicePropertyMock.object);
+        const actionsMock = createActionsMock(
+            'setIssueFilingServiceProperty',
+            setIssueFilingServicePropertyMock.object,
+        );
         const testSubject = new UserConfigurationActionCreator(actionsMock.object);
 
         testSubject.setIssueFilingServiceProperty(payload);
@@ -83,7 +89,10 @@ describe('UserConfigurationActionCreator', () => {
             issueFilingSettings: { name: 'issueFilingSettings' },
         };
         const setIssueFilingSettings = createActionMock(payload);
-        const actionsMock = createActionsMock('saveIssueFilingSettings', setIssueFilingSettings.object);
+        const actionsMock = createActionsMock(
+            'saveIssueFilingSettings',
+            setIssueFilingSettings.object,
+        );
         const testSubject = new UserConfigurationActionCreator(actionsMock.object);
 
         testSubject.saveIssueFilingSettings(payload);

--- a/src/tests/unit/tests/background/global-context-factory.test.ts
+++ b/src/tests/unit/tests/background/global-context-factory.test.ts
@@ -39,8 +39,12 @@ describe('GlobalContextFactoryTest', () => {
         browserAdapterMock = Mock.ofType<BrowserAdapter>();
         commandsAdapterMock = Mock.ofType<CommandsAdapter>();
         loggerMock = Mock.ofType<Logger>();
-        browserAdapterMock.setup(adapter => adapter.sendMessageToFrames(It.isAny())).returns(() => Promise.resolve());
-        browserAdapterMock.setup(adapter => adapter.sendMessageToTab(It.isAny(), It.isAny())).returns(() => Promise.resolve());
+        browserAdapterMock
+            .setup(adapter => adapter.sendMessageToFrames(It.isAny()))
+            .returns(() => Promise.resolve());
+        browserAdapterMock
+            .setup(adapter => adapter.sendMessageToTab(It.isAny(), It.isAny()))
+            .returns(() => Promise.resolve());
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler);
         telemetryDataFactoryMock = Mock.ofType(TelemetryDataFactory);
         issueFilingServiceProviderMock = Mock.ofType(IssueFilingServiceProvider);

--- a/src/tests/unit/tests/background/initial-assessment-store-data-generator.test.ts
+++ b/src/tests/unit/tests/background/initial-assessment-store-data-generator.test.ts
@@ -6,7 +6,10 @@ import { IMock, Mock, MockBehavior } from 'typemoq';
 import { Assessment } from 'assessments/types/iassessment';
 import { InitialDataCreator } from 'background/create-initial-assessment-test-data';
 import { InitialAssessmentStoreDataGenerator } from 'background/initial-assessment-store-data-generator';
-import { AssessmentData, AssessmentStoreData } from '../../../../common/types/store-data/assessment-result-data';
+import {
+    AssessmentData,
+    AssessmentStoreData,
+} from '../../../../common/types/store-data/assessment-result-data';
 import { VisualizationType } from '../../../../common/types/visualization-type';
 import { DictionaryStringTo } from '../../../../types/common-types';
 import { CreateTestAssessmentProvider } from '../../common/test-assessment-provider';
@@ -17,7 +20,9 @@ describe('InitialAssessmentStoreDataGenerator.generateInitialState', () => {
     const validTargetTab = { id: 1, url: 'url', title: 'title', appRefreshed: false };
     const knownTestType = assessments[0].visualizationType;
     const unknownTestType = -100 as VisualizationType;
-    const knownRequirementIds = flatMap(assessments, test => test.requirements.map(step => step.key));
+    const knownRequirementIds = flatMap(assessments, test =>
+        test.requirements.map(step => step.key),
+    );
     const knownRequirement1 = knownRequirementIds[0];
     const unknownRequirement: string = 'unknown-requirement';
     const assessmentDataStub = {} as AssessmentData;
@@ -29,7 +34,9 @@ describe('InitialAssessmentStoreDataGenerator.generateInitialState', () => {
         initialDataCreatorMock = Mock.ofInstance(() => null, MockBehavior.Strict);
         assessments.forEach(assessment => {
             (assessment as Assessment).initialDataCreator = initialDataCreatorMock.object;
-            initialDataCreatorMock.setup(mock => mock(assessment, null)).returns(() => assessmentDataStub);
+            initialDataCreatorMock
+                .setup(mock => mock(assessment, null))
+                .returns(() => assessmentDataStub);
         });
         generator = new InitialAssessmentStoreDataGenerator(assessments);
         defaultState = generator.generateInitialState();
@@ -56,7 +63,9 @@ describe('InitialAssessmentStoreDataGenerator.generateInitialState', () => {
         assessments.forEach(assessment => {
             persistedAssessments[assessment.key] = {} as AssessmentData;
             (assessment as Assessment).initialDataCreator = initialDataCreatorMock.object;
-            initialDataCreatorMock.setup(mock => mock(assessment, persistedAssessments[assessment.key])).returns(() => assessmentDataStub);
+            initialDataCreatorMock
+                .setup(mock => mock(assessment, persistedAssessments[assessment.key]))
+                .returns(() => assessmentDataStub);
         });
 
         const generatedState = generator.generateInitialState({
@@ -76,13 +85,16 @@ describe('InitialAssessmentStoreDataGenerator.generateInitialState', () => {
         expect(generatedState.resultDescription).toEqual(persistedDescription);
     });
 
-    it.each([[undefined], [null]])('propagates unspecified persistedTabInfo values as-is', persistedTabInfo => {
-        const generatedState = generator.generateInitialState({
-            persistedTabInfo,
-        } as AssessmentStoreData);
+    it.each([[undefined], [null]])(
+        'propagates unspecified persistedTabInfo values as-is',
+        persistedTabInfo => {
+            const generatedState = generator.generateInitialState({
+                persistedTabInfo,
+            } as AssessmentStoreData);
 
-        expect(generatedState.persistedTabInfo).toEqual(persistedTabInfo);
-    });
+            expect(generatedState.persistedTabInfo).toEqual(persistedTabInfo);
+        },
+    );
 
     it.each([[undefined], [true], [false]])(
         'outputs persistedTabInfo.appRefreshed as true even if it was set to %p in input persistedData',

--- a/src/tests/unit/tests/background/injector-controller.test.ts
+++ b/src/tests/unit/tests/background/injector-controller.test.ts
@@ -25,7 +25,9 @@ describe('InjectorControllerTest', () => {
     });
 
     test('initialize: inject occurs', async () => {
-        const visualizationData = new VisualizationStoreDataBuilder().with('injectingInProgress', true).build();
+        const visualizationData = new VisualizationStoreDataBuilder()
+            .with('injectingInProgress', true)
+            .build();
 
         validator
             .setupTabStore({ id: tabId })
@@ -74,7 +76,9 @@ describe('InjectorControllerTest', () => {
     });
 
     test("inject doesn't occur when inspect mode changed to off", async () => {
-        const visualizationData = new VisualizationStoreDataBuilder().with('injectingInProgress', false).build();
+        const visualizationData = new VisualizationStoreDataBuilder()
+            .with('injectingInProgress', false)
+            .build();
 
         validator
             .setupTabStore({ id: tabId })
@@ -186,17 +190,37 @@ class InjectorControllerValidator {
         return this;
     }
 
-    public setupVerifyInjectionStartedActionCalled(tabId: number, numTimes: number = 1): InjectorControllerValidator {
+    public setupVerifyInjectionStartedActionCalled(
+        tabId: number,
+        numTimes: number = 1,
+    ): InjectorControllerValidator {
         this.mockInterpreter
-            .setup(x => x.interpret(It.isObjectWith({ messageType: Messages.Visualizations.State.InjectionStarted, tabId: tabId })))
+            .setup(x =>
+                x.interpret(
+                    It.isObjectWith({
+                        messageType: Messages.Visualizations.State.InjectionStarted,
+                        tabId: tabId,
+                    }),
+                ),
+            )
             .verifiable(Times.exactly(numTimes));
 
         return this;
     }
 
-    public setupVerifyInjectionCompletedActionCalled(tabId: number, numTimes: number = 1): InjectorControllerValidator {
+    public setupVerifyInjectionCompletedActionCalled(
+        tabId: number,
+        numTimes: number = 1,
+    ): InjectorControllerValidator {
         this.mockInterpreter
-            .setup(x => x.interpret(It.isObjectWith({ messageType: Messages.Visualizations.State.InjectionCompleted, tabId: tabId })))
+            .setup(x =>
+                x.interpret(
+                    It.isObjectWith({
+                        messageType: Messages.Visualizations.State.InjectionCompleted,
+                        tabId: tabId,
+                    }),
+                ),
+            )
             .verifiable(Times.exactly(numTimes));
 
         return this;
@@ -239,7 +263,10 @@ class InjectorControllerValidator {
         return this;
     }
 
-    public setupInjectScriptsCall(calledWithTabId: number, numTimes: number): InjectorControllerValidator {
+    public setupInjectScriptsCall(
+        calledWithTabId: number,
+        numTimes: number,
+    ): InjectorControllerValidator {
         this.mockInjector
             .setup(injector => injector.injectScripts(calledWithTabId))
             .returns(() => this.injectedScriptsDeferred.promise as any)

--- a/src/tests/unit/tests/background/inspect-store.test.ts
+++ b/src/tests/unit/tests/background/inspect-store.test.ts
@@ -28,7 +28,10 @@ describe('InspectStoreTest', () => {
         const initialState = getDefaultState();
         const finalState = getDefaultState();
 
-        createStoreForInspectActions('getCurrentState').testListenerToBeCalledOnce(initialState, finalState);
+        createStoreForInspectActions('getCurrentState').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     test('on changeMode', () => {
@@ -68,14 +71,18 @@ describe('InspectStoreTest', () => {
         return createStoreWithNullParams(InspectStore).getDefaultState();
     }
 
-    function createStoreForInspectActions(actionName: keyof InspectActions): StoreTester<InspectStoreData, InspectActions> {
+    function createStoreForInspectActions(
+        actionName: keyof InspectActions,
+    ): StoreTester<InspectStoreData, InspectActions> {
         const tabActions = new TabActions();
         const factory = (actions: InspectActions) => new InspectStore(actions, tabActions);
 
         return new StoreTester(InspectActions, actionName, factory);
     }
 
-    function createStoreForTabActions(actionName: keyof TabActions): StoreTester<InspectStoreData, TabActions> {
+    function createStoreForTabActions(
+        actionName: keyof TabActions,
+    ): StoreTester<InspectStoreData, TabActions> {
         const factory = (actions: TabActions) => new InspectStore(new InspectActions(), actions);
         return new StoreTester(TabActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/install-data-generator.test.ts
+++ b/src/tests/unit/tests/background/install-data-generator.test.ts
@@ -66,7 +66,11 @@ describe('InstallDataGeneratorTest', () => {
             .verifiable();
 
         storageAdapterMock
-            .setup(bam => bam.setUserData(It.isValue({ [LocalStorageDataKeys.installationData]: installationDataStub })))
+            .setup(bam =>
+                bam.setUserData(
+                    It.isValue({ [LocalStorageDataKeys.installationData]: installationDataStub }),
+                ),
+            )
             .returns(() => Promise.resolve());
 
         expect(testSubject.getInstallationId()).toEqual(guidStub);
@@ -112,7 +116,11 @@ describe('InstallDataGeneratorTest', () => {
             .verifiable();
 
         storageAdapterMock
-            .setup(bam => bam.setUserData(It.isValue({ [LocalStorageDataKeys.installationData]: installationDataStub })))
+            .setup(bam =>
+                bam.setUserData(
+                    It.isValue({ [LocalStorageDataKeys.installationData]: installationDataStub }),
+                ),
+            )
             .returns(() => Promise.resolve());
 
         expect(testSubject.getInstallationId()).toEqual(guidStub);
@@ -158,7 +166,11 @@ describe('InstallDataGeneratorTest', () => {
             .verifiable();
 
         storageAdapterMock
-            .setup(bam => bam.setUserData(It.isValue({ [LocalStorageDataKeys.installationData]: installationDataStub })))
+            .setup(bam =>
+                bam.setUserData(
+                    It.isValue({ [LocalStorageDataKeys.installationData]: installationDataStub }),
+                ),
+            )
             .returns(() => Promise.resolve());
 
         expect(testSubject.getInstallationId()).toEqual(guidStub);
@@ -209,6 +221,11 @@ describe('InstallDataGeneratorTest', () => {
     }
 
     function createTestObject(initialInstallationData: InstallationData): InstallDataGenerator {
-        return new InstallDataGenerator(initialInstallationData, generateGuidMock.object, dateGetterMock.object, storageAdapterMock.object);
+        return new InstallDataGenerator(
+            initialInstallationData,
+            generateGuidMock.object,
+            dateGetterMock.object,
+            storageAdapterMock.object,
+        );
     }
 });

--- a/src/tests/unit/tests/background/interpreter.test.ts
+++ b/src/tests/unit/tests/background/interpreter.test.ts
@@ -10,7 +10,9 @@ class TestableInterpreter extends Interpreter {
         return this.messageToActionMapping;
     }
 
-    public setMessageToActionMapping(messageToActionMapping: DictionaryStringTo<PayloadCallback<any>>): void {
+    public setMessageToActionMapping(
+        messageToActionMapping: DictionaryStringTo<PayloadCallback<any>>,
+    ): void {
         this.messageToActionMapping = messageToActionMapping;
     }
 }

--- a/src/tests/unit/tests/background/issue-details-text-generator.test.ts
+++ b/src/tests/unit/tests/background/issue-details-text-generator.test.ts
@@ -38,10 +38,19 @@ describe('Issue details text builder', () => {
             snippet: 'RR-snippet   space',
         } as any;
 
-        issueUrlCreationUtilsMock = Mock.ofType<IssueUrlCreationUtils>(undefined, MockBehavior.Strict);
-        issueUrlCreationUtilsMock.setup(utils => utils.getSelectorLastPart(selector)).returns(() => selector);
-        issueUrlCreationUtilsMock.setup(utils => utils.getTitle(sampleIssueDetailsData)).returns(() => title);
-        issueUrlCreationUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => wcagTags);
+        issueUrlCreationUtilsMock = Mock.ofType<IssueUrlCreationUtils>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        issueUrlCreationUtilsMock
+            .setup(utils => utils.getSelectorLastPart(selector))
+            .returns(() => selector);
+        issueUrlCreationUtilsMock
+            .setup(utils => utils.getTitle(sampleIssueDetailsData))
+            .returns(() => title);
+        issueUrlCreationUtilsMock
+            .setup(utils => utils.standardizeTags(sampleIssueDetailsData))
+            .returns(() => wcagTags);
 
         const envInfo = {
             axeCoreVersion: 'AXE.CORE.VER',
@@ -52,7 +61,9 @@ describe('Issue details text builder', () => {
         envInfoProviderMock.setup(provider => provider.getEnvironmentInfo()).returns(() => envInfo);
 
         issueDetailsBuilderMock = Mock.ofType<IssueDetailsBuilder>(undefined, MockBehavior.Strict);
-        issueDetailsBuilderMock.setup(builder => builder(envInfo, sampleIssueDetailsData)).returns(() => 'test-issue-details-builder');
+        issueDetailsBuilderMock
+            .setup(builder => builder(envInfo, sampleIssueDetailsData))
+            .returns(() => 'test-issue-details-builder');
 
         testSubject = new IssueDetailsTextGenerator(
             issueUrlCreationUtilsMock.object,

--- a/src/tests/unit/tests/background/message-distributor.test.ts
+++ b/src/tests/unit/tests/background/message-distributor.test.ts
@@ -27,7 +27,12 @@ describe('MessageDistributorTest', () => {
         globalContextMock.setup(x => x.interpreter).returns(() => globalInterpreter);
 
         loggerMock = Mock.ofType<Logger>();
-        testSubject = new MessageDistributor(globalContextMock.object, tabToInterpreterMap, mockBrowserAdapter.object, loggerMock.object);
+        testSubject = new MessageDistributor(
+            globalContextMock.object,
+            tabToInterpreterMap,
+            mockBrowserAdapter.object,
+            loggerMock.object,
+        );
 
         mockBrowserAdapter
             .setup(adapter => adapter.addListenerOnMessage(It.isAny()))

--- a/src/tests/unit/tests/background/shortcuts-page-controller.test.ts
+++ b/src/tests/unit/tests/background/shortcuts-page-controller.test.ts
@@ -17,7 +17,9 @@ describe('ShortcutsPageController', () => {
 
     it('opens the shortcuts tab', async () => {
         browserAdapterMock
-            .setup(adapter => adapter.createActiveTab(ShortcutsPageController.configureCommandTabUrl))
+            .setup(adapter =>
+                adapter.createActiveTab(ShortcutsPageController.configureCommandTabUrl),
+            )
             .returns(() => Promise.resolve({} as Tabs.Tab))
             .verifiable(Times.once());
 
@@ -30,7 +32,9 @@ describe('ShortcutsPageController', () => {
         const errorMessage = 'dummy error';
 
         browserAdapterMock
-            .setup(adapter => adapter.createActiveTab(ShortcutsPageController.configureCommandTabUrl))
+            .setup(adapter =>
+                adapter.createActiveTab(ShortcutsPageController.configureCommandTabUrl),
+            )
             .returns(() => Promise.reject(errorMessage))
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -25,7 +25,11 @@ import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { Tab } from 'common/itab';
 import { StoreNames } from 'common/stores/store-names';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
-import { ManualTestStatus, ManualTestStatusData, TestStepData } from 'common/types/manual-test-status';
+import {
+    ManualTestStatus,
+    ManualTestStatusData,
+    TestStepData,
+} from 'common/types/manual-test-status';
 import {
     AssessmentData,
     AssessmentStoreData,
@@ -35,7 +39,11 @@ import {
     TestStepResult,
 } from 'common/types/store-data/assessment-result-data';
 import { VisualizationType } from 'common/types/visualization-type';
-import { ScanBasePayload, ScanCompletedPayload, ScanUpdatePayload } from 'injected/analyzers/analyzer';
+import {
+    ScanBasePayload,
+    ScanCompletedPayload,
+    ScanUpdatePayload,
+} from 'injected/analyzers/analyzer';
 import { TabStopEvent } from 'injected/tab-stops-listener';
 import { cloneDeep, isFunction } from 'lodash';
 import { ScanResults } from 'scanner/iruleresults';
@@ -87,7 +95,9 @@ describe('AssessmentStoreTest', () => {
             .returns(step => getDefaultManualTestStepResult(step));
 
         indexDBInstanceMock = Mock.ofType<IndexedDBAPI>(undefined, MockBehavior.Strict);
-        initialAssessmentStoreDataGeneratorMock = Mock.ofType<InitialAssessmentStoreDataGenerator>();
+        initialAssessmentStoreDataGeneratorMock = Mock.ofType<
+            InitialAssessmentStoreDataGenerator
+        >();
     });
 
     afterEach(() => {
@@ -125,7 +135,12 @@ describe('AssessmentStoreTest', () => {
     });
 
     test('getDefaultState with persistedData', () => {
-        const targetTab: PersistedTabInfo = { id: 1, url: 'url', title: 'title', appRefreshed: true };
+        const targetTab: PersistedTabInfo = {
+            id: 1,
+            url: 'url',
+            title: 'title',
+            appRefreshed: true,
+        };
         const expectedTestType = -1 as VisualizationType;
         const expectedTestStep: string = 'assessment-1-step-1';
         const assessmentProvider = CreateTestAssessmentProvider();
@@ -185,11 +200,15 @@ describe('AssessmentStoreTest', () => {
             assessment.requirements.forEach(step => {
                 const assessmentData = expectedState.assessments[assessment.key];
                 assessmentData.testStepStatus[step.key] = getDefaultTestStepData();
-                assessmentData.manualTestStepResultMap[step.key] = getDefaultManualTestStepResult(step.key);
+                assessmentData.manualTestStepResultMap[step.key] = getDefaultManualTestStepResult(
+                    step.key,
+                );
             });
         });
 
-        expectedState.assessments['assessment-1'].manualTestStepResultMap[expectedTestStep].status = 2;
+        expectedState.assessments['assessment-1'].manualTestStepResultMap[
+            expectedTestStep
+        ].status = 2;
 
         setupDataGeneratorMock(persisted, expectedState);
 
@@ -212,7 +231,10 @@ describe('AssessmentStoreTest', () => {
         const initialState = getDefaultState();
         const finalState = getDefaultState();
 
-        createStoreTesterForAssessmentActions('getCurrentState').testListenerToBeCalledOnce(initialState, finalState);
+        createStoreTesterForAssessmentActions('getCurrentState').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     test('on resetData: only reset data for one test', () => {
@@ -226,7 +248,10 @@ describe('AssessmentStoreTest', () => {
             .build();
 
         const initialState = getStateWithAssessment(assessmentData);
-        const expectedState = getDefaultStateWithDefaultAssessmentData(assessmentKey, requirementKey);
+        const expectedState = getDefaultStateWithDefaultAssessmentData(
+            assessmentKey,
+            requirementKey,
+        );
         setupDataGeneratorMock(null, expectedState);
         const getVisualizationConfigurationMock = Mock.ofInstance(() => {});
         const visualizationConfigStub = {
@@ -251,7 +276,9 @@ describe('AssessmentStoreTest', () => {
             ],
         } as Assessment;
 
-        assessmentsProviderMock.setup(apm => apm.forType(assessmentType)).returns(() => assessmentStub);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(assessmentType))
+            .returns(() => assessmentStub);
 
         const payload: ToggleActionPayload = {
             test: assessmentType,
@@ -300,7 +327,9 @@ describe('AssessmentStoreTest', () => {
 
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
 
-        assessmentsProviderMock.setup(apm => apm.forType(assessmentType)).returns(() => assessmentStub);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(assessmentType))
+            .returns(() => assessmentStub);
 
         const payload: ToggleActionPayload = {
             test: assessmentType,
@@ -350,7 +379,9 @@ describe('AssessmentStoreTest', () => {
 
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
 
-        assessmentsProviderMock.setup(apm => apm.forType(assessmentType)).returns(() => assessmentStub);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(assessmentType))
+            .returns(() => assessmentStub);
 
         const payload: ToggleActionPayload = {
             test: assessmentType,
@@ -381,12 +412,18 @@ describe('AssessmentStoreTest', () => {
             })
             .verifiable();
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
-        const initialState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withSelectedTestType(VisualizationType.Color)
             .withTargetTab(oldTabId, null, null, true)
             .build();
 
-        const finalState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withTargetTab(tabId, url, title, false)
             .build();
 
@@ -410,13 +447,21 @@ describe('AssessmentStoreTest', () => {
             title,
         };
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
-        browserMock.setup(adapter => adapter.getTab(tabId, It.is(isFunction), It.is(isFunction))).callback((id, resolve) => resolve(tab));
+        browserMock
+            .setup(adapter => adapter.getTab(tabId, It.is(isFunction), It.is(isFunction)))
+            .callback((id, resolve) => resolve(tab));
 
-        const initialState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withTargetTab(oldTabId, null, null, true)
             .build();
 
-        const finalState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withTargetTab(tabId, url, title, false)
             .build();
 
@@ -459,17 +504,27 @@ describe('AssessmentStoreTest', () => {
 
         const finalState = getStateWithAssessment(assessmentData);
 
-        assessmentsProviderMock.setup(provider => provider.all()).returns(() => assessmentsProvider.all());
+        assessmentsProviderMock
+            .setup(provider => provider.all())
+            .returns(() => assessmentsProvider.all());
 
-        assessmentsProviderMock.setup(provider => provider.getStepMap(assessmentType)).returns(() => stepMapStub);
+        assessmentsProviderMock
+            .setup(provider => provider.getStepMap(assessmentType))
+            .returns(() => stepMapStub);
 
-        assessmentsProviderMock.setup(provider => provider.getStep(assessmentType, 'assessment-1-step-1')).returns(() => stepConfig);
+        assessmentsProviderMock
+            .setup(provider => provider.getStep(assessmentType, 'assessment-1-step-1'))
+            .returns(() => stepConfig);
 
-        assessmentsProviderMock.setup(provider => provider.forType(payload.testType)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(provider => provider.forType(payload.testType))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
-        getInstanceIdentiferGeneratorMock.setup(idGetter => idGetter(requirementKey)).returns(() => instanceIdentifierGeneratorStub);
+        getInstanceIdentiferGeneratorMock
+            .setup(idGetter => idGetter(requirementKey))
+            .returns(() => instanceIdentifierGeneratorStub);
 
         assessmentDataConverterMock
             .setup(a =>
@@ -517,7 +572,9 @@ describe('AssessmentStoreTest', () => {
 
         const finalState = getStateWithAssessment(assessmentData);
 
-        assessmentsProviderMock.setup(provider => provider.all()).returns(() => assessmentsProvider.all());
+        assessmentsProviderMock
+            .setup(provider => provider.all())
+            .returns(() => assessmentsProvider.all());
 
         assessmentsProviderMock
             .setup(provider => provider.getStepMap(assessmentType))
@@ -527,11 +584,15 @@ describe('AssessmentStoreTest', () => {
             .setup(provider => provider.getStep(assessmentType, requirementKey))
             .returns(() => assessmentsProvider.getStep(assessmentType, requirementKey));
 
-        assessmentsProviderMock.setup(provider => provider.forType(payload.testType)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(provider => provider.forType(payload.testType))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
-        getInstanceIdentiferGeneratorMock.setup(getter => getter(requirementKey)).returns(() => instanceIdentifierGeneratorStub);
+        getInstanceIdentiferGeneratorMock
+            .setup(getter => getter(requirementKey))
+            .returns(() => instanceIdentifierGeneratorStub);
 
         assessmentDataConverterMock
             .setup(a =>
@@ -560,8 +621,12 @@ describe('AssessmentStoreTest', () => {
                 },
             } as GeneratedAssessmentInstance,
         };
-        const initialAssessmentData = new AssessmentDataBuilder().with('generatedAssessmentInstancesMap', initialInstanceMap).build();
-        const finalAssessmentData = new AssessmentDataBuilder().with('generatedAssessmentInstancesMap', {}).build();
+        const initialAssessmentData = new AssessmentDataBuilder()
+            .with('generatedAssessmentInstancesMap', initialInstanceMap)
+            .build();
+        const finalAssessmentData = new AssessmentDataBuilder()
+            .with('generatedAssessmentInstancesMap', {})
+            .build();
         const payload: ScanBasePayload = {
             testType: assessmentType,
             key: requirementKey,
@@ -570,7 +635,9 @@ describe('AssessmentStoreTest', () => {
         const initialState = getStateWithAssessment(initialAssessmentData);
         const finalState = getStateWithAssessment(finalAssessmentData);
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.testType)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.testType))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
@@ -588,8 +655,14 @@ describe('AssessmentStoreTest', () => {
     test('on selectTestStep', () => {
         const visualizationType = 1 as VisualizationType;
         const requirement = 'test-step';
-        const initialState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object).build();
-        const finalState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        ).build();
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withSelectedTestType(visualizationType)
             .withSelectedTestStep(requirement)
             .build();
@@ -623,8 +696,14 @@ describe('AssessmentStoreTest', () => {
                 cb(tab);
             })
             .verifiable();
-        const initialState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object).build();
-        const finalState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        ).build();
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withTargetTab(tabId, url, title, false)
             .build();
 
@@ -641,8 +720,14 @@ describe('AssessmentStoreTest', () => {
             .setup(b => b.getTab(tabId, It.isAny()))
             .returns((id, cb) => cb(tab))
             .verifiable();
-        const initialState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object).build();
-        const finalState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object).build();
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        ).build();
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        ).build();
 
         createStoreTesterForAssessmentActions('updateTargetTabId')
             .withActionParam(tabId)
@@ -682,7 +767,9 @@ describe('AssessmentStoreTest', () => {
             .setup(apm => apm.getStep(assessmentType, requirementKey))
             .returns(() => assessmentsProvider.getStep(assessmentType, requirementKey));
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
@@ -733,7 +820,9 @@ describe('AssessmentStoreTest', () => {
             status: ManualTestStatus.PASS,
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
@@ -779,7 +868,9 @@ describe('AssessmentStoreTest', () => {
             status: ManualTestStatus.FAIL,
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
         const expectedAssessment = new AssessmentDataBuilder()
@@ -813,7 +904,9 @@ describe('AssessmentStoreTest', () => {
             } as any,
         };
 
-        const assessmentData = new AssessmentDataBuilder().with('generatedAssessmentInstancesMap', generatedAssessmentInstancesMap).build();
+        const assessmentData = new AssessmentDataBuilder()
+            .with('generatedAssessmentInstancesMap', generatedAssessmentInstancesMap)
+            .build();
 
         const initialState = getStateWithAssessment(assessmentData);
 
@@ -824,14 +917,18 @@ describe('AssessmentStoreTest', () => {
             selector: 'selector',
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
         const expectedInstancesMap = cloneDeep(generatedAssessmentInstancesMap);
         expectedInstancesMap.selector.testStepResults[requirementKey].isVisualizationEnabled = true;
 
-        const expectedAssessment = new AssessmentDataBuilder().with('generatedAssessmentInstancesMap', expectedInstancesMap).build();
+        const expectedAssessment = new AssessmentDataBuilder()
+            .with('generatedAssessmentInstancesMap', expectedInstancesMap)
+            .build();
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
@@ -874,14 +971,20 @@ describe('AssessmentStoreTest', () => {
             selector: null,
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
         const expectedInstancesMap = cloneDeep(generatedAssessmentInstancesMap);
-        expectedInstancesMap.selector2.testStepResults[requirementKey].isVisualizationEnabled = true;
+        expectedInstancesMap.selector2.testStepResults[
+            requirementKey
+        ].isVisualizationEnabled = true;
 
-        const expectedAssessment = new AssessmentDataBuilder().with('generatedAssessmentInstancesMap', expectedInstancesMap).build();
+        const expectedAssessment = new AssessmentDataBuilder()
+            .with('generatedAssessmentInstancesMap', expectedInstancesMap)
+            .build();
 
         const finalState = getStateWithAssessment(expectedAssessment);
 
@@ -904,7 +1007,9 @@ describe('AssessmentStoreTest', () => {
 
         const assessmentData = new AssessmentDataBuilder()
             .with('generatedAssessmentInstancesMap', cloneDeep(generatedAssessmentInstancesMap))
-            .with('testStepStatus', { [requirementKey]: generateTestStepData(ManualTestStatus.UNKNOWN, false) })
+            .with('testStepStatus', {
+                [requirementKey]: generateTestStepData(ManualTestStatus.UNKNOWN, false),
+            })
             .build();
 
         const initialState = getStateWithAssessment(assessmentData);
@@ -915,7 +1020,9 @@ describe('AssessmentStoreTest', () => {
             selector: 'selector',
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentsProviderMock
             .setup(apm => apm.getStep(assessmentType, requirementKey))
@@ -924,12 +1031,15 @@ describe('AssessmentStoreTest', () => {
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
         const expectedInstancesMap = cloneDeep(generatedAssessmentInstancesMap);
-        expectedInstancesMap.selector.testStepResults[requirementKey].status = ManualTestStatus.FAIL;
+        expectedInstancesMap.selector.testStepResults[requirementKey].status =
+            ManualTestStatus.FAIL;
         expectedInstancesMap.selector.testStepResults[requirementKey].originalStatus = null;
 
         const expectedAssessment = new AssessmentDataBuilder()
             .with('generatedAssessmentInstancesMap', expectedInstancesMap)
-            .with('testStepStatus', { [requirementKey]: generateTestStepData(ManualTestStatus.FAIL, false) })
+            .with('testStepStatus', {
+                [requirementKey]: generateTestStepData(ManualTestStatus.FAIL, false),
+            })
             .build();
 
         const finalState = getStateWithAssessment(expectedAssessment);
@@ -963,7 +1073,9 @@ describe('AssessmentStoreTest', () => {
             requirement: requirementKey,
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
@@ -1011,7 +1123,9 @@ describe('AssessmentStoreTest', () => {
             status: ManualTestStatus.FAIL,
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentsProviderMock
             .setup(apm => apm.getStep(assessmentType, requirementKey))
@@ -1020,12 +1134,16 @@ describe('AssessmentStoreTest', () => {
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
         const expectedInstancesMap = cloneDeep(generatedAssessmentInstancesMap);
-        expectedInstancesMap[selector].testStepResults[requirementKey].originalStatus = ManualTestStatus.UNKNOWN;
-        expectedInstancesMap[selector].testStepResults[requirementKey].status = ManualTestStatus.FAIL;
+        expectedInstancesMap[selector].testStepResults[requirementKey].originalStatus =
+            ManualTestStatus.UNKNOWN;
+        expectedInstancesMap[selector].testStepResults[requirementKey].status =
+            ManualTestStatus.FAIL;
 
         const expectedAssessment = new AssessmentDataBuilder()
             .with('generatedAssessmentInstancesMap', expectedInstancesMap)
-            .with('testStepStatus', { [requirementKey]: generateTestStepData(ManualTestStatus.FAIL, false) })
+            .with('testStepStatus', {
+                [requirementKey]: generateTestStepData(ManualTestStatus.FAIL, false),
+            })
             .build();
 
         const finalState = getStateWithAssessment(expectedAssessment);
@@ -1066,13 +1184,19 @@ describe('AssessmentStoreTest', () => {
             html: 'snippet',
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
         assessmentDataConverterMock
             .setup(a =>
-                a.generateFailureInstance(payload.instanceData.failureDescription, payload.instanceData.path, payload.instanceData.snippet),
+                a.generateFailureInstance(
+                    payload.instanceData.failureDescription,
+                    payload.instanceData.path,
+                    payload.instanceData.snippet,
+                ),
             )
             .returns(description => failureInstance);
 
@@ -1084,7 +1208,9 @@ describe('AssessmentStoreTest', () => {
                     instances: [failureInstance],
                 },
             })
-            .with('testStepStatus', { [requirementKey]: generateTestStepData(ManualTestStatus.FAIL, false) })
+            .with('testStepStatus', {
+                [requirementKey]: generateTestStepData(ManualTestStatus.FAIL, false),
+            })
             .build();
 
         const finalState = getStateWithAssessment(expectedAssessment);
@@ -1119,7 +1245,9 @@ describe('AssessmentStoreTest', () => {
             id: '1',
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
@@ -1178,7 +1306,9 @@ describe('AssessmentStoreTest', () => {
             },
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
@@ -1253,7 +1383,9 @@ describe('AssessmentStoreTest', () => {
 
         const assessmentData = new AssessmentDataBuilder()
             .with('generatedAssessmentInstancesMap', generatedAssessmentInstancesMap)
-            .with('testStepStatus', { [requirementKey]: generateTestStepData(ManualTestStatus.FAIL, false) })
+            .with('testStepStatus', {
+                [requirementKey]: generateTestStepData(ManualTestStatus.FAIL, false),
+            })
             .build();
 
         const initialState = getStateWithAssessment(assessmentData);
@@ -1263,7 +1395,9 @@ describe('AssessmentStoreTest', () => {
             requirement: requirementKey,
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(payload.test)).returns(() => assessmentMock.object);
+        assessmentsProviderMock
+            .setup(apm => apm.forType(payload.test))
+            .returns(() => assessmentMock.object);
 
         assessmentMock.setup(am => am.getVisualizationConfiguration()).returns(() => configStub);
 
@@ -1312,7 +1446,9 @@ describe('AssessmentStoreTest', () => {
                     html: '',
                 } as GeneratedAssessmentInstance,
             })
-            .with('testStepStatus', { [requirementKey]: generateTestStepData(ManualTestStatus.FAIL, false) })
+            .with('testStepStatus', {
+                [requirementKey]: generateTestStepData(ManualTestStatus.FAIL, false),
+            })
             .build();
 
         const finalState = getStateWithAssessment(expectedAssessment);
@@ -1329,14 +1465,22 @@ describe('AssessmentStoreTest', () => {
             pivotType: DetailsViewPivotType.assessment,
         };
 
-        assessmentsProviderMock.setup(apm => apm.forType(testType)).returns(() => assessmentsProvider.forType(testType));
+        assessmentsProviderMock
+            .setup(apm => apm.forType(testType))
+            .returns(() => assessmentsProvider.forType(testType));
 
-        const initialState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withSelectedTestStep('step')
             .withSelectedTestType(VisualizationType.Color)
             .build();
 
-        const finalState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withSelectedTestStep(requirementKey)
             .withSelectedTestType(testType)
             .build();
@@ -1356,12 +1500,18 @@ describe('AssessmentStoreTest', () => {
 
         assessmentsProviderMock.setup(apm => apm.forType(testType)).verifiable(Times.never());
 
-        const initialState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withSelectedTestStep('step')
             .withSelectedTestType(selectedTest)
             .build();
 
-        const finalState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withSelectedTestStep('step')
             .withSelectedTestType(selectedTest)
             .build();
@@ -1380,12 +1530,18 @@ describe('AssessmentStoreTest', () => {
 
         assessmentsProviderMock.setup(apm => apm.forType(assessmentType)).verifiable(Times.never());
 
-        const initialState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withSelectedTestStep('step')
             .withSelectedTestType(VisualizationType.Color)
             .build();
 
-        const finalState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withSelectedTestStep('step')
             .withSelectedTestType(VisualizationType.Color)
             .build();
@@ -1406,9 +1562,15 @@ describe('AssessmentStoreTest', () => {
             description: 'new-test-description',
         };
 
-        const initialState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object).build();
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        ).build();
 
-        const finalState = new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .with('resultDescription', payload.description)
             .build();
 
@@ -1417,7 +1579,10 @@ describe('AssessmentStoreTest', () => {
             .testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    function setupDataGeneratorMock(persistedData: AssessmentStoreData, initialData: AssessmentStoreData): void {
+    function setupDataGeneratorMock(
+        persistedData: AssessmentStoreData,
+        initialData: AssessmentStoreData,
+    ): void {
         initialAssessmentStoreDataGeneratorMock
             .setup(im => im.generateInitialState(persistedData))
             .returns(() => initialData as AssessmentStoreData)
@@ -1449,7 +1614,10 @@ describe('AssessmentStoreTest', () => {
         };
     }
 
-    function generateTestStepData(stepFinalResult: ManualTestStatus, isStepScanned: boolean): TestStepData {
+    function generateTestStepData(
+        stepFinalResult: ManualTestStatus,
+        isStepScanned: boolean,
+    ): TestStepData {
         return {
             stepFinalResult,
             isStepScanned,
@@ -1457,11 +1625,20 @@ describe('AssessmentStoreTest', () => {
     }
 
     function getDefaultState(): AssessmentStoreData {
-        return new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object).build();
+        return new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        ).build();
     }
 
-    function getDefaultStateWithDefaultAssessmentData(assessment: string, selectedRequirement: string): AssessmentStoreData {
-        return new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+    function getDefaultStateWithDefaultAssessmentData(
+        assessment: string,
+        selectedRequirement: string,
+    ): AssessmentStoreData {
+        return new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withAssessment(assessmentKey, {
                 fullAxeResultsMap: null,
                 generatedAssessmentInstancesMap: null,
@@ -1473,7 +1650,10 @@ describe('AssessmentStoreTest', () => {
     }
 
     function getStateWithAssessment(data: AssessmentData): AssessmentStoreData {
-        return new AssessmentsStoreDataBuilder(assessmentsProvider, assessmentDataConverterMock.object)
+        return new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
             .withAssessment(assessmentKey, data)
             .build();
     }
@@ -1492,6 +1672,11 @@ describe('AssessmentStoreTest', () => {
                 null,
                 initialAssessmentStoreDataGeneratorMock.object,
             );
-        return new AssessmentStoreTester(AssessmentActions, actionName, factory, indexDBInstanceMock);
+        return new AssessmentStoreTester(
+            AssessmentActions,
+            actionName,
+            factory,
+            indexDBInstanceMock,
+        );
     }
 });

--- a/src/tests/unit/tests/background/stores/base-store.test.ts
+++ b/src/tests/unit/tests/background/stores/base-store.test.ts
@@ -46,7 +46,8 @@ describe('BaseStoreTest', () => {
     });
 
     test('onGetCurrentState', () => {
-        const changedListener = Mock.ofInstance((testStore: TestStore, args: any) => {}, MockBehavior.Strict);
+        const changedListener = Mock.ofInstance((testStore: TestStore, args: any) => {},
+        MockBehavior.Strict);
 
         const listenerAdder = function(): void {
             // hack to access onGetCurrentState from the BaseStore class
@@ -55,7 +56,9 @@ describe('BaseStoreTest', () => {
         };
 
         const testObject = new TestStore(listenerAdder);
-        changedListener.setup(listener => listener(IsSameObject(testObject), It.isValue(undefined))).verifiable(Times.once());
+        changedListener
+            .setup(listener => listener(IsSameObject(testObject), It.isValue(undefined)))
+            .verifiable(Times.once());
 
         testObject.addChangedListener(changedListener.object);
         testObject.initialize();

--- a/src/tests/unit/tests/background/stores/card-selection-store.test.ts
+++ b/src/tests/unit/tests/background/stores/card-selection-store.test.ts
@@ -10,7 +10,10 @@ import { CardSelectionActions } from '../../../../../background/actions/card-sel
 import { UnifiedScanResultActions } from '../../../../../background/actions/unified-scan-result-actions';
 import { CardSelectionStore } from '../../../../../background/stores/card-selection-store';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import { CardSelectionStoreData, RuleExpandCollapseData } from '../../../../../common/types/store-data/card-selection-store-data';
+import {
+    CardSelectionStoreData,
+    RuleExpandCollapseData,
+} from '../../../../../common/types/store-data/card-selection-store-data';
 import { UnifiedResult } from '../../../../../common/types/store-data/unified-data-interface';
 import { createStoreWithNullParams, StoreTester } from '../../../common/store-tester';
 
@@ -76,7 +79,8 @@ describe('CardSelectionStore Test', () => {
     function createStoreForUnifiedScanResultActions(
         actionName: keyof UnifiedScanResultActions,
     ): StoreTester<CardSelectionStoreData, UnifiedScanResultActions> {
-        const factory = (actions: UnifiedScanResultActions) => new CardSelectionStore(new CardSelectionActions(), actions);
+        const factory = (actions: UnifiedScanResultActions) =>
+            new CardSelectionStore(new CardSelectionActions(), actions);
 
         return new StoreTester(UnifiedScanResultActions, actionName, factory);
     }
@@ -229,7 +233,10 @@ describe('CardSelectionStore Test', () => {
         expandRuleSelectCards(initialState.rules['sampleRuleId1']);
         expandRuleSelectCards(initialState.rules['sampleRuleId2']);
 
-        createStoreForCardSelectionActions('collapseAllRules').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreForCardSelectionActions('collapseAllRules').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('expandAllRules', () => {
@@ -240,7 +247,10 @@ describe('CardSelectionStore Test', () => {
         expectedState.rules['sampleRuleId1'].cards['sampleUid1'] = true;
         expectedState.rules['sampleRuleId2'].isExpanded = true;
 
-        createStoreForCardSelectionActions('expandAllRules').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreForCardSelectionActions('expandAllRules').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('toggleVisualHelper on - no card selection or rule expansion changes', () => {
@@ -250,7 +260,10 @@ describe('CardSelectionStore Test', () => {
         expectedState = cloneDeep(initialState);
         expectedState.visualHelperEnabled = true;
 
-        createStoreForCardSelectionActions('toggleVisualHelper').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreForCardSelectionActions('toggleVisualHelper').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('toggleVisualHelper off - cards deselected, no rule expansion changes', () => {
@@ -260,7 +273,10 @@ describe('CardSelectionStore Test', () => {
 
         expectedState.rules['sampleRuleId1'].isExpanded = true;
 
-        createStoreForCardSelectionActions('toggleVisualHelper').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreForCardSelectionActions('toggleVisualHelper').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     function expandRuleSelectCards(rule: RuleExpandCollapseData): void {
@@ -274,7 +290,8 @@ describe('CardSelectionStore Test', () => {
     function createStoreForCardSelectionActions(
         actionName: keyof CardSelectionActions,
     ): StoreTester<CardSelectionStoreData, CardSelectionActions> {
-        const factory = (actions: CardSelectionActions) => new CardSelectionStore(actions, new UnifiedScanResultActions());
+        const factory = (actions: CardSelectionActions) =>
+            new CardSelectionStore(actions, new UnifiedScanResultActions());
 
         return new StoreTester(CardSelectionActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/details-view-store.test.ts
+++ b/src/tests/unit/tests/background/stores/details-view-store.test.ts
@@ -17,9 +17,13 @@ describe('DetailsViewStoreTest', () => {
     });
 
     test('onSetSelectedDetailsViewRightContentPanel', () => {
-        const initialState = new DetailsViewStoreDataBuilder().withDetailsViewRightContentPanel('Overview').build();
+        const initialState = new DetailsViewStoreDataBuilder()
+            .withDetailsViewRightContentPanel('Overview')
+            .build();
 
-        const expectedState = new DetailsViewStoreDataBuilder().withDetailsViewRightContentPanel('TestView').build();
+        const expectedState = new DetailsViewStoreDataBuilder()
+            .withDetailsViewRightContentPanel('TestView')
+            .build();
 
         createStoreTesterForDetailsViewActions('setSelectedDetailsViewRightContentPanel')
             .withActionParam('TestView')
@@ -27,19 +31,32 @@ describe('DetailsViewStoreTest', () => {
     });
 
     test('onOpenPreviewFeatures', () => {
-        const initialState = new DetailsViewStoreDataBuilder().withPreviewFeaturesOpen(false).build();
+        const initialState = new DetailsViewStoreDataBuilder()
+            .withPreviewFeaturesOpen(false)
+            .build();
 
-        const expectedState = new DetailsViewStoreDataBuilder().withPreviewFeaturesOpen(true).build();
+        const expectedState = new DetailsViewStoreDataBuilder()
+            .withPreviewFeaturesOpen(true)
+            .build();
 
-        createStoreTesterForPreviewFeatureActions('openPreviewFeatures').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForPreviewFeatureActions('openPreviewFeatures').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('onClosePreviewFeatures', () => {
-        const initialState = new DetailsViewStoreDataBuilder().withPreviewFeaturesOpen(true).build();
+        const initialState = new DetailsViewStoreDataBuilder()
+            .withPreviewFeaturesOpen(true)
+            .build();
 
-        const expectedState = new DetailsViewStoreDataBuilder().withPreviewFeaturesOpen(false).build();
+        const expectedState = new DetailsViewStoreDataBuilder()
+            .withPreviewFeaturesOpen(false)
+            .build();
 
-        createStoreTesterForPreviewFeatureActions('closePreviewFeatures').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForPreviewFeatureActions(
+            'closePreviewFeatures',
+        ).testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     test('onOpenScoping', () => {
@@ -47,7 +64,10 @@ describe('DetailsViewStoreTest', () => {
 
         const expectedState = new DetailsViewStoreDataBuilder().withScopingOpen(true).build();
 
-        createStoreTesterForScopingActions('openScopingPanel').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForScopingActions('openScopingPanel').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('onCloseScoping', () => {
@@ -55,7 +75,10 @@ describe('DetailsViewStoreTest', () => {
 
         const expectedState = new DetailsViewStoreDataBuilder().withScopingOpen(false).build();
 
-        createStoreTesterForScopingActions('closeScopingPanel').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForScopingActions('closeScopingPanel').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('onOpenSettings', () => {
@@ -63,21 +86,31 @@ describe('DetailsViewStoreTest', () => {
 
         const expectedState = new DetailsViewStoreDataBuilder().withSettingPanelState(true).build();
 
-        createStoreTesterForDetailsViewActions('openSettingsPanel').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForDetailsViewActions('openSettingsPanel').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('onCloseSettings', () => {
         const initialState = new DetailsViewStoreDataBuilder().withSettingPanelState(true).build();
 
-        const expectedState = new DetailsViewStoreDataBuilder().withSettingPanelState(false).build();
+        const expectedState = new DetailsViewStoreDataBuilder()
+            .withSettingPanelState(false)
+            .build();
 
-        createStoreTesterForDetailsViewActions('closeSettingsPanel').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForDetailsViewActions('closeSettingsPanel').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('onOpenContent', () => {
         const initialState = new DetailsViewStoreDataBuilder().withContentOpen(false).build();
 
-        const expectedState = new DetailsViewStoreDataBuilder().withContentOpen(true, 'content/path').build();
+        const expectedState = new DetailsViewStoreDataBuilder()
+            .withContentOpen(true, 'content/path')
+            .build();
 
         createStoreTesterForContentActions('openContentPanel')
             .withActionParam({ contentPath: 'content/path' })
@@ -85,31 +118,55 @@ describe('DetailsViewStoreTest', () => {
     });
 
     test('onCloseContent', () => {
-        const initialState = new DetailsViewStoreDataBuilder().withContentOpen(true, 'content/path').build();
+        const initialState = new DetailsViewStoreDataBuilder()
+            .withContentOpen(true, 'content/path')
+            .build();
 
         const expectedState = new DetailsViewStoreDataBuilder().withContentOpen(false).build();
 
-        createStoreTesterForContentActions('closeContentPanel').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForContentActions('closeContentPanel').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     function createStoreTesterForPreviewFeatureActions(
         actionName: keyof PreviewFeaturesActions,
     ): StoreTester<DetailsViewStoreData, PreviewFeaturesActions> {
         const factory = (actions: PreviewFeaturesActions) =>
-            new DetailsViewStore(actions, new ScopingActions(), new ContentActions(), new DetailsViewActions());
+            new DetailsViewStore(
+                actions,
+                new ScopingActions(),
+                new ContentActions(),
+                new DetailsViewActions(),
+            );
         return new StoreTester(PreviewFeaturesActions, actionName, factory);
     }
 
-    function createStoreTesterForScopingActions(actionName: keyof ScopingActions): StoreTester<DetailsViewStoreData, ScopingActions> {
+    function createStoreTesterForScopingActions(
+        actionName: keyof ScopingActions,
+    ): StoreTester<DetailsViewStoreData, ScopingActions> {
         const factory = (actions: ScopingActions) =>
-            new DetailsViewStore(new PreviewFeaturesActions(), actions, new ContentActions(), new DetailsViewActions());
+            new DetailsViewStore(
+                new PreviewFeaturesActions(),
+                actions,
+                new ContentActions(),
+                new DetailsViewActions(),
+            );
 
         return new StoreTester(ScopingActions, actionName, factory);
     }
 
-    function createStoreTesterForContentActions(actionName: keyof ContentActions): StoreTester<DetailsViewStoreData, ContentActions> {
+    function createStoreTesterForContentActions(
+        actionName: keyof ContentActions,
+    ): StoreTester<DetailsViewStoreData, ContentActions> {
         const factory = (actions: ContentActions) =>
-            new DetailsViewStore(new PreviewFeaturesActions(), new ScopingActions(), actions, new DetailsViewActions());
+            new DetailsViewStore(
+                new PreviewFeaturesActions(),
+                new ScopingActions(),
+                actions,
+                new DetailsViewActions(),
+            );
 
         return new StoreTester(ContentActions, actionName, factory);
     }
@@ -118,7 +175,12 @@ describe('DetailsViewStoreTest', () => {
         actionName: keyof DetailsViewActions,
     ): StoreTester<DetailsViewStoreData, DetailsViewActions> {
         const factory = (actions: DetailsViewActions) =>
-            new DetailsViewStore(new PreviewFeaturesActions(), new ScopingActions(), new ContentActions(), actions);
+            new DetailsViewStore(
+                new PreviewFeaturesActions(),
+                new ScopingActions(),
+                new ContentActions(),
+                actions,
+            );
 
         return new StoreTester(DetailsViewActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
+++ b/src/tests/unit/tests/background/stores/dev-tools-store.test.ts
@@ -21,7 +21,10 @@ describe('DevToolsStoreTest', () => {
         const initialState = getDefaultState();
         const expectedState = getDefaultState();
 
-        createStoreTesterForDevToolsActions('getCurrentState').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForDevToolsActions('getCurrentState').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('on setDevToolState, isOpen value change', () => {
@@ -81,7 +84,9 @@ describe('DevToolsStoreTest', () => {
         return new DevToolStore(null).getDefaultState();
     }
 
-    function createStoreTesterForDevToolsActions(actionName: keyof DevToolActions): StoreTester<DevToolStoreData, DevToolActions> {
+    function createStoreTesterForDevToolsActions(
+        actionName: keyof DevToolActions,
+    ): StoreTester<DevToolStoreData, DevToolActions> {
         const factory = (actions: DevToolActions) => new DevToolStore(actions);
 
         return new StoreTester(DevToolActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/global/command-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/command-store.test.ts
@@ -5,7 +5,10 @@ import { IMock, It, Mock, Times } from 'typemoq';
 import { CommandActions, GetCommandsPayload } from 'background/actions/command-actions';
 import { CommandStore } from 'background/stores/global/command-store';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { ModifiedCommandsTelemetryData, SHORTCUT_MODIFIED } from '../../../../../../common/extension-telemetry-events';
+import {
+    ModifiedCommandsTelemetryData,
+    SHORTCUT_MODIFIED,
+} from '../../../../../../common/extension-telemetry-events';
 import { StoreNames } from '../../../../../../common/stores/store-names';
 import { CommandStoreData } from '../../../../../../common/types/store-data/command-store-data';
 import { createStoreWithNullParams, StoreTester } from '../../../../common/store-tester';
@@ -116,8 +119,11 @@ describe('CommandStoreTest', () => {
             .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
-    function createStoreTesterForCommandActions(actionName: keyof CommandActions): StoreTester<CommandStoreData, CommandActions> {
-        const factory = (actions: CommandActions) => new CommandStore(actions, telemetryEventHandlerMock.object);
+    function createStoreTesterForCommandActions(
+        actionName: keyof CommandActions,
+    ): StoreTester<CommandStoreData, CommandActions> {
+        const factory = (actions: CommandActions) =>
+            new CommandStore(actions, telemetryEventHandlerMock.object);
 
         return new StoreTester(CommandActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/global/feature-flag-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/feature-flag-store.test.ts
@@ -82,7 +82,10 @@ describe('FeatureFlagStoreTest', () => {
         const initialState = getDefaultFeatureFlagValues();
         const finalState = getDefaultFeatureFlagValues();
 
-        createStoreTesterForFeatureFlagActions('getCurrentState').testListenerToBeCalledOnce(initialState, finalState);
+        createStoreTesterForFeatureFlagActions('getCurrentState').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     test('on setFeatureFlag', () => {
@@ -101,7 +104,9 @@ describe('FeatureFlagStoreTest', () => {
         };
 
         storageAdapterMock
-            .setup(ba => ba.setUserData(It.isValue({ [LocalStorageDataKeys.featureFlags]: finalState })))
+            .setup(ba =>
+                ba.setUserData(It.isValue({ [LocalStorageDataKeys.featureFlags]: finalState })),
+            )
             .returns(() => Promise.resolve());
 
         createStoreTesterForFeatureFlagActions('setFeatureFlag', userDataStub)
@@ -116,18 +121,26 @@ describe('FeatureFlagStoreTest', () => {
 
         const finalState = getDefaultFeatureFlagValues();
 
-        createStoreTesterForFeatureFlagActions('resetFeatureFlags').testListenerToBeCalledOnce(initialState, finalState);
+        createStoreTesterForFeatureFlagActions('resetFeatureFlags').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     function createDefaultTestObject(userDataStub: LocalStorageData): FeatureFlagStore {
-        return new FeatureFlagStore(new FeatureFlagActions(), storageAdapterMock.object, userDataStub);
+        return new FeatureFlagStore(
+            new FeatureFlagActions(),
+            storageAdapterMock.object,
+            userDataStub,
+        );
     }
 
     function createStoreTesterForFeatureFlagActions(
         actionName: keyof FeatureFlagActions,
         userData: LocalStorageData = null,
     ): StoreTester<DictionaryStringTo<boolean>, FeatureFlagActions> {
-        const factory = (actions: FeatureFlagActions) => new FeatureFlagStore(actions, storageAdapterMock.object, userData);
+        const factory = (actions: FeatureFlagActions) =>
+            new FeatureFlagStore(actions, storageAdapterMock.object, userData);
         return new StoreTester(FeatureFlagActions, actionName, factory);
     }
 });

--- a/src/tests/unit/tests/background/stores/global/launch-panel-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/launch-panel-state-store.test.ts
@@ -35,7 +35,10 @@ describe('LaunchPanelStateStoreTest', () => {
 
         const expectedState = getDefaultState();
 
-        createStoreForLaunchPanelStateActions('getCurrentState').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreForLaunchPanelStateActions('getCurrentState').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('initialize, user data is not null', () => {
@@ -60,7 +63,9 @@ describe('LaunchPanelStateStoreTest', () => {
             [LocalStorageDataKeys.launchPanelSetting]: payload,
         };
 
-        storageAdapterMock.setup(adapter => adapter.setUserData(It.isValue(expectedSetUserData))).returns(() => Promise.resolve());
+        storageAdapterMock
+            .setup(adapter => adapter.setUserData(It.isValue(expectedSetUserData)))
+            .returns(() => Promise.resolve());
 
         createStoreForLaunchPanelStateActions('setLaunchPanelType')
             .withActionParam(payload)
@@ -72,7 +77,8 @@ describe('LaunchPanelStateStoreTest', () => {
     function createStoreForLaunchPanelStateActions(
         actionName: keyof LaunchPanelStateActions,
     ): StoreTester<LaunchPanelStoreData, LaunchPanelStateActions> {
-        const factory = (actions: LaunchPanelStateActions) => new LaunchPanelStore(actions, storageAdapterMock.object, userDataStub);
+        const factory = (actions: LaunchPanelStateActions) =>
+            new LaunchPanelStore(actions, storageAdapterMock.object, userDataStub);
 
         return new StoreTester(LaunchPanelStateActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/permissions-state-store.test.ts
@@ -31,7 +31,10 @@ describe('PermissionsStateStoreTest', () => {
         const initialState = createPermissionsState();
         const finalState = createPermissionsState();
 
-        createStoreTesterForPermissionsStateActions('getCurrentState').testListenerToBeCalledOnce(initialState, finalState);
+        createStoreTesterForPermissionsStateActions('getCurrentState').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     describe('on setPermissionsState', () => {
@@ -49,17 +52,20 @@ describe('PermissionsStateStoreTest', () => {
                 .testListenerToBeCalledOnce(initialState, finalState);
         });
 
-        test.each([true, false])('does not update state when there is no change', hasPermissionsValue => {
-            const initialState = { hasAllUrlAndFilePermissions: hasPermissionsValue };
-            const finalState = { hasAllUrlAndFilePermissions: hasPermissionsValue };
-            const payload: SetAllUrlsPermissionStatePayload = {
-                hasAllUrlAndFilePermissions: hasPermissionsValue,
-            };
+        test.each([true, false])(
+            'does not update state when there is no change',
+            hasPermissionsValue => {
+                const initialState = { hasAllUrlAndFilePermissions: hasPermissionsValue };
+                const finalState = { hasAllUrlAndFilePermissions: hasPermissionsValue };
+                const payload: SetAllUrlsPermissionStatePayload = {
+                    hasAllUrlAndFilePermissions: hasPermissionsValue,
+                };
 
-            createStoreTesterForPermissionsStateActions('setPermissionsState')
-                .withActionParam(payload)
-                .testListenerToNeverBeCalled(initialState, finalState);
-        });
+                createStoreTesterForPermissionsStateActions('setPermissionsState')
+                    .withActionParam(payload)
+                    .testListenerToNeverBeCalled(initialState, finalState);
+            },
+        );
     });
 
     function createStoreTesterForPermissionsStateActions(

--- a/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/scoping-store.test.ts
@@ -4,7 +4,10 @@ import { ScopingActions, ScopingPayload } from 'background/actions/scoping-actio
 import { ScopingInputTypes } from 'background/scoping-input-types';
 import { ScopingStore } from 'background/stores/global/scoping-store';
 import { StoreNames } from '../../../../../../common/stores/store-names';
-import { ScopingStoreData, SingleElementSelector } from '../../../../../../common/types/store-data/scoping-store-data';
+import {
+    ScopingStoreData,
+    SingleElementSelector,
+} from '../../../../../../common/types/store-data/scoping-store-data';
 import { createStoreWithNullParams, StoreTester } from '../../../../common/store-tester';
 
 describe('ScopingStoreTest', () => {
@@ -31,7 +34,10 @@ describe('ScopingStoreTest', () => {
         const initialState = getDefaultState();
         const finalState = getDefaultState();
 
-        createStoreForScopingActions('getCurrentState').testListenerToBeCalledOnce(initialState, finalState);
+        createStoreForScopingActions('getCurrentState').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     test('on addSelector', () => {
@@ -97,7 +103,9 @@ describe('ScopingStoreTest', () => {
         return createStoreWithNullParams(ScopingStore).getDefaultState();
     }
 
-    function createStoreForScopingActions(actionName: keyof ScopingActions): StoreTester<ScopingStoreData, ScopingActions> {
+    function createStoreForScopingActions(
+        actionName: keyof ScopingActions,
+    ): StoreTester<ScopingStoreData, ScopingActions> {
         const factory = (actions: ScopingActions) => new ScopingStore(actions);
 
         return new StoreTester(ScopingActions, actionName, factory);

--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -45,13 +45,21 @@ describe('UserConfigurationStoreTest', () => {
     });
 
     test('verify state before initialize', () => {
-        const testSubject = new UserConfigurationStore(initialStoreData, new UserConfigurationActions(), indexDbStrictMock.object);
+        const testSubject = new UserConfigurationStore(
+            initialStoreData,
+            new UserConfigurationActions(),
+            indexDbStrictMock.object,
+        );
 
         expect(testSubject.getState()).toBeUndefined();
     });
 
     test('verify initial state when null', () => {
-        const testSubject = new UserConfigurationStore(null, new UserConfigurationActions(), indexDbStrictMock.object);
+        const testSubject = new UserConfigurationStore(
+            null,
+            new UserConfigurationActions(),
+            indexDbStrictMock.object,
+        );
 
         testSubject.initialize();
 
@@ -108,7 +116,11 @@ describe('UserConfigurationStoreTest', () => {
     });
 
     test('getDefaultState returns cloned data when initial state is null', () => {
-        const testSubject = new UserConfigurationStore(null, new UserConfigurationActions(), indexDbStrictMock.object);
+        const testSubject = new UserConfigurationStore(
+            null,
+            new UserConfigurationActions(),
+            indexDbStrictMock.object,
+        );
 
         const firstCallDefaultState = testSubject.getDefaultState();
         expect(firstCallDefaultState).toEqual(defaultStoreData);
@@ -119,7 +131,11 @@ describe('UserConfigurationStoreTest', () => {
     });
 
     test('verify store id', () => {
-        const testSubject = new UserConfigurationStore(initialStoreData, new UserConfigurationActions(), indexDbStrictMock.object);
+        const testSubject = new UserConfigurationStore(
+            initialStoreData,
+            new UserConfigurationActions(),
+            indexDbStrictMock.object,
+        );
 
         expect(testSubject.getId()).toBe(StoreNames[StoreNames.UserConfigurationStore]);
     });
@@ -136,10 +152,26 @@ describe('UserConfigurationStoreTest', () => {
         enableHighContrastMode: boolean;
     };
     test.each([
-        { enableTelemetry: true, isFirstTime: true, enableHighContrastMode: false } as SetUserConfigTestCase,
-        { enableTelemetry: true, isFirstTime: false, enableHighContrastMode: false } as SetUserConfigTestCase,
-        { enableTelemetry: false, isFirstTime: false, enableHighContrastMode: false } as SetUserConfigTestCase,
-        { enableTelemetry: false, isFirstTime: true, enableHighContrastMode: false } as SetUserConfigTestCase,
+        {
+            enableTelemetry: true,
+            isFirstTime: true,
+            enableHighContrastMode: false,
+        } as SetUserConfigTestCase,
+        {
+            enableTelemetry: true,
+            isFirstTime: false,
+            enableHighContrastMode: false,
+        } as SetUserConfigTestCase,
+        {
+            enableTelemetry: false,
+            isFirstTime: false,
+            enableHighContrastMode: false,
+        } as SetUserConfigTestCase,
+        {
+            enableTelemetry: false,
+            isFirstTime: true,
+            enableHighContrastMode: false,
+        } as SetUserConfigTestCase,
     ])('setTelemetryConfig action: %p', (testCase: SetUserConfigTestCase) => {
         const storeTester = createStoreToTestAction('setTelemetryState');
         initialStoreData = {
@@ -158,7 +190,9 @@ describe('UserConfigurationStoreTest', () => {
             bugServicePropertiesMap: {},
         };
 
-        indexDbStrictMock.setup(i => i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState))).verifiable(Times.once());
+        indexDbStrictMock
+            .setup(i => i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)))
+            .verifiable(Times.once());
 
         storeTester
             .withActionParam(testCase.enableTelemetry)
@@ -167,8 +201,16 @@ describe('UserConfigurationStoreTest', () => {
     });
 
     test.each([
-        { enableTelemetry: false, isFirstTime: false, enableHighContrastMode: true } as SetUserConfigTestCase,
-        { enableTelemetry: false, isFirstTime: false, enableHighContrastMode: false } as SetUserConfigTestCase,
+        {
+            enableTelemetry: false,
+            isFirstTime: false,
+            enableHighContrastMode: true,
+        } as SetUserConfigTestCase,
+        {
+            enableTelemetry: false,
+            isFirstTime: false,
+            enableHighContrastMode: false,
+        } as SetUserConfigTestCase,
     ])('setHighContrast action: %p', (testCase: SetUserConfigTestCase) => {
         const storeTester = createStoreToTestAction('setHighContrastMode');
         initialStoreData = {
@@ -191,7 +233,9 @@ describe('UserConfigurationStoreTest', () => {
             bugServicePropertiesMap: {},
         };
 
-        indexDbStrictMock.setup(i => i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState))).verifiable(Times.once());
+        indexDbStrictMock
+            .setup(i => i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)))
+            .verifiable(Times.once());
 
         storeTester
             .withActionParam(setHighContrastData)
@@ -221,7 +265,9 @@ describe('UserConfigurationStoreTest', () => {
             };
 
             indexDbStrictMock
-                .setup(i => i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)))
+                .setup(i =>
+                    i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
+                )
                 .verifiable(Times.once());
 
             storeTester
@@ -231,7 +277,13 @@ describe('UserConfigurationStoreTest', () => {
         },
     );
 
-    test.each([undefined, null, {}, { 'test-service': {} }, { 'test-service': { 'test-name': 'test-value' } }])(
+    test.each([
+        undefined,
+        null,
+        {},
+        { 'test-service': {} },
+        { 'test-service': { 'test-name': 'test-value' } },
+    ])(
         'setIssueFilingServiceProperty with initial map state %p',
         (initialMapState: IssueFilingServicePropertiesMap) => {
             const storeTester = createStoreToTestAction('setIssueFilingServiceProperty');
@@ -255,7 +307,9 @@ describe('UserConfigurationStoreTest', () => {
             };
 
             indexDbStrictMock
-                .setup(indexDb => indexDb.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)))
+                .setup(indexDb =>
+                    indexDb.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
+                )
                 .verifiable(Times.once());
 
             storeTester
@@ -282,7 +336,9 @@ describe('UserConfigurationStoreTest', () => {
         };
 
         indexDbStrictMock
-            .setup(indexDb => indexDb.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)))
+            .setup(indexDb =>
+                indexDb.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
+            )
             .verifiable(Times.once());
 
         storeTester

--- a/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
+++ b/src/tests/unit/tests/background/stores/path-snippet-store.test.ts
@@ -28,7 +28,10 @@ describe('PathSnippetStoreTest', () => {
         const initialState = getDefaultState();
         const finalState = getDefaultState();
 
-        createStoreForPathSnippetActions('getCurrentState').testListenerToBeCalledOnce(initialState, finalState);
+        createStoreForPathSnippetActions('getCurrentState').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     test('on addPath', () => {
@@ -69,7 +72,9 @@ describe('PathSnippetStoreTest', () => {
         return createStoreWithNullParams(PathSnippetStore).getDefaultState();
     }
 
-    function createStoreForPathSnippetActions(actionName: keyof PathSnippetActions): StoreTester<PathSnippetStoreData, PathSnippetActions> {
+    function createStoreForPathSnippetActions(
+        actionName: keyof PathSnippetActions,
+    ): StoreTester<PathSnippetStoreData, PathSnippetActions> {
         const factory = (actions: PathSnippetActions) => new PathSnippetStore(actions);
         return new StoreTester(PathSnippetActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/tab-store.test.ts
+++ b/src/tests/unit/tests/background/stores/tab-store.test.ts
@@ -87,15 +87,23 @@ describe('TabStoreTest', () => {
         const initialState = new TabStoreDataBuilder().build();
         const expectedState = new TabStoreDataBuilder().build();
 
-        createStoreTesterForTabActions('getCurrentState').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForTabActions('getCurrentState').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('onTabRemove', () => {
         const initialState: TabStoreData = new TabStoreDataBuilder().build();
 
-        const expectedState: TabStoreData = new TabStoreDataBuilder().with('isClosed', true).build();
+        const expectedState: TabStoreData = new TabStoreDataBuilder()
+            .with('isClosed', true)
+            .build();
 
-        createStoreTesterForTabActions('tabRemove').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForTabActions('tabRemove').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test.each`
@@ -137,7 +145,9 @@ describe('TabStoreTest', () => {
         const initialState: TabStoreData = new TabStoreDataBuilder().build();
 
         const payload = true;
-        const finalState: TabStoreData = new TabStoreDataBuilder().with('isPageHidden', payload).build();
+        const finalState: TabStoreData = new TabStoreDataBuilder()
+            .with('isPageHidden', payload)
+            .build();
 
         createStoreTesterForTabActions('tabVisibilityChange')
             .withActionParam(payload)
@@ -157,11 +167,16 @@ describe('TabStoreTest', () => {
     });
 
     test('onEnableVisualization, state.isChanged is true', () => {
-        const initialState: TabStoreData = new TabStoreDataBuilder().with('isChanged', true).build();
+        const initialState: TabStoreData = new TabStoreDataBuilder()
+            .with('isChanged', true)
+            .build();
 
         const finalState: TabStoreData = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions('enableVisualization').testListenerToBeCalledOnce(initialState, finalState);
+        createStoreTesterForVisualizationActions('enableVisualization').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     test('on enableVisualization, state.isChanged is false', () => {
@@ -169,7 +184,10 @@ describe('TabStoreTest', () => {
 
         const finalState = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions('enableVisualization').testListenerToNeverBeCalled(initialState, finalState);
+        createStoreTesterForVisualizationActions('enableVisualization').testListenerToNeverBeCalled(
+            initialState,
+            finalState,
+        );
     });
 
     test('on updateSelectedPivotChild, state.isChanged is true', () => {
@@ -177,7 +195,9 @@ describe('TabStoreTest', () => {
 
         const finalState = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions('updateSelectedPivotChild').testListenerToBeCalledOnce(initialState, finalState);
+        createStoreTesterForVisualizationActions(
+            'updateSelectedPivotChild',
+        ).testListenerToBeCalledOnce(initialState, finalState);
     });
 
     test('on updateSelectedPivotChild, state.isChanged is false', () => {
@@ -185,15 +205,22 @@ describe('TabStoreTest', () => {
 
         const finalState = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions('updateSelectedPivotChild').testListenerToNeverBeCalled(initialState, finalState);
+        createStoreTesterForVisualizationActions(
+            'updateSelectedPivotChild',
+        ).testListenerToNeverBeCalled(initialState, finalState);
     });
 
     test('on updateSelectedPivot, state.isChanged is true', () => {
-        const initialState: TabStoreData = new TabStoreDataBuilder().with('isChanged', true).build();
+        const initialState: TabStoreData = new TabStoreDataBuilder()
+            .with('isChanged', true)
+            .build();
 
         const finalState: TabStoreData = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions('updateSelectedPivot').testListenerToBeCalledOnce(initialState, finalState);
+        createStoreTesterForVisualizationActions('updateSelectedPivot').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     test('on updateSelectedPivot, state.isChange is false', () => {
@@ -201,10 +228,15 @@ describe('TabStoreTest', () => {
 
         const finalState: TabStoreData = new TabStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions('updateSelectedPivot').testListenerToNeverBeCalled(initialState, finalState);
+        createStoreTesterForVisualizationActions('updateSelectedPivot').testListenerToNeverBeCalled(
+            initialState,
+            finalState,
+        );
     });
 
-    function createStoreTesterForTabActions(actionName: keyof TabActions): StoreTester<TabStoreData, TabActions> {
+    function createStoreTesterForTabActions(
+        actionName: keyof TabActions,
+    ): StoreTester<TabStoreData, TabActions> {
         const factory = (actions: TabActions) => new TabStore(actions, new VisualizationActions());
         return new StoreTester(TabActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/unified-scan-result-store.test.ts
@@ -36,7 +36,10 @@ describe('UnifiedScanResultStore Test', () => {
         const initialState = getDefaultState();
         const finalState = getDefaultState();
 
-        createStoreForUnifiedScanResultActions('getCurrentState').testListenerToBeCalledOnce(initialState, finalState);
+        createStoreForUnifiedScanResultActions('getCurrentState').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     test('onScanCompleted', () => {

--- a/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-scan-result-store.test.ts
@@ -5,7 +5,10 @@ import { TabActions } from 'background/actions/tab-actions';
 import { VisualizationScanResultActions } from 'background/actions/visualization-scan-result-actions';
 import { VisualizationScanResultStore } from 'background/stores/visualization-scan-result-store';
 import { StoreNames } from '../../../../../common/stores/store-names';
-import { TabbedElementData, VisualizationScanResultData } from '../../../../../common/types/store-data/visualization-scan-result-data';
+import {
+    TabbedElementData,
+    VisualizationScanResultData,
+} from '../../../../../common/types/store-data/visualization-scan-result-data';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { HtmlElementAxeResults } from '../../../../../injected/scanner-utils';
 import { ScanResults } from '../../../../../scanner/iruleresults';
@@ -32,7 +35,10 @@ describe('VisualizationScanResultStoreTest', () => {
         const initialState = new VisualizationScanResultStoreDataBuilder().build();
         const finalState = new VisualizationScanResultStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationScanResultActions(actionName).testListenerToBeCalledOnce(initialState, finalState);
+        createStoreTesterForVisualizationScanResultActions(actionName).testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     test('onIssuesDisabled', () => {
@@ -147,7 +153,9 @@ describe('VisualizationScanResultStoreTest', () => {
             .withIssuesSelectedTargets(selectorMap)
             .build();
 
-        createStoreTesterForVisualizationScanResultActions('disableIssues').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForVisualizationScanResultActions(
+            'disableIssues',
+        ).testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     test('onTabStopDisabled', () => {
@@ -160,11 +168,17 @@ describe('VisualizationScanResultStoreTest', () => {
             },
         ];
 
-        const initialState = new VisualizationScanResultStoreDataBuilder().withTabStopsTabbedElements(tabEvents).build();
+        const initialState = new VisualizationScanResultStoreDataBuilder()
+            .withTabStopsTabbedElements(tabEvents)
+            .build();
 
-        const expectedState = new VisualizationScanResultStoreDataBuilder().withTabStopsTabbedElements(null).build();
+        const expectedState = new VisualizationScanResultStoreDataBuilder()
+            .withTabStopsTabbedElements(null)
+            .build();
 
-        createStoreTesterForVisualizationScanResultActions('disableTabStop').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForVisualizationScanResultActions(
+            'disableTabStop',
+        ).testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     test('onScanCompleted', () => {
@@ -445,7 +459,9 @@ describe('VisualizationScanResultStoreTest', () => {
             },
         ];
 
-        const expectedState = new VisualizationScanResultStoreDataBuilder().withTabStopsTabbedElements(tabbedElements).build();
+        const expectedState = new VisualizationScanResultStoreDataBuilder()
+            .withTabStopsTabbedElements(tabbedElements)
+            .build();
 
         createStoreTesterForVisualizationScanResultActions('addTabbedElement')
             .withActionParam(payload)
@@ -468,7 +484,9 @@ describe('VisualizationScanResultStoreTest', () => {
             },
         ];
 
-        const initialState = new VisualizationScanResultStoreDataBuilder().withTabStopsTabbedElements(initialTabbedElements).build();
+        const initialState = new VisualizationScanResultStoreDataBuilder()
+            .withTabStopsTabbedElements(initialTabbedElements)
+            .build();
 
         const payload: AddTabbedElementPayload = {
             tabbedElements: [
@@ -496,7 +514,9 @@ describe('VisualizationScanResultStoreTest', () => {
             },
         ];
 
-        const expectedState = new VisualizationScanResultStoreDataBuilder().withTabStopsTabbedElements(expectedTabbedElements).build();
+        const expectedState = new VisualizationScanResultStoreDataBuilder()
+            .withTabStopsTabbedElements(expectedTabbedElements)
+            .build();
 
         createStoreTesterForVisualizationScanResultActions('addTabbedElement')
             .withActionParam(payload)
@@ -512,19 +532,26 @@ describe('VisualizationScanResultStoreTest', () => {
 
         const expectedState = new VisualizationScanResultStoreDataBuilder().build();
 
-        createStoreTesterForTabActions('existingTabUpdated').testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForTabActions('existingTabUpdated').testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     function createStoreTesterForVisualizationScanResultActions(
         actionName: keyof VisualizationScanResultActions,
     ): StoreTester<VisualizationScanResultData, VisualizationScanResultActions> {
-        const factory = (actions: VisualizationScanResultActions) => new VisualizationScanResultStore(actions, new TabActions());
+        const factory = (actions: VisualizationScanResultActions) =>
+            new VisualizationScanResultStore(actions, new TabActions());
 
         return new StoreTester(VisualizationScanResultActions, actionName, factory);
     }
 
-    function createStoreTesterForTabActions(actionName: keyof TabActions): StoreTester<VisualizationScanResultData, TabActions> {
-        const factory = (actions: TabActions) => new VisualizationScanResultStore(new VisualizationScanResultActions(), actions);
+    function createStoreTesterForTabActions(
+        actionName: keyof TabActions,
+    ): StoreTester<VisualizationScanResultData, TabActions> {
+        const factory = (actions: TabActions) =>
+            new VisualizationScanResultStore(new VisualizationScanResultActions(), actions);
 
         return new StoreTester(TabActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/stores/visualization-store.test.ts
+++ b/src/tests/unit/tests/background/stores/visualization-store.test.ts
@@ -86,35 +86,42 @@ describe('VisualizationStoreTest ', () => {
                 .testListenerToBeCalledOnce(initialState, expectedState);
         });
 
-        it.each([DetailsViewPivotType.assessment, DetailsViewPivotType.fastPass])('when view & pivot are the same', pivotType => {
-            const viewType = VisualizationType.Issues;
+        it.each([DetailsViewPivotType.assessment, DetailsViewPivotType.fastPass])(
+            'when view & pivot are the same',
+            pivotType => {
+                const viewType = VisualizationType.Issues;
 
-            const expectedState = new VisualizationStoreDataBuilder()
-                .with('selectedAdhocDetailsView', viewType)
-                .with('selectedDetailsViewPivot', pivotType)
-                .build();
+                const expectedState = new VisualizationStoreDataBuilder()
+                    .with('selectedAdhocDetailsView', viewType)
+                    .with('selectedDetailsViewPivot', pivotType)
+                    .build();
 
-            const initialState = new VisualizationStoreDataBuilder()
-                .with('selectedAdhocDetailsView', viewType)
-                .with('selectedDetailsViewPivot', pivotType)
-                .build();
+                const initialState = new VisualizationStoreDataBuilder()
+                    .with('selectedAdhocDetailsView', viewType)
+                    .with('selectedDetailsViewPivot', pivotType)
+                    .build();
 
-            initialState.tests.adhoc[AdHocTestkeys.Issues] = { enabled: true };
-            expectedState.tests.adhoc[AdHocTestkeys.Issues] = { enabled: true };
+                initialState.tests.adhoc[AdHocTestkeys.Issues] = { enabled: true };
+                expectedState.tests.adhoc[AdHocTestkeys.Issues] = { enabled: true };
 
-            const payload: UpdateSelectedDetailsViewPayload = {
-                detailsViewType: viewType,
-                pivotType: pivotType,
-            };
+                const payload: UpdateSelectedDetailsViewPayload = {
+                    detailsViewType: viewType,
+                    pivotType: pivotType,
+                };
 
-            createStoreTesterForVisualizationActions(actionName)
-                .withActionParam(payload)
-                .testListenerToNeverBeCalled(initialState, expectedState);
-        });
+                createStoreTesterForVisualizationActions(actionName)
+                    .withActionParam(payload)
+                    .testListenerToNeverBeCalled(initialState, expectedState);
+            },
+        );
 
         test('when view changes to null', () => {
-            const expectedState = new VisualizationStoreDataBuilder().with('selectedAdhocDetailsView', VisualizationType.Landmarks).build();
-            const initialState = new VisualizationStoreDataBuilder().with('selectedAdhocDetailsView', VisualizationType.Landmarks).build();
+            const expectedState = new VisualizationStoreDataBuilder()
+                .with('selectedAdhocDetailsView', VisualizationType.Landmarks)
+                .build();
+            const initialState = new VisualizationStoreDataBuilder()
+                .with('selectedAdhocDetailsView', VisualizationType.Landmarks)
+                .build();
 
             const payload: UpdateSelectedDetailsViewPayload = {
                 detailsViewType: VisualizationType.Issues,
@@ -158,7 +165,9 @@ describe('VisualizationStoreTest ', () => {
         test('when view is different', () => {
             const initialState = new VisualizationStoreDataBuilder().build();
 
-            const expectedState = new VisualizationStoreDataBuilder().with('selectedAdhocDetailsView', VisualizationType.Issues).build();
+            const expectedState = new VisualizationStoreDataBuilder()
+                .with('selectedAdhocDetailsView', VisualizationType.Issues)
+                .build();
 
             const payload: UpdateSelectedDetailsViewPayload = {
                 detailsViewType: VisualizationType.Headings,
@@ -171,7 +180,9 @@ describe('VisualizationStoreTest ', () => {
         });
 
         test('when view is null', () => {
-            const initialState = new VisualizationStoreDataBuilder().with('selectedAdhocDetailsView', VisualizationType.Issues).build();
+            const initialState = new VisualizationStoreDataBuilder()
+                .with('selectedAdhocDetailsView', VisualizationType.Issues)
+                .build();
             const expectedState = cloneDeep(initialState);
 
             const payload: UpdateSelectedDetailsViewPayload = {
@@ -188,9 +199,13 @@ describe('VisualizationStoreTest ', () => {
     test('onUpdateSelectedPivot when pivot value is same as before', () => {
         const actionName = 'updateSelectedPivot';
         const oldPivotValue = DetailsViewPivotType.fastPass;
-        const initialState = new VisualizationStoreDataBuilder().with('selectedDetailsViewPivot', oldPivotValue).build();
+        const initialState = new VisualizationStoreDataBuilder()
+            .with('selectedDetailsViewPivot', oldPivotValue)
+            .build();
 
-        const expectedState = new VisualizationStoreDataBuilder().with('selectedDetailsViewPivot', oldPivotValue).build();
+        const expectedState = new VisualizationStoreDataBuilder()
+            .with('selectedDetailsViewPivot', oldPivotValue)
+            .build();
 
         const payload: UpdateSelectedPivot = {
             pivotKey: oldPivotValue,
@@ -291,7 +306,9 @@ describe('VisualizationStoreTest ', () => {
             test: VisualizationType.Headings,
         };
 
-        const initialState = new VisualizationStoreDataBuilder().withHeadingsAssessment(true, HeadingsTestStep.missingHeadings).build();
+        const initialState = new VisualizationStoreDataBuilder()
+            .withHeadingsAssessment(true, HeadingsTestStep.missingHeadings)
+            .build();
 
         const expectedState = new VisualizationStoreDataBuilder()
             .withHeadingsEnable()
@@ -333,7 +350,9 @@ describe('VisualizationStoreTest ', () => {
             requirement: HeadingsTestStep.missingHeadings,
         };
 
-        const initialState = new VisualizationStoreDataBuilder().withLandmarksAssessment(true, LandmarkTestStep.landmarkRoles).build();
+        const initialState = new VisualizationStoreDataBuilder()
+            .withLandmarksAssessment(true, LandmarkTestStep.landmarkRoles)
+            .build();
 
         const expectedState = new VisualizationStoreDataBuilder()
             .withLandmarksAssessment(false, LandmarkTestStep.landmarkRoles)
@@ -354,7 +373,9 @@ describe('VisualizationStoreTest ', () => {
             requirement: HeadingsTestStep.missingHeadings,
         };
 
-        const initialState = new VisualizationStoreDataBuilder().withHeadingsAssessment(true, HeadingsTestStep.headingFunction).build();
+        const initialState = new VisualizationStoreDataBuilder()
+            .withHeadingsAssessment(true, HeadingsTestStep.headingFunction)
+            .build();
 
         const expectedState = new VisualizationStoreDataBuilder()
             .withHeadingsAssessment(false, HeadingsTestStep.headingFunction)
@@ -640,7 +661,10 @@ describe('VisualizationStoreTest ', () => {
         const initialState = new VisualizationStoreDataBuilder().build();
         const expectedState = new VisualizationStoreDataBuilder().build();
 
-        createStoreTesterForVisualizationActions(actionName).testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForVisualizationActions(actionName).testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('enableVisualization when already scanning', () => {
@@ -648,9 +672,13 @@ describe('VisualizationStoreTest ', () => {
         const payload: ToggleActionPayload = {
             test: VisualizationType.Issues,
         };
-        const initialState = new VisualizationStoreDataBuilder().with('scanning', 'headings').build();
+        const initialState = new VisualizationStoreDataBuilder()
+            .with('scanning', 'headings')
+            .build();
 
-        const expectedState = new VisualizationStoreDataBuilder().with('scanning', 'headings').build();
+        const expectedState = new VisualizationStoreDataBuilder()
+            .with('scanning', 'headings')
+            .build();
 
         createStoreTesterForVisualizationActions(actionName)
             .withActionParam(payload)
@@ -667,41 +695,58 @@ describe('VisualizationStoreTest ', () => {
             .with('injectingStarted', false)
             .build();
 
-        createStoreTesterForInjectionActions(actionName).testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForInjectionActions(actionName).testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('onInjectionStarted when injectingStarted is false', () => {
         const actionName = 'injectionStarted';
 
-        const initialState = new VisualizationStoreDataBuilder().with('injectingStarted', false).build();
+        const initialState = new VisualizationStoreDataBuilder()
+            .with('injectingStarted', false)
+            .build();
 
         const expectedState = new VisualizationStoreDataBuilder()
             .with('injectingInProgress', true)
             .with('injectingStarted', true)
             .build();
 
-        createStoreTesterForInjectionActions(actionName).testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForInjectionActions(actionName).testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
     test('onInjectionStarted when injectingStarted is true', () => {
         const actionName = 'injectionStarted';
 
-        const initialState = new VisualizationStoreDataBuilder().with('injectingStarted', true).build();
+        const initialState = new VisualizationStoreDataBuilder()
+            .with('injectingStarted', true)
+            .build();
 
         const expectedState = new VisualizationStoreDataBuilder()
             .with('injectingInProgress', null)
             .with('injectingStarted', true)
             .build();
 
-        createStoreTesterForInjectionActions(actionName).testListenerToNeverBeCalled(initialState, expectedState);
+        createStoreTesterForInjectionActions(actionName).testListenerToNeverBeCalled(
+            initialState,
+            expectedState,
+        );
     });
 
     test('onScrollRequested', () => {
         const actionName = 'scrollRequested';
 
-        const initialState = new VisualizationStoreDataBuilder().with('focusedTarget', ['target']).build();
+        const initialState = new VisualizationStoreDataBuilder()
+            .with('focusedTarget', ['target'])
+            .build();
 
-        const expectedState = new VisualizationStoreDataBuilder().with('focusedTarget', null).build();
+        const expectedState = new VisualizationStoreDataBuilder()
+            .with('focusedTarget', null)
+            .build();
 
         const payload = {};
 
@@ -739,7 +784,9 @@ describe('VisualizationStoreTest ', () => {
 
     test('onScanHeadingsCompleted', () => {
         const actionName = 'scanCompleted';
-        const initialState = new VisualizationStoreDataBuilder().with('scanning', 'headings').build();
+        const initialState = new VisualizationStoreDataBuilder()
+            .with('scanning', 'headings')
+            .build();
 
         const expectedState = new VisualizationStoreDataBuilder().with('scanning', null).build();
 
@@ -752,7 +799,9 @@ describe('VisualizationStoreTest ', () => {
 
     test('onScanLandmarksCompleted', () => {
         const actionName = 'scanCompleted';
-        const initialState = new VisualizationStoreDataBuilder().with('scanning', 'landmarks').build();
+        const initialState = new VisualizationStoreDataBuilder()
+            .with('scanning', 'landmarks')
+            .build();
 
         const expectedState = new VisualizationStoreDataBuilder().with('scanning', null).build();
 
@@ -770,7 +819,9 @@ describe('VisualizationStoreTest ', () => {
 
         const payload = ['1'];
 
-        const expectedState = new VisualizationStoreDataBuilder().withFocusedTarget(payload).build();
+        const expectedState = new VisualizationStoreDataBuilder()
+            .withFocusedTarget(payload)
+            .build();
 
         createStoreTesterForVisualizationActions(actionName)
             .withActionParam(payload)
@@ -792,12 +843,22 @@ describe('VisualizationStoreTest ', () => {
             .withLandmarksEnable()
             .build();
 
-        createStoreTesterForTabActions(actionName).testListenerToBeCalledOnce(initialState, expectedState);
+        createStoreTesterForTabActions(actionName).testListenerToBeCalledOnce(
+            initialState,
+            expectedState,
+        );
     });
 
-    function createStoreTesterForTabActions(actionName: keyof TabActions): StoreTester<VisualizationStoreData, TabActions> {
+    function createStoreTesterForTabActions(
+        actionName: keyof TabActions,
+    ): StoreTester<VisualizationStoreData, TabActions> {
         const factory = (actions: TabActions) =>
-            new VisualizationStore(new VisualizationActions(), actions, new InjectionActions(), new VisualizationConfigurationFactory());
+            new VisualizationStore(
+                new VisualizationActions(),
+                actions,
+                new InjectionActions(),
+                new VisualizationConfigurationFactory(),
+            );
 
         return new StoreTester(TabActions, actionName, factory);
     }
@@ -806,7 +867,12 @@ describe('VisualizationStoreTest ', () => {
         actionName: keyof VisualizationActions,
     ): StoreTester<VisualizationStoreData, VisualizationActions> {
         const factory = (actions: VisualizationActions) =>
-            new VisualizationStore(actions, new TabActions(), new InjectionActions(), new VisualizationConfigurationFactory());
+            new VisualizationStore(
+                actions,
+                new TabActions(),
+                new InjectionActions(),
+                new VisualizationConfigurationFactory(),
+            );
 
         return new StoreTester(VisualizationActions, actionName, factory);
     }
@@ -815,7 +881,12 @@ describe('VisualizationStoreTest ', () => {
         actionName: keyof InjectionActions,
     ): StoreTester<VisualizationStoreData, InjectionActions> {
         const factory = (actions: InjectionActions) =>
-            new VisualizationStore(new VisualizationActions(), new TabActions(), actions, new VisualizationConfigurationFactory());
+            new VisualizationStore(
+                new VisualizationActions(),
+                new TabActions(),
+                actions,
+                new VisualizationConfigurationFactory(),
+            );
 
         return new StoreTester(InjectionActions, actionName, factory);
     }

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -46,7 +46,10 @@ describe('TabContextFactoryTest', () => {
     it('createInterpreter', () => {
         const tabId = -1;
         const windowUtilsStub = Mock.ofType(WindowUtils);
-        const broadcastMock = Mock.ofType<(message: Object) => Promise<void>>(null, MockBehavior.Strict);
+        const broadcastMock = Mock.ofType<(message: Object) => Promise<void>>(
+            null,
+            MockBehavior.Strict,
+        );
         const telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler);
         const targetTabControllerMock = Mock.ofType(TargetTabController);
         const assessmentStore = Mock.ofType(AssessmentStore);
@@ -66,7 +69,13 @@ describe('TabContextFactoryTest', () => {
 
         storeNames.forEach(storeName => {
             broadcastMock
-                .setup(bm => bm(It.isObjectWith({ storeId: StoreNames[storeName] } as StoreUpdateMessage<any>)))
+                .setup(bm =>
+                    bm(
+                        It.isObjectWith({ storeId: StoreNames[storeName] } as StoreUpdateMessage<
+                            any
+                        >),
+                    ),
+                )
                 .returns(() => Promise.resolve())
                 .verifiable(Times.once());
         });
@@ -74,8 +83,12 @@ describe('TabContextFactoryTest', () => {
         mockBrowserAdapter.setup(ba => ba.addListenerToTabsOnRemoved(It.isAny())).verifiable();
         mockBrowserAdapter.setup(ba => ba.addListenerToTabsOnUpdated(It.isAny())).verifiable();
 
-        const visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
-        visualizationConfigurationFactoryMock.setup(vcfm => vcfm.getConfiguration(It.isAny())).returns(theType => getConfigs(theType));
+        const visualizationConfigurationFactoryMock = Mock.ofType(
+            VisualizationConfigurationFactory,
+        );
+        visualizationConfigurationFactoryMock
+            .setup(vcfm => vcfm.getConfiguration(It.isAny()))
+            .returns(theType => getConfigs(theType));
 
         const promiseFactoryMock = Mock.ofType<PromiseFactory>();
         const testObject = new TabContextFactory(
@@ -100,7 +113,13 @@ describe('TabContextFactoryTest', () => {
         broadcastMock.reset();
 
         broadcastMock
-            .setup(bm => bm(It.isObjectWith({ storeId: StoreNames[StoreNames.VisualizationScanResultStore] } as StoreUpdateMessage<any>)))
+            .setup(bm =>
+                bm(
+                    It.isObjectWith({
+                        storeId: StoreNames[StoreNames.VisualizationScanResultStore],
+                    } as StoreUpdateMessage<any>),
+                ),
+            )
             .returns(() => Promise.resolve())
             .verifiable(Times.once());
 
@@ -114,7 +133,9 @@ describe('TabContextFactoryTest', () => {
         expect(tabContext.interpreter).toBeInstanceOf(Interpreter);
         expect(tabContext.stores.visualizationStore).toBeInstanceOf(VisualizationStore);
         expect(tabContext.stores.tabStore).toBeInstanceOf(TabStore);
-        expect(tabContext.stores.visualizationScanResultStore).toBeInstanceOf(VisualizationScanResultStore);
+        expect(tabContext.stores.visualizationScanResultStore).toBeInstanceOf(
+            VisualizationScanResultStore,
+        );
         expect(tabContext.stores.devToolStore).toBeInstanceOf(DevToolStore);
         expect(tabContext.stores.detailsViewStore).toBeInstanceOf(DetailsViewStore);
         expect(tabContext.stores.inspectStore).toBeInstanceOf(InspectStore);

--- a/src/tests/unit/tests/background/target-page-controller.test.ts
+++ b/src/tests/unit/tests/background/target-page-controller.test.ts
@@ -9,7 +9,10 @@ import { TargetPageController } from 'background/target-page-controller';
 import { Logger } from 'common/logging/logger';
 import { Messages } from 'common/messages';
 import { isFunction, values } from 'lodash';
-import { createSimulatedBrowserAdapter, SimulatedBrowserAdapter } from 'tests/unit/common/simulated-browser-adapter';
+import {
+    createSimulatedBrowserAdapter,
+    SimulatedBrowserAdapter,
+} from 'tests/unit/common/simulated-browser-adapter';
 import { tick } from 'tests/unit/common/tick';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DictionaryNumberTo } from 'types/common-types';
@@ -30,19 +33,39 @@ describe('TargetPageController', () => {
     const EXISTING_WINDOW = { id: EXISTING_WINDOW_ID } as chrome.windows.Window;
 
     const EXISTING_ACTIVE_TAB_ID = 1;
-    const EXISTING_ACTIVE_TAB = { id: EXISTING_ACTIVE_TAB_ID, windowId: EXISTING_WINDOW_ID, active: true } as chrome.tabs.Tab;
+    const EXISTING_ACTIVE_TAB = {
+        id: EXISTING_ACTIVE_TAB_ID,
+        windowId: EXISTING_WINDOW_ID,
+        active: true,
+    } as chrome.tabs.Tab;
 
     const EXISTING_INACTIVE_TAB_ID = 2;
-    const EXISTING_INACTIVE_TAB = { id: EXISTING_INACTIVE_TAB_ID, windowId: EXISTING_WINDOW_ID, active: false } as chrome.tabs.Tab;
+    const EXISTING_INACTIVE_TAB = {
+        id: EXISTING_INACTIVE_TAB_ID,
+        windowId: EXISTING_WINDOW_ID,
+        active: false,
+    } as chrome.tabs.Tab;
 
     const NEW_TAB_ID = 3;
-    const NEW_TAB = { id: NEW_TAB_ID, windowId: EXISTING_WINDOW_ID, active: true } as chrome.tabs.Tab;
+    const NEW_TAB = {
+        id: NEW_TAB_ID,
+        windowId: EXISTING_WINDOW_ID,
+        active: true,
+    } as chrome.tabs.Tab;
 
     beforeEach(() => {
         mockLogger = Mock.ofType<Logger>();
-        mockBroadcasterFactoryStrictMock = Mock.ofType<BrowserMessageBroadcasterFactory>(undefined, MockBehavior.Strict);
-        mockBroadcasterFactoryStrictMock.setup(m => m.createTabSpecificBroadcaster(It.isAny())).returns(_ => stubBroadcastDelegate);
-        mockBrowserAdapter = createSimulatedBrowserAdapter([EXISTING_ACTIVE_TAB, EXISTING_INACTIVE_TAB], [EXISTING_WINDOW]);
+        mockBroadcasterFactoryStrictMock = Mock.ofType<BrowserMessageBroadcasterFactory>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        mockBroadcasterFactoryStrictMock
+            .setup(m => m.createTabSpecificBroadcaster(It.isAny()))
+            .returns(_ => stubBroadcastDelegate);
+        mockBrowserAdapter = createSimulatedBrowserAdapter(
+            [EXISTING_ACTIVE_TAB, EXISTING_INACTIVE_TAB],
+            [EXISTING_WINDOW],
+        );
         mockDetailsViewController = setupMockDetailsViewController();
         tabToContextMap = {};
         mockTabInterpreters = {};
@@ -66,26 +89,47 @@ describe('TargetPageController', () => {
             await testSubject.initialize();
 
             mockBrowserAdapter.verify(m => m.addListenerOnConnect(It.isAny()), Times.once());
-            mockBrowserAdapter.verify(m => m.addListenerOnWindowsFocusChanged(It.isAny()), Times.once());
-            mockBrowserAdapter.verify(m => m.addListenerToTabsOnActivated(It.isAny()), Times.once());
+            mockBrowserAdapter.verify(
+                m => m.addListenerOnWindowsFocusChanged(It.isAny()),
+                Times.once(),
+            );
+            mockBrowserAdapter.verify(
+                m => m.addListenerToTabsOnActivated(It.isAny()),
+                Times.once(),
+            );
             mockBrowserAdapter.verify(m => m.addListenerToTabsOnRemoved(It.isAny()), Times.once());
             mockBrowserAdapter.verify(m => m.addListenerToTabsOnUpdated(It.isAny()), Times.once());
-            mockBrowserAdapter.verify(m => m.addListenerToWebNavigationUpdated(It.isAny()), Times.once());
+            mockBrowserAdapter.verify(
+                m => m.addListenerToWebNavigationUpdated(It.isAny()),
+                Times.once(),
+            );
 
-            mockDetailsViewController.verify(m => m.setupDetailsViewTabRemovedHandler(It.isAny()), Times.once());
+            mockDetailsViewController.verify(
+                m => m.setupDetailsViewTabRemovedHandler(It.isAny()),
+                Times.once(),
+            );
         });
 
         it('should create a tab context for each pre-existing tab', async () => {
             await testSubject.initialize();
 
-            mockTabContextFactory.verify(f => f.createTabContext(It.isAny(), It.isAny(), It.isAny(), EXISTING_ACTIVE_TAB_ID), Times.once());
+            mockTabContextFactory.verify(
+                f => f.createTabContext(It.isAny(), It.isAny(), It.isAny(), EXISTING_ACTIVE_TAB_ID),
+                Times.once(),
+            );
             expect(tabToContextMap[EXISTING_ACTIVE_TAB_ID]).toHaveProperty(
                 'interpreter',
                 mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].object,
             );
 
             mockTabContextFactory.verify(
-                f => f.createTabContext(It.isAny(), It.isAny(), It.isAny(), EXISTING_INACTIVE_TAB_ID),
+                f =>
+                    f.createTabContext(
+                        It.isAny(),
+                        It.isAny(),
+                        It.isAny(),
+                        EXISTING_INACTIVE_TAB_ID,
+                    ),
                 Times.once(),
             );
             expect(tabToContextMap[EXISTING_INACTIVE_TAB_ID]).toHaveProperty(
@@ -93,7 +137,10 @@ describe('TargetPageController', () => {
                 mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].object,
             );
 
-            mockTabContextFactory.verify(f => f.createTabContext(It.isAny(), It.isAny(), It.isAny(), NEW_TAB_ID), Times.never());
+            mockTabContextFactory.verify(
+                f => f.createTabContext(It.isAny(), It.isAny(), It.isAny(), NEW_TAB_ID),
+                Times.never(),
+            );
             expect(tabToContextMap[NEW_TAB_ID]).toBeUndefined();
         });
     });
@@ -106,7 +153,9 @@ describe('TargetPageController', () => {
 
         describe('onConnect', () => {
             it('should not have any observable effect', () => {
-                mockBrowserAdapter.notifyOnConnect({ name: 'irrelevant port' } as chrome.runtime.Port);
+                mockBrowserAdapter.notifyOnConnect({
+                    name: 'irrelevant port',
+                } as chrome.runtime.Port);
                 verifyNoInterpreterMessages(mockTabInterpreters);
             });
         });
@@ -130,8 +179,14 @@ describe('TargetPageController', () => {
                     tabId: NEW_TAB_ID,
                 } as chrome.webNavigation.WebNavigationFramedCallbackDetails);
 
-                mockTabContextFactory.verify(f => f.createTabContext(It.isAny(), It.isAny(), It.isAny(), NEW_TAB_ID), Times.once());
-                expect(tabToContextMap[NEW_TAB_ID]).toHaveProperty('interpreter', mockTabInterpreters[NEW_TAB_ID].object);
+                mockTabContextFactory.verify(
+                    f => f.createTabContext(It.isAny(), It.isAny(), It.isAny(), NEW_TAB_ID),
+                    Times.once(),
+                );
+                expect(tabToContextMap[NEW_TAB_ID]).toHaveProperty(
+                    'interpreter',
+                    mockTabInterpreters[NEW_TAB_ID].object,
+                );
             });
 
             it('should send an Tab.ExistingTabUpdated message for root frames in existing tabs', () => {
@@ -145,7 +200,10 @@ describe('TargetPageController', () => {
                     payload: { ...EXISTING_ACTIVE_TAB },
                     tabId: EXISTING_ACTIVE_TAB_ID,
                 };
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(i => i.interpret(expectedMessage), Times.once());
+                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                    i => i.interpret(expectedMessage),
+                    Times.once(),
+                );
             });
         });
 
@@ -162,7 +220,10 @@ describe('TargetPageController', () => {
                     tabId: EXISTING_ACTIVE_TAB_ID,
                 };
                 mockBrowserAdapter.notifyTabsOnRemoved(EXISTING_ACTIVE_TAB_ID, null);
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(i => i.interpret(expectedMessage), Times.once());
+                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                    i => i.interpret(expectedMessage),
+                    Times.once(),
+                );
             });
 
             it('should remove tabToContextMap entries for tabs that are removed', () => {
@@ -194,7 +255,10 @@ describe('TargetPageController', () => {
                     payload: null,
                     tabId: EXISTING_ACTIVE_TAB_ID,
                 };
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(i => i.interpret(expectedMessage), Times.once());
+                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                    i => i.interpret(expectedMessage),
+                    Times.once(),
+                );
             });
         });
 
@@ -221,7 +285,10 @@ describe('TargetPageController', () => {
                         payload: { hidden: expectedHiddenValue },
                         tabId: EXISTING_ACTIVE_TAB_ID,
                     };
-                    mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(i => i.interpret(expectedMessage), Times.once());
+                    mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                        i => i.interpret(expectedMessage),
+                        Times.once(),
+                    );
                 },
             );
 
@@ -232,12 +299,17 @@ describe('TargetPageController', () => {
 
             it('should ignore inactive tabs', () => {
                 mockBrowserAdapter.notifyWindowsFocusChanged(irrelevantWindowId);
-                mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].verify(i => i.interpret(It.isAny()), Times.never());
+                mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].verify(
+                    i => i.interpret(It.isAny()),
+                    Times.never(),
+                );
             });
 
             it('should ignore tabs for windows which result in a runtime error when queried', () => {
                 mockBrowserAdapter.object.getRuntimeLastError(); // clear out the first method setup from setupMockBrowserAdapter()
-                mockBrowserAdapter.setup(m => m.getRuntimeLastError()).returns(() => ({ message: 'test error' }));
+                mockBrowserAdapter
+                    .setup(m => m.getRuntimeLastError())
+                    .returns(() => ({ message: 'test error' }));
 
                 mockBrowserAdapter.notifyWindowsFocusChanged(irrelevantWindowId);
                 verifyNoInterpreterMessages(mockTabInterpreters);
@@ -253,7 +325,10 @@ describe('TargetPageController', () => {
                     payload: { hidden: false },
                     tabId: EXISTING_INACTIVE_TAB_ID,
                 };
-                mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].verify(i => i.interpret(expectedMessage), Times.once());
+                mockTabInterpreters[EXISTING_INACTIVE_TAB_ID].verify(
+                    i => i.interpret(expectedMessage),
+                    Times.once(),
+                );
             });
 
             it('should send a Tab.VisibilityChange message with isHidden=true for other known tabs in the same window when a known tab is activated', async () => {
@@ -265,7 +340,10 @@ describe('TargetPageController', () => {
                     payload: { hidden: true },
                     tabId: EXISTING_ACTIVE_TAB_ID,
                 };
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(i => i.interpret(expectedMessage), Times.once());
+                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                    i => i.interpret(expectedMessage),
+                    Times.once(),
+                );
             });
 
             it('should send a Tab.VisibilityChange message with isHidden=true for other known tabs in the same window when an untracked tab is activated', async () => {
@@ -277,7 +355,10 @@ describe('TargetPageController', () => {
                     payload: { hidden: true },
                     tabId: EXISTING_ACTIVE_TAB_ID,
                 };
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(i => i.interpret(expectedMessage), Times.once());
+                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                    i => i.interpret(expectedMessage),
+                    Times.once(),
+                );
             });
 
             it('should not send activation messages for untracked tabs', () => {
@@ -295,7 +376,9 @@ describe('TargetPageController', () => {
 
         describe('onTabUpdated', () => {
             const changeInfoWithoutUrl: chrome.tabs.TabChangeInfo = {};
-            const changeInfoWithUrl: chrome.tabs.TabChangeInfo = { url: 'https://new-host/new-page' };
+            const changeInfoWithUrl: chrome.tabs.TabChangeInfo = {
+                url: 'https://new-host/new-page',
+            };
 
             it("should ignore updates that don't change the url", () => {
                 mockBrowserAdapter.updateTab(EXISTING_ACTIVE_TAB_ID, changeInfoWithoutUrl);
@@ -306,8 +389,14 @@ describe('TargetPageController', () => {
                 mockBrowserAdapter.tabs.push(NEW_TAB);
                 mockBrowserAdapter.updateTab(NEW_TAB_ID, changeInfoWithUrl);
 
-                mockTabContextFactory.verify(f => f.createTabContext(It.isAny(), It.isAny(), It.isAny(), NEW_TAB_ID), Times.once());
-                expect(tabToContextMap[NEW_TAB_ID]).toHaveProperty('interpreter', mockTabInterpreters[NEW_TAB_ID].object);
+                mockTabContextFactory.verify(
+                    f => f.createTabContext(It.isAny(), It.isAny(), It.isAny(), NEW_TAB_ID),
+                    Times.once(),
+                );
+                expect(tabToContextMap[NEW_TAB_ID]).toHaveProperty(
+                    'interpreter',
+                    mockTabInterpreters[NEW_TAB_ID].object,
+                );
             });
 
             it('should send a Tab.ExistingTabUpdated message for url changes in tracked tabs', () => {
@@ -321,7 +410,10 @@ describe('TargetPageController', () => {
                 };
                 mockBrowserAdapter.updateTab(EXISTING_ACTIVE_TAB_ID, changeInfoWithUrl);
 
-                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(i => i.interpret(expectedMessage), Times.once());
+                mockTabInterpreters[EXISTING_ACTIVE_TAB_ID].verify(
+                    i => i.interpret(expectedMessage),
+                    Times.once(),
+                );
             });
         });
     });
@@ -332,7 +424,9 @@ describe('TargetPageController', () => {
         }
     }
 
-    function verifyNoInterpreterMessages(interpreters: DictionaryNumberTo<IMock<Interpreter>>): void {
+    function verifyNoInterpreterMessages(
+        interpreters: DictionaryNumberTo<IMock<Interpreter>>,
+    ): void {
         for (const interpreter of values(interpreters)) {
             interpreter.verify(i => i.interpret(It.isAny()), Times.never());
         }
@@ -344,14 +438,23 @@ describe('TargetPageController', () => {
 
     function setupMockDetailsViewController(): SimulatedDetailsViewController {
         const mock: SimulatedDetailsViewController = Mock.ofType<ExtensionDetailsViewController>();
-        mock.setup(m => m.setupDetailsViewTabRemovedHandler(It.is(isFunction))).callback(c => (mock.notifyDetailsViewTabRemoved = c));
+        mock.setup(m => m.setupDetailsViewTabRemovedHandler(It.is(isFunction))).callback(
+            c => (mock.notifyDetailsViewTabRemoved = c),
+        );
         return mock;
     }
 
-    function setupMockTabContextFactory(interpreters: DictionaryNumberTo<IMock<Interpreter>>): IMock<TabContextFactory> {
+    function setupMockTabContextFactory(
+        interpreters: DictionaryNumberTo<IMock<Interpreter>>,
+    ): IMock<TabContextFactory> {
         const mock = Mock.ofType(TabContextFactory);
         mock.setup(m =>
-            m.createTabContext(stubBroadcastDelegate, mockBrowserAdapter.object, mockDetailsViewController.object, It.isAnyNumber()),
+            m.createTabContext(
+                stubBroadcastDelegate,
+                mockBrowserAdapter.object,
+                mockDetailsViewController.object,
+                It.isAnyNumber(),
+            ),
         ).returns((_1, _2, _3, tabId) => ({
             stores: null,
             interpreter: interpreters[tabId].object,

--- a/src/tests/unit/tests/background/target-tab-controller.test.ts
+++ b/src/tests/unit/tests/background/target-tab-controller.test.ts
@@ -27,12 +27,17 @@ describe('TargetTabControllerTest', () => {
 
         configurationFactoryMock.setup(cfm => cfm.getConfiguration(test)).returns(() => configStub);
 
-        testSubject = new TargetTabController(browserAdapterMock.object, configurationFactoryMock.object);
+        testSubject = new TargetTabController(
+            browserAdapterMock.object,
+            configurationFactoryMock.object,
+        );
     });
 
     describe('showTargetTab', () => {
         it("test doesn't switch to target tab", async () => {
-            configurationFactoryMock.setup(cfm => cfm.getConfiguration(test)).returns(() => configStub);
+            configurationFactoryMock
+                .setup(cfm => cfm.getConfiguration(test))
+                .returns(() => configStub);
 
             getSwitchToTargetTabCallbackMock
                 .setup(cm => cm(null))
@@ -64,9 +69,13 @@ describe('TargetTabControllerTest', () => {
                 .verifiable(Times.once());
 
             const errorMessage = 'switchToTab failed error message';
-            browserAdapterMock.setup(adapter => adapter.switchToTab(tabId)).returns(() => Promise.reject(errorMessage));
+            browserAdapterMock
+                .setup(adapter => adapter.switchToTab(tabId))
+                .returns(() => Promise.reject(errorMessage));
 
-            await expect(testSubject.showTargetTab(tabId, test, step)).rejects.toEqual(errorMessage);
+            await expect(testSubject.showTargetTab(tabId, test, step)).rejects.toEqual(
+                errorMessage,
+            );
         });
     });
 

--- a/src/tests/unit/tests/background/telemetry/app-insights-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/app-insights-telemetry-client.test.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AppInsightsTelemetryClient, ExtendedEnvelop } from 'background/telemetry/app-insights-telemetry-client';
+import {
+    AppInsightsTelemetryClient,
+    ExtendedEnvelop,
+} from 'background/telemetry/app-insights-telemetry-client';
 import { ApplicationTelemetryDataFactory } from 'background/telemetry/application-telemetry-data-factory';
 import { TelemetryLogger } from 'background/telemetry/telemetry-logger';
 import { cloneDeep } from 'lodash';
@@ -34,13 +37,24 @@ describe('AppInsights telemetry client tests', () => {
         addTelemetryInitializerStrictMock = Mock.ofInstance(callback => {}, MockBehavior.Strict);
         loggerMock = Mock.ofType<TelemetryLogger>();
         loggerMock.setup(l => l.log(It.isAny()));
-        operationStub = { name: 'should be overwritten to an empty string' } as Microsoft.ApplicationInsights.Context.IOperation;
-        appInsightsStrictMock = Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>(null, MockBehavior.Strict);
+        operationStub = {
+            name: 'should be overwritten to an empty string',
+        } as Microsoft.ApplicationInsights.Context.IOperation;
+        appInsightsStrictMock = Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>(
+            null,
+            MockBehavior.Strict,
+        );
         coreTelemetryDataFactoryMock = Mock.ofType<ApplicationTelemetryDataFactory>();
 
-        coreTelemetryDataFactoryMock.setup(c => c.getData()).returns(() => cloneDeep(coreTelemetryData as any));
+        coreTelemetryDataFactoryMock
+            .setup(c => c.getData())
+            .returns(() => cloneDeep(coreTelemetryData as any));
 
-        testSubject = new AppInsightsTelemetryClient(appInsightsStrictMock.object, coreTelemetryDataFactoryMock.object, loggerMock.object);
+        testSubject = new AppInsightsTelemetryClient(
+            appInsightsStrictMock.object,
+            coreTelemetryDataFactoryMock.object,
+            loggerMock.object,
+        );
     });
 
     describe('enableTelemetry', () => {
@@ -68,11 +82,15 @@ describe('AppInsights telemetry client tests', () => {
             aiConfig.disableTelemetry = true;
 
             invokeFirstEnableTelemetryCall();
-            expect(aiConfig).toEqual({ disableTelemetry: true } as Microsoft.ApplicationInsights.IConfig);
+            expect(aiConfig).toEqual({
+                disableTelemetry: true,
+            } as Microsoft.ApplicationInsights.IConfig);
 
             invokeCallbacksForFirstEnableTelemetryCall();
 
-            expect(aiConfig).toEqual({ disableTelemetry: false } as Microsoft.ApplicationInsights.IConfig);
+            expect(aiConfig).toEqual({
+                disableTelemetry: false,
+            } as Microsoft.ApplicationInsights.IConfig);
             expect(operationStub.name).toEqual('');
         });
 
@@ -83,11 +101,15 @@ describe('AppInsights telemetry client tests', () => {
             invokeAllFunctionsInQueue();
             queue = null;
 
-            expect(aiConfig).toEqual({ disableTelemetry: true } as Microsoft.ApplicationInsights.IConfig);
+            expect(aiConfig).toEqual({
+                disableTelemetry: true,
+            } as Microsoft.ApplicationInsights.IConfig);
 
             testSubject.enableTelemetry();
 
-            expect(aiConfig).toEqual({ disableTelemetry: false } as Microsoft.ApplicationInsights.IConfig);
+            expect(aiConfig).toEqual({
+                disableTelemetry: false,
+            } as Microsoft.ApplicationInsights.IConfig);
             expect(operationStub.name).toEqual('');
         });
 
@@ -98,11 +120,15 @@ describe('AppInsights telemetry client tests', () => {
             queue = [];
 
             testSubject.enableTelemetry();
-            expect(aiConfig).toEqual({ disableTelemetry: true } as Microsoft.ApplicationInsights.IConfig);
+            expect(aiConfig).toEqual({
+                disableTelemetry: true,
+            } as Microsoft.ApplicationInsights.IConfig);
 
             invokeAllFunctionsInQueue();
 
-            expect(aiConfig).toEqual({ disableTelemetry: false } as Microsoft.ApplicationInsights.IConfig);
+            expect(aiConfig).toEqual({
+                disableTelemetry: false,
+            } as Microsoft.ApplicationInsights.IConfig);
             expect(operationStub.name).toEqual('');
         });
 
@@ -166,7 +192,9 @@ describe('AppInsights telemetry client tests', () => {
                 test: 'a',
             };
 
-            appInsightsStrictMock.setup(ai => ai.trackEvent(eventName, eventObject)).verifiable(Times.once());
+            appInsightsStrictMock
+                .setup(ai => ai.trackEvent(eventName, eventObject))
+                .verifiable(Times.once());
 
             testSubject.trackEvent(eventName, eventObject);
 

--- a/src/tests/unit/tests/background/telemetry/application-telemetry-data-factory.test.ts
+++ b/src/tests/unit/tests/background/telemetry/application-telemetry-data-factory.test.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { InstallDataGenerator } from 'background/install-data-generator';
-import { ApplicationTelemetryData, ApplicationTelemetryDataFactory } from 'background/telemetry/application-telemetry-data-factory';
+import {
+    ApplicationTelemetryData,
+    ApplicationTelemetryDataFactory,
+} from 'background/telemetry/application-telemetry-data-factory';
 import { IMock, Mock } from 'typemoq';
 
 describe('ApplicationTelemetryDataFactoryTest', () => {

--- a/src/tests/unit/tests/background/telemetry/telemetry-event-handler.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-event-handler.test.ts
@@ -5,7 +5,10 @@ import { TelemetryClient } from 'background/telemetry/telemetry-client';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import { each } from 'lodash';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { TelemetryEventSource, TriggeredBy } from '../../../../../common/extension-telemetry-events';
+import {
+    TelemetryEventSource,
+    TriggeredBy,
+} from '../../../../../common/extension-telemetry-events';
 import { DictionaryStringTo } from '../../../../../types/common-types';
 
 describe('TelemetryEventHandlerTest', () => {
@@ -35,7 +38,9 @@ describe('TelemetryEventHandlerTest', () => {
     });
 
     test('test for when tab is null', () => {
-        telemetryClientStrictMock.setup(te => te.trackEvent(It.isAny(), It.isAny())).verifiable(Times.once());
+        telemetryClientStrictMock
+            .setup(te => te.trackEvent(It.isAny(), It.isAny()))
+            .verifiable(Times.once());
 
         const testObject = createAndEnableTelemetryEventHandler();
         testObject.publishTelemetry(testEventName, testTelemetryPayload);
@@ -102,7 +107,9 @@ describe('TelemetryEventHandlerTest', () => {
         telemetryClientStrictMock.verifyAll();
     });
 
-    function createExpectedAppInsightsTelemetry(customFields?: DictionaryStringTo<any>): DictionaryStringTo<string> {
+    function createExpectedAppInsightsTelemetry(
+        customFields?: DictionaryStringTo<any>,
+    ): DictionaryStringTo<string> {
         const telemetry: any = {
             source: undefined,
             triggeredBy: 'triggered by test',
@@ -125,7 +132,12 @@ describe('TelemetryEventHandlerTest', () => {
         return telemetryEventHandler;
     }
 
-    function setupTrackEvent(eventName: string, expectedTelemetry: DictionaryStringTo<string>): void {
-        telemetryClientStrictMock.setup(te => te.trackEvent(It.isValue(eventName), It.isValue(expectedTelemetry))).verifiable(Times.once());
+    function setupTrackEvent(
+        eventName: string,
+        expectedTelemetry: DictionaryStringTo<string>,
+    ): void {
+        telemetryClientStrictMock
+            .setup(te => te.trackEvent(It.isValue(eventName), It.isValue(expectedTelemetry)))
+            .verifiable(Times.once());
     }
 });

--- a/src/tests/unit/tests/background/telemetry/telemetry-logger.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-logger.test.ts
@@ -27,18 +27,28 @@ describe('TelemetryLoggerTest', () => {
     });
 
     it('logs telemetry (flag: enabled)', () => {
-        controllerMock.setup(cm => cm.isEnabled(FeatureFlags.logTelemetryToConsole)).returns(() => true);
+        controllerMock
+            .setup(cm => cm.isEnabled(FeatureFlags.logTelemetryToConsole))
+            .returns(() => true);
 
         testObject.log(testTelemetryData);
 
         loggerMock.verify(
-            logger => logger.log('eventName: ', testTelemetryData.name, '; customProperties: ', testTelemetryData.properties),
+            logger =>
+                logger.log(
+                    'eventName: ',
+                    testTelemetryData.name,
+                    '; customProperties: ',
+                    testTelemetryData.properties,
+                ),
             Times.once(),
         );
     });
 
     it('logs telemetry (flag: disabled)', () => {
-        controllerMock.setup(cm => cm.isEnabled(FeatureFlags.logTelemetryToConsole)).returns(() => false);
+        controllerMock
+            .setup(cm => cm.isEnabled(FeatureFlags.logTelemetryToConsole))
+            .returns(() => false);
 
         testObject.log(testTelemetryData);
 

--- a/src/tests/unit/tests/background/telemetry/telemetry-state-listener.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-state-listener.test.ts
@@ -28,7 +28,10 @@ describe('TelemetryStateListenerTest', () => {
 
         userConfigStoreMock.setup(f => f.getState()).returns(() => userConfigState);
 
-        testSubject = new TelemetryStateListener(userConfigStoreMock.object, telemetryEventHandlerStrictMock.object);
+        testSubject = new TelemetryStateListener(
+            userConfigStoreMock.object,
+            telemetryEventHandlerStrictMock.object,
+        );
     });
 
     it('do nothing if not initialized', () => {

--- a/src/tests/unit/tests/background/user-configuration-controller.test.ts
+++ b/src/tests/unit/tests/background/user-configuration-controller.test.ts
@@ -16,23 +16,29 @@ describe('UserConfigurationController', () => {
         testSubject = new UserConfigurationController(interpreterMock.object);
     });
 
-    it.each([true, false])('setHighContrastMode(%s) sends the expected interpreter message', (enabled: boolean) => {
-        const expectedMessage: Message = {
-            messageType: Messages.UserConfig.SetHighContrastConfig,
-            payload: { enableHighContrast: enabled },
-            tabId: null,
-        };
-        testSubject.setHighContrastMode(enabled);
-        interpreterMock.verify(i => i.interpret(expectedMessage), Times.once());
-    });
+    it.each([true, false])(
+        'setHighContrastMode(%s) sends the expected interpreter message',
+        (enabled: boolean) => {
+            const expectedMessage: Message = {
+                messageType: Messages.UserConfig.SetHighContrastConfig,
+                payload: { enableHighContrast: enabled },
+                tabId: null,
+            };
+            testSubject.setHighContrastMode(enabled);
+            interpreterMock.verify(i => i.interpret(expectedMessage), Times.once());
+        },
+    );
 
-    it.each([true, false])('setTelemetryState(%s) sends the expected interpreter message', (enabled: boolean) => {
-        const expectedMessage: Message = {
-            messageType: Messages.UserConfig.SetTelemetryConfig,
-            payload: { enableTelemetry: enabled },
-            tabId: null,
-        };
-        testSubject.setTelemetryState(enabled);
-        interpreterMock.verify(i => i.interpret(expectedMessage), Times.once());
-    });
+    it.each([true, false])(
+        'setTelemetryState(%s) sends the expected interpreter message',
+        (enabled: boolean) => {
+            const expectedMessage: Message = {
+                messageType: Messages.UserConfig.SetTelemetryConfig,
+                payload: { enableTelemetry: enabled },
+                tabId: null,
+            };
+            testSubject.setTelemetryState(enabled);
+            interpreterMock.verify(i => i.interpret(expectedMessage), Times.once());
+        },
+    );
 });

--- a/src/tests/unit/tests/background/user-stored-data-cleaner.test.ts
+++ b/src/tests/unit/tests/background/user-stored-data-cleaner.test.ts
@@ -19,8 +19,12 @@ describe('cleanKeysFromStorage', () => {
             exist: 'yes it does',
         };
 
-        storageAdapterMock.setup(storage => storage.getUserData(keys)).returns(() => Promise.resolve(data));
-        storageAdapterMock.setup(storage => storage.removeUserData('exist')).returns(() => Promise.resolve());
+        storageAdapterMock
+            .setup(storage => storage.getUserData(keys))
+            .returns(() => Promise.resolve(data));
+        storageAdapterMock
+            .setup(storage => storage.removeUserData('exist'))
+            .returns(() => Promise.resolve());
 
         await testObject(storageAdapterMock.object, keys);
     });


### PR DESCRIPTION
#### Description of changes

Add `src/tests/unit/tests/background` folder to prettier override for the line width value.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
