### PR TITLE
feat(android-settings): update how do I connect link colors

### DIFF
--- a/src/common/styles/high-contrast-theme-palette.ts
+++ b/src/common/styles/high-contrast-theme-palette.ts
@@ -32,6 +32,7 @@ export const HighContrastThemePalette: IPartialTheme = {
     },
     semanticColors: {
         link: '#FFFF00',
+        linkHovered: '#D0D000',
         menuIcon: '#FFFFFF',
         disabledText: '#C285FF',
         primaryButtonBackground: '#38A9FF',

--- a/src/electron/views/device-connect-view/components/device-connect-body.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-body.tsx
@@ -8,7 +8,7 @@ import { DeviceConnectState } from '../../../flux/types/device-connect-state';
 import * as styles from './device-connect-body.scss';
 import { DeviceConnectConnectedDevice } from './device-connect-connected-device';
 import { DeviceConnectFooter, DeviceConnectFooterDeps } from './device-connect-footer';
-import { DeviceConnectHeader } from './device-connect-header';
+import { DeviceConnectHeader, DeviceConnectHeaderDeps } from './device-connect-header';
 import {
     DeviceConnectPortEntry,
     DeviceConnectPortEntryDeps,
@@ -24,7 +24,8 @@ export type DeviceConnectBodyState = DeviceConnectPortEntryViewState & {
 export type DeviceConnectBodyDeps = {
     currentWindow: BrowserWindow;
 } & DeviceConnectPortEntryDeps &
-    DeviceConnectFooterDeps;
+    DeviceConnectFooterDeps &
+    DeviceConnectHeaderDeps;
 
 export interface DeviceConnectBodyProps {
     deps: DeviceConnectBodyDeps;
@@ -36,7 +37,7 @@ export const DeviceConnectBody = NamedFC<DeviceConnectBodyProps>('DeviceConnectB
 
     return (
         <div className={styles.deviceConnectBody}>
-            <DeviceConnectHeader />
+            <DeviceConnectHeader deps={props.deps} />
             <DeviceConnectPortEntry
                 deps={props.deps}
                 viewState={{ deviceConnectState: props.viewState.deviceConnectState }}

--- a/src/electron/views/device-connect-view/components/device-connect-header.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-header.scss
@@ -4,14 +4,6 @@
 @import '../../../../common/styles/fonts.scss';
 
 .device-connect-header {
-    :global(.ms-Link) {
-        font-family: $fontFamily;
-        font-size: 12px;
-        line-height: 16px;
-        color: $unified-link;
-        text-decoration: underline;
-    }
-
     h2 {
         font-family: $fontFamily;
         font-size: 21px;

--- a/src/electron/views/device-connect-view/components/device-connect-header.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-header.tsx
@@ -1,18 +1,29 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
+import { LinkComponentType } from 'common/types/link-component-type';
 import * as React from 'react';
-
 import * as styles from './device-connect-header.scss';
-import { ElectronLink } from './electron-link';
 
-export const DeviceConnectHeader = NamedFC('DeviceConnectHeader', () => {
-    return (
-        <header className={styles.deviceConnectHeader}>
-            <h2>Connect to your Android device</h2>
-            <ElectronLink href="https://go.microsoft.com/fwlink/?linkid=2101252">
-                How do I connect to my device?
-            </ElectronLink>
-        </header>
-    );
-});
+export type DeviceConnectHeaderDeps = {
+    LinkComponent: LinkComponentType;
+};
+
+export type DeviceConnectHeaderProps = {
+    deps: DeviceConnectHeaderDeps;
+};
+
+export const DeviceConnectHeader = NamedFC<DeviceConnectHeaderProps>(
+    'DeviceConnectHeader',
+    ({ deps }) => {
+        const { LinkComponent } = deps;
+        return (
+            <header className={styles.deviceConnectHeader}>
+                <h2>Connect to your Android device</h2>
+                <LinkComponent href="https://go.microsoft.com/fwlink/?linkid=2101252">
+                    How do I connect to my device?
+                </LinkComponent>
+            </header>
+        );
+    },
+);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-body.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-body.test.tsx.snap
@@ -4,7 +4,15 @@ exports[`DeviceConnectBodyTest renders, with device connect state = Connected 1`
 <div
   className="deviceConnectBody"
 >
-  <DeviceConnectHeader />
+  <DeviceConnectHeader
+    deps={
+      Object {
+        "currentWindow": Object {
+          "close": [Function],
+        },
+      }
+    }
+  />
   <DeviceConnectPortEntry
     deps={
       Object {
@@ -41,7 +49,15 @@ exports[`DeviceConnectBodyTest renders, with device connect state = Connecting 1
 <div
   className="deviceConnectBody"
 >
-  <DeviceConnectHeader />
+  <DeviceConnectHeader
+    deps={
+      Object {
+        "currentWindow": Object {
+          "close": [Function],
+        },
+      }
+    }
+  />
   <DeviceConnectPortEntry
     deps={
       Object {
@@ -78,7 +94,15 @@ exports[`DeviceConnectBodyTest renders, with device connect state = Default 1`] 
 <div
   className="deviceConnectBody"
 >
-  <DeviceConnectHeader />
+  <DeviceConnectHeader
+    deps={
+      Object {
+        "currentWindow": Object {
+          "close": [Function],
+        },
+      }
+    }
+  />
   <DeviceConnectPortEntry
     deps={
       Object {
@@ -115,7 +139,15 @@ exports[`DeviceConnectBodyTest renders, with device connect state = Error 1`] = 
 <div
   className="deviceConnectBody"
 >
-  <DeviceConnectHeader />
+  <DeviceConnectHeader
+    deps={
+      Object {
+        "currentWindow": Object {
+          "close": [Function],
+        },
+      }
+    }
+  />
   <DeviceConnectPortEntry
     deps={
       Object {

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-header.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-header.test.tsx
@@ -1,12 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DeviceConnectHeader } from 'electron/views/device-connect-view/components/device-connect-header';
+import { DeviceConnectHeader, DeviceConnectHeaderProps } from 'electron/views/device-connect-view/components/device-connect-header';
+import { ElectronLink } from 'electron/views/device-connect-view/components/electron-link';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('DeviceConnectHeaderTest', () => {
     test('render', () => {
-        const rendered = shallow(<DeviceConnectHeader />);
+        const props: DeviceConnectHeaderProps = {
+            deps: {
+                LinkComponent: ElectronLink,
+            },
+        };
+
+        const rendered = shallow(<DeviceConnectHeader {...props} />);
 
         expect(rendered.getElement()).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

Currently, to render the **How do I connect to my device?** link, we directly use `<ElectronLink>` component, while for the links on the settings panel, we pass a dependency called `LinkComponent`. Now, `<ElectronLink>` can (and is) be passed as the instance for the dep `LinkComponent` but we should have only one way to do this so, defaulting to use the dep instead of have a hard dependency on `<ElectronLink>` (this helps with open/close principle).

Additionally, we have override the css styles for the link and now the **How do I connect to my device?** link looks different from the ones on the **Settings Panel**. 

In this PR, we make both links look the same (using the **Settings Panel** as the style we want to use). I'm following the **Basic buttons** style guideline from figma, specifically, the hover state, to set the new colors for the links.

Note that instead of doing this on the css, I'm updating `HighContrastThemePalette`, which means this color will apply everywhere as long as we don't have css overrides. This is the case for AI-Android, so now all our links will use this colors. I checked on AI-Web and the new yellow color use on the link hover state is not use, which means we have overrides. I think we should favor using the palette instead of css overrides as this is the intended way (although not 100% completed, nor perfect) to do this on Office UI Fabric React components.

**Default theme; default state**
![01 - how do i connect - default theme - default state](https://user-images.githubusercontent.com/2837582/75580852-5253da80-5a1d-11ea-8775-8c8336edf349.png)
**Default theme; hover state**
![02 - how do i connect - default theme - hover state](https://user-images.githubusercontent.com/2837582/75580853-52ec7100-5a1d-11ea-9a74-29123df1bb50.png)
**High contrast theme; default state**
![03 - how do i connect - high contrast theme - default state](https://user-images.githubusercontent.com/2837582/75580856-52ec7100-5a1d-11ea-80ed-794577da7c65.png)
**High contrast theme; hover state**
![04 - how do i connect - high contrast theme - hover state](https://user-images.githubusercontent.com/2837582/75580858-53850780-5a1d-11ea-80eb-168aa6a7dd05.png)

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678708
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
