### PR TITLE
feat(android-settings): update Theme to call loadTheme on mount

### DIFF
--- a/src/common/components/theme.tsx
+++ b/src/common/components/theme.tsx
@@ -21,15 +21,17 @@ export type ThemeDeps = WithStoreSubscriptionDeps<ThemeInnerState> & {
 };
 
 export class ThemeInner extends React.Component<ThemeInnerProps> {
+    public componentDidMount(): void {
+        this.loadAppropriateTheme(this.isHighContrastEnabled(this.props));
+    }
+
     public componentDidUpdate(prevProps): void {
         const enableHighContrastCurr = this.isHighContrastEnabled(this.props);
         const enableHighContrastPrev = this.isHighContrastEnabled(prevProps);
         if (enableHighContrastCurr === enableHighContrastPrev) {
             return;
         }
-        this.props.deps.loadTheme(
-            enableHighContrastCurr ? HighContrastThemePalette : DefaultThemePalette,
-        );
+        this.loadAppropriateTheme(enableHighContrastCurr);
     }
 
     public render(): JSX.Element {
@@ -41,6 +43,11 @@ export class ThemeInner extends React.Component<ThemeInnerProps> {
                 <body className={className} />
             </Helmet>
         );
+    }
+
+    private loadAppropriateTheme(isHighContrast: boolean): void {
+        const appropriateTheme = isHighContrast ? HighContrastThemePalette : DefaultThemePalette;
+        this.props.deps.loadTheme(appropriateTheme);
     }
 
     private isHighContrastEnabled(props: ThemeInnerProps): boolean {

--- a/src/tests/unit/tests/common/components/theme.test.tsx
+++ b/src/tests/unit/tests/common/components/theme.test.tsx
@@ -3,9 +3,10 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { ThemeDeps, ThemeInner, ThemeInnerProps } from '../../../../../common/components/theme';
-import { DefaultThemePalette } from '../../../../../common/styles/default-theme-palette';
-import { HighContrastThemePalette } from '../../../../../common/styles/high-contrast-theme-palette';
+import { ThemeDeps, ThemeInner, ThemeInnerProps } from 'common/components/theme';
+import { DefaultThemePalette } from 'common/styles/default-theme-palette';
+import { HighContrastThemePalette } from 'common/styles/high-contrast-theme-palette';
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 
 describe('ThemeInner', () => {
     let props: ThemeInnerProps;
@@ -34,9 +35,19 @@ describe('ThemeInner', () => {
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 
+    test.each(testStub)('componentDidMount: is high contrast mode enabled: %s', (enableHighContrast: boolean) => {
+        const theme = enableHighContrast ? HighContrastThemePalette : DefaultThemePalette;
+        const userConfigurationStoreData = { enableHighContrast } as UserConfigurationStoreData;
+        shallow(<ThemeInner {...props} storeState={{ userConfigurationStoreData }} />);
+
+        expect(loadThemeMock).toBeCalledWith(theme);
+    });
+
     test.each(testStub)('componentDidUpdate: is high contrast mode enabled: %s', (enableHighContrast: boolean) => {
         const theme = enableHighContrast ? HighContrastThemePalette : DefaultThemePalette;
         const wrapper = shallow(<ThemeInner {...props} />);
+
+        loadThemeMock.mockReset();
         wrapper.setProps({
             storeState: {
                 userConfigurationStoreData: { enableHighContrast },

--- a/src/tests/unit/tests/common/components/theme.test.tsx
+++ b/src/tests/unit/tests/common/components/theme.test.tsx
@@ -36,6 +36,8 @@ describe('ThemeInner', () => {
     test.each(testStub)('is high contrast mode enabled: %s', (enableHighContrast: boolean) => {
         props.storeState.userConfigurationStoreData.enableHighContrast = enableHighContrast;
         const wrapper = shallow(<ThemeInner {...props} />);
+
+        loadThemeMock.mockReset(); // omits irrelevant mock-call records from snapshot
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 


### PR DESCRIPTION
#### Description of changes

Today, `<Theme>` only invokes office fabric's `loadTheme` in `componentDidUpdate`; this is fine in web because it always updates soon after loading due to the store proxy not receiving info until after first mount, but in unified, it has the true store data during mount and so won't necessarily receive an initial update notification on first run. This updates it to perform an initial `loadTheme` during mount, in addition to on updates.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
