### PR TITLE
feat(docs): Decoupled ContentView from Content.

### DIFF
--- a/src/tests/unit/tests/views/content/__snapshots__/content-view.test.tsx.snap
+++ b/src/tests/unit/tests/views/content/__snapshots__/content-view.test.tsx.snap
@@ -1,15 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`content view renders 1`] = `
-"<Page deps={{...}}>
-  <div className=\\"content-container\\">
-    <div className=\\"content-left\\" />
-    <div className=\\"content\\">
+<Page
+  deps={
+    Object {
+      "applicationTitle": "THE TITLE OF OUR APPLICATION",
+    }
+  }
+>
+  <div
+    className="content-container"
+  >
+    <div
+      className="content-left"
+    />
+    <div
+      className="content"
+    >
       <p>
         THE CONTENT
       </p>
     </div>
-    <div className=\\"content-right\\" />
+    <div
+      className="content-right"
+    />
   </div>
-</Page>"
+</Page>
 `;

--- a/src/tests/unit/tests/views/content/__snapshots__/content-view.test.tsx.snap
+++ b/src/tests/unit/tests/views/content/__snapshots__/content-view.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`content view renders 1`] = `
+"<Page deps={{...}}>
+  <div className=\\"content-container\\">
+    <div className=\\"content-left\\" />
+    <div className=\\"content\\">
+      <p>
+        THE CONTENT
+      </p>
+    </div>
+    <div className=\\"content-right\\" />
+  </div>
+</Page>"
+`;

--- a/src/tests/unit/tests/views/content/__snapshots__/content.test.tsx.snap
+++ b/src/tests/unit/tests/views/content/__snapshots__/content.test.tsx.snap
@@ -1,13 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`content view renders 1`] = `
-"<Page deps={{...}}>
-  <div className=\\"content-container\\">
-    <div className=\\"content-left\\" />
-    <div className=\\"content\\">
-      <THE-CONTENT deps={{...}} options={{...}} />
-    </div>
-    <div className=\\"content-right\\" />
-  </div>
-</Page>"
+exports[`content renders 1`] = `
+"<Content deps={{...}}>
+  <THE-CONTENT deps={{...}} options={{...}} />
+</Content>"
 `;

--- a/src/tests/unit/tests/views/content/content-view.test.tsx
+++ b/src/tests/unit/tests/views/content/content-view.test.tsx
@@ -17,6 +17,6 @@ describe('content view', () => {
         );
         const result = shallow(component);
 
-        expect(result.debug()).toMatchSnapshot();
+        expect(result.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/views/content/content-view.test.tsx
+++ b/src/tests/unit/tests/views/content/content-view.test.tsx
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+import { ContentView, ContentViewDeps } from 'views/content/content-view';
+
+describe('content view', () => {
+    it('renders', () => {
+        const applicationTitle = 'THE TITLE OF OUR APPLICATION';
+        const deps = { applicationTitle } as ContentViewDeps;
+
+        const component = (
+            <ContentView deps={deps}>
+                <p>THE CONTENT</p>
+            </ContentView>
+        );
+        const result = shallow(component);
+
+        expect(result.debug()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/views/content/content.test.tsx
+++ b/src/tests/unit/tests/views/content/content.test.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { Content, ContentDeps } from 'views/content/content';
 import { ContentProvider } from 'views/content/content-page';
 
-describe('content view', () => {
+describe('content', () => {
     it('renders', () => {
         const contentFromReference = jest.fn().mockReturnValue('THE-CONTENT');
         const contentProvider = ({ contentFromReference } as Partial<ContentProvider>) as ContentProvider;

--- a/src/views/content/content-view.tsx
+++ b/src/views/content/content-view.tsx
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import * as React from 'react';
+
+import { NamedFC } from '../../common/react/named-fc';
+import { Page, PageDeps } from '../page/page';
+
+export type ContentViewDeps = PageDeps;
+
+export type ContentViewProps = { deps: ContentViewDeps };
+
+export const ContentView = NamedFC<ContentViewProps>('Content', ({ deps, children }) => {
+    return (
+        <Page deps={deps}>
+            <div className="content-container">
+                <div className="content-left" />
+                <div className="content">{children}</div>
+                <div className="content-right" />
+            </div>
+        </Page>
+    );
+});

--- a/src/views/content/content.tsx
+++ b/src/views/content/content.tsx
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import { NamedFC } from '../../common/react/named-fc';
-import { Page, PageDeps } from '../page/page';
+import { NamedFC } from 'common/react/named-fc';
 import { ContentPageDeps, ContentProvider, ContentReference } from './content-page';
+import { ContentView, ContentViewDeps } from './content-view';
 
-export type ContentDeps = { contentProvider: ContentProvider } & ContentPageDeps & PageDeps;
+export type ContentDeps = { contentProvider: ContentProvider } & ContentPageDeps & ContentViewDeps;
 
 export type ContentProps = { deps: ContentDeps; reference: ContentReference };
 
@@ -14,14 +14,8 @@ export const Content = NamedFC<ContentProps>('Content', ({ deps, reference }) =>
     const { contentProvider } = deps;
     const ContentPage = contentProvider.contentFromReference(reference);
     return (
-        <Page deps={deps}>
-            <div className="content-container">
-                <div className="content-left" />
-                <div className="content">
-                    <ContentPage deps={deps} options={{ setPageTitle: true }} />
-                </div>
-                <div className="content-right" />
-            </div>
-        </Page>
+        <ContentView deps={deps}>
+            <ContentPage deps={deps} options={{ setPageTitle: true }} />
+        </ContentView>
     );
 });


### PR DESCRIPTION
#### Description of changes

Decoupled `ContentView` from `Content`.

The `Content` component both converts a content reference into it's content and also renders that content. Now it just converts the content reference and uses a new shared `ContentView` component.

Now the newly decoupled `ContentView` component can be shared with the docs repo for reuse.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
