### PR TITLE
fix: add a description to mention port number requirements

### DIFF
--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.scss
@@ -1,9 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+
+@import '../../../../common/styles/colors.scss';
+
 .device-connect-port-entry {
-    .port-number-field {
-        float: left;
-        width: 244px;
-        margin-right: 8px;
+    .device-connect-port-entry-body {
+        display: flex;
+
+        .port-number-field {
+            display: flex;
+            flex-direction: column;
+            width: 260px;
+            margin-right: 8px;
+
+            .port-number-field-description {
+                margin-top: 8px;
+                font-size: 12px;
+                color: $secondary-text;
+            }
+        }
     }
 }

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { KeyCodeConstants } from 'common/constants/keycode-constants';
-import { DefaultButton, PrimaryButton } from 'office-ui-fabric-react';
-import { MaskedTextField } from 'office-ui-fabric-react';
+import { DefaultButton, MaskedTextField, PrimaryButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { DeviceConnectActionCreator } from '../../../flux/action-creator/device-connect-action-creator';
@@ -42,17 +41,26 @@ export class DeviceConnectPortEntry extends React.Component<
         return (
             <div className={styles.deviceConnectPortEntry}>
                 <h3>Android device port number</h3>
-                <MaskedTextField
-                    data-automation-id={deviceConnectPortNumberFieldAutomationId}
-                    ariaLabel="Port number"
-                    onChange={this.onPortTextChanged}
-                    placeholder="Ex: 12345"
-                    className={styles.portNumberField}
-                    maskChar=""
-                    mask="99999"
-                    onKeyDown={this.onEnterKey}
-                />
-                {this.renderValidationPortButton()}
+                <div className={styles.deviceConnectPortEntryBody}>
+                    <MaskedTextField
+                        data-automation-id={deviceConnectPortNumberFieldAutomationId}
+                        ariaLabel="Port number"
+                        onChange={this.onPortTextChanged}
+                        placeholder="Ex: 12345"
+                        className={styles.portNumberField}
+                        maskChar=""
+                        mask="99999"
+                        onKeyDown={this.onEnterKey}
+                        onRenderDescription={() => {
+                            return (
+                                <div className={styles.portNumberFieldDescription}>
+                                    The port number must be between 0 and 99999.
+                                </div>
+                            );
+                        }}
+                    />
+                    {this.renderValidationPortButton()}
+                </div>
             </div>
         );
     }

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -54,7 +54,7 @@ export class DeviceConnectPortEntry extends React.Component<
                         onRenderDescription={() => {
                             return (
                                 <div className={styles.portNumberFieldDescription}>
-                                    The port number must be between 0 and 99999.
+                                    The port number must be between 0 and 65535.
                                 </div>
                             );
                         }}

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`DeviceConnectPortEntryTest renders renderedDescription 1`] = `
 <div
   className="portNumberFieldDescription"
 >
-  The port number must be between 0 and 99999.
+  The port number must be between 0 and 65535.
 </div>
 `;
 

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DeviceConnectPortEntryTest renders renderedDescription 1`] = `
+<div
+  className="portNumberFieldDescription"
+>
+  The port number must be between 0 and 99999.
+</div>
+`;
+
 exports[`DeviceConnectPortEntryTest renders with "Connected" 1`] = `
 <div
   className="deviceConnectPortEntry"
@@ -7,30 +15,35 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" 1`] = `
   <h3>
     Android device port number
   </h3>
-  <MaskedTextField
-    ariaLabel="Port number"
-    className="portNumberField"
-    data-automation-id="device-connect-port-number-field"
-    mask="99999"
-    maskChar=""
-    maskFormat={
-      Object {
-        "*": /\\[a-zA-Z0-9\\]/,
-        "9": /\\[0-9\\]/,
-        "a": /\\[a-zA-Z\\]/,
-      }
-    }
-    onChange={[Function]}
-    onKeyDown={[Function]}
-    placeholder="Ex: 12345"
-  />
-  <CustomizedDefaultButton
-    data-automation-id="device-connect-validate-port-button"
-    disabled={true}
-    onClick={[Function]}
+  <div
+    className="deviceConnectPortEntryBody"
   >
