### PR TITLE
test: re-enable some action creator tests

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -4,7 +4,6 @@ import { CardSelectionActions } from 'background/actions/card-selection-actions'
 import { TestMode } from 'common/configs/test-mode';
 import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import * as TelemetryEvents from 'common/extension-telemetry-events';
-import { createDefaultLogger } from 'common/logging/default-logger';
 import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { NotificationCreator } from 'common/notification-creator';
@@ -12,7 +11,6 @@ import { StoreNames } from 'common/stores/store-names';
 import { VisualizationType } from 'common/types/visualization-type';
 import { ScanCompletedPayload } from 'injected/analyzers/analyzer';
 import { DictionaryNumberTo } from 'types/common-types';
-
 import { VisualizationActions } from '../actions/visualization-actions';
 import { VisualizationScanResultActions } from '../actions/visualization-scan-result-actions';
 import { ExtensionDetailsViewController } from '../extension-details-view-controller';

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -56,7 +56,7 @@ export class ActionCreator {
         private readonly notificationCreator: NotificationCreator,
         private readonly visualizationConfigurationFactory: VisualizationConfigurationFactory,
         private readonly targetTabController: TargetTabController,
-        private readonly logger: Logger = createDefaultLogger(),
+        private readonly logger: Logger,
     ) {
         this.visualizationActions = actionHub.visualizationActions;
         this.previewFeaturesActions = actionHub.previewFeaturesActions;

--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -300,7 +300,7 @@ export class ActionCreator {
         await this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
     };
 
-    private onScrollRequested = (payload: BaseActionPayload): void => {
+    private onScrollRequested = (): void => {
         this.visualizationActions.scrollRequested.invoke(null);
         this.cardSelectionActions.resetFocusedIdentifier.invoke(null);
     };

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -69,6 +69,7 @@ export class TabContextFactory {
             notificationCreator,
             this.visualizationConfigurationFactory,
             this.targetTabController,
+            this.logger,
         );
 
         const detailsViewActionCreator = new DetailsViewActionCreator(

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -495,7 +495,7 @@ describe('ActionCreatorTest', () => {
         builder.verifyAll();
     });
 
-    describe.only('registerCallback for onDetailsViewSelected', () => {
+    describe('registerCallback for onDetailsViewSelected', () => {
         const viewType = VisualizationType.Issues;
         const pivotType = DetailsViewPivotType.fastPass;
         const updateViewActionName = 'updateSelectedPivotChild';

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -384,12 +384,14 @@ describe('ActionCreatorTest', () => {
     });
 
     test('registerCallbacks for scrollRequested', () => {
-        const actionName = 'scrollRequested';
+        const visualizationActionName = 'scrollRequested';
+        const cardSelectionActionName = 'resetFocusedIdentifier';
         const tabId = 1;
         const builder = new ActionCreatorValidator()
-            .setupActionOnVisualizationActions(actionName)
-            .setupVisualizationActionWithInvokeParameter(actionName, null)
-            .setupCardSelectionActionWithInvokeParameter('resetFocusedIdentifier', null)
+            .setupActionOnVisualizationActions(visualizationActionName)
+            .setupVisualizationActionWithInvokeParameter(visualizationActionName, null)
+            .setupActionOnCardSelectionActions(cardSelectionActionName)
+            .setupCardSelectionActionWithInvokeParameter(cardSelectionActionName, null)
             .setupRegistrationCallback(VisualizationMessage.Common.ScrollRequested, [null, tabId]);
 
         const actionCreator = builder.buildActionCreator();
@@ -1002,6 +1004,7 @@ class ActionCreatorValidator {
     private scopingActionsContainerMock = Mock.ofType(ScopingActions);
     private assessmentActionsContainerMock = Mock.ofType(AssessmentActions);
     private inspectActionsContainerMock = Mock.ofType(InspectActions);
+    private cardSelectionActionsContainerMock = Mock.ofType(CardSelectionActions);
     private previewFeaturesActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
     private scopingActionMocks: DictionaryStringTo<IMock<Action<any>>> = {};
     private detailsViewActionsMocks: DictionaryStringTo<IMock<Action<any>>> = {};
@@ -1034,7 +1037,7 @@ class ActionCreatorValidator {
         detailsViewActions: this.detailsViewActionsContainerMock.object,
         pathSnippetActions: null,
         scanResultActions: null,
-        cardSelectionActions: null,
+        cardSelectionActions: this.cardSelectionActionsContainerMock.object,
         injectionActions: null,
     };
 
@@ -1208,6 +1211,18 @@ class ActionCreatorValidator {
         }
 
         actionsContainerMock.setup(x => x[actionName]).returns(() => action.object);
+
+        return this;
+    }
+
+    public setupActionOnCardSelectionActions(
+        actionName: keyof CardSelectionActions,
+    ): ActionCreatorValidator {
+        this.setupAction(
+            actionName,
+            this.cardSelectionActionsMocks,
+            this.cardSelectionActionsContainerMock,
+        );
 
         return this;
     }


### PR DESCRIPTION
#### Description of changes

Just found a `describe.only` on our `action-creator.test.ts`.

On this PR:
- remove stray `.only`
- remove default value for `logger` param and update only call to the constructor

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
