### PR TITLE
chore: line width for src/tests/unit/tests/views folder

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -18,7 +18,6 @@ module.exports = {
                 'src/tests/unit/tests/issue-filing/**/*',
                 'src/tests/unit/tests/popup/**/*',
                 'src/tests/unit/tests/reports/**/*',
-                'src/tests/unit/tests/views/**/*',
             ],
             options: {
                 printWidth: 140,

--- a/src/tests/unit/tests/views/content/content-link.test.tsx
+++ b/src/tests/unit/tests/views/content/content-link.test.tsx
@@ -35,22 +35,35 @@ describe('ContentLink', () => {
     });
 
     it('renders from content, only have the icon', () => {
-        const result = shallow(<ContentLink deps={deps} reference={content.for.testing} iconName={'test icon 1'} />);
+        const result = shallow(
+            <ContentLink deps={deps} reference={content.for.testing} iconName={'test icon 1'} />,
+        );
         expect(result.debug()).toMatchSnapshot();
     });
 
     it('renders from path, only have the icon', () => {
-        const result = shallow(<ContentLink deps={deps} reference={contentPath} iconName={'test icon 2'} />);
+        const result = shallow(
+            <ContentLink deps={deps} reference={contentPath} iconName={'test icon 2'} />,
+        );
         expect(result.debug()).toMatchSnapshot();
     });
 
     it('renders with only text', () => {
-        const result = shallow(<ContentLink deps={deps} reference={contentPath} linkText={'test'} />);
+        const result = shallow(
+            <ContentLink deps={deps} reference={contentPath} linkText={'test'} />,
+        );
         expect(result.debug()).toMatchSnapshot();
     });
 
     it('renders with both text and icon', () => {
-        const result = shallow(<ContentLink deps={deps} reference={contentPath} linkText={'test'} iconName="test icon" />);
+        const result = shallow(
+            <ContentLink
+                deps={deps}
+                reference={contentPath}
+                linkText={'test'}
+                iconName="test icon"
+            />,
+        );
         expect(result.debug()).toMatchSnapshot();
     });
 

--- a/src/tests/unit/tests/views/content/content-page.test.tsx
+++ b/src/tests/unit/tests/views/content/content-page.test.tsx
@@ -24,7 +24,9 @@ describe('ContentPage', () => {
                 return <>{(Markup as any).options.testString}</>;
             });
 
-            const result = shallow(<MyPage deps={deps} options={{ setPageTitle: true, testString: 'TEST STRING' }} />);
+            const result = shallow(
+                <MyPage deps={deps} options={{ setPageTitle: true, testString: 'TEST STRING' }} />,
+            );
             expect(result.getElement()).toMatchSnapshot();
         });
     });
@@ -69,7 +71,13 @@ describe('ContentPage', () => {
             expect(result.getElement()).toMatchSnapshot();
         });
 
