### PR TITLE
fix: fit-and-finish for settings/preview/failure instance panels

### DIFF
--- a/src/DetailsView/components/details-view-overlay/settings-panel/settings-panel.scss
+++ b/src/DetailsView/components/details-view-overlay/settings-panel/settings-panel.scss
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../../../common/styles/colors.scss';
+@import '../../../../common/styles/fonts.scss';
 
 .settings-panel {
     h3 {
-        font-size: 17px;
+        @include text-style-title-s;
         margin-block-end: 8px;
     }
 
@@ -18,9 +19,5 @@
         :global(.ms-TextField-field) {
             color: $neutral-100;
         }
-    }
-
-    :global(.ms-Panel-content) {
-        padding-top: 20px;
     }
 }

--- a/src/DetailsView/components/generic-panel.scss
+++ b/src/DetailsView/components/generic-panel.scss
@@ -1,27 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../common/styles/colors.scss';
+@import '../../common/styles/fonts.scss';
 
 .generic-panel {
-    margin-left: auto;
-    margin-right: auto;
+    color: $neutral-100;
+}
+
+.header-text {
+    @include text-style-title-m;
     color: $neutral-100;
 
-    .header-text {
-        color: $neutral-100;
-        font-size: 2em;
-    }
-
-    :global(.ms-Panel-commands) {
-        margin-bottom: 25px;
-
-        i[data-icon-name='Cancel'] {
-            font-size: 24px;
-        }
-    }
-
-    :global(.ms-Panel-contentInner) {
-        padding-left: 16px;
-        padding-right: 16px;
-    }
+    margin-bottom: 20px;
 }

--- a/src/DetailsView/components/generic-panel.tsx
+++ b/src/DetailsView/components/generic-panel.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { css } from '@uifabric/utilities';
 import { NamedFC } from 'common/react/named-fc';
-import { IPanelProps, Panel, PanelType } from 'office-ui-fabric-react';
+import { IPanelProps, Panel } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './generic-panel.scss';
 
