### PR TITLE
fix: device port label and headers

### DIFF
--- a/src/electron/views/device-connect-view/components/device-connect-connected-device.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-connected-device.scss
@@ -4,6 +4,12 @@
 @import '../../../../common/styles/fonts.scss';
 
 .device-connect-connected-device {
+    .label {
+        font-weight: $fontWeightSemiBold;
+
+        margin: 24px 0 8px 0;
+    }
+
     .device-connect-spinner {
         font-family: $fontFamily;
         line-height: 16px;

--- a/src/electron/views/device-connect-view/components/device-connect-connected-device.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-connected-device.scss
@@ -7,7 +7,8 @@
     .label {
         font-weight: $fontWeightSemiBold;
 
-        margin: 24px 0 8px 0;
+        margin-top: 24px;
+        margin-bottom: 8px;
     }
 
     .device-connect-spinner {

--- a/src/electron/views/device-connect-view/components/device-connect-connected-device.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-connected-device.tsx
@@ -52,7 +52,7 @@ export const DeviceConnectConnectedDevice = NamedFC<DeviceConnectConnectedDevice
 
         return (
             <div className={styles.deviceConnectConnectedDevice}>
-                <h2>Connected device</h2>
+                <div className={styles.label}>Connected device</div>
                 <div role="alert" aria-live="assertive">
                     {renderContents()}
                 </div>

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.scss
@@ -1,9 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 @import '../../../../common/styles/colors.scss';
+@import '../../../../common/styles/fonts.scss';
 
 .device-connect-port-entry {
+    .port-number-label {
+        font-weight: $fontWeightSemiBold;
+
+        margin: 24px 0 8px 0;
+    }
+
     .device-connect-port-entry-body {
         display: flex;
 

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.scss
@@ -7,7 +7,8 @@
     .port-number-label {
         font-weight: $fontWeightSemiBold;
 
-        margin: 24px 0 8px 0;
+        margin-top: 24px;
+        margin-bottom: 8px;
     }
 
     .device-connect-port-entry-body {

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.scss
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.scss
@@ -7,6 +7,8 @@
     .port-number-label {
         font-weight: $fontWeightSemiBold;
 
+        display: block;
+
         margin-top: 24px;
         margin-bottom: 8px;
     }

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -49,7 +49,6 @@ export class DeviceConnectPortEntry extends React.Component<
                     <MaskedTextField
                         id={textFieldId}
                         data-automation-id={deviceConnectPortNumberFieldAutomationId}
-                        aria-labelledby={textFieldId}
                         onChange={this.onPortTextChanged}
                         placeholder="Ex: 12345"
                         className={styles.portNumberField}

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -28,7 +28,7 @@ export interface DeviceConnectPortEntryState {
     port: string;
 }
 
-const textFieldLabelId = 'port-number-text-field-label-id';
+const textFieldId = 'port-number-text-field-id';
 
 export class DeviceConnectPortEntry extends React.Component<
     DeviceConnectPortEntryProps,
@@ -42,13 +42,14 @@ export class DeviceConnectPortEntry extends React.Component<
     public render(): JSX.Element {
         return (
             <div className={styles.deviceConnectPortEntry}>
-                <div id={textFieldLabelId} className={styles.portNumberLabel}>
+                <label htmlFor={textFieldId} className={styles.portNumberLabel}>
                     Android device port number
-                </div>
+                </label>
                 <div className={styles.deviceConnectPortEntryBody}>
                     <MaskedTextField
+                        id={textFieldId}
                         data-automation-id={deviceConnectPortNumberFieldAutomationId}
-                        aria-labelledby={textFieldLabelId}
+                        aria-labelledby={textFieldId}
                         onChange={this.onPortTextChanged}
                         placeholder="Ex: 12345"
                         className={styles.portNumberField}

--- a/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
+++ b/src/electron/views/device-connect-view/components/device-connect-port-entry.tsx
@@ -28,6 +28,8 @@ export interface DeviceConnectPortEntryState {
     port: string;
 }
 
+const textFieldLabelId = 'port-number-text-field-label-id';
+
 export class DeviceConnectPortEntry extends React.Component<
     DeviceConnectPortEntryProps,
     DeviceConnectPortEntryState
@@ -40,24 +42,24 @@ export class DeviceConnectPortEntry extends React.Component<
     public render(): JSX.Element {
         return (
             <div className={styles.deviceConnectPortEntry}>
-                <h2>Android device port number</h2>
+                <div id={textFieldLabelId} className={styles.portNumberLabel}>
+                    Android device port number
+                </div>
                 <div className={styles.deviceConnectPortEntryBody}>
                     <MaskedTextField
                         data-automation-id={deviceConnectPortNumberFieldAutomationId}
-                        ariaLabel="Port number"
+                        aria-labelledby={textFieldLabelId}
                         onChange={this.onPortTextChanged}
                         placeholder="Ex: 12345"
                         className={styles.portNumberField}
                         maskChar=""
                         mask="99999"
                         onKeyDown={this.onEnterKey}
-                        onRenderDescription={() => {
-                            return (
-                                <div className={styles.portNumberFieldDescription}>
-                                    The port number must be between 0 and 65535.
-                                </div>
-                            );
-                        }}
+                        onRenderDescription={() => (
+                            <span className={styles.portNumberFieldDescription}>
+                                The port number must be between 0 and 65535.
+                            </span>
+                        )}
                     />
                     {this.renderValidationPortButton()}
                 </div>

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-connected-device.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-connected-device.test.tsx.snap
@@ -4,9 +4,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Conne
 <div
   className="deviceConnectConnectedDevice"
 >
-  <h2>
+  <div>
     Connected device
-  </h2>
+  </div>
   <div
     aria-live="assertive"
     role="alert"
@@ -18,9 +18,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Conne
 <div
   className="deviceConnectConnectedDevice"
 >
-  <h2>
+  <div>
     Connected device
-  </h2>
+  </div>
   <div
     aria-live="assertive"
     role="alert"
@@ -39,9 +39,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Defau
 <div
   className="deviceConnectConnectedDevice"
 >
-  <h2>
+  <div>
     Connected device
-  </h2>
+  </div>
   <div
     aria-live="assertive"
     role="alert"
@@ -53,9 +53,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Error
 <div
   className="deviceConnectConnectedDevice"
 >
-  <h2>
+  <div>
     Connected device
-  </h2>
+  </div>
   <div
     aria-live="assertive"
     role="alert"
@@ -80,9 +80,9 @@ exports[`DeviceConnectConnectedDeviceTest renders the device name when state is 
 <div
   className="deviceConnectConnectedDevice"
 >
-  <h2>
+  <div>
     Connected device
-  </h2>
+  </div>
   <div
     aria-live="assertive"
     role="alert"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-connected-device.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-connected-device.test.tsx.snap
@@ -4,7 +4,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Conne
 <div
   className="deviceConnectConnectedDevice"
 >
-  <div>
+  <div
+    className="label"
+  >
     Connected device
   </div>
   <div
@@ -18,7 +20,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Conne
 <div
   className="deviceConnectConnectedDevice"
 >
-  <div>
+  <div
+    className="label"
+  >
     Connected device
   </div>
   <div
@@ -39,7 +43,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Defau
 <div
   className="deviceConnectConnectedDevice"
 >
-  <div>
+  <div
+    className="label"
+  >
     Connected device
   </div>
   <div
@@ -53,7 +59,9 @@ exports[`DeviceConnectConnectedDeviceTest renders for deviceConnectState = Error
 <div
   className="deviceConnectConnectedDevice"
 >
-  <div>
+  <div
+    className="label"
+  >
     Connected device
   </div>
   <div
@@ -80,7 +88,9 @@ exports[`DeviceConnectConnectedDeviceTest renders the device name when state is 
 <div
   className="deviceConnectConnectedDevice"
 >
-  <div>
+  <div
+    className="label"
+  >
     Connected device
   </div>
   <div

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -1,25 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DeviceConnectPortEntryTest renders renderedDescription 1`] = `
-<div
+<span
   className="portNumberFieldDescription"
 >
   The port number must be between 0 and 65535.
-</div>
+</span>
 `;
 
 exports[`DeviceConnectPortEntryTest renders with "Connected" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <h2>
+  <div
+    className="portNumberLabel"
+    id="port-number-text-field-label-id"
+  >
     Android device port number
-  </h2>
+  </div>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      ariaLabel="Port number"
+      aria-labelledby="port-number-text-field-label-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       mask="99999"
@@ -51,14 +54,17 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" and some text in th
 <div
   className="deviceConnectPortEntry"
 >
-  <h2>
+  <div
+    className="portNumberLabel"
+    id="port-number-text-field-label-id"
+  >
     Android device port number
-  </h2>
+  </div>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      ariaLabel="Port number"
+      aria-labelledby="port-number-text-field-label-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       mask="99999"
@@ -90,14 +96,17 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <h2>
+  <div
+    className="portNumberLabel"
+    id="port-number-text-field-label-id"
+  >
     Android device port number
-  </h2>
+  </div>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      ariaLabel="Port number"
+      aria-labelledby="port-number-text-field-label-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       mask="99999"
@@ -129,14 +138,17 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" and some text in t
 <div
   className="deviceConnectPortEntry"
 >
-  <h2>
+  <div
+    className="portNumberLabel"
+    id="port-number-text-field-label-id"
+  >
     Android device port number
-  </h2>
+  </div>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      ariaLabel="Port number"
+      aria-labelledby="port-number-text-field-label-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       mask="99999"
@@ -168,14 +180,17 @@ exports[`DeviceConnectPortEntryTest renders with "Default" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <h2>
+  <div
+    className="portNumberLabel"
+    id="port-number-text-field-label-id"
+  >
     Android device port number
-  </h2>
+  </div>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      ariaLabel="Port number"
+      aria-labelledby="port-number-text-field-label-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       mask="99999"
@@ -207,14 +222,17 @@ exports[`DeviceConnectPortEntryTest renders with "Default" and some text in the 
 <div
   className="deviceConnectPortEntry"
 >
-  <h2>
+  <div
+    className="portNumberLabel"
+    id="port-number-text-field-label-id"
+  >
     Android device port number
-  </h2>
+  </div>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      ariaLabel="Port number"
+      aria-labelledby="port-number-text-field-label-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       mask="99999"
@@ -246,14 +264,17 @@ exports[`DeviceConnectPortEntryTest renders with "Error" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <h2>
+  <div
+    className="portNumberLabel"
+    id="port-number-text-field-label-id"
+  >
     Android device port number
-  </h2>
+  </div>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      ariaLabel="Port number"
+      aria-labelledby="port-number-text-field-label-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       mask="99999"
@@ -285,14 +306,17 @@ exports[`DeviceConnectPortEntryTest renders with "Error" and some text in the po
 <div
   className="deviceConnectPortEntry"
 >
-  <h2>
+  <div
+    className="portNumberLabel"
+    id="port-number-text-field-label-id"
+  >
     Android device port number
-  </h2>
+  </div>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      ariaLabel="Port number"
+      aria-labelledby="port-number-text-field-label-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       mask="99999"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -12,19 +12,20 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <div
+  <label
     className="portNumberLabel"
-    id="port-number-text-field-label-id"
+    htmlFor="port-number-text-field-id"
   >
     Android device port number
-  </div>
+  </label>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-label-id"
+      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
+      id="port-number-text-field-id"
       mask="99999"
       maskChar=""
       maskFormat={
@@ -54,19 +55,20 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" and some text in th
 <div
   className="deviceConnectPortEntry"
 >
-  <div
+  <label
     className="portNumberLabel"
-    id="port-number-text-field-label-id"
+    htmlFor="port-number-text-field-id"
   >
     Android device port number
-  </div>
+  </label>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-label-id"
+      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
+      id="port-number-text-field-id"
       mask="99999"
       maskChar=""
       maskFormat={
@@ -96,19 +98,20 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <div
+  <label
     className="portNumberLabel"
-    id="port-number-text-field-label-id"
+    htmlFor="port-number-text-field-id"
   >
     Android device port number
-  </div>
+  </label>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-label-id"
+      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
+      id="port-number-text-field-id"
       mask="99999"
       maskChar=""
       maskFormat={
@@ -138,19 +141,20 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" and some text in t
 <div
   className="deviceConnectPortEntry"
 >
-  <div
+  <label
     className="portNumberLabel"
-    id="port-number-text-field-label-id"
+    htmlFor="port-number-text-field-id"
   >
     Android device port number
-  </div>
+  </label>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-label-id"
+      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
+      id="port-number-text-field-id"
       mask="99999"
       maskChar=""
       maskFormat={
@@ -180,19 +184,20 @@ exports[`DeviceConnectPortEntryTest renders with "Default" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <div
+  <label
     className="portNumberLabel"
-    id="port-number-text-field-label-id"
+    htmlFor="port-number-text-field-id"
   >
     Android device port number
-  </div>
+  </label>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-label-id"
+      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
+      id="port-number-text-field-id"
       mask="99999"
       maskChar=""
       maskFormat={
@@ -222,19 +227,20 @@ exports[`DeviceConnectPortEntryTest renders with "Default" and some text in the 
 <div
   className="deviceConnectPortEntry"
 >
-  <div
+  <label
     className="portNumberLabel"
-    id="port-number-text-field-label-id"
+    htmlFor="port-number-text-field-id"
   >
     Android device port number
-  </div>
+  </label>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-label-id"
+      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
+      id="port-number-text-field-id"
       mask="99999"
       maskChar=""
       maskFormat={
@@ -264,19 +270,20 @@ exports[`DeviceConnectPortEntryTest renders with "Error" 1`] = `
 <div
   className="deviceConnectPortEntry"
 >
-  <div
+  <label
     className="portNumberLabel"
-    id="port-number-text-field-label-id"
+    htmlFor="port-number-text-field-id"
   >
     Android device port number
-  </div>
+  </label>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-label-id"
+      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
+      id="port-number-text-field-id"
       mask="99999"
       maskChar=""
       maskFormat={
@@ -306,19 +313,20 @@ exports[`DeviceConnectPortEntryTest renders with "Error" and some text in the po
 <div
   className="deviceConnectPortEntry"
 >
-  <div
+  <label
     className="portNumberLabel"
-    id="port-number-text-field-label-id"
+    htmlFor="port-number-text-field-id"
   >
     Android device port number
-  </div>
+  </label>
   <div
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-label-id"
+      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
+      id="port-number-text-field-id"
       mask="99999"
       maskChar=""
       maskFormat={

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/__snapshots__/device-connect-port-entry.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" 1`] = `
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       id="port-number-text-field-id"
@@ -65,7 +64,6 @@ exports[`DeviceConnectPortEntryTest renders with "Connected" and some text in th
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       id="port-number-text-field-id"
@@ -108,7 +106,6 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" 1`] = `
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       id="port-number-text-field-id"
@@ -151,7 +148,6 @@ exports[`DeviceConnectPortEntryTest renders with "Connecting" and some text in t
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       id="port-number-text-field-id"
@@ -194,7 +190,6 @@ exports[`DeviceConnectPortEntryTest renders with "Default" 1`] = `
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       id="port-number-text-field-id"
@@ -237,7 +232,6 @@ exports[`DeviceConnectPortEntryTest renders with "Default" and some text in the 
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       id="port-number-text-field-id"
@@ -280,7 +274,6 @@ exports[`DeviceConnectPortEntryTest renders with "Error" 1`] = `
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       id="port-number-text-field-id"
@@ -323,7 +316,6 @@ exports[`DeviceConnectPortEntryTest renders with "Error" and some text in the po
     className="deviceConnectPortEntryBody"
   >
     <MaskedTextField
-      aria-labelledby="port-number-text-field-id"
       className="portNumberField"
       data-automation-id="device-connect-port-number-field"
       id="port-number-text-field-id"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -16,8 +16,6 @@ import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
-//
-
 describe('DeviceConnectPortEntryTest', () => {
     const testPortNumber = 111;
     const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -16,6 +16,8 @@ import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
+//
+
 describe('DeviceConnectPortEntryTest', () => {
     const testPortNumber = 111;
     const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;


### PR DESCRIPTION
#### Description of changes

Changing the current `<h2>` to only be `<div>` as per bug 1676767.

Additionally, update the input to use `aria-labelledby` associated with the `<div>` containing the text `"Android device port number"`. This way, both the visual label and what the AT announce as the label match and we don't have duplication.

AT announcement when tabbing to the input field
| AT | Announcement |
| :-- | :---------------- |
| NVDA | Android device port number edit the port number must be a number between 0 and 65535 EX: 12345 blank |
| JAWS | Android device port number edit EX: 12345 the port number must be a number between 0 and 65535 type and text |
| Narrator | Android device port number edit space |

**Note** there are not visual UI changes
![image](https://user-images.githubusercontent.com/2837582/75729100-973a7400-5c9e-11ea-8105-24c7d30c14c5.png)

#### Pull request checklist
- [x] Addresses an existing issue: 1676735 & 1676767
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
