### PR TITLE
refactor: action hub dependency on action-creator test

### DIFF
--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -1026,20 +1026,14 @@ class ActionCreatorValidator {
     private actionHubMock: ActionHub = {
         visualizationActions: this.visualizationActionsContainerMock.object,
         visualizationScanResultActions: this.visualizationScanResultActionsContainerMock.object,
-        tabActions: null,
-        featureFlagActions: null,
         devToolActions: this.devToolActionsContainerMock.object,
         previewFeaturesActions: this.previewFeaturesActionsContainerMock.object,
         scopingActions: this.scopingActionsContainerMock.object,
         assessmentActions: this.assessmentActionsContainerMock.object,
         inspectActions: this.inspectActionsContainerMock.object,
-        contentActions: null,
         detailsViewActions: this.detailsViewActionsContainerMock.object,
-        pathSnippetActions: null,
-        scanResultActions: null,
         cardSelectionActions: this.cardSelectionActionsContainerMock.object,
-        injectionActions: null,
-    };
+    } as ActionHub;
 
     private telemetryEventHandlerStrictMock = Mock.ofType<TelemetryEventHandler>(
         null,


### PR DESCRIPTION
#### Description of changes

We need an instance of `ActionHub` to run the tests for the `ActionCreator`. We are creating that instance manually, assigning each property with a mock or a null value. This force use to update this test every time we add a new "actions" property to the `ActionHub` even if that new property does not affect the `ActionCreator` test.

By using casting (as in `as ActionHub`) we can avoid this, remove the null properties and only assign mocks to what we actually need on the test.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
