### PR TITLE
feat(android-settings): add user configuration controller to window on AI-Android

### DIFF
--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -16,6 +16,7 @@ import { Interpreter } from 'background/interpreter';
 import { CardSelectionStore } from 'background/stores/card-selection-store';
 import { DetailsViewStore } from 'background/stores/details-view-store';
 import { UnifiedScanResultStore } from 'background/stores/unified-scan-result-store';
+import { UserConfigurationController } from 'background/user-configuration-controller';
 import { onlyHighlightingSupported } from 'common/components/cards/card-interaction-support';
 import { ExpandCollapseVisualHelperModifierButtons } from 'common/components/cards/cards-visualization-modifier-buttons';
 import { CardsCollapsibleControl } from 'common/components/cards/collapsible-component-cards';
@@ -87,6 +88,10 @@ import {
     RootContainerRendererDeps,
 } from './root-container/root-container-renderer';
 import { screenshotViewModelProvider } from './screenshot/screenshot-view-model-provider';
+
+declare var window: Window & {
+    insightsUserConfiguration: UserConfigurationController;
+};
 
 initializeFabricIcons();
 
@@ -330,6 +335,8 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
 
         const renderer = new RootContainerRenderer(ReactDOM.render, document, deps);
         renderer.render();
+
+        window.insightsUserConfiguration = new UserConfigurationController(interpreter);
 
         sendAppInitializedTelemetryEvent(telemetryEventHandler, platformInfo);
 

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -44,4 +44,10 @@ export class AppController {
 
         return automatedChecksView;
     }
+
+    public async setHighContrastMode(enableHighContrast: boolean): Promise<void> {
+        await this.app.webContents.executeJavaScript(
+            `window.insightsUserConfiguration.setHighContrastMode(${enableHighContrast})`,
+        );
+    }
 }


### PR DESCRIPTION
#### Description of changes

Same as we have on AI-Web, adding an instance of the `UserConfigurationController` under `window.insightsUserConfiguration` so we can set up high contrast mode programatically on our e2e tests.

#### Pull request checklist
- [x] Addresses an existing issue: WI # 1678717
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
