### PR TITLE
feat(android-settings): add e2e tests for the settings panel

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -22,6 +22,7 @@ export interface CommandBarProps {
 }
 
 export const commandButtonRefreshId = 'command-button-refresh';
+export const commandButtonSettingsId = 'command-button-settings';
 
 export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
     const { deps, deviceStoreData } = props;
@@ -40,6 +41,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
             </div>
             <div className={styles.farItems}>
                 <CommandButton
+                    data-automation-id={commandButtonSettingsId}
                     ariaLabel="settings"
                     iconProps={{ iconName: 'Gear', className: styles.buttonIcon }}
                     className={styles.menuItemButton}

--- a/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
@@ -5,6 +5,7 @@ import { instanceCardAutomationId } from 'common/components/cards/instance-detai
 import { ruleContentAutomationId } from 'common/components/cards/instance-details-group';
 import { ruleGroupAutomationId } from 'common/components/cards/rules-with-instances';
 import { automatedChecksViewAutomationId } from 'electron/views/automated-checks/automated-checks-view';
+import { commandButtonSettingsId } from 'electron/views/automated-checks/components/command-bar';
 import { highlightBoxAutomationId } from 'electron/views/screenshot/highlight-box';
 import { screenshotImageAutomationId } from 'electron/views/screenshot/screenshot';
 import { screenshotViewAutomationId } from 'electron/views/screenshot/screenshot-view';
