### PR TITLE
[draft] Trying cache in PR build

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-variables:
-    YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-
 jobs:
     - job: 'unit_tests_and_lints'
 
@@ -34,6 +31,8 @@ jobs:
           vmImage: macOS-10.14
       steps:
           - template: pipeline/install-node-prerequisites.yaml
+            parameters:
+                useCache: true
           - template: pipeline/e2e-test-from-agent.yaml
           - template: pipeline/e2e-test-publish-results.yaml
           - template: pipeline/unified/unified-e2e-test-interactive.yaml
@@ -52,5 +51,7 @@ jobs:
           vmImage: windows-latest
       steps:
           - template: pipeline/install-node-prerequisites.yaml
+            parameters:
+                useCache: true
           - template: pipeline/unified/unified-e2e-test-interactive.yaml
           - template: pipeline/unified/unified-e2e-publish-results.yaml

--- a/build.yaml
+++ b/build.yaml
@@ -11,6 +11,49 @@ jobs:
             parameters:
                 useCache: true
 
+          - script: yarn lint:check
+            displayName: check lint errors
+
+          - script: yarn format:check
+            displayName: check formatting errors
+
+          - script: yarn copyright:check
+            displayName: check copyrightheaders
+
+          - script: yarn scss:build
+            displayName: generate typings for scss files
+
+          - script: yarn test --ci
+            displayName: run unit tests
+
+          - task: PublishTestResults@2
+            inputs:
+                testResultsFiles: $(System.DefaultWorkingDirectory)/test-results/unit/junit.xml
+                testRunTitle: $(Agent.JobName)
+            condition: always()
+            displayName: publish test results
+
+          - task: PublishCodeCoverageResults@1
+            inputs:
+                codeCoverageTool: Cobertura
+                summaryFileLocation: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/cobertura-coverage.xml
+                failIfCoverageEmpty: true
+                # We care most about the summary information; adding the detailed files doesn't give enough extra information
+                # to be worth the 1min it adds to the build.
+                # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.
+                # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/lcov-report
+            displayName: publish code coverage
+
+          - script: yarn publish-code-coverage -t $(CODECOV_TOKEN)
+            displayName: Publish code coverage to codecov
+
+          # CI build only
+          - task: ComponentGovernanceComponentDetection@0
+            displayName: 'Component Detection'
+            condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+            inputs:
+                verbosity: Normal
+
     - job: 'publish_build_drops'
       pool:
           vmImage: 'ubuntu-16.04'

--- a/build.yaml
+++ b/build.yaml
@@ -8,6 +8,8 @@ jobs:
 
       steps:
           - template: pipeline/install-node-prerequisites.yaml
+            parameters:
+                useCache: true
 
           - script: yarn lint:check
             displayName: check lint errors

--- a/build.yaml
+++ b/build.yaml
@@ -1,5 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+variables:
+    YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+
 jobs:
     - job: 'unit_tests_and_lints'
 

--- a/build.yaml
+++ b/build.yaml
@@ -11,49 +11,6 @@ jobs:
             parameters:
                 useCache: true
 
-          - script: yarn lint:check
-            displayName: check lint errors
-
-          - script: yarn format:check
-            displayName: check formatting errors
-
-          - script: yarn copyright:check
-            displayName: check copyrightheaders
-
-          - script: yarn scss:build
-            displayName: generate typings for scss files
-
-          - script: yarn test --ci
-            displayName: run unit tests
-
-          - task: PublishTestResults@2
-            inputs:
-                testResultsFiles: $(System.DefaultWorkingDirectory)/test-results/unit/junit.xml
-                testRunTitle: $(Agent.JobName)
-            condition: always()
-            displayName: publish test results
-
-          - task: PublishCodeCoverageResults@1
-            inputs:
-                codeCoverageTool: Cobertura
-                summaryFileLocation: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/cobertura-coverage.xml
-                failIfCoverageEmpty: true
-                # We care most about the summary information; adding the detailed files doesn't give enough extra information
-                # to be worth the 1min it adds to the build.
-                # Consider re-enabling this once https://github.com/Microsoft/azure-pipelines-tasks/issues/4945 is resolved.
-                # reportDirectory: $(System.DefaultWorkingDirectory)/test-results/unit/coverage/lcov-report
-            displayName: publish code coverage
-
-          - script: yarn publish-code-coverage -t $(CODECOV_TOKEN)
-            displayName: Publish code coverage to codecov
-
-          # CI build only
-          - task: ComponentGovernanceComponentDetection@0
-            displayName: 'Component Detection'
-            condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
-            inputs:
-                verbosity: Normal
-
     - job: 'publish_build_drops'
       pool:
           vmImage: 'ubuntu-16.04'

--- a/pipeline/install-node-prerequisites.yaml
+++ b/pipeline/install-node-prerequisites.yaml
@@ -17,6 +17,8 @@ steps:
     - script: npm install yarn@1.17.3 -g
       displayName: install yarn as a global dependency
 
+    - script: yarn cache dir
+
     - task: Cache@2
       inputs:
           key: 'yarn | "$(Agent.OS)" | yarn.lock'

--- a/pipeline/install-node-prerequisites.yaml
+++ b/pipeline/install-node-prerequisites.yaml
@@ -4,6 +4,9 @@ parameters:
     - name: useCache
       type: boolean
       default: false
