### PR TITLE
feat(android-settings): window control buttons respect high contrast mode

### DIFF
--- a/src/electron/views/common/window-title/window-title.scss
+++ b/src/electron/views/common/window-title/window-title.scss
@@ -69,7 +69,7 @@
         padding: 10px;
 
         i {
-            color: $always-white;
+            color: $neutral-0;
             font-size: 12px;
         }
         svg {
@@ -77,7 +77,7 @@
             height: 12px;
 
             path {
-                fill: $always-white;
+                fill: $neutral-0;
             }
         }
     }


### PR DESCRIPTION
#### Description of changes

Fix the window control buttons by using a high theme dependent color (`$neutral-0`), instead of a fixed one (`$always-white`).

**Window NOT maximized**
![01 - high contrast window no maximized](https://user-images.githubusercontent.com/2837582/74887587-24d9a380-5330-11ea-91c1-3e2c9cad41dd.png)

**Window maximized**
![02 - high contrast window maximized](https://user-images.githubusercontent.com/2837582/74887591-260ad080-5330-11ea-9157-043a6c2d0876.png)

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1677806
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
