### PR TITLE
fix: connected device info still present even if device disconnected (unified) 

### DIFF
--- a/src/electron/flux/action-creator/scan-action-creator.ts
+++ b/src/electron/flux/action-creator/scan-action-creator.ts
@@ -10,7 +10,7 @@ export class ScanActionCreator {
     ) {}
 
     public scan(port: number): void {
-        this.deviceActions.resetConnection.invoke(null);
+        this.deviceActions.resetConnection.invoke();
         this.scanActions.scanStarted.invoke({ port });
     }
 }

--- a/src/electron/flux/action-creator/scan-action-creator.ts
+++ b/src/electron/flux/action-creator/scan-action-creator.ts
@@ -1,11 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { DeviceActions } from 'electron/flux/action/device-actions';
 import { ScanActions } from 'electron/flux/action/scan-actions';
 
 export class ScanActionCreator {
-    constructor(private readonly scanActions: ScanActions) {}
+    constructor(
+        private readonly scanActions: ScanActions,
+        private readonly deviceActions: DeviceActions,
+    ) {}
 
     public scan(port: number): void {
+        this.deviceActions.resetConnection.invoke(null);
         this.scanActions.scanStarted.invoke({ port });
     }
 }

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -218,7 +218,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             windowStateActions,
             windowFrameActionCreator,
         );
-        const scanActionCreator = new ScanActionCreator(scanActions);
+        const scanActionCreator = new ScanActionCreator(scanActions, deviceActions);
 
         const cardSelectionActionCreator = new CardSelectionActionCreator(
             interpreter,

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -35,6 +35,6 @@ describe('ScanActionCreator', () => {
         testSubject.scan(port);
 
         scanStartedMock.verify(scanStarted => scanStarted.invoke(It.isValue({ port })), Times.once());
-        resetConnectionMock.verify(resetConnection => resetConnection.invoke(null), Times.once());
+        resetConnectionMock.verify(resetConnection => resetConnection.invoke(), Times.once());
     });
 });

--- a/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/scan-action-creator.test.ts
@@ -3,6 +3,7 @@
 import { Action } from 'common/flux/action';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { PortPayload } from 'electron/flux/action/device-action-payloads';
+import { DeviceActions } from 'electron/flux/action/device-actions';
 import { ScanActions } from 'electron/flux/action/scan-actions';
 import { IMock, It, Mock, Times } from 'typemoq';
 
@@ -11,22 +12,29 @@ describe('ScanActionCreator', () => {
 
     let scanActionsMock: IMock<ScanActions>;
     let scanStartedMock: IMock<Action<PortPayload>>;
+    let deviceActionsMock: IMock<DeviceActions>;
+    let resetConnectionMock: IMock<Action<void>>;
 
     let testSubject: ScanActionCreator;
 
     beforeEach(() => {
         scanActionsMock = Mock.ofType<ScanActions>();
-
         scanStartedMock = Mock.ofType<Action<PortPayload>>();
 
         scanActionsMock.setup(actions => actions.scanStarted).returns(() => scanStartedMock.object);
 
-        testSubject = new ScanActionCreator(scanActionsMock.object);
+        deviceActionsMock = Mock.ofType<DeviceActions>();
+        resetConnectionMock = Mock.ofType<Action<void>>();
+
+        deviceActionsMock.setup(actions => actions.resetConnection).returns(() => resetConnectionMock.object);
+
+        testSubject = new ScanActionCreator(scanActionsMock.object, deviceActionsMock.object);
     });
 
     it('scans', () => {
         testSubject.scan(port);
 
         scanStartedMock.verify(scanStarted => scanStarted.invoke(It.isValue({ port })), Times.once());
+        resetConnectionMock.verify(resetConnection => resetConnection.invoke(null), Times.once());
     });
 });

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
         "getCardsViewData": [Function],
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
           "scanActions": undefined,
         },
         "screenshotViewModelProvider": [Function],
@@ -32,6 +33,7 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
             "getCardsViewData": [Function],
             "scanActionCreator": proxy {
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "deviceActions": undefined,
               "scanActions": undefined,
             },
             "screenshotViewModelProvider": [Function],
@@ -64,6 +66,7 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
               "getCardsViewData": [Function],
               "scanActionCreator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+                "deviceActions": undefined,
                 "scanActions": undefined,
               },
               "screenshotViewModelProvider": [Function],
@@ -99,6 +102,7 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
         "getCardsViewData": [Function],
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
           "scanActions": undefined,
         },
         "screenshotViewModelProvider": [Function],
@@ -125,6 +129,7 @@ exports[`AutomatedChecksView renders when status scan <Failed> 1`] = `
       Object {
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
           "scanActions": undefined,
         },
         "windowStateActionCreator": proxy {
@@ -148,6 +153,7 @@ exports[`AutomatedChecksView renders when status scan <Failed> 1`] = `
           Object {
             "scanActionCreator": proxy {
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "deviceActions": undefined,
               "scanActions": undefined,
             },
             "windowStateActionCreator": proxy {
@@ -183,6 +189,7 @@ exports[`AutomatedChecksView renders when status scan <Failed> 1`] = `
       Object {
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
           "scanActions": undefined,
         },
         "windowStateActionCreator": proxy {
@@ -209,6 +216,7 @@ exports[`AutomatedChecksView renders when status scan <Scanning> 1`] = `
       Object {
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
           "scanActions": undefined,
         },
         "windowStateActionCreator": proxy {
@@ -232,6 +240,7 @@ exports[`AutomatedChecksView renders when status scan <Scanning> 1`] = `
           Object {
             "scanActionCreator": proxy {
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "deviceActions": undefined,
               "scanActions": undefined,
             },
             "windowStateActionCreator": proxy {
@@ -267,6 +276,7 @@ exports[`AutomatedChecksView renders when status scan <Scanning> 1`] = `
       Object {
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
           "scanActions": undefined,
         },
         "windowStateActionCreator": proxy {
@@ -293,6 +303,7 @@ exports[`AutomatedChecksView renders when status scan <undefined> 1`] = `
       Object {
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
           "scanActions": undefined,
         },
         "windowStateActionCreator": proxy {
@@ -316,6 +327,7 @@ exports[`AutomatedChecksView renders when status scan <undefined> 1`] = `
           Object {
             "scanActionCreator": proxy {
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+              "deviceActions": undefined,
               "scanActions": undefined,
             },
             "windowStateActionCreator": proxy {
@@ -351,6 +363,7 @@ exports[`AutomatedChecksView renders when status scan <undefined> 1`] = `
       Object {
         "scanActionCreator": proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "deviceActions": undefined,
           "scanActions": undefined,
         },
         "windowStateActionCreator": proxy {


### PR DESCRIPTION
#### Description of changes

Invoking `resetConnection` action fixes this issues.

#### Pull request checklist
- [x] Addresses an existing issue: #2323
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
