### PR TITLE
chore: line width for src/tests/unit/tests/debug-tools folder

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -12,7 +12,6 @@ module.exports = {
                 'src/content/**/*',
                 'src/icons/**/*',
                 'src/tests/unit/tests/common/**/*',
-                'src/tests/unit/tests/debug-tools/**/*',
                 'src/tests/unit/tests/DetailsView/**/*',
                 'src/tests/unit/tests/electron/**/*',
                 'src/tests/unit/tests/injected/**/*',

--- a/src/tests/unit/tests/debug-tools/action-creators/debug-tools-action-creator.test.ts
+++ b/src/tests/unit/tests/debug-tools/action-creators/debug-tools-action-creator.test.ts
@@ -11,7 +11,10 @@ describe('DebugToolsActionCreator', () => {
         const interpreterMock = createInterpreterMock(Messages.DebugTools.Open, undefined);
         const debugToolsControllerMock = Mock.ofType<DebugToolsController>();
 
-        const testSubject = new DebugToolsActionCreator(interpreterMock.object, debugToolsControllerMock.object);
+        const testSubject = new DebugToolsActionCreator(
+            interpreterMock.object,
+            debugToolsControllerMock.object,
+        );
 
         testSubject.registerCallback();
 

--- a/src/tests/unit/tests/debug-tools/components/stores-tree.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/stores-tree.test.tsx
@@ -2,7 +2,12 @@
 // Licensed under the MIT License.
 import { BaseStore } from 'common/base-store';
 import { StoreActionMessageCreator } from 'common/message-creators/store-action-message-creator';
-import { columns, StoresTree, StoresTreeProps, StoresTreeState } from 'debug-tools/components/stores-tree';
+import {
+    columns,
+    StoresTree,
+    StoresTreeProps,
+    StoresTreeState,
+} from 'debug-tools/components/stores-tree';
 import { shallow } from 'enzyme';
 import { GroupedList } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -39,7 +44,9 @@ describe('StoresTree', () => {
         it('should add listeners to the stores', () => {
             shallow(<StoresTree {...props} />);
 
-            storeMocks.forEach(mock => mock.verify(store => store.addChangedListener(itIsFunction), Times.once()));
+            storeMocks.forEach(mock =>
+                mock.verify(store => store.addChangedListener(itIsFunction), Times.once()),
+            );
         });
 
         it('should call to get all the states', () => {
@@ -116,7 +123,9 @@ describe('StoresTree', () => {
 
         let storeListener: Function;
 
-        storeMock.setup(store => store.addChangedListener(itIsFunction)).callback(listener => (storeListener = listener));
+        storeMock
+            .setup(store => store.addChangedListener(itIsFunction))
+            .callback(listener => (storeListener = listener));
 
         storeMock.setup(store => store.getId()).returns(() => 'test-store-id');
         storeMock


### PR DESCRIPTION
#### Description of changes

Add `src/tests/unit/tests/debug-tools` folder to prettier override for the line width value.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
