### PR TITLE
refactor: clean up import from uuid

### DIFF
--- a/src/common/uid-generator.ts
+++ b/src/common/uid-generator.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as uuid4 from 'uuid/v4';
+import { v4 } from 'uuid';
 
 export type UUIDGenerator = () => string;
 
-export let generateUID: UUIDGenerator = uuid4;
+export let generateUID: UUIDGenerator = v4;


### PR DESCRIPTION
#### Description of changes

After we updated uuid from v3.x to v7.x we started to get a warning message about how we are importing from the library.

```console
(node:26968) DeprecationWarning: Deep requiring like `const uuidv4 = require('uuid/v4');` is deprecated as of uuid@7.x. Please require the top-level module when using the Node.js CommonJS module or use ECMAScript Modules when bundling for the browser. See https://github.com/uuidjs/uuid/blob/master/README.md#upgrading-from-v3x-of-this-module for more information.
```

On this PR:
 - update how we import so we don't get the warning.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
