### PR TITLE
feat(android-settings): using a more specific selector to set body color

### DIFF
--- a/src/electron/views/device-connect-view/device-connect-view.scss
+++ b/src/electron/views/device-connect-view/device-connect-view.scss
@@ -5,7 +5,7 @@
 @import '../../../reports/components/outcome.scss';
 @import '../../../common/components/cards/fix-instruction-color-box.scss';
 
-body {
+body.ms-Fabric {
     color: $primary-text;
 }
 


### PR DESCRIPTION
#### Description of changes

It looks like using `body` as a selector is not enough to beat office fabric `ms-Fabric` selector, which make the body color to not respect high contrast theme.

Using `body.ms-Fabric` is more specific than what we currently have and it fix the text color issue on AI-Android.

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678708
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
