### PR TITLE
feat(android-settings): update primary button active state color

### DIFF
--- a/src/common/styles/high-contrast-theme-palette.ts
+++ b/src/common/styles/high-contrast-theme-palette.ts
@@ -35,5 +35,6 @@ export const HighContrastThemePalette: IPartialTheme = {
         menuIcon: '#FFFFFF',
         disabledText: '#C285FF',
         primaryButtonBackground: '#38A9FF',
+        primaryButtonBackgroundPressed: '#2184D0',
     },
 };


### PR DESCRIPTION
#### Description of changes

We are updating the primary button color for the active state so it does pass color contrast. 

This affect primary buttons on AI-Android and AI-Web. The difference is not easy to "see" but running the self validation find the color does pass color contrast.

**enabled, primary button on active state**
![image](https://user-images.githubusercontent.com/2837582/75594218-e2554c80-5a3c-11ea-84d0-940c91920bd4.png)

#### Pull request checklist
- [ ] Addresses an existing issue: part of WI # 1678713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
