### PR TITLE
chore: line width for src/tests/unit/tests/electron folder

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -11,7 +11,6 @@ module.exports = {
             files: [
                 'src/content/**/*',
                 'src/tests/unit/tests/DetailsView/**/*',
-                'src/tests/unit/tests/electron/**/*',
                 'src/tests/unit/tests/injected/**/*',
             ],
             options: {

--- a/src/tests/unit/tests/electron/adapters/electron-storage-adapter.test.ts
+++ b/src/tests/unit/tests/electron/adapters/electron-storage-adapter.test.ts
@@ -24,7 +24,9 @@ describe('ElectronStorageAdapter', () => {
         `('succeed to set $items', async ({ items }) => {
             await testSubject.setUserData(items);
 
-            Object.keys(items).forEach(key => indexedDBInstanceMock.verify(db => db.setItem(key, items[key]), Times.once()));
+            Object.keys(items).forEach(key =>
+                indexedDBInstanceMock.verify(db => db.setItem(key, items[key]), Times.once()),
+            );
         });
 
         it('propagates exceptions from indexedDB as-is', async () => {
@@ -36,7 +38,9 @@ describe('ElectronStorageAdapter', () => {
                 [firstKey]: 1,
             };
 
-            indexedDBInstanceMock.setup(indexedDB => indexedDB.setItem(firstKey, items[firstKey])).returns(() => Promise.reject(reason));
+            indexedDBInstanceMock
+                .setup(indexedDB => indexedDB.setItem(firstKey, items[firstKey]))
+                .returns(() => Promise.reject(reason));
 
             await expect(testSubject.setUserData(items)).rejects.toMatch(reason);
         });
@@ -53,7 +57,11 @@ describe('ElectronStorageAdapter', () => {
         `('properly reads $items', async ({ items }) => {
             const keys = Object.keys(items);
 
-            keys.forEach(key => indexedDBInstanceMock.setup(db => db.getItem(key)).returns(() => Promise.resolve(items[key])));
+            keys.forEach(key =>
+                indexedDBInstanceMock
+                    .setup(db => db.getItem(key))
+                    .returns(() => Promise.resolve(items[key])),
+            );
 
             const result = await testSubject.getUserData(keys);
 
@@ -66,7 +74,9 @@ describe('ElectronStorageAdapter', () => {
 
             const firstKey = 'first';
 
-            indexedDBInstanceMock.setup(db => db.getItem(firstKey)).returns(() => Promise.reject(reason));
+            indexedDBInstanceMock
+                .setup(db => db.getItem(firstKey))
+                .returns(() => Promise.reject(reason));
 
             await expect(testSubject.getUserData([firstKey])).rejects.toMatch(reason);
         });
@@ -84,7 +94,9 @@ describe('ElectronStorageAdapter', () => {
         it('propagate exceptions from indexedDB as-is', async () => {
             const reason = 'test-error-reason';
 
-            indexedDBInstanceMock.setup(db => db.removeItem(key)).returns(() => Promise.reject(reason));
+            indexedDBInstanceMock
+                .setup(db => db.removeItem(key))
+                .returns(() => Promise.reject(reason));
 
             await expect(testSubject.removeUserData(key)).rejects.toMatch(reason);
         });

--- a/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/device-connect-action-creator.test.ts
@@ -41,11 +41,15 @@ describe('DeviceConnectActionCreator', () => {
         const deviceName = 'test device';
         const appIdentifier = 'test app';
 
-        fetchDeviceConfigMock.setup(fetch => fetch(port)).returns(() => Promise.resolve({ deviceName, appIdentifier } as DeviceConfig));
+        fetchDeviceConfigMock
+            .setup(fetch => fetch(port))
+            .returns(() => Promise.resolve({ deviceName, appIdentifier } as DeviceConfig));
 
         const connectionSucceedMock = Mock.ofType<Action<ConnectedDevicePayload>>();
 
-        deviceActionsMock.setup(actions => actions.connectionSucceeded).returns(() => connectionSucceedMock.object);
+        deviceActionsMock
+            .setup(actions => actions.connectionSucceeded)
+            .returns(() => connectionSucceedMock.object);
 
         testSubject.validatePort(port);
 
@@ -58,18 +62,28 @@ describe('DeviceConnectActionCreator', () => {
             },
         };
 
-        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(VALIDATE_PORT, It.isValue(expectedTelemetry)), Times.once());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(VALIDATE_PORT, It.isValue(expectedTelemetry)),
+            Times.once(),
+        );
 
         connectingMock.verify(connecting => connecting.invoke({ port }), Times.once());
-        connectionSucceedMock.verify(succeed => succeed.invoke({ connectedDevice: `${deviceName} - ${appIdentifier}` }), Times.once());
+        connectionSucceedMock.verify(
+            succeed => succeed.invoke({ connectedDevice: `${deviceName} - ${appIdentifier}` }),
+            Times.once(),
+        );
     });
 
     it('validates port, connection fails', async () => {
-        fetchDeviceConfigMock.setup(fetch => fetch(port)).returns(() => Promise.reject('dummy reason'));
+        fetchDeviceConfigMock
+            .setup(fetch => fetch(port))
+            .returns(() => Promise.reject('dummy reason'));
 
         const connectionFailedMock = Mock.ofType<Action<void>>();
 
-        deviceActionsMock.setup(actions => actions.connectionFailed).returns(() => connectionFailedMock.object);
+        deviceActionsMock
+            .setup(actions => actions.connectionFailed)
+            .returns(() => connectionFailedMock.object);
 
         testSubject.validatePort(port);
 
@@ -82,7 +96,10 @@ describe('DeviceConnectActionCreator', () => {
             },
         };
 
-        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(VALIDATE_PORT, It.isValue(expectedTelemetry)), Times.once());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(VALIDATE_PORT, It.isValue(expectedTelemetry)),
+            Times.once(),
+        );
 
         connectingMock.verify(connecting => connecting.invoke({ port }), Times.once());
         connectionFailedMock.verify(succeed => succeed.invoke(), Times.once());
@@ -91,7 +108,9 @@ describe('DeviceConnectActionCreator', () => {
     it('resets to default', () => {
         const resetConnectionMock = Mock.ofType<Action<void>>();
 
-        deviceActionsMock.setup(actions => actions.resetConnection).returns(() => resetConnectionMock.object);
+        deviceActionsMock
+            .setup(actions => actions.resetConnection)
+            .returns(() => resetConnectionMock.object);
 
         testSubject.resetConnection();
 

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -27,6 +27,9 @@ describe('ScanActionCreator', () => {
     it('scans', () => {
         testSubject.scan(port);
 
-        scanStartedMock.verify(scanStarted => scanStarted.invoke(It.isValue({ port })), Times.once());
+        scanStartedMock.verify(
+            scanStarted => scanStarted.invoke(It.isValue({ port })),
+            Times.once(),
+        );
     });
 });

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-result-example.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-result-example.ts
@@ -3,5 +3,10 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
-const resultExamplePath = path.join(__dirname, '../../../../../miscellaneous/mock-service-for-android/AccessibilityInsights/result.json');
-export const axeRuleResultExample = JSON.parse(fs.readFileSync(resultExamplePath, { encoding: 'utf-8' }));
+const resultExamplePath = path.join(
+    __dirname,
+    '../../../../../miscellaneous/mock-service-for-android/AccessibilityInsights/result.json',
+);
+export const axeRuleResultExample = JSON.parse(
+    fs.readFileSync(resultExamplePath, { encoding: 'utf-8' }),
+);

--- a/src/tests/unit/tests/electron/flux/action-creator/window-frame-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/window-frame-action-creator.test.ts
@@ -22,7 +22,9 @@ describe(WindowFrameActionCreator, () => {
             height: 1,
             width: 2,
         };
-        windowFrameActionsMock.setup(actions => actions.setWindowSize).returns(() => setRouteActionMock.object);
+        windowFrameActionsMock
+            .setup(actions => actions.setWindowSize)
+            .returns(() => setRouteActionMock.object);
         setRouteActionMock.setup(s => s.invoke(testPayload)).verifiable(Times.once());
 
         testSubject.setWindowSize(testPayload);
@@ -33,7 +35,9 @@ describe(WindowFrameActionCreator, () => {
     it('calling maximize invokes maximize action', () => {
         const maximizeActionMock = Mock.ofType<Action<void>>();
 
-        windowFrameActionsMock.setup(actions => actions.maximize).returns(() => maximizeActionMock.object);
+        windowFrameActionsMock
+            .setup(actions => actions.maximize)
+            .returns(() => maximizeActionMock.object);
         maximizeActionMock.setup(s => s.invoke()).verifiable(Times.once());
 
         testSubject.maximize();
@@ -44,7 +48,9 @@ describe(WindowFrameActionCreator, () => {
     it('calling minimize invokes minimize action', () => {
         const minimizeActionMock = Mock.ofType<Action<void>>();
 
-        windowFrameActionsMock.setup(actions => actions.minimize).returns(() => minimizeActionMock.object);
+        windowFrameActionsMock
+            .setup(actions => actions.minimize)
+            .returns(() => minimizeActionMock.object);
         minimizeActionMock.setup(s => s.invoke()).verifiable(Times.once());
 
         testSubject.minimize();
@@ -55,7 +61,9 @@ describe(WindowFrameActionCreator, () => {
     it('calling maximize invokes restore action', () => {
         const restoreActionMock = Mock.ofType<Action<void>>();
 
-        windowFrameActionsMock.setup(actions => actions.restore).returns(() => restoreActionMock.object);
+        windowFrameActionsMock
+            .setup(actions => actions.restore)
+            .returns(() => restoreActionMock.object);
         restoreActionMock.setup(s => s.invoke()).verifiable(Times.once());
 
         testSubject.restore();
@@ -66,7 +74,9 @@ describe(WindowFrameActionCreator, () => {
     it('calling close invokes close action', () => {
         const closeActionMock = Mock.ofType<Action<void>>();
 
-        windowFrameActionsMock.setup(actions => actions.close).returns(() => closeActionMock.object);
+        windowFrameActionsMock
+            .setup(actions => actions.close)
+            .returns(() => closeActionMock.object);
         closeActionMock.setup(s => s.invoke()).verifiable(Times.once());
 
         testSubject.close();

--- a/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/window-state-action-creator.test.ts
@@ -16,9 +16,15 @@ describe(WindowStateActionCreator, () => {
 
     beforeEach(() => {
         windowStateActionsMock = Mock.ofType<WindowStateActions>();
-        windowFrameActionCreatorMock = Mock.ofType<WindowFrameActionCreator>(WindowFrameActionCreator, MockBehavior.Strict);
+        windowFrameActionCreatorMock = Mock.ofType<WindowFrameActionCreator>(
+            WindowFrameActionCreator,
+            MockBehavior.Strict,
+        );
 
-        testSubject = new WindowStateActionCreator(windowStateActionsMock.object, windowFrameActionCreatorMock.object);
+        testSubject = new WindowStateActionCreator(
+            windowStateActionsMock.object,
+            windowFrameActionCreatorMock.object,
+        );
     });
 
     it('calling setRoute invokes setRoute action with given payload', () => {
@@ -26,7 +32,9 @@ describe(WindowStateActionCreator, () => {
         const testPayload: RoutePayload = {
             routeId: 'resultsView',
         };
-        windowStateActionsMock.setup(actions => actions.setRoute).returns(() => setRouteActionMock.object);
+        windowStateActionsMock
+            .setup(actions => actions.setRoute)
+            .returns(() => setRouteActionMock.object);
         setRouteActionMock.setup(s => s.invoke(testPayload)).verifiable(Times.once());
 
         testSubject.setRoute(testPayload);
@@ -40,9 +48,13 @@ describe(WindowStateActionCreator, () => {
             routeId: 'deviceConnectView',
         };
 
-        windowFrameActionCreatorMock.setup(w => w.setWindowSize({ width: 600, height: 391 })).verifiable(Times.once());
+        windowFrameActionCreatorMock
+            .setup(w => w.setWindowSize({ width: 600, height: 391 }))
+            .verifiable(Times.once());
 
-        windowStateActionsMock.setup(actions => actions.setRoute).returns(() => setRouteActionMock.object);
+        windowStateActionsMock
+            .setup(actions => actions.setRoute)
+            .returns(() => setRouteActionMock.object);
         setRouteActionMock.setup(s => s.invoke(testPayload)).verifiable(Times.once());
 
         testSubject.setRoute(testPayload);
@@ -57,7 +69,9 @@ describe(WindowStateActionCreator, () => {
             currentWindowState: 'maximized',
         };
 
-        windowStateActionsMock.setup(actions => actions.setWindowState).returns(() => setWindowStatePayload.object);
+        windowStateActionsMock
+            .setup(actions => actions.setWindowState)
+            .returns(() => setWindowStatePayload.object);
         setWindowStatePayload.setup(s => s.invoke(testPayload)).verifiable(Times.once());
 
         testSubject.setWindowState(testPayload);

--- a/src/tests/unit/tests/electron/flux/store/device-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/device-store.test.ts
@@ -117,7 +117,10 @@ describe('DeviceStore', () => {
                 deviceConnectState: DeviceConnectState.Error,
             };
 
-            createStoreTesterForDeviceActions('connectionFailed').testListenerToBeCalledOnce(initialState, expectedState);
+            createStoreTesterForDeviceActions('connectionFailed').testListenerToBeCalledOnce(
+                initialState,
+                expectedState,
+            );
         });
 
         it('does not updates if state is already Error', () => {
@@ -127,7 +130,10 @@ describe('DeviceStore', () => {
                 ...initialState,
             };
 
-            createStoreTesterForDeviceActions('connectionFailed').testListenerToNeverBeCalled(initialState, expectedState);
+            createStoreTesterForDeviceActions('connectionFailed').testListenerToNeverBeCalled(
+                initialState,
+                expectedState,
+            );
         });
     });
 
@@ -140,7 +146,10 @@ describe('DeviceStore', () => {
                 deviceConnectState: DeviceConnectState.Default,
             };
 
-            createStoreTesterForDeviceActions('resetConnection').testListenerToBeCalledOnce(initialState, expectedState);
+            createStoreTesterForDeviceActions('resetConnection').testListenerToBeCalledOnce(
+                initialState,
+                expectedState,
+            );
         });
 
         it('does not updated if status is already DEFAULT', () => {
@@ -150,11 +159,16 @@ describe('DeviceStore', () => {
                 ...initialState,
             };
 
-            createStoreTesterForDeviceActions('resetConnection').testListenerToNeverBeCalled(initialState, expectedState);
+            createStoreTesterForDeviceActions('resetConnection').testListenerToNeverBeCalled(
+                initialState,
+                expectedState,
+            );
         });
     });
 
-    function createStoreTesterForDeviceActions(actionName: keyof DeviceActions): StoreTester<DeviceStoreData, DeviceActions> {
+    function createStoreTesterForDeviceActions(
+        actionName: keyof DeviceActions,
+    ): StoreTester<DeviceStoreData, DeviceActions> {
         const factory = (actions: DeviceActions) => new DeviceStore(actions);
 
         return new StoreTester(DeviceActions, actionName, factory);

--- a/src/tests/unit/tests/electron/flux/store/scan-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/scan-store.test.ts
@@ -28,7 +28,11 @@ describe('ScanStore', () => {
 
     describe('on scan started', () => {
         describe('updates to scanning', () => {
-            const initialStatuses = [ScanStatus[ScanStatus.Default], ScanStatus[ScanStatus.Completed], ScanStatus[ScanStatus.Failed]];
+            const initialStatuses = [
+                ScanStatus[ScanStatus.Default],
+                ScanStatus[ScanStatus.Completed],
+                ScanStatus[ScanStatus.Failed],
+            ];
 
             it.each(initialStatuses)('from initial state <%s>', initialStatus => {
                 initialState.status = ScanStatus[initialStatus];
@@ -37,7 +41,10 @@ describe('ScanStore', () => {
                     status: ScanStatus.Scanning,
                 };
 
-                createStoreTesterForScanActions('scanStarted').testListenerToBeCalledOnce(initialState, expectedState);
+                createStoreTesterForScanActions('scanStarted').testListenerToBeCalledOnce(
+                    initialState,
+                    expectedState,
+                );
             });
         });
 
@@ -46,7 +53,10 @@ describe('ScanStore', () => {
 
             const expectedState: ScanStoreData = { ...initialState };
 
-            createStoreTesterForScanActions('scanStarted').testListenerToNeverBeCalled(initialState, expectedState);
+            createStoreTesterForScanActions('scanStarted').testListenerToNeverBeCalled(
+                initialState,
+                expectedState,
+            );
         });
     });
 
@@ -58,18 +68,28 @@ describe('ScanStore', () => {
                 status: ScanStatus.Completed,
             };
 
-            createStoreTesterForScanActions('scanCompleted').testListenerToBeCalledOnce(initialState, expectedState);
+            createStoreTesterForScanActions('scanCompleted').testListenerToBeCalledOnce(
+                initialState,
+                expectedState,
+            );
         });
 
         describe('does not update if previous state is not scanning', () => {
-            const initialStatuses = [ScanStatus[ScanStatus.Default], ScanStatus[ScanStatus.Failed], ScanStatus[ScanStatus.Completed]];
+            const initialStatuses = [
+                ScanStatus[ScanStatus.Default],
+                ScanStatus[ScanStatus.Failed],
+                ScanStatus[ScanStatus.Completed],
+            ];
 
             it.each(initialStatuses)('with initial status <%s>', initialStatus => {
                 initialState.status = ScanStatus[initialStatus];
 
                 const expectedState: ScanStoreData = { ...initialState };
 
-                createStoreTesterForScanActions('scanCompleted').testListenerToNeverBeCalled(initialState, expectedState);
+                createStoreTesterForScanActions('scanCompleted').testListenerToNeverBeCalled(
+                    initialState,
+                    expectedState,
+                );
             });
         });
     });
@@ -82,23 +102,35 @@ describe('ScanStore', () => {
                 status: ScanStatus.Failed,
             };
 
-            createStoreTesterForScanActions('scanFailed').testListenerToBeCalledOnce(initialState, expectedState);
+            createStoreTesterForScanActions('scanFailed').testListenerToBeCalledOnce(
+                initialState,
+                expectedState,
+            );
         });
 
         describe('does not update if previous state is not scanning', () => {
-            const initialStatuses = [ScanStatus[ScanStatus.Default], ScanStatus[ScanStatus.Failed], ScanStatus[ScanStatus.Completed]];
+            const initialStatuses = [
+                ScanStatus[ScanStatus.Default],
+                ScanStatus[ScanStatus.Failed],
+                ScanStatus[ScanStatus.Completed],
+            ];
 
             it.each(initialStatuses)('with initial status <%s>', initialStatus => {
                 initialState.status = ScanStatus[initialStatus];
 
                 const expectedState: ScanStoreData = { ...initialState };
 
-                createStoreTesterForScanActions('scanFailed').testListenerToNeverBeCalled(initialState, expectedState);
+                createStoreTesterForScanActions('scanFailed').testListenerToNeverBeCalled(
+                    initialState,
+                    expectedState,
+                );
             });
         });
     });
 
-    function createStoreTesterForScanActions(actionName: keyof ScanActions): StoreTester<ScanStoreData, ScanActions> {
+    function createStoreTesterForScanActions(
+        actionName: keyof ScanActions,
+    ): StoreTester<ScanStoreData, ScanActions> {
         const factory = (actions: ScanActions) => new ScanStore(actions);
 
         return new StoreTester(ScanActions, actionName, factory);

--- a/src/tests/unit/tests/electron/ipc/ipc-message-receiver.test.ts
+++ b/src/tests/unit/tests/electron/ipc/ipc-message-receiver.test.ts
@@ -36,9 +36,15 @@ describe('IpcMessageReceiver', () => {
             })
             .verifiable();
 
-        mockInterpreter.setup(m => m.interpret(It.isAny())).callback(message => sentMessages.push(message));
+        mockInterpreter
+            .setup(m => m.interpret(It.isAny()))
+            .callback(message => sentMessages.push(message));
 
-        testSubject = new IpcMessageReceiver(mockInterpreter.object, mockIpcRenderer.object, mockLogger.object);
+        testSubject = new IpcMessageReceiver(
+            mockInterpreter.object,
+            mockIpcRenderer.object,
+            mockLogger.object,
+        );
         testSubject.initialize();
 
         mockIpcRenderer.verifyAll();
@@ -48,7 +54,10 @@ describe('IpcMessageReceiver', () => {
         testSubjectMessageHandler({ senderId: 1 }, validMessage);
 
         expect(sentMessages).toEqual([]);
-        mockLogger.verify(l => l.error('Ignoring unexpected message from non-main-process senderId'), Times.once());
+        mockLogger.verify(
+            l => l.error('Ignoring unexpected message from non-main-process senderId'),
+            Times.once(),
+        );
     });
 
     it('rejects messages with no args', () => {

--- a/src/tests/unit/tests/electron/main/native-high-contrast-mode-listener.test.ts
+++ b/src/tests/unit/tests/electron/main/native-high-contrast-mode-listener.test.ts
@@ -26,7 +26,10 @@ describe('NativeHighContrastModeListener', () => {
             })
             .verifiable();
 
-        testSubject = new NativeHighContrastModeListener(mockNativeTheme.object, mockMessageCreator.object);
+        testSubject = new NativeHighContrastModeListener(
+            mockNativeTheme.object,
+            mockMessageCreator.object,
+        );
     });
 
     function setNativeContrastMode(value: boolean): void {
@@ -40,12 +43,15 @@ describe('NativeHighContrastModeListener', () => {
         mockNativeTheme.verify(m => m.on(It.isAny(), It.isAny()), Times.never());
     });
 
-    it.each([true, false])('should send an initial message on startListening in state %p', initialState => {
-        mockNativeTheme.setup(m => m.shouldUseHighContrastColors).returns(() => initialState);
-        testSubject.startListening();
+    it.each([true, false])(
+        'should send an initial message on startListening in state %p',
+        initialState => {
+            mockNativeTheme.setup(m => m.shouldUseHighContrastColors).returns(() => initialState);
+            testSubject.startListening();
 
-        mockMessageCreator.verify(m => m.setNativeHighContrastMode(initialState), Times.once());
-    });
+            mockMessageCreator.verify(m => m.setNativeHighContrastMode(initialState), Times.once());
+        },
+    );
 
     it('should send messages when the underlying high contrast state changes', () => {
         setNativeContrastMode(false);
@@ -73,7 +79,9 @@ describe('NativeHighContrastModeListener', () => {
         setNativeContrastMode(false);
         testSubject.startListening();
 
-        mockNativeTheme.setup(m => m.removeListener('updated', testSubjectOnNativeThemeUpdateHandler)).verifiable(Times.once());
+        mockNativeTheme
+            .setup(m => m.removeListener('updated', testSubjectOnNativeThemeUpdateHandler))
+            .verifiable(Times.once());
         testSubject.stopListening();
 
         mockNativeTheme.verifyAll();

--- a/src/tests/unit/tests/electron/platform/android/fetch-device-config.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/fetch-device-config.test.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AxiosResponse } from 'axios';
-import { createDeviceConfigFetcher, DeviceConfig, DeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
+import {
+    createDeviceConfigFetcher,
+    DeviceConfig,
+    DeviceConfigFetcher,
+} from 'electron/platform/android/device-config-fetcher';
 import { HttpGet } from 'electron/platform/android/fetch-scan-results';
 import { IMock, Mock } from 'typemoq';
 
@@ -36,7 +40,9 @@ describe('fetchDeviceConfig', () => {
     it('propagates errors properly', async () => {
         const reason = 'test exception reason';
 
-        httpGetMock.setup(getter => getter(`http://localhost:${port}/AccessibilityInsights/config`)).returns(() => Promise.reject(reason));
+        httpGetMock
+            .setup(getter => getter(`http://localhost:${port}/AccessibilityInsights/config`))
+            .returns(() => Promise.reject(reason));
 
         await expect(testSubject(port)).rejects.toMatch(reason);
     });

--- a/src/tests/unit/tests/electron/platform/android/fetch-scan-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/fetch-scan-results.test.ts
@@ -1,7 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AxiosResponse } from 'axios';
-import { createScanResultsFetcher, HttpGet, ScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
+import {
+    createScanResultsFetcher,
+    HttpGet,
+    ScanResultsFetcher,
+} from 'electron/platform/android/fetch-scan-results';
 import { ScanResults } from 'electron/platform/android/scan-results';
 import { IMock, Mock } from 'typemoq';
 
@@ -41,7 +45,9 @@ describe('fetchScanResults', () => {
     it('propagates errors properly', async () => {
         const reason = 'test exception reason';
 
-        httpGetMock.setup(getter => getter(`http://localhost:${port}/AccessibilityInsights/result`)).returns(() => Promise.reject(reason));
+        httpGetMock
+            .setup(getter => getter(`http://localhost:${port}/AccessibilityInsights/result`))
+            .returns(() => Promise.reject(reason));
 
         await expect(testSubject(port)).rejects.toMatch(reason);
     });

--- a/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information-provider.test.ts
@@ -14,7 +14,12 @@ describe('RuleInformationProvider', () => {
         provider = new RuleInformationProvider();
     });
 
-    function buildTouchSizeWcagRuleResultObject(status: string, dpi: number, height: number, width: number): RuleResultsData {
+    function buildTouchSizeWcagRuleResultObject(
+        status: string,
+        dpi: number,
+        height: number,
+        width: number,
+    ): RuleResultsData {
         const props = {};
         // This is based on the output of the Android service.
         props['Screen Dots Per Inch'] = dpi;
@@ -57,7 +62,10 @@ describe('RuleInformationProvider', () => {
         expect(provider.getRuleInformation('unknown rule')).toBeNull();
     });
 
-    function validateUnifiedFormattableResolution(ruleId: string, ruleResult: RuleResultsData): UnifiedFormattableResolution {
+    function validateUnifiedFormattableResolution(
+        ruleId: string,
+        ruleResult: RuleResultsData,
+    ): UnifiedFormattableResolution {
         const ruleInformation: RuleInformation = provider.getRuleInformation(ruleId);
         const unifiedResolution = ruleInformation.getUnifiedFormattableResolution(ruleResult);
 
@@ -70,60 +78,118 @@ describe('RuleInformationProvider', () => {
 
     test('getRuleInformation returns correct data for ColorContrast rule', () => {
         const testRuleId: string = 'ColorContrast';
-        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject('FAIL', 2.798498811425733, 'ff979797', 'fffafafa', 'High');
-        const unifiedFormattableResolution = validateUnifiedFormattableResolution(testRuleId, ruleResult);
+        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject(
+            'FAIL',
+            2.798498811425733,
+            'ff979797',
+            'fffafafa',
+            'High',
+        );
+        const unifiedFormattableResolution = validateUnifiedFormattableResolution(
+            testRuleId,
+            ruleResult,
+        );
         expect(unifiedFormattableResolution).toMatchSnapshot();
     });
 
     test('getRuleInformation handles no foreground/background color values', () => {
         const testRuleId: string = 'ColorContrast';
-        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject('FAIL', null, null, null, 'None');
-        const unifiedFormattableResolution = validateUnifiedFormattableResolution(testRuleId, ruleResult);
+        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject(
+            'FAIL',
+            null,
+            null,
+            null,
+            'None',
+        );
+        const unifiedFormattableResolution = validateUnifiedFormattableResolution(
+            testRuleId,
+            ruleResult,
+        );
         expect(unifiedFormattableResolution).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for TouchSizeWcag rule', () => {
         const testRuleId: string = 'TouchSizeWcag';
-        const ruleResult: RuleResultsData = buildTouchSizeWcagRuleResultObject('FAIL', 2.25, 86, 95);
-        const unifiedFormattableResolution = validateUnifiedFormattableResolution(testRuleId, ruleResult);
+        const ruleResult: RuleResultsData = buildTouchSizeWcagRuleResultObject(
+            'FAIL',
+            2.25,
+            86,
+            95,
+        );
+        const unifiedFormattableResolution = validateUnifiedFormattableResolution(
+            testRuleId,
+            ruleResult,
+        );
         expect(unifiedFormattableResolution).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for ActiveViewName rule', () => {
-        const unifiedFormattableResolution = validateUnifiedFormattableResolution('ActiveViewName', null);
+        const unifiedFormattableResolution = validateUnifiedFormattableResolution(
+            'ActiveViewName',
+            null,
+        );
         expect(unifiedFormattableResolution).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for EditTextValue rule', () => {
-        const unifiedFormattableResolution = validateUnifiedFormattableResolution('EditTextValue', null);
+        const unifiedFormattableResolution = validateUnifiedFormattableResolution(
+            'EditTextValue',
+            null,
+        );
         expect(unifiedFormattableResolution).toMatchSnapshot();
     });
 
     test('getRuleInformation returns correct data for ImageViewName rule', () => {
-        const unifiedFormattableResolution = validateUnifiedFormattableResolution('ImageViewName', null);
+        const unifiedFormattableResolution = validateUnifiedFormattableResolution(
+            'ImageViewName',
+            null,
+        );
         expect(unifiedFormattableResolution).toMatchSnapshot();
     });
 
     test('ColorContrast includeThisResult returns true when confidence is defined and High', () => {
-        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject('FAIL', 2.798498811425733, 'ff979797', 'fffafafa', 'High');
+        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject(
+            'FAIL',
+            2.798498811425733,
+            'ff979797',
+            'fffafafa',
+            'High',
+        );
         const ruleInformation: RuleInformation = provider.getRuleInformation(ruleResult.ruleId);
         expect(ruleInformation.includeThisResult(ruleResult)).toBe(true);
     });
 
     test('ColorContrast includeThisResult returns false when confidence is defined but not High', () => {
-        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject('FAIL', 2.798498811425733, 'ff979797', 'fffafafa', 'Medium');
+        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject(
+            'FAIL',
+            2.798498811425733,
+            'ff979797',
+            'fffafafa',
+            'Medium',
+        );
         const ruleInformation: RuleInformation = provider.getRuleInformation(ruleResult.ruleId);
         expect(ruleInformation.includeThisResult(ruleResult)).toBe(false);
     });
 
     test('ColorContrast includeThisResult returns false when confidence is not defined', () => {
-        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject('PASS', null, null, null, null);
+        const ruleResult: RuleResultsData = buildColorContrastRuleResultObject(
+            'PASS',
+            null,
+            null,
+            null,
+            null,
+        );
         const ruleInformation: RuleInformation = provider.getRuleInformation(ruleResult.ruleId);
         expect(ruleInformation.includeThisResult(ruleResult)).toBe(false);
     });
 
     test('TouchSizeWcag includeThisResult returns true', () => {
-        const ruleResult: RuleResultsData = buildTouchSizeWcagRuleResultObject('FAIL', 2.25, 86, 95);
+        const ruleResult: RuleResultsData = buildTouchSizeWcagRuleResultObject(
+            'FAIL',
+            2.25,
+            86,
+            95,
+        );
         const ruleInformation: RuleInformation = provider.getRuleInformation(ruleResult.ruleId);
         expect(ruleInformation.includeThisResult(null)).toBe(true);
     });

--- a/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
@@ -41,14 +41,27 @@ describe('RuleInformation', () => {
         };
 
         for (const howToFixString of testInputs) {
-            const expectedUnifiedFormattableResolution: UnifiedFormattableResolution = { howToFixSummary: howToFixString };
+            const expectedUnifiedFormattableResolution: UnifiedFormattableResolution = {
+                howToFixSummary: howToFixString,
+            };
 
-            const getUnifiedFormattableResolutionDelegateMock = Mock.ofType<GetUnifiedFormattableResolutionDelegate>();
-            getUnifiedFormattableResolutionDelegateMock.setup(func => func(testData)).returns(() => expectedUnifiedFormattableResolution);
+            const getUnifiedFormattableResolutionDelegateMock = Mock.ofType<
+                GetUnifiedFormattableResolutionDelegate
+            >();
+            getUnifiedFormattableResolutionDelegateMock
+                .setup(func => func(testData))
+                .returns(() => expectedUnifiedFormattableResolution);
 
-            const ruleInformation = new RuleInformation(null, null, getUnifiedFormattableResolutionDelegateMock.object, failIfCalled);
+            const ruleInformation = new RuleInformation(
+                null,
+                null,
+                getUnifiedFormattableResolutionDelegateMock.object,
+                failIfCalled,
+            );
 
-            const actualUnifiedResolution = ruleInformation.getUnifiedFormattableResolution(testData);
+            const actualUnifiedResolution = ruleInformation.getUnifiedFormattableResolution(
+                testData,
+            );
 
             expect(actualUnifiedResolution).toBe(expectedUnifiedFormattableResolution);
         }
@@ -68,7 +81,12 @@ describe('RuleInformation', () => {
             const includeThisResultMock = Mock.ofType<IncludeThisResultDelegate>();
             includeThisResultMock.setup(func => func(testData)).returns(() => expectedResult);
 
-            const ruleInformation = new RuleInformation(null, null, null, includeThisResultMock.object);
+            const ruleInformation = new RuleInformation(
+                null,
+                null,
+                null,
+                includeThisResultMock.object,
+            );
 
             const actualResult = ruleInformation.includeThisResult(testData);
 

--- a/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-controller.test.ts
@@ -7,7 +7,11 @@ import { TelemetryEventSource } from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
 import { Logger } from 'common/logging/logger';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
-import { SCAN_COMPLETED, SCAN_FAILED, SCAN_STARTED } from 'electron/common/electron-telemetry-events';
+import {
+    SCAN_COMPLETED,
+    SCAN_FAILED,
+    SCAN_STARTED,
+} from 'electron/common/electron-telemetry-events';
 import { PortPayload } from 'electron/flux/action/device-action-payloads';
 import { ScanActions } from 'electron/flux/action/scan-actions';
 import { ScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
@@ -54,12 +58,16 @@ describe('ScanController', () => {
         scanActionsMock = Mock.ofType<ScanActions>();
 
         scanStartedMock = Mock.ofType<Action<PortPayload>>();
-        scanStartedMock.setup(scanStarted => scanStarted.addListener(It.is(isFunction))).callback(listener => listener(payload));
+        scanStartedMock
+            .setup(scanStarted => scanStarted.addListener(It.is(isFunction)))
+            .callback(listener => listener(payload));
 
         scanCompletedMock = Mock.ofType<Action<void>>();
         scanFailedMock = Mock.ofType<Action<void>>();
 
-        scanActionsMock.setup(actions => actions.scanCompleted).returns(() => scanCompletedMock.object);
+        scanActionsMock
+            .setup(actions => actions.scanCompleted)
+            .returns(() => scanCompletedMock.object);
         scanActionsMock.setup(actions => actions.scanStarted).returns(() => scanStartedMock.object);
         scanActionsMock.setup(actions => actions.scanFailed).returns(() => scanFailedMock.object);
 
@@ -68,7 +76,10 @@ describe('ScanController', () => {
         getCurrentDateMock.setup(getter => getter()).returns(() => new Date(2019, 10, 8, 9, 2, 15));
 
         unifiedScanResultActionsMock = Mock.ofType<UnifiedScanResultActions>();
-        unifiedResultsBuilderMock = Mock.ofType<UnifiedScanCompletedPayloadBuilder>(undefined, MockBehavior.Strict);
+        unifiedResultsBuilderMock = Mock.ofType<UnifiedScanCompletedPayloadBuilder>(
+            undefined,
+            MockBehavior.Strict,
+        );
 
         loggerMock = Mock.ofType<Logger>();
 
@@ -86,10 +97,14 @@ describe('ScanController', () => {
     it('scans and handle successful response', async () => {
         const scanResults = new ScanResults(axeRuleResultExample);
 
-        fetchScanResultsMock.setup(fetch => fetch(port)).returns(() => Promise.resolve(scanResults));
+        fetchScanResultsMock
+            .setup(fetch => fetch(port))
+            .returns(() => Promise.resolve(scanResults));
 
         telemetryEventHandlerMock
-            .setup(handler => handler.publishTelemetry(SCAN_STARTED, It.isValue(expectedScanStartedTelemetry)))
+            .setup(handler =>
+                handler.publishTelemetry(SCAN_STARTED, It.isValue(expectedScanStartedTelemetry)),
+            )
             .verifiable(Times.once(), ExpectedCallType.InSequence);
 
         telemetryEventHandlerMock
@@ -107,7 +122,12 @@ describe('ScanController', () => {
                                 DontMoveAccessibilityFocus: 1,
                                 TouchSizeWcag: 6,
                             },
-                            FAIL: { ImageViewName: 1, ActiveViewName: 2, TouchSizeWcag: 1, ColorContrast: 1 },
+                            FAIL: {
+                                ImageViewName: 1,
+                                ActiveViewName: 2,
+                                TouchSizeWcag: 1,
+                                ColorContrast: 1,
+                            },
                             INCOMPLETE: {},
                         },
                     }),
@@ -132,12 +152,18 @@ describe('ScanController', () => {
             scanIncompleteWarnings: ['test-scan-incomplete-warning' as ScanIncompleteWarningId],
         };
 
-        unifiedResultsBuilderMock.setup(builder => builder(scanResults)).returns(() => unifiedPayload);
+        unifiedResultsBuilderMock
+            .setup(builder => builder(scanResults))
+            .returns(() => unifiedPayload);
 
         const unifiedScanCompletedMock = Mock.ofType<Action<UnifiedScanCompletedPayload>>();
-        unifiedScanCompletedMock.setup(action => action.invoke(unifiedPayload)).verifiable(Times.once());
+        unifiedScanCompletedMock
+            .setup(action => action.invoke(unifiedPayload))
+            .verifiable(Times.once());
 
-        unifiedScanResultActionsMock.setup(actions => actions.scanCompleted).returns(() => unifiedScanCompletedMock.object);
+        unifiedScanResultActionsMock
+            .setup(actions => actions.scanCompleted)
+            .returns(() => unifiedScanCompletedMock.object);
 
         testSubject.initialize();
 
@@ -153,7 +179,9 @@ describe('ScanController', () => {
         fetchScanResultsMock.setup(fetch => fetch(port)).returns(() => Promise.reject(errorReason));
 
         telemetryEventHandlerMock
-            .setup(handler => handler.publishTelemetry(SCAN_STARTED, It.isValue(expectedScanStartedTelemetry)))
+            .setup(handler =>
+                handler.publishTelemetry(SCAN_STARTED, It.isValue(expectedScanStartedTelemetry)),
+            )
             .verifiable(Times.once(), ExpectedCallType.InSequence);
 
         telemetryEventHandlerMock

--- a/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
@@ -2,7 +2,12 @@
 // Licensed under the MIT License.
 import { UnifiedResolution } from 'common/types/store-data/unified-data-interface';
 import { RuleInformation } from 'electron/platform/android/rule-information';
-import { DeviceInfo, RuleResultsData, ScanResults, ViewElementData } from 'electron/platform/android/scan-results';
+import {
+    DeviceInfo,
+    RuleResultsData,
+    ScanResults,
+    ViewElementData,
+} from 'electron/platform/android/scan-results';
 
 export function buildScanResultsObject(
     deviceName: string = null,
@@ -65,7 +70,12 @@ export function buildScanResultsObject(
     return new ScanResults(scanResults);
 }
 
-export function buildRuleResultObject(ruleId: string, status: string, axeViewId: string = null, props: any = null): RuleResultsData {
+export function buildRuleResultObject(
+    ruleId: string,
+    status: string,
+    axeViewId: string = null,
+    props: any = null,
+): RuleResultsData {
     const result = {};
     result['ruleId'] = ruleId;
     result['status'] = status;
@@ -99,7 +109,10 @@ export function buildViewElement(
     return viewElement as ViewElementData;
 }
 
-export function buildRuleInformation(ruleId: string, includeResults: boolean = true): RuleInformation {
+export function buildRuleInformation(
+    ruleId: string,
+    includeResults: boolean = true,
+): RuleInformation {
     return {
         ruleId: ruleId,
         ruleDescription: 'This describes ' + ruleId,

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-platform-data.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-platform-data.test.ts
@@ -7,7 +7,9 @@ import { axeRuleResultExample } from 'tests/unit/tests/electron/flux/action-crea
 
 describe('convertScanResultsToPlatformData', () => {
     it('produces the pinned output for the pinned example input', () => {
-        expect(convertScanResultsToPlatformData(new ScanResults(axeRuleResultExample))).toMatchSnapshot();
+        expect(
+            convertScanResultsToPlatformData(new ScanResults(axeRuleResultExample)),
+        ).toMatchSnapshot();
     });
 
     it('populates output from the ScanResults axeDevice properties', () => {
@@ -53,10 +55,19 @@ describe('convertScanResultsToPlatformData', () => {
     });
 
     it.each([null, undefined, {}])('outputs null if scanResults.axeContext is %p', emptyObject => {
-        expect(convertScanResultsToPlatformData(new ScanResults({ axeContext: emptyObject }))).toBeNull();
+        expect(
+            convertScanResultsToPlatformData(new ScanResults({ axeContext: emptyObject })),
+        ).toBeNull();
     });
 
-    it.each([null, undefined])('outputs null if scanResults.axeContext.axeDevice is %p', emptyObject => {
-        expect(convertScanResultsToPlatformData(new ScanResults({ axeContext: { axeDevice: emptyObject } }))).toBeNull();
-    });
+    it.each([null, undefined])(
+        'outputs null if scanResults.axeContext.axeDevice is %p',
+        emptyObject => {
+            expect(
+                convertScanResultsToPlatformData(
+                    new ScanResults({ axeContext: { axeDevice: emptyObject } }),
+                ),
+            ).toBeNull();
+        },
+    );
 });

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
@@ -9,7 +9,12 @@ import { RuleInformation } from 'electron/platform/android/rule-information';
 import { RuleInformationProviderType } from 'electron/platform/android/rule-information-provider-type';
 import { RuleResultsData, ScanResults } from 'electron/platform/android/scan-results';
 import { convertScanResultsToUnifiedResults } from 'electron/platform/android/scan-results-to-unified-results';
-import { buildRuleInformation, buildRuleResultObject, buildScanResultsObject, buildViewElement } from './scan-results-helpers';
+import {
+    buildRuleInformation,
+    buildRuleResultObject,
+    buildScanResultsObject,
+    buildViewElement,
+} from './scan-results-helpers';
 
 describe('ScanResultsToUnifiedResults', () => {
     let generateGuidMock: IMock<() => string>;
@@ -31,10 +36,18 @@ describe('ScanResultsToUnifiedResults', () => {
         const ruleInformation4: RuleInformation = buildRuleInformation(ruleId4, false);
 
         ruleInformationProviderMock = Mock.ofType<RuleInformationProviderType>();
-        ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId1)).returns(() => ruleInformation1);
-        ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId2)).returns(() => ruleInformation2);
-        ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId3)).returns(() => ruleInformation3);
-        ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId4)).returns(() => ruleInformation4);
+        ruleInformationProviderMock
+            .setup(x => x.getRuleInformation(ruleId1))
+            .returns(() => ruleInformation1);
+        ruleInformationProviderMock
+            .setup(x => x.getRuleInformation(ruleId2))
+            .returns(() => ruleInformation2);
+        ruleInformationProviderMock
+            .setup(x => x.getRuleInformation(ruleId3))
+            .returns(() => ruleInformation3);
+        ruleInformationProviderMock
+            .setup(x => x.getRuleInformation(ruleId4))
+            .returns(() => ruleInformation4);
     });
 
     function verifyMockCounts(
@@ -44,24 +57,52 @@ describe('ScanResultsToUnifiedResults', () => {
         expectedRule4Count: number,
         expectedOtherCount: number,
     ): void {
-        const totalCalls: number = expectedRule1Count + expectedRule2Count + expectedRule3Count + expectedRule4Count + expectedOtherCount;
+        const totalCalls: number =
+            expectedRule1Count +
+            expectedRule2Count +
+            expectedRule3Count +
+            expectedRule4Count +
+            expectedOtherCount;
 
-        ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId1), Times.exactly(expectedRule1Count));
-        ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId2), Times.exactly(expectedRule2Count));
-        ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId3), Times.exactly(expectedRule3Count));
-        ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId4), Times.exactly(expectedRule4Count));
-        ruleInformationProviderMock.verify(x => x.getRuleInformation(It.isAnyString()), Times.exactly(totalCalls));
+        ruleInformationProviderMock.verify(
+            x => x.getRuleInformation(ruleId1),
+            Times.exactly(expectedRule1Count),
+        );
+        ruleInformationProviderMock.verify(
+            x => x.getRuleInformation(ruleId2),
+            Times.exactly(expectedRule2Count),
+        );
+        ruleInformationProviderMock.verify(
+            x => x.getRuleInformation(ruleId3),
+            Times.exactly(expectedRule3Count),
+        );
+        ruleInformationProviderMock.verify(
+            x => x.getRuleInformation(ruleId4),
+            Times.exactly(expectedRule4Count),
+        );
+        ruleInformationProviderMock.verify(
+            x => x.getRuleInformation(It.isAnyString()),
+            Times.exactly(totalCalls),
+        );
     }
 
     test('Null ScanResults input returns empty output', () => {
-        const results: UnifiedResult[] = convertScanResultsToUnifiedResults(null, ruleInformationProviderMock.object, null);
+        const results: UnifiedResult[] = convertScanResultsToUnifiedResults(
+            null,
+            ruleInformationProviderMock.object,
+            null,
+        );
         expect(results).toMatchSnapshot();
         verifyMockCounts(0, 0, 0, 0, 0);
     });
 
     test('ScanResults with no RuleResults returns empty output', () => {
         const scanResults: ScanResults = buildScanResultsObject();
-        const results: UnifiedResult[] = convertScanResultsToUnifiedResults(scanResults, ruleInformationProviderMock.object, null);
+        const results: UnifiedResult[] = convertScanResultsToUnifiedResults(
+            scanResults,
+            ruleInformationProviderMock.object,
+            null,
+        );
         expect(results).toMatchSnapshot();
         verifyMockCounts(0, 0, 0, 0, 0);
     });
@@ -89,14 +130,31 @@ describe('ScanResultsToUnifiedResults', () => {
             'myDescription1',
             'myText1',
             [
-                buildViewElement(id2, { top: 10, left: 20, right: 35, bottom: 50 }, 'myClass2', null, null, [
-                    buildViewElement(id3, null, 'myClass3', null, null, null),
-                ]),
-                buildViewElement(id4, { top: 50, left: 10, right: 500, bottom: 300 }, 'myClass4', 'myDescription4', 'myText4', null),
+                buildViewElement(
+                    id2,
+                    { top: 10, left: 20, right: 35, bottom: 50 },
+                    'myClass2',
+                    null,
+                    null,
+                    [buildViewElement(id3, null, 'myClass3', null, null, null)],
+                ),
+                buildViewElement(
+                    id4,
+                    { top: 50, left: 10, right: 500, bottom: 300 },
+                    'myClass4',
+                    'myDescription4',
+                    'myText4',
+                    null,
+                ),
             ],
         );
 
-        const scanResults: ScanResults = buildScanResultsObject('Some device', 'Some app', ruleResults, viewElementTree);
+        const scanResults: ScanResults = buildScanResultsObject(
+            'Some device',
+            'Some app',
+            ruleResults,
+            viewElementTree,
+        );
         const results: UnifiedResult[] = convertScanResultsToUnifiedResults(
             scanResults,
             ruleInformationProviderMock.object,

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-rules.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-rules.test.ts
@@ -9,7 +9,11 @@ import { RuleInformation } from 'electron/platform/android/rule-information';
 import { RuleInformationProviderType } from 'electron/platform/android/rule-information-provider-type';
 import { RuleResultsData, ScanResults } from 'electron/platform/android/scan-results';
 import { convertScanResultsToUnifiedRules } from 'electron/platform/android/scan-results-to-unified-rules';
-import { buildRuleInformation, buildRuleResultObject, buildScanResultsObject } from './scan-results-helpers';
+import {
+    buildRuleInformation,
+    buildRuleResultObject,
+    buildScanResultsObject,
+} from './scan-results-helpers';
 
 describe('ScanResultsToUnifiedRules', () => {
     let ruleInformationProviderMock: IMock<RuleInformationProviderType>;
@@ -25,13 +29,33 @@ describe('ScanResultsToUnifiedRules', () => {
         expectedRule4Count: number,
         expectedOtherCount: number,
     ): void {
-        const totalCalls: number = expectedRule1Count + expectedRule2Count + expectedRule3Count + expectedRule4Count + expectedOtherCount;
+        const totalCalls: number =
+            expectedRule1Count +
+            expectedRule2Count +
+            expectedRule3Count +
+            expectedRule4Count +
+            expectedOtherCount;
 
-        ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId1), Times.exactly(expectedRule1Count));
-        ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId2), Times.exactly(expectedRule2Count));
-        ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId3), Times.exactly(expectedRule3Count));
-        ruleInformationProviderMock.verify(x => x.getRuleInformation(ruleId4), Times.exactly(expectedRule4Count));
-        ruleInformationProviderMock.verify(x => x.getRuleInformation(It.isAnyString()), Times.exactly(totalCalls));
+        ruleInformationProviderMock.verify(
+            x => x.getRuleInformation(ruleId1),
+            Times.exactly(expectedRule1Count),
+        );
+        ruleInformationProviderMock.verify(
+            x => x.getRuleInformation(ruleId2),
+            Times.exactly(expectedRule2Count),
+        );
+        ruleInformationProviderMock.verify(
+            x => x.getRuleInformation(ruleId3),
+            Times.exactly(expectedRule3Count),
+        );
+        ruleInformationProviderMock.verify(
+            x => x.getRuleInformation(ruleId4),
+            Times.exactly(expectedRule4Count),
+        );
+        ruleInformationProviderMock.verify(
+            x => x.getRuleInformation(It.isAnyString()),
+            Times.exactly(totalCalls),
+        );
     }
 
     const ruleId1: string = 'Rule #1';
@@ -50,21 +74,37 @@ describe('ScanResultsToUnifiedRules', () => {
         const ruleInformation4: RuleInformation = buildRuleInformation(ruleId4, false);
 
         ruleInformationProviderMock = Mock.ofType<RuleInformationProviderType>();
-        ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId1)).returns(() => ruleInformation1);
-        ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId2)).returns(() => ruleInformation2);
-        ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId3)).returns(() => ruleInformation3);
-        ruleInformationProviderMock.setup(x => x.getRuleInformation(ruleId4)).returns(() => ruleInformation4);
+        ruleInformationProviderMock
+            .setup(x => x.getRuleInformation(ruleId1))
+            .returns(() => ruleInformation1);
+        ruleInformationProviderMock
+            .setup(x => x.getRuleInformation(ruleId2))
+            .returns(() => ruleInformation2);
+        ruleInformationProviderMock
+            .setup(x => x.getRuleInformation(ruleId3))
+            .returns(() => ruleInformation3);
+        ruleInformationProviderMock
+            .setup(x => x.getRuleInformation(ruleId4))
+            .returns(() => ruleInformation4);
     });
 
     test('Null ScanResults input returns empty output', () => {
-        const results: UnifiedRule[] = convertScanResultsToUnifiedRules(null, ruleInformationProviderMock.object, null);
+        const results: UnifiedRule[] = convertScanResultsToUnifiedRules(
+            null,
+            ruleInformationProviderMock.object,
+            null,
+        );
         expect(results).toMatchSnapshot();
         verifyMockCounts(0, 0, 0, 0, 0);
     });
 
     test('ScanResults with no RuleResults returns empty output', () => {
         const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier);
-        const results: UnifiedRule[] = convertScanResultsToUnifiedRules(scanResults, ruleInformationProviderMock.object, null);
+        const results: UnifiedRule[] = convertScanResultsToUnifiedRules(
+            scanResults,
+            ruleInformationProviderMock.object,
+            null,
+        );
         expect(results).toMatchSnapshot();
         verifyMockCounts(0, 0, 0, 0, 0);
     });
@@ -76,7 +116,11 @@ describe('ScanResultsToUnifiedRules', () => {
             buildRuleResultObject('unsupported 3', 'PASS'),
         ];
 
-        const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier, ruleResults);
+        const scanResults: ScanResults = buildScanResultsObject(
+            deviceName,
+            appIdentifier,
+            ruleResults,
+        );
         const results: UnifiedRule[] = convertScanResultsToUnifiedRules(
             scanResults,
             ruleInformationProviderMock.object,
@@ -89,7 +133,11 @@ describe('ScanResultsToUnifiedRules', () => {
     test('ScanResults with 1 supported rule', () => {
         const ruleResults: RuleResultsData[] = [buildRuleResultObject(ruleId1, 'PASS')];
 
-        const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier, ruleResults);
+        const scanResults: ScanResults = buildScanResultsObject(
+            deviceName,
+            appIdentifier,
+            ruleResults,
+        );
         const results: UnifiedRule[] = convertScanResultsToUnifiedRules(
             scanResults,
             ruleInformationProviderMock.object,
@@ -106,7 +154,11 @@ describe('ScanResultsToUnifiedRules', () => {
             buildRuleResultObject(ruleId1, 'FAIL'),
         ];
 
-        const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier, ruleResults);
+        const scanResults: ScanResults = buildScanResultsObject(
+            deviceName,
+            appIdentifier,
+            ruleResults,
+        );
         const results: UnifiedRule[] = convertScanResultsToUnifiedRules(
             scanResults,
             ruleInformationProviderMock.object,
@@ -132,7 +184,11 @@ describe('ScanResultsToUnifiedRules', () => {
             buildRuleResultObject('thanks for playing', 'FAIL'),
         ];
 
-        const scanResults: ScanResults = buildScanResultsObject(deviceName, appIdentifier, ruleResults);
+        const scanResults: ScanResults = buildScanResultsObject(
+            deviceName,
+            appIdentifier,
+            ruleResults,
+        );
         const results: UnifiedRule[] = convertScanResultsToUnifiedRules(
             scanResults,
             ruleInformationProviderMock.object,

--- a/src/tests/unit/tests/electron/platform/android/scan-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results.test.ts
@@ -3,7 +3,11 @@
 import { ScreenshotData } from 'common/types/store-data/unified-data-interface';
 import { DeviceInfo } from 'electron/platform/android/scan-results';
 
-import { buildRuleResultObject, buildScanResultsObject, buildViewElement } from './scan-results-helpers';
+import {
+    buildRuleResultObject,
+    buildScanResultsObject,
+    buildViewElement,
+} from './scan-results-helpers';
 
 describe('ScanResults', () => {
     test('axeVersion is "no-version" if missing from input', () => {
@@ -30,7 +34,15 @@ describe('ScanResults', () => {
             screenHeight: 1,
             screenWidth: 2,
         };
-        const scanResults = buildScanResultsObject(null, null, null, null, null, null, expectedDeviceInfo);
+        const scanResults = buildScanResultsObject(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            expectedDeviceInfo,
+        );
         expect(scanResults.deviceInfo).toEqual(expectedDeviceInfo);
     });
 
@@ -62,7 +74,10 @@ describe('ScanResults', () => {
     });
 
     test('ruleResults is correct if specified in input', () => {
-        const resultsArray = [buildRuleResultObject('Rule1', 'PASS'), buildRuleResultObject('Rule2', 'FAIL')];
+        const resultsArray = [
+            buildRuleResultObject('Rule1', 'PASS'),
+            buildRuleResultObject('Rule2', 'FAIL'),
+        ];
         const scanResults = buildScanResultsObject(null, null, resultsArray);
         expect(scanResults.ruleResults).toHaveLength(2);
         expect(scanResults.ruleResults).toEqual(resultsArray);
@@ -92,7 +107,10 @@ describe('ScanResults', () => {
             'myClass1',
             'myDescription1',
             'myText1',
-            [buildViewElement('id2', null, null, null, null, null), buildViewElement('id3', null, null, null, null, null)],
+            [
+                buildViewElement('id2', null, null, null, null, null),
+                buildViewElement('id3', null, null, null, null, null),
+            ],
         );
         expect(viewElementTree).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/unified-result-builder.test.ts
@@ -21,7 +21,13 @@ describe('buildUnifiedScanCompletedPayload', () => {
 
         const getUnifiedResultsMock = Mock.ofType<ConvertScanResultsToUnifiedResultsDelegate>();
         getUnifiedResultsMock
-            .setup(converter => converter(exampleScanResults, ruleInformationProviderMock.object, generateUIDMock.object))
+            .setup(converter =>
+                converter(
+                    exampleScanResults,
+                    ruleInformationProviderMock.object,
+                    generateUIDMock.object,
+                ),
+            )
             .returns(() => {
                 return [
                     {
@@ -35,9 +41,18 @@ describe('buildUnifiedScanCompletedPayload', () => {
                 ];
             });
 
-        const getUnifiedRulesMock = Mock.ofType<ConvertScanResultsToUnifiedRulesDelegate>(undefined, MockBehavior.Strict);
+        const getUnifiedRulesMock = Mock.ofType<ConvertScanResultsToUnifiedRulesDelegate>(
+            undefined,
+            MockBehavior.Strict,
+        );
         getUnifiedRulesMock
-            .setup(converter => converter(exampleScanResults, ruleInformationProviderMock.object, generateUIDMock.object))
+            .setup(converter =>
+                converter(
+                    exampleScanResults,
+                    ruleInformationProviderMock.object,
+                    generateUIDMock.object,
+                ),
+            )
             .returns(() => {
                 return [
                     {
@@ -49,7 +64,10 @@ describe('buildUnifiedScanCompletedPayload', () => {
                 ];
             });
 
-        const getPlatformDataMock = Mock.ofType<ConvertScanResultsToPlatformDataDelegate>(undefined, MockBehavior.Strict);
+        const getPlatformDataMock = Mock.ofType<ConvertScanResultsToPlatformDataDelegate>(
+            undefined,
+            MockBehavior.Strict,
+        );
         getPlatformDataMock
             .setup(converter => converter(exampleScanResults))
             .returns(() => ({

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -1,14 +1,28 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { CardSelectionViewData, getCardSelectionViewData } from 'common/get-card-selection-view-data';
+import {
+    CardSelectionViewData,
+    getCardSelectionViewData,
+} from 'common/get-card-selection-view-data';
 import { getCardViewData } from 'common/rule-based-view-model-provider';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
-import { CardRuleResult, CardRuleResultsByStatus, CardsViewModel } from 'common/types/store-data/card-view-model';
-import { UnifiedResult, UnifiedRule, UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import {
+    CardRuleResult,
+    CardRuleResultsByStatus,
+    CardsViewModel,
+} from 'common/types/store-data/card-view-model';
+import {
+    UnifiedResult,
+    UnifiedRule,
+    UnifiedScanResultStoreData,
+} from 'common/types/store-data/unified-data-interface';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
-import { AutomatedChecksView, AutomatedChecksViewProps } from 'electron/views/automated-checks/automated-checks-view';
+import {
+    AutomatedChecksView,
+    AutomatedChecksViewProps,
+} from 'electron/views/automated-checks/automated-checks-view';
 import { DeviceDisconnectedPopup } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
 import { ScreenshotViewModel } from 'electron/views/screenshot/screenshot-view-model';
 import { screenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
@@ -37,7 +51,11 @@ describe('AutomatedChecksView', () => {
             } as AutomatedChecksViewProps;
         });
 
-        const scanStatuses = [undefined, ScanStatus[ScanStatus.Scanning], ScanStatus[ScanStatus.Failed]];
+        const scanStatuses = [
+            undefined,
+            ScanStatus[ScanStatus.Scanning],
+            ScanStatus[ScanStatus.Failed],
+        ];
 
         it.each(scanStatuses)('when status scan <%s>', scanStatusName => {
             bareMinimumProps.scanStoreData.status = ScanStatus[scanStatusName];
@@ -81,11 +99,18 @@ describe('AutomatedChecksView', () => {
                 .verifiable(Times.once());
 
             const screenshotViewModelStub = {
-                screenshotData: { base64PngData: 'this should appear in snapshotted ScreenshotView props' },
+                screenshotData: {
+                    base64PngData: 'this should appear in snapshotted ScreenshotView props',
+                },
             } as ScreenshotViewModel;
             const screenshotViewModelProviderMock = Mock.ofInstance(screenshotViewModelProvider);
             screenshotViewModelProviderMock
-                .setup(provider => provider(unifiedScanResultStoreData, cardSelectionViewDataStub.highlightedResultUids))
+                .setup(provider =>
+                    provider(
+                        unifiedScanResultStoreData,
+                        cardSelectionViewDataStub.highlightedResultUids,
+                    ),
+                )
                 .returns(() => screenshotViewModelStub)
                 .verifiable(Times.once());
 
@@ -197,7 +222,10 @@ describe('AutomatedChecksView', () => {
 
             wrapped.find(DeviceDisconnectedPopup).prop('onConnectNewDevice')();
 
-            windowStateActionCreatorMock.verify(creator => creator.setRoute(It.isValue({ routeId: 'deviceConnectView' })), Times.once());
+            windowStateActionCreatorMock.verify(
+                creator => creator.setRoute(It.isValue({ routeId: 'deviceConnectView' })),
+                Times.once(),
+            );
         });
     });
 });

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -4,7 +4,11 @@ import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { EnumHelper } from 'common/enum-helper';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
-import { CommandBar, CommandBarProps, commandButtonRefreshId } from 'electron/views/automated-checks/components/command-bar';
+import {
+    CommandBar,
+    CommandBarProps,
+    commandButtonRefreshId,
+} from 'electron/views/automated-checks/components/command-bar';
 import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import { getAutomationIdSelector } from 'tests/common/get-automation-id-selector';
@@ -50,7 +54,10 @@ describe('CommandBar', () => {
         it('handles start over click', () => {
             const port = 111;
 
-            const scanActionCreatorMock = Mock.ofType<ScanActionCreator>(undefined, MockBehavior.Strict);
+            const scanActionCreatorMock = Mock.ofType<ScanActionCreator>(
+                undefined,
+                MockBehavior.Strict,
+            );
             scanActionCreatorMock.setup(creator => creator.scan(port)).verifiable(Times.once());
 
             const props = {
@@ -92,7 +99,10 @@ describe('CommandBar', () => {
 
             button.simulate('click', eventStub);
 
-            dropdownClickHandlerMock.verify(handler => handler.openSettingsPanelHandler(It.isAny()), Times.once());
+            dropdownClickHandlerMock.verify(
+                handler => handler.openSettingsPanelHandler(It.isAny()),
+                Times.once(),
+            );
         });
     });
 });

--- a/src/tests/unit/tests/electron/views/automated-checks/components/maximize-restore-button.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/maximize-restore-button.test.tsx
@@ -5,7 +5,10 @@ import { Button } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
 
-import { MaximizeRestoreButton, MaximizeRestoreButtonProps } from 'electron/views/automated-checks/components/maximize-restore-button';
+import {
+    MaximizeRestoreButton,
+    MaximizeRestoreButtonProps,
+} from 'electron/views/automated-checks/components/maximize-restore-button';
 import { EventStubFactory } from 'tests/unit/common/event-stub-factory';
 
 describe('MaximizeRestoreButton', () => {
@@ -27,9 +30,14 @@ describe('MaximizeRestoreButton', () => {
     });
 
     it('handles click', () => {
-        const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
+        const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<
+            Button
+        >;
         const onClickMock = Mock.ofInstance(() => {});
-        const props: MaximizeRestoreButtonProps = { isMaximized: false, onClick: onClickMock.object };
+        const props: MaximizeRestoreButtonProps = {
+            isMaximized: false,
+            onClick: onClickMock.object,
+        };
 
         const rendered = shallow(<MaximizeRestoreButton {...props} />);
         rendered.simulate('click', eventStub);

--- a/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/title-bar.test.tsx
@@ -23,14 +23,18 @@ describe('TitleBar', () => {
     let props: TitleBarProps;
 
     beforeEach(() => {
-        windowFrameActionCreator = Mock.ofType<WindowFrameActionCreator>(undefined, MockBehavior.Strict);
+        windowFrameActionCreator = Mock.ofType<WindowFrameActionCreator>(
+            undefined,
+            MockBehavior.Strict,
+        );
         windowStateStoreData = { routeId: 'resultsView', currentWindowState: 'maximized' };
         props = {
             deps: {
                 windowFrameActionCreator: windowFrameActionCreator.object,
                 platformInfo: Mock.ofType(PlatformInfo).object,
                 storeActionMessageCreator: Mock.ofType(StoreActionMessageCreatorImpl).object,
-                storesHub: Mock.ofType<ClientStoresHub<ThemeInnerState>>(BaseClientStoresHub).object,
+                storesHub: Mock.ofType<ClientStoresHub<ThemeInnerState>>(BaseClientStoresHub)
+                    .object,
             },
             pageTitle: 'test page title',
             windowStateStoreData,
@@ -91,9 +95,21 @@ describe('TitleBar', () => {
     });
 
     const maximizeButtonTestCases = [
-        { label: 'maximize when on custom size', setupMock: setupVerifiableWindowMaximizeAction, isMaximized: false }, // maximize validation
-        { label: 'restore when on full screen', setupMock: setupVerifiableWindowRestoreActionFromFullScreen, isMaximized: true }, // restore validation from full screen
-        { label: 'restore when on maximized state', setupMock: setupVerifiableWindowRestoreActionFromMaximized, isMaximized: true }, // restore validation from maximized state
+        {
+            label: 'maximize when on custom size',
+            setupMock: setupVerifiableWindowMaximizeAction,
+            isMaximized: false,
+        }, // maximize validation
+        {
+            label: 'restore when on full screen',
+            setupMock: setupVerifiableWindowRestoreActionFromFullScreen,
+            isMaximized: true,
+        }, // restore validation from full screen
+        {
+            label: 'restore when on maximized state',
+            setupMock: setupVerifiableWindowRestoreActionFromMaximized,
+            isMaximized: true,
+        }, // restore validation from maximized state
     ];
 
     maximizeButtonTestCases.forEach(testCase => {

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-body.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-body.test.tsx
@@ -12,7 +12,9 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 describe('DeviceConnectBodyTest', () => {
-    const deviceConnectStates = EnumHelper.getNumericValues<DeviceConnectState>(DeviceConnectState).map(state => DeviceConnectState[state]);
+    const deviceConnectStates = EnumHelper.getNumericValues<DeviceConnectState>(
+        DeviceConnectState,
+    ).map(state => DeviceConnectState[state]);
 
     it.each(deviceConnectStates)(`renders, with device connect state = %s`, stateName => {
         const props: DeviceConnectBodyProps = {

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-footer.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-footer.test.tsx
@@ -8,7 +8,10 @@ import {
     DeviceConnectFooterDeps,
     DeviceConnectFooterProps,
 } from 'electron/views/device-connect-view/components/device-connect-footer';
-import { footerButtonCancel, footerButtonStart } from 'electron/views/device-connect-view/components/device-connect-footer.scss';
+import {
+    footerButtonCancel,
+    footerButtonStart,
+} from 'electron/views/device-connect-view/components/device-connect-footer.scss';
 import { shallow } from 'enzyme';
 import { Button } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -60,7 +63,9 @@ describe('DeviceConnectFooterTest', () => {
     });
 
     test('start testing changes route & maximizes window', () => {
-        windowStateActionCreatorMock.setup(w => w.setRoute({ routeId: 'resultsView' })).verifiable(Times.once());
+        windowStateActionCreatorMock
+            .setup(w => w.setRoute({ routeId: 'resultsView' }))
+            .verifiable(Times.once());
         windowFrameActionCreatorMock.setup(w => w.maximize()).verifiable(Times.once());
         const props: DeviceConnectFooterProps = {
             cancelClick: onClickMock.object,

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-header.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-header.test.tsx
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DeviceConnectHeader, DeviceConnectHeaderProps } from 'electron/views/device-connect-view/components/device-connect-header';
+import {
+    DeviceConnectHeader,
+    DeviceConnectHeaderProps,
+} from 'electron/views/device-connect-view/components/device-connect-header';
 import { ElectronLink } from 'electron/views/device-connect-view/components/electron-link';
 import { shallow } from 'enzyme';
 import * as React from 'react';

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/device-connect-port-entry.test.tsx
@@ -24,13 +24,16 @@ describe('DeviceConnectPortEntryTest', () => {
     let deviceConnectActionCreatorMock: IMock<DeviceConnectActionCreator>;
 
     beforeEach(() => {
-        deviceConnectActionCreatorMock = Mock.ofType<DeviceConnectActionCreator>(undefined, MockBehavior.Strict);
+        deviceConnectActionCreatorMock = Mock.ofType<DeviceConnectActionCreator>(
+            undefined,
+            MockBehavior.Strict,
+        );
     });
 
     describe('renders', () => {
-        const deviceConnectStates = EnumHelper.getNumericValues<DeviceConnectState>(DeviceConnectState).map(
-            state => DeviceConnectState[state],
-        );
+        const deviceConnectStates = EnumHelper.getNumericValues<DeviceConnectState>(
+            DeviceConnectState,
+        ).map(state => DeviceConnectState[state]);
 
         it.each(deviceConnectStates)('with %p', deviceConnectStateName => {
             const props: DeviceConnectPortEntryProps = {
@@ -44,18 +47,21 @@ describe('DeviceConnectPortEntryTest', () => {
             expect(rendered.getElement()).toMatchSnapshot();
         });
 
-        it.each(deviceConnectStates)('with %p and some text in the port text field', deviceConnectStateName => {
-            const props: DeviceConnectPortEntryProps = {
-                viewState: {
-                    deviceConnectState: DeviceConnectState[deviceConnectStateName],
-                },
-            } as DeviceConnectPortEntryProps;
+        it.each(deviceConnectStates)(
+            'with %p and some text in the port text field',
+            deviceConnectStateName => {
+                const props: DeviceConnectPortEntryProps = {
+                    viewState: {
+                        deviceConnectState: DeviceConnectState[deviceConnectStateName],
+                    },
+                } as DeviceConnectPortEntryProps;
 
-            const rendered = shallow(<DeviceConnectPortEntry {...props} />);
-            rendered.setState({ port: '1234' });
+                const rendered = shallow(<DeviceConnectPortEntry {...props} />);
+                rendered.setState({ port: '1234' });
 
-            expect(rendered.getElement()).toMatchSnapshot();
-        });
+                expect(rendered.getElement()).toMatchSnapshot();
+            },
+        );
 
         it('renderedDescription', () => {
             const props: DeviceConnectPortEntryProps = {
@@ -63,7 +69,9 @@ describe('DeviceConnectPortEntryTest', () => {
             } as DeviceConnectPortEntryProps;
 
             const rendered = shallow(<DeviceConnectPortEntry {...props} />);
-            const renderedDescription = shallow(rendered.find(MaskedTextField).prop('onRenderDescription')());
+            const renderedDescription = shallow(
+                rendered.find(MaskedTextField).prop('onRenderDescription')(),
+            );
 
             expect(renderedDescription.getElement()).toMatchSnapshot();
         });
@@ -74,7 +82,9 @@ describe('DeviceConnectPortEntryTest', () => {
             const portNumberCases = [testPortNumber.toString(), '', null];
 
             it.each(portNumberCases)('handles port text = "%s"', portNumberText => {
-                deviceConnectActionCreatorMock.setup(creator => creator.resetConnection()).verifiable(Times.once());
+                deviceConnectActionCreatorMock
+                    .setup(creator => creator.resetConnection())
+                    .verifiable(Times.once());
 
                 const props = {
                     viewState: {
@@ -97,7 +107,9 @@ describe('DeviceConnectPortEntryTest', () => {
         });
 
         it('validates port', () => {
-            deviceConnectActionCreatorMock.setup(creator => creator.validatePort(testPortNumber)).verifiable(Times.once());
+            deviceConnectActionCreatorMock
+                .setup(creator => creator.validatePort(testPortNumber))
+                .verifiable(Times.once());
 
             const props = {
                 deps: {
@@ -110,7 +122,9 @@ describe('DeviceConnectPortEntryTest', () => {
             const rendered = shallow(<DeviceConnectPortEntry {...props} />);
             rendered.setState({ port: testPortNumber });
 
-            const buttonSelector = getAutomationIdSelector(deviceConnectValidatePortButtonAutomationId);
+            const buttonSelector = getAutomationIdSelector(
+                deviceConnectValidatePortButtonAutomationId,
+            );
             const button = rendered.find(buttonSelector);
 
             button.simulate('click', eventStub);
@@ -119,7 +133,9 @@ describe('DeviceConnectPortEntryTest', () => {
         });
 
         it('validates port through enter key', () => {
-            deviceConnectActionCreatorMock.setup(creator => creator.validatePort(testPortNumber)).verifiable(Times.once());
+            deviceConnectActionCreatorMock
+                .setup(creator => creator.validatePort(testPortNumber))
+                .verifiable(Times.once());
 
             const props = {
                 deps: {

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/electron-external-link.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/electron-external-link.test.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Shell } from 'electron';
-import { ElectronExternalLink, ElectronExternalLinkProps } from 'electron/views/device-connect-view/components/electron-external-link';
+import {
+    ElectronExternalLink,
+    ElectronExternalLinkProps,
+} from 'electron/views/device-connect-view/components/electron-external-link';
 import { shallow } from 'enzyme';
 import { Button } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -26,7 +29,9 @@ describe('ElectronExternalLink', () => {
 
     test('click', () => {
         const shellMock = Mock.ofType<Shell>();
-        const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<Button>;
+        const eventStub = new EventStubFactory().createMouseClickEvent() as React.MouseEvent<
+            Button
+        >;
         shellMock.setup(shell => shell.openExternal(testHref)).verifiable(Times.once());
 
         const props: ElectronExternalLinkProps = {

--- a/src/tests/unit/tests/electron/views/device-connect-view/send-app-initialized-telemetry.test.ts
+++ b/src/tests/unit/tests/electron/views/device-connect-view/send-app-initialized-telemetry.test.ts
@@ -30,6 +30,9 @@ describe('sendAppInitializedTelemetry', () => {
             },
         };
 
-        telemetryEventHandlerMock.verify(handler => handler.publishTelemetry(APP_INITIALIZED, It.isValue(expectedTelemetry)), Times.once());
+        telemetryEventHandlerMock.verify(
+            handler => handler.publishTelemetry(APP_INITIALIZED, It.isValue(expectedTelemetry)),
+            Times.once(),
+        );
     });
 });

--- a/src/tests/unit/tests/electron/views/device-disconnected-popup/device-disconnected-popup.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-disconnected-popup/device-disconnected-popup.test.tsx
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DeviceDisconnectedPopup, DeviceDisconnectedPopupProps } from 'electron/views/device-disconnected-popup/device-disconnected-popup';
+import {
+    DeviceDisconnectedPopup,
+    DeviceDisconnectedPopupProps,
+} from 'electron/views/device-disconnected-popup/device-disconnected-popup';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 

--- a/src/tests/unit/tests/electron/views/root-container/components/root-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/components/root-container.test.tsx
@@ -26,7 +26,10 @@ describe('RootContainer', () => {
         props = {
             deps,
             storeState: {
-                windowStateStoreData: { routeId: 'deviceConnectView', currentWindowState: 'customSize' },
+                windowStateStoreData: {
+                    routeId: 'deviceConnectView',
+                    currentWindowState: 'customSize',
+                },
                 userConfigurationStoreData: {
                     isFirstTime: false,
                 },

--- a/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
+++ b/src/tests/unit/tests/electron/views/root-container/root-container-renderer.test.tsx
@@ -6,7 +6,10 @@ import { BrowserWindow } from 'electron';
 import { WindowStateActionCreator } from 'electron/flux/action-creator/window-state-action-creator';
 import { PlatformBodyClassModifier } from 'electron/views/root-container/components/platform-body-class-modifier';
 import { RootContainer } from 'electron/views/root-container/components/root-container';
-import { RootContainerRenderer, RootContainerRendererDeps } from 'electron/views/root-container/root-container-renderer';
+import {
+    RootContainerRenderer,
+    RootContainerRendererDeps,
+} from 'electron/views/root-container/root-container-renderer';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { IMock, It, Mock, Times } from 'typemoq';
@@ -42,7 +45,9 @@ describe('RootContainerRendererTest', () => {
         );
 
         renderMock.setup(r => r(It.isValue(expectedComponent), containerDiv)).verifiable();
-        windowStateActionCreatorMock.setup(w => w.setRoute({ routeId: 'deviceConnectView' })).verifiable(Times.once());
+        windowStateActionCreatorMock
+            .setup(w => w.setRoute({ routeId: 'deviceConnectView' }))
+            .verifiable(Times.once());
 
         const renderer = new RootContainerRenderer(renderMock.object, dom, deps);
 

--- a/src/tests/unit/tests/electron/views/screenshot/screenshot-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/screenshot/screenshot-container.test.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ScreenshotData } from 'common/types/store-data/unified-data-interface';
-import { ScreenshotContainer, ScreenshotContainerProps } from 'electron/views/screenshot/screenshot-container';
+import {
+    ScreenshotContainer,
+    ScreenshotContainerProps,
+} from 'electron/views/screenshot/screenshot-container';
 import { HighlightBoxViewModel } from 'electron/views/screenshot/screenshot-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -22,8 +25,20 @@ describe('ScreenshotContainer', () => {
 
     it('renders per snapshot with highlight boxes', () => {
         const highlightBoxViewModels: HighlightBoxViewModel[] = [
-            { resultUid: 'result-1', top: 'top-1', left: 'left-1', width: 'width-1', height: 'height-1' },
-            { resultUid: 'result-2', top: 'top-2', left: 'left-2', width: 'width-2', height: 'height-2' },
+            {
+                resultUid: 'result-1',
+                top: 'top-1',
+                left: 'left-1',
+                width: 'width-1',
+                height: 'height-1',
+            },
+            {
+                resultUid: 'result-2',
+                top: 'top-2',
+                left: 'left-2',
+                width: 'width-2',
+                height: 'height-2',
+            },
         ];
 
         const props: ScreenshotContainerProps = {

--- a/src/tests/unit/tests/electron/views/screenshot/screenshot-view-model-provider.test.ts
+++ b/src/tests/unit/tests/electron/views/screenshot/screenshot-view-model-provider.test.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ScreenshotData, UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import {
+    ScreenshotData,
+    UnifiedScanResultStoreData,
+} from 'common/types/store-data/unified-data-interface';
 import { BoundingRectangle } from 'electron/platform/android/scan-results';
 import { HighlightBoxViewModel } from 'electron/views/screenshot/screenshot-view-model';
 import { screenshotViewModelProvider } from 'electron/views/screenshot/screenshot-view-model-provider';
@@ -25,7 +28,9 @@ describe('screenshotViewModelProvider', () => {
             platformInfo: { viewPortInfo: { width: 1, height: 1 } },
         } as UnifiedScanResultStoreData;
 
-        const output = screenshotViewModelProvider(unifiedScanResultStoreData, [exampleUnifiedResult.uid]);
+        const output = screenshotViewModelProvider(unifiedScanResultStoreData, [
+            exampleUnifiedResult.uid,
+        ]);
 
         expect(output.highlightBoxViewModels).toStrictEqual([]);
     });
@@ -37,7 +42,9 @@ describe('screenshotViewModelProvider', () => {
             results: [exampleUnifiedResult],
         } as UnifiedScanResultStoreData;
 
-        const output = screenshotViewModelProvider(unifiedScanResultStoreData, [exampleUnifiedResult.uid]);
+        const output = screenshotViewModelProvider(unifiedScanResultStoreData, [
+            exampleUnifiedResult.uid,
+        ]);
 
         expect(output.highlightBoxViewModels).toStrictEqual([]);
     });
@@ -89,7 +96,9 @@ describe('screenshotViewModelProvider', () => {
         const output = screenshotViewModelProvider(unifiedScanResultStoreData, highlightedUids);
 
         expect(output.highlightBoxViewModels).toHaveLength(1);
-        expect(output.highlightBoxViewModels[0].resultUid).toBe(resultCases.highlightedResultWithBoundingRectangle.uid);
+        expect(output.highlightBoxViewModels[0].resultUid).toBe(
+            resultCases.highlightedResultWithBoundingRectangle.uid,
+        );
     });
 
     it('calculates highlight box positional values as percentages relative to the viewport size', () => {
@@ -101,7 +110,11 @@ describe('screenshotViewModelProvider', () => {
             right: 80,
             bottom: 150,
         };
-        const highlightBoxViewModel = provideHighlightBoxViewModelForBoundingRectangle(inputRectangle, viewPortWidth, viewPortHeight);
+        const highlightBoxViewModel = provideHighlightBoxViewModelForBoundingRectangle(
+            inputRectangle,
+            viewPortWidth,
+            viewPortHeight,
+        );
 
         expect(highlightBoxViewModel.top).toBe('25%');
         expect(highlightBoxViewModel.left).toBe('20%');

--- a/src/tests/unit/tests/electron/views/screenshot/screenshot-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/screenshot/screenshot-view.test.tsx
@@ -20,15 +20,18 @@ describe('ScreenshotView', () => {
         });
 
         const emptyScreenshotDataCases: ScreenshotData[] = [null, undefined, {} as ScreenshotData];
-        it.each(emptyScreenshotDataCases)('matches snapshot when passed empty screenshotData %p', (screenshotDataCase: ScreenshotData) => {
-            const viewModel: ScreenshotViewModel = {
-                screenshotData: screenshotDataCase,
-                highlightBoxViewModels: [],
-                deviceName: null,
-            };
-            const wrapper = shallow(<ScreenshotView viewModel={viewModel} />);
+        it.each(emptyScreenshotDataCases)(
+            'matches snapshot when passed empty screenshotData %p',
+            (screenshotDataCase: ScreenshotData) => {
+                const viewModel: ScreenshotViewModel = {
+                    screenshotData: screenshotDataCase,
+                    highlightBoxViewModels: [],
+                    deviceName: null,
+                };
+                const wrapper = shallow(<ScreenshotView viewModel={viewModel} />);
 
-            expect(wrapper.getElement()).toMatchSnapshot();
-        });
+                expect(wrapper.getElement()).toMatchSnapshot();
+            },
+        );
     });
 });

--- a/src/tests/unit/tests/electron/window-management/window-frame-listener.test.ts
+++ b/src/tests/unit/tests/electron/window-management/window-frame-listener.test.ts
@@ -15,7 +15,10 @@ describe(WindowFrameListener, () => {
         windowStateActionsCreatorMock = Mock.ofType(WindowStateActionCreator);
         browserWindowMock = Mock.ofType(BrowserWindow, MockBehavior.Strict);
 
-        testSubject = new WindowFrameListener(windowStateActionsCreatorMock.object, browserWindowMock.object);
+        testSubject = new WindowFrameListener(
+            windowStateActionsCreatorMock.object,
+            browserWindowMock.object,
+        );
     });
 
     afterEach(() => {
@@ -36,45 +39,64 @@ describe(WindowFrameListener, () => {
         beforeEach(() => {
             setupVerifiableWindowEventCallback('maximize', cb => (maximizeCallback = cb));
             setupVerifiableWindowEventCallback('unmaximize', cb => (unmaximizeCallback = cb));
-            setupVerifiableWindowEventCallback('enter-full-screen', cb => (enterFullScreenCallback = cb));
-            setupVerifiableWindowEventCallback('leave-full-screen', cb => (leaveFullScreenCallback = cb));
+            setupVerifiableWindowEventCallback(
+                'enter-full-screen',
+                cb => (enterFullScreenCallback = cb),
+            );
+            setupVerifiableWindowEventCallback(
+                'leave-full-screen',
+                cb => (leaveFullScreenCallback = cb),
+            );
 
             testSubject.initialize();
         });
 
         it('validate window state on maximize', () => {
-            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'maximized' })).verifiable(Times.once());
+            windowStateActionsCreatorMock
+                .setup(b => b.setWindowState({ currentWindowState: 'maximized' }))
+                .verifiable(Times.once());
 
             maximizeCallback();
         });
 
         it('validate window state on unmaximize', () => {
-            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'customSize' })).verifiable(Times.once());
+            windowStateActionsCreatorMock
+                .setup(b => b.setWindowState({ currentWindowState: 'customSize' }))
+                .verifiable(Times.once());
 
             unmaximizeCallback();
         });
 
         it('validate window state on fullscreen', () => {
-            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'fullScreen' })).verifiable(Times.once());
+            windowStateActionsCreatorMock
+                .setup(b => b.setWindowState({ currentWindowState: 'fullScreen' }))
+                .verifiable(Times.once());
 
             enterFullScreenCallback();
         });
 
         it('validate window state on leaving full screen to maximized state', () => {
             browserWindowMock.setup(b => b.isMaximized()).returns(() => true);
-            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'maximized' })).verifiable(Times.once());
+            windowStateActionsCreatorMock
+                .setup(b => b.setWindowState({ currentWindowState: 'maximized' }))
+                .verifiable(Times.once());
 
             leaveFullScreenCallback();
         });
 
         it('validate window state on leaving full screen to custom size', () => {
             browserWindowMock.setup(b => b.isMaximized()).returns(() => false);
-            windowStateActionsCreatorMock.setup(b => b.setWindowState({ currentWindowState: 'customSize' })).verifiable(Times.once());
+            windowStateActionsCreatorMock
+                .setup(b => b.setWindowState({ currentWindowState: 'customSize' }))
+                .verifiable(Times.once());
 
             leaveFullScreenCallback();
         });
 
-        function setupVerifiableWindowEventCallback(eventName: string, callback: (eventCallback: Function) => void): void {
+        function setupVerifiableWindowEventCallback(
+            eventName: string,
+            callback: (eventCallback: Function) => void,
+        ): void {
             browserWindowMock
                 .setup(b => b.on(eventName as any, It.isAny()))
                 .callback((event, cb) => {

--- a/src/tests/unit/tests/electron/window-management/window-frame-updater.test.ts
+++ b/src/tests/unit/tests/electron/window-management/window-frame-updater.test.ts
@@ -81,7 +81,9 @@ describe(WindowFrameUpdater, () => {
             browserWindowMock
                 .setup(b => b.setSize(sizePayload.width, sizePayload.height))
                 .verifiable(Times.once(), ExpectedCallType.InSequence);
-            browserWindowMock.setup(b => b.center()).verifiable(Times.once(), ExpectedCallType.InSequence);
+            browserWindowMock
+                .setup(b => b.center())
+                .verifiable(Times.once(), ExpectedCallType.InSequence);
 
             windowFrameActions.setWindowSize.invoke(sizePayload);
         });


### PR DESCRIPTION
#### Description of changes

Remove` src/tests/unit/tests/electron` folder from prettier override for the line width value.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
