### PR TITLE
feat(android-settings): Failed instance title text respect high contrast

### DIFF
--- a/src/common/components/cards/result-section-title.scss
+++ b/src/common/components/cards/result-section-title.scss
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../../common/styles/fonts.scss';
+@import '../../../common/styles/colors.scss';
 
 .result-section-title {
     display: flex;
@@ -29,6 +30,7 @@
     .title {
         @include text-style-title-s;
         margin-right: 6px;
+        color: $primary-text;
     }
 
     .outcome-chip-container {


### PR DESCRIPTION
#### Description of changes

Make the text color of **Failed instances** to respect high contrast mode on the cards ui.

**Incorrect high contrast color**
![02 - bug - high contrast filed instances title text](https://user-images.githubusercontent.com/2837582/74891803-bfd87a80-533c-11ea-9a8b-ed33e6576826.png)

**Fixed high contrast color** 
![01 - fix - high contrast failed instaces title text](https://user-images.githubusercontent.com/2837582/74891812-c535c500-533c-11ea-8244-fe0ad4c5df52.png)

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678709
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
