### PR TITLE
feat(android-settings): add body color value

### DIFF
--- a/src/electron/views/device-connect-view/device-connect-view.scss
+++ b/src/electron/views/device-connect-view/device-connect-view.scss
@@ -5,6 +5,10 @@
 @import '../../../reports/components/outcome.scss';
 @import '../../../common/components/cards/fix-instruction-color-box.scss';
 
+body {
+    color: $primary-text;
+}
+
 .device-connect-view {
     -webkit-app-region: drag;
 


### PR DESCRIPTION
#### Description of changes

Currently, we don't have a body color value on AI-Android. This makes the color value to be black (the default value). This default value does not change when we enable high contrast mode which make the text practically invisible against the black background.

This is easily fixed by adding a explicit color value for the body. Using `$primary-text` for this.

**Bug: text is invisible on device port entry view when high contrast mode is enabled**
![image](https://user-images.githubusercontent.com/2837582/74990654-b1e82f80-53f8-11ea-841d-26dc36d5902f.png)

**Fixed: device port entry view shows white text**
![01 - high contrast theme - fixed](https://user-images.githubusercontent.com/2837582/74990510-528a1f80-53f8-11ea-8d12-98f2f6e495f7.png)

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678708
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
