### PR TITLE
fix: Electron app > How to fix - Text should not break in the middle of a word

### DIFF
--- a/src/reports/components/instance-details.scss
+++ b/src/reports/components/instance-details.scss
@@ -96,7 +96,7 @@
 table.report-instance-table {
     border-collapse: collapse;
     overflow-x: auto;
-    word-break: break-all;
+    word-break: break-word;
 }
 
 @media screen and (max-width: 480px) {


### PR DESCRIPTION
#### Description of changes

Fix work break on Automated Check View Cards UI on AI-Android.

![01 - word break at different window sizes](https://user-images.githubusercontent.com/2837582/76028998-85e4a800-5ee8-11ea-90b7-4b23b6c75e6b.gif)


#### Pull request checklist
- [x] Addresses an existing issue: #2265
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
