### PR TITLE
feat(android-settings): fix command bar menu item active state color

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -21,7 +21,9 @@
         font-size: $fontSizeM;
         font-family: $fontFamily;
 
-        &:hover {
+        &:hover,
+        &:active,
+        &:hover:active {
             color: $button-hover;
         }
     }


### PR DESCRIPTION
#### Description of changes

AI-Android command bar menu item were missing the proper color for the active and active+hover state.

This PR adds those missing selector using the existing color.

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678709
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