@@ -24,7 +25,7 @@ export const AutomatedChecksViewSelectors = {
     nthRuleGroupInstances: (position: number) =>
         `${nthRuleGroup(position)} [data-automation-id="${instanceCardAutomationId}"]`,
 
-    settingsButton: 'button[aria-label="settings"]',
+    settingsButton: `[data-automation-id="${commandButtonSettingsId}"]`,
 };
 
 export const ScreenshotViewSelectors = {

--- a/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
@@ -23,6 +23,8 @@ export const AutomatedChecksViewSelectors = {
         `${nthRuleGroup(position)} [data-automation-id="${cardsRuleIdAutomationId}"]`,
     nthRuleGroupInstances: (position: number) =>
         `${nthRuleGroup(position)} [data-automation-id="${instanceCardAutomationId}"]`,
+
+    settingsButton: 'button[aria-label="settings"]',
 };
 
 export const ScreenshotViewSelectors = {

--- a/src/tests/electron/common/scan-for-accessibility-issues.ts
+++ b/src/tests/electron/common/scan-for-accessibility-issues.ts
@@ -11,6 +11,7 @@ declare var axe;
 
 export async function scanForAccessibilityIssues(
     view: ViewController,
+    selector?: string,
 ): Promise<PrintableAxeResult[]> {
     await injectAxeIfUndefined(view);
 
@@ -21,14 +22,21 @@ export async function scanForAccessibilityIssues(
         },
     };
 
-    const executeOutput = await view.client.executeAsync((options, done) => {
-        axe.run(document, options, function(err: Error, results: any): void {
-            if (err) {
-                throw err;
-            }
-            done(results);
-        });
-    }, axeRunOptions);
+    const executeOutput = await view.client.executeAsync(
+        (options, selectorInEvaluate, done) => {
+            const elementContext =
+                selectorInEvaluate === null ? document : { include: [selectorInEvaluate] };
+
+            axe.run(elementContext, options, function(err: Error, results: any): void {
+                if (err) {
+                    throw err;
+                }
+                done(results);
+            });
+        },
+        axeRunOptions,
+        selector,
+    );
 
     // This is how webdriverio indicates success
     expect(executeOutput).toHaveProperty('status', 0);

--- a/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { settingsPanelSelectors } from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
 import * as WebDriverIO from 'webdriverio';
 import {
     AutomatedChecksViewSelectors,
@@ -32,5 +33,29 @@ export class AutomatedChecksViewController extends ViewController {
 
     public async waitForScreenshotViewVisible(): Promise<void> {
         await this.waitForSelector(ScreenshotViewSelectors.screenshotView);
+    }
+
+    public async openSettingsPanel(): Promise<void> {
+        await this.waitForSelector(AutomatedChecksViewSelectors.settingsButton);
+        await this.click(AutomatedChecksViewSelectors.settingsButton);
+        await this.waitForSelector(settingsPanelSelectors.settingsPanel);
+    }
+
+    public async setToggleState(toggleSelector: string, newState: boolean): Promise<void> {
+        await this.waitForSelector(toggleSelector);
+        const oldState = await this.client.$(toggleSelector).getAttribute('aria-checked');
+
+        if (oldState !== newState) {
+            await this.click(toggleSelector);
+            await this.expectToggleState(toggleSelector, newState);
+        }
+    }
+
+    public async expectToggleState(toggleSelector: string, expectedState: boolean): Promise<void> {
+        const toggleInStateSelector = expectedState
+            ? settingsPanelSelectors.enabledToggle(toggleSelector)
+            : settingsPanelSelectors.disabledToggle(toggleSelector);
+
+        await this.waitForSelector(toggleInStateSelector);
     }
 }

--- a/src/tests/electron/common/view-controllers/view-controller.ts
+++ b/src/tests/electron/common/view-controllers/view-controller.ts
@@ -24,6 +24,22 @@ export abstract class ViewController {
         await this.screenshotOnError(async () => this.client.waitForExist(selector, timeout));
     }
 
+    public async waitForSelectorToDisappear(
+        selector: string,
+        timeout: number = DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS,
+    ): Promise<void> {
+        await this.screenshotOnError(async () =>
+            this.client.waitUntil(
+                async () => {
+                    const selected = await this.client.$(selector);
+                    return selected.value === null;
+                },
+                timeout,
+                `was expecting element by selector ${selector} to disappear`,
+            ),
+        );
+    }
+
     public async click(selector: string): Promise<void> {
         await this.screenshotOnError(async () => this.client.click(selector));
     }

--- a/src/tests/electron/tests/unified-settings-panel.test.ts
+++ b/src/tests/electron/tests/unified-settings-panel.test.ts
@@ -35,10 +35,14 @@ describe('AutomatedChecksView -> Settings Panel', () => {
     });
 
     describe('High Contrast Mode toggle', () => {
-        it('should default to non-high-contrast mode', async () => {
+        // skipping this test for now as we don't have a good, clean way to check if the system is using
+        // high contrast from the running test.
+        it.skip('should default to system setting or non-high-contrast mode', async () => {
+            const highContrastModeEnabled = false;
+
             await automatedChecksView.expectToggleState(
                 settingsPanelSelectors.highContrastModeToggle,
-                false,
+                highContrastModeEnabled,
             );
         });
 

--- a/src/tests/electron/tests/unified-settings-panel.test.ts
+++ b/src/tests/electron/tests/unified-settings-panel.test.ts
@@ -1,0 +1,92 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { createApplication } from 'tests/electron/common/create-application';
+import { scanForAccessibilityIssues } from 'tests/electron/common/scan-for-accessibility-issues';
+import { AppController } from 'tests/electron/common/view-controllers/app-controller';
+import { AutomatedChecksViewController } from 'tests/electron/common/view-controllers/automated-checks-view-controller';
+import { CommonSelectors } from 'tests/end-to-end/common/element-identifiers/common-selectors';
+import { settingsPanelSelectors } from 'tests/end-to-end/common/element-identifiers/details-view-selectors';
+
+describe('AutomatedChecksView -> Settings Panel', () => {
+    let app: AppController;
+    let automatedChecksView: AutomatedChecksViewController;
+
+    beforeEach(async () => {
+        app = await createApplication();
+        automatedChecksView = await app.openAutomatedChecksView();
+        await automatedChecksView.waitForViewVisible();
+        await automatedChecksView.openSettingsPanel();
+    });
+
+    afterEach(async () => {
+        automatedChecksView = null;
+        if (app != null) {
+            await app.stop();
+        }
+    });
+
+    describe('Telemetry toggle', () => {
+        it('should default to "on" in the usual configuration our E2E tests use', async () => {
+            await automatedChecksView.expectToggleState(
+                settingsPanelSelectors.telemetryStateToggle,
+                true,
+            );
+        });
+    });
+
+    describe('High Contrast Mode toggle', () => {
+        it('should default to non-high-contrast mode', async () => {
+            await automatedChecksView.expectToggleState(
+                settingsPanelSelectors.highContrastModeToggle,
+                false,
+            );
+        });
+
+        it('should apply the appropriate CSS style when High Contrast Mode setting is toggled', async () => {
+            await automatedChecksView.setToggleState(
+                settingsPanelSelectors.highContrastModeToggle,
+                true,
+            );
+
+            await automatedChecksView.waitForSelector(CommonSelectors.highContrastThemeSelector);
+
+            await automatedChecksView.setToggleState(
+                settingsPanelSelectors.highContrastModeToggle,
+                false,
+            );
+
+            await automatedChecksView.waitForSelectorToDisappear(
+                CommonSelectors.highContrastThemeSelector,
+            );
+        });
+
+        it('should reflect the state applied via the background page insightsUserConfiguration controller all other tests use', async () => {
+            await app.setHighContrastMode(true);
+            await automatedChecksView.expectToggleState(
+                settingsPanelSelectors.highContrastModeToggle,
+                true,
+            );
+
+            await app.setHighContrastMode(false);
+            await automatedChecksView.expectToggleState(
+                settingsPanelSelectors.highContrastModeToggle,
+                false,
+            );
+        });
+
+        it.each([true, false])(
+            'should pass accessibility validation with highContrastMode=%s',
+            async highContrastMode => {
+                await app.setHighContrastMode(highContrastMode);
+                await app.waitForHighContrastMode(highContrastMode);
+
+                const violations = await scanForAccessibilityIssues(
+                    automatedChecksView,
+                    settingsPanelSelectors.settingsPanel,
+                );
+
+                expect(violations).toStrictEqual([]);
+            },
+        );
+    });
+});

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -28,6 +28,7 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
     <CustomizedActionButton
       ariaLabel="settings"
       className="menuItemButton"
+      data-automation-id="command-button-settings"
       iconProps={
         Object {
           "className": "buttonIcon",
@@ -68,6 +69,7 @@ exports[`CommandBar renders while status is <Default> 1`] = `
     <CustomizedActionButton
       ariaLabel="settings"
       className="menuItemButton"
+      data-automation-id="command-button-settings"
       iconProps={
         Object {
           "className": "buttonIcon",
@@ -108,6 +110,7 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
     <CustomizedActionButton
       ariaLabel="settings"
       className="menuItemButton"
+      data-automation-id="command-button-settings"
       iconProps={
         Object {
           "className": "buttonIcon",
@@ -148,6 +151,7 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
     <CustomizedActionButton
       ariaLabel="settings"
       className="menuItemButton"
+      data-automation-id="command-button-settings"
       iconProps={
         Object {
           "className": "buttonIcon",

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -10,8 +10,6 @@ import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
 
-//
-
 describe('CommandBar', () => {
     describe('renders', () => {
         it('while status is <Scanning>', () => {

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -10,6 +10,8 @@ import * as React from 'react';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
 
+//
+
 describe('CommandBar', () => {
     describe('renders', () => {
         it('while status is <Scanning>', () => {


### PR DESCRIPTION
#### Description of changes

Adding e2e test for the settings panel on AI-Android, including accessibility issues scan in default and high contrast theme.

The general strategy was to bring the same scenarios on the settings panel e2e test from AI-Web but translated to AI-Android.

**Note**
We have the idea to update the app controller to use the user config controller instead of hitting buttons in the UI for dismissing the first time telemetry dialog. This will lead to some changes to other e2e as well as adding a couple more e2e test. I left that for follow up PR to keep this one smaller.

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1678715
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