@@ -14,8 +14,6 @@ export const GenericPanel = NamedFC<GenericPanelProps>('GenericPanel', props => 
     <Panel
         {...props}
         data-automation-id={props.innerPanelAutomationId}
-        type={PanelType.custom}
-        customWidth="550px"
         className={css(styles.genericPanel, props.className)}
         isLightDismiss={true}
         headerClassName={styles.headerText}

--- a/src/DetailsView/components/generic-toggle.scss
+++ b/src/DetailsView/components/generic-toggle.scss
@@ -1,21 +1,23 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../common/styles/colors.scss';
+@import '../../common/styles/fonts.scss';
 
 .generic-toggle-component {
     margin-bottom: 4vh;
 
     .toggle-container {
+        display: flex;
+        justify-content: space-between;
         margin-bottom: 1vh;
 
         .toggle-name {
-            display: inline-block;
-            font-size: 17px;
-            font-weight: bold;
+            @include text-style-title-s;
         }
 
         .toggle {
-            float: right;
+            margin-top: 3px;
+            margin-bottom: unset;
         }
     }
 

--- a/src/DetailsView/components/generic-toggle.scss
+++ b/src/DetailsView/components/generic-toggle.scss
@@ -16,6 +16,7 @@
         }
 
         .toggle {
+            margin-left: 12px;
             margin-top: 3px;
             margin-bottom: unset;
         }

--- a/src/DetailsView/components/no-displayable-preview-features-message.scss
+++ b/src/DetailsView/components/no-displayable-preview-features-message.scss
@@ -3,6 +3,5 @@
 @import '../../common/styles/fonts.scss';
 
 .no-preview-feature-message {
-    font-size: 20px;
-    font-family: $semiBoldFontFamily;
+    @include text-style-body-m;
 }

--- a/src/common/styles/fonts.scss
+++ b/src/common/styles/fonts.scss
@@ -60,6 +60,14 @@ $fontSizeXXXXL: 72px !default;
 $codeFontFamily: Menlo, Consolas, Courier New, monospace !default;
 $semiBoldFontFamily: make-font-family($semiBoldFonts) !default;
 
+@mixin text-style-title-m {
+    font-family: $semiBoldFontFamily;
+    font-weight: $fontWeightSemiBold;
+    font-size: $fontSizeLML;
+    line-height: 32px;
+    letter-spacing: -0.02em;
+}
+
 @mixin text-style-title-s {
     font-family: $semiBoldFontFamily;
     font-weight: $fontWeightSemiBold;

--- a/src/electron/views/automated-checks/components/header-section.scss
+++ b/src/electron/views/automated-checks/components/header-section.scss
@@ -8,11 +8,8 @@
     margin-bottom: 24px;
 
     .title {
-        font-family: $semiBoldFontFamily;
-        font-weight: $fontWeightSemiBold;
-        font-size: $fontSizeLML;
+        @include text-style-title-m;
         line-height: 25px;
-        letter-spacing: -0.02em;
         color: $primary-text;
         margin-top: 0;
         margin-bottom: 8px;

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
@@ -4,14 +4,13 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
 <DocumentFragment>
   <div
     aria-hidden="false"
-    class="ms-Panel is-open ms-Panel--hasCloseButton ms-Panel--custom generic-panel--{{CSS_MODULE_HASH}} preview-features-panel root-000"
+    class="ms-Panel is-open ms-Panel--hasCloseButton generic-panel--{{CSS_MODULE_HASH}} preview-features-panel root-000"
   >
     <div
       class="ms-Overlay overlay-000"
     />
     <div
       class="ms-Panel-main main-000"
-      style="width: 550px;"
     >
       <div
         data-is-visible="true"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-panel.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/generic-panel.test.tsx.snap
@@ -4,14 +4,12 @@ exports[`GenericPanel renders isPanelOpen: false 1`] = `
 <StyledPanelBase
   className="genericPanel panel-custom-class"
   closeButtonAriaLabel="close button label"
-  customWidth="550px"
   hasCloseButton={true}
   headerClassName="headerText"
   headerText="panel title"
   isLightDismiss={true}
   isOpen={false}
   onDismiss={[Function]}
-  type={7}
 >
   <div>
     child content
@@ -23,14 +21,12 @@ exports[`GenericPanel renders isPanelOpen: true 1`] = `
 <StyledPanelBase
   className="genericPanel panel-custom-class"
   closeButtonAriaLabel="close button label"
-  customWidth="550px"
   hasCloseButton={true}
   headerClassName="headerText"
   headerText="panel title"
   isLightDismiss={true}
   isOpen={true}
   onDismiss={[Function]}
-  type={7}
 >
   <div>
     child content
@@ -41,9 +37,7 @@ exports[`GenericPanel renders isPanelOpen: true 1`] = `
 exports[`GenericPanel renders minimal content 1`] = `
 <StyledPanelBase
   className="genericPanel"
-  customWidth="550px"
   headerClassName="headerText"
   isLightDismiss={true}
-  type={7}
 />
 `;


### PR DESCRIPTION
#### Description of changes

We noticed in #2256 that at some point we'd taken office fabric updates that changed how our "generic panels" render (this include our settings panel, preview features panel, "add failure instance details" panel, and the hidden-feature-flagged scoping panel).

This PR covers updates per discussion with @ichelsea and @ferBonnin bringing our panel styling up to date with standard office fabric layouts and our current typography codex.

Setting as "2 reviewers required" because I want one engineering signoff and one signoff from @ichelsea

(all screenshots below use the same window size for both; the panels are intentionally thinner in the after versions)

Before left / after right: Settings panel 100% zoom
![Before left / after right: Settings panel 100% zoom](https://user-images.githubusercontent.com/376284/76029255-f7245b00-5ee8-11ea-9046-d48e48f1ce9d.png)

Before left / after right: Settings panel 200% zoom
![image](https://user-images.githubusercontent.com/376284/76029340-1cb16480-5ee9-11ea-9f50-72a844b14886.png)

Before left / after right: Preview features panel 100% zoom
![Before left / after right: Preview features panel 100% zoom](https://user-images.githubusercontent.com/376284/76029403-3baff680-5ee9-11ea-9106-45606ceceb26.png)

Before left / after right: Preview features panel 200% zoom
![Before left / after right: Preview features panel 200% zoom](https://user-images.githubusercontent.com/376284/76029373-2b981700-5ee9-11ea-9f9d-85aa47af64de.png)

Before left / after right: Failure instance panel 100% zoom
![Before left / after right: Failure instance panel 100% zoom](https://user-images.githubusercontent.com/376284/76029435-4f5b5d00-5ee9-11ea-8f07-f82610f06da9.png)

Before left / after right: Failure instance panel 200% zoom
![Before left / after right: Failure instance panel 200% zoom](https://user-images.githubusercontent.com/376284/76029457-5e420f80-5ee9-11ea-89cc-5daa48d4929a.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2256
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
