### PR TITLE
chore: line width for src/tests/unit/tests/issue-filing folder

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -13,7 +13,6 @@ module.exports = {
                 'src/tests/unit/tests/DetailsView/**/*',
                 'src/tests/unit/tests/electron/**/*',
                 'src/tests/unit/tests/injected/**/*',
-                'src/tests/unit/tests/issue-filing/**/*',
                 'src/tests/unit/tests/popup/**/*',
             ],
             options: {

--- a/src/tests/unit/tests/issue-filing/common/create-file-issue-handler.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/create-file-issue-handler.test.ts
@@ -31,11 +31,16 @@ describe('createFileIssueHandler', () => {
     let browserAdapterMock: IMock<BrowserAdapter>;
 
     beforeEach(() => {
-        settingsGetterMock = Mock.ofType<(data: IssueFilingServicePropertiesMap) => any>(undefined, MockBehavior.Strict);
+        settingsGetterMock = Mock.ofType<(data: IssueFilingServicePropertiesMap) => any>(
+            undefined,
+            MockBehavior.Strict,
+        );
         settingsGetterMock.setup(getter => getter(serviceMap)).returns(() => settingsStub);
 
         urlProviderMock = Mock.ofType<IssueFilingUrlProvider<any>>(undefined, MockBehavior.Strict);
-        urlProviderMock.setup(provider => provider(settingsStub, issueData, environmentInfoStub)).returns(() => urlStub);
+        urlProviderMock
+            .setup(provider => provider(settingsStub, issueData, environmentInfoStub))
+            .returns(() => urlStub);
 
         browserAdapterMock = Mock.ofType<BrowserAdapter>(undefined, MockBehavior.Strict);
     });
@@ -46,9 +51,14 @@ describe('createFileIssueHandler', () => {
             .returns(() => Promise.resolve({} as Tabs.Tab))
             .verifiable(Times.once());
 
-        const testSubject = createFileIssueHandler(urlProviderMock.object, settingsGetterMock.object);
+        const testSubject = createFileIssueHandler(
+            urlProviderMock.object,
+            settingsGetterMock.object,
+        );
 
-        await expect(testSubject(browserAdapterMock.object, serviceMap, issueData, environmentInfoStub)).resolves.toBe(undefined);
+        await expect(
+            testSubject(browserAdapterMock.object, serviceMap, issueData, environmentInfoStub),
+        ).resolves.toBe(undefined);
 
         browserAdapterMock.verifyAll();
     });
@@ -56,10 +66,17 @@ describe('createFileIssueHandler', () => {
     it('properly surfaces errors', async () => {
         const errorMessage = 'dummy error';
 
-        browserAdapterMock.setup(adapter => adapter.createActiveTab(urlStub)).returns(() => Promise.reject(errorMessage));
+        browserAdapterMock
+            .setup(adapter => adapter.createActiveTab(urlStub))
+            .returns(() => Promise.reject(errorMessage));
 
-        const testSubject = createFileIssueHandler(urlProviderMock.object, settingsGetterMock.object);
+        const testSubject = createFileIssueHandler(
+            urlProviderMock.object,
+            settingsGetterMock.object,
+        );
 
-        await expect(testSubject(browserAdapterMock.object, serviceMap, issueData, environmentInfoStub)).rejects.toEqual(errorMessage);
+        await expect(
+            testSubject(browserAdapterMock.object, serviceMap, issueData, environmentInfoStub),
+        ).rejects.toEqual(errorMessage);
     });
 });

--- a/src/tests/unit/tests/issue-filing/common/http-query-builder.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/http-query-builder.test.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { repeat } from 'lodash';
-import { HTTPQueryBuilder, QueryParam } from '../../../../../issue-filing/common/http-query-builder';
+import {
+    HTTPQueryBuilder,
+    QueryParam,
+} from '../../../../../issue-filing/common/http-query-builder';
 
 describe('HTTPQueryBuilder', () => {
     const testUrl = 'https://some-test-url';
@@ -57,9 +60,17 @@ describe('HTTPQueryBuilder', () => {
         const expectedUrlNoHtmlTags = actualUrlNoHtmlTags.substr(0, actualUrlNoHtmlTags.length - 3);
 
         const testCases = [
-            [`length ${HTTPQueryBuilder.maxUrlLength - 1}, with html tags`, actualUrl1, expectedUrl1],
+            [
+                `length ${HTTPQueryBuilder.maxUrlLength - 1}, with html tags`,
+                actualUrl1,
+                expectedUrl1,
+            ],
             [`length ${HTTPQueryBuilder.maxUrlLength}, with html tags`, actualUrl2, expectedUrl2],
-            [`length ${HTTPQueryBuilder.maxUrlLength + 1}, with html tags`, actualUrl3, expectedUrl3],
+            [
+                `length ${HTTPQueryBuilder.maxUrlLength + 1}, with html tags`,
+                actualUrl3,
+                expectedUrl3,
+            ],
             ['no html tags', actualUrlNoHtmlTags, expectedUrlNoHtmlTags],
         ];
 

--- a/src/tests/unit/tests/issue-filing/common/issue-details-builder.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-details-builder.test.ts
@@ -35,11 +35,19 @@ describe('Name of the group', () => {
     beforeEach(() => {
         markupMock = Mock.ofType<MarkupFormatter>(undefined, MockBehavior.Strict);
 
-        markupMock.setup(factory => factory.snippet(It.isAnyString())).returns(text => `s-${text}-s`);
-        markupMock.setup(factory => factory.link(It.isAnyString(), It.isAnyString())).returns((href, text) => `l-${href}-${text}-l`);
+        markupMock
+            .setup(factory => factory.snippet(It.isAnyString()))
+            .returns(text => `s-${text}-s`);
+        markupMock
+            .setup(factory => factory.link(It.isAnyString(), It.isAnyString()))
+            .returns((href, text) => `l-${href}-${text}-l`);
         markupMock.setup(factory => factory.link(It.isAnyString())).returns(href => `l-${href}-l`);
-        markupMock.setup(factory => factory.sectionHeader(It.isAnyString())).returns(header => `h-${header}-h`);
-        markupMock.setup(factory => factory.howToFixSection(It.isAnyString())).returns(text => `h-t--${text}--h-t`);
+        markupMock
+            .setup(factory => factory.sectionHeader(It.isAnyString()))
+            .returns(header => `h-${header}-h`);
+        markupMock
+            .setup(factory => factory.howToFixSection(It.isAnyString()))
+            .returns(text => `h-t--${text}--h-t`);
         markupMock.setup(factory => factory.sectionHeaderSeparator()).returns(() => '--s-h-s--');
         markupMock.setup(factory => factory.footerSeparator()).returns(() => '--f-s--');
         markupMock.setup(factory => factory.sectionSeparator()).returns(() => '\n');

--- a/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
@@ -4,7 +4,10 @@ import { BaseStore } from 'common/base-store';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { EnvironmentInfo } from 'common/environment-info-provider';
 import { CreateIssueDetailsTextData } from 'common/types/create-issue-details-text-data';
-import { IssueFilingServicePropertiesMap, UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import {
+    IssueFilingServicePropertiesMap,
+    UserConfigurationStoreData,
+} from 'common/types/store-data/user-configuration-store';
 import { IssueFilingControllerImpl } from 'issue-filing/common/issue-filing-controller-impl';
 import { IssueFilingServiceProvider } from 'issue-filing/issue-filing-service-provider';
 import { IssueFilingService } from 'issue-filing/types/issue-filing-service';
@@ -32,11 +35,15 @@ describe('IssueFilingControllerImpl', () => {
         const browserAdapterMock = Mock.ofType<BrowserAdapter>();
         const issueFilingServiceMock = Mock.ofType<IssueFilingService>();
         issueFilingServiceMock
-            .setup(service => service.fileIssue(browserAdapterMock.object, map, issueData, environmentInfoStub))
+            .setup(service =>
+                service.fileIssue(browserAdapterMock.object, map, issueData, environmentInfoStub),
+            )
             .returns(() => Promise.resolve());
 
         const providerMock = Mock.ofType<IssueFilingServiceProvider>();
-        providerMock.setup(provider => provider.forKey(serviceKey)).returns(() => issueFilingServiceMock.object);
+        providerMock
+            .setup(provider => provider.forKey(serviceKey))
+            .returns(() => issueFilingServiceMock.object);
 
         const storeMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>();
         storeMock.setup(store => store.getState()).returns(() => serviceConfig);

--- a/src/tests/unit/tests/issue-filing/common/markup/plain-text-formatter.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/markup/plain-text-formatter.test.ts
@@ -15,7 +15,9 @@ describe('PlainTextFormatter', () => {
     });
 
     it('returns how to fix section', () => {
-        expect(testSubject.howToFixSection('test-failure-summary')).toEqual('\ntest-failure-summary');
+        expect(testSubject.howToFixSection('test-failure-summary')).toEqual(
+            '\ntest-failure-summary',
+        );
     });
 
     it('returns section header separator', () => {

--- a/src/tests/unit/tests/issue-filing/common/markup/truncate-snippet.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/markup/truncate-snippet.test.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 import { repeat } from 'lodash';
 
-import { maxSnippetLength, truncateSnippet } from '../../../../../../issue-filing/common/markup/truncate-snippet';
+import {
+    maxSnippetLength,
+    truncateSnippet,
+} from '../../../../../../issue-filing/common/markup/truncate-snippet';
 
 describe('truncateSnippet', () => {
     const testSubject = truncateSnippet;

--- a/src/tests/unit/tests/issue-filing/components/issue-filing-option-choice-group.test.tsx
+++ b/src/tests/unit/tests/issue-filing/components/issue-filing-option-choice-group.test.tsx
@@ -6,7 +6,10 @@ import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
 import { SetIssueFilingServicePayload } from 'background/actions/action-payloads';
-import { IssueFilingChoiceGroup, IssueFilingChoiceGroupProps } from '../../../../../issue-filing/components/issue-filing-choice-group';
+import {
+    IssueFilingChoiceGroup,
+    IssueFilingChoiceGroupProps,
+} from '../../../../../issue-filing/components/issue-filing-choice-group';
 import { OnSelectedServiceChange } from '../../../../../issue-filing/components/issue-filing-settings-container';
 import { IssueFilingService } from '../../../../../issue-filing/types/issue-filing-service';
 

--- a/src/tests/unit/tests/issue-filing/components/issue-filing-settings-container.test.tsx
+++ b/src/tests/unit/tests/issue-filing/components/issue-filing-settings-container.test.tsx
@@ -5,7 +5,10 @@ import * as React from 'react';
 import { Mock } from 'typemoq';
 
 import { UserConfigMessageCreator } from '../../../../../common/message-creators/user-config-message-creator';
-import { IssueFilingServiceProperties, UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
+import {
+    IssueFilingServiceProperties,
+    UserConfigurationStoreData,
+} from '../../../../../common/types/store-data/user-configuration-store';
 import {
     IssueFilingSettingsContainer,
     IssueFilingSettingsContainerDeps,
@@ -44,7 +47,9 @@ describe('IssueFilingSettingsContainerTest', () => {
     };
 
     test('render', () => {
-        issueFilingServicesProviderMock.setup(mock => mock.allVisible()).returns(() => issueFilingServices);
+        issueFilingServicesProviderMock
+            .setup(mock => mock.allVisible())
+            .returns(() => issueFilingServices);
         const wrapper = shallow(<IssueFilingSettingsContainer {...props} />);
         expect(wrapper.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/issue-filing/issue-filing-service-provider.test.ts
+++ b/src/tests/unit/tests/issue-filing/issue-filing-service-provider.test.ts
@@ -34,7 +34,9 @@ describe('IssueFilingServiceProviderTest', () => {
 
         const expectedTestOptions = [givenTestOptions[0]];
 
-        expect(new IssueFilingServiceProvider(givenTestOptions).allVisible()).toEqual(expectedTestOptions);
+        expect(new IssueFilingServiceProvider(givenTestOptions).allVisible()).toEqual(
+            expectedTestOptions,
+        );
     });
 
     test('forKey', () => {
@@ -52,7 +54,9 @@ describe('IssueFilingServiceProviderTest', () => {
 
         const expectedTestOption = givenTestOptions[0];
 
-        expect(new IssueFilingServiceProvider(givenTestOptions).forKey('github')).toEqual(expectedTestOption);
+        expect(new IssueFilingServiceProvider(givenTestOptions).forKey('github')).toEqual(
+            expectedTestOption,
+        );
     });
 
     test('forKey: service not found', () => {
@@ -68,6 +72,8 @@ describe('IssueFilingServiceProviderTest', () => {
             } as IssueFilingService,
         ];
 
-        expect(new IssueFilingServiceProvider(givenTestOptions).forKey('invalid key')).not.toBeDefined();
+        expect(
+            new IssueFilingServiceProvider(givenTestOptions).forKey('invalid key'),
+        ).not.toBeDefined();
     });
 });

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-issue-filing-service.test.tsx
@@ -23,7 +23,9 @@ describe('AzureBoardsIssueFilingServiceTest', () => {
             projectURL: projectUrlStub,
             issueDetailsField: issueDetailsLocationStub,
         };
-        expect(AzureBoardsIssueFilingService.buildStoreData(projectUrlStub, issueDetailsLocationStub)).toEqual(expectedStoreData);
+        expect(
+            AzureBoardsIssueFilingService.buildStoreData(projectUrlStub, issueDetailsLocationStub),
+        ).toEqual(expectedStoreData);
     });
 
     it('getSettingsFromStoreData', () => {
@@ -35,7 +37,9 @@ describe('AzureBoardsIssueFilingServiceTest', () => {
             'some other service': {},
             [AzureBoardsIssueFilingService.key]: expectedStoreData,
         };
-        expect(AzureBoardsIssueFilingService.getSettingsFromStoreData(givenData)).toEqual(expectedStoreData);
+        expect(AzureBoardsIssueFilingService.getSettingsFromStoreData(givenData)).toEqual(
+            expectedStoreData,
+        );
     });
 
     describe('isSettingsValid', () => {
@@ -46,7 +50,10 @@ describe('AzureBoardsIssueFilingServiceTest', () => {
             { projectURL: '' } as AzureBoardsIssueFilingSettings,
             { projectURL: '', issueDetailsField: '' as AzureBoardsIssueDetailField },
             { projectURL: 'some project', issueDetailsField: '' as AzureBoardsIssueDetailField },
-            { projectURL: '', issueDetailsField: 'some issue details location' as AzureBoardsIssueDetailField },
+            {
+                projectURL: '',
+                issueDetailsField: 'some issue details location' as AzureBoardsIssueDetailField,
+            },
         ];
 
         it.each(invalidTestSettings)('handles invalid settings: %p', settings => {

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-settings-form.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/azure-boards-settings-form.test.tsx
@@ -57,7 +57,9 @@ describe('AzureBoardsSettingsForm', () => {
                 propertyName: projectUrlProperty,
                 propertyValue: newProjectUrl,
             };
-            onPropertyUpdateCallbackMock.setup(updateCallback => updateCallback(payload)).verifiable(Times.once());
+            onPropertyUpdateCallbackMock
+                .setup(updateCallback => updateCallback(payload))
+                .verifiable(Times.once());
 
             const testSubject = shallow(<AzureBoardsSettingsForm {...props} />);
 
@@ -69,13 +71,16 @@ describe('AzureBoardsSettingsForm', () => {
         it('handles issues details field change', () => {
             const newIssueDetailsFieldKey = 'a-different-field-key';
 
-            const issueDetailsFieldProperty: keyof AzureBoardsIssueFilingSettings = 'issueDetailsField';
+            const issueDetailsFieldProperty: keyof AzureBoardsIssueFilingSettings =
+                'issueDetailsField';
             const payload = {
                 issueFilingServiceName: AzureBoardsIssueFilingService.key,
                 propertyName: issueDetailsFieldProperty,
                 propertyValue: newIssueDetailsFieldKey,
             };
-            onPropertyUpdateCallbackMock.setup(updateCallback => updateCallback(payload)).verifiable(Times.once());
+            onPropertyUpdateCallbackMock
+                .setup(updateCallback => updateCallback(payload))
+                .verifiable(Times.once());
 
             const testSubject = shallow(<AzureBoardsSettingsForm {...props} />);
 

--- a/src/tests/unit/tests/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.test.ts
+++ b/src/tests/unit/tests/issue-filing/services/azure-boards/create-azure-boards-issue-filing-url.test.ts
@@ -58,15 +58,23 @@ describe('createAzureBoardsIssueFilingUrl', () => {
 
         stringUtilsMock = Mock.ofType<IssueUrlCreationUtils>();
         const testTitle = 'test title';
-        stringUtilsMock.setup(utils => utils.getTitle(sampleIssueDetailsData)).returns(() => testTitle);
+        stringUtilsMock
+            .setup(utils => utils.getTitle(sampleIssueDetailsData))
+            .returns(() => testTitle);
 
         issueDetailsGetterMock = Mock.ofType<IssueDetailsBuilder>();
-        issueDetailsGetterMock.setup(getter => getter(environmentInfo, sampleIssueDetailsData)).returns(() => testIssueDetails);
+        issueDetailsGetterMock
+            .setup(getter => getter(environmentInfo, sampleIssueDetailsData))
+            .returns(() => testIssueDetails);
 
         queryBuilderMock = Mock.ofType<HTTPQueryBuilder>();
 
-        queryBuilderMock.setup(builder => builder.withParam('fullScreen', 'true')).returns(() => queryBuilderMock.object);
-        queryBuilderMock.setup(builder => builder.withParam('[System.Title]', testTitle)).returns(() => queryBuilderMock.object);
+        queryBuilderMock
+            .setup(builder => builder.withParam('fullScreen', 'true'))
+            .returns(() => queryBuilderMock.object);
+        queryBuilderMock
+            .setup(builder => builder.withParam('[System.Title]', testTitle))
+            .returns(() => queryBuilderMock.object);
 
         queryBuilderMock.setup(builder => builder.build()).returns(() => 'https://builded-url');
 
@@ -79,12 +87,18 @@ describe('createAzureBoardsIssueFilingUrl', () => {
 
     describe('creates url', () => {
         it('uses description field, without tags', () => {
-            stringUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => []);
+            stringUtilsMock
+                .setup(utils => utils.standardizeTags(sampleIssueDetailsData))
+                .returns(() => []);
 
             queryBuilderMock
-                .setup(builder => builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Issue`))
+                .setup(builder =>
+                    builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Issue`),
+                )
                 .returns(() => queryBuilderMock.object);
-            queryBuilderMock.setup(builder => builder.withParam('[System.Tags]', baseTags)).returns(() => queryBuilderMock.object);
+            queryBuilderMock
+                .setup(builder => builder.withParam('[System.Tags]', baseTags))
+                .returns(() => queryBuilderMock.object);
 
             queryBuilderMock
                 .setup(builder => builder.withParam('[System.Description]', testIssueDetails))
@@ -96,14 +110,20 @@ describe('createAzureBoardsIssueFilingUrl', () => {
         });
 
         it('uses description field, with tags', () => {
-            stringUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => ['TAG1', 'TAG2']);
+            stringUtilsMock
+                .setup(utils => utils.standardizeTags(sampleIssueDetailsData))
+                .returns(() => ['TAG1', 'TAG2']);
 
             queryBuilderMock
-                .setup(builder => builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Issue`))
+                .setup(builder =>
+                    builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Issue`),
+                )
                 .returns(() => queryBuilderMock.object);
 
             const expectedTags = `${baseTags}; TAG1; TAG2`;
-            queryBuilderMock.setup(builder => builder.withParam('[System.Tags]', expectedTags)).returns(() => queryBuilderMock.object);
+            queryBuilderMock
+                .setup(builder => builder.withParam('[System.Tags]', expectedTags))
+                .returns(() => queryBuilderMock.object);
             queryBuilderMock
                 .setup(builder => builder.withParam('[System.Description]', testIssueDetails))
                 .returns(() => queryBuilderMock.object);
@@ -115,15 +135,23 @@ describe('createAzureBoardsIssueFilingUrl', () => {
 
         it('uses repro steps field, without tags', () => {
             settingsData.issueDetailsField = 'reproSteps';
-            stringUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => []);
+            stringUtilsMock
+                .setup(utils => utils.standardizeTags(sampleIssueDetailsData))
+                .returns(() => []);
 
             queryBuilderMock
-                .setup(builder => builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Bug`))
+                .setup(builder =>
+                    builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Bug`),
+                )
                 .returns(() => queryBuilderMock.object);
 
-            queryBuilderMock.setup(builder => builder.withParam('[System.Tags]', baseTags)).returns(() => queryBuilderMock.object);
             queryBuilderMock
-                .setup(builder => builder.withParam('[Microsoft.VSTS.TCM.ReproSteps]', testIssueDetails))
+                .setup(builder => builder.withParam('[System.Tags]', baseTags))
+                .returns(() => queryBuilderMock.object);
+            queryBuilderMock
+                .setup(builder =>
+                    builder.withParam('[Microsoft.VSTS.TCM.ReproSteps]', testIssueDetails),
+                )
                 .returns(() => queryBuilderMock.object);
 
             const result = testSubject(settingsData, sampleIssueDetailsData, environmentInfo);
@@ -133,16 +161,24 @@ describe('createAzureBoardsIssueFilingUrl', () => {
 
         it('uses repro steps field, with tags', () => {
             settingsData.issueDetailsField = 'reproSteps';
-            stringUtilsMock.setup(utils => utils.standardizeTags(sampleIssueDetailsData)).returns(() => ['TAG1', 'TAG2']);
+            stringUtilsMock
+                .setup(utils => utils.standardizeTags(sampleIssueDetailsData))
+                .returns(() => ['TAG1', 'TAG2']);
 
             queryBuilderMock
-                .setup(builder => builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Bug`))
+                .setup(builder =>
+                    builder.withBaseUrl(`${settingsData.projectURL}/_workitems/create/Bug`),
+                )
                 .returns(() => queryBuilderMock.object);
 
             const expectedTags = `${baseTags}; TAG1; TAG2`;
-            queryBuilderMock.setup(builder => builder.withParam('[System.Tags]', expectedTags)).returns(() => queryBuilderMock.object);
             queryBuilderMock
-                .setup(builder => builder.withParam('[Microsoft.VSTS.TCM.ReproSteps]', testIssueDetails))
+                .setup(builder => builder.withParam('[System.Tags]', expectedTags))
+                .returns(() => queryBuilderMock.object);
+            queryBuilderMock
+                .setup(builder =>
+                    builder.withParam('[Microsoft.VSTS.TCM.ReproSteps]', testIssueDetails),
+                )
                 .returns(() => queryBuilderMock.object);
 
             const result = testSubject(settingsData, sampleIssueDetailsData, environmentInfo);

--- a/src/tests/unit/tests/issue-filing/services/github/create-github-issue-filing-url.test.ts
+++ b/src/tests/unit/tests/issue-filing/services/github/create-github-issue-filing-url.test.ts
@@ -49,22 +49,34 @@ describe('createGitHubIssueFilingUrlTest', () => {
         stringUtilsMock = Mock.ofType<IssueUrlCreationUtils>();
 
         const testTitle = 'test title';
-        stringUtilsMock.setup(utils => utils.getTitle(sampleIssueDetailsData)).returns(() => testTitle);
+        stringUtilsMock
+            .setup(utils => utils.getTitle(sampleIssueDetailsData))
+            .returns(() => testTitle);
 
         issueDetailsGetter = Mock.ofType<IssueDetailsBuilder>();
         const testIssueDetails = 'test issue details';
-        issueDetailsGetter.setup(getter => getter(environmentInfo, sampleIssueDetailsData)).returns(() => testIssueDetails);
+        issueDetailsGetter
+            .setup(getter => getter(environmentInfo, sampleIssueDetailsData))
+            .returns(() => testIssueDetails);
 
         const rectifiedUrl = 'rectified-url';
         rectifyMock = Mock.ofType<UrlRectifier>();
-        rectifyMock.setup(rectifier => rectifier(settingsData.repository)).returns(() => rectifiedUrl);
+        rectifyMock
+            .setup(rectifier => rectifier(settingsData.repository))
+            .returns(() => rectifiedUrl);
 
         queryBuilderMock = Mock.ofType<HTTPQueryBuilder>();
 
-        queryBuilderMock.setup(builder => builder.withBaseUrl(`${rectifiedUrl}/new`)).returns(() => queryBuilderMock.object);
+        queryBuilderMock
+            .setup(builder => builder.withBaseUrl(`${rectifiedUrl}/new`))
+            .returns(() => queryBuilderMock.object);
 
-        queryBuilderMock.setup(builder => builder.withParam('title', testTitle)).returns(() => queryBuilderMock.object);
-        queryBuilderMock.setup(builder => builder.withParam('body', testIssueDetails)).returns(() => queryBuilderMock.object);
+        queryBuilderMock
+            .setup(builder => builder.withParam('title', testTitle))
+            .returns(() => queryBuilderMock.object);
+        queryBuilderMock
+            .setup(builder => builder.withParam('body', testIssueDetails))
+            .returns(() => queryBuilderMock.object);
 
         queryBuilderMock.setup(builder => builder.build()).returns(() => buildedUrl);
 

--- a/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
+++ b/src/tests/unit/tests/issue-filing/services/github/github-issue-filing-service.test.tsx
@@ -52,13 +52,18 @@ describe('GithubIssueFilingServiceTest', () => {
             'some other service': {},
             [GitHubIssueFilingService.key]: expectedStoreData,
         };
-        expect(GitHubIssueFilingService.getSettingsFromStoreData(givenData)).toEqual(expectedStoreData);
+        expect(GitHubIssueFilingService.getSettingsFromStoreData(givenData)).toEqual(
+            expectedStoreData,
+        );
     });
 
     describe('isSettingsValid', () => {
-        it.each(invalidTestSettings)('invalid settings with %p', (settings: GitHubIssueFilingSettings) => {
-            expect(GitHubIssueFilingService.isSettingsValid(settings)).toBe(false);
-        });
+        it.each(invalidTestSettings)(
+            'invalid settings with %p',
+            (settings: GitHubIssueFilingSettings) => {
+                expect(GitHubIssueFilingService.isSettingsValid(settings)).toBe(false);
+            },
+        );
 
         it('valid settings', () => {
             const validSettings: GitHubIssueFilingSettings = {
@@ -94,7 +99,9 @@ describe('GithubIssueFilingServiceTest', () => {
                 propertyName: 'repository',
                 propertyValue: newRepositoryValue,
             };
-            onPropertyUpdateCallbackMock.setup(updateCallback => updateCallback(It.isValue(payload))).verifiable(Times.once());
+            onPropertyUpdateCallbackMock
+                .setup(updateCallback => updateCallback(It.isValue(payload)))
+                .verifiable(Times.once());
             wrapper
                 .find(TextField)
                 .props()

--- a/src/tests/unit/tests/issue-filing/unified-result-to-issue-filing-data.test.ts
+++ b/src/tests/unit/tests/issue-filing/unified-result-to-issue-filing-data.test.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { TargetAppData, UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
+import {
+    TargetAppData,
+    UnifiedResult,
+    UnifiedRule,
+} from 'common/types/store-data/unified-data-interface';
 
 import { CreateIssueDetailsTextData } from '../../../../common/types/create-issue-details-text-data';
 import { UnifiedResultToIssueFilingDataConverter } from '../../../../issue-filing/unified-result-to-issue-filing-data';


### PR DESCRIPTION
#### Description of changes

Add ` src/tests/unit/tests/issue-filing` folder to prettier override for the line width value.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
