### PR TITLE
chore: line width for src/tests/unit/tests/popup folder

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -13,7 +13,6 @@ module.exports = {
                 'src/tests/unit/tests/DetailsView/**/*',
                 'src/tests/unit/tests/electron/**/*',
                 'src/tests/unit/tests/injected/**/*',
-                'src/tests/unit/tests/popup/**/*',
             ],
             options: {
                 printWidth: 140,

--- a/src/tests/unit/tests/popup/actions/popup-action-message-creator.test.ts
+++ b/src/tests/unit/tests/popup/actions/popup-action-message-creator.test.ts
@@ -63,7 +63,10 @@ describe('PopupActionMessageCreatorTest', () => {
 
         testSubject.popupInitialized(stubTab);
 
-        actionMessageDispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)), Times.once());
+        actionMessageDispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
     });
 
     it('dispatches for openLaunchPad', () => {
@@ -76,7 +79,10 @@ describe('PopupActionMessageCreatorTest', () => {
 
         testSubject.openLaunchPad(panelType);
 
-        actionMessageDispatcherMock.verify(dispatcher => dispatcher.sendTelemetry(LAUNCH_PANEL_OPEN, It.isValue(telemetry)), Times.once());
+        actionMessageDispatcherMock.verify(
+            dispatcher => dispatcher.sendTelemetry(LAUNCH_PANEL_OPEN, It.isValue(telemetry)),
+            Times.once(),
+        );
     });
 
     test('openDetailsView', () => {
@@ -100,13 +106,23 @@ describe('PopupActionMessageCreatorTest', () => {
             payload: expectedPayload,
         };
 
-        telemetryFactoryMock.setup(tf => tf.forOpenDetailsView(stubKeypressEvent, viewType, testSource)).returns(() => telemetry);
+        telemetryFactoryMock
+            .setup(tf => tf.forOpenDetailsView(stubKeypressEvent, viewType, testSource))
+            .returns(() => telemetry);
 
         mockWindowUtils.setup(x => x.closeWindow()).verifiable(Times.once());
 
-        testSubject.openDetailsView(stubKeypressEvent, VisualizationType.Headings, testSource, pivotType);
+        testSubject.openDetailsView(
+            stubKeypressEvent,
+            VisualizationType.Headings,
+            testSource,
+            pivotType,
+        );
 
-        actionMessageDispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)), Times.once());
+        actionMessageDispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
         mockWindowUtils.verifyAll();
     });
 
@@ -123,11 +139,16 @@ describe('PopupActionMessageCreatorTest', () => {
             },
         };
 
-        telemetryFactoryMock.setup(tf => tf.fromHamburgerMenu(stubKeypressEvent)).returns(() => telemetry);
+        telemetryFactoryMock
+            .setup(tf => tf.fromHamburgerMenu(stubKeypressEvent))
+            .returns(() => telemetry);
 
         testSubject.openShortcutConfigureTab(stubKeypressEvent);
 
-        actionMessageDispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(It.isValue(message)), Times.once());
+        actionMessageDispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(message)),
+            Times.once(),
+        );
     });
 
     it('dispatches for openTutorial', () => {
@@ -136,11 +157,16 @@ describe('PopupActionMessageCreatorTest', () => {
             source: TelemetryEventSource.LaunchPad,
         };
 
-        telemetryFactoryMock.setup(tf => tf.fromLaunchPad(stubKeypressEvent)).returns(() => telemetry);
+        telemetryFactoryMock
+            .setup(tf => tf.fromLaunchPad(stubKeypressEvent))
+            .returns(() => telemetry);
 
         testSubject.openTutorial(stubKeypressEvent);
 
-        actionMessageDispatcherMock.verify(dispatcher => dispatcher.sendTelemetry(TUTORIAL_OPEN, It.isValue(telemetry)), Times.once());
+        actionMessageDispatcherMock.verify(
+            dispatcher => dispatcher.sendTelemetry(TUTORIAL_OPEN, It.isValue(telemetry)),
+            Times.once(),
+        );
     });
 
     it('dispatches for setLaunchPanelType', () => {
@@ -157,6 +183,9 @@ describe('PopupActionMessageCreatorTest', () => {
 
         testSubject.setLaunchPanelType(panelType);
 
-        actionMessageDispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)), Times.once());
+        actionMessageDispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
     });
 });

