### PR TITLE
feat(android-settings): cloneDeep on UserConfigurationStore

### DIFF
--- a/src/background/stores/global/user-configuration-store.ts
+++ b/src/background/stores/global/user-configuration-store.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { cloneDeep, isPlainObject } from 'lodash';
-
 import { IndexedDBAPI } from '../../../common/indexedDB/indexedDB';
 import { StoreNames } from '../../../common/stores/store-names';
 import { UserConfigurationStoreData } from '../../../common/types/store-data/user-configuration-store';
@@ -42,6 +41,10 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
 
     public getDefaultState(): UserConfigurationStoreData {
         return this.generateDefaultState(this.persistedState);
+    }
+
+    public getState(): UserConfigurationStoreData {
+        return cloneDeep(this.state);
     }
 
     protected addActionListeners(): void {

--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -100,7 +100,7 @@ describe('UserConfigurationStoreTest', () => {
         expect(testSubject.getState()).toEqual(expected);
     });
 
-    test.only('get state returns clone data', () => {
+    test('get state returns clone data', () => {
         const testSubject = new UserConfigurationStore(
             null,
             new UserConfigurationActions(),

--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -54,7 +54,7 @@ describe('UserConfigurationStoreTest', () => {
         expect(testSubject.getState()).toBeUndefined();
     });
 
-    test('verify initial state when null', () => {
+    test('verify initial state when persisted state is null', () => {
         const testSubject = new UserConfigurationStore(
             null,
             new UserConfigurationActions(),
@@ -98,6 +98,21 @@ describe('UserConfigurationStoreTest', () => {
         testSubject.initialize();
 
         expect(testSubject.getState()).toEqual(expected);
+    });
+
+    test.only('get state returns clone data', () => {
+        const testSubject = new UserConfigurationStore(
+            null,
+            new UserConfigurationActions(),
+            indexDbStrictMock.object,
+        );
+        testSubject.initialize();
+
+        const firstResult = testSubject.getState();
+        const secondResult = testSubject.getState();
+
+        expect(firstResult).toEqual(secondResult);
+        expect(firstResult).not.toBe(secondResult);
     });
 
     test('getDefaultState returns cloned data when initial state is not null', () => {


### PR DESCRIPTION
#### Description of changes

This is a follow up of #2199. 

The previous approach allows us to change the behavior of `getState` when building instances of any store. The **any** store part is the critical part here. We do want to make our states immutable and we have #2228 to track that work but following the original approach cause a series of issues on AI-Web so instead of opening the door and facilitate this change on any and all the stores, we'd like to take a safer approach and update only the offending store (on AI-Android, that would be `UserConfigurationStore` where the `enableHighContrast` flag is store).

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1677805
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