+    - name: yarnCacheFolder
+      type: string
+      default: $(Pipeline.Workspace)/.yarn
 
 steps:
     - task: NodeTool@0
@@ -17,14 +20,12 @@ steps:
     - script: npm install yarn@1.17.3 -g
       displayName: install yarn as a global dependency
 
-    - script: yarn cache dir
-
     - task: Cache@2
       inputs:
           key: 'yarn | "$(Agent.OS)" | yarn.lock'
-          path: $(YARN_CACHE_FOLDER)
+          path: ${{ parameters.yarnCacheFolder }}
       displayName: Cache Yarn packages
       condition: and(succeeded(), eq('${{ parameters.useCache }}', true))
 
-    - script: yarn install --frozen-lockfile
+    - script: yarn install --frozen-lockfile --cache-folder ${{ parameters.yarnCacheFolder }}
       displayName: install packages and dependencies

--- a/pipeline/install-node-prerequisites.yaml
+++ b/pipeline/install-node-prerequisites.yaml
@@ -1,5 +1,10 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
+parameters:
+    - name: useCache
+      type: boolean
+      default: false
+
 steps:
     - task: NodeTool@0
       inputs:
@@ -11,6 +16,13 @@ steps:
 
     - script: npm install yarn@1.17.3 -g
       displayName: install yarn as a global dependency
+
+    - task: Cache@2
+      inputs:
+          key: 'yarn | "$(Agent.OS)" | yarn.lock'
+          path: $(Pipeline.Workspace)/.yarn
+      displayName: Cache Yarn packages
+      condition: and(succeeded(), eq('${{ parameters.useCache }}', true))
 
     - script: yarn install --frozen-lockfile
       displayName: install packages and dependencies

--- a/pipeline/install-node-prerequisites.yaml
+++ b/pipeline/install-node-prerequisites.yaml
@@ -5,6 +5,9 @@ parameters:
       type: boolean
       default: false
 
+variables:
+    YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
+
 steps:
     - task: NodeTool@0
       inputs:
@@ -22,7 +25,7 @@ steps:
     - task: Cache@2
       inputs:
           key: 'yarn | "$(Agent.OS)" | yarn.lock'
-          path: $(Pipeline.Workspace)/.yarn
+          path: $(YARN_CACHE_FOLDER)
       displayName: Cache Yarn packages
       condition: and(succeeded(), eq('${{ parameters.useCache }}', true))
 

--- a/pipeline/install-node-prerequisites.yaml
+++ b/pipeline/install-node-prerequisites.yaml
@@ -5,9 +5,6 @@ parameters:
       type: boolean
       default: false
 
-variables:
-    YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn
-
 steps:
     - task: NodeTool@0
       inputs:


### PR DESCRIPTION
#### Description of changes

This PR explored using [pipeline caching](https://docs.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops) to save yarn dependencies in simple cases (for example, we may not want this in tasks that do custom dependency work like the electron build).

Times for a sample caching build can be found [here](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=65383&view=logs&j=3613c2bd-8b62-5a70-8491-3e8459586450) - the times don't seem to merit the extra step (slower on linux, similar on windows/mac).

Current pipeline times for the "install dependencies step" (OData query [here](https://analytics.dev.azure.com/ms/accessibility-insights-web/_odata/v3.0-preview/PipelineRunActivityResults?$apply=filter(%20%20%20%20Pipeline/PipelineName%20eq%20'AccessibilityInsights-Web-PR'%20%20%20%20and%20PipelineRunCompletedOn/Date%20ge%202020-01-01Z%20%20%20%20and%20TaskDisplayName%20eq%20'install%20packages%20and%20dependencies'%20%20%20%20and%20(PipelineRunOutcome%20eq%20'Succeed'%20or%20PipelineRunOutcome%20eq%20'PartiallySucceeded')%20%20%20%20and%20(CanceledCount%20ne%201%20and%20SkippedCount%20ne%201%20and%20AbandonedCount%20ne%201)%20%20%20%20)/compute(percentile_cont(ActivityDurationSeconds,%200.5,%20PipelineJob/JobName)%20as%20TaskDuration50thPercentileInSeconds,%20%20%20%20percentile_cont(ActivityDurationSeconds,%200.8,%20PipelineJob/JobName)%20as%20TaskDuration80thPercentileInSeconds,%20%20%20%20percentile_cont(ActivityDurationSeconds,%200.95,%20PipelineJob/JobName)%20as%20TaskDuration95thPercentileInSeconds)/groupby(%20%20%20%20(TaskDuration95thPercentileInSeconds,%20TaskDuration80thPercentileInSeconds,TaskDuration50thPercentileInSeconds,%20PipelineJob/JobName)))), docs [here](https://docs.microsoft.com/en-us/azure/devops/report/powerbi/sample-pipelines-task-duration?view=azure-devops&tabs=odata):


| parent job | os | 50th percentile (master) | 80th percentile (master) |
| ------------- |---- |-------------|-------------| 
| e2e_linux_unified    | Linux | 49s | 53s | 
| publish_build_drops | Linux | 51s      | 55s  | 
| unit_tests_and_lints | mac |  62s     |  70s | 
| e2e_mac_web_unified | mac |  60s     |  67s | 
| e2e_windows_unified | windows |  117s  | 127s | 
