### PR TITLE
feat(android-settings): make app HC setting persist across system HC toggling

### DIFF
--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -138,6 +138,10 @@ export interface SetHighContrastModePayload extends BaseActionPayload {
     enableHighContrast: boolean;
 }
 
+export interface SetNativeHighContrastModePayload extends BaseActionPayload {
+    enableHighContrast: boolean;
+}
+
 export interface SetIssueFilingServicePayload extends BaseActionPayload {
     issueFilingServiceName: string;
 }

--- a/src/background/actions/user-configuration-actions.ts
+++ b/src/background/actions/user-configuration-actions.ts
@@ -12,6 +12,7 @@ export class UserConfigurationActions {
     public readonly setTelemetryState = new Action<boolean>();
     public readonly getCurrentState = new Action<void>();
     public readonly setHighContrastMode = new Action<SetHighContrastModePayload>();
+    public readonly setNativeHighContrastMode = new Action<SetHighContrastModePayload>();
     public readonly setIssueFilingService = new Action<SetIssueFilingServicePayload>();
     public readonly setIssueFilingServiceProperty = new Action<
         SetIssueFilingServicePropertyPayload

--- a/src/background/global-action-creators/registrar/register-user-configuration-message-callbacks.ts
+++ b/src/background/global-action-creators/registrar/register-user-configuration-message-callbacks.ts
@@ -23,6 +23,10 @@ export const registerUserConfigurationMessageCallback = (
         userConfigurationActionCreator.setHighContrastMode,
     );
     interpreter.registerTypeToPayloadCallback(
+        Messages.UserConfig.SetNativeHighContrastConfig,
+        userConfigurationActionCreator.setNativeHighContrastMode,
+    );
+    interpreter.registerTypeToPayloadCallback(
         Messages.UserConfig.SetIssueFilingService,
         userConfigurationActionCreator.setIssueFilingService,
     );

--- a/src/background/global-action-creators/user-configuration-action-creator.ts
+++ b/src/background/global-action-creators/user-configuration-action-creator.ts
@@ -5,6 +5,7 @@ import {
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
+    SetNativeHighContrastModePayload,
 } from '../actions/action-payloads';
 import { UserConfigurationActions } from '../actions/user-configuration-actions';
 
@@ -18,6 +19,9 @@ export class UserConfigurationActionCreator {
 
     public setHighContrastMode = (payload: SetHighContrastModePayload) =>
         this.userConfigActions.setHighContrastMode.invoke(payload);
+
+    public setNativeHighContrastMode = (payload: SetNativeHighContrastModePayload) =>
+        this.userConfigActions.setNativeHighContrastMode.invoke(payload);
 
     public setIssueFilingService = (payload: SetIssueFilingServicePayload) =>
         this.userConfigActions.setIssueFilingService.invoke(payload);

--- a/src/background/stores/global/user-configuration-store.ts
+++ b/src/background/stores/global/user-configuration-store.ts
@@ -9,6 +9,7 @@ import {
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
+    SetNativeHighContrastModePayload,
 } from '../../actions/action-payloads';
 import { UserConfigurationActions } from '../../actions/user-configuration-actions';
 import { IndexedDBDataKeys } from '../../IndexedDBDataKeys';
@@ -19,6 +20,7 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
         isFirstTime: true,
         enableTelemetry: false,
         enableHighContrast: false,
+        lastSelectedHighContrast: false,
         bugService: 'none',
         bugServicePropertiesMap: {},
     };
@@ -51,6 +53,9 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
         this.userConfigActions.getCurrentState.addListener(this.onGetCurrentState);
         this.userConfigActions.setTelemetryState.addListener(this.onSetTelemetryState);
         this.userConfigActions.setHighContrastMode.addListener(this.onSetHighContrastMode);
+        this.userConfigActions.setNativeHighContrastMode.addListener(
+            this.onSetNativeHighContrastMode,
+        );
         this.userConfigActions.setIssueFilingService.addListener(this.onSetIssueFilingService);
         this.userConfigActions.setIssueFilingServiceProperty.addListener(
             this.onSetIssueFilingServiceProperty,
@@ -66,6 +71,14 @@ export class UserConfigurationStore extends BaseStoreImpl<UserConfigurationStore
 
     private onSetHighContrastMode = (payload: SetHighContrastModePayload): void => {
         this.state.enableHighContrast = payload.enableHighContrast;
+        this.state.lastSelectedHighContrast = payload.enableHighContrast;
+        this.saveAndEmitChanged();
+    };
+
+    private onSetNativeHighContrastMode = (payload: SetNativeHighContrastModePayload): void => {
+        this.state.enableHighContrast = payload.enableHighContrast
+            ? true
+            : this.state.lastSelectedHighContrast;
         this.saveAndEmitChanged();
     };
 

--- a/src/common/message-creators/user-config-message-creator.ts
+++ b/src/common/message-creators/user-config-message-creator.ts
@@ -5,6 +5,7 @@ import {
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
+    SetNativeHighContrastModePayload,
     SetTelemetryStatePayload,
 } from 'background/actions/action-payloads';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
@@ -31,6 +32,17 @@ export class UserConfigMessageCreator {
 
         this.dispatcher.dispatchMessage({
             messageType: Messages.UserConfig.SetHighContrastConfig,
+            payload,
+        });
+    }
+
+    public setNativeHighContrastMode(enableHighContrast: boolean): void {
+        const payload: SetNativeHighContrastModePayload = {
+            enableHighContrast,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.UserConfig.SetNativeHighContrastConfig,
             payload,
         });
     }

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -95,6 +95,7 @@ export class Messages {
     public static readonly UserConfig = {
         SetTelemetryConfig: `${messagePrefix}/userConfig/setTelemetryConfig`,
         SetHighContrastConfig: `${messagePrefix}/userConfig/setHighContrastConfig`,
+        SetNativeHighContrastConfig: `${messagePrefix}/userConfig/setNativeHighContrastConfig`,
         SetIssueFilingService: `${messagePrefix}/userConfig/setIssueFilingService`,
         SetIssueFilingServiceProperty: `${messagePrefix}/userConfig/setIssueFilingServiceProperty`,
         SaveIssueFilingSettings: `${messagePrefix}/userConfig/saveIssueFilingSettings`,

--- a/src/common/types/store-data/user-configuration-store.ts
+++ b/src/common/types/store-data/user-configuration-store.ts
@@ -3,7 +3,12 @@
 export interface UserConfigurationStoreData {
     isFirstTime: boolean;
     enableTelemetry: boolean;
+
+    // Native/system high-contrast mode can cause high contrast to be enabled even if it was
+    // not the last-selected option in our settings UI.
     enableHighContrast: boolean;
+    lastSelectedHighContrast: boolean;
+
     bugService: string;
     bugServicePropertiesMap: IssueFilingServicePropertiesMap;
 }

--- a/src/electron/main/native-high-contrast-mode-listener.ts
+++ b/src/electron/main/native-high-contrast-mode-listener.ts
@@ -22,7 +22,7 @@ export class NativeHighContrastModeListener {
 
     private notifyHighContrastModeChanged = (): void => {
         this.highContrastStateAtLastNotify = this.nativeTheme.shouldUseHighContrastColors;
-        this.userConfigMessageCreator.setHighContrastMode(this.highContrastStateAtLastNotify);
+        this.userConfigMessageCreator.setNativeHighContrastMode(this.highContrastStateAtLastNotify);
     };
 
     private onNativeThemeUpdated = (): void => {

--- a/src/tests/unit/tests/DetailsView/components/details-view-overlay/settings-panel/settings/issue-filing/issue-filing-settings.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-overlay/settings-panel/settings/issue-filing/issue-filing-settings.test.tsx
@@ -25,6 +25,7 @@ describe('IssueFilingSettings', () => {
             isFirstTime: true,
             enableTelemetry: true,
             enableHighContrast: true,
+            lastSelectedHighContrast: true,
             bugService: 'gitHub',
             bugServicePropertiesMap: { gitHub: { repository: 'test-repository' } },
         };

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -423,6 +423,7 @@ describe('DetailsViewContainer', () => {
             isFirstTime: false,
             enableTelemetry: true,
             enableHighContrast: false,
+            lastSelectedHighContrast: false,
             bugService: 'gitHub',
             bugServicePropertiesMap: { gitHub: { repository: 'gitHub-repository' } },
         };

--- a/src/tests/unit/tests/background/get-persisted-data.test.ts
+++ b/src/tests/unit/tests/background/get-persisted-data.test.ts
@@ -29,6 +29,7 @@ describe('GetPersistedDataTest', () => {
             isFirstTime: true,
             enableTelemetry: false,
             enableHighContrast: false,
+            lastSelectedHighContrast: false,
             bugService: 'none',
             bugServicePropertiesMap: {},
         };

--- a/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/user-configuration-action-creator.test.ts
@@ -5,6 +5,7 @@ import {
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
+    SetNativeHighContrastModePayload,
 } from 'background/actions/action-payloads';
 import { UserConfigurationActions } from 'background/actions/user-configuration-actions';
 import { UserConfigurationActionCreator } from 'background/global-action-creators/user-configuration-action-creator';
@@ -50,6 +51,22 @@ describe('UserConfigurationActionCreator', () => {
         testSubject.setHighContrastMode(payload);
 
         setHighContrastConfigMock.verifyAll();
+    });
+
+    it('should SetHighContrastConfig message', () => {
+        const payload: SetNativeHighContrastModePayload = {
+            enableHighContrast: true,
+        };
+        const setNativeHighContrastConfigMock = createActionMock(payload);
+        const actionsMock = createActionsMock(
+            'setNativeHighContrastMode',
+            setNativeHighContrastConfigMock.object,
+        );
+        const testSubject = new UserConfigurationActionCreator(actionsMock.object);
+
+        testSubject.setNativeHighContrastMode(payload);
+
+        setNativeHighContrastConfigMock.verifyAll();
     });
 
     it('should SetBugService message', () => {

--- a/src/tests/unit/tests/background/keyboard-shortcut-handler.test.ts
+++ b/src/tests/unit/tests/background/keyboard-shortcut-handler.test.ts
@@ -95,6 +95,7 @@ describe('KeyboardShortcutHandler', () => {
                     isFirstTime: simulatedIsFirstTimeUserConfiguration,
                     enableTelemetry: true,
                     enableHighContrast: false,
+                    lastSelectedHighContrast: false,
                     bugService: 'none',
                     bugServicePropertiesMap: {},
                 };

--- a/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
+++ b/src/tests/unit/tests/background/stores/global/user-configuration-store.test.ts
@@ -5,6 +5,7 @@ import {
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
+    SetNativeHighContrastModePayload,
 } from 'background/actions/action-payloads';
 import { UserConfigurationActions } from 'background/actions/user-configuration-actions';
 import { IndexedDBDataKeys } from 'background/IndexedDBDataKeys';
@@ -31,6 +32,7 @@ describe('UserConfigurationStoreTest', () => {
             enableTelemetry: true,
             isFirstTime: false,
             enableHighContrast: false,
+            lastSelectedHighContrast: false,
             bugService: 'none',
             bugServicePropertiesMap: {},
         };
@@ -38,6 +40,7 @@ describe('UserConfigurationStoreTest', () => {
             enableTelemetry: false,
             isFirstTime: true,
             enableHighContrast: false,
+            lastSelectedHighContrast: false,
             bugService: 'none',
             bugServicePropertiesMap: {},
         };
@@ -87,6 +90,7 @@ describe('UserConfigurationStoreTest', () => {
         const expected: UserConfigurationStoreData = {
             bugService: 'none',
             bugServicePropertiesMap: {},
+            lastSelectedHighContrast: false,
             ...persisted,
         } as UserConfigurationStoreData;
         const testSubject = new UserConfigurationStore(
@@ -161,101 +165,145 @@ describe('UserConfigurationStoreTest', () => {
         storeTester.testListenerToBeCalledOnce(initialStoreData, cloneDeep(initialStoreData));
     });
 
-    type SetUserConfigTestCase = {
-        isFirstTime: boolean;
-        enableTelemetry: boolean;
-        enableHighContrastMode: boolean;
-    };
-    test.each([
-        {
-            enableTelemetry: true,
-            isFirstTime: true,
-            enableHighContrastMode: false,
-        } as SetUserConfigTestCase,
-        {
-            enableTelemetry: true,
-            isFirstTime: false,
-            enableHighContrastMode: false,
-        } as SetUserConfigTestCase,
-        {
-            enableTelemetry: false,
-            isFirstTime: false,
-            enableHighContrastMode: false,
-        } as SetUserConfigTestCase,
-        {
-            enableTelemetry: false,
-            isFirstTime: true,
-            enableHighContrastMode: false,
-        } as SetUserConfigTestCase,
-    ])('setTelemetryConfig action: %p', (testCase: SetUserConfigTestCase) => {
-        const storeTester = createStoreToTestAction('setTelemetryState');
-        initialStoreData = {
-            enableTelemetry: testCase.enableTelemetry,
-            isFirstTime: testCase.isFirstTime,
-            enableHighContrast: false,
-            bugService: 'none',
-            bugServicePropertiesMap: {},
-        };
+    describe('setTelemetryConfig action', () => {
+        it.each`
+            isFirstTime | enableTelemetry
+            ${true}     | ${true}
+            ${true}     | ${false}
+            ${false}    | ${true}
+            ${false}    | ${false}
+        `(
+            'sets enableTelemetry per payload and isFirstTime to false for initial state isFirstTime=$isFirstTime enableTelemetry=$enableTelemetry',
+            ({ isFirstTime, enableTelemetry }) => {
+                const storeTester = createStoreToTestAction('setTelemetryState');
+                initialStoreData = {
+                    enableTelemetry: enableTelemetry,
+                    isFirstTime: isFirstTime,
+                    enableHighContrast: false,
+                    lastSelectedHighContrast: false,
+                    bugService: 'none',
+                    bugServicePropertiesMap: {},
+                };
 
-        const expectedState: UserConfigurationStoreData = {
-            enableTelemetry: testCase.enableTelemetry,
-            isFirstTime: false,
-            enableHighContrast: false,
-            bugService: 'none',
-            bugServicePropertiesMap: {},
-        };
+                const expectedState: UserConfigurationStoreData = {
+                    enableTelemetry: enableTelemetry,
+                    isFirstTime: false,
+                    enableHighContrast: false,
+                    lastSelectedHighContrast: false,
+                    bugService: 'none',
+                    bugServicePropertiesMap: {},
+                };
 
-        indexDbStrictMock
-            .setup(i => i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)))
-            .verifiable(Times.once());
+                indexDbStrictMock
+                    .setup(i =>
+                        i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
+                    )
+                    .verifiable(Times.once());
 
-        storeTester
-            .withActionParam(testCase.enableTelemetry)
-            .withPostListenerMock(indexDbStrictMock)
-            .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
+                storeTester
+                    .withActionParam(enableTelemetry)
+                    .withPostListenerMock(indexDbStrictMock)
+                    .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
+            },
+        );
     });
 
-    test.each([
-        {
-            enableTelemetry: false,
-            isFirstTime: false,
-            enableHighContrastMode: true,
-        } as SetUserConfigTestCase,
-        {
-            enableTelemetry: false,
-            isFirstTime: false,
-            enableHighContrastMode: false,
-        } as SetUserConfigTestCase,
-    ])('setHighContrast action: %p', (testCase: SetUserConfigTestCase) => {
-        const storeTester = createStoreToTestAction('setHighContrastMode');
-        initialStoreData = {
-            enableTelemetry: false,
-            isFirstTime: false,
-            enableHighContrast: testCase.enableHighContrastMode,
-            bugService: 'none',
-            bugServicePropertiesMap: {},
-        };
+    describe('setHighContrastMode action', () => {
+        it.each`
+            payload  | initialEnabled | initialLastSelected
+            ${true}  | ${true}        | ${true}
+            ${true}  | ${true}        | ${false}
+            ${true}  | ${false}       | ${false}
+            ${false} | ${true}        | ${true}
+            ${false} | ${true}        | ${false}
+            ${false} | ${false}       | ${false}
+        `(
+            'sets both enableHighContrast and lastSelectedHighContrast per payload $payload from initialState $initialState',
+            ({ payload, initialEnabled, initialLastSelected }) => {
+                const storeTester = createStoreToTestAction('setHighContrastMode');
+                initialStoreData = {
+                    enableTelemetry: false,
+                    isFirstTime: false,
+                    enableHighContrast: initialEnabled,
+                    lastSelectedHighContrast: initialLastSelected,
+                    bugService: 'none',
+                    bugServicePropertiesMap: {},
+                };
 
-        const setHighContrastData: SetHighContrastModePayload = {
-            enableHighContrast: testCase.enableHighContrastMode,
-        };
+                const setHighContrastData: SetHighContrastModePayload = {
+                    enableHighContrast: payload,
+                };
 
-        const expectedState: UserConfigurationStoreData = {
-            enableTelemetry: false,
-            isFirstTime: false,
-            enableHighContrast: testCase.enableHighContrastMode,
-            bugService: 'none',
-            bugServicePropertiesMap: {},
-        };
+                const expectedState: UserConfigurationStoreData = {
+                    enableTelemetry: false,
+                    isFirstTime: false,
+                    enableHighContrast: payload,
+                    lastSelectedHighContrast: payload,
+                    bugService: 'none',
+                    bugServicePropertiesMap: {},
+                };
 
-        indexDbStrictMock
-            .setup(i => i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)))
-            .verifiable(Times.once());
+                indexDbStrictMock
+                    .setup(i =>
+                        i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
+                    )
+                    .verifiable(Times.once());
 
-        storeTester
-            .withActionParam(setHighContrastData)
-            .withPostListenerMock(indexDbStrictMock)
-            .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
+                storeTester
+                    .withActionParam(setHighContrastData)
+                    .withPostListenerMock(indexDbStrictMock)
+                    .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
+            },
+        );
+    });
+
+    describe('setNativeHighContrastMode action', () => {
+        it.each`
+            payload  | initialEnabled | initialLastSelected | expectedEnabled
+            ${true}  | ${true}        | ${true}             | ${true}
+            ${true}  | ${true}        | ${false}            | ${true}
+            ${true}  | ${false}       | ${false}            | ${true}
+            ${false} | ${true}        | ${true}             | ${true}
+            ${false} | ${true}        | ${false}            | ${false}
+            ${false} | ${false}       | ${false}            | ${false}
+        `(
+            'sets enableHighContrast by merging initialLastSelected=$initialLastSelected, initialEanbled=$initialEnabled, payload=$payload into $expectedEnabled',
+            ({ payload, initialEnabled, initialLastSelected, expectedEnabled }) => {
+                const storeTester = createStoreToTestAction('setNativeHighContrastMode');
+                initialStoreData = {
+                    enableTelemetry: false,
+                    isFirstTime: false,
+                    enableHighContrast: initialEnabled,
+                    lastSelectedHighContrast: initialLastSelected,
+                    bugService: 'none',
+                    bugServicePropertiesMap: {},
+                };
+
+                const setNativeHighContrastData: SetNativeHighContrastModePayload = {
+                    enableHighContrast: payload,
+                };
+
+                const expectedState: UserConfigurationStoreData = {
+                    enableTelemetry: false,
+                    isFirstTime: false,
+                    enableHighContrast: expectedEnabled,
+                    lastSelectedHighContrast: initialLastSelected,
+                    bugService: 'none',
+                    bugServicePropertiesMap: {},
+                };
+
+                indexDbStrictMock
+                    .setup(i =>
+                        i.setItem(IndexedDBDataKeys.userConfiguration, It.isValue(expectedState)),
+                    )
+                    .verifiable(Times.once());
+
+                storeTester
+                    .withActionParam(setNativeHighContrastData)
+                    .withPostListenerMock(indexDbStrictMock)
+                    .testListenerToBeCalledOnce(cloneDeep(initialStoreData), expectedState);
+            },
+        );
     });
 
     test.each(['none', 'userConfigurationStoreTestIssueFilingService'])(
@@ -266,6 +314,7 @@ describe('UserConfigurationStoreTest', () => {
                 isFirstTime: false,
                 enableTelemetry: false,
                 enableHighContrast: false,
+                lastSelectedHighContrast: false,
                 bugService: 'none',
                 bugServicePropertiesMap: {},
             };
@@ -306,6 +355,7 @@ describe('UserConfigurationStoreTest', () => {
                 isFirstTime: false,
                 enableTelemetry: false,
                 enableHighContrast: false,
+                lastSelectedHighContrast: false,
                 bugService: 'none',
                 bugServicePropertiesMap: initialMapState,
             };

--- a/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
@@ -92,6 +92,7 @@ describe('CardKebabMenuButtonTest', () => {
                 [testKey]: {},
             },
             enableHighContrast: false,
+            lastSelectedHighContrast: false,
             enableTelemetry: true,
             isFirstTime: true,
         };

--- a/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/user-config-message-creator.test.ts
@@ -5,6 +5,7 @@ import {
     SetHighContrastModePayload,
     SetIssueFilingServicePayload,
     SetIssueFilingServicePropertyPayload,
+    SetNativeHighContrastModePayload,
     SetTelemetryStatePayload,
 } from 'background/actions/action-payloads';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
@@ -50,6 +51,21 @@ describe('UserConfigMessageCreator', () => {
         };
 
         testSubject.setHighContrastMode(enableHighContrast);
+
+        dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
+    });
+
+    it('dispatches message for setNativeHighContrastModeConfig', () => {
+        const enableHighContrast = true;
+        const payload: SetNativeHighContrastModePayload = {
+            enableHighContrast,
+        };
+        const expectedMessage: Message = {
+            messageType: Messages.UserConfig.SetNativeHighContrastConfig,
+            payload,
+        };
+
+        testSubject.setNativeHighContrastMode(enableHighContrast);
 
         dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
     });

--- a/src/tests/unit/tests/electron/main/native-high-contrast-mode-listener.test.ts
+++ b/src/tests/unit/tests/electron/main/native-high-contrast-mode-listener.test.ts
@@ -44,7 +44,7 @@ describe('NativeHighContrastModeListener', () => {
         mockNativeTheme.setup(m => m.shouldUseHighContrastColors).returns(() => initialState);
         testSubject.startListening();
 
-        mockMessageCreator.verify(m => m.setHighContrastMode(initialState), Times.once());
+        mockMessageCreator.verify(m => m.setNativeHighContrastMode(initialState), Times.once());
     });
 
     it('should send messages when the underlying high contrast state changes', () => {
@@ -56,7 +56,7 @@ describe('NativeHighContrastModeListener', () => {
         setNativeContrastMode(true);
 
         testSubjectOnNativeThemeUpdateHandler();
-        mockMessageCreator.verify(m => m.setHighContrastMode(true), Times.once());
+        mockMessageCreator.verify(m => m.setNativeHighContrastMode(true), Times.once());
     });
 
     it("should avoid sending messages for underlying state changes that don't impact high contrast mode", () => {
@@ -66,7 +66,7 @@ describe('NativeHighContrastModeListener', () => {
 
         // shouldUseHighContrastColors still false
         testSubjectOnNativeThemeUpdateHandler();
-        mockMessageCreator.verify(m => m.setHighContrastMode(It.isAny()), Times.never());
+        mockMessageCreator.verify(m => m.setNativeHighContrastMode(It.isAny()), Times.never());
     });
 
     it('should unregister all underlying event handlers on stopListening', () => {

--- a/src/tests/unit/tests/popup/components/popup-view.test.tsx
+++ b/src/tests/unit/tests/popup/components/popup-view.test.tsx
@@ -76,6 +76,7 @@ describe('PopupView', () => {
             isFirstTime: true,
             enableTelemetry: false,
             enableHighContrast: false,
+            lastSelectedHighContrast: false,
             bugService: 'none',
             bugServicePropertiesMap: {},
         };


### PR DESCRIPTION
#### Description of changes

Before this PR, the interaction between the user and system high contrast states was that the native state overwrote the app setting on app startup and whenever the system state was toggled, and the user setting in our settings panel was strictly transient, forgotten with each new app launch.

With this PR, we now remember the last high contrast mode setting the user selected in the app across system high contrast mode switches. We still switch to high contrast mode if the system switches to that mode or if the app is started with the system in high contrast mode, but now if you switch the system out of high contrast mode (or start the app with the system not in high contrast mode), we will remember whatever setting you previously had set in the Settings panel and return to it.

In particular, if you toggle into high contrast mode explicitly in the settings panel, we will now "remember" that even if you toggle the system into and out of HC mode.

This behavior is based on the behavior of Team's theme selector.

Most of the code change here is in:

* Separating the wiring of the original "SetHighContrastMode" message (which previously we re-used for native contrast mode changes) to give native notifications a separate message
* Adding a new `lastSelectedHighContrast` property to `UserConfigurationStoreState` and updating all the tests that initialize test versions of that store state type

The interesting new logic to focus review attention on are in `src/background/stores/global/user-configuration-store.ts` and its associated new tests (@smoralesd / @JGibson2019 , this is unchanged from the version I mentioned in our teams chat earlier) 

Before (app state not persisted across system state being toggled):
![animation showing app state not persisting](https://user-images.githubusercontent.com/376284/75926297-2b334980-5e1f-11ea-952d-e260d896ca80.gif)

After (app state persists after toggling system state):
![animation showing app state persisting](https://user-images.githubusercontent.com/376284/75926310-2e2e3a00-5e1f-11ea-8d82-578e574ab9c1.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1678723
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
