### PR TITLE
fix: true-up electron-storage-adapter

### DIFF
--- a/src/electron/adapters/electron-storage-adapter.ts
+++ b/src/electron/adapters/electron-storage-adapter.ts
@@ -7,11 +7,12 @@ export class ElectronStorageAdapter implements StorageAdapter {
     constructor(private readonly indexedDBInstance: IndexedDBAPI) {}
 
     public async setUserData(items: Object): Promise<void> {
-        const setItemPromises = Object.keys(items).map(itemKey =>
-            this.indexedDBInstance.setItem(itemKey, items[itemKey]),
-        );
+        const keys = Object.keys(items);
 
-        await Promise.all(setItemPromises);
+        for (let index = 0; index < keys.length; index++) {
+            const key = keys[index];
+            await this.indexedDBInstance.setItem(key, items[key]);
+        }
     }
 
     public async getUserData(keys: string[]): Promise<{ [key: string]: any }> {

--- a/src/electron/adapters/electron-storage-adapter.ts
+++ b/src/electron/adapters/electron-storage-adapter.ts
@@ -1,30 +1,35 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { StorageAdapter } from 'common/browser-adapters/storage-adapter';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
-import { pick } from 'lodash';
 
 export class ElectronStorageAdapter implements StorageAdapter {
     constructor(private readonly indexedDBInstance: IndexedDBAPI) {}
 
     public async setUserData(items: Object): Promise<void> {
-        await this.indexedDBInstance.setItem(IndexedDBDataKeys.installation, items);
+        const setItemPromises = Object.keys(items).map(itemKey =>
+            this.indexedDBInstance.setItem(itemKey, items[itemKey]),
+        );
+
+        await Promise.all(setItemPromises);
     }
 
     public async getUserData(keys: string[]): Promise<{ [key: string]: any }> {
-        const data = await this.indexedDBInstance.getItem(IndexedDBDataKeys.installation);
-        return pick(data, keys);
+        const result = {};
+
+        for (let index = 0; index < keys.length; index++) {
+            const key = keys[index];
+            const value = await this.indexedDBInstance.getItem(key);
+
+            if (value != null) {
+                result[key] = value;
+            }
+        }
+
+        return result;
     }
 
     public async removeUserData(key: string): Promise<void> {
-        const data = await this.indexedDBInstance.getItem(IndexedDBDataKeys.installation);
-        const filtered = Object.keys(data)
-            .filter(internalKey => internalKey !== key)
-            .reduce((obj, k) => {
-                obj[k] = data[k];
-                return obj;
-            }, {});
-        await this.indexedDBInstance.setItem(IndexedDBDataKeys.installation, filtered);
+        await this.indexedDBInstance.removeItem(key);
     }
 }

--- a/src/tests/unit/tests/electron/adapters/electron-storage-adapter.test.ts
+++ b/src/tests/unit/tests/electron/adapters/electron-storage-adapter.test.ts
@@ -1,17 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock, Times } from 'typemoq';
-
-import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
 import { IndexedDBAPI } from 'common/indexedDB/indexedDB';
 import { ElectronStorageAdapter } from 'electron/adapters/electron-storage-adapter';
+import { IMock, Mock, Times } from 'typemoq';
 
 describe('ElectronStorageAdapter', () => {
-    const testData = {
-        testKey1: 'test-value-1',
-        testKey2: 'test-value-2',
-    };
-
     let indexedDBInstanceMock: IMock<IndexedDBAPI>;
 
     let testSubject: ElectronStorageAdapter;
@@ -22,112 +15,78 @@ describe('ElectronStorageAdapter', () => {
     });
 
     describe('setUserData', () => {
-        it('succeed', async () => {
-            indexedDBInstanceMock
-                .setup(indexedDB => indexedDB.setItem(IndexedDBDataKeys.installation, It.isValue(testData)))
-                .returns(() => Promise.resolve(true))
-                .verifiable(Times.once());
+        it.each`
+            items
+            ${{}}
+            ${{ first: 1 }}
+            ${{ first: 1, second: '2' }}
+            ${{ first: [1, 2], second: { a: 'a', b: 'b' } }}
+        `('succeed to set $items', async ({ items }) => {
+            await testSubject.setUserData(items);
 
-            await testSubject.setUserData(testData);
-
-            indexedDBInstanceMock.verifyAll();
+            Object.keys(items).forEach(key => indexedDBInstanceMock.verify(db => db.setItem(key, items[key]), Times.once()));
         });
 
         it('propagates exceptions from indexedDB as-is', async () => {
             const reason = 'test-error-reason';
 
-            indexedDBInstanceMock
-                .setup(indexedDB => indexedDB.setItem(IndexedDBDataKeys.installation, It.isValue(testData)))
-                .returns(() => Promise.reject(reason));
+            const firstKey = 'first';
 
-            await expect(testSubject.setUserData(testData)).rejects.toMatch(reason);
+            const items = {
+                [firstKey]: 1,
+            };
+
+            indexedDBInstanceMock.setup(indexedDB => indexedDB.setItem(firstKey, items[firstKey])).returns(() => Promise.reject(reason));
+
+            await expect(testSubject.setUserData(items)).rejects.toMatch(reason);
         });
     });
 
     describe('getUserData', () => {
-        it('gets data, one key', async () => {
-            const key = Object.keys(testData)[0];
-            const keys = [key];
+        it.only.each`
+            items
+            ${{}}
+            ${{ first: 1 }}
+            ${{ first: 1, second: '2' }}
+            ${{ first: [1, 2], second: { a: 'a', b: 'b' } }}
+            ${{ first: 1, second: undefined }}
+        `('properly reads $items', async ({ items }) => {
+            const keys = Object.keys(items);
 
-            indexedDBInstanceMock.setup(db => db.getItem(IndexedDBDataKeys.installation)).returns(() => Promise.resolve(testData));
-
-            const result = await testSubject.getUserData(keys);
-
-            const expected = {
-                [key]: testData[key],
-            };
-
-            expect(result).toEqual(expected);
-        });
-
-        it('gets data, two keys', async () => {
-            const keys = Object.keys(testData);
-
-            indexedDBInstanceMock.setup(db => db.getItem(IndexedDBDataKeys.installation)).returns(() => Promise.resolve(testData));
+            keys.forEach(key => indexedDBInstanceMock.setup(db => db.getItem(key)).returns(() => Promise.resolve(items[key])));
 
             const result = await testSubject.getUserData(keys);
 
-            expect(result).toEqual(testData);
+            expect(result).toEqual(items);
+            expect(result).not.toBe(items);
         });
 
         it('propagates exceptions from indexedDB as-is', async () => {
             const reason = 'test-error-reason';
 
-            indexedDBInstanceMock.setup(db => db.getItem(IndexedDBDataKeys.installation)).returns(() => Promise.reject(reason));
+            const firstKey = 'first';
 
-            await expect(testSubject.getUserData([])).rejects.toMatch(reason);
+            indexedDBInstanceMock.setup(db => db.getItem(firstKey)).returns(() => Promise.reject(reason));
+
+            await expect(testSubject.getUserData([firstKey])).rejects.toMatch(reason);
         });
     });
 
     describe('removeUserData', () => {
-        it('removes based on input key', async () => {
-            const keys = Object.keys(testData);
+        const key = 'first';
 
-            const keyToRemove = keys[0];
-            const keyToKeep = keys[1];
+        it('based on input key', async () => {
+            await testSubject.removeUserData(key);
 
-            indexedDBInstanceMock
-                .setup(indexedDB => indexedDB.getItem(IndexedDBDataKeys.installation))
-                .returns(() => Promise.resolve(testData))
-                .verifiable(Times.once());
-
-            const expectedDataToSet = {
-                [keyToKeep]: testData[keyToKeep],
-            };
-
-            indexedDBInstanceMock
-                .setup(indexedDB => indexedDB.setItem(IndexedDBDataKeys.installation, It.isValue(expectedDataToSet)))
-                .returns(() => Promise.resolve(true))
-                .verifiable(Times.once());
-
-            await testSubject.removeUserData(keyToRemove);
-
-            indexedDBInstanceMock.verifyAll();
+            indexedDBInstanceMock.verify(db => db.removeItem(key), Times.once());
         });
 
-        it('fails during getItem when trying to remove data', async () => {
-            indexedDBInstanceMock
-                .setup(indexedDB => indexedDB.getItem(IndexedDBDataKeys.installation))
-                .returns(() => Promise.reject('remove-error'))
-                .verifiable(Times.once());
+        it('propagate exceptions from indexedDB as-is', async () => {
+            const reason = 'test-error-reason';
 
-            indexedDBInstanceMock
-                .setup(indexedDB => indexedDB.setItem(IndexedDBDataKeys.installation, It.isAny()))
-                .verifiable(Times.never());
+            indexedDBInstanceMock.setup(db => db.removeItem(key)).returns(() => Promise.reject(reason));
 
-            await expect(testSubject.removeUserData(IndexedDBDataKeys.installation)).rejects.toMatch('remove-error');
-
-            indexedDBInstanceMock.verifyAll();
-        });
-
-        it('fails during setItem when trying to remove data', async () => {
-            indexedDBInstanceMock.setup(indexedDB => indexedDB.getItem(IndexedDBDataKeys.installation)).returns(() => Promise.resolve({}));
-
-            indexedDBInstanceMock
-                .setup(indexedDB => indexedDB.setItem(IndexedDBDataKeys.installation, It.isAny()))
-                .returns(() => Promise.reject('fail-set-item'));
-
-            await expect(testSubject.removeUserData(IndexedDBDataKeys.installation)).rejects.toMatch('fail-set-item');
+            await expect(testSubject.removeUserData(key)).rejects.toMatch(reason);
         });
     });
 });

--- a/src/tests/unit/tests/electron/adapters/electron-storage-adapter.test.ts
+++ b/src/tests/unit/tests/electron/adapters/electron-storage-adapter.test.ts
@@ -43,7 +43,7 @@ describe('ElectronStorageAdapter', () => {
     });
 
     describe('getUserData', () => {
-        it.only.each`
+        it.each`
             items
             ${{}}
             ${{ first: 1 }}


### PR DESCRIPTION
#### Description of changes

Currently, our `ElectronStorageAdapter`, which implements the `StorageAdapter` interface and serves as a "double" of our `ChromeAdapter` (around accessing local storage) wraps any object we want to store around a single key: `installationData`. 

We are only using the `ElectronStorageAdapter` to store `installationData` so the issue mention above cause the storage to write something like this:
```js
{
installationData: {
  installationData: {
      month: 1,
      year: 2020,
      installationId: <guid>
    }
  }
}
```
Notice the duplicated `installationData` key on the object.

This causes our `InstallDataGenerator` to always generate a new `installationId` (basically, because is checking for an existing `installationId` at the "wrong" level of the object.

This PR fixes this issue by properly and directly using the keys of the object pass to `setUserData` to make calls to the underlying indexedDB API. Get and remove API's have been update accordingly too.

**installationData from master (bugged)**
![01 - bug storage adapter](https://user-images.githubusercontent.com/2837582/75194494-1a8f1f00-570d-11ea-870a-1780962e6749.png)

**installationData from this branch (fixed)**
![02 - fixed storage adapter](https://user-images.githubusercontent.com/2837582/75194518-27137780-570d-11ea-8189-b90a5177da1e.png)

**Notes**
- Notoriously, there was no need to update `renderer-initializer` which instanciate `ElectronStorageAdapter`
- The fix is applied seemingly by the `InstallDataGenerator`
- I test this fix under a "update scenario". Basically, build and run AI-Android from master, check the `installationData` using dev tools (it's wrong) and then build and run AI-Android from this branch and check again. There is no error and telemetry is being send properly, keeping the same `installationId` in between app restarts.

#### Pull request checklist
- [x] Addresses an existing issue: yes, but there is not an issue on the repo
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
