### PR TITLE
fix: unified: make window title a non-heading

### DIFF
--- a/src/electron/views/automated-checks/components/title-bar.scss
+++ b/src/electron/views/automated-checks/components/title-bar.scss
@@ -4,8 +4,8 @@
 
 .title-bar {
     background: $ada-brand-color;
+}
 
-    h1 {
-        color: $header-bar-title-color !important;
-    }
+.header-text {
+    color: $header-bar-title-color !important;
 }

--- a/src/electron/views/automated-checks/components/title-bar.tsx
+++ b/src/electron/views/automated-checks/components/title-bar.tsx
@@ -65,6 +65,7 @@ export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps
             windowStateStoreData={props.windowStateStoreData}
             deps={props.deps}
             className={styles.titleBar}
+            headerTextClassName={styles.headerText}
         >
             <HeaderIcon deps={props.deps} />
         </WindowTitle>

--- a/src/electron/views/common/window-title/window-title.tsx
+++ b/src/electron/views/common/window-title/window-title.tsx
@@ -17,6 +17,7 @@ export interface WindowTitleProps {
     children?: JSX.Element;
     actionableIcons?: JSX.Element[];
     className?: string;
+    headerTextClassName?: string;
     windowStateStoreData: WindowStateStoreData;
 }
 
