### PR TITLE
fix: handle 'color' attribute for dialogs in HC mode

### DIFF
--- a/src/electron/views/device-connect-view/device-connect-view.scss
+++ b/src/electron/views/device-connect-view/device-connect-view.scss
@@ -5,8 +5,7 @@
 @import '../../../reports/components/outcome.scss';
 @import '../../../common/components/cards/fix-instruction-color-box.scss';
 
-body.ms-Fabric,
-body .ms-Fabric {
+.ms-Fabric {
     color: $primary-text;
 }
 

--- a/src/electron/views/device-connect-view/device-connect-view.scss
+++ b/src/electron/views/device-connect-view/device-connect-view.scss
@@ -5,7 +5,8 @@
 @import '../../../reports/components/outcome.scss';
 @import '../../../common/components/cards/fix-instruction-color-box.scss';
 
-body.ms-Fabric {
+body.ms-Fabric,
+body .ms-Fabric {
     color: $primary-text;
 }
 


### PR DESCRIPTION
#### Description of changes

Currently the text in unified/electron dialogs does not change color in when high contrast mode is enabled. Two examples include the telemetry permissions dialog and the device disconnected dialog. These render in a layer inside body and adjacent to #root-container. 

This PR includes one approach to fix this by targeting all .ms-Fabric descendants of body in addition to body itself. It feels a bit odd to me that a change in device-connect-view.scss would affect the device disconnected popup - would like to better understand what approach is best.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
