### PR TITLE
refactor: using getAutomationIdSelector from unique source

### DIFF
--- a/src/tests/common/get-automation-id-selector.ts
+++ b/src/tests/common/get-automation-id-selector.ts
@@ -1,0 +1,4 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const getAutomationIdSelector = (id: string) => `[data-automation-id="${id}"]`;

--- a/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/automated-checks-view-selectors.ts
@@ -10,28 +10,29 @@ import { highlightBoxAutomationId } from 'electron/views/screenshot/highlight-bo
 import { screenshotImageAutomationId } from 'electron/views/screenshot/screenshot';
 import { screenshotViewAutomationId } from 'electron/views/screenshot/screenshot-view';
 import { cardsRuleIdAutomationId } from 'reports/components/report-sections/minimal-rule-header';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 
 const nthRuleGroup = (n: number) => `${AutomatedChecksViewSelectors.ruleGroup}:nth-of-type(${n})`;
 
 export const AutomatedChecksViewSelectors = {
-    mainContainer: `[data-automation-id="${automatedChecksViewAutomationId}"]`,
-    ruleGroup: `[data-automation-id="${ruleGroupAutomationId}"]`,
-    ruleContent: `[data-automation-id="${ruleContentAutomationId}"]`,
+    mainContainer: getAutomationIdSelector(automatedChecksViewAutomationId),
+    ruleGroup: getAutomationIdSelector(ruleGroupAutomationId),
+    ruleContent: getAutomationIdSelector(ruleContentAutomationId),
 
     nthRuleGroupCollapseExpandButton: (position: number) =>
-        `${nthRuleGroup(position)} [data-automation-id="${collapsibleButtonAutomationId}"]`,
+        `${nthRuleGroup(position)} ${getAutomationIdSelector(collapsibleButtonAutomationId)}`,
     nthRuleGroupTitle: (position: number) =>
-        `${nthRuleGroup(position)} [data-automation-id="${cardsRuleIdAutomationId}"]`,
+        `${nthRuleGroup(position)} ${getAutomationIdSelector(cardsRuleIdAutomationId)}`,
     nthRuleGroupInstances: (position: number) =>
-        `${nthRuleGroup(position)} [data-automation-id="${instanceCardAutomationId}"]`,
+        `${nthRuleGroup(position)} ${getAutomationIdSelector(instanceCardAutomationId)}`,
 
-    settingsButton: `[data-automation-id="${commandButtonSettingsId}"]`,
+    settingsButton: getAutomationIdSelector(commandButtonSettingsId),
 };
 
 export const ScreenshotViewSelectors = {
-    screenshotView: `[data-automation-id="${screenshotViewAutomationId}"]`,
-    screenshotImage: `[data-automation-id="${screenshotImageAutomationId}"]`,
-    highlightBox: `[data-automation-id="${highlightBoxAutomationId}"]`,
+    screenshotView: getAutomationIdSelector(screenshotViewAutomationId),
+    screenshotImage: getAutomationIdSelector(screenshotImageAutomationId),
+    highlightBox: getAutomationIdSelector(highlightBoxAutomationId),
     getHighlightBoxByIndex: (index: number) =>
         `${ScreenshotViewSelectors.highlightBox}:nth-of-type(${index})`,
 };

--- a/src/tests/electron/common/element-identifiers/device-connection-dialog-selectors.ts
+++ b/src/tests/electron/common/element-identifiers/device-connection-dialog-selectors.ts
@@ -8,10 +8,11 @@ import {
     deviceConnectPortNumberFieldAutomationId,
     deviceConnectValidatePortButtonAutomationId,
 } from 'electron/views/device-connect-view/components/device-connect-port-entry';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 
 export const DeviceConnectionDialogSelectors = {
-    portNumber: `[data-automation-id="${deviceConnectPortNumberFieldAutomationId}"]`,
-    validateButton: `[data-automation-id="${deviceConnectValidatePortButtonAutomationId}"]`,
-    cancelButton: `[data-automation-id="${deviceConnectCancelAutomationId}"]`,
-    startButton: `[data-automation-id="${deviceConnectStartAutomationId}"]`,
+    portNumber: getAutomationIdSelector(deviceConnectPortNumberFieldAutomationId),
+    validateButton: getAutomationIdSelector(deviceConnectValidatePortButtonAutomationId),
+    cancelButton: getAutomationIdSelector(deviceConnectCancelAutomationId),
+    startButton: getAutomationIdSelector(deviceConnectStartAutomationId),
 };

