### PR TITLE
feat(compliance-contrast): use 3:1 contrast text for disabled command buttons in high contrast

### DIFF
--- a/src/DetailsView/components/assessment-instance-table.tsx
+++ b/src/DetailsView/components/assessment-instance-table.tsx
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { IRenderFunction } from '@uifabric/utilities';
 import { has } from 'lodash';
-import { ActionButton } from 'office-ui-fabric-react';
 import {
     CheckboxVisibility,
     ConstrainMode,
@@ -15,6 +14,7 @@ import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { ManualTestStatus } from '../../common/types/manual-test-status';
 import {
     AssessmentNavState,
@@ -124,13 +124,13 @@ export class AssessmentInstanceTable extends React.Component<AssessmentInstanceT
         );
 
         return (
-            <ActionButton
+            <InsightsCommandButton
                 iconProps={{ iconName: 'skypeCheck' }}
                 onClick={this.onPassUnmarkedInstances}
                 disabled={disabled}
             >
                 Pass unmarked instances
-            </ActionButton>
+            </InsightsCommandButton>
         );
     }
 

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { CommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { StartOverDropdown, StartOverProps } from 'DetailsView/components/start-over-dropdown';
-import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export function getStartOverComponentForAssessment(props: CommandBarProps): JSX.Element {
@@ -27,7 +27,7 @@ export function getStartOverComponentForFastPass(props: CommandBarProps): JSX.El
     const detailsViewActionMessageCreator = props.deps.detailsViewActionMessageCreator;
 
     return (
-        <ActionButton
+        <InsightsCommandButton
             iconProps={{ iconName: 'Refresh' }}
             onClick={event =>
                 detailsViewActionMessageCreator.rescanVisualization(selectedTest, event)
@@ -36,6 +36,6 @@ export function getStartOverComponentForFastPass(props: CommandBarProps): JSX.El
             data-automation-id={startOverAutomationId}
         >
             Start over
-        </ActionButton>
+        </InsightsCommandButton>
     );
 }

--- a/src/common/components/controls/insights-command-button.scss
+++ b/src/common/components/controls/insights-command-button.scss
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../common/styles/colors.scss';
+
+button.insights-command-button {
+    &:disabled {
+        color: $disabled-text;
+    }
+}

--- a/src/common/components/controls/insights-command-button.tsx
+++ b/src/common/components/controls/insights-command-button.tsx
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { ActionButton, css, IButtonProps } from 'office-ui-fabric-react';
+import * as React from 'react';
+import * as styles from './insights-command-button.scss';
+
+export type InsightsCommandButtonProps = IButtonProps;
+
+// See https://www.figma.com/file/Wj4Ggf6GGQBQkiDIaHfXRX2B/Accessibility-Insights%3A-Styles?node-id=1%3A27
+export const InsightsCommandButton = NamedFC<InsightsCommandButtonProps>(
+    'InsightsCommandButton',
+    props => {
+        return (
+            <ActionButton
+                {...props}
+                className={css(styles.insightsCommandButton, props.className)}
+            />
+        );
+    },
+);

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-instance-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-instance-table.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssessmentInstanceTableTest renders default instance table header disabled with instance 1`] = `
-<CustomizedActionButton
+<InsightsCommandButton
   disabled={true}
   iconProps={
     Object {
@@ -11,11 +11,11 @@ exports[`AssessmentInstanceTableTest renders default instance table header disab
   onClick={[Function]}
 >
   Pass unmarked instances
-</CustomizedActionButton>
+</InsightsCommandButton>
 `;
 
 exports[`AssessmentInstanceTableTest renders default instance table header disabled without instance 1`] = `
-<CustomizedActionButton
+<InsightsCommandButton
   disabled={true}
   iconProps={
     Object {
@@ -25,11 +25,11 @@ exports[`AssessmentInstanceTableTest renders default instance table header disab
   onClick={[Function]}
 >
   Pass unmarked instances
-</CustomizedActionButton>
+</InsightsCommandButton>
 `;
 
 exports[`AssessmentInstanceTableTest renders default instance table header enabled 1`] = `
-<CustomizedActionButton
+<InsightsCommandButton
   disabled={false}
   iconProps={
     Object {
@@ -39,5 +39,5 @@ exports[`AssessmentInstanceTableTest renders default instance table header enabl
   onClick={[Function]}
 >
   Pass unmarked instances
-</CustomizedActionButton>
+</InsightsCommandButton>
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-component-factory.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`StartOverComponentFactory getStartOverComponentForAssessments renders 1
 `;
 
 exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders scanResults is not null, scanning is false => component matches snapshot 1`] = `
-<CustomizedActionButton
+<InsightsCommandButton
   data-automation-id="start-over"
   disabled={false}
   iconProps={
@@ -21,11 +21,11 @@ exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders
   onClick={[Function]}
 >
   Start over
-</CustomizedActionButton>
+</InsightsCommandButton>
 `;
 
 exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders scanResults is not null, scanning is true => component matches snapshot 1`] = `
-<CustomizedActionButton
+<InsightsCommandButton
   data-automation-id="start-over"
   disabled={true}
   iconProps={
@@ -36,11 +36,11 @@ exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders
   onClick={[Function]}
 >
   Start over
-</CustomizedActionButton>
+</InsightsCommandButton>
 `;
 
 exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders scanResults is null => component matches snapshot 1`] = `
-<CustomizedActionButton
+<InsightsCommandButton
   data-automation-id="start-over"
   disabled={false}
   iconProps={
@@ -51,5 +51,5 @@ exports[`StartOverComponentFactory getStartOverComponentPropsForFastPass renders
   onClick={[Function]}
 >
   Start over
-</CustomizedActionButton>
+</InsightsCommandButton>
 `;

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ActionButton } from 'office-ui-fabric-react';
 import { CheckboxVisibility, ConstrainMode, DetailsList, IColumn } from 'office-ui-fabric-react';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -12,6 +11,7 @@ import {
     IGetMessageGenerator,
     IMessageGenerator,
 } from 'assessments/assessment-default-message-generator';
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
 import { AssessmentResultType, GeneratedAssessmentInstance } from '../../../../../common/types/store-data/assessment-result-data';
 import {
@@ -108,9 +108,13 @@ describe('AssessmentInstanceTableTest', () => {
 
         const expected = (
             <div>
-                <ActionButton iconProps={{ iconName: 'skypeCheck' }} onClick={testObject.getOnPassUnmarkedInstances()} disabled={true}>
+                <InsightsCommandButton
+                    iconProps={{ iconName: 'skypeCheck' }}
+                    onClick={testObject.getOnPassUnmarkedInstances()}
+                    disabled={true}
+                >
                     Pass unmarked instances
-                </ActionButton>
+                </InsightsCommandButton>
                 <DetailsList
                     ariaLabelForGrid="Use arrow keys to navigate inside the instances grid"
                     items={items}

--- a/src/tests/unit/tests/common/components/controls/__snapshots__/insights-command-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/controls/__snapshots__/insights-command-button.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InsightsCommandButton renders per snapshot with extra className combined with its own 1`] = `
+<CustomizedActionButton
+  className="insightsCommandButton test-extra-class-name"
+/>
+`;
+
+exports[`InsightsCommandButton renders per snapshot with props passed through 1`] = `
+<CustomizedActionButton
+  className="insightsCommandButton"
+  text="test-text"
+/>
+`;

--- a/src/tests/unit/tests/common/components/controls/insights-command-button.test.tsx
+++ b/src/tests/unit/tests/common/components/controls/insights-command-button.test.tsx
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('InsightsCommandButton', () => {
+    it('renders per snapshot with props passed through', () => {
+        const testSubject = shallow(<InsightsCommandButton text={'test-text'} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    it('renders per snapshot with extra className combined with its own', () => {
+        const testSubject = shallow(<InsightsCommandButton className={'test-extra-class-name'} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
### Description of changes

This PR introduces a new `InsightsCommandButton` control to match the "Command button" in our [style figma](https://www.figma.com/file/Wj4Ggf6GGQBQkiDIaHfXRX2B/Accessibility-Insights%3A-Styles?node-id=1%3A27). I gave it a new `controls` folder because I expect it to be reasonable to use a similar structure for the other controls present in that Figma that we want to enforce specific insights styles for.

#757 only calls out the "Pass unmarked instances" button as failing contrast requirements in the disabled state; I audited all the other places we use `<ActionButton>`s for other cases with disable states and found that the same issue also applies to the FastPass start over button while a scan is in progress, so I fixed it while I was here.

For the initial PR, I kept its usage targeted to the specific use case we need to override the default fabric `ActionButton` styles for (the disabled text color, per #757); there are ~9 other places where we currently use an `ActionButton` that would be reasonable to replace with this new control, but I wanted to keep this PR small, so leaving them for a separate PR.

#### FastPass Start over button:
**Before**:
![fastpass-start-over-before](https://user-images.githubusercontent.com/376284/75816613-631c8d00-5d4a-11ea-94b5-bbec4671bdc9.gif)

**After**:
![fastpass-start-over-after](https://user-images.githubusercontent.com/376284/75816622-6748aa80-5d4a-11ea-83c9-58c94b4ed35e.gif)

#### Disabled "Pass all unmarked instances" button:
**Before**:
![pass-all-unmarked-before](https://user-images.githubusercontent.com/376284/75816724-93fcc200-5d4a-11ea-846d-07ef2fc6db1f.png)

**After:
![pass-all-unmarked-after](https://user-images.githubusercontent.com/376284/75816704-89dac380-5d4a-11ea-9cb4-42933178f17f.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #757, 1686479
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
