### PR TITLE
refactor: clean up details view container props/deps

### DIFF
--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -52,6 +52,14 @@ export type DetailsViewContainerDeps = {
     getDetailsSwitcherNavConfiguration: GetDetailsSwitcherNavConfiguration;
     getCardViewData: GetCardViewData;
     getCardSelectionViewData: GetCardSelectionViewData;
+    issuesSelection: ISelection;
+    clickHandlerFactory: DetailsViewToggleClickHandlerFactory;
+    scopingActionMessageCreator: ScopingActionMessageCreator;
+    inspectActionMessageCreator: InspectActionMessageCreator;
+    issuesTableHandler: IssuesTableHandler;
+    assessmentInstanceTableHandler: AssessmentInstanceTableHandler;
+    previewFeatureFlagsHandler: PreviewFeatureFlagsHandler;
+    dropdownClickHandler: DropdownClickHandler;
 } & DetailsViewBodyDeps &
     DetailsViewOverlayDeps &
     DetailsViewCommandBarDeps &
@@ -62,17 +70,6 @@ export type DetailsViewContainerDeps = {
 
 export interface DetailsViewContainerProps {
     deps: DetailsViewContainerDeps;
-    issuesSelection: ISelection;
-    clickHandlerFactory: DetailsViewToggleClickHandlerFactory;
-    scopingActionMessageCreator: ScopingActionMessageCreator;
-    inspectActionMessageCreator: InspectActionMessageCreator;
-    visualizationConfigurationFactory: VisualizationConfigurationFactory;
-    issuesTableHandler: IssuesTableHandler;
-    assessmentInstanceTableHandler: AssessmentInstanceTableHandler;
-    previewFeatureFlagsHandler: PreviewFeatureFlagsHandler;
-    scopingFlagsHandler: PreviewFeatureFlagsHandler;
-    dropdownClickHandler: DropdownClickHandler;
-    assessmentsProvider: AssessmentsProvider;
     storeState: DetailsViewContainerState;
 }
 
@@ -153,7 +150,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
                     visualizationStoreData ? visualizationStoreData.selectedDetailsViewPivot : null
                 }
                 featureFlagStoreData={this.hasStores() ? storeState.featureFlagStoreData : null}
-                dropdownClickHandler={this.props.dropdownClickHandler}
+                dropdownClickHandler={this.props.deps.dropdownClickHandler}
                 tabClosed={this.hasStores() ? this.props.storeState.tabStoreData.isClosed : true}
             />
         );
