### PR TITLE
feat(android-settings): fix connecting to device spinner text color

### DIFF
--- a/src/electron/views/device-connect-view/components/device-connect-connected-device.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-connected-device.scss
@@ -11,7 +11,7 @@
 
         :global(.ms-Spinner-label) {
             font-size: 14px;
-            color: $communication-tint-40;
+            color: $spinner-text;
         }
     }
 

--- a/src/electron/views/device-connect-view/components/device-connect-connected-device.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-connected-device.tsx
@@ -1,17 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { Icon } from 'office-ui-fabric-react';
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
+import { Icon, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
-
 import { DeviceConnectState } from '../../../flux/types/device-connect-state';
-import {
-    connectionErrorIcon,
-    deviceConnectConnectedDevice,
-    deviceConnectSpinner,
-    scannedText,
-} from './device-connect-connected-device.scss';
+import * as styles from './device-connect-connected-device.scss';
 
 export interface DeviceConnectConnectedDeviceProps {
     deviceConnectState: DeviceConnectState;
@@ -25,7 +18,7 @@ export const DeviceConnectConnectedDevice = NamedFC<DeviceConnectConnectedDevice
             if (props.deviceConnectState === DeviceConnectState.Connecting) {
                 return (
                     <Spinner
-                        className={deviceConnectSpinner}
+                        className={styles.deviceConnectSpinner}
                         labelPosition="right"
                         size={SpinnerSize.xSmall}
                         label="Connecting to mobile device"
@@ -38,10 +31,10 @@ export const DeviceConnectConnectedDevice = NamedFC<DeviceConnectConnectedDevice
                     <>
                         <Icon
                             iconName="statusErrorFull"
-                            className={connectionErrorIcon}
+                            className={styles.connectionErrorIcon}
                             ariaLabel="Connection failed"
                         ></Icon>
-                        <span className={scannedText}>
+                        <span className={styles.scannedText}>
                             No active applications were found at the provided local host.
                         </span>
                     </>
@@ -53,12 +46,12 @@ export const DeviceConnectConnectedDevice = NamedFC<DeviceConnectConnectedDevice
             }
 
             if (props.connectedDevice) {
-                return <span className={scannedText}>{props.connectedDevice}</span>;
+                return <span className={styles.scannedText}>{props.connectedDevice}</span>;
             }
         };
 
         return (
-            <div className={deviceConnectConnectedDevice}>
+            <div className={styles.deviceConnectConnectedDevice}>
                 <h3>Connected device</h3>
                 <div role="alert" aria-live="assertive">
                     {renderContents()}

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-connected-device.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-connected-device.test.tsx.snap
@@ -1,6 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DeviceConnectConnectedDeviceTest render connection failure: connection failure 1`] = `
+exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Connected 1`] = `
+<div
+  className="deviceConnectConnectedDevice"
+>
+  <h3>
+    Connected device
+  </h3>
+  <div
+    aria-live="assertive"
+    role="alert"
+  />
+</div>
+`;
+
+exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Connecting 1`] = `
+<div
+  className="deviceConnectConnectedDevice"
+>
+  <h3>
+    Connected device
+  </h3>
+  <div
+    aria-live="assertive"
+    role="alert"
+  >
+    <StyledSpinnerBase
+      className="deviceConnectSpinner"
+      label="Connecting to mobile device"
+      labelPosition="right"
+      size={0}
+    />
+  </div>
+</div>
+`;
+
+exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Default 1`] = `
+<div
+  className="deviceConnectConnectedDevice"
+>
+  <h3>
+    Connected device
+  </h3>
+  <div
+    aria-live="assertive"
+    role="alert"
+  />
+</div>
+`;
+
+exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Error 1`] = `
 <div
   className="deviceConnectConnectedDevice"
 >
@@ -27,7 +76,7 @@ exports[`DeviceConnectConnectedDeviceTest render connection failure: connection 
 </div>
 `;
 
-exports[`DeviceConnectConnectedDeviceTest render connection success: connection success 1`] = `
+exports[`DeviceConnectConnectedDeviceTest renders the device name when state is connected 1`] = `
 <div
   className="deviceConnectConnectedDevice"
 >
@@ -41,57 +90,8 @@ exports[`DeviceConnectConnectedDeviceTest render connection success: connection 
     <span
       className="scannedText"
     >
-      A Test Device!
+      test-device
     </span>
   </div>
-</div>
-`;
-
-exports[`DeviceConnectConnectedDeviceTest render no content: no content 1`] = `
-<div
-  className="deviceConnectConnectedDevice"
->
-  <h3>
-    Connected device
-  </h3>
-  <div
-    aria-live="assertive"
-    role="alert"
-  />
-</div>
-`;
-
-exports[`DeviceConnectConnectedDeviceTest render scanning spinner: scanning spinner 1`] = `
-<div
-  className="deviceConnectConnectedDevice"
->
-  <h3>
-    Connected device
-  </h3>
-  <div
-    aria-live="assertive"
-    role="alert"
-  >
-    <StyledSpinnerBase
-      className="deviceConnectSpinner"
-      label="Connecting to mobile device"
-      labelPosition="right"
-      size={0}
-    />
-  </div>
-</div>
-`;
-
-exports[`DeviceConnectConnectedDeviceTest render user change the port number: user change the port number 1`] = `
-<div
-  className="deviceConnectConnectedDevice"
->
-  <h3>
-    Connected device
-  </h3>
-  <div
-    aria-live="assertive"
-    role="alert"
-  />
 </div>
 `;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-connected-device.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-connected-device.test.tsx
@@ -9,44 +9,30 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('DeviceConnectConnectedDeviceTest', () => {
-    const testProps = [
-        [
-            'no content',
-            {
-                deviceConnectState: DeviceConnectState.Default,
-            },
-        ],
-        [
-            'user change the port number',
-            {
-                connectedDevice: 'A Test Device!',
-                deviceConnectState: DeviceConnectState.Default,
-            },
-        ],
-        [
-            'scanning spinner',
-            {
-                deviceConnectState: DeviceConnectState.Connecting,
-            },
-        ],
-        [
-            'connection success',
-            {
-                connectedDevice: 'A Test Device!',
-                deviceConnectState: DeviceConnectState.Connected,
-            },
-        ],
-        [
-            'connection failure',
-            {
-                deviceConnectState: DeviceConnectState.Error,
-            },
-        ],
-    ];
+    it.each`
+        state
+        ${DeviceConnectState[DeviceConnectState.Connecting]}
+        ${DeviceConnectState[DeviceConnectState.Error]}
+        ${DeviceConnectState[DeviceConnectState.Default]}
+        ${DeviceConnectState[DeviceConnectState.Connected]}
+    `('renders for deviceConnectState = $state', ({ state }) => {
+        const props: DeviceConnectConnectedDeviceProps = {
+            deviceConnectState: DeviceConnectState[state as string],
+        };
 
-    test.each(testProps)('render %s', (testName: string, props: DeviceConnectConnectedDeviceProps) => {
         const rendered = shallow(<DeviceConnectConnectedDevice {...props} />);
 
-        expect(rendered.getElement()).toMatchSnapshot(testName);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('renders the device name when state is connected', () => {
+        const props: DeviceConnectConnectedDeviceProps = {
+            deviceConnectState: DeviceConnectState.Connected,
+            connectedDevice: 'test-device',
+        };
+
+        const rendered = shallow(<DeviceConnectConnectedDevice {...props} />);
+
+        expect(rendered.getElement()).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
#### Description of changes

Update the spinner text color to work on both, the default and the high contrast theme.

I use the opportunity to update how we import styles definition files (`*.scss.d.ts` files) to match our current choice to do so.

**default theme**
![01 - default theme](https://user-images.githubusercontent.com/2837582/75179081-2b7c6800-56ee-11ea-968d-323bab21f565.png)

**high contrast theme**
![02 - high contrast mode on](https://user-images.githubusercontent.com/2837582/75179088-2f0fef00-56ee-11ea-94b7-cc0ed690e937.png)

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678708
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
