### PR TITLE
fix rule description hover state text color on high contrast

### DIFF
--- a/src/common/components/cards/collapsible-component-cards.scss
+++ b/src/common/components/cards/collapsible-component-cards.scss
@@ -38,7 +38,7 @@
 
         &:hover {
             background-color: $neutral-alpha-4;
-            color: unset;
+            color: $primary-text;
         }
     }
 


### PR DESCRIPTION
#### Description of changes

Currently, hovering over a rule group on AI-Android makes the description to change text color to something closer to black, which makes it unreadable. This is due to a `color: unset;` value we are setting specifically for the hover state plus some missing color value on the parent/ancestor of this element (color is an inheritable property, `color: unset;` makes css to look up to the parent of an element and up the hierarchy until it finds a color or uses a default value).

In this PR: using an explicit color for the hover state which fixes AI-Android and leaves AI-Web and the report with the same, original behavior.

**Current master**
ImageViewName rule hovered over, where the description is not visible due to the text using black.
![image](https://user-images.githubusercontent.com/2837582/74987275-a7756800-53ef-11ea-9143-872e895a9b5e.png)

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678709
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
