### PR TITLE
fix: disabling visual helper toggle causes scrollbar issue

### DIFF
--- a/src/electron/views/screenshot/screenshot-view.scss
+++ b/src/electron/views/screenshot/screenshot-view.scss
@@ -11,6 +11,7 @@
     padding-left: 24px;
     padding-right: 24px;
     background-color: $neutral-6-5;
+    max-height: 100%;
 
     .header {
         @include text-style-title-s;


### PR DESCRIPTION
#### Description of changes

I don't fully understand why this happening but it seems like when the visualizations are not present, the height of the screenshot view extends for as long as the screenshot itself. Setting a max-value on that to be 100% leads to the appropriate behavior.

¯\\\_(ツ)\_/¯

Here's a gif of the fixed behavior:

![androidscrollbarheightfix](https://user-images.githubusercontent.com/32555133/75732239-c7861080-5ca6-11ea-9e89-0fed454a5470.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2243 
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
