### PR TITLE
refactor: clean up common header component

### DIFF
--- a/src/common/components/header.scss
+++ b/src/common/components/header.scss
@@ -7,7 +7,7 @@
 .header-bar {
     display: flex;
     flex-wrap: nowrap;
-    justify-content: flex-start;
+    justify-content: space-between;
     align-items: center;
     align-content: stretch;
 
@@ -36,8 +36,9 @@
         @include ellipsedText();
     }
 
-    .spacer {
-        flex: 1 1 auto;
+    .items {
+        display: flex;
+        align-items: center;
     }
 
     .far-items {

--- a/src/common/components/header.tsx
+++ b/src/common/components/header.tsx
@@ -19,10 +19,11 @@ export const Header = NamedFC<HeaderProps>('Header', props => {
     const { applicationTitle } = props.deps.textContent;
     return (
         <header className={styles.headerBar}>
-            <HeaderIcon deps={props.deps} />
-            <span className={styles.headerTitle}>{applicationTitle}</span>
-            <div>{props.items}</div>
-            <div className={styles.spacer}></div>
+            <div className={styles.items}>
+                <HeaderIcon deps={props.deps} />
+                <span className={styles.headerTitle}>{applicationTitle}</span>
+                <div>{props.items}</div>
+            </div>
             <div className={styles.farItems}>{props.farItems}</div>
         </header>
     );

--- a/src/tests/unit/tests/common/components/__snapshots__/header.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/header.test.tsx.snap
@@ -4,24 +4,25 @@ exports[`Header renders per snapshot 1`] = `
 <header
   className="headerBar"
 >
-  <WithStoreSubscriptionForHeaderIconComponent
-    deps={
-      Object {
-        "textContent": Object {
-          "applicationTitle": "THE_APPLICATION_TITLE",
-        },
-      }
-    }
-  />
-  <span
-    className="headerTitle"
-  >
-    THE_APPLICATION_TITLE
-  </span>
-  <div />
   <div
-    className="spacer"
-  />
+    className="items"
+  >
+    <WithStoreSubscriptionForHeaderIconComponent
+      deps={
+        Object {
+          "textContent": Object {
+            "applicationTitle": "THE_APPLICATION_TITLE",
+          },
+        }
+      }
+    />
+    <span
+      className="headerTitle"
+    >
+      THE_APPLICATION_TITLE
+    </span>
+    <div />
+  </div>
   <div
     className="farItems"
   />

--- a/src/tests/unit/tests/common/components/header.test.tsx
+++ b/src/tests/unit/tests/common/components/header.test.tsx
@@ -13,6 +13,7 @@ describe('Header', () => {
                 applicationTitle,
             },
         } as HeaderDeps;
+
         const wrapper = shallow(<Header deps={deps} />);
         expect(wrapper.getElement()).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

Remove "spacer" `<div>` element in favor of using a flex container with `align-items: space-between`.

This is the same as what we did on the AI-Android command bar.

**Notes** there are no actual UI/UX changes

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
