### PR TITLE
feat(android-settings): update command bar to fix a11y issues

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -3,29 +3,58 @@
 @import '../../../../common/styles/colors.scss';
 @import '../../../../common/styles/fonts.scss';
 
+@mixin buttonColors($bckColor) {
+    color: $primary-text;
+    background-color: $bckColor;
+
+    .button-icon {
+        color: $primary-text;
+    }
+}
+
+// specificity required to override fabric style
+button.menu-item-button {
+    color: $primary-text;
+
+    .button-icon {
+        color: $primary-text;
+        line-height: 16px;
+    }
+
+    &:hover {
+        @include buttonColors($neutral-alpha-4);
+    }
+
+    &:active {
+        @include buttonColors($neutral-alpha-8);
+    }
+
+    &:focus::after {
+        outline: $secondary-text solid 1px !important;
+    }
+}
+
 .command-bar {
     border-bottom: 1px solid $neutral-alpha-8;
 
-    div[role='menubar'] {
-        background-color: $neutral-2;
-        height: 44px;
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: center;
+    align-content: stretch;
+
+    .spacer {
+        flex: 1 1 auto;
     }
 
-    .menu-item-button {
-        background-color: $neutral-2;
+    .items {
+        padding-left: 15px;
     }
 
-    // specificity required to override fabric style
-    button.menu-item-button {
-        color: $primary-text;
-        font-size: $fontSizeM;
-        font-family: $fontFamily;
-
-        &:hover,
-        &:active,
-        &:hover:active {
-            color: $button-hover;
-        }
+    .far-items {
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
     }
 
     .button-icon {

--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -39,13 +39,9 @@ button.menu-item-button {
 
     display: flex;
     flex-wrap: nowrap;
-    justify-content: flex-start;
+    justify-content: space-between;
     align-items: center;
     align-content: stretch;
-
-    .spacer {
-        flex: 1 1 auto;
-    }
 
     .items {
         padding-left: 15px;

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -38,7 +38,6 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
                     disabled={props.scanStoreData.status === ScanStatus.Scanning}
                 />
             </div>
-            <div className={styles.spacer} />
             <div className={styles.farItems}>
                 <CommandButton
                     ariaLabel="settings"

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -6,7 +6,7 @@ import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-crea
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
-import { CommandBar as UICommandBar, ICommandBarItemProps } from 'office-ui-fabric-react';
+import { CommandButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './command-bar.scss';
 
@@ -21,35 +21,34 @@ export interface CommandBarProps {
     scanStoreData: ScanStoreData;
 }
 
-export const CommandBar = NamedFC<CommandBarProps>('CommandBar', (props: CommandBarProps) => {
+export const commandButtonRefreshId = 'command-button-refresh';
+
+export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
     const { deps, deviceStoreData } = props;
 
-    const startOverCommandBarItem: ICommandBarItemProps = {
-        key: 'startOver',
-        name: 'Start over',
-        iconProps: {
-            className: styles.buttonIcon,
-            iconName: 'Refresh',
-        },
-        className: styles.menuItemButton,
-        onClick: () => deps.scanActionCreator.scan(deviceStoreData.port),
-        disabled: props.scanStoreData.status === ScanStatus.Scanning,
-    };
-
-    const items: ICommandBarItemProps[] = [startOverCommandBarItem];
-
-    const settingsCommandBarItem: ICommandBarItemProps = {
-        key: 'settings',
-        ariaLabel: 'settings',
-        iconProps: {
-            className: styles.buttonIcon,
-            iconName: 'Gear',
-        },
-        className: styles.menuItemButton,
-        onClick: event => deps.dropdownClickHandler.openSettingsPanelHandler(event as any),
-    };
-
-    const farItems: ICommandBarItemProps[] = [settingsCommandBarItem];
-
-    return <UICommandBar items={items} className={styles.commandBar} farItems={farItems} />;
+    return (
+        <div className={styles.commandBar}>
+            <div className={styles.items}>
+                <CommandButton
+                    data-automation-id={commandButtonRefreshId}
+                    text="Start over"
+                    iconProps={{ iconName: 'Refresh', className: styles.buttonIcon }}
+                    className={styles.menuItemButton}
+                    onClick={() => deps.scanActionCreator.scan(deviceStoreData.port)}
+                    disabled={props.scanStoreData.status === ScanStatus.Scanning}
+                />
+            </div>
+            <div className={styles.spacer} />
+            <div className={styles.farItems}>
+                <CommandButton
+                    ariaLabel="settings"
+                    iconProps={{ iconName: 'Gear', className: styles.buttonIcon }}
+                    className={styles.menuItemButton}
+                    onClick={event =>
+                        deps.dropdownClickHandler.openSettingsPanelHandler(event as any)
+                    }
+                />
+            </div>
+        </div>
+    );
 });

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -1,141 +1,169 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CommandBar renders while status is <Completed> 1`] = `
-<StyledCommandBarBase
-  className="commandBar"
-  farItems={
-    Array [
-      Object {
-        "ariaLabel": "settings",
-        "className": "menuItemButton",
-        "iconProps": Object {
-          "className": "buttonIcon",
-          "iconName": "Gear",
-        },
-        "key": "settings",
-        "onClick": [Function],
-      },
-    ]
-  }
-  items={
-    Array [
-      Object {
-        "className": "menuItemButton",
-        "disabled": false,
-        "iconProps": Object {
+<div
+  className="commandBarTwo"
+>
+  <div
+    className="items"
+  >
+    <CustomizedActionButton
+      className="menuItemButton"
+      data-automation-id="command-button-refresh"
+      disabled={false}
+      iconProps={
+        Object {
           "className": "buttonIcon",
           "iconName": "Refresh",
-        },
-        "key": "startOver",
-        "name": "Start over",
-        "onClick": [Function],
-      },
-    ]
-  }
-/>
+        }
+      }
+      onClick={[Function]}
+      text="Start over"
+    />
+  </div>
+  <div
+    className="spacer"
+  />
+  <div
+    className="farItems"
+  >
+    <CustomizedActionButton
+      ariaLabel="settings"
+      className="menuItemButton"
+      iconProps={
+        Object {
+          "className": "buttonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</div>
 `;
 
 exports[`CommandBar renders while status is <Default> 1`] = `
-<StyledCommandBarBase
-  className="commandBar"
-  farItems={
-    Array [
-      Object {
-        "ariaLabel": "settings",
-        "className": "menuItemButton",
-        "iconProps": Object {
-          "className": "buttonIcon",
-          "iconName": "Gear",
-        },
-        "key": "settings",
-        "onClick": [Function],
-      },
-    ]
-  }
-  items={
-    Array [
-      Object {
-        "className": "menuItemButton",
-        "disabled": false,
-        "iconProps": Object {
+<div
+  className="commandBarTwo"
+>
+  <div
+    className="items"
+  >
+    <CustomizedActionButton
+      className="menuItemButton"
+      data-automation-id="command-button-refresh"
+      disabled={false}
+      iconProps={
+        Object {
           "className": "buttonIcon",
           "iconName": "Refresh",
-        },
-        "key": "startOver",
-        "name": "Start over",
-        "onClick": [Function],
-      },
-    ]
-  }
-/>
+        }
+      }
+      onClick={[Function]}
+      text="Start over"
+    />
+  </div>
+  <div
+    className="spacer"
+  />
+  <div
+    className="farItems"
+  >
+    <CustomizedActionButton
+      ariaLabel="settings"
+      className="menuItemButton"
+      iconProps={
+        Object {
+          "className": "buttonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</div>
 `;
 
 exports[`CommandBar renders while status is <Failed> 1`] = `
-<StyledCommandBarBase
-  className="commandBar"
-  farItems={
-    Array [
-      Object {
-        "ariaLabel": "settings",
-        "className": "menuItemButton",
-        "iconProps": Object {
-          "className": "buttonIcon",
-          "iconName": "Gear",
-        },
-        "key": "settings",
-        "onClick": [Function],
-      },
-    ]
-  }
-  items={
-    Array [
-      Object {
-        "className": "menuItemButton",
-        "disabled": false,
-        "iconProps": Object {
+<div
+  className="commandBarTwo"
+>
+  <div
+    className="items"
+  >
+    <CustomizedActionButton
+      className="menuItemButton"
+      data-automation-id="command-button-refresh"
+      disabled={false}
+      iconProps={
+        Object {
           "className": "buttonIcon",
           "iconName": "Refresh",
-        },
-        "key": "startOver",
-        "name": "Start over",
-        "onClick": [Function],
-      },
-    ]
-  }
-/>
+        }
+      }
+      onClick={[Function]}
+      text="Start over"
+    />
+  </div>
+  <div
+    className="spacer"
+  />
+  <div
+    className="farItems"
+  >
+    <CustomizedActionButton
+      ariaLabel="settings"
+      className="menuItemButton"
+      iconProps={
+        Object {
+          "className": "buttonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</div>
 `;
 
 exports[`CommandBar renders while status is <Scanning> 1`] = `
-<StyledCommandBarBase
-  className="commandBar"
-  farItems={
-    Array [
-      Object {
-        "ariaLabel": "settings",
-        "className": "menuItemButton",
-        "iconProps": Object {
-          "className": "buttonIcon",
-          "iconName": "Gear",
-        },
-        "key": "settings",
-        "onClick": [Function],
-      },
-    ]
-  }
-  items={
-    Array [
-      Object {
-        "className": "menuItemButton",
-        "disabled": true,
-        "iconProps": Object {
+<div
+  className="commandBarTwo"
+>
+  <div
+    className="items"
+  >
+    <CustomizedActionButton
+      className="menuItemButton"
+      data-automation-id="command-button-refresh"
+      disabled={true}
+      iconProps={
+        Object {
           "className": "buttonIcon",
           "iconName": "Refresh",
-        },
-        "key": "startOver",
-        "name": "Start over",
-        "onClick": [Function],
-      },
-    ]
-  }
-/>
+        }
+      }
+      onClick={[Function]}
+      text="Start over"
+    />
+  </div>
+  <div
+    className="spacer"
+  />
+  <div
+    className="farItems"
+  >
+    <CustomizedActionButton
+      ariaLabel="settings"
+      className="menuItemButton"
+      iconProps={
+        Object {
+          "className": "buttonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</div>
 `;

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CommandBar renders while status is <Completed> 1`] = `
 <div
-  className="commandBarTwo"
+  className="commandBar"
 >
   <div
     className="items"
@@ -21,9 +21,6 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
       text="Start over"
     />
   </div>
-  <div
-    className="spacer"
-  />
   <div
     className="farItems"
   >
@@ -44,7 +41,7 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
 
 exports[`CommandBar renders while status is <Default> 1`] = `
 <div
-  className="commandBarTwo"
+  className="commandBar"
 >
   <div
     className="items"
@@ -63,9 +60,6 @@ exports[`CommandBar renders while status is <Default> 1`] = `
       text="Start over"
     />
   </div>
-  <div
-    className="spacer"
-  />
   <div
     className="farItems"
   >
@@ -86,7 +80,7 @@ exports[`CommandBar renders while status is <Default> 1`] = `
 
 exports[`CommandBar renders while status is <Failed> 1`] = `
 <div
-  className="commandBarTwo"
+  className="commandBar"
 >
   <div
     className="items"
@@ -105,9 +99,6 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
       text="Start over"
     />
   </div>
-  <div
-    className="spacer"
-  />
   <div
     className="farItems"
   >
@@ -128,7 +119,7 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
 
 exports[`CommandBar renders while status is <Scanning> 1`] = `
 <div
-  className="commandBarTwo"
+  className="commandBar"
 >
   <div
     className="items"
@@ -147,9 +138,6 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
       text="Start over"
     />
   </div>
-  <div
-    className="spacer"
-  />
   <div
     className="farItems"
   >

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -4,7 +4,7 @@ import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { EnumHelper } from 'common/enum-helper';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
-import { CommandBar, CommandBarProps } from 'electron/views/automated-checks/components/command-bar';
+import { CommandBar, CommandBarProps, commandButtonRefreshId } from 'electron/views/automated-checks/components/command-bar';
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
@@ -65,7 +65,7 @@ describe('CommandBar', () => {
             } as CommandBarProps;
 
             const rendered = mount(<CommandBar {...props} />);
-            const button = rendered.find('button[name="Start over"]');
+            const button = rendered.find(`button[data-automation-id="${commandButtonRefreshId}"]`);
 
             button.simulate('click', eventStub);
 


### PR DESCRIPTION
#### Description of changes

Currently, we are using `<CommandBar>` from Office Fabric on the Automated Checks View to show the start over button and the settings gear. The component has some accessibility issues capture on [OF#11832](https://github.com/OfficeDev/office-ui-fabric-react/issues/11832). 

I fiddle around a little bit with the `<CommandBar>` and the `<FocusZone>` components to see if we could get a walk-around and still use the Office Fabric component but I didn't find anything promising and already hit my time box.

So instead, we are falling back to the approach we have on AI-Web with the export report and start over buttons: basically, the buttons live inside a simple `<div>` and the user can tab between them normally. There is no special announcement from the AT (like amount of items in the "command bar") but everything is keyboard-navigable and discover-able.

I also used the opportunity to update the buttons style to match the figma mock with the general style for command buttons.

**default state picture**
![01 - default state](https://user-images.githubusercontent.com/2837582/75401720-ddb35b80-58b7-11ea-9d65-e8025ab3ea27.png)

**mouse interaction animated gif**
![02 - mouse interaction](https://user-images.githubusercontent.com/2837582/75401790-063b5580-58b8-11ea-8ea4-0eac2f6c7661.gif)

**keyboard interaction animated gif**
![03 - keyboard interaction](https://user-images.githubusercontent.com/2837582/75401796-0cc9cd00-58b8-11ea-9b71-b3cad2067bbf.gif)

#### Pull request checklist
- [x] Addresses an existing issue: completes WI # 1681110
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
