### PR TITLE
feat(android-settings): window title bar icon high contrast theme

### DIFF
--- a/src/common/components/header-icon.tsx
+++ b/src/common/components/header-icon.tsx
@@ -12,21 +12,27 @@ import {
     WithStoreSubscriptionProps,
 } from './with-store-subscription';
 
-export type HeaderIconDeps = WithStoreSubscriptionDeps<HeaderIconState>;
-
-export type HeaderIconProps = WithStoreSubscriptionProps<HeaderIconState>;
-
 export type HeaderIconState = ThemeInnerState;
 
-export const HeaderIconComponent = NamedFC<HeaderIconProps>(
-    'HeaderIconComponent',
-    (props: HeaderIconProps) => {
-        const state = props.storeState.userConfigurationStoreData;
-        const enableHighContrast = state && state.enableHighContrast;
+export type HeaderIconDeps = WithStoreSubscriptionDeps<HeaderIconState>;
 
-        return enableHighContrast ? <BrandBlue /> : <BrandWhite />;
-    },
-);
+export type HeaderIconProps = {
+    invertColors?: boolean;
+} & WithStoreSubscriptionProps<HeaderIconState>;
+
+export const HeaderIconComponent = NamedFC<HeaderIconProps>('HeaderIconComponent', props => {
+    const state = props.storeState.userConfigurationStoreData;
+    const enableHighContrast = state && state.enableHighContrast;
+
+    const { invertColors = false } = props;
+
+    console.log('invertColors', invertColors);
+
+    const defaultIcon = invertColors ? <BrandBlue /> : <BrandWhite />;
+    const highContrastIcon = invertColors ? <BrandWhite /> : <BrandBlue />;
+
+    return enableHighContrast ? highContrastIcon : defaultIcon;
+});
 
 export const HeaderIcon = withStoreSubscription<HeaderIconProps, HeaderIconState>(
     HeaderIconComponent,

--- a/src/electron/views/automated-checks/components/title-bar.tsx
+++ b/src/electron/views/automated-checks/components/title-bar.tsx
@@ -1,20 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ActionButton } from 'office-ui-fabric-react';
-import * as React from 'react';
-
+import { HeaderIcon, HeaderIconDeps } from 'common/components/header-icon';
 import { NamedFC } from 'common/react/named-fc';
 import { brand } from 'content/strings/application';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { WindowTitle, WindowTitleDeps } from 'electron/views/common/window-title/window-title';
-import { BrandWhite } from 'icons/brand/white/brand-white';
+import { ActionButton } from 'office-ui-fabric-react';
+import * as React from 'react';
 import { MaximizeRestoreButton } from './maximize-restore-button';
 import * as styles from './title-bar.scss';
 
 export type TitleBarDeps = {
     windowFrameActionCreator: WindowFrameActionCreator;
-} & WindowTitleDeps;
+} & WindowTitleDeps &
+    HeaderIconDeps;
 
 export interface TitleBarProps {
     deps: TitleBarDeps;
@@ -66,7 +66,7 @@ export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps
             deps={props.deps}
             className={styles.titleBar}
         >
-            <BrandWhite />
+            <HeaderIcon deps={props.deps} />
         </WindowTitle>
     );
 });

--- a/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { HeaderIcon, HeaderIconDeps } from 'common/components/header-icon';
 import {
     TelemetryPermissionDialog,
     TelemetryPermissionDialogDeps,
@@ -8,7 +9,6 @@ import { NamedFC } from 'common/react/named-fc';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { brand } from 'content/strings/application';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
-import { BrandBlue } from 'icons/brand/blue/brand-blue';
 import * as React from 'react';
 import { DeviceStoreData } from '../../../flux/types/device-store-data';
 import { WindowTitle, WindowTitleDeps } from '../../common/window-title/window-title';
@@ -17,7 +17,8 @@ import { DeviceConnectBody, DeviceConnectBodyDeps } from './device-connect-body'
 
 export type DeviceConnectViewContainerDeps = TelemetryPermissionDialogDeps &
     DeviceConnectBodyDeps &
-    WindowTitleDeps;
+    WindowTitleDeps &
+    HeaderIconDeps;
 
 export type DeviceConnectViewContainerProps = {
     deps: DeviceConnectViewContainerDeps;
@@ -36,7 +37,7 @@ export const DeviceConnectViewContainer = NamedFC<DeviceConnectViewContainerProp
                     deps={props.deps}
                     windowStateStoreData={props.windowStateStoreData}
                 >
-                    <BrandBlue />
+                    <HeaderIcon invertColors deps={props.deps} />
                 </WindowTitle>
                 <div className={mainContentWrapper}>
                     <DeviceConnectBody

--- a/src/tests/unit/tests/common/components/__snapshots__/header-icon.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/header-icon.test.tsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`HeaderIconComponent is high contrast mode enabled: false 1`] = `<BrandWhite />`;
+exports[`HeaderIconComponent renders with invertColors = false and high contrast mode = false 1`] = `<BrandWhite />`;
 
-exports[`HeaderIconComponent is high contrast mode enabled: true 1`] = `<BrandBlue />`;
+exports[`HeaderIconComponent renders with invertColors = false and high contrast mode = true 1`] = `<BrandBlue />`;
+
+exports[`HeaderIconComponent renders with invertColors = true and high contrast mode = false 1`] = `<BrandBlue />`;
+
+exports[`HeaderIconComponent renders with invertColors = true and high contrast mode = true 1`] = `<BrandWhite />`;
+
+exports[`HeaderIconComponent renders with invertColors = undefined and high contrast mode = false 1`] = `<BrandWhite />`;
+
+exports[`HeaderIconComponent renders with invertColors = undefined and high contrast mode = true 1`] = `<BrandBlue />`;

--- a/src/tests/unit/tests/common/components/header-icon.test.tsx
+++ b/src/tests/unit/tests/common/components/header-icon.test.tsx
@@ -21,9 +21,15 @@ describe('HeaderIconComponent', () => {
             },
         } as HeaderIconProps;
     });
