### PR TITLE
fix: device port placeholder text

### DIFF
--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -46,7 +46,7 @@ export class DeviceConnectPortEntry extends React.Component<
                     data-automation-id={deviceConnectPortNumberFieldAutomationId}
                     ariaLabel="Port number"
                     onChange={this.onPortTextChanged}
-                    placeholder="12345"
+                    placeholder="Ex: 12345"
                     className={styles.portNumberField}
                     maskChar=""
                     mask="99999"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" 1`] = `
     }
     onChange={[Function]}
     onKeyDown={[Function]}
-    placeholder="12345"
+    placeholder="Ex: 12345"
   />
   <CustomizedDefaultButton
     data-automation-id="device-connect-validate-port-button"
@@ -56,7 +56,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" and some text in th
     }
     onChange={[Function]}
     onKeyDown={[Function]}
-    placeholder="12345"
+    placeholder="Ex: 12345"
   />
   <CustomizedDefaultButton
     data-automation-id="device-connect-validate-port-button"
@@ -90,7 +90,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" 1`] = `
     }
     onChange={[Function]}
     onKeyDown={[Function]}
-    placeholder="12345"
+    placeholder="Ex: 12345"
   />
   <CustomizedPrimaryButton
     data-automation-id="device-connect-validate-port-button"
@@ -124,7 +124,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" and some text in t
     }
     onChange={[Function]}
     onKeyDown={[Function]}
-    placeholder="12345"
+    placeholder="Ex: 12345"
   />
   <CustomizedPrimaryButton
     data-automation-id="device-connect-validate-port-button"
@@ -158,7 +158,7 @@ exports[`DeviceConnectPortEntryTest renders with "Default" 1`] = `
     }
     onChange={[Function]}
     onKeyDown={[Function]}
-    placeholder="12345"
+    placeholder="Ex: 12345"
   />
   <CustomizedPrimaryButton
     data-automation-id="device-connect-validate-port-button"
@@ -192,7 +192,7 @@ exports[`DeviceConnectPortEntryTest renders with "Default" and some text in the 
     }
     onChange={[Function]}
     onKeyDown={[Function]}
-    placeholder="12345"
+    placeholder="Ex: 12345"
   />
   <CustomizedPrimaryButton
     data-automation-id="device-connect-validate-port-button"
@@ -226,7 +226,7 @@ exports[`DeviceConnectPortEntryTest renders with "Error" 1`] = `
     }
     onChange={[Function]}
     onKeyDown={[Function]}
-    placeholder="12345"
+    placeholder="Ex: 12345"
   />
   <CustomizedPrimaryButton
     data-automation-id="device-connect-validate-port-button"
@@ -260,7 +260,7 @@ exports[`DeviceConnectPortEntryTest renders with "Error" and some text in the po
     }
     onChange={[Function]}
     onKeyDown={[Function]}
-    placeholder="12345"
+    placeholder="Ex: 12345"
   />
   <CustomizedPrimaryButton
     data-automation-id="device-connect-validate-port-button"


### PR DESCRIPTION
#### Description of changes

Fixes WI # 1676700 by updating the placeholder text. 

Check NVDA/JAWS doesn't read the placeholder if the user input a port number and make the AT to "read the input control" again.

#### Pull request checklist
- [x] Addresses an existing issue: WI # 1676700
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
