### PR TITLE
fix: unified: page-specific window titles

### DIFF
--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -27,6 +27,7 @@ import * as React from 'react';
 import * as styles from './automated-checks-view.scss';
 import { CommandBar, CommandBarDeps } from './components/command-bar';
 import { HeaderSection } from './components/header-section';
+import { brand } from 'content/strings/application';
 
 export const automatedChecksViewAutomationId = 'automated-checks-view';
 
@@ -91,6 +92,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
             >
                 <TitleBar
                     deps={this.props.deps}
+                    pageTitle={'Automated checks'}
                     windowStateStoreData={this.props.windowStateStoreData}
                 ></TitleBar>
                 <div className={styles.automatedChecksPanelLayout}>

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -27,7 +27,6 @@ import * as React from 'react';
 import * as styles from './automated-checks-view.scss';
 import { CommandBar, CommandBarDeps } from './components/command-bar';
 import { HeaderSection } from './components/header-section';
-import { brand } from 'content/strings/application';
 
 export const automatedChecksViewAutomationId = 'automated-checks-view';
 

--- a/src/electron/views/automated-checks/components/title-bar.tsx
+++ b/src/electron/views/automated-checks/components/title-bar.tsx
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { HeaderIcon, HeaderIconDeps } from 'common/components/header-icon';
 import { NamedFC } from 'common/react/named-fc';
-import { brand } from 'content/strings/application';
 import { WindowFrameActionCreator } from 'electron/flux/action-creator/window-frame-action-creator';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { WindowTitle, WindowTitleDeps } from 'electron/views/common/window-title/window-title';