-        ['forest', 'notForest/thePage', 'forest/notThePage', 'extraPath/forest/thePage', 'thePage'].forEach(page =>
+        [
+            'forest',
+            'notForest/thePage',
+            'forest/notThePage',
+            'extraPath/forest/thePage',
+            'thePage',
+        ].forEach(page =>
             it(`doesn't find ${page}`, () => {
                 const MyPage = provider.getPage(page);
                 expect(MyPage.displayName).toEqual('ContentPageComponent');

--- a/src/tests/unit/tests/views/content/content-panel.test.tsx
+++ b/src/tests/unit/tests/views/content/content-panel.test.tsx
@@ -24,7 +24,9 @@ describe('ContentPanel', () => {
     };
 
     it('renders from content', () => {
-        const result = shallow(<ContentPanel deps={deps} content={content.for.testing} isOpen={true} />);
+        const result = shallow(
+            <ContentPanel deps={deps} content={content.for.testing} isOpen={true} />,
+        );
         expect(result.debug()).toMatchSnapshot();
     });
 

--- a/src/tests/unit/tests/views/content/content.test.tsx
+++ b/src/tests/unit/tests/views/content/content.test.tsx
@@ -9,7 +9,9 @@ import { ContentProvider } from 'views/content/content-page';
 describe('content', () => {
     it('renders', () => {
         const contentFromReference = jest.fn().mockReturnValue('THE-CONTENT');
-        const contentProvider = ({ contentFromReference } as Partial<ContentProvider>) as ContentProvider;
+        const contentProvider = ({ contentFromReference } as Partial<
+            ContentProvider
+        >) as ContentProvider;
         const deps = ({ contentProvider } as Partial<ContentDeps>) as ContentDeps;
 
         const component = <Content deps={deps} reference="content/path" />;

--- a/src/tests/unit/tests/views/content/markup.test.tsx
+++ b/src/tests/unit/tests/views/content/markup.test.tsx
@@ -139,7 +139,11 @@ describe('ContentPage', () => {
                 const wrapper = shallow(
                     <PassFail
                         failText={<p>I FAILED :(</p>}
-                        failExample={<CodeExample title="How I failed">This is the failure [example].</CodeExample>}
+                        failExample={
+                            <CodeExample title="How I failed">
+                                This is the failure [example].
+                            </CodeExample>
+                        }
                         passText={<p>I PASSED!</p>}
                         passExample={
                             <CodeExample
@@ -170,7 +174,10 @@ describe('ContentPage', () => {
             it('registers click with event', () => {
                 wrapper.simulate('click');
 
-                contentActionMessageCreatorMock.verify(m => m.openContentHyperLink(It.isAny(), href), Times.once());
+                contentActionMessageCreatorMock.verify(
+                    m => m.openContentHyperLink(It.isAny(), href),
+                    Times.once(),
+                );
             });
         });
 

--- a/src/tests/unit/tests/views/content/markup/code-example.test.tsx
+++ b/src/tests/unit/tests/views/content/markup/code-example.test.tsx
@@ -43,7 +43,9 @@ describe('<CodeExample>', () => {
     });
 
     it('renders with many highlighted regions', () => {
-        const wrapper = shallow(<CodeExample>With [quite] a [number] of [highlights].</CodeExample>);
+        const wrapper = shallow(
+            <CodeExample>With [quite] a [number] of [highlights].</CodeExample>,
+        );
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 
@@ -63,7 +65,9 @@ describe('<CodeExample>', () => {
     });
 
     it('renders with a highlight that breaks in the middle of multiple lines', () => {
-        const wrapper = shallow(<CodeExample>{`Line 1\nLine 2 [HIGHLIGHT\nHERE]Line 3\nLine 4`}</CodeExample>);
+        const wrapper = shallow(
+            <CodeExample>{`Line 1\nLine 2 [HIGHLIGHT\nHERE]Line 3\nLine 4`}</CodeExample>,
+        );
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 

--- a/src/tests/unit/tests/views/insights/dependencies.test.ts
+++ b/src/tests/unit/tests/views/insights/dependencies.test.ts
@@ -12,7 +12,10 @@ import { RendererDeps } from 'views/insights/renderer';
 describe('rendererDependencies', () => {
     let subject: RendererDeps;
     beforeAll(() => {
-        subject = rendererDependencies(Mock.ofType<BrowserAdapter>().object, Mock.ofType<Logger>().object);
+        subject = rendererDependencies(
+            Mock.ofType<BrowserAdapter>().object,
+            Mock.ofType<Logger>().object,
+        );
     });
 
     it('includes dom', () => {

--- a/src/tests/unit/tests/views/insights/renderer.test.tsx
+++ b/src/tests/unit/tests/views/insights/renderer.test.tsx
@@ -15,7 +15,8 @@ describe('insights renderer', () => {
     } as Partial<RendererDeps>) as RendererDeps;
 
     beforeEach(() => {
-        document.head.innerHTML = '<link rel="shortcut icon" type="image/x-icon" href="../old-icon.png" />';
+        document.head.innerHTML =
+            '<link rel="shortcut icon" type="image/x-icon" href="../old-icon.png" />';
         document.body.innerHTML = '<div id="insights-root" />';
 
         configMutator.setOption('icon128', 'new-icon.png');


### PR DESCRIPTION
#### Description of changes

Add ` src/tests/unit/tests/views` folder to prettier override for the line width value.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
