### PR TITLE
feat(android-settings): window title text color respects high contrast mode

### DIFF
--- a/src/electron/views/automated-checks/components/title-bar.scss
+++ b/src/electron/views/automated-checks/components/title-bar.scss
@@ -6,6 +6,6 @@
     background: $ada-brand-color;
 
     h1 {
-        color: $always-white !important;
+        color: $header-bar-title-color !important;
     }
 }


### PR DESCRIPTION
#### Description of changes

Fix the text color for the window title text under automated checks.

**loos like not text, it's actually the same color as the background color**
![image](https://user-images.githubusercontent.com/2837582/74886161-46389080-532c-11ea-986e-af1703fea07f.png)

**fixed**
![01 - fix high contast window title text color](https://user-images.githubusercontent.com/2837582/74886086-12f60180-532c-11ea-915c-cbe33fde3411.png)

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1677806
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
