### PR TITLE
fix: remove unnecessary telemetry dialog id attribute

### DIFF
--- a/src/common/components/telemetry-permission-dialog.tsx
+++ b/src/common/components/telemetry-permission-dialog.tsx
@@ -51,9 +51,6 @@ export class TelemetryPermissionDialog extends React.Component<
                     type: DialogType.normal,
                     showCloseButton: false,
                     title: telemetryPopupTitle,
-                    titleProps: {
-                        id: 'telemetry-permission-title',
-                    },
                 }}
                 modalProps={{
                     className: 'telemetry-permission-dialog-modal',

--- a/src/tests/end-to-end/tests/popup/__snapshots__/first-time-dialog.test.ts.snap
+++ b/src/tests/end-to-end/tests/popup/__snapshots__/first-time-dialog.test.ts.snap
@@ -29,7 +29,7 @@ exports[`First time Dialog content should match snapshot 1`] = `
             <div
               aria-level="2"
               class="ms-Dialog-title title-000"
-              id="telemetry-permission-title"
+              id="Dialog000-title"
               role="heading"
             >
               We need your help

--- a/src/tests/unit/tests/common/components/__snapshots__/telemetry-permission-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/telemetry-permission-dialog.test.tsx.snap
@@ -6,9 +6,6 @@ exports[`TelemetryPermissionDialogTest render dialog 1`] = `
     Object {
       "showCloseButton": false,
       "title": "We need your help",
-      "titleProps": Object {
-        "id": "telemetry-permission-title",
-      },
       "type": 0,
     }
   }


### PR DESCRIPTION
#### Description of changes

This PR removes a title ID attribute for the telemetry permission dialog. I was unable to find any usages of this id, and its inclusion leads to an invalid aria label, as described in #2316. 

This is the first of a few PRs in this area; I'd like to run accessibility tests on this dialog in our e2e tests, and that requires a little refactoring.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 2316
- [ ] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
