### PR TITLE
feat(android-settings): style start over button 

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -25,10 +25,14 @@
         &:active,
         &:hover:active {
             color: $button-hover;
+
+            i.button-icon {
+                color: $button-hover;
+            }
         }
     }
 
-    .button-icon {
+    i.button-icon {
         color: $primary-text;
         line-height: 16px;
     }


### PR DESCRIPTION
#### Description of changes

Add missing selector for the icon insider the start over button for hover state when high contrast mode is on.

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678709
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
