### PR TITLE
fix: use 7:1 contrast ratio for primary button background in high-contrast mode

### DIFF
--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -22,14 +22,6 @@ button::after {
     position: absolute;
 }
 
-.ms-Button.ms-Button--primary:not(.is-disabled) {
-    background: $communication-primary;
-
-    &:hover {
-        background: $communication-shade-10;
-    }
-}
-
 .ms-fontColor-neutralPrimary,
 .ms-fontColor-neutralPrimary--hover:hover {
     color: $neutral-100 !important;

--- a/src/common/styles/default-theme-palette.ts
+++ b/src/common/styles/default-theme-palette.ts
@@ -26,4 +26,7 @@ export const DefaultThemePalette: IPartialTheme = {
         black: '#1d1d1d',
         white: '#ffffff',
     },
+    semanticColors: {
+        primaryButtonBackground: '#106ebe',
+    },
 };

--- a/src/common/styles/high-contrast-theme-palette.ts
+++ b/src/common/styles/high-contrast-theme-palette.ts
@@ -34,5 +34,6 @@ export const HighContrastThemePalette: IPartialTheme = {
         link: '#FFFF00',
         menuIcon: '#FFFFFF',
         disabledText: '#C285FF',
+        primaryButtonBackground: '#38A9FF',
     },
 };


### PR DESCRIPTION
#### Description of changes

Previously, in high contrast mode, we were using our default "primary theme color" for primary button colors, which in high contrast mode is `#0078d4` and looks like this (with a 4:1 contrast ratio against the near-black text/background):

![screenshot of button with old darker/lower-contrast background color](https://user-images.githubusercontent.com/376284/75296701-cbb3b900-57e2-11ea-8087-784ba0bb8abf.png)

With this change, we now use our high contrast palette's "selected items/checkboxes/toggles" color (`#38A9FF`) instead, which has a 7.141:1 ratio against the background/text:

![screenshot of button with new lighter/higher-contrast background color](https://user-images.githubusercontent.com/376284/75296518-44fedc00-57e2-11ea-9b88-04e178eb2db1.png)

This PR removes a style in web's `common.scss` that already overrode the default office fabric value, but did so in a way that did not meet contrast requirements, such that web's dialogs use the same high-contrast palette; this gets an early start on one of the requirements in feature 1559424

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: part of 1559424
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