-    test.each([true, false])('is high contrast mode enabled: %s', (enableHighContrast: boolean) => {
-        props.storeState.userConfigurationStoreData.enableHighContrast = enableHighContrast;
-        const wrapper = shallow(<HeaderIconComponent {...props} />);
-        expect(wrapper.getElement()).toMatchSnapshot();
+
+    describe('renders', () => {
+        describe.each([true, false, undefined])('with invertColors = %s', invertColors => {
+            it.each([true, false])('and high contrast mode = %s', enableHighContrast => {
+                props.invertColors = invertColors;
+                props.storeState.userConfigurationStoreData.enableHighContrast = enableHighContrast;
+                const wrapper = shallow(<HeaderIconComponent {...props} />);
+                expect(wrapper.getElement()).toMatchSnapshot();
+            });
+        });
     });
 });

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/title-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/title-bar.test.tsx.snap
@@ -39,6 +39,15 @@ exports[`TitleBar renders 1`] = `
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
         "currentProcess": undefined,
       },
+      "storeActionMessageCreator": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "dispatcher": undefined,
+        "getStateMessages": undefined,
+      },
+      "storesHub": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "stores": undefined,
+      },
       "windowFrameActionCreator": proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
         "windowFrameActions": undefined,
@@ -53,6 +62,28 @@ exports[`TitleBar renders 1`] = `
     }
   }
 >
-  <BrandWhite />
+  <Component
+    deps={
+      Object {
+        "platformInfo": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "currentProcess": undefined,
+        },
+        "storeActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dispatcher": undefined,
+          "getStateMessages": undefined,
+        },
+        "storesHub": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "stores": undefined,
+        },
+        "windowFrameActionCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "windowFrameActions": undefined,
+        },
+      }
+    }
+  />
 </WindowTitle>
 `;

--- a/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { ThemeInnerState } from 'common/components/theme';
+import { StoreActionMessageCreatorImpl } from 'common/message-creators/store-action-message-creator-impl';
+import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
+import { ClientStoresHub } from 'common/stores/client-stores-hub';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { MaximizeRestoreButtonProps } from 'electron/views/automated-checks/components/maximize-restore-button';
@@ -25,6 +29,8 @@ describe('TitleBar', () => {
             deps: {
                 windowFrameActionCreator: windowFrameActionCreator.object,
                 platformInfo: Mock.ofType(PlatformInfo).object,
+                storeActionMessageCreator: Mock.ofType(StoreActionMessageCreatorImpl).object,
+                storesHub: Mock.ofType<ClientStoresHub<ThemeInnerState>>(BaseClientStoresHub).object,
             },
             windowStateStoreData,
         };

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
@@ -14,7 +14,10 @@ exports[`DeviceConnectViewContainer renders 1`] = `
       }
     }
   >
-    <BrandBlue />
+    <Component
+      deps={Object {}}
+      invertColors={true}
+    />
   </WindowTitle>
   <div
     className="mainContentWrapper"


### PR DESCRIPTION
#### Description of changes

Update the icon we use on the window title bar to have high contrast styles.

**Device port - high contrast theme**
![01 - device port - high contrast theme](https://user-images.githubusercontent.com/2837582/74872585-5774a380-5312-11ea-8c95-0d30a1f757fe.png)

**Device port - default theme**
![02 - device port - default theme](https://user-images.githubusercontent.com/2837582/74872614-66f3ec80-5312-11ea-84bb-3c0411649835.png)

**Automated checks - high contrast theme**
![03 - automated checks - high contrast theme](https://user-images.githubusercontent.com/2837582/74872623-6ce9cd80-5312-11ea-94c2-872e850097eb.png)

**Automated checks - default theme**
![04 - automated checks - default theme](https://user-images.githubusercontent.com/2837582/74872630-71ae8180-5312-11ea-9352-2845b78fd70b.png)

**Notes**
- This only change the icon, no the title text (which explains why you can't see the title text in one of the screenshots)
- Currently on master, there is no way to set high contrast mode on, I have this on a local branch but I'm not adding those changes to this PR as the changes are a hacky way to have high contrast setting to show up.
- The red line on the screenshots are not part of the actual UI; they are there to highlight the impacted portion of the UI

#### Pull request checklist

- [x] Addresses an existing issue: part of WI # 1677806
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