-    Validate port number
-  </CustomizedDefaultButton>
+    <MaskedTextField
+      ariaLabel="Port number"
+      className="portNumberField"
+      data-automation-id="device-connect-port-number-field"
+      mask="99999"
+      maskChar=""
+      maskFormat={
+        Object {
+          "*": /\\[a-zA-Z0-9\\]/,
+          "9": /\\[0-9\\]/,
+          "a": /\\[a-zA-Z\\]/,
+        }
+      }
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onRenderDescription={[Function]}
+      placeholder="Ex: 12345"
+    />
+    <CustomizedDefaultButton
+      data-automation-id="device-connect-validate-port-button"
+      disabled={true}
+      onClick={[Function]}
+    >
+      Validate port number
+    </CustomizedDefaultButton>
+  </div>
 </div>
 `;
 
@@ -41,30 +54,35 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" and some text in th
   <h3>
     Android device port number
   </h3>
-  <MaskedTextField
-    ariaLabel="Port number"
-    className="portNumberField"
-    data-automation-id="device-connect-port-number-field"
-    mask="99999"
-    maskChar=""
-    maskFormat={
-      Object {
-        "*": /\\[a-zA-Z0-9\\]/,
-        "9": /\\[0-9\\]/,
-        "a": /\\[a-zA-Z\\]/,
-      }
-    }
-    onChange={[Function]}
-    onKeyDown={[Function]}
-    placeholder="Ex: 12345"
-  />
-  <CustomizedDefaultButton
-    data-automation-id="device-connect-validate-port-button"
-    disabled={false}
-    onClick={[Function]}
+  <div
+    className="deviceConnectPortEntryBody"
   >
-    Validate port number
-  </CustomizedDefaultButton>
+    <MaskedTextField
+      ariaLabel="Port number"
+      className="portNumberField"
+      data-automation-id="device-connect-port-number-field"
+      mask="99999"
+      maskChar=""
+      maskFormat={
+        Object {
+          "*": /\\[a-zA-Z0-9\\]/,
+          "9": /\\[0-9\\]/,
+          "a": /\\[a-zA-Z\\]/,
+        }
+      }
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onRenderDescription={[Function]}
+      placeholder="Ex: 12345"
+    />
+    <CustomizedDefaultButton
+      data-automation-id="device-connect-validate-port-button"
+      disabled={false}
+      onClick={[Function]}
+    >
+      Validate port number
+    </CustomizedDefaultButton>
+  </div>
 </div>
 `;
 
@@ -75,30 +93,35 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" 1`] = `
   <h3>
     Android device port number
   </h3>
-  <MaskedTextField
-    ariaLabel="Port number"
-    className="portNumberField"
-    data-automation-id="device-connect-port-number-field"
-    mask="99999"
-    maskChar=""
-    maskFormat={
-      Object {
-        "*": /\\[a-zA-Z0-9\\]/,
-        "9": /\\[0-9\\]/,
-        "a": /\\[a-zA-Z\\]/,
-      }
-    }
-    onChange={[Function]}
-    onKeyDown={[Function]}
-    placeholder="Ex: 12345"
-  />
-  <CustomizedPrimaryButton
-    data-automation-id="device-connect-validate-port-button"
-    disabled={true}
-    onClick={[Function]}
+  <div
+    className="deviceConnectPortEntryBody"
   >
-    Validate port number
-  </CustomizedPrimaryButton>
+    <MaskedTextField
+      ariaLabel="Port number"
+      className="portNumberField"
+      data-automation-id="device-connect-port-number-field"
+      mask="99999"
+      maskChar=""
+      maskFormat={
+        Object {
+          "*": /\\[a-zA-Z0-9\\]/,
+          "9": /\\[0-9\\]/,
+          "a": /\\[a-zA-Z\\]/,
+        }
+      }
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onRenderDescription={[Function]}
+      placeholder="Ex: 12345"
+    />
+    <CustomizedPrimaryButton
+      data-automation-id="device-connect-validate-port-button"
+      disabled={true}
+      onClick={[Function]}
+    >
+      Validate port number
+    </CustomizedPrimaryButton>
+  </div>
 </div>
 `;
 
@@ -109,30 +132,35 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" and some text in t
   <h3>
     Android device port number
   </h3>
-  <MaskedTextField
-    ariaLabel="Port number"
-    className="portNumberField"
-    data-automation-id="device-connect-port-number-field"
-    mask="99999"
-    maskChar=""
-    maskFormat={
-      Object {
-        "*": /\\[a-zA-Z0-9\\]/,
-        "9": /\\[0-9\\]/,
-        "a": /\\[a-zA-Z\\]/,
-      }
-    }
-    onChange={[Function]}
-    onKeyDown={[Function]}
-    placeholder="Ex: 12345"
-  />
-  <CustomizedPrimaryButton
-    data-automation-id="device-connect-validate-port-button"
-    disabled={true}
-    onClick={[Function]}
+  <div
+    className="deviceConnectPortEntryBody"
   >
-    Validate port number
-  </CustomizedPrimaryButton>
+    <MaskedTextField
+      ariaLabel="Port number"
+      className="portNumberField"
+      data-automation-id="device-connect-port-number-field"
+      mask="99999"
+      maskChar=""
+      maskFormat={
+        Object {
+          "*": /\\[a-zA-Z0-9\\]/,
+          "9": /\\[0-9\\]/,
+          "a": /\\[a-zA-Z\\]/,
+        }
+      }
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onRenderDescription={[Function]}
+      placeholder="Ex: 12345"
+    />
+    <CustomizedPrimaryButton
+      data-automation-id="device-connect-validate-port-button"
+      disabled={true}
+      onClick={[Function]}
+    >
+      Validate port number
+    </CustomizedPrimaryButton>
+  </div>
 </div>
 `;
 
