### PR TITLE
chore: line width for src/tests/unit/tests/report folder

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -16,7 +16,6 @@ module.exports = {
                 'src/tests/unit/tests/injected/**/*',
                 'src/tests/unit/tests/issue-filing/**/*',
                 'src/tests/unit/tests/popup/**/*',
-                'src/tests/unit/tests/reports/**/*',
             ],
             options: {
                 printWidth: 140,

--- a/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
@@ -5,7 +5,10 @@ import { AssessmentStoreData } from 'common/types/store-data/assessment-result-d
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import * as React from 'react';
-import { AssessmentReportHtmlGenerator, AssessmentReportHtmlGeneratorDeps } from 'reports/assessment-report-html-generator';
+import {
+    AssessmentReportHtmlGenerator,
+    AssessmentReportHtmlGeneratorDeps,
+} from 'reports/assessment-report-html-generator';
 import { ReportModel } from 'reports/assessment-report-model';
 import { AssessmentReportModelBuilder } from 'reports/assessment-report-model-builder';
 import { AssessmentReportModelBuilderFactory } from 'reports/assessment-report-model-builder-factory';
@@ -32,7 +35,9 @@ describe('AssessmentReportHtmlGenerator', () => {
         const description = 'generateHtml-description';
 
         const deps: AssessmentReportHtmlGeneratorDeps = {
-            outcomeTypeSemanticsFromTestStatus: { stub: 'outcomeTypeSemanticsFromTestStatus' } as any,
+            outcomeTypeSemanticsFromTestStatus: {
+                stub: 'outcomeTypeSemanticsFromTestStatus',
+            } as any,
         } as AssessmentReportHtmlGeneratorDeps;
 
         const modelBuilderMock = Mock.ofType(AssessmentReportModelBuilder, MockBehavior.Strict);
@@ -67,12 +72,22 @@ describe('AssessmentReportHtmlGenerator', () => {
         dateGetterMock.setup(dg => dg()).returns(() => testDate);
 
         factoryMock
-            .setup(f => f.create(It.isAny(), assessmentStoreData, tabStoreData, testDate, assessmentDefaultMessageGenerator))
+            .setup(f =>
+                f.create(
+                    It.isAny(),
+                    assessmentStoreData,
+                    tabStoreData,
+                    testDate,
+                    assessmentDefaultMessageGenerator,
+                ),
+            )
             .returns(() => modelBuilderMock.object);
 
         modelBuilderMock.setup(mb => mb.getReportModelData()).returns(() => model);
 
-        rendererMock.setup(r => r.renderToStaticMarkup(It.isObjectWith(expectedComponent))).returns(() => expectedBody);
+        rendererMock
+            .setup(r => r.renderToStaticMarkup(It.isObjectWith(expectedComponent)))
+            .returns(() => expectedBody);
 
         const testSubject = new AssessmentReportHtmlGenerator(
             deps,

--- a/src/tests/unit/tests/reports/components/assessment-report-assessment-list.test.tsx
+++ b/src/tests/unit/tests/reports/components/assessment-report-assessment-list.test.tsx
@@ -63,7 +63,10 @@ describe('AssessmentReportAssessmentListTest', () => {
         expect(wrapper.getElement()).toMatchSnapshot();
     }
 
-    function testAssessmentHeader(assessment: AssessmentDetailsReportModel, assessmentHeader: Enzyme.ShallowWrapper<any, any>): void {
+    function testAssessmentHeader(
+        assessment: AssessmentDetailsReportModel,
+        assessmentHeader: Enzyme.ShallowWrapper<any, any>,
+    ): void {
         expect(assessmentHeader.hasClass('assessment-header')).toBe(true);
         expect(assessmentHeader.children()).toHaveLength(2);
 

--- a/src/tests/unit/tests/reports/components/assessment-report-body.test.tsx
+++ b/src/tests/unit/tests/reports/components/assessment-report-body.test.tsx
@@ -2,13 +2,19 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { AssessmentReportBody, AssessmentReportBodyDeps, AssessmentReportBodyProps } from 'reports/components/assessment-report-body';
+import {
+    AssessmentReportBody,
+    AssessmentReportBodyDeps,
+    AssessmentReportBodyProps,
+} from 'reports/components/assessment-report-body';
 import { AssessmentReportBuilderTestHelper } from '../../DetailsView/assessment-report-builder-test-helper';
 
 describe('AssessmentReportBody', () => {
     test('render', () => {
         const deps: AssessmentReportBodyDeps = {
-            outcomeTypeSemanticsFromTestStatus: { stub: 'outcomeTypeSemanticsFromTestStatus' } as any,
+            outcomeTypeSemanticsFromTestStatus: {
+                stub: 'outcomeTypeSemanticsFromTestStatus',
+            } as any,
         } as AssessmentReportBodyDeps;
 
         const props: AssessmentReportBodyProps = {

--- a/src/tests/unit/tests/reports/components/assessment-report-footer.test.tsx
+++ b/src/tests/unit/tests/reports/components/assessment-report-footer.test.tsx
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { AssessmentReportFooter, AssessmentReportFooterProps } from 'reports/components/assessment-report-footer';
+import {
+    AssessmentReportFooter,
+    AssessmentReportFooterProps,
+} from 'reports/components/assessment-report-footer';
 
 describe('AssessmentReportFooter', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/reports/components/assessment-report-step-header.test.tsx
+++ b/src/tests/unit/tests/reports/components/assessment-report-step-header.test.tsx
@@ -7,7 +7,10 @@ import { Mock } from 'typemoq';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { ManualTestStatus } from 'common/types/manual-test-status';
 import { RequirementHeaderReportModel, RequirementType } from 'reports/assessment-report-model';
-import { AssessmentReportStepHeader, AssessmentReportStepHeaderDeps } from 'reports/components/assessment-report-step-header';
+import {
+    AssessmentReportStepHeader,
+    AssessmentReportStepHeaderDeps,
+} from 'reports/components/assessment-report-step-header';
 import { OutcomeChip } from 'reports/components/outcome-chip';
 import { RequirementOutcomeType } from 'reports/components/requirement-outcome-type';
 
@@ -34,7 +37,13 @@ describe('AssessmentReportStepHeader', () => {
         const header = genHeader('assisted');
 
         const actual = shallow(
-            <AssessmentReportStepHeader deps={deps} status={FAIL} header={header} instanceCount={42} defaultMessageComponent={null} />,
+            <AssessmentReportStepHeader
+                deps={deps}
+                status={FAIL}
+                header={header}
+                instanceCount={42}
+                defaultMessageComponent={null}
+            />,
         );
         expect(actual.getElement()).toMatchSnapshot();
     });
@@ -55,14 +64,20 @@ describe('AssessmentReportStepHeader', () => {
                         describe(`with instance count of ${instanceCount}`, () => {
                             let expectedCount = instanceCount;
 
-                            if (outcomeType === 'pass' && requirementType === 'manual' && expectedCount === 0) {
+                            if (
+                                outcomeType === 'pass' &&
+                                requirementType === 'manual' &&
+                                expectedCount === 0
+                            ) {
                                 expectedCount = 1;
                             }
 
                             const header = genHeader(requirementType);
 
                             const defaultMessageComponent = {
-                                message: <div className="no-failure-view">No failing instances</div>,
+                                message: (
+                                    <div className="no-failure-view">No failing instances</div>
+                                ),
                                 instanceCount: expectedCount,
                             };
                             const component = (
@@ -79,7 +94,9 @@ describe('AssessmentReportStepHeader', () => {
 
                             it(`will have OutcomeChip with count of ${expectedCount} and outcomeType of ${outcomeType}`, () => {
                                 const chip = wrapper.find(OutcomeChip).getElement();
-                                expect(chip).toEqual(<OutcomeChip count={expectedCount} outcomeType={outcomeType} />);
+                                expect(chip).toEqual(
+                                    <OutcomeChip count={expectedCount} outcomeType={outcomeType} />,
+                                );
                             });
 
                             const messageWrapper = wrapper.find('.no-failure-view');

--- a/src/tests/unit/tests/reports/components/assessment-report-summary.test.tsx
+++ b/src/tests/unit/tests/reports/components/assessment-report-summary.test.tsx
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentReportSummary, AssessmentReportSummaryProps } from 'reports/components/assessment-report-summary';
+import {
+    AssessmentReportSummary,
+    AssessmentReportSummaryProps,
+} from 'reports/components/assessment-report-summary';
 
 describe('AssessmentReportSummary', () => {
     describe('render', () => {

--- a/src/tests/unit/tests/reports/components/assessment-report.test.tsx
+++ b/src/tests/unit/tests/reports/components/assessment-report.test.tsx
@@ -9,7 +9,9 @@ import { AssessmentReportBuilderTestHelper } from '../../DetailsView/assessment-
 describe('AssessmentReport', () => {
     test('render', () => {
         const deps: AssessmentReportDeps = {
-            outcomeTypeSemanticsFromTestStatus: { stub: 'outcomeTypeSemanticsFromTestStatus' } as any,
+            outcomeTypeSemanticsFromTestStatus: {
+                stub: 'outcomeTypeSemanticsFromTestStatus',
+            } as any,
         } as AssessmentReportDeps;
 
         const data = AssessmentReportBuilderTestHelper.getAssessmentReportModel();

--- a/src/tests/unit/tests/reports/components/assessment-scan-details.test.tsx
+++ b/src/tests/unit/tests/reports/components/assessment-scan-details.test.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScanDetailsReportModel } from 'reports/assessment-report-model';
-import { AssessmentScanDetails, AssessmentScanDetailsProps } from 'reports/components/assessment-scan-details';
+import {
+    AssessmentScanDetails,
+    AssessmentScanDetailsProps,
+} from 'reports/components/assessment-scan-details';
 
 describe('AssessmentScanDetails', () => {
     describe('render', () => {

--- a/src/tests/unit/tests/reports/components/assessment-summary-details.test.tsx
+++ b/src/tests/unit/tests/reports/components/assessment-summary-details.test.tsx
@@ -2,14 +2,18 @@
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { AssessmentSummaryDetails, AssessmentSummaryDetailsProps } from 'reports/components/assessment-summary-details';
+import {
+    AssessmentSummaryDetails,
+    AssessmentSummaryDetailsProps,
+} from 'reports/components/assessment-summary-details';
 import { AssessmentReportBuilderTestHelper } from '../../DetailsView/assessment-report-builder-test-helper';
 
 describe('AssessmentSummaryDetails', () => {
     describe('render', () => {
         test('Correct composition', () => {
             const props: AssessmentSummaryDetailsProps = {
-                testSummaries: AssessmentReportBuilderTestHelper.getAssessmentsSummaryReportModel().reportSummaryDetailsData,
+                testSummaries: AssessmentReportBuilderTestHelper.getAssessmentsSummaryReportModel()
+                    .reportSummaryDetailsData,
             };
 
             const wrapper = shallow(<AssessmentSummaryDetails {...props} />);

--- a/src/tests/unit/tests/reports/components/inline-image.test.tsx
+++ b/src/tests/unit/tests/reports/components/inline-image.test.tsx
@@ -21,7 +21,13 @@ describe('InlineImageTest', () => {
 
     test('optional class name', () => {
         const testClassName = 'test-class-name';
-        const wrapped = shallow(<InlineImage imageType={InlineImageType.SleepingAda} alt="" className={testClassName} />);
+        const wrapped = shallow(
+            <InlineImage
+                imageType={InlineImageType.SleepingAda}
+                alt=""
+                className={testClassName}
+            />,
+        );
 
         const element = wrapped.getElement();
 

--- a/src/tests/unit/tests/reports/components/outcome-icon.test.tsx
+++ b/src/tests/unit/tests/reports/components/outcome-icon.test.tsx
@@ -21,7 +21,14 @@ describe('OutcomeIcon', () => {
     });
 });
 
-[CheckIcon, CheckIconInverted, CircleIcon, CrossIconInverted, InapplicableIcon, InapplicableIconInverted].forEach(Icon => {
+[
+    CheckIcon,
+    CheckIconInverted,
+    CircleIcon,
+    CrossIconInverted,
+    InapplicableIcon,
+    InapplicableIconInverted,
+].forEach(Icon => {
     const name = Icon.displayName;
     describe(name, () => {
         test('render', () => {

--- a/src/tests/unit/tests/reports/components/outcome-summary-bar.test.tsx
+++ b/src/tests/unit/tests/reports/components/outcome-summary-bar.test.tsx
@@ -28,7 +28,11 @@ describe('OutcomeSummaryBar', () => {
     });
 
     it('render inverted badges', () => {
-        const props: OutcomeSummaryBarProps = { outcomeStats, allOutcomeTypes, iconStyleInverted: true };
+        const props: OutcomeSummaryBarProps = {
+            outcomeStats,
+            allOutcomeTypes,
+            iconStyleInverted: true,
+        };
         const wrapper = shallow(<OutcomeSummaryBar {...props} />);
 
         expect(wrapper.getElement()).toMatchSnapshot();

--- a/src/tests/unit/tests/reports/components/report-sections/collapsible-result-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/collapsible-result-section.test.tsx
@@ -12,7 +12,9 @@ import { Mock } from 'typemoq';
 
 describe('CollapsibleResultSection', () => {
     it('renders', () => {
-        const collapsibleControlMock = Mock.ofType<(props: CollapsibleComponentCardsProps) => JSX.Element>();
+        const collapsibleControlMock = Mock.ofType<
+            (props: CollapsibleComponentCardsProps) => JSX.Element
+        >();
         const props: CollapsibleResultSectionProps = {
             deps: {
                 collapsibleControl: collapsibleControlMock.object,

--- a/src/tests/unit/tests/reports/components/report-sections/collapsible-script-provider.test.ts
+++ b/src/tests/unit/tests/reports/components/report-sections/collapsible-script-provider.test.ts
@@ -27,7 +27,9 @@ describe('CollapsibleScriptProvider', () => {
         const collapsibleNextSiblingMock = Mock.ofType<Element>();
 
         const collapsibleParentMock = Mock.ofType<HTMLElement>();
-        collapsibleParentMock.setup(parent => parent.nextElementSibling).returns(() => collapsibleNextSiblingMock.object);
+        collapsibleParentMock
+            .setup(parent => parent.nextElementSibling)
+            .returns(() => collapsibleNextSiblingMock.object);
 
         const collapsibleContainerMock = Mock.ofType<Element>();
         const collapsibleButtonMock = Mock.ofType<Element>();
@@ -38,11 +40,17 @@ describe('CollapsibleScriptProvider', () => {
             .callback((event, listener) => {
                 registeredButtonClickHandler = listener;
             });
-        collapsibleButtonMock.setup(collapsible => collapsible.parentElement).returns(() => collapsibleParentMock.object);
-        collapsibleButtonMock.setup(collapsible => collapsible.getAttribute('aria-expanded')).returns(() => isExpandedString);
+        collapsibleButtonMock
+            .setup(collapsible => collapsible.parentElement)
+            .returns(() => collapsibleParentMock.object);
+        collapsibleButtonMock
+            .setup(collapsible => collapsible.getAttribute('aria-expanded'))
+            .returns(() => isExpandedString);
 
         collapsibleContainerMock.setup(ccm => ccm.classList).returns(() => classListMock.object);
-        collapsibleContainerMock.setup(ccm => ccm.querySelector('.collapsible-control')).returns(() => collapsibleButtonMock.object);
+        collapsibleContainerMock
+            .setup(ccm => ccm.querySelector('.collapsible-control'))
+            .returns(() => collapsibleButtonMock.object);
 
         const docMock = Mock.ofType<Document>(undefined, MockBehavior.Strict);
         docMock
@@ -51,13 +59,25 @@ describe('CollapsibleScriptProvider', () => {
 
         addEventListenerForCollapsibleSection(docMock.object);
 
-        collapsibleButtonMock.verify(ccm => ccm.addEventListener('click', It.is(isFunction)), Times.once());
-        collapsibleContainerMock.verify(ccm => ccm.addEventListener('click', It.is(isFunction)), Times.never());
+        collapsibleButtonMock.verify(
+            ccm => ccm.addEventListener('click', It.is(isFunction)),
+            Times.once(),
+        );
+        collapsibleContainerMock.verify(
+            ccm => ccm.addEventListener('click', It.is(isFunction)),
+            Times.never(),
+        );
 
         registeredButtonClickHandler();
 
-        collapsibleButtonMock.verify(collapsible => collapsible.setAttribute('aria-expanded', isHiddenString), Times.once());
-        collapsibleNextSiblingMock.verify(sibling => sibling.setAttribute('aria-hidden', isExpandedString), Times.once());
+        collapsibleButtonMock.verify(
+            collapsible => collapsible.setAttribute('aria-expanded', isHiddenString),
+            Times.once(),
+        );
+        collapsibleNextSiblingMock.verify(
+            sibling => sibling.setAttribute('aria-hidden', isExpandedString),
+            Times.once(),
+        );
 
         if (isExpanded) {
             classListMock.verify(clm => clm.add('collapsed'), Times.once());

--- a/src/tests/unit/tests/reports/components/report-sections/details-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/details-section.test.tsx
@@ -4,7 +4,10 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { DateProvider } from 'common/date-provider';
-import { DetailsSection, DetailsSectionProps } from 'reports/components/report-sections/details-section';
+import {
+    DetailsSection,
+    DetailsSectionProps,
+} from 'reports/components/report-sections/details-section';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
 describe('DetailsSection', () => {
@@ -13,7 +16,10 @@ describe('DetailsSection', () => {
     test.each(descriptionValues)('renders with description: %s', description => {
         const scanDate = new Date(Date.UTC(2018, 2, 9, 9, 48));
 
-        const toUtcStringMock: IMock<(date: Date) => string> = Mock.ofInstance(DateProvider.getUTCStringFromDate, MockBehavior.Strict);
+        const toUtcStringMock: IMock<(date: Date) => string> = Mock.ofInstance(
+            DateProvider.getUTCStringFromDate,
+            MockBehavior.Strict,
+        );
 
         toUtcStringMock.setup(getter => getter(scanDate)).returns(() => '2018-03-12 11:24 PM UTC');
 

--- a/src/tests/unit/tests/reports/components/report-sections/full-rule-header.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/full-rule-header.test.tsx
@@ -4,7 +4,11 @@ import { CardRuleResult } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { allInstanceOutcomeTypes } from 'reports/components/instance-outcome-type';
-import { FullRuleHeader, FullRuleHeaderDeps, FullRuleHeaderProps } from 'reports/components/report-sections/full-rule-header';
+import {
+    FullRuleHeader,
+    FullRuleHeaderDeps,
+    FullRuleHeaderProps,
+} from 'reports/components/report-sections/full-rule-header';
 
 describe('FullRuleHeader', () => {
     const depsStub = {} as FullRuleHeaderDeps;

--- a/src/tests/unit/tests/reports/components/report-sections/minimal-rule-header.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/minimal-rule-header.test.tsx
@@ -3,7 +3,10 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { allInstanceOutcomeTypes } from 'reports/components/instance-outcome-type';
-import { MinimalRuleHeader, MinimalRuleHeaderProps } from 'reports/components/report-sections/minimal-rule-header';
+import {
+    MinimalRuleHeader,
+    MinimalRuleHeaderProps,
+} from 'reports/components/report-sections/minimal-rule-header';
 
 describe('MinimalRuleHeader', () => {
     const rule = {

--- a/src/tests/unit/tests/reports/components/report-sections/no-failed-instances-congrats.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/no-failed-instances-congrats.test.tsx
@@ -3,7 +3,10 @@
 import * as React from 'react';
 
 import { shallow } from 'enzyme';
-import { NoFailedInstancesCongrats, NoFailedInstancesCongratsDeps } from 'reports/components/report-sections/no-failed-instances-congrats';
+import {
+    NoFailedInstancesCongrats,
+    NoFailedInstancesCongratsDeps,
+} from 'reports/components/report-sections/no-failed-instances-congrats';
 
 describe('NoFailedInstancesCongrats with default message', () => {
     it('renders', () => {

--- a/src/tests/unit/tests/reports/components/report-sections/not-applicable-checks-sections.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/not-applicable-checks-sections.test.tsx
@@ -15,7 +15,11 @@ describe('NotApplicableChecksSection', () => {
             deps: {} as SectionDeps,
             cardsViewData: {
                 cards: {
-                    inapplicable: [{} as CardRuleResult, {} as CardRuleResult, {} as CardRuleResult],
+                    inapplicable: [
+                        {} as CardRuleResult,
+                        {} as CardRuleResult,
+                        {} as CardRuleResult,
+                    ],
                     fail: [],
                     pass: [],
                     unknown: [],

--- a/src/tests/unit/tests/reports/components/report-sections/passed-checks-sections.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/passed-checks-sections.test.tsx
@@ -3,7 +3,10 @@
 import { CardRuleResult, CardsViewModel } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { PassedChecksSection, PassedChecksSectionProps } from 'reports/components/report-sections/passed-checks-section';
+import {
+    PassedChecksSection,
+    PassedChecksSectionProps,
+} from 'reports/components/report-sections/passed-checks-section';
 
 import { SectionDeps } from '../../../../../../reports/components/report-sections/report-section-factory';
 

--- a/src/tests/unit/tests/reports/components/report-sections/report-body.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/report-body.test.tsx
@@ -6,7 +6,10 @@ import { NamedFC } from 'common/react/named-fc';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';
-import { ReportSectionFactory, SectionProps } from 'reports/components/report-sections/report-section-factory';
+import {
+    ReportSectionFactory,
+    SectionProps,
+} from 'reports/components/report-sections/report-section-factory';
 import { Mock } from 'typemoq';
 import { exampleUnifiedStatusResults } from '../../../common/components/cards/sample-view-model-data';
 
@@ -42,7 +45,11 @@ describe('ReportBody', () => {
             toUtcString: () => '',
             getCollapsibleScript: getScriptStub,
             getGuidanceTagsFromGuidanceLinks: getGuidanceTagsStub,
-            cardsViewData: { cards: exampleUnifiedStatusResults, visualHelperEnabled: true, allCardsCollapsed: true },
+            cardsViewData: {
+                cards: exampleUnifiedStatusResults,
+                visualHelperEnabled: true,
+                allCardsCollapsed: true,
+            },
             userConfigurationStoreData: null,
             targetAppInfo: { name: 'app' },
             shouldAlertFailuresCount: false,

--- a/src/tests/unit/tests/reports/components/report-sections/results-container.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/results-container.test.tsx
@@ -3,7 +3,10 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-import { ResultsContainer, ResultsContainerProps } from 'reports/components/report-sections/results-container';
+import {
+    ResultsContainer,
+    ResultsContainerProps,
+} from 'reports/components/report-sections/results-container';
 import { Mock } from 'typemoq';
 
 describe('ResultsContainer', () => {

--- a/src/tests/unit/tests/reports/components/report-sections/rules-only.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/rules-only.test.tsx
@@ -9,9 +9,15 @@ describe('RulesOnly', () => {
     const depsStub = {} as RulesOnlyDeps;
 
     it('renders', () => {
-        const cardResults = [{ id: '1' } as CardRuleResult, { id: '2' } as CardRuleResult, { id: '3' } as CardRuleResult];
+        const cardResults = [
+            { id: '1' } as CardRuleResult,
+            { id: '2' } as CardRuleResult,
+            { id: '3' } as CardRuleResult,
+        ];
 
-        const wrapped = shallow(<RulesOnly deps={depsStub} outcomeType={'pass'} cardRuleResults={cardResults} />);
+        const wrapped = shallow(
+            <RulesOnly deps={depsStub} outcomeType={'pass'} cardRuleResults={cardResults} />,
+        );
 
         expect(wrapped.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/reports/components/report-sections/summary-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/summary-section.test.tsx
@@ -3,7 +3,10 @@
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { SummarySection, SummarySectionProps } from 'reports/components/report-sections/summary-section';
+import {
+    SummarySection,
+    SummarySectionProps,
+} from 'reports/components/report-sections/summary-section';
 
 describe('SummarySection', () => {
     const noViolations = [];

--- a/src/tests/unit/tests/reports/components/requirement-outcome-type.test.ts
+++ b/src/tests/unit/tests/reports/components/requirement-outcome-type.test.ts
@@ -18,9 +18,15 @@ describe('OutcomeType', () => {
     });
 
     it('translates test status to outcomeTypeSemantics', () => {
-        expect(outcomeTypeSemanticsFromTestStatus(ManualTestStatus.PASS)).toEqual({ pastTense: 'Passed' } as OutcomeTypeSemantic);
-        expect(outcomeTypeSemanticsFromTestStatus(ManualTestStatus.FAIL)).toEqual({ pastTense: 'Failed' } as OutcomeTypeSemantic);
-        expect(outcomeTypeSemanticsFromTestStatus(ManualTestStatus.UNKNOWN)).toEqual({ pastTense: 'Incomplete' } as OutcomeTypeSemantic);
+        expect(outcomeTypeSemanticsFromTestStatus(ManualTestStatus.PASS)).toEqual({
+            pastTense: 'Passed',
+        } as OutcomeTypeSemantic);
+        expect(outcomeTypeSemanticsFromTestStatus(ManualTestStatus.FAIL)).toEqual({
+            pastTense: 'Failed',
+        } as OutcomeTypeSemantic);
+        expect(outcomeTypeSemanticsFromTestStatus(ManualTestStatus.UNKNOWN)).toEqual({
+            pastTense: 'Incomplete',
+        } as OutcomeTypeSemantic);
     });
 
     describe('outcomeStatsFromManualTestStatus', () => {
@@ -29,11 +35,16 @@ describe('OutcomeType', () => {
             expect(stats).toEqual({ pass: 0, fail: 0, incomplete: 0 });
         });
 
-        function generateManualTestStatus(pass: number, fail: number, incomplete: number): ManualTestStatusData {
+        function generateManualTestStatus(
+            pass: number,
+            fail: number,
+            incomplete: number,
+        ): ManualTestStatusData {
             let i = 0;
             const result: ManualTestStatusData = {};
             function setStep(status): () => { stepFinalResult: string; isStepScanned: boolean } {
-                return () => (result['step' + ++i] = { stepFinalResult: status, isStepScanned: true });
+                return () =>
+                    (result['step' + ++i] = { stepFinalResult: status, isStepScanned: true });
             }
             times(pass, setStep(ManualTestStatus.PASS));
             times(fail, setStep(ManualTestStatus.FAIL));

--- a/src/tests/unit/tests/reports/get-assessment-summary-model.test.ts
+++ b/src/tests/unit/tests/reports/get-assessment-summary-model.test.ts
@@ -69,7 +69,9 @@ describe('getAssessmentSummaryModel', () => {
     };
 
     const zeroRequirementsAll: IAssessmentSubsetForSummary[] = [];
-    const zeroAssessmentsProvider: AssessmentsProvider = createTestAssessmentsProvider(zeroRequirementsAll);
+    const zeroAssessmentsProvider: AssessmentsProvider = createTestAssessmentsProvider(
+        zeroRequirementsAll,
+    );
     const zeroRequirementsStatusData: AssessmentStatusData = {} as any;
     const zeroRequirementsStoreData: AssessmentStoreData = {} as any;
     const zeroRequirementsResults: AssessmentSummaryResult[] = [];
@@ -88,7 +90,9 @@ describe('getAssessmentSummaryModel', () => {
     };
 
     const singleRequirementAll: IAssessmentSubsetForSummary[] = [sampleTests.test1];
-    const singleAssessmentsProvider: AssessmentsProvider = createTestAssessmentsProvider(singleRequirementAll);
+    const singleAssessmentsProvider: AssessmentsProvider = createTestAssessmentsProvider(
+        singleRequirementAll,
+    );
     const singleRequirementStatusData: AssessmentStatusData = {
         [sampleTests.test1.key]: sampleResults[sampleTests.test1.key].storeData.testStepStatus,
     } as any;
@@ -97,7 +101,9 @@ describe('getAssessmentSummaryModel', () => {
             [sampleTests.test1.key]: sampleResults[sampleTests.test1.key].storeData,
         },
     } as any;
-    const singleRequirementResults: AssessmentSummaryResult[] = [sampleResults[sampleTests.test1.key]];
+    const singleRequirementResults: AssessmentSummaryResult[] = [
+        sampleResults[sampleTests.test1.key],
+    ];
     const singleRequirementModel: OverviewSummaryReportModel = {
         byPercentage: {
             fail: 0,
@@ -119,8 +125,13 @@ describe('getAssessmentSummaryModel', () => {
         ],
     };
 
-    const multipleRequirementsAll: IAssessmentSubsetForSummary[] = [sampleTests.test1, sampleTests.test2];
-    const multipleAssessmentsProvider: AssessmentsProvider = createTestAssessmentsProvider(multipleRequirementsAll);
+    const multipleRequirementsAll: IAssessmentSubsetForSummary[] = [
+        sampleTests.test1,
+        sampleTests.test2,
+    ];
+    const multipleAssessmentsProvider: AssessmentsProvider = createTestAssessmentsProvider(
+        multipleRequirementsAll,
+    );
     const multipleRequirementsStatusData: AssessmentStatusData = {
         [sampleTests.test1.key]: sampleResults[sampleTests.test1.key].storeData.testStepStatus,
         [sampleTests.test2.key]: sampleResults[sampleTests.test2.key].storeData.testStepStatus,
@@ -162,7 +173,9 @@ describe('getAssessmentSummaryModel', () => {
         ],
     };
 
-    function createTestAssessmentsProvider(requirements: IAssessmentSubsetForSummary[]): AssessmentsProvider {
+    function createTestAssessmentsProvider(
+        requirements: IAssessmentSubsetForSummary[],
+    ): AssessmentsProvider {
         const testAssessmentsProvider: AssessmentsProvider = {
             all: () => requirements,
         } as any;
@@ -171,19 +184,28 @@ describe('getAssessmentSummaryModel', () => {
 
     describe('getAssessmentSummaryModelFromProviderAndStoreData', () => {
         it('handles zero requirements', () => {
-            const actual = getAssessmentSummaryModelFromProviderAndStoreData(zeroAssessmentsProvider, zeroRequirementsStoreData);
+            const actual = getAssessmentSummaryModelFromProviderAndStoreData(
+                zeroAssessmentsProvider,
+                zeroRequirementsStoreData,
+            );
 
             expect(actual).toEqual(zeroRequirementsModel);
         });
 
         it('handles one requirement', () => {
-            const actual = getAssessmentSummaryModelFromProviderAndStoreData(singleAssessmentsProvider, singleRequirementStoreData);
+            const actual = getAssessmentSummaryModelFromProviderAndStoreData(
+                singleAssessmentsProvider,
+                singleRequirementStoreData,
+            );
 
             expect(actual).toEqual(singleRequirementModel);
         });
 
         it('handles multiple requirements', () => {
-            const actual = getAssessmentSummaryModelFromProviderAndStoreData(multipleAssessmentsProvider, multipleRequirementsStoreData);
+            const actual = getAssessmentSummaryModelFromProviderAndStoreData(
+                multipleAssessmentsProvider,
+                multipleRequirementsStoreData,
+            );
 
             expect(actual).toEqual(multipleRequirementsModel);
         });
@@ -191,19 +213,28 @@ describe('getAssessmentSummaryModel', () => {
 
     describe('getAssessmentSummaryModelFromProviderAndStatusData', () => {
         it('handles zero requirements', () => {
-            const actual = getAssessmentSummaryModelFromProviderAndStatusData(zeroAssessmentsProvider, zeroRequirementsStatusData);
+            const actual = getAssessmentSummaryModelFromProviderAndStatusData(
+                zeroAssessmentsProvider,
+                zeroRequirementsStatusData,
+            );
 
             expect(actual).toEqual(zeroRequirementsModel);
         });
 
         it('handles one requirement', () => {
-            const actual = getAssessmentSummaryModelFromProviderAndStatusData(singleAssessmentsProvider, singleRequirementStatusData);
+            const actual = getAssessmentSummaryModelFromProviderAndStatusData(
+                singleAssessmentsProvider,
+                singleRequirementStatusData,
+            );
 
             expect(actual).toEqual(singleRequirementModel);
         });
 
         it('handles multiple requirements', () => {
-            const actual = getAssessmentSummaryModelFromProviderAndStatusData(multipleAssessmentsProvider, multipleRequirementsStatusData);
+            const actual = getAssessmentSummaryModelFromProviderAndStatusData(
+                multipleAssessmentsProvider,
+                multipleRequirementsStatusData,
+            );
 
             expect(actual).toEqual(multipleRequirementsModel);
         });

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -17,7 +17,11 @@ describe('ReportGenerator', () => {
     const title = 'title';
     const url = 'http://url/';
     const description = 'description';
-    const cardsViewDataStub = { cards: exampleUnifiedStatusResults, visualHelperEnabled: true, allCardsCollapsed: true };
+    const cardsViewDataStub = {
+        cards: exampleUnifiedStatusResults,
+        visualHelperEnabled: true,
+        allCardsCollapsed: true,
+    };
 
     let dataBuilderMock: IMock<ReportHtmlGenerator>;
     let nameBuilderMock: IMock<ReportNameGenerator>;
@@ -26,7 +30,10 @@ describe('ReportGenerator', () => {
     beforeEach(() => {
         nameBuilderMock = Mock.ofType<ReportNameGenerator>(undefined, MockBehavior.Strict);
         dataBuilderMock = Mock.ofType<ReportHtmlGenerator>(undefined, MockBehavior.Strict);
-        assessmentReportHtmlGeneratorMock = Mock.ofType(AssessmentReportHtmlGenerator, MockBehavior.Strict);
+        assessmentReportHtmlGeneratorMock = Mock.ofType(
+            AssessmentReportHtmlGenerator,
+            MockBehavior.Strict,
+        );
     });
 
     test('generateHtml', () => {
@@ -42,8 +49,18 @@ describe('ReportGenerator', () => {
             )
             .returns(() => 'returned-data');
 
-        const testObject = new ReportGenerator(nameBuilderMock.object, dataBuilderMock.object, assessmentReportHtmlGeneratorMock.object);
-        const actual = testObject.generateFastPassAutomatedChecksReport(date, title, url, cardsViewDataStub, description);
+        const testObject = new ReportGenerator(
+            nameBuilderMock.object,
+            dataBuilderMock.object,
+            assessmentReportHtmlGeneratorMock.object,
+        );
+        const actual = testObject.generateFastPassAutomatedChecksReport(
+            date,
+            title,
+            url,
+            cardsViewDataStub,
+            description,
+        );
 
         expect(actual).toMatchSnapshot();
     });
@@ -57,12 +74,22 @@ describe('ReportGenerator', () => {
 
         assessmentReportHtmlGeneratorMock
             .setup(builder =>
-                builder.generateHtml(assessmentStoreData, assessmentsProvider, featureFlagStoreData, tabStoreData, assessmentDescription),
+                builder.generateHtml(
+                    assessmentStoreData,
+                    assessmentsProvider,
+                    featureFlagStoreData,
+                    tabStoreData,
+                    assessmentDescription,
+                ),
             )
             .returns(() => 'generated-assessment-html')
             .verifiable(Times.once());
 
-        const testObject = new ReportGenerator(nameBuilderMock.object, dataBuilderMock.object, assessmentReportHtmlGeneratorMock.object);
+        const testObject = new ReportGenerator(
+            nameBuilderMock.object,
+            dataBuilderMock.object,
+            assessmentReportHtmlGeneratorMock.object,
+        );
         const actual = testObject.generateAssessmentReport(
             assessmentStoreData,
             assessmentsProvider,
@@ -77,11 +104,17 @@ describe('ReportGenerator', () => {
 
     test('generateName', () => {
         nameBuilderMock
-            .setup(builder => builder.generateName('InsightsScan', It.isValue(date), It.isValue(title)))
+            .setup(builder =>
+                builder.generateName('InsightsScan', It.isValue(date), It.isValue(title)),
+            )
             .returns(() => 'returned-name')
             .verifiable(Times.once());
 
-        const testObject = new ReportGenerator(nameBuilderMock.object, dataBuilderMock.object, assessmentReportHtmlGeneratorMock.object);
+        const testObject = new ReportGenerator(
+            nameBuilderMock.object,
+            dataBuilderMock.object,
+            assessmentReportHtmlGeneratorMock.object,
+        );
         const actual = testObject.generateName('InsightsScan', date, title);
 
         const expected = 'returned-name';

--- a/src/tests/unit/tests/reports/report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/report-html-generator.test.tsx
@@ -10,7 +10,10 @@ import * as React from 'react';
 import { ReportHead } from 'reports/components/report-head';
 import { ReportBody, ReportBodyProps } from 'reports/components/report-sections/report-body';
 import { ReportCollapsibleContainerControl } from 'reports/components/report-sections/report-collapsible-container';
-import { ReportSectionFactory, SectionDeps } from 'reports/components/report-sections/report-section-factory';
+import {
+    ReportSectionFactory,
+    SectionDeps,
+} from 'reports/components/report-sections/report-section-factory';
 import { ReactStaticRenderer } from 'reports/react-static-renderer';
 import { ReportHtmlGenerator } from 'reports/report-html-generator';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
@@ -60,7 +63,11 @@ describe('ReportHtmlGenerator', () => {
             toUtcString: getUTCStringFromDateStub,
             getCollapsibleScript: getScriptMock.object,
             getGuidanceTagsFromGuidanceLinks: getGuidanceTagsStub,
-            cardsViewData: { cards: exampleUnifiedStatusResults, visualHelperEnabled: true, allCardsCollapsed: true },
+            cardsViewData: {
+                cards: exampleUnifiedStatusResults,
+                visualHelperEnabled: true,
+                allCardsCollapsed: true,
+            },
         } as ReportBodyProps;
 
         const headElement: JSX.Element = <ReportHead />;


### PR DESCRIPTION
#### Description of changes

Add ` src/tests/unit/tests/report` folder to prettier override for the line width value.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
