### PR TITLE
feat(android-settings): make unified command bar a region landmark

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -27,7 +27,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
     const { deps, deviceStoreData } = props;
 
     return (
-        <div className={styles.commandBar}>
+        <section className={styles.commandBar} role="region" aria-label="command bar">
             <div className={styles.items}>
                 <CommandButton
                     data-automation-id={commandButtonRefreshId}
@@ -48,6 +48,6 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
                     }
                 />
             </div>
-        </div>
+        </section>
     );
 });

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -27,7 +27,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
     const { deps, deviceStoreData } = props;
 
     return (
-        <section className={styles.commandBar} role="region" aria-label="command bar">
+        <section className={styles.commandBar} aria-label="command bar">
             <div className={styles.items}>
                 <CommandButton
                     data-automation-id={commandButtonRefreshId}

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
 <section
   aria-label="command bar"
   className="commandBar"
-  role="region"
 >
   <div
     className="items"
@@ -45,7 +44,6 @@ exports[`CommandBar renders while status is <Default> 1`] = `
 <section
   aria-label="command bar"
   className="commandBar"
-  role="region"
 >
   <div
     className="items"
@@ -86,7 +84,6 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
 <section
   aria-label="command bar"
   className="commandBar"
-  role="region"
 >
   <div
     className="items"
@@ -127,7 +124,6 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
 <section
   aria-label="command bar"
   className="commandBar"
-  role="region"
 >
   <div
     className="items"

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CommandBar renders while status is <Completed> 1`] = `
-<div
+<section
+  aria-label="command bar"
   className="commandBar"
+  role="region"
 >
   <div
     className="items"
@@ -36,12 +38,14 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
       onClick={[Function]}
     />
   </div>
-</div>
+</section>
 `;
 
 exports[`CommandBar renders while status is <Default> 1`] = `
-<div
+<section
+  aria-label="command bar"
   className="commandBar"
+  role="region"
 >
   <div
     className="items"
@@ -75,12 +79,14 @@ exports[`CommandBar renders while status is <Default> 1`] = `
       onClick={[Function]}
     />
   </div>
-</div>
+</section>
 `;
 
 exports[`CommandBar renders while status is <Failed> 1`] = `
-<div
+<section
+  aria-label="command bar"
   className="commandBar"
+  role="region"
 >
   <div
     className="items"
@@ -114,12 +120,14 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
       onClick={[Function]}
     />
   </div>
-</div>
+</section>
 `;
 
 exports[`CommandBar renders while status is <Scanning> 1`] = `
-<div
+<section
+  aria-label="command bar"
   className="commandBar"
+  role="region"
 >
   <div
     className="items"
@@ -153,5 +161,5 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
       onClick={[Function]}
     />
   </div>
-</div>
+</section>
 `;


### PR DESCRIPTION
#### Description of changes

This PR updates the newly redone unified command bar to be a "region" landmark named "command bar", per the figma (`<section>` elements are the semantic HTML equivalent for the `region` role). We think eventually a "menubar" role would be more appropriate, using this as a stopgap while we wait for https://github.com/OfficeDev/office-ui-fabric-react/issues/11832

No visible UI changes. Verified reading behavior in JAWS (it makes the region navigable with "r").

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
