### PR TITLE
chore: modernize AssessmentInstanceTable unit tests

### DIFF
--- a/src/DetailsView/components/assessment-instance-table.tsx
+++ b/src/DetailsView/components/assessment-instance-table.tsx
@@ -24,6 +24,9 @@ import {
 import { DictionaryStringTo } from '../../types/common-types';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
 
+export const passUnmarkedInstancesButtonAutomationId =
+    'assessment-instance-table-pass-unmarked-instances-button';
+
 export interface AssessmentInstanceTableProps {
     instancesMap: DictionaryStringTo<GeneratedAssessmentInstance>;
     assessmentNavState: AssessmentNavState;
@@ -125,6 +128,7 @@ export class AssessmentInstanceTable extends React.Component<AssessmentInstanceT
 
         return (
             <InsightsCommandButton
+                data-automation-id={passUnmarkedInstancesButtonAutomationId}
                 iconProps={{ iconName: 'skypeCheck' }}
                 onClick={this.onPassUnmarkedInstances}
                 disabled={disabled}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-instance-table.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-instance-table.test.tsx.snap
@@ -1,43 +1,95 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AssessmentInstanceTableTest renders default instance table header disabled with instance 1`] = `
-<InsightsCommandButton
-  disabled={true}
-  iconProps={
-    Object {
-      "iconName": "skypeCheck",
+exports[`AssessmentInstanceTable with instances renders per snapshot 1`] = `
+<div>
+  <InsightsCommandButton
+    data-automation-id="assessment-instance-table-pass-unmarked-instances-button"
+    disabled={false}
+    iconProps={
+      Object {
+        "iconName": "skypeCheck",
+      }
     }
-  }
-  onClick={[Function]}
->
-  Pass unmarked instances
-</InsightsCommandButton>
+    onClick={[Function]}
+  >
+    Pass unmarked instances
+  </InsightsCommandButton>
+  <StyledWithViewportComponent
+    ariaLabelForGrid="Use arrow keys to navigate inside the instances grid"
+    checkboxVisibility={2}
+    columns={
+      Array [
+        Object {
+          "fieldName": "fieldName",
+          "key": "col1",
+          "minWidth": 0,
+          "name": "col1",
+        },
+      ]
+    }
+    constrainMode={1}
+    items={
+      Array [
+        Object {
+          "instance": Object {
+            "testStepResults": Object {
+              "step": Object {
+                "status": 1,
+              },
+            },
+          },
+          "statusChoiceGroup": null,
+          "visualizationButton": null,
+        },
+      ]
+    }
+    onItemInvoked={[Function]}
+    onRenderRow={[Function]}
+  />
+</div>
 `;
 
-exports[`AssessmentInstanceTableTest renders default instance table header disabled without instance 1`] = `
-<InsightsCommandButton
-  disabled={true}
-  iconProps={
-    Object {
-      "iconName": "skypeCheck",
+exports[`AssessmentInstanceTable with instances renders per snapshot with null header 1`] = `
+<div>
+  <StyledWithViewportComponent
+    ariaLabelForGrid="Use arrow keys to navigate inside the instances grid"
+    checkboxVisibility={2}
+    columns={
+      Array [
+        Object {
+          "fieldName": "fieldName",
+          "key": "col1",
+          "minWidth": 0,
+          "name": "col1",
+        },
+      ]
     }
-  }
-  onClick={[Function]}
->
-  Pass unmarked instances
-</InsightsCommandButton>
+    constrainMode={1}
+    items={
+      Array [
+        Object {
+          "instance": Object {
+            "testStepResults": Object {
+              "step": Object {
+                "status": 1,
+              },
+            },
+          },
+          "statusChoiceGroup": null,
+          "visualizationButton": null,
+        },
+      ]
+    }
+    onItemInvoked={[Function]}
+    onRenderRow={[Function]}
+  />
+</div>
 `;
 
-exports[`AssessmentInstanceTableTest renders default instance table header enabled 1`] = `
-<InsightsCommandButton
-  disabled={false}
-  iconProps={
-    Object {
-      "iconName": "skypeCheck",
-    }
-  }
-  onClick={[Function]}
->
-  Pass unmarked instances
-</InsightsCommandButton>
+exports[`AssessmentInstanceTable with null instance data renders a spinner per snapshot 1`] = `
+<StyledSpinnerBase
+  className="details-view-spinner"
+  label="Scanning"
+  size={3}
+/>
 `;

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
@@ -154,7 +154,7 @@ describe('AssessmentInstanceTable', () => {
                 testStepResults[selectedTestStep] = { status: ManualTestStatus.UNKNOWN };
 
                 const testSubject = mount(<AssessmentInstanceTable {...props} />);
-                expect(testSubject.find(passUnmarkedInstancesButtonSelector).prop('disabled')).toBeFalsy();
+                expect(testSubject.find(passUnmarkedInstancesButtonSelector).prop('disabled')).toBeUndefined();
             });
 
             it.each([ManualTestStatus.FAIL, ManualTestStatus.PASS])(
@@ -163,7 +163,7 @@ describe('AssessmentInstanceTable', () => {
                     testStepResults[selectedTestStep] = { status: testStatus };
 
                     const testSubject = mount(<AssessmentInstanceTable {...props} />);
-                    expect(testSubject.find(passUnmarkedInstancesButtonSelector).prop('disabled')).toBeTruthy();
+                    expect(testSubject.find(passUnmarkedInstancesButtonSelector).prop('disabled')).toBe(true);
                 },
             );
 

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CheckboxVisibility, ConstrainMode, DetailsList, IColumn } from 'office-ui-fabric-react';
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
+import { DetailsList, IColumn } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { Mock, MockBehavior, Times } from 'typemoq';
+import { IMock, Mock, MockBehavior, Times, It } from 'typemoq';
 
 import {
     AssessmentDefaultMessageGenerator,
@@ -11,24 +10,27 @@ import {
     IGetMessageGenerator,
     IMessageGenerator,
 } from 'assessments/assessment-default-message-generator';
-import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
+import { mount, shallow } from 'enzyme';
 import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
 import { AssessmentResultType, GeneratedAssessmentInstance } from '../../../../../common/types/store-data/assessment-result-data';
 import {
     AssessmentInstanceRowData,
     AssessmentInstanceTable,
     AssessmentInstanceTableProps,
+    passUnmarkedInstancesButtonAutomationId,
 } from '../../../../../DetailsView/components/assessment-instance-table';
 import { AssessmentInstanceTableHandler } from '../../../../../DetailsView/handlers/assessment-instance-table-handler';
 import { DictionaryStringTo } from '../../../../../types/common-types';
 
-describe('AssessmentInstanceTableTest', () => {
+describe('AssessmentInstanceTable', () => {
     let getDefaultMessageStub: IGetMessageGenerator;
-    let getDefaultMessageMock;
-    let assessmentDefaultMessageGeneratorMock;
+    let getDefaultMessageMock: IMock<IGetMessageGenerator>;
+    let assessmentDefaultMessageGeneratorMock: IMock<AssessmentDefaultMessageGenerator>;
     let generatorStub: IMessageGenerator;
-    let generatorMock;
-    let expectedMessage: DefaultMessageInterface;
+    let generatorMock: IMock<IMessageGenerator>;
+    let defaultMessage: DefaultMessageInterface;
+    let assessmentInstanceTableHandlerMock: IMock<AssessmentInstanceTableHandler>;
+    const selectedTestStep = 'step';
 
     beforeEach(() => {
         getDefaultMessageStub = generator => (map, step) => null;
@@ -41,7 +43,9 @@ describe('AssessmentInstanceTableTest', () => {
         generatorStub = (instances, step) => null;
         generatorMock = Mock.ofInstance(generatorStub);
 
-        expectedMessage = {} as DefaultMessageInterface;
+        defaultMessage = {} as DefaultMessageInterface;
+
+        assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
 
         getDefaultMessageMock
             .setup(gdm => gdm(assessmentDefaultMessageGeneratorMock.object))
@@ -49,294 +53,133 @@ describe('AssessmentInstanceTableTest', () => {
             .verifiable();
 
         generatorMock
-            .setup(gm => gm({}, 'step'))
-            .returns(() => expectedMessage)
+            .setup(gm => gm(It.isAny(), selectedTestStep))
+            .returns(() => defaultMessage)
             .verifiable();
     });
 
-    it('render spinner', () => {
-        const assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
+    describe('with null instance data', () => {
+        it('renders a spinner per snapshot', () => {
+            const props: AssessmentInstanceTableProps = getProps(
+                null,
+                assessmentInstanceTableHandlerMock.object,
+                assessmentDefaultMessageGeneratorMock.object,
+                getDefaultMessageMock.object,
+            );
 
-        const props: AssessmentInstanceTableProps = getProps(
-            null,
-            assessmentInstanceTableHandlerMock.object,
-            assessmentDefaultMessageGeneratorMock.object,
-            getDefaultMessageMock.object,
-        );
-        const testObject = new AssessmentInstanceTable(props);
-        const expected = <Spinner className="details-view-spinner" size={SpinnerSize.large} label={'Scanning'} />;
-        expect(testObject.render()).toEqual(expected);
+            const testSubject = shallow(<AssessmentInstanceTable {...props} />);
+            expect(testSubject.getElement()).toMatchSnapshot();
+        });
     });
 
-    it('render', () => {
-        const assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
-        expectedMessage = null;
+    describe('with instances', () => {
+        let props: AssessmentInstanceTableProps;
+        let testStepResults: AssessmentResultType<{}>;
 
-        const props: AssessmentInstanceTableProps = getProps(
-            {},
-            assessmentInstanceTableHandlerMock.object,
-            assessmentDefaultMessageGeneratorMock.object,
-            getDefaultMessageMock.object,
-        );
-        const items: AssessmentInstanceRowData[] = [
-            {
-                statusChoiceGroup: null,
-                visualizationButton: null,
-                instance: {} as GeneratedAssessmentInstance,
-            },
-        ];
-        const cols: IColumn[] = [
-            {
-                key: 'col1',
-                name: 'col1',
-                fieldName: 'fieldName',
-                minWidth: 0,
-            },
-        ];
+        beforeEach(() => {
+            testStepResults = {
+                [selectedTestStep]: { status: ManualTestStatus.UNKNOWN },
+            };
 
-        assessmentInstanceTableHandlerMock
-            .setup(a => a.createAssessmentInstanceTableItems(props.instancesMap, props.assessmentNavState, props.hasVisualHelper))
-            .returns(() => items)
-            .verifiable(Times.once());
+            defaultMessage = null;
 
-        assessmentInstanceTableHandlerMock
-            .setup(a => a.getColumnConfigs(props.instancesMap, props.assessmentNavState, props.hasVisualHelper))
-            .returns(() => cols)
-            .verifiable(Times.once());
-
-        const testObject = new TestableAssessmentInstanceTable(props);
-
-        const expected = (
-            <div>
-                <InsightsCommandButton
-                    iconProps={{ iconName: 'skypeCheck' }}
-                    onClick={testObject.getOnPassUnmarkedInstances()}
-                    disabled={true}
-                >
-                    Pass unmarked instances
-                </InsightsCommandButton>
-                <DetailsList
-                    ariaLabelForGrid="Use arrow keys to navigate inside the instances grid"
-                    items={items}
-                    columns={cols}
-                    checkboxVisibility={CheckboxVisibility.hidden}
-                    constrainMode={ConstrainMode.horizontalConstrained}
-                    onRenderRow={testObject.renderRow}
-                    onItemInvoked={testObject.onItemInvoked}
-                />
-            </div>
-        );
-
-        const actualObj = testObject.render();
-
-        assessmentInstanceTableHandlerMock.verifyAll();
-        getDefaultMessageMock.verifyAll();
-        expect(actualObj).toEqual(expected);
-    });
-
-    it('renders with empty header', () => {
-        const assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler, MockBehavior.Strict);
-        expectedMessage = null;
-
-        const props: AssessmentInstanceTableProps = getProps(
-            {},
-            assessmentInstanceTableHandlerMock.object,
-            assessmentDefaultMessageGeneratorMock.object,
-            getDefaultMessageMock.object,
-        );
-        props.renderInstanceTableHeader = () => null;
-        const items: AssessmentInstanceRowData[] = [
-            {
-                statusChoiceGroup: null,
-                visualizationButton: null,
-                instance: {} as GeneratedAssessmentInstance,
-            },
-        ];
-        const cols: IColumn[] = [
-            {
-                key: 'col1',
-                name: 'col1',
-                fieldName: 'fieldName',
-                minWidth: 0,
-            },
-        ];
-
-        assessmentInstanceTableHandlerMock
-            .setup(a => a.createAssessmentInstanceTableItems(props.instancesMap, props.assessmentNavState, props.hasVisualHelper))
-            .returns(() => items)
-            .verifiable(Times.once());
-
-        assessmentInstanceTableHandlerMock
-            .setup(a => a.getColumnConfigs(props.instancesMap, props.assessmentNavState, props.hasVisualHelper))
-            .returns(() => cols)
-            .verifiable(Times.once());
-
-        const testObject = new TestableAssessmentInstanceTable(props);
-
-        const expected = (
-            <div>
-                {null}
-                <DetailsList
-                    ariaLabelForGrid="Use arrow keys to navigate inside the instances grid"
-                    items={items}
-                    columns={cols}
-                    checkboxVisibility={CheckboxVisibility.hidden}
-                    constrainMode={ConstrainMode.horizontalConstrained}
-                    onRenderRow={testObject.renderRow}
-                    onItemInvoked={testObject.onItemInvoked}
-                />
-            </div>
-        );
-
-        expect(testObject.render()).toEqual(expected);
-        assessmentInstanceTableHandlerMock.verifyAll();
-        assessmentDefaultMessageGeneratorMock.verifyAll();
-        getDefaultMessageMock.verifyAll();
-    });
-
-    it('renders default instance table header enabled', () => {
-        const selectedTestStep = 'step';
-        const testStepResults = {} as AssessmentResultType<{}>;
-        testStepResults[selectedTestStep] = { status: ManualTestStatus.UNKNOWN };
-        const props = getProps({}, null, null, null);
-        const testObject = new AssessmentInstanceTable(props);
-        const items: AssessmentInstanceRowData[] = [
-            {
-                statusChoiceGroup: null,
-                visualizationButton: null,
-                instance: { testStepResults } as GeneratedAssessmentInstance,
-            },
-        ];
-
-        const actual = testObject.renderDefaultInstanceTableHeader(items);
-
-        expect(actual).toMatchSnapshot();
-    });
-
-    it('renders default instance table header disabled with instance', () => {
-        const selectedTestStep = 'step';
-        const testStepResults = {} as AssessmentResultType<{}>;
-        testStepResults[selectedTestStep] = { status: ManualTestStatus.PASS };
-        const props = getProps({}, null, null, null);
-        const testObject = new AssessmentInstanceTable(props);
-        const items: AssessmentInstanceRowData[] = [
-            {
-                statusChoiceGroup: null,
-                visualizationButton: null,
-                instance: { testStepResults } as GeneratedAssessmentInstance,
-            },
-        ];
-
-        const actual = testObject.renderDefaultInstanceTableHeader(items);
-
-        expect(actual).toMatchSnapshot();
-    });
-
-    it('renders default instance table header disabled without instance', () => {
-        const props = getProps({}, null, null, null);
-        const testObject = new AssessmentInstanceTable(props);
-        const items: AssessmentInstanceRowData[] = [];
-
-        const actual = testObject.renderDefaultInstanceTableHeader(items);
-
-        expect(actual).toMatchSnapshot();
-    });
-
-    it('onItemInvoked, updateFocusedTarget', () => {
-        const assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
-
-        const props: AssessmentInstanceTableProps = getProps(
-            {},
-            assessmentInstanceTableHandlerMock.object,
-            assessmentDefaultMessageGeneratorMock.object,
-            getDefaultMessageMock.object,
-        );
-
-        const items: AssessmentInstanceRowData[] = [
-            {
-                statusChoiceGroup: null,
-                visualizationButton: null,
-                instance: {
-                    target: ['target'],
-                } as GeneratedAssessmentInstance,
-            },
-        ];
-
-        assessmentInstanceTableHandlerMock.setup(a => a.updateFocusedTarget(items[0].instance.target)).verifiable(Times.once());
-
-        const testObject = new TestableAssessmentInstanceTable(props);
-        testObject.onItemInvoked(items[0]);
-
-        assessmentInstanceTableHandlerMock.verifyAll();
-    });
-
-    it('passUnmarkedInstances', () => {
-        const assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
-
-        const props: AssessmentInstanceTableProps = getProps(
-            {},
-            assessmentInstanceTableHandlerMock.object,
-            assessmentDefaultMessageGeneratorMock.object,
-            getDefaultMessageMock.object,
-        );
-
-        assessmentInstanceTableHandlerMock
-            .setup(a => a.passUnmarkedInstances(props.assessmentNavState.selectedTestType, props.assessmentNavState.selectedTestStep))
-            .verifiable(Times.once());
-
-        const testObject = new TestableAssessmentInstanceTable(props);
-        testObject.getOnPassUnmarkedInstances()();
-
-        assessmentInstanceTableHandlerMock.verifyAll();
-    });
-
-    it('if the function returns no failing instances message when there are instances but no failing ones', () => {
-        const assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
-        const instancesMap: DictionaryStringTo<GeneratedAssessmentInstance> = {
-            selector1: {
-                target: ['target1'],
-                html: 'html',
-                testStepResults: {
-                    step: {
-                        status: ManualTestStatus.PASS,
-                        originalStatus: 2,
-                        isVisualizationEnabled: false,
-                        isVisible: false,
-                    },
+            props = getProps(
+                {},
+                assessmentInstanceTableHandlerMock.object,
+                assessmentDefaultMessageGeneratorMock.object,
+                getDefaultMessageMock.object,
+            );
+            const items: AssessmentInstanceRowData[] = [
+                {
+                    statusChoiceGroup: null,
+                    visualizationButton: null,
+                    instance: { testStepResults } as GeneratedAssessmentInstance,
                 },
-            },
-            selector2: {
-                target: ['target2'],
-                html: 'html',
-                testStepResults: {
-                    step1: {
-                        status: ManualTestStatus.PASS,
-                        isVisualizationEnabled: false,
-                        isVisible: false,
-                    },
+            ];
+            const cols: IColumn[] = [
+                {
+                    key: 'col1',
+                    name: 'col1',
+                    fieldName: 'fieldName',
+                    minWidth: 0,
                 },
-            },
-        };
-        expectedMessage = {
-            message: <div className="no-failure-view">No failing instances</div>,
-            instanceCount: 1,
-        } as DefaultMessageInterface;
+            ];
 
-        generatorMock
-            .setup(gm => gm(instancesMap, 'step'))
-            .returns(() => expectedMessage)
-            .verifiable();
+            assessmentInstanceTableHandlerMock
+                .setup(a => a.createAssessmentInstanceTableItems(props.instancesMap, props.assessmentNavState, props.hasVisualHelper))
+                .returns(() => items)
+                .verifiable(Times.once());
 
-        const props: AssessmentInstanceTableProps = getProps(
-            instancesMap,
-            assessmentInstanceTableHandlerMock.object,
-            assessmentDefaultMessageGeneratorMock.object,
-            getDefaultMessageMock.object,
-        );
+            assessmentInstanceTableHandlerMock
+                .setup(a => a.getColumnConfigs(props.instancesMap, props.assessmentNavState, props.hasVisualHelper))
+                .returns(() => cols)
+                .verifiable(Times.once());
+        });
 
-        const testObject = new TestableAssessmentInstanceTable(props);
-        expect(testObject.render()).toEqual(expectedMessage.message);
-        getDefaultMessageMock.verifyAll();
+        it('renders per snapshot', () => {
+            const testSubject = shallow(<AssessmentInstanceTable {...props} />);
+            expect(testSubject.getElement()).toMatchSnapshot();
+        });
+
+        it('renders per snapshot with null header', () => {
+            const testSubject = shallow(<AssessmentInstanceTable {...props} renderInstanceTableHeader={() => null} />);
+            expect(testSubject.getElement()).toMatchSnapshot();
+        });
+
+        it('prefers rendering with getDefaultMessage if non-null', () => {
+            defaultMessage = {
+                message: <>Message from getDefaultMessage</>,
+                instanceCount: 1,
+            } as DefaultMessageInterface;
+
+            const testSubject = shallow(<AssessmentInstanceTable {...props} />);
+            expect(testSubject.getElement()).toEqual(defaultMessage.message);
+
+            getDefaultMessageMock.verifyAll();
+        });
+
+        it("delegates the underlying list's onItemInvoked to the handler's updateFocusedTarget", () => {
+            const fakeItem = { instance: { target: ['fake-instance-target-0'] } };
+            assessmentInstanceTableHandlerMock.setup(a => a.updateFocusedTarget(fakeItem.instance.target)).verifiable(Times.once());
+
+            const testSubject = mount(<AssessmentInstanceTable {...props} />);
+            testSubject.find(DetailsList).prop('onItemInvoked')(fakeItem);
+
+            assessmentInstanceTableHandlerMock.verifyAll();
+        });
+
+        describe('"Pass all unmarked instances" button', () => {
+            const passUnmarkedInstancesButtonSelector = `button[data-automation-id="${passUnmarkedInstancesButtonAutomationId}"]`;
+            it('is enabled if there is an instance with unknown status', () => {
+                testStepResults[selectedTestStep] = { status: ManualTestStatus.UNKNOWN };
+
+                const testSubject = mount(<AssessmentInstanceTable {...props} />);
+                expect(testSubject.find(passUnmarkedInstancesButtonSelector).prop('disabled')).toBeFalsy();
+            });
+
+            it.each([ManualTestStatus.FAIL, ManualTestStatus.PASS])(
+                'is disabled if all instances are in non-UNKNOWN status %p',
+                testStatus => {
+                    testStepResults[selectedTestStep] = { status: testStatus };
+
+                    const testSubject = mount(<AssessmentInstanceTable {...props} />);
+                    expect(testSubject.find(passUnmarkedInstancesButtonSelector).prop('disabled')).toBeTruthy();
+                },
+            );
+
+            it("delegates the button action to the handler's passUnmarkedInstances", () => {
+                assessmentInstanceTableHandlerMock
+                    .setup(a =>
+                        a.passUnmarkedInstances(props.assessmentNavState.selectedTestType, props.assessmentNavState.selectedTestStep),
+                    )
+                    .verifiable(Times.once());
+
+                const testSubject = mount(<AssessmentInstanceTable {...props} />);
+                testSubject.find(passUnmarkedInstancesButtonSelector).simulate('click');
+
+                assessmentInstanceTableHandlerMock.verifyAll();
+            });
+        });
     });
 
     function getProps(
@@ -349,7 +192,7 @@ describe('AssessmentInstanceTableTest', () => {
             instancesMap: instancesMap,
             columnConfiguration: [],
             assessmentNavState: {
-                selectedTestStep: 'step',
+                selectedTestStep: selectedTestStep,
                 selectedTestType: 1,
             },
             assessmentInstanceTableHandler: assessmentInstanceTableHandler,
@@ -361,9 +204,3 @@ describe('AssessmentInstanceTableTest', () => {
         };
     }
 });
-
-class TestableAssessmentInstanceTable extends AssessmentInstanceTable {
-    public getOnPassUnmarkedInstances(): () => void {
-        return this.onPassUnmarkedInstances;
-    }
-}

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { DetailsList, IColumn } from 'office-ui-fabric-react';
 import * as React from 'react';
-import { IMock, Mock, MockBehavior, Times, It } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import {
     AssessmentDefaultMessageGenerator,


### PR DESCRIPTION
#### Description of changes

Followup to comment from #2273 suggesting redoing AssessmentInstanceTable tests in terms of `enzyme`. I ended up basically doing a complete rewrite.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