@@ -29,7 +30,9 @@ export const WindowTitle = NamedFC<WindowTitleProps>('WindowTitle', (props: Wind
         <header className={css(styles.windowTitle, props.className)}>
             <div className={styles.titleContainer}>
                 {props.children}
-                <h1 className={styles.headerText}>{props.title}</h1>
+                <span className={css(styles.headerText, props.headerTextClassName)}>
+                    {props.title}
+                </span>
             </div>
             {getIconsContainer(props)}
         </header>

--- a/src/electron/views/device-connect-view/components/device-connect-body.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-body.scss
@@ -5,7 +5,7 @@
 .device-connect-body {
     margin: 16px 32px;
 
-    h3 {
+    h2 {
         font-family: $fontFamily;
         font-size: 14px;
         font-weight: $fontWeightSemiBold;

--- a/src/electron/views/device-connect-view/components/device-connect-connected-device.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-connected-device.tsx
@@ -52,7 +52,7 @@ export const DeviceConnectConnectedDevice = NamedFC<DeviceConnectConnectedDevice
 
         return (
             <div className={styles.deviceConnectConnectedDevice}>
-                <h3>Connected device</h3>
+                <h2>Connected device</h2>
                 <div role="alert" aria-live="assertive">
                     {renderContents()}
                 </div>

--- a/src/electron/views/device-connect-view/components/device-connect-header.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-header.scss
@@ -4,7 +4,7 @@
 @import '../../../../common/styles/fonts.scss';
 
 .device-connect-header {
-    h2 {
+    h1 {
         font-family: $fontFamily;
         font-size: 21px;
         font-weight: normal;

--- a/src/electron/views/device-connect-view/components/device-connect-header.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-header.tsx
@@ -19,7 +19,7 @@ export const DeviceConnectHeader = NamedFC<DeviceConnectHeaderProps>(
         const { LinkComponent } = deps;
         return (
             <header className={styles.deviceConnectHeader}>
-                <h2>Connect to your Android device</h2>
+                <h1>Connect to your Android device</h1>
                 <LinkComponent href="https://go.microsoft.com/fwlink/?linkid=2101252">
                     How do I connect to my device?
                 </LinkComponent>

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -40,7 +40,7 @@ export class DeviceConnectPortEntry extends React.Component<
     public render(): JSX.Element {
         return (
             <div className={styles.deviceConnectPortEntry}>
-                <h3>Android device port number</h3>
+                <h2>Android device port number</h2>
                 <div className={styles.deviceConnectPortEntryBody}>
                     <MaskedTextField
                         data-automation-id={deviceConnectPortNumberFieldAutomationId}

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/title-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/title-bar.test.tsx.snap
@@ -54,6 +54,7 @@ exports[`TitleBar renders 1`] = `
       },
     }
   }
+  headerTextClassName="headerText"
   title="Accessibility Insights"
   windowStateStoreData={
     Object {

--- a/src/tests/unit/tests/electron/views/common/window-title/__snapshots__/window-title.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/common/window-title/__snapshots__/window-title.test.tsx.snap
@@ -12,11 +12,11 @@ exports[`WindowTitleTest renders with actionable icons 1`] = `
     <span>
       logo
     </span>
-    <h1
+    <span
       className="headerText"
     >
       title 1
-    </h1>
+    </span>
   </div>
   <div
     className="actionableIconsContainer"
@@ -41,11 +41,40 @@ exports[`WindowTitleTest renders with custom class name 1`] = `
     <span>
       logo
     </span>
-    <h1
+    <span
       className="headerText"
     >
       title 1
-    </h1>
+    </span>
+  </div>
+  <div
+    className="actionableIconsContainer"
+  >
+    <div>
+      icon1
+    </div>
+    <div>
+      icon2
+    </div>
+  </div>
+</header>
+`;
+
+exports[`WindowTitleTest renders with custom header text class name 1`] = `
+<header
+  className="windowTitle"
+>
+  <div
+    className="titleContainer"
+  >
+    <span>
+      logo
+    </span>
+    <span
+      className="headerText custom-class-name"
+    >
+      title 1
+    </span>
   </div>
   <div
     className="actionableIconsContainer"
@@ -70,11 +99,11 @@ exports[`WindowTitleTest renders without actionable buttons for mac 1`] = `
     <span>
       logo
     </span>
-    <h1
+    <span
       className="headerText"
     >
       title 1
-    </h1>
+    </span>
   </div>
 </header>
 `;
@@ -89,11 +118,11 @@ exports[`WindowTitleTest renders without actionable icons 1`] = `
     <span>
       logo
     </span>
-    <h1
+    <span
       className="headerText"
     >
       title 1
-    </h1>
+    </span>
   </div>
 </header>
 `;
@@ -105,11 +134,11 @@ exports[`WindowTitleTest renders without children & actionable icon 1`] = `
   <div
     className="titleContainer"
   >
-    <h1
+    <span
       className="headerText"
     >
       title 1
-    </h1>
+    </span>
   </div>
 </header>
 `;

--- a/src/tests/unit/tests/electron/views/common/window-title/window-title.test.tsx
+++ b/src/tests/unit/tests/electron/views/common/window-title/window-title.test.tsx
@@ -72,4 +72,12 @@ describe('WindowTitleTest', () => {
 
         expect(rendered.getElement()).toMatchSnapshot();
     });
+
+    it('renders with custom header text class name', () => {
+        props.headerTextClassName = 'custom-class-name';
+
+        const rendered = shallow(<WindowTitle {...props} />);
+
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
 });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-connected-device.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-connected-device.test.tsx.snap
@@ -4,9 +4,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Conne
 <div
   className="deviceConnectConnectedDevice"
 >
-  <h3>
+  <h2>
     Connected device
-  </h3>
+  </h2>
   <div
     aria-live="assertive"
     role="alert"
@@ -18,9 +18,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Conne
 <div
   className="deviceConnectConnectedDevice"
 >
-  <h3>
+  <h2>
     Connected device
-  </h3>
+  </h2>
   <div
     aria-live="assertive"
     role="alert"
@@ -39,9 +39,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Defau
 <div
   className="deviceConnectConnectedDevice"
 >
-  <h3>
+  <h2>
     Connected device
-  </h3>
+  </h2>
   <div
     aria-live="assertive"
     role="alert"
@@ -53,9 +53,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Error
 <div
   className="deviceConnectConnectedDevice"
 >
-  <h3>
+  <h2>
     Connected device
-  </h3>
+  </h2>
   <div
     aria-live="assertive"
     role="alert"
@@ -80,9 +80,9 @@ exports[`DeviceConnectConnectedDeviceTest renders the device name when state is 
 <div
   className="deviceConnectConnectedDevice"
 >
-  <h3>
+  <h2>
     Connected device
-  </h3>
+  </h2>
   <div
     aria-live="assertive"
     role="alert"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-header.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-header.test.tsx.snap
@@ -4,9 +4,9 @@ exports[`DeviceConnectHeaderTest render 1`] = `
 <header
   className="deviceConnectHeader"
 >
-  <h2>
+  <h1>
     Connect to your Android device
-  </h2>
+  </h1>
   <ElectronLink
     href="https://go.microsoft.com/fwlink/?linkid=2101252"
   >

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -12,9 +12,9 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <h3>
+  <h2>
     Android device port number
-  </h3>
+  </h2>
   <div
     className="deviceConnectPortEntryBody"
   >
@@ -51,9 +51,9 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" and some text in th
 <div
   className="deviceConnectPortEntry"
 >
-  <h3>
+  <h2>
     Android device port number
-  </h3>
+  </h2>
   <div
     className="deviceConnectPortEntryBody"
   >
@@ -90,9 +90,9 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <h3>
+  <h2>
     Android device port number
-  </h3>
+  </h2>
   <div
     className="deviceConnectPortEntryBody"
   >
@@ -129,9 +129,9 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" and some text in t
 <div
   className="deviceConnectPortEntry"
 >
-  <h3>
+  <h2>
     Android device port number
-  </h3>
+  </h2>
   <div
     className="deviceConnectPortEntryBody"
   >
@@ -168,9 +168,9 @@ exports[`DeviceConnectPortEntryTest renders with "Default" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <h3>
+  <h2>
     Android device port number
-  </h3>
+  </h2>
   <div
     className="deviceConnectPortEntryBody"
   >
@@ -207,9 +207,9 @@ exports[`DeviceConnectPortEntryTest renders with "Default" and some text in the 
 <div
   className="deviceConnectPortEntry"
 >
-  <h3>
+  <h2>
     Android device port number
-  </h3>
+  </h2>
   <div
     className="deviceConnectPortEntryBody"
   >
@@ -246,9 +246,9 @@ exports[`DeviceConnectPortEntryTest renders with "Error" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <h3>
+  <h2>
     Android device port number
-  </h3>
+  </h2>
   <div
     className="deviceConnectPortEntryBody"
   >
@@ -285,9 +285,9 @@ exports[`DeviceConnectPortEntryTest renders with "Error" and some text in the po
 <div
   className="deviceConnectPortEntry"
 >
-  <h3>
+  <h2>
     Android device port number
-  </h3>
+  </h2>
   <div
     className="deviceConnectPortEntryBody"
   >


### PR DESCRIPTION
#### Description of changes

Per @ferBonnin , we think the window title is not supposed to be a heading (it should be in a `<header>`/banner landmark, as it already is, but not be an actual `<h1>`; that should be the element in the page.

This required:
* updating the title bar component to pass through a className that was previously inferring information owned by the window title component
* updating the device connect view to bump its in-page heading levels (h2 -> h1 and h3->h2) to ensure page still has an h1

Out of scope:
* Making the port entry label a label instead of a heading at all (will be covered in later a11y fix)

Should be no visual changes as part of this PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
