### PR TITLE
fix: how do I connect my device? link role

### DIFF
--- a/src/electron/views/device-connect-view/components/electron-external-link.tsx
+++ b/src/electron/views/device-connect-view/components/electron-external-link.tsx
@@ -15,6 +15,10 @@ export const ElectronExternalLink = NamedFC<ElectronExternalLinkProps>(
     'ElectronExternalLink',
     (props: ElectronExternalLinkProps) => {
         const onClick = () => props.shell.openExternal(props.href);
-        return <Link onClick={onClick}>{props.children}</Link>;
+        return (
+            <Link role="link" onClick={onClick}>
+                {props.children}
+            </Link>
+        );
     },
 );

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/electron-external-link.test.tsx.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ElectronExternalLinkTest render 1`] = `
+exports[`ElectronExternalLink render 1`] = `
 <StyledLinkBase
   onClick={[Function]}
+  role="link"
 >
   test-text
 </StyledLinkBase>

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/electron-external-link.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/electron-external-link.test.tsx
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { Mock, Times } from 'typemoq';
 
-describe('ElectronExternalLinkTest', () => {
+describe('ElectronExternalLink', () => {
     const testHref = 'test-href';
     const testText = 'test-text';
 


### PR DESCRIPTION
#### Description of changes

Office Fabric `<Link>` component uses a native `<button>` element when there is no `href` prop pass to it.
We are using the `<Link>` component but we can't pass the `href` because we want AI-Android to use the native, OS default browser to open the link. This works by us passing a `onClick` function that wraps the `shell` object from `electron` to call into the OS to open the link.

Due to the previously exposed, it's kind of hard to use Office Fabric component **and** get a `<a>` element, so instead. Thus, the approach taken on this PR is to force the `<Link>` to use `role='link'`.

#### Pull request checklist
- [x] Addresses an existing issue: fixes WI # 1676645
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
