### PR TITLE
fix: external electron link not announce as a link

### DIFF
--- a/src/electron/views/device-connect-view/components/electron-external-link.tsx
+++ b/src/electron/views/device-connect-view/components/electron-external-link.tsx
@@ -15,6 +15,10 @@ export const ElectronExternalLink = NamedFC<ElectronExternalLinkProps>(
     'ElectronExternalLink',
     (props: ElectronExternalLinkProps) => {
         const onClick = () => props.shell.openExternal(props.href);
-        return <Link onClick={onClick}>{props.children}</Link>;
+        return (
+            <Link as="a" tabIndex={0} onClick={onClick}>
+                {props.children}
+            </Link>
+        );
     },
 );

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
@@ -2,7 +2,9 @@
 
 exports[`ElectronExternalLinkTest render 1`] = `
 <StyledLinkBase
+  as="a"
   onClick={[Function]}
+  tabIndex={0}
 >
   test-text
 </StyledLinkBase>


### PR DESCRIPTION
#### Description of changes

Currently, each link on AI-Android that uses `ElectronExternalLink` is being render as a `button`. This is normal Office UI Fabric React behavior when we pass no `href` property.

The use case of `ElectronExternalLink` is to open an `href` outside of AI-Android, as in, on the default browser at the OS level, hence the *External* on the name. This means: even when we have an `href` to open, we don't actually pass it to the `Link` component which in times, makes Office Fabric to render it as a button instead of an anchor tag.

In this PR:
- Force the `Link` component to render a an anchor tag by passing `as="a"` property

**NOTE**
- The change `as="a"` seems to break *"tab-ability"* which means we need to add `tabIndex={0}` so the link is *tab-able*.
- There are no actual visual changes from this PR

#### Pull request checklist
- [x] Addresses an existing issue: WI # 1676645
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
