### PR TITLE
feat(android-settings): fix outcome chip color to respect high contrast theme

### DIFF
--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -202,7 +202,6 @@ $neutral-55: var(--neutral-55);
 $neutral-60: var(--neutral-60);
 $neutral-70: var(--neutral-70);
 $neutral-80: var(--neutral-80);
-$neutral-90: var(--neutral-90);
 $neutral-alpha-2: var(--neutral-alpha-2);
 $neutral-alpha-4: var(--neutral-alpha-4);
 $neutral-alpha-6: var(--neutral-alpha-6);

--- a/src/reports/components/outcome.scss
+++ b/src/reports/components/outcome.scss
@@ -40,7 +40,7 @@ $outcome-count-border-size: 1.5px;
 .outcome-chip {
     $outcome-chip-icon-size: 16px;
     height: $outcome-chip-icon-size;
-    color: $neutral-90;
+    color: $primary-text;
     border-radius: 0px 8px 8px 0px;
     margin: 0 4px 0 4px;
     display: inline-flex;


### PR DESCRIPTION
#### Description of changes

Currently on master, out outcome chip is using `color: $neutral-90`, which is defined as `$neutral-90: var(--neutral-90)`. 
The issues with this is `--neutral-90` is not actually defined. 
The normal behavior of CSS custom properties (more info [here](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties)) make the outcome chip to set the color by using one of  it's ancestors color value, which mask the fact that `--neutral-90` is not defined. 
Another issues with this is: for some reason, on AI-Android the outcome chip does not react to high contrast mode being turned on (probably because there is no ancestor that set the color value following high contrast mode).

On this PR:
- I used `$primary-text` value to set the outcome chip color. This matches what we currently see on the UI.
- Remove all references to **neutral-90** (var and custom property) so we don't end up using it somewhere else by mystake

**bugged color definition from master**
![01 - bug - outcome-chip color value](https://user-images.githubusercontent.com/2837582/74884065-2eaad900-5327-11ea-8c99-122e68447a07.png)
_notice the color value does not show the colored little box as usual_

**fixed - default theme**
![02 - fixed - outcome-chip color value - default theme](https://user-images.githubusercontent.com/2837582/74884098-41bda900-5327-11ea-965c-c9b87ad3e23d.png)

**fixed - high contrast theme** 
![03 - fixed - outcome-chip color value - high constrat theme](https://user-images.githubusercontent.com/2837582/74884112-497d4d80-5327-11ea-9560-fc91a174e1cb.png)

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1677806
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
