### PR TITLE
test: add missing tests for StoresTree

### DIFF
--- a/src/debug-tools/components/stores-tree.tsx
+++ b/src/debug-tools/components/stores-tree.tsx
@@ -20,7 +20,7 @@ export type StoresTreeProps = {
     storeActionMessageCreator: StoreActionMessageCreator;
 };
 
-type StoresTreeState = {
+export type StoresTreeState = {
     global: {
         [storeId: string]: any;
     };

--- a/src/debug-tools/components/stores-tree.tsx
+++ b/src/debug-tools/components/stores-tree.tsx
@@ -26,7 +26,7 @@ export type StoresTreeState = {
     };
 };
 
-const columns: IColumn[] = [
+export const columns: IColumn[] = [
     {
         key: 'key',
         name: 'property',

--- a/src/tests/unit/tests/debug-tools/components/__snapshots__/stores-tree.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/__snapshots__/stores-tree.test.tsx.snap
@@ -1,0 +1,135 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StoresTree handles store updates by updating the state: after update 1`] = `
+Object {
+  "global": Object {
+    "test-store-id": Object {
+      "value": "1",
+    },
+  },
+}
+`;
+
+exports[`StoresTree handles store updates by updating the state: before update 1`] = `
+Object {
+  "global": Object {},
+}
+`;
+
+exports[`StoresTree renders with NO global state 1`] = `
+<StyledSpinnerBase
+  label="loading..."
+/>
+`;
+
+exports[`StoresTree renders with global state 1`] = `
+<FocusZone
+  direction={2}
+  isCircularNavigation={false}
+>
+  <SelectionZone
+    isSelectedOnFocus={true}
+    selection={
+      Selection {
+        "_anchoredIndex": 0,
+        "_canSelectItem": [Function],
+        "_changeEventSuppressionCount": 0,
+        "_exemptedCount": 0,
+        "_exemptedIndices": Object {},
+        "_getKey": [Function],
+        "_isModal": false,
+        "_items": Array [
+          Object {
+            "key": "0",
+            "value": "1",
+          },
+          Object {
+            "key": "0",
+            "value": "2",
+          },
+        ],
+        "_keyToIndexMap": Object {
+          "0": 1,
+        },
+        "_onSelectionChanged": undefined,
+        "_selectedItems": null,
+        "_unselectableCount": 0,
+        "_unselectableIndices": Object {
+          "0": false,
+          "1": false,
+        },
+        "count": 0,
+        "mode": 2,
+      }
+    }
+    selectionMode={0}
+  >
+    <StyledGroupedListBase
+      compact={true}
+      groups={
+        Array [
+          Object {
+            "count": 1,
+            "key": "first",
+            "name": "first",
+            "startIndex": 0,
+          },
+          Object {
+            "count": 1,
+            "key": "second",
+            "name": "second",
+            "startIndex": 1,
+          },
+        ]
+      }
+      items={
+        Array [
+          Object {
+            "key": "0",
+            "value": "1",
+          },
+          Object {
+            "key": "0",
+            "value": "2",
+          },
+        ]
+      }
+      onRenderCell={[Function]}
+      selection={
+        Selection {
+          "_anchoredIndex": 0,
+          "_canSelectItem": [Function],
+          "_changeEventSuppressionCount": 0,
+          "_exemptedCount": 0,
+          "_exemptedIndices": Object {},
+          "_getKey": [Function],
+          "_isModal": false,
+          "_items": Array [
+            Object {
+              "key": "0",
+              "value": "1",
+            },
+            Object {
+              "key": "0",
+              "value": "2",
+            },
+          ],
+          "_keyToIndexMap": Object {
+            "0": 1,
+          },
+          "_onSelectionChanged": undefined,
+          "_selectedItems": null,
+          "_unselectableCount": 0,
+          "_unselectableIndices": Object {
+            "0": false,
+            "1": false,
+          },
+          "count": 0,
+          "mode": 2,
+        }
+      }
+      selectionMode={0}
+    />
+  </SelectionZone>
+</FocusZone>
+`;

--- a/src/tests/unit/tests/debug-tools/components/__snapshots__/stores-tree.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/__snapshots__/stores-tree.test.tsx.snap
@@ -16,6 +16,72 @@ Object {
 }
 `;
 
+exports[`StoresTree renders each row properly 1`] = `
+<StyledDetailsRowBase
+  columns={
+    Array [
+      Object {
+        "fieldName": "key",
+        "key": "key",
+        "minWidth": 300,
+        "name": "property",
+      },
+      Object {
+        "fieldName": "value",
+        "key": "value",
+        "minWidth": 300,
+        "name": "value",
+        "onRender": [Function],
+      },
+    ]
+  }
+  compact={true}
+  groupNestingDepth={0}
+  item={
+    Object {
+      "key": "value",
+    }
+  }
+  itemIndex={1}
+  selection={
+    Selection {
+      "_anchoredIndex": 0,
+      "_canSelectItem": [Function],
+      "_changeEventSuppressionCount": 0,
+      "_exemptedCount": 0,
+      "_exemptedIndices": Object {},
+      "_getKey": [Function],
+      "_isModal": false,
+      "_items": Array [
+        Object {
+          "key": "0",
+          "value": "1",
+        },
+        Object {
+          "key": "0",
+          "value": "2",
+        },
+      ],
+      "_keyToIndexMap": Object {
+        "0": 1,
+      },
+      "_onSelectionChanged": undefined,
+      "_selectedItems": null,
+      "_unselectableCount": 0,
+      "_unselectableIndices": Object {
+        "0": false,
+        "1": false,
+      },
+      "count": 0,
+      "mode": 2,
+    }
+  }
+  selectionMode={0}
+/>
+`;
+
+exports[`StoresTree renders the value column properly 1`] = `"{\\"first\\":1,\\"second\\":\\"2\\",\\"third\\":true,\\"fourth\\":[4],\\"fifth\\":{\\"sixth\\":\\"6\\"}}"`;
+
 exports[`StoresTree renders with NO global state 1`] = `
 <StyledSpinnerBase
   label="loading..."

--- a/src/tests/unit/tests/debug-tools/components/stores-tree.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/stores-tree.test.tsx
@@ -2,11 +2,12 @@
 // Licensed under the MIT License.
 import { BaseStore } from 'common/base-store';
 import { StoreActionMessageCreator } from 'common/message-creators/store-action-message-creator';
-import { StoresTree, StoresTreeProps, StoresTreeState } from 'debug-tools/components/stores-tree';
+import { StoresTree, StoresTreeProps, StoresTreeState, columns } from 'debug-tools/components/stores-tree';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { itIsFunction } from 'tests/unit/common/it-is-function';
 import { IMock, Mock, Times } from 'typemoq';
+import { GroupedList } from 'office-ui-fabric-react';
 
 type TestStoreData = {
     value: string;
@@ -67,6 +68,46 @@ describe('StoresTree', () => {
             wrapped.update();
 
             expect(wrapped.getElement()).toMatchSnapshot();
+        });
+
+        it('the value column properly', () => {
+            const onRender = columns.find(column => column.key === 'value').onRender;
+
+            const testItem = {
+                first: 1,
+                second: '2',
+                third: true,
+                fourth: [4],
+                fifth: {
+                    sixth: '6',
+                },
+            };
+
+            const result = onRender({ value: testItem });
+
+            expect(result).toMatchSnapshot();
+        });
+
+        it('each row properly', () => {
+            props = {
+                global: storeMocks.map(mock => mock.object),
+                storeActionMessageCreator: storeActionMessageCreatorMock.object,
+            };
+
+            const wrapped = shallow<StoresTreeProps, StoresTreeState>(<StoresTree {...props} />);
+
+            wrapped.setState({ global: { first: '1', second: '2' } });
+            wrapped.update();
+
+            const list = wrapped.find(GroupedList);
+
+            const onRenderCell = list.prop('onRenderCell');
+
+            const testItem = {
+                key: 'value',
+            };
+
+            expect(onRenderCell(0, testItem, 1)).toMatchSnapshot();
         });
     });
 

--- a/src/tests/unit/tests/debug-tools/components/stores-tree.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/stores-tree.test.tsx
@@ -2,12 +2,12 @@
 // Licensed under the MIT License.
 import { BaseStore } from 'common/base-store';
 import { StoreActionMessageCreator } from 'common/message-creators/store-action-message-creator';
-import { StoresTree, StoresTreeProps, StoresTreeState, columns } from 'debug-tools/components/stores-tree';
+import { columns, StoresTree, StoresTreeProps, StoresTreeState } from 'debug-tools/components/stores-tree';
 import { shallow } from 'enzyme';
+import { GroupedList } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { itIsFunction } from 'tests/unit/common/it-is-function';
 import { IMock, Mock, Times } from 'typemoq';
-import { GroupedList } from 'office-ui-fabric-react';
 
 type TestStoreData = {
     value: string;

--- a/src/tests/unit/tests/debug-tools/components/stores-tree.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/stores-tree.test.tsx
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BaseStore } from 'common/base-store';
+import { StoreActionMessageCreator } from 'common/message-creators/store-action-message-creator';
+import { StoresTree, StoresTreeProps } from 'debug-tools/components/stores-tree';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { itIsFunction } from 'tests/unit/common/it-is-function';
+import { IMock, Mock, Times } from 'typemoq';
+
+type TestStoreData = {
+    value: string;
+};
+
+describe('StoresTree', () => {
+    let storeMocks: IMock<BaseStore<any>>[];
+    let storeActionMessageCreatorMock: IMock<StoreActionMessageCreator>;
+    let props: StoresTreeProps;
+
+    beforeEach(() => {
+        storeMocks = [
+            Mock.ofType<BaseStore<TestStoreData>>(),
+            Mock.ofType<BaseStore<TestStoreData>>(),
+            Mock.ofType<BaseStore<TestStoreData>>(),
+        ];
+
+        storeActionMessageCreatorMock = Mock.ofType<StoreActionMessageCreator>();
+    });
+
+    describe('on componentDidMount', () => {
+        beforeEach(() => {
+            props = {
+                global: storeMocks.map(mock => mock.object),
+                storeActionMessageCreator: storeActionMessageCreatorMock.object,
+            };
+        });
+
+        it('should add listeners to the stores', () => {
+            shallow(<StoresTree {...props} />);
+
+            storeMocks.forEach(mock => mock.verify(store => store.addChangedListener(itIsFunction), Times.once()));
+        });
+
+        it('should call to get all the states', () => {
+            shallow(<StoresTree {...props} />);
+
+            storeActionMessageCreatorMock.verify(creator => creator.getAllStates(), Times.once());
+        });
+    });
+});


### PR DESCRIPTION
#### Description of changes

As part of adding the debug page, we missing adding some tests on the new code.

This PR add the missing tests for the `<StoresTree>` component, covering 100%.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
