### PR TITLE
feat(android-settings): How do I connect high contrast color

### DIFF
--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -80,6 +80,7 @@
     --menu-item-background-hover: var(--neutral-alpha-4);
     --menu-item-background-active: var(--neutral-alpha-8);
     --link: var(--communication-primary);
+    --unified-link: var(black);
     --link-hover: var(--communication-shade-20);
     --switcher-border: var(--ada-brand-variant);
     --switcher-focus-border: var(--neutral-0);
@@ -149,6 +150,7 @@
         --group-selected-background: var(--grey);
         --row-hover-background: var(--communication-tint-40);
         --link: var(--communication-shade-10);
+        --unified-link: var(--communication-tint-40);
         --link-hover: var(--communication-shade-10);
         --switcher-border: var(--brand-blue);
         --switcher-focus-border: var(--black);
@@ -247,6 +249,7 @@ $row-selected-background: var(--row-selected-background);
 $group-selected-background: var(--group-selected-background);
 $row-hover-background: var(--row-hover-background);
 $link: var(--link);
+$unified-link: var(--unified-link);
 $link-hover: var(--link-hover);
 $switcher-border: var(--switcher-border);
 $switcher-focus-border: var(--switcher-focus-border);

--- a/src/electron/views/device-connect-view/components/device-connect-header.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-header.scss
@@ -8,7 +8,7 @@
         font-family: $fontFamily;
         font-size: 12px;
         line-height: 16px;
-        color: black;
+        color: $unified-link;
         text-decoration: underline;
     }
 


### PR DESCRIPTION
#### Description of changes

Add new color for link on AI-Android. Use it on the _How do I connect to my device?_ link.

**default theme**
![01 - default theme](https://user-images.githubusercontent.com/2837582/75201378-28e53700-571d-11ea-8fc6-2a670f3ea985.png)

**high contrast theme**
![02 - high contrast theme](https://user-images.githubusercontent.com/2837582/75201395-30a4db80-571d-11ea-98a9-9cd073eb32cb.png)

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678708
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