--- a/src/tests/unit/tests/popup/components/ad-hoc-tools-panel.test.tsx
+++ b/src/tests/unit/tests/popup/components/ad-hoc-tools-panel.test.tsx
@@ -34,7 +34,9 @@ describe('AdHocToolsPanelTest', () => {
     });
 
     test('back link clicked', () => {
-        diagnosticViewToggleFactoryMock.setup(factory => factory.createTogglesForAdHocToolsPanel()).returns(() => []);
+        diagnosticViewToggleFactoryMock
+            .setup(factory => factory.createTogglesForAdHocToolsPanel())
+            .returns(() => []);
 
         const backLinkHandlerMock = Mock.ofInstance(() => {});
         backLinkHandlerMock.setup(b => b()).verifiable(Times.once());

--- a/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
+++ b/src/tests/unit/tests/popup/components/diagnostic-view-toggle.test.tsx
@@ -10,7 +10,10 @@ import { VisualizationType } from 'common/types/visualization-type';
 import { mount, shallow } from 'enzyme';
 import { Link } from 'office-ui-fabric-react';
 import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-creator';
-import { DiagnosticViewToggle, DiagnosticViewToggleProps } from 'popup/components/diagnostic-view-toggle';
+import {
+    DiagnosticViewToggle,
+    DiagnosticViewToggleProps,
+} from 'popup/components/diagnostic-view-toggle';
 import { DiagnosticViewClickHandler } from 'popup/handlers/diagnostic-view-toggle-click-handler';
 import * as React from 'react';
 import * as TestUtils from 'react-dom/test-utils';
@@ -32,7 +35,10 @@ describe('DiagnosticViewToggleTest', () => {
             const visualizationType = VisualizationType.Headings;
             const data = new VisualizationStoreDataBuilder().with('scanning', 'headings').build();
 
-            const props: DiagnosticViewToggleProps = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource)
+            const props: DiagnosticViewToggleProps = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            )
                 .setupVisualizationStoreData(data)
                 .build();
 
@@ -45,7 +51,10 @@ describe('DiagnosticViewToggleTest', () => {
             const visualizationType = VisualizationType.Headings;
             const data = new VisualizationStoreDataBuilder().with('scanning', 'landmarks').build();
 
-            const props: DiagnosticViewToggleProps = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource)
+            const props: DiagnosticViewToggleProps = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            )
                 .setupVisualizationStoreData(data)
                 .build();
 
@@ -57,7 +66,10 @@ describe('DiagnosticViewToggleTest', () => {
         it('toggle when not scanning', () => {
             const visualizationType = VisualizationType.Headings;
 
-            const props: DiagnosticViewToggleProps = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource).build();
+            const props: DiagnosticViewToggleProps = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            ).build();
 
             const wrapper = shallow(<DiagnosticViewToggle {...props} />);
 
@@ -67,7 +79,10 @@ describe('DiagnosticViewToggleTest', () => {
         it('details view link when the test does not have a guidance', () => {
             const visualizationType = VisualizationType.Issues;
 
-            const props: DiagnosticViewToggleProps = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource).build();
+            const props: DiagnosticViewToggleProps = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            ).build();
 
             const wrapper = shallow(<DiagnosticViewToggle {...props} />);
 
@@ -79,7 +94,10 @@ describe('DiagnosticViewToggleTest', () => {
         it('handles click on details view link, it will open FastPass when Assessment enabled', () => {
             const visualizationType = VisualizationType.Issues;
             const event = eventStubFactory.createKeypressEvent();
-            const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource);
+            const propsBuilder = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            );
             const props: DiagnosticViewToggleProps = propsBuilder
                 .setupFeatureFlags({ 'test-flag': true })
                 .setupOpenDetailsViewCall(event)
@@ -96,9 +114,10 @@ describe('DiagnosticViewToggleTest', () => {
             const visualizationType = VisualizationType.Headings;
             const event = eventStubFactory.createKeypressEvent();
 
-            const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource).setupToggleVisualizationCall(
-                event,
-            );
+            const propsBuilder = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            ).setupToggleVisualizationCall(event);
 
             const props: DiagnosticViewToggleProps = propsBuilder.build();
 
@@ -115,7 +134,10 @@ describe('DiagnosticViewToggleTest', () => {
 
             const event = eventStubFactory.createKeypressEvent();
 
-            const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource)
+            const propsBuilder = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            )
                 .setupVisualizationStoreData(data)
                 .setupOpenDetailsViewCall(event);
 
@@ -131,9 +153,10 @@ describe('DiagnosticViewToggleTest', () => {
             const visualizationType = VisualizationType.Issues;
             const event = eventStubFactory.createKeypressEvent();
 
-            const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource).setupOpenDetailsViewCall(
-                event,
-            );
+            const propsBuilder = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            ).setupOpenDetailsViewCall(event);
 
             const props: DiagnosticViewToggleProps = propsBuilder.build();
 
@@ -145,7 +168,10 @@ describe('DiagnosticViewToggleTest', () => {
 
         it('handles command not found', () => {
             const visualizationType = VisualizationType.Color;
-            const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource).setupShortcutCommands([]);
+            const propsBuilder = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            ).setupShortcutCommands([]);
 
             const props: DiagnosticViewToggleProps = propsBuilder.build();
 
@@ -153,7 +179,9 @@ describe('DiagnosticViewToggleTest', () => {
 
             const renderAction = () => component.render();
 
-            const commandName = visualizationConfigurationFactory.getConfiguration(visualizationType).chromeCommand;
+            const commandName = visualizationConfigurationFactory.getConfiguration(
+                visualizationType,
+            ).chromeCommand;
             expect(renderAction).toThrowError(`Cannot find command for name: ${commandName}`);
         });
     });
@@ -165,7 +193,10 @@ describe('DiagnosticViewToggleTest', () => {
 
             const depsMock = createDepsMock();
 
-            const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource)
+            const propsBuilder = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            )
                 .setupOpenDetailsViewCall(event)
                 .setupDeps(depsMock.object);
 
@@ -189,7 +220,10 @@ describe('DiagnosticViewToggleTest', () => {
 
             const depsMock = createDepsMock();
 
-            const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource)
+            const propsBuilder = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            )
                 .setupOpenDetailsViewCall(event)
                 .setupDeps(depsMock.object);
 
@@ -215,7 +249,10 @@ describe('DiagnosticViewToggleTest', () => {
 
             const depsMock = createDepsMock();
 
-            const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource)
+            const propsBuilder = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            )
                 .setupOpenDetailsViewCall(event)
                 .setupDeps(depsMock.object);
 
@@ -239,7 +276,10 @@ describe('DiagnosticViewToggleTest', () => {
 
             const depsMock = createDepsMock();
 
-            const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource)
+            const propsBuilder = new DiagnosticViewTogglePropsBuilder(
+                visualizationType,
+                testTelemetrySource,
+            )
                 .setupOpenDetailsViewCall(event)
                 .setupDeps(depsMock.object);
 
@@ -264,7 +304,10 @@ describe('DiagnosticViewToggleTest', () => {
 
         const depsMock = createDepsMock();
 
-        const propsBuilder = new DiagnosticViewTogglePropsBuilder(visualizationType, testTelemetrySource)
+        const propsBuilder = new DiagnosticViewTogglePropsBuilder(
+            visualizationType,
+            testTelemetrySource,
+        )
             .setupOpenDetailsViewCall(event)
             .setupDeps(depsMock.object);
 
@@ -296,7 +339,9 @@ class DiagnosticViewTogglePropsBuilder {
     private visualizationType: VisualizationType;
     private data: VisualizationStoreData = new VisualizationStoreDataBuilder().build();
     private visualizationConfigurationFactory = new VisualizationConfigurationFactory();
-    private defaultVisualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
+    private defaultVisualizationConfigurationFactoryMock = Mock.ofType(
+        VisualizationConfigurationFactory,
+    );
     private actionMessageCreatorMock = Mock.ofType(PopupActionMessageCreator);
     private clickHandlerMock = Mock.ofType(DiagnosticViewClickHandler);
     private telemetrySource: TelemetryEventSource;
@@ -316,31 +361,46 @@ class DiagnosticViewTogglePropsBuilder {
         this.deps = deps;
         return this;
     }
-    public setupShortcutCommands(shortcutCommands: chrome.commands.Command[]): DiagnosticViewTogglePropsBuilder {
+    public setupShortcutCommands(
+        shortcutCommands: chrome.commands.Command[],
+    ): DiagnosticViewTogglePropsBuilder {
         this.shortcutCommands = shortcutCommands;
         return this;
     }
 
-    public setupVisualizationStoreData(data: VisualizationStoreData): DiagnosticViewTogglePropsBuilder {
+    public setupVisualizationStoreData(
+        data: VisualizationStoreData,
+    ): DiagnosticViewTogglePropsBuilder {
         this.data = data;
         return this;
     }
 
     public setupOpenDetailsViewCall(event): DiagnosticViewTogglePropsBuilder {
         this.actionMessageCreatorMock
-            .setup(ac => ac.openDetailsView(event, this.visualizationType, this.telemetrySource, DetailsViewPivotType.fastPass))
+            .setup(ac =>
+                ac.openDetailsView(
+                    event,
+                    this.visualizationType,
+                    this.telemetrySource,
+                    DetailsViewPivotType.fastPass,
+                ),
+            )
             .verifiable(Times.once());
 
         return this;
     }
 
     public setupToggleVisualizationCall(event): DiagnosticViewTogglePropsBuilder {
-        this.clickHandlerMock.setup(ch => ch.toggleVisualization(this.data, this.visualizationType, event)).verifiable(Times.once());
+        this.clickHandlerMock
+            .setup(ch => ch.toggleVisualization(this.data, this.visualizationType, event))
+            .verifiable(Times.once());
 
         return this;
     }
 
-    public setupFeatureFlags(featureFlags: DictionaryStringTo<boolean>): DiagnosticViewTogglePropsBuilder {
+    public setupFeatureFlags(
+        featureFlags: DictionaryStringTo<boolean>,
+    ): DiagnosticViewTogglePropsBuilder {
         this.featureFlags = featureFlags;
         return this;
     }
@@ -364,7 +424,9 @@ class DiagnosticViewTogglePropsBuilder {
         this.defaultVisualizationConfigurationFactoryMock
             .setup(v => v.getConfiguration(It.isAny()))
             .returns(
-                visualizationType => this.configurationStub || this.visualizationConfigurationFactory.getConfiguration(visualizationType),
+                visualizationType =>
+                    this.configurationStub ||
+                    this.visualizationConfigurationFactory.getConfiguration(visualizationType),
             )
             .verifiable();
 

--- a/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
+++ b/src/tests/unit/tests/popup/components/file-url-unsupported-message-panel.test.tsx
@@ -32,8 +32,12 @@ describe('FileUrlUnsupportedMessagePanel', () => {
     it('has a NewTabLink that uses createActiveTab to open the manage extension page', async () => {
         const stubExtensionPageUrl = 'protocol://extension-page';
         const browserAdapterMock = Mock.ofType<BrowserAdapter>(null, MockBehavior.Strict);
-        browserAdapterMock.setup(adapter => adapter.getManageExtensionUrl()).returns(() => stubExtensionPageUrl);
-        browserAdapterMock.setup(adapter => adapter.createActiveTab(stubExtensionPageUrl)).returns(() => Promise.resolve({} as Tabs.Tab));
+        browserAdapterMock
+            .setup(adapter => adapter.getManageExtensionUrl())
+            .returns(() => stubExtensionPageUrl);
+        browserAdapterMock
+            .setup(adapter => adapter.createActiveTab(stubExtensionPageUrl))
+            .returns(() => Promise.resolve({} as Tabs.Tab));
 
         const props: FileUrlUnsupportedMessagePanelProps = {
             deps: {

--- a/src/tests/unit/tests/popup/components/launch-pad-item-row.test.tsx
+++ b/src/tests/unit/tests/popup/components/launch-pad-item-row.test.tsx
@@ -8,7 +8,10 @@ import * as TestUtils from 'react-dom/test-utils';
 import { Mock, Times } from 'typemoq';
 
 import { kebabCase } from 'lodash';
-import { LaunchPadItemRow, LaunchPadItemRowProps } from '../../../../../popup/components/launch-pad-item-row';
+import {
+    LaunchPadItemRow,
+    LaunchPadItemRowProps,
+} from '../../../../../popup/components/launch-pad-item-row';
 import { EventStubFactory } from '../../../common/event-stub-factory';
 
 describe('LaunchPadItemRow', () => {
@@ -49,7 +52,10 @@ describe('LaunchPadItemRow', () => {
         const expected = (
             <div className="ms-Grid">
                 <div className="ms-Grid-row">
-                    <div className="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle" aria-hidden="true">
+                    <div
+                        className="ms-Grid-col ms-sm3 popup-start-dialog-icon-circle"
+                        aria-hidden="true"
+                    >
                         <Icon iconName={props.iconName} className="popup-start-dialog-icon" />
                     </div>
                     <div className="ms-Grid-col ms-sm9">

--- a/src/tests/unit/tests/popup/components/launch-pad.test.tsx
+++ b/src/tests/unit/tests/popup/components/launch-pad.test.tsx
@@ -5,7 +5,12 @@ import * as React from 'react';
 
 import { toolName } from 'content/strings/application';
 import { ExternalLink } from '../../../../../common/components/external-link';
-import { LaunchPad, LaunchPadDeps, LaunchPadProps, LaunchPadRowConfiguration } from '../../../../../popup/components/launch-pad';
+import {
+    LaunchPad,
+    LaunchPadDeps,
+    LaunchPadProps,
+    LaunchPadRowConfiguration,
+} from '../../../../../popup/components/launch-pad';
 import { LaunchPadItemRow } from '../../../../../popup/components/launch-pad-item-row';
 
 const AXE_CORE_VERSION = 'axe.core.version';
@@ -51,23 +56,42 @@ describe('LaunchPad', () => {
         const expected = (
             <div className="ms-Grid main-section">
                 <main>
-                    <div role="heading" aria-level={2} className="launch-pad-title ms-fontWeight-semibold">
+                    <div
+                        role="heading"
+                        aria-level={2}
+                        className="launch-pad-title ms-fontWeight-semibold"
+                    >
                         Launch pad
                     </div>
                     <hr className="ms-fontColor-neutralTertiaryAlt launch-pad-hr" />
                     <div className="launch-pad-main-section">
                         <div key="row-item-1">
-                            <LaunchPadItemRow iconName={'Rocket'} description="Description 1" title="Title 1" onClickTitle={null} />
+                            <LaunchPadItemRow
+                                iconName={'Rocket'}
+                                description="Description 1"
+                                title="Title 1"
+                                onClickTitle={null}
+                            />
                             <hr className="ms-fontColor-neutralTertiaryAlt launch-pad-hr" />
                         </div>
 
                         <div key="row-item-2">
-                            <LaunchPadItemRow iconName={'testBeaker'} description="Description 2" title="Title 2" onClickTitle={null} />
+                            <LaunchPadItemRow
+                                iconName={'testBeaker'}
+                                description="Description 2"
+                                title="Title 2"
+                                onClickTitle={null}
+                            />
                             <hr className="ms-fontColor-neutralTertiaryAlt launch-pad-hr" />
                         </div>
 
                         <div key="row-item-3">
-                            <LaunchPadItemRow iconName={'Medical'} description="Description 3" title="Title 3" onClickTitle={null} />
+                            <LaunchPadItemRow
+                                iconName={'Medical'}
+                                description="Description 3"
+                                title="Title 3"
+                                onClickTitle={null}
+                            />
                             <hr className="ms-fontColor-neutralTertiaryAlt launch-pad-hr" />
                         </div>
                     </div>
@@ -75,7 +99,11 @@ describe('LaunchPad', () => {
                 <div role="complementary" className="launch-pad-footer">
                     <div>
                         {`Version ${props.version} | Powered by `}
-                        <ExternalLink deps={deps} title="Navigate to axe-core npm page" href="https://www.npmjs.com/package/axe-core">
+                        <ExternalLink
+                            deps={deps}
+                            title="Navigate to axe-core npm page"
+                            href="https://www.npmjs.com/package/axe-core"
+                        >
                             axe-core
                         </ExternalLink>{' '}
                         {AXE_CORE_VERSION}

--- a/src/tests/unit/tests/popup/components/launch-panel-header.test.tsx
+++ b/src/tests/unit/tests/popup/components/launch-panel-header.test.tsx
@@ -5,7 +5,11 @@ import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { mount, shallow } from 'enzyme';
 import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-creator';
-import { LaunchPanelHeader, LaunchPanelHeaderDeps, LaunchPanelHeaderProps } from 'popup/components/launch-panel-header';
+import {
+    LaunchPanelHeader,
+    LaunchPanelHeaderDeps,
+    LaunchPanelHeaderProps,
+} from 'popup/components/launch-panel-header';
 import { LaunchPanelHeaderClickHandler } from 'popup/handlers/launch-panel-header-click-handler';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
@@ -44,7 +48,9 @@ describe('LaunchPanelHeaderTest', () => {
 
         const wrapped = mount(<LaunchPanelHeader {...props} />);
 
-        dropdownClickHandlerMock.setup(handler => handler.openDebugTools()).verifiable(Times.once());
+        dropdownClickHandlerMock
+            .setup(handler => handler.openDebugTools())
+            .verifiable(Times.once());
 
         const flaggedComponent = wrapped.find(FlaggedComponent);
 

--- a/src/tests/unit/tests/popup/components/popup-view-controller-handler.test.tsx
+++ b/src/tests/unit/tests/popup/components/popup-view-controller-handler.test.tsx
@@ -17,7 +17,9 @@ describe('PopupViewControllerHandlerTest', () => {
         const testSubject: PopupViewControllerHandler = new PopupViewControllerHandler();
 
         const actionMessageCreatorMock = Mock.ofType(PopupActionMessageCreator);
-        actionMessageCreatorMock.setup(a => a.setLaunchPanelType(testPanelType)).verifiable(Times.once());
+        actionMessageCreatorMock
+            .setup(a => a.setLaunchPanelType(testPanelType))
+            .verifiable(Times.once());
 
         setlaunchPanelTypeMock.setup(cM => cM(testPanelType)).verifiable(Times.once());
 
@@ -47,7 +49,9 @@ describe('PopupViewControllerHandlerTest', () => {
         const testSubject: PopupViewControllerHandler = new PopupViewControllerHandler();
 
         const actionMessageCreatorMock = Mock.ofType(PopupActionMessageCreator);
-        actionMessageCreatorMock.setup(a => a.setLaunchPanelType(testPanelType)).verifiable(Times.once());
+        actionMessageCreatorMock
+            .setup(a => a.setLaunchPanelType(testPanelType))
+            .verifiable(Times.once());
 
         setlaunchPanelTypeMock.setup(cM => cM(testPanelType)).verifiable(Times.once());
 

--- a/src/tests/unit/tests/popup/components/popup-view.test.tsx
+++ b/src/tests/unit/tests/popup/components/popup-view.test.tsx
@@ -82,14 +82,21 @@ describe('PopupView', () => {
         };
 
         beforeEach(() => {
-            actionMessageCreatorStrictMock = Mock.ofType<PopupActionMessageCreator>(null, MockBehavior.Strict);
+            actionMessageCreatorStrictMock = Mock.ofType<PopupActionMessageCreator>(
+                null,
+                MockBehavior.Strict,
+            );
             dropdownClickHandlerMock = Mock.ofType(DropdownClickHandler);
             handlerMock = Mock.ofType(PopupViewControllerHandler);
             clickHandlerMock = Mock.ofType(DiagnosticViewClickHandler);
             storesHubMock = createDefaultStoresHubMock();
             launchPadRowConfigurationFactoryMock
                 .setup(l =>
-                    l.createRowConfigs(It.isAny(), IsSameObject(actionMessageCreatorStrictMock.object), IsSameObject(handlerMock.object)),
+                    l.createRowConfigs(
+                        It.isAny(),
+                        IsSameObject(actionMessageCreatorStrictMock.object),
+                        IsSameObject(handlerMock.object),
+                    ),
                 )
                 .returns(() => rowConfigStub as any)
                 .verifiable();
@@ -108,7 +115,9 @@ describe('PopupView', () => {
         });
 
         test('render toggles view: launch pad', () => {
-            actionMessageCreatorStrictMock.setup(acm => acm.openLaunchPad(launchPanelStateStoreState.launchPanelType)).verifiable();
+            actionMessageCreatorStrictMock
+                .setup(acm => acm.openLaunchPad(launchPanelStateStoreState.launchPanelType))
+                .verifiable();
             const props = createDefaultPropsBuilder(storesHubMock.object)
                 .withDefaultTitleAndSubtitle()
                 .with('deps', deps)
@@ -119,7 +128,10 @@ describe('PopupView', () => {
                     shortcutModifyHandler: shortcutModifyHandlerStub as any,
                 })
                 .with('hasAccess', true)
-                .with('launchPadRowConfigurationFactory', launchPadRowConfigurationFactoryMock.object)
+                .with(
+                    'launchPadRowConfigurationFactory',
+                    launchPadRowConfigurationFactoryMock.object,
+                )
                 .with('storeState', storeState)
                 .build();
             props.deps.storesHub = storesHubMock.object;
@@ -147,7 +159,9 @@ describe('PopupView', () => {
                 launchPanelType: LaunchPanelType.AdhocToolsPanel,
             };
             storeState.launchPanelStateStoreData = adHocLaunchPanelStateStoreState;
-            actionMessageCreatorStrictMock.setup(acm => acm.openLaunchPad(adHocLaunchPanelStateStoreState.launchPanelType)).verifiable();
+            actionMessageCreatorStrictMock
+                .setup(acm => acm.openLaunchPad(adHocLaunchPanelStateStoreState.launchPanelType))
+                .verifiable();
             const props = createDefaultPropsBuilder(storesHubMock.object)
                 .withDefaultTitleAndSubtitle()
                 .with('deps', deps)
@@ -158,7 +172,10 @@ describe('PopupView', () => {
                     shortcutModifyHandler: shortcutModifyHandlerStub as any,
                 })
                 .with('hasAccess', true)
-                .with('launchPadRowConfigurationFactory', launchPadRowConfigurationFactoryMock.object)
+                .with(
+                    'launchPadRowConfigurationFactory',
+                    launchPadRowConfigurationFactoryMock.object,
+                )
                 .with('storeState', storeState)
                 .build();
             props.deps.storesHub = storesHubMock.object;
@@ -178,7 +195,9 @@ describe('PopupView', () => {
 
             storeState.launchPanelStateStoreData = launchPanelStateStoreStateStub;
 
-            actionMessageCreatorStrictMock.setup(acm => acm.openLaunchPad(launchPanelStateStoreStateStub.launchPanelType)).verifiable();
+            actionMessageCreatorStrictMock
+                .setup(acm => acm.openLaunchPad(launchPanelStateStoreStateStub.launchPanelType))
+                .verifiable();
 
             const props = createDefaultPropsBuilder(storesHubMock.object)
                 .withDefaultTitleAndSubtitle()
@@ -191,7 +210,10 @@ describe('PopupView', () => {
                 })
                 .with('hasAccess', true)
                 .with('diagnosticViewToggleFactory', null)
-                .with('launchPadRowConfigurationFactory', launchPadRowConfigurationFactoryMock.object)
+                .with(
+                    'launchPadRowConfigurationFactory',
+                    launchPadRowConfigurationFactoryMock.object,
+                )
                 .with('storeState', storeState)
                 .build();
             props.deps.storesHub = storesHubMock.object;
@@ -239,10 +261,15 @@ describe('PopupView', () => {
     });
 
     function createDefaultPropsBuilder(storeHub: BaseClientStoresHub<any>): PopupViewPropsBuilder {
-        return new PopupViewPropsBuilder().withStoresHub(storeHub).withBrowserAdapter(browserAdapterStub);
+        return new PopupViewPropsBuilder()
+            .withStoresHub(storeHub)
+            .withBrowserAdapter(browserAdapterStub);
     }
 
-    function createDefaultStoresHubMock(hasStores = true, hasStoreData = true): IMock<BaseClientStoresHub<any>> {
+    function createDefaultStoresHubMock(
+        hasStores = true,
+        hasStoreData = true,
+    ): IMock<BaseClientStoresHub<any>> {
         const storesHubMock = Mock.ofType(BaseClientStoresHub);
         storesHubMock.setup(s => s.hasStores()).returns(() => hasStores);
         storesHubMock.setup(s => s.hasStoreData()).returns(() => hasStoreData);

--- a/src/tests/unit/tests/popup/handlers/diagnostic-view-toggle-click-handler.test.ts
+++ b/src/tests/unit/tests/popup/handlers/diagnostic-view-toggle-click-handler.test.ts
@@ -3,7 +3,10 @@
 import { It, Mock } from 'typemoq';
 
 import { VisualizationConfigurationFactory } from '../../../../../common/configs/visualization-configuration-factory';
-import { TelemetryEventSource, ToggleTelemetryData } from '../../../../../common/extension-telemetry-events';
+import {
+    TelemetryEventSource,
+    ToggleTelemetryData,
+} from '../../../../../common/extension-telemetry-events';
 import { VisualizationActionMessageCreator } from '../../../../../common/message-creators/visualization-action-message-creator';
 import { TelemetryDataFactory } from '../../../../../common/telemetry-data-factory';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
@@ -31,7 +34,13 @@ describe('DiagnosticViewToggleClickHandlerTest', () => {
         const visualizationActionCreatorMock = Mock.ofType(VisualizationActionMessageCreator);
 
         visualizationActionCreatorMock
-            .setup(ac => ac.setVisualizationState(visualizationType, true, It.isValue(expectedTelemetryInfo)))
+            .setup(ac =>
+                ac.setVisualizationState(
+                    visualizationType,
+                    true,
+                    It.isValue(expectedTelemetryInfo),
+                ),
+            )
             .verifiable();
 
         const telemetryFactoryMock = Mock.ofType(TelemetryDataFactory);
@@ -63,12 +72,20 @@ describe('DiagnosticViewToggleClickHandlerTest', () => {
 
         const visualizationType = VisualizationType.Headings;
 
-        const visualizationStoreData = new VisualizationStoreDataBuilder().withEnable(visualizationType).build();
+        const visualizationStoreData = new VisualizationStoreDataBuilder()
+            .withEnable(visualizationType)
+            .build();
 
         const visualizationActionCreatorMock = Mock.ofType(VisualizationActionMessageCreator);
 
         visualizationActionCreatorMock
-            .setup(ac => ac.setVisualizationState(visualizationType, false, It.isValue(expectedTelemetryInfo)))
+            .setup(ac =>
+                ac.setVisualizationState(
+                    visualizationType,
+                    false,
+                    It.isValue(expectedTelemetryInfo),
+                ),
+            )
             .verifiable();
 
         const telemetryFactoryMock = Mock.ofType(TelemetryDataFactory);

--- a/src/tests/unit/tests/popup/handlers/launch-panel-header-click-handler.test.ts
+++ b/src/tests/unit/tests/popup/handlers/launch-panel-header-click-handler.test.ts
@@ -147,7 +147,9 @@ describe('FeedbackMenuClickHandlerTest', () => {
 
         const setStateMock = Mock.ofInstance((state: LaunchPanelHeaderState) => {});
 
-        setStateMock.setup(setter => setter({ isContextMenuVisible: false })).verifiable(Times.once());
+        setStateMock
+            .setup(setter => setter({ isContextMenuVisible: false }))
+            .verifiable(Times.once());
 
         header.setState = setStateMock.object;
 

--- a/src/tests/unit/tests/popup/incompatible-browser-renderer.test.tsx
+++ b/src/tests/unit/tests/popup/incompatible-browser-renderer.test.tsx
@@ -11,7 +11,9 @@ describe('IncompatibleBrowserRenderer', () => {
         const containerMock = Mock.ofType<HTMLElement>();
         const documentMock = Mock.ofType<Document>();
 
-        documentMock.setup(mock => mock.querySelector('#popup-container')).returns(() => containerMock.object);
+        documentMock
+            .setup(mock => mock.querySelector('#popup-container'))
+            .returns(() => containerMock.object);
 
         renderMock
             .setup(mock => mock(It.isAny(), containerMock.object))

--- a/src/tests/unit/tests/popup/launch-pad-row-configuration-factory.test.ts
+++ b/src/tests/unit/tests/popup/launch-pad-row-configuration-factory.test.ts
@@ -19,13 +19,15 @@ describe('LaunchPadRowConfigurationFactoryTests', () => {
         const fastPassRowConfig = {
             iconName: 'Rocket',
             title: 'FastPass',
-            description: 'Run two tests to find the most common accessibility issues in less than 5 minutes.',
+            description:
+                'Run two tests to find the most common accessibility issues in less than 5 minutes.',
             onClickTitle: null,
         };
         const adhocRowConfig = {
             iconName: 'Medical',
             title: 'Ad hoc tools',
-            description: 'Get quick access to visualizations that help you identify accessibility issues.',
+            description:
+                'Get quick access to visualizations that help you identify accessibility issues.',
             onClickTitle: null,
         };
         const assessmentRowConfig = {
@@ -35,9 +37,17 @@ describe('LaunchPadRowConfigurationFactoryTests', () => {
             onClickTitle: null,
         };
 
-        const expectedConfig: LaunchPadRowConfiguration[] = [fastPassRowConfig, assessmentRowConfig, adhocRowConfig];
+        const expectedConfig: LaunchPadRowConfiguration[] = [
+            fastPassRowConfig,
+            assessmentRowConfig,
+            adhocRowConfig,
+        ];
 
-        const configs = testSubject.createRowConfigs(componentStub as any, actionMessageCreatorMock.object, handlerMock.object);
+        const configs = testSubject.createRowConfigs(
+            componentStub as any,
+            actionMessageCreatorMock.object,
+            handlerMock.object,
+        );
 
         compareStaticProperties(expectedConfig, configs);
     });
@@ -50,17 +60,35 @@ describe('LaunchPadRowConfigurationFactoryTests', () => {
 
         actionMessageCreatorMock
             .setup(a =>
-                a.openDetailsView(null, VisualizationType.Issues, TelemetryEventSource.LaunchPadFastPass, DetailsViewPivotType.fastPass),
+                a.openDetailsView(
+                    null,
+                    VisualizationType.Issues,
+                    TelemetryEventSource.LaunchPadFastPass,
+                    DetailsViewPivotType.fastPass,
+                ),
             )
             .verifiable(Times.once());
 
         actionMessageCreatorMock
-            .setup(a => a.openDetailsView(null, null, TelemetryEventSource.LaunchPadAssessment, DetailsViewPivotType.assessment))
+            .setup(a =>
+                a.openDetailsView(
+                    null,
+                    null,
+                    TelemetryEventSource.LaunchPadAssessment,
+                    DetailsViewPivotType.assessment,
+                ),
+            )
             .verifiable(Times.once());
 
-        handlerMock.setup(h => h.openAdhocToolsPanel(componentStub as any)).verifiable(Times.once());
+        handlerMock
+            .setup(h => h.openAdhocToolsPanel(componentStub as any))
+            .verifiable(Times.once());
 
-        const configs = testSubject.createRowConfigs(componentStub as any, actionMessageCreatorMock.object, handlerMock.object);
+        const configs = testSubject.createRowConfigs(
+            componentStub as any,
+            actionMessageCreatorMock.object,
+            handlerMock.object,
+        );
 
         configs[0].onClickTitle(null);
         configs[1].onClickTitle(null);
@@ -70,7 +98,10 @@ describe('LaunchPadRowConfigurationFactoryTests', () => {
         handlerMock.verifyAll();
     });
 
-    function compareStaticProperties(expected: LaunchPadRowConfiguration[], actual: LaunchPadRowConfiguration[]): void {
+    function compareStaticProperties(
+        expected: LaunchPadRowConfiguration[],
+        actual: LaunchPadRowConfiguration[],
+    ): void {
         expect(actual.length).toEqual(expected.length);
 
         expected.forEach((config: LaunchPadRowConfiguration, index: number) => {

--- a/src/tests/unit/tests/popup/main-renderer.test.tsx
+++ b/src/tests/unit/tests/popup/main-renderer.test.tsx
@@ -20,7 +20,9 @@ describe('MainRenderer', () => {
     const expectedTitle = title;
 
     test('render', () => {
-        const fakeDocument = TestDocumentCreator.createTestDocument('<div id="popup-container"></div>');
+        const fakeDocument = TestDocumentCreator.createTestDocument(
+            '<div id="popup-container"></div>',
+        );
 
         const diagnosticViewClickHandlerMock = Mock.ofType(DiagnosticViewClickHandler);
         const gettingStartedDialogHandlerMock = Mock.ofType(PopupViewControllerHandler);
@@ -48,15 +50,20 @@ describe('MainRenderer', () => {
                                 deps={deps}
                                 title={expectedTitle}
                                 popupHandlers={{
-                                    diagnosticViewClickHandler: diagnosticViewClickHandlerMock.object,
-                                    popupViewControllerHandler: gettingStartedDialogHandlerMock.object,
-                                    launchPanelHeaderClickHandler: feedbackMenuClickhandlerMock.object,
+                                    diagnosticViewClickHandler:
+                                        diagnosticViewClickHandlerMock.object,
+                                    popupViewControllerHandler:
+                                        gettingStartedDialogHandlerMock.object,
+                                    launchPanelHeaderClickHandler:
+                                        feedbackMenuClickhandlerMock.object,
                                     browserAdapter: browserAdapterMock.object,
                                 }}
                                 popupWindow={popupWindowMock.object}
                                 targetTabUrl={targetTabUrl}
                                 hasAccess={hasAccess}
-                                launchPadRowConfigurationFactory={launchPadRowConfigurationFactoryMock.object}
+                                launchPadRowConfigurationFactory={
+                                    launchPadRowConfigurationFactoryMock.object
+                                }
                                 diagnosticViewToggleFactory={diagnosticViewToggleFactoryMock.object}
                                 dropdownClickHandler={dropdownClickHandlerMock.object}
                             />

--- a/src/tests/unit/tests/popup/popup-initializer.test.ts
+++ b/src/tests/unit/tests/popup/popup-initializer.test.ts
@@ -71,7 +71,8 @@ describe('PopupInitializerTests', () => {
             isSupportedBrowserMock.object,
             loggerMock.object,
         );
-        (testSubject as any).useIncompatibleBrowserRenderer = useIncompatibleBrowserRendererMock.object;
+        (testSubject as any).useIncompatibleBrowserRenderer =
+            useIncompatibleBrowserRendererMock.object;
 
         const promise = await testSubject.initialize();
 

--- a/src/tests/unit/tests/popup/target-tab-finder.test.ts
+++ b/src/tests/unit/tests/popup/target-tab-finder.test.ts
@@ -34,7 +34,12 @@ describe('TargetTabFinderTest', () => {
         urlParserMock = Mock.ofType(UrlParser);
         urlValidatorMock = Mock.ofType(UrlValidator);
 
-        testSubject = new TargetTabFinder(windowStub, browserAdapterMock.object, urlValidatorMock.object, urlParserMock.object);
+        testSubject = new TargetTabFinder(
+            windowStub,
+            browserAdapterMock.object,
+            urlValidatorMock.object,
+            urlParserMock.object,
+        );
     });
 
     type TestCase = {
@@ -87,11 +92,15 @@ describe('TargetTabFinderTest', () => {
                 reject();
             });
         setupIsSupportedCall(true);
-        await testSubject.getTargetTab().catch(error => expect(error).toEqual(`Tab with Id ${tabId} not found`));
+        await testSubject
+            .getTargetTab()
+            .catch(error => expect(error).toEqual(`Tab with Id ${tabId} not found`));
     });
 
     function setupGetTabIdParamFromUrl(tabIdValue: number): void {
-        urlParserMock.setup(p => p.getIntParam(windowStub.location.href, 'tabId')).returns(() => tabIdValue);
+        urlParserMock
+            .setup(p => p.getIntParam(windowStub.location.href, 'tabId'))
+            .returns(() => tabIdValue);
     }
 
     function setupGetTabCall(): void {
@@ -109,6 +118,8 @@ describe('TargetTabFinderTest', () => {
     }
 
     function setupIsSupportedCall(isSupported: boolean): void {
-        urlValidatorMock.setup(v => v.isSupportedUrl(tabStub.url)).returns(() => Promise.resolve(isSupported));
+        urlValidatorMock
+            .setup(v => v.isSupportedUrl(tabStub.url))
+            .returns(() => Promise.resolve(isSupported));
     }
 });


### PR DESCRIPTION
#### Description of changes

Add ` src/tests/unit/tests/popup` folder to prettier override for the line width value.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
