### PR TITLE
feat(android-settings): "immutable" state on base store

### DIFF
--- a/src/background/stores/base-store-impl.ts
+++ b/src/background/stores/base-store-impl.ts
@@ -1,14 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { identity } from 'lodash';
 import { BaseStore } from '../../common/base-store';
 import { Store } from '../../common/flux/store';
 import { StoreNames } from '../../common/stores/store-names';
 
+export type StateProcessor<State> = (state: State) => State;
+
 export abstract class BaseStoreImpl<TState> extends Store implements BaseStore<TState> {
-    private storeName: StoreNames;
     protected state: TState;
 
-    constructor(storeName: StoreNames) {
+    constructor(
+        private readonly storeName: StoreNames,
+        private readonly getStateProcessor: StateProcessor<TState> = identity,
+    ) {
         super();
         this.storeName = storeName;
         this.onGetCurrentState = this.onGetCurrentState.bind(this);
@@ -28,7 +33,7 @@ export abstract class BaseStoreImpl<TState> extends Store implements BaseStore<T
     }
 
     public getState(): TState {
-        return this.state;
+        return this.getStateProcessor(this.state);
     }
 
     protected onGetCurrentState(): void {

--- a/src/background/stores/global/user-configuration-store.ts
+++ b/src/background/stores/global/user-configuration-store.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
+import { StoreNames } from 'common/stores/store-names';
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { cloneDeep, isPlainObject } from 'lodash';
-
-import { IndexedDBAPI } from '../../../common/indexedDB/indexedDB';
-import { StoreNames } from '../../../common/stores/store-names';
-import { UserConfigurationStoreData } from '../../../common/types/store-data/user-configuration-store';
 import {
     SaveIssueFilingSettingsPayload,
     SetHighContrastModePayload,
@@ -13,7 +12,7 @@ import {
 } from '../../actions/action-payloads';
 import { UserConfigurationActions } from '../../actions/user-configuration-actions';
 import { IndexedDBDataKeys } from '../../IndexedDBDataKeys';
-import { BaseStoreImpl } from '../base-store-impl';
+import { BaseStoreImpl, StateProcessor } from '../base-store-impl';
 
 export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStoreData> {
     public static readonly defaultState: UserConfigurationStoreData = {
@@ -28,8 +27,9 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
         private readonly persistedState: UserConfigurationStoreData,
         private readonly userConfigActions: UserConfigurationActions,
         private readonly indexDbApi: IndexedDBAPI,
+        getStateProcessor?: StateProcessor<UserConfigurationStoreData>,
     ) {
-        super(StoreNames.UserConfigurationStore);
+        super(StoreNames.UserConfigurationStore, getStateProcessor);
     }
 
     private generateDefaultState(

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -56,6 +56,7 @@ import { RootContainerState } from 'electron/views/root-container/components/roo
 import { PlatformInfo } from 'electron/window-management/platform-info';
 import { WindowFrameListener } from 'electron/window-management/window-frame-listener';
 import { WindowFrameUpdater } from 'electron/window-management/window-frame-updater';
+import { cloneDeep } from 'lodash';
 import { loadTheme, setFocusVisibility } from 'office-ui-fabric-react';
 import * as ReactDOM from 'react-dom';
 import { UserConfigurationActions } from '../../background/actions/user-configuration-actions';
@@ -135,6 +136,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             persistedData.userConfigurationData,
             userConfigActions,
             indexedDBInstance,
+            cloneDeep,
         );
         userConfigurationStore.initialize();
 

--- a/src/tests/unit/tests/background/stores/base-store.test.ts
+++ b/src/tests/unit/tests/background/stores/base-store.test.ts
@@ -1,11 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { BaseStoreImpl } from 'background/stores/base-store-impl';
-import { StoreNames } from '../../../../../common/stores/store-names';
-import { IsSameObject } from '../../../common/typemoq-helper';
+import { StoreNames } from 'common/stores/store-names';
 import { cloneDeep } from 'lodash';
+import { It, Mock, MockBehavior, Times } from 'typemoq';
+import { IsSameObject } from '../../../common/typemoq-helper';
 
 describe('BaseStoreTest', () => {
     test('getId', () => {

--- a/src/tests/unit/tests/background/stores/base-store.test.ts
+++ b/src/tests/unit/tests/background/stores/base-store.test.ts
@@ -5,6 +5,7 @@ import { It, Mock, MockBehavior, Times } from 'typemoq';
 import { BaseStoreImpl } from 'background/stores/base-store-impl';
 import { StoreNames } from '../../../../../common/stores/store-names';
 import { IsSameObject } from '../../../common/typemoq-helper';
+import { cloneDeep } from 'lodash';
 
 describe('BaseStoreTest', () => {
     test('getId', () => {
@@ -66,6 +67,30 @@ describe('BaseStoreTest', () => {
         changedListener.verifyAll();
     });
 
+    describe('get state decorator', () => {
+        const initialState: TestData = {
+            value: 'initial-value',
+        };
+
+        it('return same object when no decorator is passed', () => {
+            const testObject = new TestStore(() => {});
+
+            testObject.initialize(initialState);
+
+            expect(testObject.getState()).toEqual(initialState);
+            expect(testObject.getState()).toBe(initialState);
+        });
+
+        it('return different object, same values when deepClone decorator is passed', () => {
+            const testObject = new TestStore(() => {}, cloneDeep);
+
+            testObject.initialize(initialState);
+
+            expect(testObject.getState()).not.toBe(initialState);
+            expect(testObject.getState()).toEqual(initialState);
+        });
+    });
+
     interface TestData {
         value: string;
     }
@@ -73,8 +98,8 @@ describe('BaseStoreTest', () => {
     class TestStore extends BaseStoreImpl<TestData> {
         private listener: () => void;
 
-        constructor(listener: () => void) {
-            super(StoreNames[StoreNames[0]]);
+        constructor(listener: () => void, getStateDecorator?: (state: TestData) => TestData) {
+            super(StoreNames[StoreNames[0]], getStateDecorator);
 
             this.listener = listener;
         }


### PR DESCRIPTION
#### Description of changes

Currently, our `Store`s use mutable state object, i.e. every time an action causes a state to change, the `Store` is only updating values inside the state, the object that holds the state is fundamentally the same.

This doesn't seem to have any interesting effect on AI-Web basically because of the messaging infrastructure we use to communicate between the background (where stores live) and the "front-end" side, where we use `StoreProxy`, where we have this line of code to update the state:
```ts
this.state = message.payload;
```
Note that the `message` is being marshalled by chrome messaging API, meaning, it has the same values that the state we are sending from the background but it's not the same object (in the C world, basically they are 2 different references or pointers that happen to hold the same values).

Now, this happen to reveal a bug on AI-Android, around how we handle default/high contrast themes. On `ThemeInner` component, we have this couple of lines inside `componentDidUpdate`:
```ts
const enableHighContrastCurr = this.isHighContrastEnabled(this.props);
const enableHighContrastPrev = this.isHighContrastEnabled(prevProps);
```
then, base on the current and previous state of the high contrast flag we decide if we need to call `loadTheme` or not (`loadTheme` is the one that allows to update office fabric components styles).
This is fine on AI-Web because the `Store` <-> `StoreProxy` structure we have makes the previous and current state a different object every time we get an update from the background; this is **not** fine on AI-Android because we don't use `StoreProxy`, we don't have a background, basically, our "source of truth" is in the same page and we only use `Store` instances; this plus the fact our `Store` uses a mutable state make the comparison we use on `ThemeInner` to always be `false`  (basically previous and current state is the same all the time) which prevent us from calling `loadTheme`.

In order to solve this, we could make sure our `Store` uses an immutable `state` like redux does, i.e, every time we update the state we create a new object with all the same values plus the updated ones (that's kind of easy to do with the spread operator: `const newState = {...this.state}` ), but doing so in `BaseStoreImpl` or `Store` seems risky at this point.

Considering the last point, the approach I chose to tackle this is add a sort of decorator or processor that we use as part of the `getState` logic inside `BaseStoreImpl`, going from this code:
```ts
public getState(): TState {
    return this.state;
}
```
to this code:
```ts
public getState(): TState {
    return this.getStateProcessor(this.state);
}
````
By default, we set `getStateProcessor` to be the identity function (from `lodash`) and make the constructor param to be optional, this way, the store instances we use on AI-Web are left unchanged (both, on behavior and on how we instanciate them); but in the case of AI-Android we use lodash's `cloneDeep` as the `getStateProcessor`. This way, every time there is an update on the `Store` and a component ask for the `state` we get a new copy of the state, effectively making the previous state and current state different objects (at least in the Component level)

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1677805
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