@@ -143,30 +171,35 @@ exports[`DeviceConnectPortEntryTest renders with "Default" 1`] = `
   <h3>
     Android device port number
   </h3>
-  <MaskedTextField
-    ariaLabel="Port number"
-    className="portNumberField"
-    data-automation-id="device-connect-port-number-field"
-    mask="99999"
-    maskChar=""
-    maskFormat={
-      Object {
-        "*": /\\[a-zA-Z0-9\\]/,
-        "9": /\\[0-9\\]/,
-        "a": /\\[a-zA-Z\\]/,
-      }
-    }
-    onChange={[Function]}
-    onKeyDown={[Function]}
-    placeholder="Ex: 12345"
-  />
-  <CustomizedPrimaryButton
-    data-automation-id="device-connect-validate-port-button"
-    disabled={true}
-    onClick={[Function]}
+  <div
+    className="deviceConnectPortEntryBody"
   >
-    Validate port number
-  </CustomizedPrimaryButton>
+    <MaskedTextField
+      ariaLabel="Port number"
+      className="portNumberField"
+      data-automation-id="device-connect-port-number-field"
+      mask="99999"
+      maskChar=""
+      maskFormat={
+        Object {
+          "*": /\\[a-zA-Z0-9\\]/,
+          "9": /\\[0-9\\]/,
+          "a": /\\[a-zA-Z\\]/,
+        }
+      }
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onRenderDescription={[Function]}
+      placeholder="Ex: 12345"
+    />
+    <CustomizedPrimaryButton
+      data-automation-id="device-connect-validate-port-button"
+      disabled={true}
+      onClick={[Function]}
+    >
+      Validate port number
+    </CustomizedPrimaryButton>
+  </div>
 </div>
 `;
 
