### PR TITLE
refactor: device config and tests

### DIFF
--- a/src/electron/platform/android/device-config-fetcher.ts
+++ b/src/electron/platform/android/device-config-fetcher.ts
@@ -1,28 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
+import { DeviceConfig } from 'electron/platform/android/device-config';
 import { HttpGet } from 'electron/platform/android/fetch-scan-results';
+
 export type DeviceConfigFetcher = (port: number) => Promise<DeviceConfig>;
-
-export class DeviceConfig {
-    constructor(readonly rawData: any) {}
-
-    public get deviceName(): string {
-        try {
-            return this.rawData.deviceName;
-        } catch {
-            return null;
-        }
-    }
-
-    public get appIdentifier(): string {
-        try {
-            return this.rawData.packageName;
-        } catch {
-            return null;
-        }
-    }
-}
 
 export const createDeviceConfigFetcher = (httpGet: HttpGet): DeviceConfigFetcher => {
     return async (port: number) => {

--- a/src/electron/platform/android/device-config.ts
+++ b/src/electron/platform/android/device-config.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export class DeviceConfig {
+    constructor(readonly rawData: any) {}
+
+    public get deviceName(): string {
+        try {
+            return this.rawData.deviceName;
+        } catch {
+            return null;
+        }
+    }
+
+    public get appIdentifier(): string {
+        try {
+            return this.rawData.packageName;
+        } catch {
+            return null;
+        }
+    }
+}

--- a/src/electron/platform/android/device-config.ts
+++ b/src/electron/platform/android/device-config.ts
@@ -1,22 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 export class DeviceConfig {
     constructor(readonly rawData: any) {}
 
     public get deviceName(): string {
-        try {
-            return this.rawData.deviceName;
-        } catch {
-            return null;
-        }
+        return this.rawData?.deviceName || null;
     }
 
     public get appIdentifier(): string {
-        try {
-            return this.rawData.packageName;
-        } catch {
-            return null;
-        }
+        return this.rawData?.packageName || null;
     }
 }

--- a/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
@@ -7,11 +7,10 @@ import { VALIDATE_PORT } from 'electron/common/electron-telemetry-events';
 import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
 import { ConnectedDevicePayload, PortPayload } from 'electron/flux/action/device-action-payloads';
 import { DeviceActions } from 'electron/flux/action/device-actions';
+import { DeviceConfig } from 'electron/platform/android/device-config';
 import { DeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
 import { IMock, It, Mock, Times } from 'typemoq';
-
 import { tick } from '../../../../common/tick';
-import { DeviceConfig } from 'electron/platform/android/device-config';
 
 describe('DeviceConnectActionCreator', () => {
     const port = 1111;

--- a/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
@@ -7,10 +7,11 @@ import { VALIDATE_PORT } from 'electron/common/electron-telemetry-events';
 import { DeviceConnectActionCreator } from 'electron/flux/action-creator/device-connect-action-creator';
 import { ConnectedDevicePayload, PortPayload } from 'electron/flux/action/device-action-payloads';
 import { DeviceActions } from 'electron/flux/action/device-actions';
-import { DeviceConfig, DeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
+import { DeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { tick } from '../../../../common/tick';
+import { DeviceConfig } from 'electron/platform/android/device-config';
 
 describe('DeviceConnectActionCreator', () => {
     const port = 1111;

--- a/src/tests/unit/tests/electron/platform/android/device-config.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/device-config.test.ts
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DeviceConfig } from 'electron/platform/android/device-config';
+import { set } from 'lodash';
+
+describe('DeviceConfig', () => {
+    it.each`
+        rawDataPath              | rawDataValue           | deviceConfigProp   | expectedValue
+        ${'rawData.deviceName'}  | ${'test-device-name'}  | ${'deviceName'}    | ${'test-device-name'}
+        ${'rawData'}             | ${undefined}           | ${'deviceName'}    | ${null}
+        ${'rawData.packageName'} | ${'test-package-name'} | ${'appIdentifier'} | ${'test-package-name'}
+        ${'rawData'}             | ${undefined}           | ${'appIdentifier'} | ${null}
+    `(
+        'gets DeviceConfig.$deviceConfigProp when $rawDataPath = $rawDataValue',
+        ({ rawDataPath, rawDataValue, deviceConfigProp, expectedValue }) => {
+            const dataContainer = {};
+            set(dataContainer, rawDataPath, rawDataValue);
+
+            const testSubject = new DeviceConfig(dataContainer['rawData']);
+
+            expect(testSubject[deviceConfigProp]).toEqual(expectedValue);
+        },
+    );
+});

--- a/src/tests/unit/tests/electron/platform/android/fetch-device-config.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/fetch-device-config.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AxiosResponse } from 'axios';
-import { createDeviceConfigFetcher, DeviceConfig, DeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
+import { DeviceConfig } from 'electron/platform/android/device-config';
+import { createDeviceConfigFetcher, DeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
 import { HttpGet } from 'electron/platform/android/fetch-scan-results';
 import { IMock, Mock } from 'typemoq';
 


### PR DESCRIPTION
#### Description of changes

- Simplify testing by using `it.each` and lodash `set` function to make custom `rawData` objects
- Take advantage of typescript optional chaining to get rid of the try-catch blocks

**Note** I ended up explicitly returning `null` on both of the getters as the default case. Not doing so causes the getter to return `undefined` instead of null and I'm not sure I want to just "break" the current contract. But I can see it that we want that instead.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
