### PR TITLE
fix: use 7:1 contrast blue for neutral color of enabled toggles in high contrast mode

### DIFF
--- a/src/common/styles/high-contrast-theme-palette.ts
+++ b/src/common/styles/high-contrast-theme-palette.ts
@@ -37,5 +37,6 @@ export const HighContrastThemePalette: IPartialTheme = {
         disabledText: '#C285FF',
         primaryButtonBackground: '#38A9FF',
         primaryButtonBackgroundPressed: '#2184D0',
+        inputBackgroundChecked: '#38A9FF',
     },
 };


### PR DESCRIPTION
#### Description of changes

Previously, enabled toggles in high-contrast mode used our default `themePrimary` color from our office fabric palette, which is a 4.5:1 contrast blue in high contrast mode:

![screenshot of enabled toggle using original medium-contrast blue](https://user-images.githubusercontent.com/376284/75733015-f604eb00-5ca8-11ea-96bf-244c3dadb238.png)


This overrides the semantic color used by enabled toggles (and shared by other types of enabled form components [checkboxes, option groups, sliders] that we would also want affected similarly) to be the 7:1 blue specified by our high contrast palette mock instead:

![screenshot of enabled toggle using new high-contrast blue](https://user-images.githubusercontent.com/376284/75732998-e685a200-5ca8-11ea-9f90-523f5095bde7.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: part of 1559424
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