@@ -164,9 +161,9 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
         return (
             <DetailsViewOverlay
                 deps={deps}
-                previewFeatureFlagsHandler={this.props.previewFeatureFlagsHandler}
-                scopingActionMessageCreator={this.props.scopingActionMessageCreator}
-                inspectActionMessageCreator={this.props.inspectActionMessageCreator}
+                previewFeatureFlagsHandler={this.props.deps.previewFeatureFlagsHandler}
+                scopingActionMessageCreator={this.props.deps.scopingActionMessageCreator}
+                inspectActionMessageCreator={this.props.deps.inspectActionMessageCreator}
                 detailsViewStoreData={storeState.detailsViewStoreData}
                 scopingStoreData={storeState.scopingPanelStateStoreData}
                 featureFlagStoreData={storeState.featureFlagStoreData}
@@ -212,13 +209,15 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
                 detailsViewStoreData={storeState.detailsViewStoreData}
                 visualizationStoreData={storeState.visualizationStoreData}
                 visualizationScanResultData={storeState.visualizationScanResultStoreData}
-                visualizationConfigurationFactory={this.props.visualizationConfigurationFactory}
-                assessmentsProvider={this.props.assessmentsProvider}
-                dropdownClickHandler={this.props.dropdownClickHandler}
-                clickHandlerFactory={this.props.clickHandlerFactory}
-                assessmentInstanceTableHandler={this.props.assessmentInstanceTableHandler}
-                issuesSelection={this.props.issuesSelection}
-                issuesTableHandler={this.props.issuesTableHandler}
+                visualizationConfigurationFactory={
+                    this.props.deps.visualizationConfigurationFactory
+                }
+                assessmentsProvider={this.props.deps.assessmentsProvider}
+                dropdownClickHandler={this.props.deps.dropdownClickHandler}
+                clickHandlerFactory={this.props.deps.clickHandlerFactory}
+                assessmentInstanceTableHandler={this.props.deps.assessmentInstanceTableHandler}
+                issuesSelection={this.props.deps.issuesSelection}
+                issuesTableHandler={this.props.deps.issuesTableHandler}
                 rightPanelConfiguration={selectedDetailsRightPanelConfiguration}
                 switcherNavConfiguration={selectedDetailsViewSwitcherNavConfiguration}
                 userConfigurationStoreData={storeState.userConfigurationStoreData}

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -1,18 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
-import { ISelection } from 'office-ui-fabric-react';
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
+import { ISelection, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
-
 import { ThemeDeps } from '../common/components/theme';
 import {
     withStoreSubscription,
     WithStoreSubscriptionDeps,
 } from '../common/components/with-store-subscription';
-import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { DropdownClickHandler } from '../common/dropdown-click-handler';
 import { InspectActionMessageCreator } from '../common/message-creators/inspect-action-message-creator';
 import { ScopingActionMessageCreator } from '../common/message-creators/scoping-action-message-creator';

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -415,25 +415,24 @@ if (isNaN(tabId) === false) {
                 setFocusVisibility,
                 documentManipulator,
                 customCongratsMessage: null, // uses default message
+                scopingActionMessageCreator,
+                inspectActionMessageCreator,
+                issuesSelection,
+                clickHandlerFactory,
+                issuesTableHandler,
+                assessmentInstanceTableHandler,
+                previewFeatureFlagsHandler,
+                scopingFlagsHandler,
+                Assessments,
             };
 
             const renderer = new DetailsViewRenderer(
                 deps,
                 dom,
                 ReactDOM.render,
-                scopingActionMessageCreator,
-                inspectActionMessageCreator,
-                issuesSelection,
-                clickHandlerFactory,
-                visualizationConfigurationFactory,
-                issuesTableHandler,
-                assessmentInstanceTableHandler,
-                previewFeatureFlagsHandler,
-                scopingFlagsHandler,
-                dropdownClickHandler,
-                Assessments,
                 documentElementSetter,
             );
+
             renderer.render();
 
             const a11ySelfValidator = new A11YSelfValidator(
@@ -451,21 +450,5 @@ if (isNaN(tabId) === false) {
 }
 
 function createNullifiedRenderer(doc, render): DetailsViewRenderer {
-    return new DetailsViewRenderer(
-        null,
-        doc,
-        render,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        null,
-        documentElementSetter,
-    );
+    return new DetailsViewRenderer(null, doc, render, documentElementSetter);
 }

--- a/src/DetailsView/details-view-renderer.tsx
+++ b/src/DetailsView/details-view-renderer.tsx
@@ -1,21 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import { Theme } from '../common/components/theme';
-import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { config } from '../common/configuration';
 import { DocumentManipulator } from '../common/document-manipulator';
-import { DropdownClickHandler } from '../common/dropdown-click-handler';
-import { InspectActionMessageCreator } from '../common/message-creators/inspect-action-message-creator';
-import { ScopingActionMessageCreator } from '../common/message-creators/scoping-action-message-creator';
-import { IssuesTableHandler } from './components/issues-table-handler';
 import { DetailsView, DetailsViewContainerDeps } from './details-view-container';
-import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-table-handler';
-import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
-import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-handler';
 
 export class DetailsViewRenderer {
     constructor(

--- a/src/DetailsView/details-view-renderer.tsx
+++ b/src/DetailsView/details-view-renderer.tsx
@@ -22,17 +22,6 @@ export class DetailsViewRenderer {
         private readonly deps: DetailsViewContainerDeps,
         private readonly dom: Document,
         private readonly renderer: typeof ReactDOM.render,
-        private readonly scopingActionMessageCreator: ScopingActionMessageCreator,
-        private readonly inspectActionMessageCreator: InspectActionMessageCreator,
-        private readonly issuesSelection: ISelection,
-        private readonly clickHandlerFactory: DetailsViewToggleClickHandlerFactory,
-        private readonly visualizationConfigurationFactory: VisualizationConfigurationFactory,
-        private readonly issuesTableHandler: IssuesTableHandler,
-        private readonly assessmentInstanceTableHandler: AssessmentInstanceTableHandler,
-        private readonly previewFeatureFlagsHandler: PreviewFeatureFlagsHandler,
-        private readonly scopingFlagsHandler: PreviewFeatureFlagsHandler,
-        private readonly dropdownClickHandler: DropdownClickHandler,
-        private readonly assessmentsProvider: AssessmentsProvider,
         private readonly documentManipulator: DocumentManipulator,
     ) {}
 
@@ -44,20 +33,7 @@ export class DetailsViewRenderer {
         this.renderer(
             <>
                 <Theme deps={this.deps} />
-                <DetailsView
-                    deps={this.deps}
-                    issuesSelection={this.issuesSelection}
-                    clickHandlerFactory={this.clickHandlerFactory}
-                    visualizationConfigurationFactory={this.visualizationConfigurationFactory}
-                    issuesTableHandler={this.issuesTableHandler}
-                    assessmentInstanceTableHandler={this.assessmentInstanceTableHandler}
-                    previewFeatureFlagsHandler={this.previewFeatureFlagsHandler}
-                    scopingFlagsHandler={this.scopingFlagsHandler}
-                    dropdownClickHandler={this.dropdownClickHandler}
-                    scopingActionMessageCreator={this.scopingActionMessageCreator}
-                    inspectActionMessageCreator={this.inspectActionMessageCreator}
-                    assessmentsProvider={this.assessmentsProvider}
-                />
+                <DetailsView deps={this.deps} />
             </>,
             detailsViewContainer,
         );

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`DetailsViewContainer render renders spinner when stores not ready 1`] =
 
 exports[`DetailsViewContainer renderContent renders TargetPageClosedView when target page closed 1`] = `
 "<Fragment>
-  <InteractiveHeader deps={{...}} selectedPivot={{...}} featureFlagStoreData={{...}} dropdownClickHandler={[undefined]} tabClosed={true} />
+  <InteractiveHeader deps={{...}} selectedPivot={{...}} featureFlagStoreData={{...}} dropdownClickHandler={{...}} tabClosed={true} />
   <NoContentAvailable />
 </Fragment>"
 `;

--- a/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
+++ b/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { BaseStore } from 'common/base-store';
 import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { StoreActionMessageCreator } from 'common/message-creators/store-action-message-creator';
@@ -13,9 +12,6 @@ import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { DetailsViewContainerDeps, DetailsViewContainerProps } from 'DetailsView/details-view-container';
-import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
-import { PreviewFeatureFlagsHandler } from 'DetailsView/handlers/preview-feature-flags-handler';
-import { ISelection } from 'office-ui-fabric-react';
 import { DictionaryStringTo } from 'types/common-types';
 import { StoreMocks } from './store-mocks';
 
@@ -29,35 +25,11 @@ export class DetailsViewContainerPropsBuilder {
     private scopingStateStore: BaseStore<ScopingStoreData>;
     private detailsViewStore: BaseStore<DetailsViewStoreData>;
     private storeActionCreator: StoreActionMessageCreator;
-    private issuesSelection: ISelection;
-    private clickHandlerFactory: DetailsViewToggleClickHandlerFactory;
-    private previewFeatureFlagsHandler: PreviewFeatureFlagsHandler;
-    private assessmentProvider: AssessmentsProvider;
     private storesHub: BaseClientStoresHub<any>;
     constructor(private deps: DetailsViewContainerDeps) {}
 
     public setDetailsViewStoreActionMessageCreator(creator: StoreActionMessageCreator): DetailsViewContainerPropsBuilder {
         this.storeActionCreator = creator;
-        return this;
-    }
-
-    public setAssessmentProvider(provider: AssessmentsProvider): DetailsViewContainerPropsBuilder {
-        this.assessmentProvider = provider;
-        return this;
-    }
-
-    public setClickHandlerFactory(factory: DetailsViewToggleClickHandlerFactory): DetailsViewContainerPropsBuilder {
-        this.clickHandlerFactory = factory;
-        return this;
-    }
-
-    public setPreviewFeatureFlagsHandler(previewFeatureFlagsHandler: PreviewFeatureFlagsHandler): DetailsViewContainerPropsBuilder {
-        this.previewFeatureFlagsHandler = previewFeatureFlagsHandler;
-        return this;
-    }
-
-    public setIssuesSelection(selection: ISelection): DetailsViewContainerPropsBuilder {
-        this.issuesSelection = selection;
         return this;
     }
 

--- a/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
+++ b/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
@@ -2,10 +2,7 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { BaseStore } from 'common/base-store';
-import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { DropdownClickHandler } from 'common/dropdown-click-handler';
-import { InspectActionMessageCreator } from 'common/message-creators/inspect-action-message-creator';
-import { ScopingActionMessageCreator } from 'common/message-creators/scoping-action-message-creator';
 import { StoreActionMessageCreator } from 'common/message-creators/store-action-message-creator';
 import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
@@ -15,9 +12,7 @@ import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
-import { IssuesTableHandler } from 'DetailsView/components/issues-table-handler';
 import { DetailsViewContainerDeps, DetailsViewContainerProps } from 'DetailsView/details-view-container';
-import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
 import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { PreviewFeatureFlagsHandler } from 'DetailsView/handlers/preview-feature-flags-handler';
 import { ISelection } from 'office-ui-fabric-react';

--- a/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
+++ b/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
@@ -100,7 +100,12 @@ export class DetailsViewContainerPropsBuilder {
     }
 
     public setDropdownClickHandler(creator: DropdownClickHandler): DetailsViewContainerPropsBuilder {
-        this.dropdownClickHandler = creator;
+        if (this.deps == null) {
+            this.deps = {} as DetailsViewContainerDeps;
+        }
+
+        this.deps.dropdownClickHandler = creator;
+
         return this;
     }
 
@@ -148,21 +153,11 @@ export class DetailsViewContainerPropsBuilder {
             this.deps.storeActionMessageCreator = this.storeActionCreator;
         }
 
-        return {
+        const props: DetailsViewContainerProps = {
             deps: this.deps,
-            document: this.document,
-            issuesSelection: this.issuesSelection,
-            clickHandlerFactory: this.clickHandlerFactory,
-            visualizationConfigurationFactory: this.configFactory,
-            issuesTableHandler: this.issuesTableHandler,
-            previewFeatureFlagsHandler: this.previewFeatureFlagsHandler,
-            scopingFlagsHandler: this.scopingFlagsHandler,
-            dropdownClickHandler: this.dropdownClickHandler,
-            assessmentInstanceTableHandler: this.assessmentInstanceTableHandler,
-            scopingActionMessageCreator: this.scopingActionMessageCreator,
-            inspectActionMessageCreator: this.inspectActionMessageCreator,
-            assessmentsProvider: this.assessmentProvider,
             storeState: storeState,
         };
+
+        return props;
     }
 }

--- a/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
+++ b/src/tests/unit/tests/DetailsView/details-view-container-props-builder.ts
@@ -1,27 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { BaseStore } from 'common/base-store';
+import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
+import { DropdownClickHandler } from 'common/dropdown-click-handler';
+import { InspectActionMessageCreator } from 'common/message-creators/inspect-action-message-creator';
+import { ScopingActionMessageCreator } from 'common/message-creators/scoping-action-message-creator';
+import { StoreActionMessageCreator } from 'common/message-creators/store-action-message-creator';
+import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
+import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
+import { DetailsViewStoreData } from 'common/types/store-data/details-view-store-data';
+import { ScopingStoreData } from 'common/types/store-data/scoping-store-data';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { IssuesTableHandler } from 'DetailsView/components/issues-table-handler';
+import { DetailsViewContainerDeps, DetailsViewContainerProps } from 'DetailsView/details-view-container';
+import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
+import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
+import { PreviewFeatureFlagsHandler } from 'DetailsView/handlers/preview-feature-flags-handler';
 import { ISelection } from 'office-ui-fabric-react';
-import { BaseStore } from '../../../../common/base-store';
-import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
-import { DropdownClickHandler } from '../../../../common/dropdown-click-handler';
-import { InspectActionMessageCreator } from '../../../../common/message-creators/inspect-action-message-creator';
-import { ScopingActionMessageCreator } from '../../../../common/message-creators/scoping-action-message-creator';
-import { StoreActionMessageCreator } from '../../../../common/message-creators/store-action-message-creator';
-import { BaseClientStoresHub } from '../../../../common/stores/base-client-stores-hub';
-import { AssessmentStoreData } from '../../../../common/types/store-data/assessment-result-data';
-import { DetailsViewStoreData } from '../../../../common/types/store-data/details-view-store-data';
-import { ScopingStoreData } from '../../../../common/types/store-data/scoping-store-data';
-import { TabStoreData } from '../../../../common/types/store-data/tab-store-data';
-import { UnifiedScanResultStoreData } from '../../../../common/types/store-data/unified-data-interface';
-import { VisualizationScanResultData } from '../../../../common/types/store-data/visualization-scan-result-data';
-import { VisualizationStoreData } from '../../../../common/types/store-data/visualization-store-data';
-import { IssuesTableHandler } from '../../../../DetailsView/components/issues-table-handler';
-import { DetailsViewContainerDeps, DetailsViewContainerProps } from '../../../../DetailsView/details-view-container';
-import { AssessmentInstanceTableHandler } from '../../../../DetailsView/handlers/assessment-instance-table-handler';
-import { DetailsViewToggleClickHandlerFactory } from '../../../../DetailsView/handlers/details-view-toggle-click-handler-factory';
-import { PreviewFeatureFlagsHandler } from '../../../../DetailsView/handlers/preview-feature-flags-handler';
-import { DictionaryStringTo } from '../../../../types/common-types';
+import { DictionaryStringTo } from 'types/common-types';
 import { StoreMocks } from './store-mocks';
 
 export class DetailsViewContainerPropsBuilder {
@@ -33,19 +33,11 @@ export class DetailsViewContainerPropsBuilder {
     private featureFlagStore: BaseStore<DictionaryStringTo<boolean>>;
     private scopingStateStore: BaseStore<ScopingStoreData>;
     private detailsViewStore: BaseStore<DetailsViewStoreData>;
-    private scopingActionMessageCreator: ScopingActionMessageCreator;
-    private inspectActionMessageCreator: InspectActionMessageCreator;
     private storeActionCreator: StoreActionMessageCreator;
-    private document: Document = document;
     private issuesSelection: ISelection;
     private clickHandlerFactory: DetailsViewToggleClickHandlerFactory;
-    private issuesTableHandler: IssuesTableHandler;
     private previewFeatureFlagsHandler: PreviewFeatureFlagsHandler;
-    private scopingFlagsHandler: PreviewFeatureFlagsHandler;
-    private dropdownClickHandler: DropdownClickHandler;
-    private assessmentInstanceTableHandler: AssessmentInstanceTableHandler;
     private assessmentProvider: AssessmentsProvider;
-    private configFactory: VisualizationConfigurationFactory;
     private storesHub: BaseClientStoresHub<any>;
     constructor(private deps: DetailsViewContainerDeps) {}
 
@@ -59,18 +51,8 @@ export class DetailsViewContainerPropsBuilder {
         return this;
     }
 
-    public setVisualizationConfigurationFactory(configFactory: VisualizationConfigurationFactory): DetailsViewContainerPropsBuilder {
-        this.configFactory = configFactory;
-        return this;
-    }
-
     public setClickHandlerFactory(factory: DetailsViewToggleClickHandlerFactory): DetailsViewContainerPropsBuilder {
         this.clickHandlerFactory = factory;
-        return this;
-    }
-
-    public setIssuesTableHandler(issuesTableHandler: IssuesTableHandler): DetailsViewContainerPropsBuilder {
-        this.issuesTableHandler = issuesTableHandler;
         return this;
     }
 
@@ -81,16 +63,6 @@ export class DetailsViewContainerPropsBuilder {
 
     public setIssuesSelection(selection: ISelection): DetailsViewContainerPropsBuilder {
         this.issuesSelection = selection;
-        return this;
-    }
-
-    public setScopingActionMessageCreator(creator: ScopingActionMessageCreator): DetailsViewContainerPropsBuilder {
-        this.scopingActionMessageCreator = creator;
-        return this;
-    }
-
-    public setInspectActionMessageCreator(creator: InspectActionMessageCreator): DetailsViewContainerPropsBuilder {
-        this.inspectActionMessageCreator = creator;
         return this;
     }
 
@@ -106,13 +78,6 @@ export class DetailsViewContainerPropsBuilder {
 
         this.deps.dropdownClickHandler = creator;
 
-        return this;
-    }
-
-    public setAssessmentInstanceTableHandler(
-        assessmentInstanceTableHandler: AssessmentInstanceTableHandler,
-    ): DetailsViewContainerPropsBuilder {
-        this.assessmentInstanceTableHandler = assessmentInstanceTableHandler;
         return this;
     }
 

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -37,12 +37,10 @@ import {
 } from 'DetailsView/details-view-container';
 import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
 import { shallow } from 'enzyme';
-import { ISelection, Selection } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DetailsViewStoreDataBuilder } from '../../common/details-view-store-data-builder';
 import { TabStoreDataBuilder } from '../../common/tab-store-data-builder';
-import { CreateTestAssessmentProviderWithFeatureFlag } from '../../common/test-assessment-provider';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 import { DetailsViewContainerPropsBuilder } from './details-view-container-props-builder';
 import { StoreMocks } from './store-mocks';
@@ -74,8 +72,6 @@ describe('DetailsViewContainer', () => {
             getCardSelectionViewData: getCardSelectionViewDataMock.object,
         } as DetailsViewContainerDeps;
     });
-
-    const assessmentProviderMock = Mock.ofInstance(CreateTestAssessmentProviderWithFeatureFlag());
 
     describe('render', () => {
         it('renders spinner when stores not ready', () => {
@@ -147,7 +143,6 @@ describe('DetailsViewContainer', () => {
 
         it('render twice; should not call details view opened on 2nd render', () => {
             const storeActionCreator = Mock.ofType(StoreActionMessageCreatorImpl, MockBehavior.Strict);
-            const clickHandlerFactoryMock = Mock.ofType(DetailsViewToggleClickHandlerFactory);
             const getSelectedDetailsViewMock = Mock.ofInstance((theProps: GetSelectedDetailsViewProps) => null, MockBehavior.Strict);
             const rightContentPanelType = 'TestView';
             const viewType = VisualizationType.Headings;
@@ -177,7 +172,6 @@ describe('DetailsViewContainer', () => {
             const props = new DetailsViewContainerPropsBuilder(deps)
                 .setStoreMocks(storeMocks)
                 .setStoreActionMessageCreator(storeActionCreator.object)
-                .setClickHandlerFactory(clickHandlerFactoryMock.object)
                 .setStoresHubMock(createStoresHubMock(storeMocks).object)
                 .build();
 
@@ -231,7 +225,6 @@ describe('DetailsViewContainer', () => {
 
             const props = new DetailsViewContainerPropsBuilder(deps)
                 .setStoreMocks(storeMocks)
-                .setClickHandlerFactory(clickHandlerFactoryMock.object)
                 .setStoreActionMessageCreator(storeActionCreator.object)
                 .setStoresHubMock(createStoresHubMock(storeMocks, false).object)
                 .build();
@@ -382,7 +375,6 @@ describe('DetailsViewContainer', () => {
     }
 
     function testRenderStaticContent(viewType: VisualizationType, isPreviewFeaturesOpen: boolean): void {
-        const selectionMock = Mock.ofType<ISelection>(Selection);
         const clickHandlerFactoryMock = Mock.ofType(DetailsViewToggleClickHandlerFactory);
         const dropdownClickHandler = Mock.ofType(DropdownClickHandler);
         const getSelectedDetailsViewMock = Mock.ofInstance((theProps: GetSelectedDetailsViewProps) => null, MockBehavior.Strict);
@@ -439,7 +431,6 @@ describe('DetailsViewContainer', () => {
 
         const props = new DetailsViewContainerPropsBuilder(deps)
             .setStoreMocks(storeMocks)
-            .setIssuesSelection(selectionMock.object)
             .setStoresHubMock(storesHubMock.object)
             .build();
 

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -36,7 +36,6 @@ import {
     DetailsViewContainerState,
 } from 'DetailsView/details-view-container';
 import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
-import { PreviewFeatureFlagsHandler } from 'DetailsView/handlers/preview-feature-flags-handler';
 import { shallow } from 'enzyme';
 import { ISelection, Selection } from 'office-ui-fabric-react';
 import * as React from 'react';
@@ -385,7 +384,6 @@ describe('DetailsViewContainer', () => {
     function testRenderStaticContent(viewType: VisualizationType, isPreviewFeaturesOpen: boolean): void {
         const selectionMock = Mock.ofType<ISelection>(Selection);
         const clickHandlerFactoryMock = Mock.ofType(DetailsViewToggleClickHandlerFactory);
-        const previewFeatureFlagsHandlerMock = Mock.ofType(PreviewFeatureFlagsHandler);
         const dropdownClickHandler = Mock.ofType(DropdownClickHandler);
         const getSelectedDetailsViewMock = Mock.ofInstance((theProps: GetSelectedDetailsViewProps) => null, MockBehavior.Strict);
         const rightContentPanelType = 'TestView';
@@ -441,11 +439,7 @@ describe('DetailsViewContainer', () => {
 
         const props = new DetailsViewContainerPropsBuilder(deps)
             .setStoreMocks(storeMocks)
-            // TODO remove any set from here for props that we move to deps
             .setIssuesSelection(selectionMock.object)
-            .setClickHandlerFactory(clickHandlerFactoryMock.object)
-            .setPreviewFeatureFlagsHandler(previewFeatureFlagsHandlerMock.object)
-            .setAssessmentProvider(assessmentProviderMock.object)
             .setStoresHubMock(storesHubMock.object)
             .build();
 

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -1,52 +1,46 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { CardSelectionViewData, GetCardSelectionViewData } from 'common/get-card-selection-view-data';
+import { StoreActionMessageCreator } from 'common/message-creators/store-action-message-creator';
+import { StoreActionMessageCreatorImpl } from 'common/message-creators/store-action-message-creator-impl';
 import { GetCardViewData } from 'common/rule-based-view-model-provider';
+import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
-import { shallow } from 'enzyme';
-import { ISelection, Selection } from 'office-ui-fabric-react';
-import * as React from 'react';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
-import { DropdownClickHandler } from '../../../../common/dropdown-click-handler';
-import { StoreActionMessageCreator } from '../../../../common/message-creators/store-action-message-creator';
-import { StoreActionMessageCreatorImpl } from '../../../../common/message-creators/store-action-message-creator-impl';
-import { BaseClientStoresHub } from '../../../../common/stores/base-client-stores-hub';
-import { DetailsViewPivotType } from '../../../../common/types/details-view-pivot-type';
-import { CardsViewModel } from '../../../../common/types/store-data/card-view-model';
-import { TabStoreData } from '../../../../common/types/store-data/tab-store-data';
-import {
-    TargetAppData,
-    UnifiedResult,
-    UnifiedRule,
-    UnifiedScanResultStoreData,
-} from '../../../../common/types/store-data/unified-data-interface';
-import { UserConfigurationStoreData } from '../../../../common/types/store-data/user-configuration-store';
-import { VisualizationType } from '../../../../common/types/visualization-type';
-import { DetailsViewActionMessageCreator } from '../../../../DetailsView/actions/details-view-action-message-creator';
-import { DetailsViewOverlay } from '../../../../DetailsView/components/details-view-overlay/details-view-overlay';
+import { CardsViewModel } from 'common/types/store-data/card-view-model';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { TargetAppData, UnifiedResult, UnifiedRule, UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { VisualizationType } from 'common/types/visualization-type';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { DetailsViewOverlay } from 'DetailsView/components/details-view-overlay/details-view-overlay';
 import {
     DetailsRightPanelConfiguration,
     GetDetailsRightPanelConfiguration,
     GetDetailsRightPanelConfigurationProps,
-} from '../../../../DetailsView/components/details-view-right-panel';
+} from 'DetailsView/components/details-view-right-panel';
 import {
     DetailsViewSwitcherNavConfiguration,
     GetDetailsSwitcherNavConfiguration,
     GetDetailsSwitcherNavConfigurationProps,
-} from '../../../../DetailsView/components/details-view-switcher-nav';
-import { InteractiveHeader } from '../../../../DetailsView/components/interactive-header';
-import { DetailsViewRightContentPanelType } from '../../../../DetailsView/components/left-nav/details-view-right-content-panel-type';
-import { GetSelectedDetailsViewProps } from '../../../../DetailsView/components/left-nav/get-selected-details-view';
-import { DetailsViewBody } from '../../../../DetailsView/details-view-body';
+} from 'DetailsView/components/details-view-switcher-nav';
+import { InteractiveHeader } from 'DetailsView/components/interactive-header';
+import { DetailsViewRightContentPanelType } from 'DetailsView/components/left-nav/details-view-right-content-panel-type';
+import { GetSelectedDetailsViewProps } from 'DetailsView/components/left-nav/get-selected-details-view';
+import { DetailsViewBody } from 'DetailsView/details-view-body';
 import {
     DetailsViewContainer,
     DetailsViewContainerDeps,
     DetailsViewContainerProps,
     DetailsViewContainerState,
-} from '../../../../DetailsView/details-view-container';
-import { DetailsViewToggleClickHandlerFactory } from '../../../../DetailsView/handlers/details-view-toggle-click-handler-factory';
-import { PreviewFeatureFlagsHandler } from '../../../../DetailsView/handlers/preview-feature-flags-handler';
+} from 'DetailsView/details-view-container';
+import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
+import { PreviewFeatureFlagsHandler } from 'DetailsView/handlers/preview-feature-flags-handler';
+import { shallow } from 'enzyme';
+import { ISelection, Selection } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { DetailsViewStoreDataBuilder } from '../../common/details-view-store-data-builder';
 import { TabStoreDataBuilder } from '../../common/tab-store-data-builder';
 import { CreateTestAssessmentProviderWithFeatureFlag } from '../../common/test-assessment-provider';
@@ -113,7 +107,8 @@ describe('DetailsViewContainer', () => {
         });
 
         it('renders TargetPageClosedView when target page closed', () => {
-            const props = new DetailsViewContainerPropsBuilder(null).build();
+            const dropdownClickHandler = Mock.ofType(DropdownClickHandler);
+            const props = new DetailsViewContainerPropsBuilder(null).setDropdownClickHandler(dropdownClickHandler.object).build();
             const rendered = shallow(<DetailsViewContainer {...props} />);
             expect(rendered.debug()).toMatchSnapshot();
         });
@@ -302,13 +297,13 @@ describe('DetailsViewContainer', () => {
                 detailsViewStoreData={storeMocks.detailsViewStoreData}
                 visualizationStoreData={storeMocks.visualizationStoreData}
                 visualizationScanResultData={storeMocks.visualizationScanResultsStoreData}
-                visualizationConfigurationFactory={props.visualizationConfigurationFactory}
-                assessmentsProvider={props.assessmentsProvider}
-                dropdownClickHandler={props.dropdownClickHandler}
-                clickHandlerFactory={props.clickHandlerFactory}
-                assessmentInstanceTableHandler={props.assessmentInstanceTableHandler}
-                issuesSelection={props.issuesSelection}
-                issuesTableHandler={props.issuesTableHandler}
+                visualizationConfigurationFactory={props.deps.visualizationConfigurationFactory}
+                assessmentsProvider={props.deps.assessmentsProvider}
+                dropdownClickHandler={props.deps.dropdownClickHandler}
+                clickHandlerFactory={props.deps.clickHandlerFactory}
+                assessmentInstanceTableHandler={props.deps.assessmentInstanceTableHandler}
+                issuesSelection={props.deps.issuesSelection}
+                issuesTableHandler={props.deps.issuesTableHandler}
                 rightPanelConfiguration={rightPanelConfiguration}
                 switcherNavConfiguration={switcherNavConfiguration}
                 userConfigurationStoreData={storeMocks.userConfigurationStoreData}
@@ -346,9 +341,9 @@ describe('DetailsViewContainer', () => {
         return (
             <DetailsViewOverlay
                 deps={props.deps}
-                previewFeatureFlagsHandler={props.previewFeatureFlagsHandler}
-                scopingActionMessageCreator={props.scopingActionMessageCreator}
-                inspectActionMessageCreator={props.inspectActionMessageCreator}
+                previewFeatureFlagsHandler={props.deps.previewFeatureFlagsHandler}
+                scopingActionMessageCreator={props.deps.scopingActionMessageCreator}
+                inspectActionMessageCreator={props.deps.inspectActionMessageCreator}
                 detailsViewStoreData={storeMocks.detailsViewStoreData}
                 scopingStoreData={storeMocks.scopingStoreData}
                 featureFlagStoreData={storeMocks.featureFlagStoreData}
@@ -442,9 +437,11 @@ describe('DetailsViewContainer', () => {
 
         const storesHubMock = createStoresHubMock(storeMocks);
 
+        deps.dropdownClickHandler = dropdownClickHandler.object;
+
         const props = new DetailsViewContainerPropsBuilder(deps)
             .setStoreMocks(storeMocks)
-            .setDropdownClickHandler(dropdownClickHandler.object)
+            // TODO remove any set from here for props that we move to deps
             .setIssuesSelection(selectionMock.object)
             .setClickHandlerFactory(clickHandlerFactoryMock.object)
             .setPreviewFeatureFlagsHandler(previewFeatureFlagsHandlerMock.object)

--- a/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-renderer.test.tsx
@@ -1,44 +1,22 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { Theme } from 'common/components/theme';
-import { VisualizationConfigurationFactory } from 'common/configs/visualization-configuration-factory';
 import { configMutator } from 'common/configuration';
 import { DocumentManipulator } from 'common/document-manipulator';
-import { DropdownClickHandler } from 'common/dropdown-click-handler';
-import { InspectActionMessageCreator } from 'common/message-creators/inspect-action-message-creator';
-import { ScopingActionMessageCreator } from 'common/message-creators/scoping-action-message-creator';
-import { IssuesTableHandler } from 'DetailsView/components/issues-table-handler';
 import { DetailsView, DetailsViewContainerDeps } from 'DetailsView/details-view-container';
 import { DetailsViewRenderer } from 'DetailsView/details-view-renderer';
-import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
-import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
-import { PreviewFeatureFlagsHandler } from 'DetailsView/handlers/preview-feature-flags-handler';
-import { ISelection, Selection } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import { IMock, It, Mock, MockBehavior } from 'typemoq';
-import { CreateTestAssessmentProvider } from '../../common/test-assessment-provider';
+import { IMock, It, Mock } from 'typemoq';
 import { TestDocumentCreator } from '../../common/test-document-creator';
 
 describe('DetailsViewRendererTest', () => {
     test('render', () => {
         const deps = Mock.ofType<DetailsViewContainerDeps>().object;
 
-        const scopingActionMessageCreatorStrictMock = Mock.ofType<ScopingActionMessageCreator>(null, MockBehavior.Strict);
-        const inspectActionMessageCreatorStrictMock = Mock.ofType<InspectActionMessageCreator>(null, MockBehavior.Strict);
-
         const fakeDocument = TestDocumentCreator.createTestDocument('<div id="details-container"></div>');
 
         const renderMock: IMock<typeof ReactDOM.render> = Mock.ofInstance(() => null);
-        const selectionMock = Mock.ofType<ISelection>(Selection);
-        const clickHandlerFactoryMock = Mock.ofType(DetailsViewToggleClickHandlerFactory);
-        const visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
-        const issuesTableHandlerMock = Mock.ofType(IssuesTableHandler);
-        const previewFeatureFlagsHandlerMock = Mock.ofType(PreviewFeatureFlagsHandler);
-        const scopingFlagsHandlerMock = Mock.ofType(PreviewFeatureFlagsHandler);
-        const dropdownClickHandlerMock = Mock.ofType(DropdownClickHandler);
-        const assessmentInstanceTableHandlerMock = Mock.ofType(AssessmentInstanceTableHandler);
-        const assessmentsProviderMock = Mock.ofInstance(CreateTestAssessmentProvider());
 
         const expectedIcon16 = 'icon128.png';
         configMutator.setOption('icon128', expectedIcon16);
@@ -51,20 +29,7 @@ describe('DetailsViewRendererTest', () => {
                     It.isValue(
                         <>
                             <Theme deps={deps} />
-                            <DetailsView
-                                deps={deps}
-                                scopingActionMessageCreator={scopingActionMessageCreatorStrictMock.object}
-                                inspectActionMessageCreator={inspectActionMessageCreatorStrictMock.object}
-                                issuesSelection={selectionMock.object}
-                                clickHandlerFactory={clickHandlerFactoryMock.object}
-                                visualizationConfigurationFactory={visualizationConfigurationFactoryMock.object}
-                                issuesTableHandler={issuesTableHandlerMock.object}
-                                assessmentInstanceTableHandler={assessmentInstanceTableHandlerMock.object}
-                                previewFeatureFlagsHandler={previewFeatureFlagsHandlerMock.object}
-                                scopingFlagsHandler={scopingFlagsHandlerMock.object}
-                                dropdownClickHandler={dropdownClickHandlerMock.object}
-                                assessmentsProvider={assessmentsProviderMock.object}
-                            />
+                            <DetailsView deps={deps} />
                         </>,
                     ),
                     fakeDocument.getElementById('details-container'),
@@ -72,23 +37,7 @@ describe('DetailsViewRendererTest', () => {
             )
             .verifiable();
 
-        const renderer = new DetailsViewRenderer(
-            deps,
-            fakeDocument,
-            renderMock.object,
-            scopingActionMessageCreatorStrictMock.object,
-            inspectActionMessageCreatorStrictMock.object,
-            selectionMock.object,
-            clickHandlerFactoryMock.object,
-            visualizationConfigurationFactoryMock.object,
-            issuesTableHandlerMock.object,
-            assessmentInstanceTableHandlerMock.object,
-            previewFeatureFlagsHandlerMock.object,
-            scopingFlagsHandlerMock.object,
-            dropdownClickHandlerMock.object,
-            assessmentsProviderMock.object,
-            documentManipulatorMock.object,
-        );
+        const renderer = new DetailsViewRenderer(deps, fakeDocument, renderMock.object, documentManipulatorMock.object);
 
         renderer.render();
 


### PR DESCRIPTION
#### Description of changes

Currently, the `DetailsViewContainerProps` contains props that are actually deps. This make the testing and refactoring (in general of `DetailsViewContainer` and related component children) harder than it should be.

In this PR: moving all props that are deps to the deps prop.

**Notes** 
- this refactor will in time help solving #2324
- there is a lot of more clean up we could do, but right now seems like a rabbit hole, or something I would like to iron out by chunks

#### Pull request checklist
- [x] Addresses an existing issue: related to #2324
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