@@ -177,30 +210,35 @@ exports[`DeviceConnectPortEntryTest renders with "Default" and some text in the 
   <h3>
     Android device port number
   </h3>
-  <MaskedTextField
-    ariaLabel="Port number"
-    className="portNumberField"
-    data-automation-id="device-connect-port-number-field"
-    mask="99999"
-    maskChar=""
-    maskFormat={
-      Object {
-        "*": /\\[a-zA-Z0-9\\]/,
-        "9": /\\[0-9\\]/,
-        "a": /\\[a-zA-Z\\]/,
-      }
-    }
-    onChange={[Function]}
-    onKeyDown={[Function]}
-    placeholder="Ex: 12345"
-  />
-  <CustomizedPrimaryButton
-    data-automation-id="device-connect-validate-port-button"
-    disabled={false}
-    onClick={[Function]}
+  <div
+    className="deviceConnectPortEntryBody"
   >
-    Validate port number
-  </CustomizedPrimaryButton>
+    <MaskedTextField
+      ariaLabel="Port number"
+      className="portNumberField"
+      data-automation-id="device-connect-port-number-field"
+      mask="99999"
+      maskChar=""
+      maskFormat={
+        Object {
+          "*": /\\[a-zA-Z0-9\\]/,
+          "9": /\\[0-9\\]/,
+          "a": /\\[a-zA-Z\\]/,
+        }
+      }
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onRenderDescription={[Function]}
+      placeholder="Ex: 12345"
+    />
+    <CustomizedPrimaryButton
+      data-automation-id="device-connect-validate-port-button"
+      disabled={false}
+      onClick={[Function]}
+    >
+      Validate port number
+    </CustomizedPrimaryButton>
+  </div>
 </div>
 `;
 
@@ -211,30 +249,35 @@ exports[`DeviceConnectPortEntryTest renders with "Error" 1`] = `
   <h3>
     Android device port number
   </h3>
-  <MaskedTextField
-    ariaLabel="Port number"
-    className="portNumberField"
-    data-automation-id="device-connect-port-number-field"
-    mask="99999"
-    maskChar=""
-    maskFormat={
-      Object {
-        "*": /\\[a-zA-Z0-9\\]/,
-        "9": /\\[0-9\\]/,
-        "a": /\\[a-zA-Z\\]/,
-      }
-    }
-    onChange={[Function]}
-    onKeyDown={[Function]}
-    placeholder="Ex: 12345"
-  />
-  <CustomizedPrimaryButton
-    data-automation-id="device-connect-validate-port-button"
-    disabled={true}
-    onClick={[Function]}
+  <div
+    className="deviceConnectPortEntryBody"
   >
-    Validate port number
-  </CustomizedPrimaryButton>
+    <MaskedTextField
+      ariaLabel="Port number"
+      className="portNumberField"
+      data-automation-id="device-connect-port-number-field"
+      mask="99999"
+      maskChar=""
+      maskFormat={
+        Object {
+          "*": /\\[a-zA-Z0-9\\]/,
+          "9": /\\[0-9\\]/,
+          "a": /\\[a-zA-Z\\]/,
+        }
+      }
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onRenderDescription={[Function]}
+      placeholder="Ex: 12345"
+    />
+    <CustomizedPrimaryButton
+      data-automation-id="device-connect-validate-port-button"
+      disabled={true}
+      onClick={[Function]}
+    >
+      Validate port number
+    </CustomizedPrimaryButton>
+  </div>
 </div>
 `;
 
@@ -245,30 +288,35 @@ exports[`DeviceConnectPortEntryTest renders with "Error" and some text in the po
   <h3>
     Android device port number
   </h3>
-  <MaskedTextField
-    ariaLabel="Port number"
-    className="portNumberField"
-    data-automation-id="device-connect-port-number-field"
-    mask="99999"
-    maskChar=""
-    maskFormat={
-      Object {
-        "*": /\\[a-zA-Z0-9\\]/,
-        "9": /\\[0-9\\]/,
-        "a": /\\[a-zA-Z\\]/,
-      }
-    }
-    onChange={[Function]}
-    onKeyDown={[Function]}
-    placeholder="Ex: 12345"
-  />
-  <CustomizedPrimaryButton
-    data-automation-id="device-connect-validate-port-button"
-    disabled={false}
-    onClick={[Function]}
+  <div
+    className="deviceConnectPortEntryBody"
   >
-    Validate port number
-  </CustomizedPrimaryButton>
+    <MaskedTextField
+      ariaLabel="Port number"
+      className="portNumberField"
+      data-automation-id="device-connect-port-number-field"
+      mask="99999"
+      maskChar=""
+      maskFormat={
+        Object {
+          "*": /\\[a-zA-Z0-9\\]/,
+          "9": /\\[0-9\\]/,
+          "a": /\\[a-zA-Z\\]/,
+        }
+      }
+      onChange={[Function]}
+      onKeyDown={[Function]}
+      onRenderDescription={[Function]}
+      placeholder="Ex: 12345"
+    />
+    <CustomizedPrimaryButton
+      data-automation-id="device-connect-validate-port-button"
+      disabled={false}
+      onClick={[Function]}
+    >
+      Validate port number
+    </CustomizedPrimaryButton>
+  </div>
 </div>
 `;
 

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -11,8 +11,7 @@ import {
 } from 'electron/views/device-connect-view/components/device-connect-port-entry';
 import { portNumberField } from 'electron/views/device-connect-view/components/device-connect-port-entry.scss';
 import { shallow } from 'enzyme';
-import { Button } from 'office-ui-fabric-react';
-import { MaskedTextField } from 'office-ui-fabric-react';
+import { Button, MaskedTextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
@@ -38,7 +37,6 @@ describe('DeviceConnectPortEntryTest', () => {
                     deviceConnectState: DeviceConnectState[deviceConnectStateName],
                 },
             } as DeviceConnectPortEntryProps;
-
             const rendered = shallow(<DeviceConnectPortEntry {...props} />);
 
             expect(rendered.getElement()).toMatchSnapshot();
@@ -55,6 +53,17 @@ describe('DeviceConnectPortEntryTest', () => {
             rendered.setState({ port: '1234' });
 
             expect(rendered.getElement()).toMatchSnapshot();
+        });
+
+        it('renderedDescription', () => {
+            const props: DeviceConnectPortEntryProps = {
+                viewState: {},
+            } as DeviceConnectPortEntryProps;
+
+            const rendered = shallow(<DeviceConnectPortEntry {...props} />);
+            const renderedDescription = shallow(rendered.find(MaskedTextField).prop('onRenderDescription')());
+
+            expect(renderedDescription.getElement()).toMatchSnapshot();
         });
     });
 

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -37,6 +37,7 @@ describe('DeviceConnectPortEntryTest', () => {
                     deviceConnectState: DeviceConnectState[deviceConnectStateName],
                 },
             } as DeviceConnectPortEntryProps;
+
             const rendered = shallow(<DeviceConnectPortEntry {...props} />);
 
             expect(rendered.getElement()).toMatchSnapshot();


### PR DESCRIPTION
#### Description of changes

This fixes an accessibility issue we had where users with screen readers would not be made aware of the port numbers limit. This adds a description to the text field highlighting the limit.

![image](https://user-images.githubusercontent.com/32555133/75487180-caa99580-5962-11ea-8254-25bdb5e06c98.png)

![image](https://user-images.githubusercontent.com/32555133/75487185-cda48600-5962-11ea-8036-410a99d02c61.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