--- a/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
+++ b/src/tests/end-to-end/common/element-identifiers/details-view-selectors.ts
@@ -11,8 +11,7 @@ import {
     cardsRuleIdAutomationId,
     ruleDetailAutomationId,
 } from 'reports/components/report-sections/minimal-rule-header';
-
-const getAutomationIdSelector = (id: string) => `[data-automation-id="${id}"]`;
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 
 export const detailsViewSelectors = {
     previewFeaturesPanel: '.preview-features-panel',

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
@@ -1,9 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DetailsList, IColumn } from 'office-ui-fabric-react';
-import * as React from 'react';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import {
     AssessmentDefaultMessageGenerator,
     DefaultMessageInterface,
@@ -11,6 +7,10 @@ import {
     IMessageGenerator,
 } from 'assessments/assessment-default-message-generator';
 import { mount, shallow } from 'enzyme';
+import { DetailsList, IColumn } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
 import { AssessmentResultType, GeneratedAssessmentInstance } from '../../../../../common/types/store-data/assessment-result-data';
 import {
@@ -149,7 +149,7 @@ describe('AssessmentInstanceTable', () => {
         });
 
         describe('"Pass all unmarked instances" button', () => {
-            const passUnmarkedInstancesButtonSelector = `button[data-automation-id="${passUnmarkedInstancesButtonAutomationId}"]`;
+            const passUnmarkedInstancesButtonSelector = `button${getAutomationIdSelector(passUnmarkedInstancesButtonAutomationId)}`;
             it('is enabled if there is an instance with unknown status', () => {
                 testStepResults[selectedTestStep] = { status: ManualTestStatus.UNKNOWN };
 

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -7,6 +7,7 @@ import { ScanStatus } from 'electron/flux/types/scan-status';
 import { CommandBar, CommandBarProps, commandButtonRefreshId } from 'electron/views/automated-checks/components/command-bar';
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
 
@@ -65,7 +66,9 @@ describe('CommandBar', () => {
             } as CommandBarProps;
 
             const rendered = mount(<CommandBar {...props} />);
-            const button = rendered.find(`button[data-automation-id="${commandButtonRefreshId}"]`);
+
+            const buttonSelector = `button${getAutomationIdSelector(commandButtonRefreshId)}`;
+            const button = rendered.find(buttonSelector);
 
             button.simulate('click', eventStub);
 

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -13,6 +13,7 @@ import { portNumberField } from 'electron/views/device-connect-view/components/d
 import { shallow } from 'enzyme';
 import { Button, MaskedTextField } from 'office-ui-fabric-react';
 import * as React from 'react';
+import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
@@ -108,7 +109,9 @@ describe('DeviceConnectPortEntryTest', () => {
             } as DeviceConnectPortEntryProps;
             const rendered = shallow(<DeviceConnectPortEntry {...props} />);
             rendered.setState({ port: testPortNumber });
-            const button = rendered.find(`[data-automation-id="${deviceConnectValidatePortButtonAutomationId}"]`);
+
+            const buttonSelector = getAutomationIdSelector(deviceConnectValidatePortButtonAutomationId);
+            const button = rendered.find(buttonSelector);
 
             button.simulate('click', eventStub);
 


### PR DESCRIPTION
#### Description of changes

Currently, we have some tests (unit and e2e) that have selectors using `[data-automation-id="..."]` as a hardcoded value which may induce errors on either side, the test and the prod code.

We already have a function to generate this selector base on the id value but it's local to the file we are declaring it.

In this PR:
- Extract `getAutomationIdSelector` function to it's own file
- Update all e2e test that use this type of selector
- Update a few unit test that also use this pattern.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
