### PR TITLE
refactor: ad hoc tools panel to use CSS Grid

### DIFF
--- a/src/popup/Styles/popup.scss
+++ b/src/popup/Styles/popup.scss
@@ -133,22 +133,6 @@ html {
     max-height: 30px;
 }
 
-#popup-container .main-section .ad-hoc-tools-panel-group-0 {
-    padding-right: 15px;
-}
-
-#popup-container .main-section .ad-hoc-tools-panel-group-1 {
-    padding-left: 15px;
-}
-
-#popup-container .main-section .ad-hoc-tools-panel-footer {
-    margin-top: 24px;
-
-    .back-to-launch-pad-icon {
-        margin-right: 6px;
-    }
-}
-
 #popup-container .main-section h3 {
     margin-top: 7px;
     margin-bottom: 7px;
@@ -159,23 +143,9 @@ html {
     margin-bottom: 8px;
 }
 
-#popup-container .main-section .launch-panel-hr {
-    margin-top: 14px;
-    margin-bottom: 14px;
-    cursor: default;
-    display: block;
-    height: 1px;
-    background-color: $neutral-8;
-    position: relative;
-}
-
 #popup-container .main-section .footer {
     padding-top: 11px;
     padding-bottom: 10px;
-}
-
-#popup-container .main-section .ad-hoc-tools-panel-footer {
-    font-size: 11px;
 }
 
 #popup-container .main-section .ms-Toggle {

