### PR TITLE
feat(android-settings): remove hover state style that's not needed

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -29,9 +29,5 @@
     .button-icon {
         color: $primary-text;
         line-height: 16px;
-
-        &:hover {
-            color: $button-hover;
-        }
     }
 }


### PR DESCRIPTION
#### Description of changes

There is an "extra" hover state style that make the start over button to respond oddly to the user hovering over the text and not the icon.

Removing the extra style fix the issue.

![01 - start over hover style](https://user-images.githubusercontent.com/2837582/74989763-36857e80-53f6-11ea-81a1-29fe93461487.gif)

#### Pull request checklist
- [x] Addresses an existing issue: part fo WI # 1677806
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
