### PR TITLE
feat(android-settings): update e2e a11y test to include high contrast mode

### DIFF
--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -333,10 +333,10 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             documentManipulator,
         };
 
+        window.insightsUserConfiguration = new UserConfigurationController(interpreter);
+
         const renderer = new RootContainerRenderer(ReactDOM.render, document, deps);
         renderer.render();
-
-        window.insightsUserConfiguration = new UserConfigurationController(interpreter);
 
         sendAppInitializedTelemetryEvent(telemetryEventHandler, platformInfo);
 

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -3,7 +3,7 @@
 import { Application } from 'spectron';
 import { DeviceConnectionDialogController } from 'tests/electron/common/view-controllers/device-connection-dialog-controller';
 import { testResourceServerConfig } from 'tests/electron/setup/test-resource-server-config';
-import { DEFAULT_WAIT_FOR_ELEMENT_CLASS_TIMEOUT_MS } from 'tests/electron/setup/timeouts';
+import { DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS } from 'tests/electron/setup/timeouts';
 import * as WebDriverIO from 'webdriverio';
 import { dismissTelemetryOptInDialog } from '../dismiss-telemetry-opt-in-dialog';
 import { AutomatedChecksViewController } from './automated-checks-view-controller';
@@ -65,7 +65,7 @@ export class AppController {
                     return !classes.includes(highContrastThemeClass);
                 }
             },
-            DEFAULT_WAIT_FOR_ELEMENT_CLASS_TIMEOUT_MS,
+            DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS,
             `was expecting body element ${
                 expectedHighContrastMode ? 'with' : 'without'
             } class high-contrast-theme`,

--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -3,6 +3,7 @@
 import { Application } from 'spectron';
 import { DeviceConnectionDialogController } from 'tests/electron/common/view-controllers/device-connection-dialog-controller';
 import { testResourceServerConfig } from 'tests/electron/setup/test-resource-server-config';
+import { DEFAULT_WAIT_FOR_ELEMENT_CLASS_TIMEOUT_MS } from 'tests/electron/setup/timeouts';
 import * as WebDriverIO from 'webdriverio';
 import { dismissTelemetryOptInDialog } from '../dismiss-telemetry-opt-in-dialog';
 import { AutomatedChecksViewController } from './automated-checks-view-controller';
@@ -48,6 +49,26 @@ export class AppController {
     public async setHighContrastMode(enableHighContrast: boolean): Promise<void> {
         await this.app.webContents.executeJavaScript(
             `window.insightsUserConfiguration.setHighContrastMode(${enableHighContrast})`,
+        );
+    }
+
+    public async waitForHighContrastMode(expectedHighContrastMode: boolean): Promise<void> {
+        const highContrastThemeClass = 'high-contrast-theme';
+
+        await this.client.waitUntil(
+            async () => {
+                const classes = await this.client.$('body').getAttribute('class');
+
+                if (expectedHighContrastMode) {
+                    return classes.includes(highContrastThemeClass);
+                } else {
+                    return !classes.includes(highContrastThemeClass);
+                }
+            },
+            DEFAULT_WAIT_FOR_ELEMENT_CLASS_TIMEOUT_MS,
+            `was expecting body element ${
+                expectedHighContrastMode ? 'with' : 'without'
+            } class high-contrast-theme`,
         );
     }
 }

--- a/src/tests/electron/setup/timeouts.ts
+++ b/src/tests/electron/setup/timeouts.ts
@@ -6,3 +6,6 @@ export const DEFAULT_ELECTRON_TEST_TIMEOUT_MS = 20000;
 
 // How long to wait for an element to be visible
 export const DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS = 5000;
+
+// How long to wait for an element to have (or not have) a class
+export const DEFAULT_WAIT_FOR_ELEMENT_CLASS_TIMEOUT_MS = 500;

--- a/src/tests/electron/setup/timeouts.ts
+++ b/src/tests/electron/setup/timeouts.ts
@@ -6,6 +6,3 @@ export const DEFAULT_ELECTRON_TEST_TIMEOUT_MS = 20000;
 
 // How long to wait for an element to be visible
 export const DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS = 5000;
-
-// How long to wait for an element to have (or not have) a class
-export const DEFAULT_WAIT_FOR_ELEMENT_CLASS_TIMEOUT_MS = 500;

--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -73,10 +73,16 @@ describe('AutomatedChecksView', () => {
         await assertExpandedRuleGroup(3, 'TouchSizeWcag', 1);
     });
 
-    it('should not contain any accessibility issues', async () => {
-        const violations = await scanForAccessibilityIssues(automatedChecksView);
-        expect(violations).toStrictEqual([]);
-    });
+    it.each([true, false])(
+        'should pass accessibility validation with highContrastMode=%s',
+        async highContrastMode => {
+            await app.setHighContrastMode(highContrastMode);
+            await app.waitForHighContrastMode(highContrastMode);
+
+            const violations = await scanForAccessibilityIssues(automatedChecksView);
+            expect(violations).toStrictEqual([]);
+        },
+    );
 
     async function assertExpandedRuleGroup(
         position: number,

--- a/src/tests/electron/tests/device-connection-dialog.test.ts
+++ b/src/tests/electron/tests/device-connection-dialog.test.ts
@@ -49,8 +49,14 @@ describe('device connection dialog', () => {
         expect(await dialog.isEnabled(DeviceConnectionDialogSelectors.startButton)).toBe(false);
     });
 
-    it('should not contain any accessibility issues', async () => {
-        const violations = await scanForAccessibilityIssues(dialog);
-        expect(violations).toStrictEqual([]);
-    });
+    it.each([true, false])(
+        'should pass accessibility validation with highContrastMode=%s',
+        async highContrastMode => {
+            await app.setHighContrastMode(highContrastMode);
+            await app.waitForHighContrastMode(highContrastMode);
+
+            const violations = await scanForAccessibilityIssues(dialog);
+            expect(violations).toStrictEqual([]);
+        },
+    );
 });


### PR DESCRIPTION
#### Description of changes

- Update `AppController` to allow the tests to set and wait for high contrast mode
- Update both, device connect view and automated checks view a11y test to include both, default theme and high contrast theme, scans.

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678716
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