@@ -18,6 +17,7 @@ export type TitleBarDeps = {
 
 export interface TitleBarProps {
     deps: TitleBarDeps;
+    pageTitle: string;
     windowStateStoreData: WindowStateStoreData;
 }
 
@@ -60,7 +60,7 @@ export const TitleBar = NamedFC<TitleBarProps>('TitleBar', (props: TitleBarProps
 
     return (
         <WindowTitle
-            title={brand}
+            pageTitle={props.pageTitle}
             actionableIcons={icons}
             windowStateStoreData={props.windowStateStoreData}
             deps={props.deps}

--- a/src/electron/views/common/window-title/window-title.tsx
+++ b/src/electron/views/common/window-title/window-title.tsx
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
 import { NamedFC } from 'common/react/named-fc';
+import { androidAppTitle, brand } from 'content/strings/application';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import { PlatformInfo } from 'electron/window-management/platform-info';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
+import Helmet from 'react-helmet';
 import * as styles from './window-title.scss';
 
 export interface WindowTitleDeps {
@@ -13,7 +15,7 @@ export interface WindowTitleDeps {
 }
 export interface WindowTitleProps {
     deps: WindowTitleDeps;
-    title: string;
+    pageTitle: string;
     children?: JSX.Element;
     actionableIcons?: JSX.Element[];
     className?: string;
@@ -28,11 +30,14 @@ export const WindowTitle = NamedFC<WindowTitleProps>('WindowTitle', (props: Wind
 
     return (
         <header className={css(styles.windowTitle, props.className)}>
+            <Helmet>
+                <title>
+                    {androidAppTitle} - {props.pageTitle}
+                </title>
+            </Helmet>
             <div className={styles.titleContainer}>
                 {props.children}
-                <span className={css(styles.headerText, props.headerTextClassName)}>
-                    {props.title}
-                </span>
+                <span className={css(styles.headerText, props.headerTextClassName)}>{brand}</span>
             </div>
             {getIconsContainer(props)}
         </header>

--- a/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-view-container.tsx
@@ -7,7 +7,6 @@ import {
 } from 'common/components/telemetry-permission-dialog';
 import { NamedFC } from 'common/react/named-fc';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
-import { brand } from 'content/strings/application';
 import { WindowStateStoreData } from 'electron/flux/types/window-state-store-data';
 import * as React from 'react';
 import { DeviceStoreData } from '../../../flux/types/device-store-data';
@@ -33,7 +32,7 @@ export const DeviceConnectViewContainer = NamedFC<DeviceConnectViewContainerProp
         return (
             <div className={deviceConnectView}>
                 <WindowTitle
-                    title={brand}
+                    pageTitle={'Connect to your Android device'}
                     deps={props.deps}
                     windowStateStoreData={props.windowStateStoreData}
                 >

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -29,6 +29,10 @@ describe('AutomatedChecksView', () => {
         }
     });
 
+    it('should use the expected window title', async () => {
+        expect(await app.getTitle()).toBe('Accessibility Insights for Android - Automated checks');
+    });
+
     it('displays automated checks results collapsed by default', async () => {
         const ruleGroups = await automatedChecksView.queryRuleGroups();
         expect(ruleGroups).toHaveLength(4);

--- a/src/tests/electron/tests/device-connection-dialog.test.ts
+++ b/src/tests/electron/tests/device-connection-dialog.test.ts
@@ -23,7 +23,9 @@ describe('device connection dialog', () => {
     });
 
     it('should use the expected window title', async () => {
-        expect(await app.getTitle()).toBe('Accessibility Insights for Android');
+        expect(await app.getTitle()).toBe(
+            'Accessibility Insights for Android - Connect to your Android device',
+        );
     });
 
     it('should initially have the cancel button and port field enabled, but validate and start buttons disabled', async () => {

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
         "screenshotViewModelProvider": [Function],
       }
     }
+    pageTitle="Automated checks"
   />
   <div
     className="automatedChecksPanelLayout"
@@ -133,6 +134,7 @@ exports[`AutomatedChecksView renders when status scan <Failed> 1`] = `
         },
       }
     }
+    pageTitle="Automated checks"
     windowStateStoreData="window state store data"
   />
   <div
@@ -216,6 +218,7 @@ exports[`AutomatedChecksView renders when status scan <Scanning> 1`] = `
         },
       }
     }
+    pageTitle="Automated checks"
     windowStateStoreData="window state store data"
   />
   <div
@@ -299,6 +302,7 @@ exports[`AutomatedChecksView renders when status scan <undefined> 1`] = `
         },
       }
     }
+    pageTitle="Automated checks"
     windowStateStoreData="window state store data"
   />
   <div

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/title-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/title-bar.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`TitleBar renders 1`] = `
     }
   }
   headerTextClassName="headerText"
-  title="Accessibility Insights"
+  pageTitle="test page title"
   windowStateStoreData={
     Object {
       "currentWindowState": "maximized",

--- a/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
@@ -32,6 +32,7 @@ describe('TitleBar', () => {
                 storeActionMessageCreator: Mock.ofType(StoreActionMessageCreatorImpl).object,
                 storesHub: Mock.ofType<ClientStoresHub<ThemeInnerState>>(BaseClientStoresHub).object,
             },
+            pageTitle: 'test page title',
             windowStateStoreData,
         };
     });

--- a/src/tests/unit/tests/electron/views/common/window-title/__snapshots__/window-title.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/common/window-title/__snapshots__/window-title.test.tsx.snap
@@ -6,6 +6,16 @@ exports[`WindowTitleTest renders with actionable icons 1`] = `
 <header
   className="windowTitle"
 >
+  <HelmetWrapper
+    defer={true}
+    encodeSpecialCharacters={true}
+  >
+    <title>
+      Accessibility Insights for Android
+       - 
+      page title 1
+    </title>
+  </HelmetWrapper>
   <div
     className="titleContainer"
   >
@@ -15,7 +25,7 @@ exports[`WindowTitleTest renders with actionable icons 1`] = `
     <span
       className="headerText"
     >
-      title 1
+      Accessibility Insights
     </span>
   </div>
   <div
@@ -35,6 +45,16 @@ exports[`WindowTitleTest renders with custom class name 1`] = `
 <header
   className="windowTitle custom-class-name"
 >
+  <HelmetWrapper
+    defer={true}
+    encodeSpecialCharacters={true}
+  >
+    <title>
+      Accessibility Insights for Android
+       - 
+      page title 1
+    </title>
+  </HelmetWrapper>
   <div
     className="titleContainer"
   >
@@ -44,7 +64,7 @@ exports[`WindowTitleTest renders with custom class name 1`] = `
     <span
       className="headerText"
     >
-      title 1
+      Accessibility Insights
     </span>
   </div>
   <div
@@ -64,6 +84,16 @@ exports[`WindowTitleTest renders with custom header text class name 1`] = `
 <header
   className="windowTitle"
 >
+  <HelmetWrapper
+    defer={true}
+    encodeSpecialCharacters={true}
+  >
+    <title>
+      Accessibility Insights for Android
+       - 
+      page title 1
+    </title>
+  </HelmetWrapper>
   <div
     className="titleContainer"
   >
@@ -73,7 +103,7 @@ exports[`WindowTitleTest renders with custom header text class name 1`] = `
     <span
       className="headerText custom-class-name"
     >
-      title 1
+      Accessibility Insights
     </span>
   </div>
   <div
@@ -93,6 +123,16 @@ exports[`WindowTitleTest renders without actionable buttons for mac 1`] = `
 <header
   className="windowTitle"
 >
+  <HelmetWrapper
+    defer={true}
+    encodeSpecialCharacters={true}
+  >
+    <title>
+      Accessibility Insights for Android
+       - 
+      page title 1
+    </title>
+  </HelmetWrapper>
   <div
     className="titleContainer"
   >
@@ -102,7 +142,7 @@ exports[`WindowTitleTest renders without actionable buttons for mac 1`] = `
     <span
       className="headerText"
     >
-      title 1
+      Accessibility Insights
     </span>
   </div>
 </header>
@@ -112,6 +152,16 @@ exports[`WindowTitleTest renders without actionable icons 1`] = `
 <header
   className="windowTitle"
 >
+  <HelmetWrapper
+    defer={true}
+    encodeSpecialCharacters={true}
+  >
+    <title>
+      Accessibility Insights for Android
+       - 
+      page title 1
+    </title>
+  </HelmetWrapper>
   <div
     className="titleContainer"
   >
@@ -121,7 +171,7 @@ exports[`WindowTitleTest renders without actionable icons 1`] = `
     <span
       className="headerText"
     >
-      title 1
+      Accessibility Insights
     </span>
   </div>
 </header>
@@ -131,13 +181,23 @@ exports[`WindowTitleTest renders without children & actionable icon 1`] = `
 <header
   className="windowTitle"
 >
+  <HelmetWrapper
+    defer={true}
+    encodeSpecialCharacters={true}
+  >
+    <title>
+      Accessibility Insights for Android
+       - 
+      page title 1
+    </title>
+  </HelmetWrapper>
   <div
     className="titleContainer"
   >
     <span
       className="headerText"
     >
-      title 1
+      Accessibility Insights
     </span>
   </div>
 </header>

--- a/src/tests/unit/tests/electron/views/common/window-title/window-title.test.tsx
+++ b/src/tests/unit/tests/electron/views/common/window-title/window-title.test.tsx
@@ -17,7 +17,7 @@ describe('WindowTitleTest', () => {
         windowStateStoreData = { currentWindowState: 'maximized', routeId: 'deviceConnectView' };
 
         props = {
-            title: 'title 1',
+            pageTitle: 'page title 1',
             deps: { platformInfo: platformInfoMock.object },
             children: <span>logo</span>,
             actionableIcons: [<div key="key1">icon1</div>, <div key="key2">icon2</div>],

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-view-container.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`DeviceConnectViewContainer renders 1`] = `
 >
   <WindowTitle
     deps={Object {}}
-    title="Accessibility Insights"
+    pageTitle="Connect to your Android device"
     windowStateStoreData={
       Object {
         "currentWindowState": "customSize",


### PR DESCRIPTION
#### Description of changes

This PR updates unified page `<title>`s (which are used by Electron to inform the OS about window titles, eg, for the purposes of alt-tab/win-tab/taskbar UI) to adhere to [WCAG SC 2.4.2](https://www.w3.org/WAI/WCAG21/Understanding/page-titled.html) by using titles that communicate individual pages' purpose (in our case, using titles that include the terms "Connect to your Android device" or "Automated checks" per-view).

Windows win-tab UI with this change:
![screenshot of win-tab UI showing updated page-specific title with "connect" dialog](https://user-images.githubusercontent.com/376284/75715943-20dc4880-5c83-11ea-8979-c2ff86aa27b0.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