--- a/src/popup/components/ad-hoc-tools-panel.scss
+++ b/src/popup/components/ad-hoc-tools-panel.scss
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+@import '../../common/styles/colors.scss';
+
 .ad-hoc-tools-panel {
     padding-right: 8px;
     padding-left: 8px;
@@ -7,11 +9,17 @@
     .ad-hoc-tools-grid {
         display: grid;
 
+        grid-auto-flow: column;
+
         grid-template-columns: auto auto;
-        grid-template-rows: auto auto auto;
+        grid-template-rows: auto 1px auto 1px auto;
 
         grid-column-gap: 30px;
-        grid-row-gap: 28px;
+        grid-row-gap: 14px;
+    }
+
+    .divider {
+        border-bottom: 1px solid $neutral-8;
     }
 
     .ad-hoc-tools-panel-footer {

--- a/src/popup/components/ad-hoc-tools-panel.scss
+++ b/src/popup/components/ad-hoc-tools-panel.scss
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.ad-hoc-tools-panel {
+    padding-right: 8px;
+    padding-left: 8px;
+
+    .ad-hoc-tools-grid {
+        display: grid;
+
+        grid-template-columns: auto auto;
+        grid-template-rows: auto auto auto;
+
+        grid-column-gap: 30px;
+        grid-row-gap: 28px;
+    }
+
+    .ad-hoc-tools-panel-footer {
+        margin-top: 24px;
+
+        .link {
+            font-size: 11px;
+        }
+
+        .back-to-launch-pad-icon {
+            margin-right: 6px;
+        }
+    }
+}

--- a/src/popup/components/ad-hoc-tools-panel.scss
+++ b/src/popup/components/ad-hoc-tools-panel.scss
@@ -26,6 +26,7 @@
         margin-top: 24px;
 
         .link {
+            color: $link !important;
             font-size: 11px;
         }
 

--- a/src/popup/components/ad-hoc-tools-panel.tsx
+++ b/src/popup/components/ad-hoc-tools-panel.tsx
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Icon } from 'office-ui-fabric-react';
-import { Link } from 'office-ui-fabric-react';
+import { NamedFC } from 'common/react/named-fc';
+import { css, Icon, Link } from 'office-ui-fabric-react';
 import * as React from 'react';
-
+import * as styles from './ad-hoc-tools-panel.scss';
 import { DiagnosticViewToggleFactory } from './diagnostic-view-toggle-factory';
 
 export interface AdHocToolsPanelProps {
@@ -11,65 +11,22 @@ export interface AdHocToolsPanelProps {
     diagnosticViewToggleFactory: DiagnosticViewToggleFactory;
 }
 
-export class AdHocToolsPanel extends React.Component<AdHocToolsPanelProps, {}> {
-    private sliceSize: number = 3;
+export const AdHocToolsPanel = NamedFC<AdHocToolsPanelProps>('AdHocToolsPanel', props => {
+    const toggles = props.diagnosticViewToggleFactory.createTogglesForAdHocToolsPanel();
 
-    public render(): JSX.Element {
-        const toggles = this.props.diagnosticViewToggleFactory.createTogglesForAdHocToolsPanel();
-        const groups = this.getToggleGroups(toggles);
-
-        return (
-            <div className="ms-Grid main-section">
-                <main>
-                    <div className="ms-Grid-row">{groups}</div>
-                </main>
-                <div role="navigation" className="ad-hoc-tools-panel-footer">
-                    <Link
-                        className="insights-link"
-                        onClick={this.props.backLinkHandler}
-                        id="back-to-launchpad-link"
-                    >
-                        <Icon className="back-to-launch-pad-icon" iconName="back" />
-                        Back to launch pad
-                    </Link>
-                </div>
-            </div>
-        );
-    }
-
-    private getToggleGroups(toggles: JSX.Element[]): JSX.Element[] {
-        const groups: JSX.Element[] = [];
-
-        while (toggles.length > 0) {
-            const groupIndex = groups.length;
-            const currentSlice = toggles.splice(0, this.sliceSize);
-            this.insertDivider(currentSlice, groupIndex);
-
-            const currentGroup: JSX.Element = (
-                <div
-                    key={`visualization-toggle-group-${groupIndex}`}
-                    className={`ms-Grid-col ms-sm6 ms-md6 ms-lg6 ad-hoc-tools-panel-group-${groupIndex}`}
+    return (
+        <div className={css('main-section', styles.adHocToolsPanel)}>
+            <main className={styles.adHocToolsGrid}>{toggles}</main>
+            <div role="navigation" className={styles.adHocToolsPanelFooter}>
+                <Link
+                    className={styles.link}
+                    onClick={props.backLinkHandler}
+                    id="back-to-launchpad-link"
                 >
-                    {currentSlice}
-                </div>
-            );
-
-            groups.push(currentGroup);
-        }
-
-        return groups;
-    }
-
-    private insertDivider(toggles: JSX.Element[], groupIndex: number): void {
-        for (let index = 1; index < toggles.length; index += 2) {
-            toggles.splice(
-                index,
-                0,
-                <div
-                    key={`diagnostic-view-toggle-divider-${groupIndex}-${index}`}
-                    className="ms-fontColor-neutralLight launch-panel-hr"
-                />,
-            );
-        }
-    }
-}
+                    <Icon className={styles.backToLaunchPadIcon} iconName="back" />
+                    Back to launch pad
+                </Link>
+            </div>
+        </div>
+    );
+});

--- a/src/popup/components/ad-hoc-tools-panel.tsx
+++ b/src/popup/components/ad-hoc-tools-panel.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
+import { flatMap } from 'lodash';
 import { css, Icon, Link } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './ad-hoc-tools-panel.scss';
@@ -12,11 +13,44 @@ export interface AdHocToolsPanelProps {
 }
 
 export const AdHocToolsPanel = NamedFC<AdHocToolsPanelProps>('AdHocToolsPanel', props => {
-    const toggles = props.diagnosticViewToggleFactory.createTogglesForAdHocToolsPanel();
+    const getTogglesWithDividers = () => {
+        const toggles = props.diagnosticViewToggleFactory.createTogglesForAdHocToolsPanel();
+
+        let dividerIndex = 0;
+
+        const getDivider = () => (
+            <span key={`divider-${dividerIndex++}`} className={styles.divider}></span>
+        );
+
+        const totalRows = 3;
+        const totalIterableRows = totalRows - 1; // we treat the last row differently
+
+        const result = flatMap(toggles, (toggle, index) => {
+            console.log('index', index);
+
+            if (index === 0) {
+                return [toggle, getDivider()];
+            }
+
+            if (index % totalIterableRows === 0) {
+                return [toggle];
+            }
+
+            if (index === toggles.length) {
+                return [toggles];
+            }
+
+            return [toggle, getDivider()];
+        });
+
+        return result;
+    };
+
+    const togglesWithDividers = getTogglesWithDividers();
 
     return (
         <div className={css('main-section', styles.adHocToolsPanel)}>
-            <main className={styles.adHocToolsGrid}>{toggles}</main>
+            <main className={styles.adHocToolsGrid}>{togglesWithDividers}</main>
             <div role="navigation" className={styles.adHocToolsPanelFooter}>
                 <Link
                     className={styles.link}

--- a/src/popup/components/ad-hoc-tools-panel.tsx
+++ b/src/popup/components/ad-hoc-tools-panel.tsx
@@ -26,8 +26,6 @@ export const AdHocToolsPanel = NamedFC<AdHocToolsPanelProps>('AdHocToolsPanel', 
         const totalIterableRows = totalRows - 1; // we treat the last row differently
 
         const result = flatMap(toggles, (toggle, index) => {
-            console.log('index', index);
-
             if (index === 0) {
                 return [toggle, getDivider()];
             }

--- a/src/tests/unit/tests/popup/components/__snapshots__/ad-hoc-tools-panel.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/ad-hoc-tools-panel.test.tsx.snap
@@ -10,30 +10,39 @@ exports[`AdHocToolsPanelTest adhoc panel matches snapshot 1`] = `
     <div>
       first
     </div>
+    <span
+      className="divider"
+    />
     <div>
       second
     </div>
+    <span
+      className="divider"
+    />
     <div>
       third
     </div>
     <div>
       fourth
     </div>
+    <span
+      className="divider"
+    />
     <div>
       fifth
     </div>
   </main>
   <div
-    className="ad-hoc-tools-panel-footer"
+    className="adHocToolsPanelFooter"
     role="navigation"
   >
     <StyledLinkBase
-      className="insights-link"
+      className="link"
       id="back-to-launchpad-link"
       onClick={null}
     >
       <StyledIconBase
-        className="back-to-launch-pad-icon"
+        className="backToLaunchPadIcon"
         iconName="back"
       />
       Back to launch pad

--- a/src/tests/unit/tests/popup/components/__snapshots__/ad-hoc-tools-panel.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/ad-hoc-tools-panel.test.tsx.snap
@@ -2,44 +2,25 @@
 
 exports[`AdHocToolsPanelTest adhoc panel matches snapshot 1`] = `
 <div
-  className="ms-Grid main-section"
+  className="main-section adHocToolsPanel"
 >
-  <main>
-    <div
-      className="ms-Grid-row"
-    >
-      <div
-        className="ms-Grid-col ms-sm6 ms-md6 ms-lg6 ad-hoc-tools-panel-group-0"
-      >
-        <div>
-          first
-        </div>
-        <div
-          className="ms-fontColor-neutralLight launch-panel-hr"
-        />
-        <div>
-          second
-        </div>
-        <div
-          className="ms-fontColor-neutralLight launch-panel-hr"
-        />
-        <div>
-          third
-        </div>
-      </div>
-      <div
-        className="ms-Grid-col ms-sm6 ms-md6 ms-lg6 ad-hoc-tools-panel-group-1"
-      >
-        <div>
-          fourth
-        </div>
-        <div
-          className="ms-fontColor-neutralLight launch-panel-hr"
-        />
-        <div>
-          fifth
-        </div>
-      </div>
+  <main
+    className="adHocToolsGrid"
+  >
+    <div>
+      first
+    </div>
+    <div>
+      second
+    </div>
+    <div>
+      third
+    </div>
+    <div>
+      fourth
+    </div>
+    <div>
+      fifth
     </div>
   </main>
   <div

--- a/src/tests/unit/tests/popup/components/ad-hoc-tools-panel.test.tsx
+++ b/src/tests/unit/tests/popup/components/ad-hoc-tools-panel.test.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enzyme from 'enzyme';
-import { Icon, Link } from 'office-ui-fabric-react';
+import { shallow } from 'enzyme';
+import { Link } from 'office-ui-fabric-react';
 import { AdHocToolsPanel, AdHocToolsPanelProps } from 'popup/components/ad-hoc-tools-panel';
 import { DiagnosticViewToggleFactory } from 'popup/components/diagnostic-view-toggle-factory';
 import * as React from 'react';
-import * as TestUtils from 'react-dom/test-utils';
 import { Mock, Times } from 'typemoq';
 
 describe('AdHocToolsPanelTest', () => {
@@ -23,55 +23,14 @@ describe('AdHocToolsPanelTest', () => {
             ]);
     });
 
-    test('render toggles', () => {
-        const props: AdHocToolsPanelProps = {
-            backLinkHandler: null,
-            diagnosticViewToggleFactory: diagnosticViewToggleFactoryMock.object,
-        };
-
-        const component = React.createElement(AdHocToolsPanel, props);
-        const testObject = TestUtils.renderIntoDocument(component);
-
-        const result = testObject.render();
-
-        const expectedElements: JSX.Element = (
-            <div className="ms-Grid main-section">
-                <main>
-                    <div className="ms-Grid-row">
-                        <div key="visualization-toggle-group-0" className="ms-Grid-col ms-sm6 ms-md6 ms-lg6 ad-hoc-tools-panel-group-0">
-                            <div key="first">first</div>
-                            <div key="diagnostic-view-toggle-divider-0-1" className="ms-fontColor-neutralLight launch-panel-hr" />
-                            <div key="second">second</div>
-                            <div key="diagnostic-view-toggle-divider-0-3" className="ms-fontColor-neutralLight launch-panel-hr" />
-                            <div key="third">third</div>
-                        </div>
-                        <div key="visualization-toggle-group-1" className="ms-Grid-col ms-sm6 ms-md6 ms-lg6 ad-hoc-tools-panel-group-1">
-                            <div key="fourth">fourth</div>
-                            <div key="diagnostic-view-toggle-divider-1-1" className="ms-fontColor-neutralLight launch-panel-hr" />
-                            <div key="fifth">fifth</div>
-                        </div>
-                    </div>
-                </main>
-                <div role="navigation" className="ad-hoc-tools-panel-footer">
-                    <Link className="insights-link" onClick={props.backLinkHandler} id="back-to-launchpad-link">
-                        <Icon className="back-to-launch-pad-icon" iconName="back" />
-                        Back to launch pad
-                    </Link>
-                </div>
-            </div>
-        );
-
-        expect(result).toEqual(expectedElements);
-    });
-
     test('adhoc panel matches snapshot', () => {
         const props: AdHocToolsPanelProps = {
             backLinkHandler: null,
             diagnosticViewToggleFactory: diagnosticViewToggleFactoryMock.object,
         };
 
-        const adhocPanelComponent = Enzyme.shallow(<AdHocToolsPanel {...props} />);
-        expect(adhocPanelComponent.getElement()).toMatchSnapshot();
+        const wrapper = shallow(<AdHocToolsPanel {...props} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
     });
 
     test('back link clicked', () => {


### PR DESCRIPTION
#### Description of changes

Currently, the ad hoc tools panel is using `ms-Grid` styles to layout the toggles. This put a lot of knowledge about layout on the component. Also, using `ms-Grid` is not that great, specially compared to using CSS Grid.

In this PR: refactor the component to use CSS Grid instead.

**NOTE** there are no visible UI changes.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
