### PR TITLE
fix: outdated "how to test" text for High contrast mode requirement

### DIFF
--- a/src/assessments/text-legibility/test-steps/high-contrast-mode.tsx
+++ b/src/assessments/text-legibility/test-steps/high-contrast-mode.tsx
@@ -14,13 +14,13 @@ const highContrastModeDescription: JSX.Element = (
 
 const highContrastModeHowToTest: JSX.Element = (
     <div>
-        Google Chrome and Microsoft Edge Insider do not support Windows' high contrast mode.
+        Google Chrome does not support Windows' high contrast mode.
         <ol>
-            <li>Open the target page in Microsoft Edge.</li>
+            <li>Open the target page in the new Microsoft Edge or Microsoft Edge Legacy.</li>
             <li>
                 Use <Markup.Term>Windows Settings</Markup.Term> >{' '}
-                <Markup.Term>Ease of Access</Markup.Term> >{' '}
-                <Markup.Term>Color & high contrast</Markup.Term> to apply a high contrast theme.
+                <Markup.Term>Ease of Access</Markup.Term> > <Markup.Term>High contrast</Markup.Term>{' '}
+                to apply a high contrast theme.
             </li>
             <li>Verify that the target page adopts the colors specified for the theme.</li>
             <ManualTestRecordYourResults isMultipleFailurePossible={true} />


### PR DESCRIPTION
#### Description of changes

Text updates to test 17 requirement 1 per discussion in #2266 ([comment 1](https://github.com/microsoft/accessibility-insights-web/issues/2266#issuecomment-593714619), [comment 2](https://github.com/microsoft/accessibility-insights-web/issues/2266#issuecomment-593718212))

Before on left, after on right:
![screenshot comparing before and after text](https://user-images.githubusercontent.com/376284/75929394-620c5e00-5e25-11ea-865e-b404ff39a5b4.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2266
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
