### PR TITLE
feat(compliance-contrast): update switcher

### DIFF
--- a/src/DetailsView/components/switcher.scss
+++ b/src/DetailsView/components/switcher.scss
@@ -2,6 +2,11 @@
 // Licensed under the MIT License.
 @import '../../common/styles/colors.scss';
 
+@mixin title-border {
+    border: 1px $neutral-0 solid;
+    border-radius: 2px;
+}
+
 // The two layers of class selector and the explicit enumeration of the states are both
 // required to beat the specificity of office fabric styles
 .header-switcher .header-switcher-dropdown {
@@ -11,11 +16,12 @@
     &:active,
     &:hover:active {
         :global(.ms-Dropdown-title) {
-            background-color: $ada-brand-variant;
+            @include title-border;
+
+            background-color: $ada-brand-color;
             height: 32px;
-            border: 2px $switcher-border solid;
+
             box-sizing: border-box;
-            border-radius: 2px;
             width: 165px;
             color: $neutral-0;
             i {
@@ -23,7 +29,8 @@
             }
         }
         :global(.ms-Dropdown-caretDownWrapper) {
-            top: 4px;
+            top: 2px;
+            right: 10px;
         }
         :global(.ms-Dropdown-caretDown) {
             color: $neutral-0;
@@ -31,8 +38,10 @@
     }
 
     :global(.ms-Dropdown):focus::after {
-        border: 2px $switcher-focus-border solid;
-        border-style: dotted;
+        @include title-border;
+
+        outline: 1px $neutral-0 solid;
+        outline-offset: -5px;
     }
 }
 

--- a/src/DetailsView/components/switcher.tsx
+++ b/src/DetailsView/components/switcher.tsx
@@ -69,7 +69,7 @@ export class Switcher extends React.Component<SwitcherProps, SwitcherState> {
                 key: DetailsViewPivotType.assessment,
                 text: 'Assessment',
                 data: {
-                    icon: 'testBeaker',
+                    icon: 'testBeakerSolid',
                 },
             },
         ];

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/switcher.test.tsx.snap
@@ -11,7 +11,7 @@ Array [
   },
   Object {
     "data": Object {
-      "icon": "testBeaker",
+      "icon": "testBeakerSolid",
     },
     "key": 2,
     "text": "Assessment",


### PR DESCRIPTION
#### Description of changes

Update the switcher styles so:
- we solve the color contrast issues between the dropdown background color and the surrounding background color by making both background colors the same and adding a permanent border with enough contrast against the background color
- update the assessment icon to match the mock
- update the focus ring indicator to match the new focus ring design from the mocks

**Note** the screenshots were taken at 110% zoom

#### Default theme
**default state**
![01 - default theme - default state](https://user-images.githubusercontent.com/2837582/75828395-9a963400-5d60-11ea-9cde-8c6c5da6f0ec.png)
**focus state**
![02 - default theme - focus state](https://user-images.githubusercontent.com/2837582/75828397-9b2eca80-5d60-11ea-848b-192e51d18d51.png)
**expanded state**
![03 - default theme - expanded state](https://user-images.githubusercontent.com/2837582/75828398-9b2eca80-5d60-11ea-8534-54460d3e7bfd.png)
##### High contrast theme
**default state**
![04 - high contrast theme - default state](https://user-images.githubusercontent.com/2837582/75828399-9b2eca80-5d60-11ea-8303-e40b901d9d2c.png)
**focus state**
![05 - high contast theme - focus state](https://user-images.githubusercontent.com/2837582/75828401-9bc76100-5d60-11ea-8b23-74c500d7073f.png)
**expanded state**
![06 - high contrast theme - expanded state](https://user-images.githubusercontent.com/2837582/75828402-9bc76100-5d60-11ea-9178-a2487da726b5.png)

#### Pull request checklist
- [x] Addresses an existing issue: #761
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
