### PR TITLE
fix: unified: move focusability from screenshot view header to image

### DIFF
--- a/src/electron/views/screenshot/screenshot-view.tsx
+++ b/src/electron/views/screenshot/screenshot-view.tsx
@@ -32,15 +32,7 @@ export const ScreenshotView = NamedFC<ScreenshotViewProps>(
 );
 
 function renderHeader(): JSX.Element {
-    // The tabIndex=0 is because the view is independently scrollable, which means there must always be at least one focusable element
-    // inside it to enable keyboard users to scroll it. See https://dequeuniversity.com/rules/axe/3.3/scrollable-region-focusable
-    //
-    // Once we add the "enable visualizations" toggle, we should remove it.
-    return (
-        <h2 className={styles.header} tabIndex={0}>
-            Target app screenshot
-        </h2>
-    );
+    return <h2 className={styles.header}>Target app screenshot</h2>;
 }
 
 function renderUnavailableMessage(): JSX.Element {

--- a/src/electron/views/screenshot/screenshot.scss
+++ b/src/electron/views/screenshot/screenshot.scss
@@ -7,4 +7,9 @@
     object-fit: contain;
     outline: 1px solid $screenshot-image-outline;
     box-shadow: 0px 6px 12px $neutral-alpha-20;
+
+    &:focus {
+        outline-offset: 4px;
+        outline: 2px solid $primary-text;
+    }
 }

--- a/src/electron/views/screenshot/screenshot.tsx
+++ b/src/electron/views/screenshot/screenshot.tsx
@@ -13,12 +13,16 @@ export type ScreenshotProps = {
 export const Screenshot = NamedFC<ScreenshotProps>('Screenshot', props => {
     const altText = 'axe-android results screenshot with highlighted components';
 
+    // The tabIndex=0 is because the view is independently scrollable, which means there must always
+    // be at least one focusable element inside it to enable keyboard users to scroll it. See
+    // https://dequeuniversity.com/rules/axe/3.3/scrollable-region-focusable
     return (
         <img
             className={styles.screenshotImage}
             src={'data:image/png;base64,' + props.encodedImage}
             alt={altText}
             data-automation-id={screenshotImageAutomationId}
+            tabIndex={0}
         />
     );
 });

--- a/src/tests/unit/tests/electron/views/screenshot/__snapshots__/screenshot-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/screenshot/__snapshots__/screenshot-view.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`ScreenshotView render matches snapshot when passed empty screenshotData
 >
   <h2
     className="header"
-    tabIndex={0}
   >
     Target app screenshot
   </h2>
@@ -26,7 +25,6 @@ exports[`ScreenshotView render matches snapshot when passed empty screenshotData
 >
   <h2
     className="header"
-    tabIndex={0}
   >
     Target app screenshot
   </h2>
@@ -44,7 +42,6 @@ exports[`ScreenshotView render matches snapshot when passed empty screenshotData
 >
   <h2
     className="header"
-    tabIndex={0}
   >
     Target app screenshot
   </h2>
@@ -62,7 +59,6 @@ exports[`ScreenshotView render matches snapshot when screenshot data is availabl
 >
   <h2
     className="header"
-    tabIndex={0}
   >
     Target app screenshot
   </h2>

--- a/src/tests/unit/tests/electron/views/screenshot/__snapshots__/screenshot.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/screenshot/__snapshots__/screenshot.test.tsx.snap
@@ -6,5 +6,6 @@ exports[`Screenshot renders 1`] = `
   className="screenshotImage"
   data-automation-id="screenshot-image"
   src="data:image/png;base64,test-image-string"
+  tabIndex={0}
 />
 `;


### PR DESCRIPTION
#### Description of changes

This PR moves the artificial `tabIndex=0` we use to enable keyboard-only scrolling of the screenshot view panel in unified from the header to the image itself, per discussion/trusted tester feedback in 1676714. Since the default focus ring on the image itself is invisible, it also gives a custom focus style that is based on the focus style of selected cards in the cards view (per discussion with Fer).

![screenshot of focused screenshot image](https://user-images.githubusercontent.com/376284/75402678-4ef40e00-58ba-11ea-8b87-79d6304ac811.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1676714
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
