### PR TITLE
feat(android-settings): add theme support to unified root container

### DIFF
--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -356,6 +356,8 @@ if (isNaN(tabId) === false) {
 
             const unifiedResultToIssueFilingDataConverter = new UnifiedResultToIssueFilingDataConverter();
 
+            const documentManipulator = new DocumentManipulator(document);
+
             const deps: DetailsViewContainerDeps = {
                 textContent,
                 fixInstructionProcessor,
@@ -411,6 +413,7 @@ if (isNaN(tabId) === false) {
                     detailsViewActionMessageCreator,
                 ),
                 setFocusVisibility,
+                documentManipulator,
             };
 
             const renderer = new DetailsViewRenderer(

--- a/src/common/components/theme.tsx
+++ b/src/common/components/theme.tsx
@@ -34,15 +34,13 @@ export class ThemeInner extends React.Component<ThemeInnerProps> {
     }
 
     public render(): JSX.Element {
-        const enableHighContrast = this.isHighContrastEnabled(this.props);
-        const classNames = enableHighContrast ? ['high-contrast-theme'] : [];
+        const classNames = ['theme-switcher'];
 
-        return (
-            <BodyClassModifier
-                documentManipulator={this.props.deps.documentManipulator}
-                classNames={classNames}
-            />
-        );
+        if (this.isHighContrastEnabled(this.props)) {
+            classNames.push('high-contrast-theme');
+        }
+
+        return <BodyClassModifier deps={this.props.deps} classNames={classNames} />;
     }
 
     private isHighContrastEnabled(props: ThemeInnerProps): boolean {

--- a/src/common/components/theme.tsx
+++ b/src/common/components/theme.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { css } from '@uifabric/utilities';
 import * as React from 'react';
-import { Helmet } from 'react-helmet';
 
+import { DocumentManipulator } from 'common/document-manipulator';
 import { DefaultThemePalette } from '../styles/default-theme-palette';
 import { HighContrastThemePalette } from '../styles/high-contrast-theme-palette';
 import { UserConfigurationStoreData } from '../types/store-data/user-configuration-store';
+import { BodyClassModifier } from './body-class-modifier';
 import { withStoreSubscription, WithStoreSubscriptionDeps } from './with-store-subscription';
 
 export interface ThemeInnerState {
@@ -17,6 +17,7 @@ export type ThemeInnerProps = {
     storeState: ThemeInnerState;
 };
 export type ThemeDeps = WithStoreSubscriptionDeps<ThemeInnerState> & {
+    documentManipulator: DocumentManipulator;
     loadTheme: (theme) => void;
 };
 
@@ -34,12 +35,13 @@ export class ThemeInner extends React.Component<ThemeInnerProps> {
 
     public render(): JSX.Element {
         const enableHighContrast = this.isHighContrastEnabled(this.props);
-        const className = css('theme-switcher', enableHighContrast && 'high-contrast-theme');
+        const classNames = enableHighContrast ? ['high-contrast-theme'] : [];
 
         return (
-            <Helmet>
-                <body className={className} />
-            </Helmet>
+            <BodyClassModifier
+                documentManipulator={this.props.deps.documentManipulator}
+                classNames={classNames}
+            />
         );
     }
 

--- a/src/electron/settings/unified-settings-provider.ts
+++ b/src/electron/settings/unified-settings-provider.ts
@@ -1,11 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { androidAppTitle } from 'content/strings/application';
-import { HighContrastSettings } from 'DetailsView/components/details-view-overlay/settings-panel/settings/high-contrast/high-contrast-settings';
 import { createSettingsProvider } from 'DetailsView/components/details-view-overlay/settings-panel/settings/settings-provider';
 import { createTelemetrySettings } from 'DetailsView/components/details-view-overlay/settings-panel/settings/telemetry/telemetry-settings';
 
 export const UnifiedSettingsProvider = createSettingsProvider([
     createTelemetrySettings(androidAppTitle),
-    HighContrastSettings,
 ]);

--- a/src/electron/settings/unified-settings-provider.ts
+++ b/src/electron/settings/unified-settings-provider.ts
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { androidAppTitle } from 'content/strings/application';
+import { HighContrastSettings } from 'DetailsView/components/details-view-overlay/settings-panel/settings/high-contrast/high-contrast-settings';
 import { createSettingsProvider } from 'DetailsView/components/details-view-overlay/settings-panel/settings/settings-provider';
 import { createTelemetrySettings } from 'DetailsView/components/details-view-overlay/settings-panel/settings/telemetry/telemetry-settings';
 
 export const UnifiedSettingsProvider = createSettingsProvider([
     createTelemetrySettings(androidAppTitle),
+    HighContrastSettings,
 ]);

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -56,7 +56,7 @@ import { RootContainerState } from 'electron/views/root-container/components/roo
 import { PlatformInfo } from 'electron/window-management/platform-info';
 import { WindowFrameListener } from 'electron/window-management/window-frame-listener';
 import { WindowFrameUpdater } from 'electron/window-management/window-frame-updater';
-import { setFocusVisibility } from 'office-ui-fabric-react';
+import { loadTheme, setFocusVisibility } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
 import { getPersistedData, PersistedData } from '../../background/get-persisted-data';
@@ -310,13 +310,14 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             storesHub,
             scanActionCreator,
             windowFrameActionCreator,
-            platformInfo: new PlatformInfo(process),
+            platformInfo,
             getCardsViewData: getCardViewData,
             getCardSelectionViewData: getCardSelectionViewData,
             screenshotViewModelProvider,
             ...cardsViewDeps,
             storeActionMessageCreator: new NullStoreActionMessageCreator(),
             settingsProvider: UnifiedSettingsProvider,
+            loadTheme,
             documentManipulator,
         };
 

--- a/src/electron/views/root-container/root-container-renderer.tsx
+++ b/src/electron/views/root-container/root-container-renderer.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Theme, ThemeDeps } from 'common/components/theme';
 import {
     PlatformBodyClassModifier,
     PlatformBodyClassModifierDeps,
@@ -11,7 +12,10 @@ import {
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
-export type RootContainerRendererDeps = PlatformBodyClassModifierDeps & RootContainerDeps;
+export type RootContainerRendererDeps = RootContainerDeps &
+    ThemeDeps &
+    PlatformBodyClassModifierDeps;
+
 export class RootContainerRenderer {
     constructor(
         private readonly renderer: typeof ReactDOM.render,
@@ -26,6 +30,7 @@ export class RootContainerRenderer {
         this.renderer(
             <>
                 <PlatformBodyClassModifier deps={this.deps} />
+                <Theme deps={this.deps} />
                 <RootContainer deps={this.deps} />
             </>,
             rootContainer,

--- a/src/popup/popup-initializer.ts
+++ b/src/popup/popup-initializer.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DocumentManipulator } from 'common/document-manipulator';
 import { loadTheme } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
 import { A11YSelfValidator } from '../common/a11y-self-validator';
@@ -198,6 +199,8 @@ export class PopupInitializer {
 
         const axeInfo = AxeInfo.Default;
 
+        const documentManipulator = new DocumentManipulator(document);
+
         const deps: DiagnosticViewToggleDeps & MainRendererDeps = {
             contentProvider: contentPages,
             popupActionMessageCreator,
@@ -212,6 +215,7 @@ export class PopupInitializer {
             launchPanelHeaderClickHandler,
             browserAdapter: this.browserAdapter,
             LinkComponent: NewTabLink,
+            documentManipulator,
         };
 
         const diagnosticViewToggleFactory = new DiagnosticViewToggleFactory(

--- a/src/tests/unit/tests/common/components/__snapshots__/theme.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/theme.test.tsx.snap
@@ -1,23 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ThemeInner is high contrast mode enabled: false 1`] = `
-<HelmetWrapper
-  defer={true}
-  encodeSpecialCharacters={true}
->
-  <body
-    className="theme-switcher"
-  />
-</HelmetWrapper>
+<BodyClassModifier
+  classNames={
+    Array [
+      "theme-switcher",
+    ]
+  }
+  deps={
+    Object {
+      "documentManipulator": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "document": undefined,
+      },
+      "loadTheme": [MockFunction],
+      "storeActionMessageCreator": null,
+      "storesHub": null,
+    }
+  }
+/>
 `;
 
 exports[`ThemeInner is high contrast mode enabled: true 1`] = `
-<HelmetWrapper
-  defer={true}
-  encodeSpecialCharacters={true}
->
-  <body
-    className="theme-switcher high-contrast-theme"
-  />
-</HelmetWrapper>
+<BodyClassModifier
+  classNames={
+    Array [
+      "theme-switcher",
+      "high-contrast-theme",
+    ]
+  }
+  deps={
+    Object {
+      "documentManipulator": proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "document": undefined,
+      },
+      "loadTheme": [MockFunction],
+      "storeActionMessageCreator": null,
+      "storesHub": null,
+    }
+  }
+/>
 `;

--- a/src/tests/unit/tests/common/components/theme.test.tsx
+++ b/src/tests/unit/tests/common/components/theme.test.tsx
@@ -12,7 +12,7 @@ import { HighContrastThemePalette } from 'common/styles/high-contrast-theme-pale
 describe('ThemeInner', () => {
     let props: ThemeInnerProps;
     const loadThemeMock = jest.fn();
-    const documentManipulatorMock = Mock.ofType<DocumentManipulator>();
+    const documentManipulatorMock = Mock.ofType(DocumentManipulator);
 
     beforeEach(() => {
         props = {

--- a/src/tests/unit/tests/common/components/theme.test.tsx
+++ b/src/tests/unit/tests/common/components/theme.test.tsx
@@ -2,19 +2,23 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { Mock } from 'typemoq';
 
-import { ThemeDeps, ThemeInner, ThemeInnerProps } from '../../../../../common/components/theme';
-import { DefaultThemePalette } from '../../../../../common/styles/default-theme-palette';
-import { HighContrastThemePalette } from '../../../../../common/styles/high-contrast-theme-palette';
+import { ThemeDeps, ThemeInner, ThemeInnerProps } from 'common/components/theme';
+import { DocumentManipulator } from 'common/document-manipulator';
+import { DefaultThemePalette } from 'common/styles/default-theme-palette';
+import { HighContrastThemePalette } from 'common/styles/high-contrast-theme-palette';
 
 describe('ThemeInner', () => {
     let props: ThemeInnerProps;
     const loadThemeMock = jest.fn();
+    const documentManipulatorMock = Mock.ofType<DocumentManipulator>();
 
     beforeEach(() => {
         props = {
             deps: {
                 loadTheme: loadThemeMock,
+                documentManipulator: documentManipulatorMock.object,
                 storeActionMessageCreator: null,
                 storesHub: null,
             } as ThemeDeps,

--- a/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Theme } from 'common/components/theme';
+import { DocumentManipulator } from 'common/document-manipulator';
 import { BrowserWindow } from 'electron';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { PlatformBodyClassModifier } from 'electron/views/root-container/components/platform-body-class-modifier';
@@ -13,6 +15,7 @@ describe('RootContainerRendererTest', () => {
     test('render', () => {
         const dom = document.createElement('div');
         const containerDiv = document.createElement('div');
+        const documentManipulatorMock = Mock.ofType<DocumentManipulator>();
         const renderMock: IMock<typeof ReactDOM.render> = Mock.ofInstance(() => null);
         const windowStateActionCreatorMock = Mock.ofType(WindowStateActionCreator);
         const browserWindow: BrowserWindow = {
@@ -27,11 +30,13 @@ describe('RootContainerRendererTest', () => {
         const deps = {
             currentWindow: browserWindow,
             windowStateActionCreator: windowStateActionCreatorMock.object,
+            documentManipulator: documentManipulatorMock.object,
         } as RootContainerRendererDeps;
 
         const expectedComponent = (
             <>
                 <PlatformBodyClassModifier deps={deps} />
+                <Theme deps={deps} />
                 <RootContainer deps={deps} />
             </>
         );

--- a/src/views/insights/dependencies.ts
+++ b/src/views/insights/dependencies.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DocumentManipulator } from 'common/document-manipulator';
 import { Logger } from 'common/logging/logger';
 import { textContent } from 'content/strings/text-content';
 import { loadTheme } from 'office-ui-fabric-react';
@@ -48,6 +49,8 @@ export const rendererDependencies: (
     );
     const storeActionMessageCreator = storeActionMessageCreatorFactory.fromStores(storesHub.stores);
 
+    const documentManipulator = new DocumentManipulator(document);
+
     return {
         textContent,
         dom: document,
@@ -58,5 +61,6 @@ export const rendererDependencies: (
         contentActionMessageCreator,
         storesHub,
         storeActionMessageCreator,
+        documentManipulator,
     };
 };


### PR DESCRIPTION
#### Description of changes

* Adds `<Theme>` to the unified `RootContainerRenderer` to implement it
* Updates `<Theme>` to use the new `BodyClassModifier` so it can live side-by-side with `PlatformBodyClassModifier`
* Updates the other initializers that transitively use `<Theme>` to pass down its new `DocumentManipulator` dep

No UI changes in web (verified that high contrast toggle still works in popup/details/content views).

Out of scope:
* high contrast styling
* Adding setting to the settings panel (waiting til styles are more complete)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: closes 1677805
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
