### PR TITLE
fix: set label-content-name-mismatch to best practice as it's experimental

### DIFF
--- a/src/scanner/rule-to-links-mappings.ts
+++ b/src/scanner/rule-to-links-mappings.ts
@@ -103,7 +103,7 @@ export const ruleToLinkConfiguration: DictionaryStringTo<HyperlinkDefinition[]> 
     'css-orientation-lock': [BestPractice],
     'aria-hidden-focus': [link.WCAG_4_1_2, link.WCAG_1_3_1],
     'form-field-multiple-labels': [BestPractice],
-    'label-content-name-mismatch': [link.WCAG_2_5_3],
+    'label-content-name-mismatch': [BestPractice],
     'landmark-complementary-is-top-level': [link.WCAG_1_3_1, BestPractice],
     'svg-img-alt': [link.WCAG_1_1_1],
     'aria-roledescription': [link.WCAG_4_1_2],


### PR DESCRIPTION
#### Description of changes

The 'label-content-name-mismatch' rule is experimental for axe-core, as such setting it to best practice for us.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
