### PR TITLE
fix: Revise Aria label for device port number

### DIFF
--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -44,7 +44,7 @@ export class DeviceConnectPortEntry extends React.Component<
                 <h3>Android device port number</h3>
                 <MaskedTextField
                     data-automation-id={deviceConnectPortNumberFieldAutomationId}
-                    ariaLabel="Android Device port number e.g. 12345"
+                    label="Android device port number"
                     onChange={this.onPortTextChanged}
                     placeholder="Ex: 12345"
                     className={styles.portNumberField}

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -44,7 +44,7 @@ export class DeviceConnectPortEntry extends React.Component<
                 <h3>Android device port number</h3>
                 <MaskedTextField
                     data-automation-id={deviceConnectPortNumberFieldAutomationId}
-                    ariaLabel="Port number"
+                    ariaLabel="Android Device port number e.g. 12345"
                     onChange={this.onPortTextChanged}
                     placeholder="Ex: 12345"
                     className={styles.portNumberField}

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -8,9 +8,9 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" 1`] = `
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
+    label="Android device port number"
     mask="99999"
     maskChar=""
     maskFormat={
@@ -42,9 +42,9 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" and some text in th
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
+    label="Android device port number"
     mask="99999"
     maskChar=""
     maskFormat={
@@ -76,9 +76,9 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" 1`] = `
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
+    label="Android device port number"
     mask="99999"
     maskChar=""
     maskFormat={
@@ -110,9 +110,9 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" and some text in t
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
+    label="Android device port number"
     mask="99999"
     maskChar=""
     maskFormat={
@@ -144,9 +144,9 @@ exports[`DeviceConnectPortEntryTest renders with "Default" 1`] = `
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
+    label="Android device port number"
     mask="99999"
     maskChar=""
     maskFormat={
@@ -178,9 +178,9 @@ exports[`DeviceConnectPortEntryTest renders with "Default" and some text in the 
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
+    label="Android device port number"
     mask="99999"
     maskChar=""
     maskFormat={
@@ -212,9 +212,9 @@ exports[`DeviceConnectPortEntryTest renders with "Error" 1`] = `
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
+    label="Android device port number"
     mask="99999"
     maskChar=""
     maskFormat={
@@ -246,9 +246,9 @@ exports[`DeviceConnectPortEntryTest renders with "Error" and some text in the po
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
+    label="Android device port number"
     mask="99999"
     maskChar=""
     maskFormat={

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" 1`] = `
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Port number"
+    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
     mask="99999"
@@ -42,7 +42,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" and some text in th
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Port number"
+    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
     mask="99999"
@@ -76,7 +76,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" 1`] = `
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Port number"
+    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
     mask="99999"
@@ -110,7 +110,7 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" and some text in t
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Port number"
+    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
     mask="99999"
@@ -144,7 +144,7 @@ exports[`DeviceConnectPortEntryTest renders with "Default" 1`] = `
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Port number"
+    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
     mask="99999"
@@ -178,7 +178,7 @@ exports[`DeviceConnectPortEntryTest renders with "Default" and some text in the 
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Port number"
+    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
     mask="99999"
@@ -212,7 +212,7 @@ exports[`DeviceConnectPortEntryTest renders with "Error" 1`] = `
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Port number"
+    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
     mask="99999"
@@ -246,7 +246,7 @@ exports[`DeviceConnectPortEntryTest renders with "Error" and some text in the po
     Android device port number
   </h3>
   <MaskedTextField
-    ariaLabel="Port number"
+    ariaLabel="Android Device port number e.g. 12345"
     className="portNumberField"
     data-automation-id="device-connect-port-number-field"
     mask="99999"


### PR DESCRIPTION
#### Description of changes

Bug 1676735 calls out that the port number dialog lacks context when accessed via NVDA or JAWS. The suggested change from that bug is to update the Aria label from "Port label" to "Android Device port number e.g. 12345"

Tested with both NVDA and JAWS

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1676735
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
