### PR TITLE
feat(docs): Changed productName to use deps.applicationTitle

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -9,7 +9,7 @@ import { getCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { createDefaultLogger } from 'common/logging/default-logger';
 import { CardSelectionMessageCreator } from 'common/message-creators/card-selection-message-creator';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
-import { title as applicationTitle } from 'content/strings/application';
+import { textContent } from 'content/strings/text-content';
 import { AllUrlsPermissionHandler } from 'DetailsView/handlers/allurls-permission-handler';
 import { loadTheme, setFocusVisibility } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
@@ -357,7 +357,7 @@ if (isNaN(tabId) === false) {
             const unifiedResultToIssueFilingDataConverter = new UnifiedResultToIssueFilingDataConverter();
 
             const deps: DetailsViewContainerDeps = {
-                applicationTitle,
+                textContent,
                 fixInstructionProcessor,
                 axeResultToIssueFilingDataConverter,
                 unifiedResultToIssueFilingDataConverter,

--- a/src/common/components/header.tsx
+++ b/src/common/components/header.tsx
@@ -4,9 +4,10 @@ import * as React from 'react';
 
 import { HeaderIcon, HeaderIconDeps } from 'common/components/header-icon';
 import { NamedFC } from 'common/react/named-fc';
+import { TextContent } from 'content/strings/text-content';
 import * as styles from './header.scss';
 
-export type HeaderDeps = { applicationTitle: string } & HeaderIconDeps;
+export type HeaderDeps = { textContent: Pick<TextContent, 'applicationTitle'> } & HeaderIconDeps;
 
 export type HeaderProps = {
     deps: HeaderDeps;
@@ -15,11 +16,11 @@ export type HeaderProps = {
 };
 
 export const Header = NamedFC<HeaderProps>('Header', props => {
-    const { applicationTitle: title } = props.deps;
+    const { applicationTitle } = props.deps.textContent;
     return (
         <header className={styles.headerBar}>
             <HeaderIcon deps={props.deps} />
-            <span className={styles.headerTitle}>{title}</span>
+            <span className={styles.headerTitle}>{applicationTitle}</span>
             <div>{props.items}</div>
             <div className={styles.spacer}></div>
             <div className={styles.farItems}>{props.farItems}</div>

--- a/src/content/strings/text-content.ts
+++ b/src/content/strings/text-content.ts
@@ -1,0 +1,9 @@
+import { title } from './application';
+
+export type TextContent = {
+    applicationTitle: string;
+};
+
+export const textContent: TextContent = {
+    applicationTitle: title,
+};

--- a/src/content/strings/text-content.ts
+++ b/src/content/strings/text-content.ts
@@ -1,3 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 import { title } from './application';
 
 export type TextContent = {

--- a/src/tests/unit/tests/common/components/__snapshots__/header.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/header.test.tsx.snap
@@ -7,14 +7,16 @@ exports[`Header renders per snapshot 1`] = `
   <Component
     deps={
       Object {
-        "applicationTitle": "APPLICATION_TITLE",
+        "textContent": Object {
+          "applicationTitle": "THE_APPLICATION_TITLE",
+        },
       }
     }
   />
   <span
     className="headerTitle"
   >
-    APPLICATION_TITLE
+    THE_APPLICATION_TITLE
   </span>
   <div />
   <div

--- a/src/tests/unit/tests/common/components/header.test.tsx
+++ b/src/tests/unit/tests/common/components/header.test.tsx
@@ -7,9 +7,10 @@ import { Header, HeaderDeps } from 'common/components/header';
 
 describe('Header', () => {
     it('renders per snapshot', () => {
+        const applicationTitle = 'THE_APPLICATION_TITLE';
         const deps = {
             textContent: {
-                applicationTitle: 'THE_APPLICATION_TITLE',
+                applicationTitle,
             },
         } as HeaderDeps;
         const wrapper = shallow(<Header deps={deps} />);

--- a/src/tests/unit/tests/common/components/header.test.tsx
+++ b/src/tests/unit/tests/common/components/header.test.tsx
@@ -8,7 +8,9 @@ import { Header, HeaderDeps } from 'common/components/header';
 describe('Header', () => {
     it('renders per snapshot', () => {
         const deps = {
-            applicationTitle: 'APPLICATION_TITLE',
+            textContent: {
+                applicationTitle: 'THE_APPLICATION_TITLE',
+            },
         } as HeaderDeps;
         const wrapper = shallow(<Header deps={deps} />);
         expect(wrapper.getElement()).toMatchSnapshot();

--- a/src/tests/unit/tests/content/index.test.tsx
+++ b/src/tests/unit/tests/content/index.test.tsx
@@ -10,7 +10,9 @@ import { contentPages } from '../../../../content';
 describe('content', () => {
     const contentActionMessageCreator = Mock.ofType<ContentActionMessageCreator>().object;
     const deps = {
-        applicationTitle: 'MY_APPLICATION_TITLE',
+        textContent: {
+            applicationTitle: 'THE_APPLICATION_TITLE',
+        },
         contentActionMessageCreator,
     };
 

--- a/src/tests/unit/tests/content/index.test.tsx
+++ b/src/tests/unit/tests/content/index.test.tsx
@@ -9,9 +9,10 @@ import { contentPages } from '../../../../content';
 
 describe('content', () => {
     const contentActionMessageCreator = Mock.ofType<ContentActionMessageCreator>().object;
+    const applicationTitle = 'THE_APPLICATION_TITLE';
     const deps = {
         textContent: {
-            applicationTitle: 'THE_APPLICATION_TITLE',
+            applicationTitle,
         },
         contentActionMessageCreator,
     };

--- a/src/tests/unit/tests/content/index.test.tsx
+++ b/src/tests/unit/tests/content/index.test.tsx
@@ -9,7 +9,10 @@ import { contentPages } from '../../../../content';
 
 describe('content', () => {
     const contentActionMessageCreator = Mock.ofType<ContentActionMessageCreator>().object;
-    const deps = { contentActionMessageCreator };
+    const deps = {
+        applicationTitle: 'MY_APPLICATION_TITLE',
+        contentActionMessageCreator,
+    };
 
     contentPages.allPaths().forEach(path =>
         it(`can render ${path}`, () => {

--- a/src/tests/unit/tests/views/content/__snapshots__/content-view.test.tsx.snap
+++ b/src/tests/unit/tests/views/content/__snapshots__/content-view.test.tsx.snap
@@ -4,7 +4,9 @@ exports[`content view renders 1`] = `
 <Page
   deps={
     Object {
-      "applicationTitle": "THE TITLE OF OUR APPLICATION",
+      "textContent": Object {
+        "applicationTitle": "THE_APPLICATION_TITLE",
+      },
     }
   }
 >

--- a/src/tests/unit/tests/views/content/__snapshots__/markup.test.tsx.snap
+++ b/src/tests/unit/tests/views/content/__snapshots__/markup.test.tsx.snap
@@ -357,7 +357,7 @@ exports[`ContentPage .Markup <Title> renders where setPageTitle === true 1`] = `
     <title>
       TEST
        - 
-      Accessibility Insights for Web
+      THE_APPLICATION_TITLE
     </title>
   </HelmetWrapper>
   <h1>

--- a/src/tests/unit/tests/views/content/content-include.test.tsx
+++ b/src/tests/unit/tests/views/content/content-include.test.tsx
@@ -14,9 +14,10 @@ describe('ContentInclude', () => {
         },
     };
 
+    const applicationTitle = 'THE_APPLICATION_TITLE';
     const deps = {
         textContent: {
-            applicationTitle: 'THE_APPLICATION_TITLE',
+            applicationTitle,
         },
         contentProvider: ContentPage.provider(content),
         contentActionMessageCreator: ({} as any) as ContentActionMessageCreator,

--- a/src/tests/unit/tests/views/content/content-include.test.tsx
+++ b/src/tests/unit/tests/views/content/content-include.test.tsx
@@ -15,6 +15,7 @@ describe('ContentInclude', () => {
     };
 
     const deps = {
+        applicationTitle: 'MY_APPLICATION_TITLE',
         contentProvider: ContentPage.provider(content),
         contentActionMessageCreator: ({} as any) as ContentActionMessageCreator,
     };

--- a/src/tests/unit/tests/views/content/content-include.test.tsx
+++ b/src/tests/unit/tests/views/content/content-include.test.tsx
@@ -15,7 +15,9 @@ describe('ContentInclude', () => {
     };
 
     const deps = {
-        applicationTitle: 'MY_APPLICATION_TITLE',
+        textContent: {
+            applicationTitle: 'THE_APPLICATION_TITLE',
+        },
         contentProvider: ContentPage.provider(content),
         contentActionMessageCreator: ({} as any) as ContentActionMessageCreator,
     };

--- a/src/tests/unit/tests/views/content/content-panel.test.tsx
+++ b/src/tests/unit/tests/views/content/content-panel.test.tsx
@@ -15,6 +15,7 @@ describe('ContentPanel', () => {
     };
 
     const deps = {
+        applicationTitle: 'MY_APPLICATION_TITLE',
         contentProvider: ContentPage.provider(content),
         contentActionMessageCreator: ({} as any) as ContentActionMessageCreator,
     };

--- a/src/tests/unit/tests/views/content/content-panel.test.tsx
+++ b/src/tests/unit/tests/views/content/content-panel.test.tsx
@@ -15,7 +15,9 @@ describe('ContentPanel', () => {
     };
 
     const deps = {
-        applicationTitle: 'MY_APPLICATION_TITLE',
+        textContent: {
+            applicationTitle: 'THE_APPLICATION_TITLE',
+        },
         contentProvider: ContentPage.provider(content),
         contentActionMessageCreator: ({} as any) as ContentActionMessageCreator,
     };

--- a/src/tests/unit/tests/views/content/content-panel.test.tsx
+++ b/src/tests/unit/tests/views/content/content-panel.test.tsx
@@ -14,9 +14,10 @@ describe('ContentPanel', () => {
         },
     };
 
+    const applicationTitle = 'THE_APPLICATION_TITLE';
     const deps = {
         textContent: {
-            applicationTitle: 'THE_APPLICATION_TITLE',
+            applicationTitle,
         },
         contentProvider: ContentPage.provider(content),
         contentActionMessageCreator: ({} as any) as ContentActionMessageCreator,

--- a/src/tests/unit/tests/views/content/content-view.test.tsx
+++ b/src/tests/unit/tests/views/content/content-view.test.tsx
@@ -7,8 +7,11 @@ import { ContentView, ContentViewDeps } from 'views/content/content-view';
 
 describe('content view', () => {
     it('renders', () => {
-        const applicationTitle = 'THE TITLE OF OUR APPLICATION';
-        const deps = { applicationTitle } as ContentViewDeps;
+        const deps = {
+            textContent: {
+                applicationTitle: 'THE_APPLICATION_TITLE',
+            },
+        } as ContentViewDeps;
 
         const component = (
             <ContentView deps={deps}>

--- a/src/tests/unit/tests/views/content/content-view.test.tsx
+++ b/src/tests/unit/tests/views/content/content-view.test.tsx
@@ -7,9 +7,10 @@ import { ContentView, ContentViewDeps } from 'views/content/content-view';
 
 describe('content view', () => {
     it('renders', () => {
+        const applicationTitle = 'THE_APPLICATION_TITLE';
         const deps = {
             textContent: {
-                applicationTitle: 'THE_APPLICATION_TITLE',
+                applicationTitle,
             },
         } as ContentViewDeps;
 

--- a/src/tests/unit/tests/views/content/markup.test.tsx
+++ b/src/tests/unit/tests/views/content/markup.test.tsx
@@ -10,7 +10,10 @@ import { ContentActionMessageCreator } from '../../../../../common/message-creat
 
 describe('ContentPage', () => {
     const contentActionMessageCreatorMock = Mock.ofType<ContentActionMessageCreator>();
-    const deps = { contentActionMessageCreator: contentActionMessageCreatorMock.object };
+    const deps = {
+        applicationTitle: 'THE_APPLICATION_TITLE',
+        contentActionMessageCreator: contentActionMessageCreatorMock.object,
+    };
 
     beforeEach(() => {
         contentActionMessageCreatorMock.reset();

--- a/src/tests/unit/tests/views/content/markup.test.tsx
+++ b/src/tests/unit/tests/views/content/markup.test.tsx
@@ -10,9 +10,10 @@ import { ContentActionMessageCreator } from '../../../../../common/message-creat
 
 describe('ContentPage', () => {
     const contentActionMessageCreatorMock = Mock.ofType<ContentActionMessageCreator>();
+    const applicationTitle = 'THE_APPLICATION_TITLE';
     const deps = {
         textContent: {
-            applicationTitle: 'THE_APPLICATION_TITLE',
+            applicationTitle,
         },
         contentActionMessageCreator: contentActionMessageCreatorMock.object,
     };

--- a/src/tests/unit/tests/views/content/markup.test.tsx
+++ b/src/tests/unit/tests/views/content/markup.test.tsx
@@ -11,7 +11,9 @@ import { ContentActionMessageCreator } from '../../../../../common/message-creat
 describe('ContentPage', () => {
     const contentActionMessageCreatorMock = Mock.ofType<ContentActionMessageCreator>();
     const deps = {
-        applicationTitle: 'THE_APPLICATION_TITLE',
+        textContent: {
+            applicationTitle: 'THE_APPLICATION_TITLE',
+        },
         contentActionMessageCreator: contentActionMessageCreatorMock.object,
     };
 

--- a/src/views/content/markup.tsx
+++ b/src/views/content/markup.tsx
@@ -44,7 +44,7 @@ export type Markup = {
 };
 
 export type MarkupDeps = {
-    textContent: Pick<TextContent, 'applicationTitle'>,
+    textContent: Pick<TextContent, 'applicationTitle'>;
     contentActionMessageCreator: ContentActionMessageCreator;
 };
 

--- a/src/views/content/markup.tsx
+++ b/src/views/content/markup.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 
 import { Code, Emphasis, Tag, Term } from 'assessments/markup';
-import { productName } from 'content/strings/application';
 import { NewTabLink } from '../../common/components/new-tab-link';
 import { CheckIcon } from '../../common/icons/check-icon';
 import { CrossIcon } from '../../common/icons/cross-icon';
@@ -43,10 +42,12 @@ export type Markup = {
     Include: React.FC<{ content: ContentPageComponent }>;
 };
 
-export type MarkupDeps = { contentActionMessageCreator: ContentActionMessageCreator };
+export type MarkupDeps = {
+    applicationTitle: string,
+    contentActionMessageCreator: ContentActionMessageCreator,
+};
 
 export const createMarkup = (deps: MarkupDeps, options: ContentPageOptions) => {
-    const { openContentHyperLink } = deps.contentActionMessageCreator;
 
     function Include(props: { content: ContentPageComponent }): JSX.Element {
         const Content = props.content;
@@ -54,10 +55,11 @@ export const createMarkup = (deps: MarkupDeps, options: ContentPageOptions) => {
     }
 
     function Title(props: { children: string }): JSX.Element {
+        const { applicationTitle } = deps;
         const helmet = (
             <Helmet>
                 <title>
-                    {props.children} - {productName}
+                    {props.children} - {applicationTitle}
                 </title>
             </Helmet>
         );
@@ -72,6 +74,7 @@ export const createMarkup = (deps: MarkupDeps, options: ContentPageOptions) => {
 
     function HyperLink(props: { href: string; children: React.ReactNode }): JSX.Element {
         const { href } = props;
+        const { openContentHyperLink } = deps.contentActionMessageCreator;
 
         return (
             <NewTabLink href={href} onClick={e => openContentHyperLink(e, href)}>

--- a/src/views/content/markup.tsx
+++ b/src/views/content/markup.tsx
@@ -10,6 +10,7 @@ import { CrossIcon } from '../../common/icons/cross-icon';
 import { ContentActionMessageCreator } from '../../common/message-creators/content-action-message-creator';
 import { ContentPageComponent, ContentPageOptions } from './content-page';
 import { CodeExample, CodeExampleProps } from './markup/code-example';
+import { TextContent } from 'content/strings/application';
 
 type PassFailProps = {
     passText: JSX.Element;
@@ -43,7 +44,7 @@ export type Markup = {
 };
 
 export type MarkupDeps = {
-    applicationTitle: string;
+    textContent: Pick<TextContent, 'applicationTitle'>,
     contentActionMessageCreator: ContentActionMessageCreator;
 };
 
@@ -54,7 +55,7 @@ export const createMarkup = (deps: MarkupDeps, options: ContentPageOptions) => {
     }
 
     function Title(props: { children: string }): JSX.Element {
-        const { applicationTitle } = deps;
+        const { applicationTitle } = deps.textContent;
         const helmet = (
             <Helmet>
                 <title>

--- a/src/views/content/markup.tsx
+++ b/src/views/content/markup.tsx
@@ -4,13 +4,13 @@ import * as React from 'react';
 import { Helmet } from 'react-helmet';
 
 import { Code, Emphasis, Tag, Term } from 'assessments/markup';
+import { TextContent } from 'content/strings/text-content';
 import { NewTabLink } from '../../common/components/new-tab-link';
 import { CheckIcon } from '../../common/icons/check-icon';
 import { CrossIcon } from '../../common/icons/cross-icon';
 import { ContentActionMessageCreator } from '../../common/message-creators/content-action-message-creator';
 import { ContentPageComponent, ContentPageOptions } from './content-page';
 import { CodeExample, CodeExampleProps } from './markup/code-example';
-import { TextContent } from 'content/strings/application';
 
 type PassFailProps = {
     passText: JSX.Element;

--- a/src/views/content/markup.tsx
+++ b/src/views/content/markup.tsx
@@ -43,12 +43,11 @@ export type Markup = {
 };
 
 export type MarkupDeps = {
-    applicationTitle: string,
-    contentActionMessageCreator: ContentActionMessageCreator,
+    applicationTitle: string;
+    contentActionMessageCreator: ContentActionMessageCreator;
 };
 
 export const createMarkup = (deps: MarkupDeps, options: ContentPageOptions) => {
-
     function Include(props: { content: ContentPageComponent }): JSX.Element {
         const Content = props.content;
         return <Content deps={deps} options={options} />;

--- a/src/views/insights/dependencies.ts
+++ b/src/views/insights/dependencies.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Logger } from 'common/logging/logger';
-import { title as applicationTitle } from 'content/strings/application';
+import { textContent } from 'content/strings/text-content';
 import { loadTheme } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
 import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
@@ -49,7 +49,7 @@ export const rendererDependencies: (
     const storeActionMessageCreator = storeActionMessageCreatorFactory.fromStores(storesHub.stores);
 
     return {
-        applicationTitle,
+        textContent,
         dom: document,
         render: ReactDOM.render,
         initializeFabricIcons,


### PR DESCRIPTION
#### Description of changes

Another refactor to support sharing UI components into the docs repo.

There is another reference to a hard-coded constant in the Markup classes. It uses `productName` which is identical to `applicationTitle`. Changed to use the `applicationTitle` found in `deps` to abstract.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
