### PR TITLE
feat(android-settings) : update start over button styles

### DIFF
--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -94,6 +94,7 @@
     --screenshot-image-outline: #8b8b8b;
     --card-border: transparent;
     --card-footer-border: var(--neutral-10);
+    --button-hover: var(--communication-primary);
 
     // Landmark colors
     --landmark-contentinfo: #00a88c;
@@ -164,6 +165,7 @@
         --screenshot-image-outline: var(--white);
         --card-border: var(--white);
         --card-footer-border: var(--white);
+        --button-hover: #0078d4; // this is the same color office fabric uses on hover
     }
 }
 
@@ -261,6 +263,7 @@ $menu-background: var(--menu-background);
 $screenshot-image-outline: var(--screenshot-image-outline);
 $card-border: var(--card-border);
 $card-footer-border: var(--card-footer-border);
+$button-hover: var(--button-hover);
 
 // consistent colors
 $always-white: #ffffff;

--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -20,10 +20,18 @@
         color: $primary-text;
         font-size: $fontSizeM;
         font-family: $fontFamily;
+
+        &:hover {
+            color: $button-hover;
+        }
     }
 
     .button-icon {
         color: $primary-text;
         line-height: 16px;
+
+        &:hover {
+            color: $button-hover;
+        }
     }
 }


### PR DESCRIPTION
#### Description of changes

Update start over buttons styles on default and high contrast themes.

**default theme - default state**
![01 - default theme - default state](https://user-images.githubusercontent.com/2837582/74972054-f0b8be00-53d5-11ea-965a-0581d894ab6f.png)

**default theme - hover state**
![02 - default theme- hover state](https://user-images.githubusercontent.com/2837582/74972093-ff06da00-53d5-11ea-983e-e63cda1a191f.png)

**high contrast theme - default state**
![03 - high contrast theme - default state](https://user-images.githubusercontent.com/2837582/74972111-0928d880-53d6-11ea-8104-c15c0dc97e89.png)

**high contrast theme - hover state**
![04 - high contrast theme - hover state](https://user-images.githubusercontent.com/2837582/74972130-0f1eb980-53d6-11ea-9cb7-d177ffd6142d.png)

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678709
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
