### PR TITLE
chrome: line width for injected tests folder

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -14,7 +14,7 @@ module.exports = {
                 'src/tests/unit/tests/injected/adapters/**/*',
                 'src/tests/unit/tests/injected/analyzers/**/*',
                 'src/tests/unit/tests/injected/components/**/*',
-                'src/tests/unit/tests/injected/frameCommunucators/**/*',
+                'src/tests/unit/tests/injected/frameCommunicators/**/*',
                 'src/tests/unit/tests/injected/styles/**/*',
                 'src/tests/unit/tests/injected/visualization/**/*',
             ],

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -11,7 +11,12 @@ module.exports = {
             files: [
                 'src/content/**/*',
                 'src/tests/unit/tests/DetailsView/**/*',
-                'src/tests/unit/tests/injected/**/*',
+                'src/tests/unit/tests/injected/adapters/**/*',
+                'src/tests/unit/tests/injected/analyzers/**/*',
+                'src/tests/unit/tests/injected/components/**/*',
+                'src/tests/unit/tests/injected/frameCommunucators/**/*',
+                'src/tests/unit/tests/injected/styles/**/*',
+                'src/tests/unit/tests/injected/visualization/**/*',
             ],
             options: {
                 printWidth: 140,

--- a/src/tests/unit/tests/injected/analyzer-controller.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-controller.test.ts
@@ -12,7 +12,11 @@ import { VisualizationConfigurationFactory } from '../../../../common/configs/vi
 import { EnumHelper } from '../../../../common/enum-helper';
 import { FeatureFlagStoreData } from '../../../../common/types/store-data/feature-flag-store-data';
 import { ScopingStoreData } from '../../../../common/types/store-data/scoping-store-data';
-import { ScanData, TestsEnabledState, VisualizationStoreData } from '../../../../common/types/store-data/visualization-store-data';
+import {
+    ScanData,
+    TestsEnabledState,
+    VisualizationStoreData,
+} from '../../../../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../../../../common/types/visualization-type';
 import { AnalyzerController } from '../../../../injected/analyzer-controller';
 import { AnalyzerStateUpdateHandler } from '../../../../injected/analyzer-state-update-handler';
@@ -76,7 +80,10 @@ describe('AnalyzerControllerTests', () => {
         scopingStoreMock.setup(sm => sm.getState()).returns(() => scopingStoreState);
 
         analyzerProviderStrictMock = Mock.ofType<AnalyzerProvider>(null, MockBehavior.Strict);
-        analyzerStateUpdateHandlerStrictMock = Mock.ofType<AnalyzerStateUpdateHandler>(null, MockBehavior.Strict);
+        analyzerStateUpdateHandlerStrictMock = Mock.ofType<AnalyzerStateUpdateHandler>(
+            null,
+            MockBehavior.Strict,
+        );
         analyzerStateUpdateHandlerStrictMock
             .setup(handler => handler.setupHandlers(It.isAny(), It.isAny()))
             .returns((startScanCb, teardownCb) => {
@@ -125,11 +132,15 @@ describe('AnalyzerControllerTests', () => {
             .returns(() => false)
             .verifiable(Times.atLeastOnce());
 
-        visualizationStoreState = new VisualizationStoreDataBuilder().with('scanning', testType.toString()).build();
+        visualizationStoreState = new VisualizationStoreDataBuilder()
+            .with('scanning', testType.toString())
+            .build();
 
         scopingStoreState = new ScopingStoreDataBuilder().build();
 
-        analyzerStateUpdateHandlerStrictMock.setup(handler => handler.handleUpdate(visualizationStoreState)).verifiable(Times.once());
+        analyzerStateUpdateHandlerStrictMock
+            .setup(handler => handler.handleUpdate(visualizationStoreState))
+            .verifiable(Times.once());
 
         testObject.listenToStore();
 
@@ -149,7 +160,9 @@ describe('AnalyzerControllerTests', () => {
             .returns(() => false)
             .verifiable(Times.atLeastOnce());
 
-        analyzerStateUpdateHandlerStrictMock.setup(handler => handler.handleUpdate(visualizationStoreState)).verifiable(Times.never());
+        analyzerStateUpdateHandlerStrictMock
+            .setup(handler => handler.handleUpdate(visualizationStoreState))
+            .verifiable(Times.never());
 
         testObject.listenToStore();
 

--- a/src/tests/unit/tests/injected/analyzer-state-update-handler.test.ts
+++ b/src/tests/unit/tests/injected/analyzer-state-update-handler.test.ts
@@ -19,7 +19,9 @@ describe('AnalyzerStateUpdateHandlerTest', () => {
         visualizationConfigurationFactoryMock = Mock.ofType(VisualizationConfigurationFactory);
         startScanMock = Mock.ofInstance(id => {});
         teardownMock = Mock.ofInstance(id => {});
-        testObject = new TestableAnalyzerStateUpdateHandler(visualizationConfigurationFactoryMock.object);
+        testObject = new TestableAnalyzerStateUpdateHandler(
+            visualizationConfigurationFactoryMock.object,
+        );
         testObject.setupHandlers(startScanMock.object, teardownMock.object);
     });
 
@@ -83,7 +85,9 @@ describe('AnalyzerStateUpdateHandlerTest', () => {
             .with('scanning', HeadingsTestStep.headingFunction)
             .withHeadingsAssessment(true, enabledStep)
             .build();
-        startScanMock.setup(start => start(HeadingsTestStep.headingFunction)).verifiable(Times.once());
+        startScanMock
+            .setup(start => start(HeadingsTestStep.headingFunction))
+            .verifiable(Times.once());
         setupDefaultVisualizationConfigFactory();
 
         testObject.handleUpdate(state);
@@ -140,8 +144,12 @@ describe('AnalyzerStateUpdateHandlerTest', () => {
 
     test('teardown when a test is turned form enabled to disabled', () => {
         const enabledStep = HeadingsTestStep.headingFunction;
-        const prevState = new VisualizationStoreDataBuilder().withHeadingsAssessment(true, enabledStep).build();
-        const currState = new VisualizationStoreDataBuilder().withHeadingsAssessment(false, enabledStep).build();
+        const prevState = new VisualizationStoreDataBuilder()
+            .withHeadingsAssessment(true, enabledStep)
+            .build();
+        const currState = new VisualizationStoreDataBuilder()
+            .withHeadingsAssessment(false, enabledStep)
+            .build();
         testObject.setPrevState(prevState);
         teardownMock.setup(teardown => teardown(enabledStep)).verifiable(Times.once());
         setupDefaultVisualizationConfigFactory();
@@ -154,7 +162,9 @@ describe('AnalyzerStateUpdateHandlerTest', () => {
     test('teardown when enabled step is changed', () => {
         const prevEnabledStep = HeadingsTestStep.headingFunction;
         const currEnabledStep = HeadingsTestStep.headingLevel;
-        const prevState = new VisualizationStoreDataBuilder().withHeadingsAssessment(true, prevEnabledStep).build();
+        const prevState = new VisualizationStoreDataBuilder()
+            .withHeadingsAssessment(true, prevEnabledStep)
+            .build();
         const currState = new VisualizationStoreDataBuilder()
             .withHeadingsAssessment(false, prevEnabledStep)
             .withHeadingsAssessment(true, currEnabledStep)
@@ -171,7 +181,9 @@ describe('AnalyzerStateUpdateHandlerTest', () => {
     test('both test and step get changed', () => {
         const prevEnabledStep = LandmarkTestStep.landmarkRoles;
         const currEnabledStep = HeadingsTestStep.headingLevel;
-        const prevState = new VisualizationStoreDataBuilder().withLandmarksAssessment(true, prevEnabledStep).build();
+        const prevState = new VisualizationStoreDataBuilder()
+            .withLandmarksAssessment(true, prevEnabledStep)
+            .build();
         const currState = new VisualizationStoreDataBuilder()
             .with('scanning', currEnabledStep)
             .withLandmarksAssessment(false, prevEnabledStep)

--- a/src/tests/unit/tests/injected/client-store-listener.test.ts
+++ b/src/tests/unit/tests/injected/client-store-listener.test.ts
@@ -3,31 +3,46 @@
 import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
-import { ClientStoreListener, TargetPageStoreData } from '../../../../injected/client-store-listener';
+import {
+    ClientStoreListener,
+    TargetPageStoreData,
+} from '../../../../injected/client-store-listener';
 
 describe('ClientStoreListener', () => {
     describe('initialize', () => {
         let testSubject: ClientStoreListener;
         let storeHubMock: IMock<BaseClientStoresHub<TargetPageStoreData>>;
-        let onReadyToExecuteVisualizationUpdatesMock: IMock<(storeData: TargetPageStoreData) => void>;
+        let onReadyToExecuteVisualizationUpdatesMock: IMock<(
+            storeData: TargetPageStoreData,
+        ) => void>;
         let triggerOnChange: () => void;
 
         beforeEach(() => {
-            storeHubMock = Mock.ofType<BaseClientStoresHub<TargetPageStoreData>>(null, MockBehavior.Strict);
-            onReadyToExecuteVisualizationUpdatesMock = Mock.ofType<(storeData: TargetPageStoreData) => void>();
+            storeHubMock = Mock.ofType<BaseClientStoresHub<TargetPageStoreData>>(
+                null,
+                MockBehavior.Strict,
+            );
+            onReadyToExecuteVisualizationUpdatesMock = Mock.ofType<
+                (storeData: TargetPageStoreData) => void
+            >();
 
             storeHubMock
                 .setup(shm => shm.addChangedListenerToAllStores(It.isAny()))
                 .callback(givenCallback => (triggerOnChange = givenCallback));
 
             testSubject = new ClientStoreListener(storeHubMock.object);
-            testSubject.registerOnReadyToExecuteVisualizationCallback(onReadyToExecuteVisualizationUpdatesMock.object);
+            testSubject.registerOnReadyToExecuteVisualizationCallback(
+                onReadyToExecuteVisualizationUpdatesMock.object,
+            );
         });
 
         test('registerOnReadyToExecuteVisualizationCallback: no store data', () => {
             storeHubMock.setup(shm => shm.hasStoreData()).returns(() => false);
             triggerOnChange();
-            onReadyToExecuteVisualizationUpdatesMock.verify(callback => callback(It.isAny()), Times.never());
+            onReadyToExecuteVisualizationUpdatesMock.verify(
+                callback => callback(It.isAny()),
+                Times.never(),
+            );
         });
 
         test('registerOnReadyToExecuteVisualizationCallback: with store data & not scanning', () => {
@@ -41,7 +56,10 @@ describe('ClientStoreListener', () => {
 
             triggerOnChange();
 
-            onReadyToExecuteVisualizationUpdatesMock.verify(callback => callback(storeDataMock), Times.once());
+            onReadyToExecuteVisualizationUpdatesMock.verify(
+                callback => callback(storeDataMock),
+                Times.once(),
+            );
         });
 
         test('registerOnReadyToExecuteVisualizationCallback: with store data & scanning', () => {
@@ -55,7 +73,10 @@ describe('ClientStoreListener', () => {
 
             triggerOnChange();
 
-            onReadyToExecuteVisualizationUpdatesMock.verify(callback => callback(storeDataMock), Times.never());
+            onReadyToExecuteVisualizationUpdatesMock.verify(
+                callback => callback(storeDataMock),
+                Times.never(),
+            );
         });
     });
 });

--- a/src/tests/unit/tests/injected/details-dialog-handler.test.ts
+++ b/src/tests/unit/tests/injected/details-dialog-handler.test.ts
@@ -90,8 +90,14 @@ describe('DetailsDialogHandlerTest', () => {
     });
 
     test('inspectButtonClickHandler when the devtools are opened', () => {
-        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(undefined, MockBehavior.Strict);
-        const devToolActionMessageCreatorMock = Mock.ofType<DevToolActionMessageCreator>(undefined, MockBehavior.Strict);
+        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        const devToolActionMessageCreatorMock = Mock.ofType<DevToolActionMessageCreator>(
+            undefined,
+            MockBehavior.Strict,
+        );
         const eventFactory = new EventStubFactory();
         const event = eventFactory.createMouseClickEvent();
         const target = ['frame', 'div'];
@@ -106,7 +112,9 @@ describe('DetailsDialogHandlerTest', () => {
             .verifiable(Times.once());
 
         devToolActionMessageCreatorMock
-            .setup(creator => creator.setInspectElement(It.isValue(event as any), It.isValue(target)))
+            .setup(creator =>
+                creator.setInspectElement(It.isValue(event as any), It.isValue(target)),
+            )
             .verifiable(Times.once());
 
         detailsDialogMock
@@ -121,7 +129,9 @@ describe('DetailsDialogHandlerTest', () => {
             .verifiable(Times.atLeastOnce());
 
         detailsDialogMock
-            .setup(dialog => dialog.setState(It.isValue({ showDialog: false, showInspectMessage: false })))
+            .setup(dialog =>
+                dialog.setState(It.isValue({ showDialog: false, showInspectMessage: false })),
+            )
             .verifiable(Times.once());
 
         testSubject.inspectButtonClickHandler(detailsDialogMock.object, event as any);
@@ -132,8 +142,14 @@ describe('DetailsDialogHandlerTest', () => {
     });
 
     test('inspectButtonClickHandler when the devtools are not opened', () => {
-        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(undefined, MockBehavior.Strict);
-        const devToolActionMessageCreatorMock = Mock.ofType<DevToolActionMessageCreator>(undefined, MockBehavior.Strict);
+        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        const devToolActionMessageCreatorMock = Mock.ofType<DevToolActionMessageCreator>(
+            undefined,
+            MockBehavior.Strict,
+        );
         const eventFactory = new EventStubFactory();
         const event = eventFactory.createMouseClickEvent();
 
@@ -156,7 +172,9 @@ describe('DetailsDialogHandlerTest', () => {
             })
             .verifiable(Times.atLeastOnce());
 
-        detailsDialogMock.setup(dialog => dialog.setState(It.isValue({ showInspectMessage: true }))).verifiable(Times.once());
+        detailsDialogMock
+            .setup(dialog => dialog.setState(It.isValue({ showInspectMessage: true })))
+            .verifiable(Times.once());
 
         testSubject.inspectButtonClickHandler(detailsDialogMock.object, event as any);
 
@@ -359,7 +377,9 @@ describe('DetailsDialogHandlerTest', () => {
                 } as any;
             });
 
-        expect(testSubject.getFailureInfo(detailsDialogMock.object)).toEqual('Failure 1 of 4 for this target');
+        expect(testSubject.getFailureInfo(detailsDialogMock.object)).toEqual(
+            'Failure 1 of 4 for this target',
+        );
     });
 
     test('onLayoutDidMount_ableToFindDialog', () => {
@@ -405,8 +425,14 @@ describe('DetailsDialogHandlerTest', () => {
     });
 
     test('componentDidMount adds listener if clickable objects are available', () => {
-        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(undefined, MockBehavior.Strict);
-        const userConfigStoreMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>(undefined, MockBehavior.Strict);
+        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        const userConfigStoreMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>(
+            undefined,
+            MockBehavior.Strict,
+        );
         const userConfigStoreData: UserConfigurationStoreData = {
             bugServicePropertiesMap: {
                 gitHub: {
@@ -446,8 +472,12 @@ describe('DetailsDialogHandlerTest', () => {
             shadowRoot: shadowRootMock.object,
         } as any;
 
-        devToolStoreMock.setup(store => store.addChangedListener(It.isAny())).verifiable(Times.once());
-        userConfigStoreMock.setup(store => store.addChangedListener(It.isAny())).verifiable(Times.once());
+        devToolStoreMock
+            .setup(store => store.addChangedListener(It.isAny()))
+            .verifiable(Times.once());
+        userConfigStoreMock
+            .setup(store => store.addChangedListener(It.isAny()))
+            .verifiable(Times.once());
 
         devToolStoreMock
             .setup(store => store.getState())
@@ -492,9 +522,13 @@ describe('DetailsDialogHandlerTest', () => {
             })
             .verifiable(Times.atLeastOnce());
 
-        detailsDialogMock.setup(dialog => dialog.setState(It.isValue({ canInspect: false }))).verifiable(Times.once());
         detailsDialogMock
-            .setup(dialog => dialog.setState(It.isValue({ userConfigurationStoreData: userConfigStoreData })))
+            .setup(dialog => dialog.setState(It.isValue({ canInspect: false })))
+            .verifiable(Times.once());
+        detailsDialogMock
+            .setup(dialog =>
+                dialog.setState(It.isValue({ userConfigurationStoreData: userConfigStoreData })),
+            )
             .verifiable(Times.once());
 
         setupDetailsDialogMockForShadowComponents();
@@ -528,11 +562,21 @@ describe('DetailsDialogHandlerTest', () => {
     });
 
     test('componentWillUnmount removes listener', () => {
-        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(undefined, MockBehavior.Strict);
-        const userConfigStoreMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>(undefined, MockBehavior.Strict);
+        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        const userConfigStoreMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>(
+            undefined,
+            MockBehavior.Strict,
+        );
 
-        devToolStoreMock.setup(store => store.removeChangedListener(It.isAny())).verifiable(Times.once());
-        userConfigStoreMock.setup(store => store.removeChangedListener(It.isAny())).verifiable(Times.once());
+        devToolStoreMock
+            .setup(store => store.removeChangedListener(It.isAny()))
+            .verifiable(Times.once());
+        userConfigStoreMock
+            .setup(store => store.removeChangedListener(It.isAny()))
+            .verifiable(Times.once());
 
         detailsDialogMock
             .setup(dialog => dialog.props)
@@ -586,7 +630,10 @@ describe('DetailsDialogHandlerTest', () => {
         htmlElementUtilsMock.verifyAll();
     });
 
-    function setupInspectButtonQuerySelector(shadowRootMock: IMock<Element>, clickableMock: IMock<any>): void {
+    function setupInspectButtonQuerySelector(
+        shadowRootMock: IMock<Element>,
+        clickableMock: IMock<any>,
+    ): void {
         shadowRootMock
             .setup(x => x.querySelector('.insights-dialog-button-inspect'))
             .returns(selector => {
@@ -595,7 +642,10 @@ describe('DetailsDialogHandlerTest', () => {
             .verifiable(Times.once());
     }
 
-    function setupDialogContainerQuerySelector(shadowRootMock: IMock<Element>, clickableMock: IMock<any>): void {
+    function setupDialogContainerQuerySelector(
+        shadowRootMock: IMock<Element>,
+        clickableMock: IMock<any>,
+    ): void {
         shadowRootMock
             .setup(x => x.querySelector('.insights-dialog-main-override-shadow'))
             .returns(selector => {
@@ -604,7 +654,10 @@ describe('DetailsDialogHandlerTest', () => {
             .verifiable(Times.once());
     }
 
-    function setupCloseButtonQuerySelector(shadowRootMock: IMock<Element>, clickableMock: IMock<any>): void {
+    function setupCloseButtonQuerySelector(
+        shadowRootMock: IMock<Element>,
+        clickableMock: IMock<any>,
+    ): void {
         shadowRootMock
             .setup(x => x.querySelector('.insights-dialog-close'))
             .returns(selector => {
@@ -613,7 +666,10 @@ describe('DetailsDialogHandlerTest', () => {
             .verifiable(Times.once());
     }
 
-    function setupNextButtonQuerySelector(shadowRootMock: IMock<Element>, clickableMock: IMock<any>): void {
+    function setupNextButtonQuerySelector(
+        shadowRootMock: IMock<Element>,
+        clickableMock: IMock<any>,
+    ): void {
         shadowRootMock
             .setup(x => x.querySelector('.insights-dialog-button-right'))
             .returns(selector => {
@@ -622,7 +678,10 @@ describe('DetailsDialogHandlerTest', () => {
             .verifiable(Times.once());
     }
 
-    function setupBackButtonQuerySelector(shadowRootMock: IMock<Element>, clickableMock: IMock<any>): void {
+    function setupBackButtonQuerySelector(
+        shadowRootMock: IMock<Element>,
+        clickableMock: IMock<any>,
+    ): void {
         shadowRootMock
             .setup(x => x.querySelector('.insights-dialog-button-left'))
             .returns(selector => {
@@ -648,7 +707,10 @@ describe('DetailsDialogHandlerTest', () => {
     }
 
     function testOnDevToolChangeSetsCanInspectToIsOpen(isOpen: boolean): void {
-        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(undefined, MockBehavior.Strict);
+        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(
+            undefined,
+            MockBehavior.Strict,
+        );
 
         devToolStoreMock
             .setup(store => store.getState())
@@ -668,7 +730,9 @@ describe('DetailsDialogHandlerTest', () => {
             })
             .verifiable(Times.once());
 
-        detailsDialogMock.setup(dialog => dialog.setState(It.isValue({ canInspect: isOpen }))).verifiable(Times.once());
+        detailsDialogMock
+            .setup(dialog => dialog.setState(It.isValue({ canInspect: isOpen })))
+            .verifiable(Times.once());
 
         testSubject.onDevToolChanged(detailsDialogMock.object);
 
@@ -677,7 +741,10 @@ describe('DetailsDialogHandlerTest', () => {
     }
 
     function testOnUserConfigChangedUpdateState(itp: string): void {
-        const userConfigStoreMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>(undefined, MockBehavior.Strict);
+        const userConfigStoreMock = Mock.ofType<BaseStore<UserConfigurationStoreData>>(
+            undefined,
+            MockBehavior.Strict,
+        );
         const storeData: UserConfigurationStoreData = {
             bugServicePropertiesMap: {
                 gitHub: {
@@ -699,7 +766,9 @@ describe('DetailsDialogHandlerTest', () => {
             })
             .verifiable(Times.once());
 
-        detailsDialogMock.setup(dialog => dialog.setState(It.isValue({ userConfigurationStoreData: storeData }))).verifiable(Times.once());
+        detailsDialogMock
+            .setup(dialog => dialog.setState(It.isValue({ userConfigurationStoreData: storeData })))
+            .verifiable(Times.once());
 
         testSubject.onUserConfigChanged(detailsDialogMock.object);
 
@@ -708,7 +777,10 @@ describe('DetailsDialogHandlerTest', () => {
     }
 
     function testCanInspectEqualsIsOpen(isOpen: boolean): void {
-        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(undefined, MockBehavior.Strict);
+        const devToolStoreMock = Mock.ofType<BaseStore<DevToolStoreData>>(
+            undefined,
+            MockBehavior.Strict,
+        );
 
         devToolStoreMock
             .setup(store => store.getState())
@@ -785,6 +857,8 @@ describe('DetailsDialogHandlerTest', () => {
             .returns(() => false)
             .verifiable(Times.once());
 
-        detailsDialogMock.setup(dialog => dialog.onClickInspectButton(It.isAny())).verifiable(Times.once());
+        detailsDialogMock
+            .setup(dialog => dialog.onClickInspectButton(It.isAny()))
+            .verifiable(Times.once());
     }
 });

--- a/src/tests/unit/tests/injected/dialog-renderer.test.tsx
+++ b/src/tests/unit/tests/injected/dialog-renderer.test.tsx
@@ -2,7 +2,16 @@
 // Licensed under the MIT License.
 import { getRTL } from '@uifabric/utilities';
 import * as ReactDOM from 'react-dom';
-import { GlobalMock, GlobalScope, IGlobalMock, IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+import {
+    GlobalMock,
+    GlobalScope,
+    IGlobalMock,
+    IMock,
+    It,
+    Mock,
+    MockBehavior,
+    Times,
+} from 'typemoq';
 
 import { DevToolStore } from 'background/stores/dev-tools-store';
 import { UserConfigurationStore } from 'background/stores/global/user-configuration-store';
@@ -20,7 +29,10 @@ import { rootContainerId } from '../../../../injected/constants';
 import { DetailsDialogHandler } from '../../../../injected/details-dialog-handler';
 import { DetailsDialogWindowMessage, DialogRenderer } from '../../../../injected/dialog-renderer';
 import { ErrorMessageContent } from '../../../../injected/frameCommunicators/error-message-content';
-import { FrameCommunicator, MessageRequest } from '../../../../injected/frameCommunicators/frame-communicator';
+import {
+    FrameCommunicator,
+    MessageRequest,
+} from '../../../../injected/frameCommunicators/frame-communicator';
 import { FrameMessageResponseCallback } from '../../../../injected/frameCommunicators/window-message-handler';
 import { LayeredDetailsDialogComponent } from '../../../../injected/layered-details-dialog-component';
 import { MainWindowContext } from '../../../../injected/main-window-context';
@@ -61,7 +73,11 @@ describe('DialogRendererTests', () => {
         browserAdapter = Mock.ofType<BrowserAdapter>();
         detailsDialogHandlerMock = Mock.ofType<DetailsDialogHandler>();
 
-        getMainWindoContextMock = GlobalMock.ofInstance(MainWindowContext.getMainWindowContext, 'getMainWindowContext', MainWindowContext);
+        getMainWindoContextMock = GlobalMock.ofInstance(
+            MainWindowContext.getMainWindowContext,
+            'getMainWindowContext',
+            MainWindowContext,
+        );
         frameCommunicator = Mock.ofType(FrameCommunicator);
         domMock = Mock.ofInstance({
             createElement: selector => null,
@@ -85,7 +101,10 @@ describe('DialogRendererTests', () => {
         rootContainerMock = Mock.ofType<HTMLElement>();
 
         const devToolStoreStrictMock = Mock.ofType<DevToolStore>(null, MockBehavior.Strict);
-        const userConfigStoreStrictMock = Mock.ofType<UserConfigurationStore>(null, MockBehavior.Strict);
+        const userConfigStoreStrictMock = Mock.ofType<UserConfigurationStore>(
+            null,
+            MockBehavior.Strict,
+        );
         const devToolActionMessageCreatorMock = Mock.ofType(DevToolActionMessageCreator);
         const targetActionPageMessageCreatorMock = Mock.ofType(TargetPageActionMessageCreator);
         const issueFilingActionMessageCreatorMock = Mock.ofType(IssueFilingActionMessageCreator);
@@ -137,7 +156,9 @@ describe('DialogRendererTests', () => {
         const testObject = createDialogRenderer();
 
         GlobalScope.using(getMainWindoContextMock).with(() => {
-            expect(testObject.render(testData, getDefaultFeatureFlagValuesWithShadowOn())).toBeUndefined();
+            expect(
+                testObject.render(testData, getDefaultFeatureFlagValuesWithShadowOn()),
+            ).toBeUndefined();
         });
 
         attachShadowToDomVerify();
@@ -274,7 +295,10 @@ describe('DialogRendererTests', () => {
         const windowMessageRequest: MessageRequest<DetailsDialogWindowMessage> = {
             win: 'this is main window' as any,
             command: 'insights.detailsDialog',
-            message: { data: testData, featureFlagStoreData: getDefaultFeatureFlagValuesWithShadowOn() },
+            message: {
+                data: testData,
+                featureFlagStoreData: getDefaultFeatureFlagValuesWithShadowOn(),
+            },
         };
 
         attachShadowToDom(false);
@@ -324,7 +348,10 @@ describe('DialogRendererTests', () => {
             ruleResults: null,
             target: ['test string'],
         };
-        const message: DetailsDialogWindowMessage = { data: testData, featureFlagStoreData: getDefaultFeatureFlagValuesWithShadowOn() };
+        const message: DetailsDialogWindowMessage = {
+            data: testData,
+            featureFlagStoreData: getDefaultFeatureFlagValuesWithShadowOn(),
+        };
 
         setupDomMockForMainWindow(true);
         setupWindowUtilsMockAndFrameCommunicatorInMainWindow();
@@ -350,7 +377,10 @@ describe('DialogRendererTests', () => {
             ruleResults: null,
             target: ['test string'],
         };
-        const message: DetailsDialogWindowMessage = { data: testData, featureFlagStoreData: getDefaultFeatureFlagValues() };
+        const message: DetailsDialogWindowMessage = {
+            data: testData,
+            featureFlagStoreData: getDefaultFeatureFlagValues(),
+        };
 
         setupDomMockForMainWindow(false);
         setupWindowUtilsMockAndFrameCommunicatorInMainWindow();
@@ -463,7 +493,9 @@ describe('DialogRendererTests', () => {
         frameCommunicator.verifyAll();
     }
 
-    function setupWindowUtilsMockAndFrameCommunicatorInIframe(windowMessageRequest: MessageRequest<DetailsDialogWindowMessage>): void {
+    function setupWindowUtilsMockAndFrameCommunicatorInIframe(
+        windowMessageRequest: MessageRequest<DetailsDialogWindowMessage>,
+    ): void {
         windowUtilsMock
             .setup(wum => wum.getTopWindow())
             .returns(() => {
@@ -477,8 +509,12 @@ describe('DialogRendererTests', () => {
             })
             .verifiable(Times.atLeastOnce());
 
-        frameCommunicator.setup(fcm => fcm.subscribe(It.isAny(), It.isAny())).verifiable(Times.never());
-        frameCommunicator.setup(fcm => fcm.sendMessage(It.isValue(windowMessageRequest))).verifiable(Times.once());
+        frameCommunicator
+            .setup(fcm => fcm.subscribe(It.isAny(), It.isAny()))
+            .verifiable(Times.never());
+        frameCommunicator
+            .setup(fcm => fcm.sendMessage(It.isValue(windowMessageRequest)))
+            .verifiable(Times.once());
     }
 
     function getDefaultFeatureFlagValuesWithShadowOn(): FeatureFlagStoreData {
@@ -496,7 +532,10 @@ describe('DialogRendererTests', () => {
         }
     }
 
-    function attachShadowToDomVerify(needAppendChild: boolean = false, inMainWindow: boolean = true): void {
+    function attachShadowToDomVerify(
+        needAppendChild: boolean = false,
+        inMainWindow: boolean = true,
+    ): void {
         if (inMainWindow) {
             shadowUtilMock.verifyAll();
         }
@@ -511,7 +550,9 @@ describe('DialogRendererTests', () => {
 
     function setupDomMockForMainWindow(underShadowDom: boolean = true): void {
         if (!underShadowDom) {
-            htmlElementUtilsMock.setup(h => h.deleteAllElements('.insights-dialog-container')).verifiable(Times.once());
+            htmlElementUtilsMock
+                .setup(h => h.deleteAllElements('.insights-dialog-container'))
+                .verifiable(Times.once());
 
             domMock
                 .setup(dom => dom.querySelector(`#${rootContainerId}`))

--- a/src/tests/unit/tests/injected/drawing-controller.test.ts
+++ b/src/tests/unit/tests/injected/drawing-controller.test.ts
@@ -5,7 +5,10 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { getDefaultFeatureFlagValues } from '../../../../common/feature-flags';
 import { HTMLElementUtils } from '../../../../common/html-element-utils';
 import { FeatureFlagStoreData } from '../../../../common/types/store-data/feature-flag-store-data';
-import { DrawingController, VisualizationWindowMessage } from '../../../../injected/drawing-controller';
+import {
+    DrawingController,
+    VisualizationWindowMessage,
+} from '../../../../injected/drawing-controller';
 import { FrameCommunicator } from '../../../../injected/frameCommunicators/frame-communicator';
 import {
     AssessmentVisualizationInstance,
@@ -37,12 +40,16 @@ class VisualizationWindowMessageStubBuilder {
         return this;
     }
 
-    public setElementResults(results: AssessmentVisualizationInstance[]): VisualizationWindowMessageStubBuilder {
+    public setElementResults(
+        results: AssessmentVisualizationInstance[],
+    ): VisualizationWindowMessageStubBuilder {
         this.elementResults = results;
         return this;
     }
 
-    public setFeatureFlagStoreData(featureFlagStoreData: FeatureFlagStoreData): VisualizationWindowMessageStubBuilder {
+    public setFeatureFlagStoreData(
+        featureFlagStoreData: FeatureFlagStoreData,
+    ): VisualizationWindowMessageStubBuilder {
         this.featureFlagStoreData = featureFlagStoreData;
         return this;
     }
@@ -73,15 +80,24 @@ describe('DrawingControllerTest', () => {
         let subscribeCallback: (result: any, error: any, win: any, responder?: any) => void;
         const configId = 'id';
         frameCommunicatorMock
-            .setup(fcm => fcm.subscribe(It.isValue(DrawingController.triggerVisualizationCommand), It.isAny()))
+            .setup(fcm =>
+                fcm.subscribe(
+                    It.isValue(DrawingController.triggerVisualizationCommand),
+                    It.isAny(),
+                ),
+            )
             .returns((cmd, func) => {
                 subscribeCallback = func;
             })
             .verifiable(Times.once());
 
-        axeResultsHelperMock.setup(am => am.splitResultsByFrame(It.isAny())).verifiable(Times.never());
+        axeResultsHelperMock
+            .setup(am => am.splitResultsByFrame(It.isAny()))
+            .verifiable(Times.never());
 
-        const message: VisualizationWindowMessage = new VisualizationWindowMessageStubBuilder(configId)
+        const message: VisualizationWindowMessage = new VisualizationWindowMessageStubBuilder(
+            configId,
+        )
             .setVisualizationDisabled()
             .setElementResults([])
             .build();
@@ -99,7 +115,11 @@ describe('DrawingControllerTest', () => {
         const drawerMock = Mock.ofType(HighlightBoxDrawer, MockBehavior.Strict);
         drawerMock.setup(m => m.eraseLayout()).verifiable(Times.once());
 
-        const testObject = new DrawingController(frameCommunicatorMock.object, axeResultsHelperMock.object, hTMLElementUtils.object);
+        const testObject = new DrawingController(
+            frameCommunicatorMock.object,
+            axeResultsHelperMock.object,
+            hTMLElementUtils.object,
+        );
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
@@ -115,7 +135,9 @@ describe('DrawingControllerTest', () => {
 
         const configId = 'id';
         let subscribeCallback: (result: any, error: any, responder?: any) => void;
-        const message: VisualizationWindowMessage = new VisualizationWindowMessageStubBuilder(configId)
+        const message: VisualizationWindowMessage = new VisualizationWindowMessageStubBuilder(
+            configId,
+        )
             .setVisualizationEnabled()
             .setElementResults(['some data'] as any)
             .setFeatureFlagStoreData(featureFlagStoreData)
@@ -123,7 +145,9 @@ describe('DrawingControllerTest', () => {
         const iframeResults = ['iframeContent'];
         const iframeElement = 'iframeElement';
         const visibleResultStub = {} as HtmlElementAxeResults;
-        const disabledResultStub = { isVisualizationEnabled: false } as AssessmentVisualizationInstance;
+        const disabledResultStub = {
+            isVisualizationEnabled: false,
+        } as AssessmentVisualizationInstance;
         const resultsByFrames = [
             {
                 frame: null,
@@ -137,7 +161,12 @@ describe('DrawingControllerTest', () => {
         const drawerMock = Mock.ofType(HighlightBoxDrawer, MockBehavior.Strict);
 
         frameCommunicatorMock
-            .setup(fcm => fcm.subscribe(It.isValue(DrawingController.triggerVisualizationCommand), It.isAny()))
+            .setup(fcm =>
+                fcm.subscribe(
+                    It.isValue(DrawingController.triggerVisualizationCommand),
+                    It.isAny(),
+                ),
+            )
             .returns((cmd, func) => {
                 subscribeCallback = func;
             })
@@ -167,7 +196,9 @@ describe('DrawingControllerTest', () => {
             })
             .verifiable(Times.once());
 
-        hTMLElementUtils.setup(dm => dm.getAllElementsByTagName(It.isAny())).verifiable(Times.never());
+        hTMLElementUtils
+            .setup(dm => dm.getAllElementsByTagName(It.isAny()))
+            .verifiable(Times.never());
 
         const expected: DrawerInitData<HtmlElementAxeResults> = {
             data: [visibleResultStub],
@@ -177,7 +208,11 @@ describe('DrawingControllerTest', () => {
 
         drawerMock.setup(dm => dm.drawLayout()).verifiable(Times.once());
 
-        const testObject = new DrawingController(frameCommunicatorMock.object, axeResultsHelperMock.object, hTMLElementUtils.object);
+        const testObject = new DrawingController(
+            frameCommunicatorMock.object,
+            axeResultsHelperMock.object,
+            hTMLElementUtils.object,
+        );
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
@@ -192,12 +227,21 @@ describe('DrawingControllerTest', () => {
     test('enable visualization test when results is null - tabstops', () => {
         const configId = 'id';
         let subscribeCallback: (result: any, error: any, responder?: any) => void;
-        const message: VisualizationWindowMessage = new VisualizationWindowMessageStubBuilder(configId).setVisualizationEnabled().build();
+        const message: VisualizationWindowMessage = new VisualizationWindowMessageStubBuilder(
+            configId,
+        )
+            .setVisualizationEnabled()
+            .build();
         const iframeElement = 'iframeElement';
         const drawerMock = Mock.ofType(HighlightBoxDrawer, MockBehavior.Strict);
 
         frameCommunicatorMock
-            .setup(fcm => fcm.subscribe(It.isValue(DrawingController.triggerVisualizationCommand), It.isAny()))
+            .setup(fcm =>
+                fcm.subscribe(
+                    It.isValue(DrawingController.triggerVisualizationCommand),
+                    It.isAny(),
+                ),
+            )
             .returns((cmd, func) => {
                 subscribeCallback = func;
             })
@@ -220,7 +264,9 @@ describe('DrawingControllerTest', () => {
             )
             .verifiable(Times.once());
 
-        axeResultsHelperMock.setup(am => am.splitResultsByFrame(It.isAny())).verifiable(Times.never());
+        axeResultsHelperMock
+            .setup(am => am.splitResultsByFrame(It.isAny()))
+            .verifiable(Times.never());
 
         hTMLElementUtils
             .setup(dm => dm.getAllElementsByTagName('iframe'))
@@ -228,11 +274,19 @@ describe('DrawingControllerTest', () => {
             .verifiable(Times.once());
 
         drawerMock
-            .setup(dm => dm.initialize(It.isValue({ data: null, featureFlagStoreData: getDefaultFeatureFlagValues() })))
+            .setup(dm =>
+                dm.initialize(
+                    It.isValue({ data: null, featureFlagStoreData: getDefaultFeatureFlagValues() }),
+                ),
+            )
             .verifiable(Times.once());
         drawerMock.setup(dm => dm.drawLayout()).verifiable(Times.once());
 
-        const testObject = new DrawingController(frameCommunicatorMock.object, axeResultsHelperMock.object, hTMLElementUtils.object);
+        const testObject = new DrawingController(
+            frameCommunicatorMock.object,
+            axeResultsHelperMock.object,
+            hTMLElementUtils.object,
+        );
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
@@ -246,7 +300,9 @@ describe('DrawingControllerTest', () => {
 
     test('disable visualization test', () => {
         const configId = 'id';
-        const disableMessage = new VisualizationWindowMessageStubBuilder(configId).setVisualizationDisabled().build();
+        const disableMessage = new VisualizationWindowMessageStubBuilder(configId)
+            .setVisualizationDisabled()
+            .build();
         const iframes = ['1'];
         const drawerMock = Mock.ofType(HighlightBoxDrawer, MockBehavior.Strict);
 
@@ -273,7 +329,11 @@ describe('DrawingControllerTest', () => {
             )
             .verifiable(Times.once());
 
-        const testObject = new DrawingController(frameCommunicatorMock.object, axeResultsHelperMock.object, hTMLElementUtils.object);
+        const testObject = new DrawingController(
+            frameCommunicatorMock.object,
+            axeResultsHelperMock.object,
+            hTMLElementUtils.object,
+        );
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
@@ -287,7 +347,9 @@ describe('DrawingControllerTest', () => {
 
     test('dispose should call eraseLayout on drawers', () => {
         const configId = 'id';
-        const enableMessage: VisualizationWindowMessage = new VisualizationWindowMessageStubBuilder(configId)
+        const enableMessage: VisualizationWindowMessage = new VisualizationWindowMessageStubBuilder(
+            configId,
+        )
             .setVisualizationEnabled()
             .build();
         const drawerMock = Mock.ofType(HighlightBoxDrawer, MockBehavior.Strict);
@@ -314,7 +376,11 @@ describe('DrawingControllerTest', () => {
             .returns(() => HTMLCollectionOfBuilder.create([iframeElement as any]))
             .verifiable(Times.once());
 
-        const testObject = new DrawingController(frameCommunicatorMock.object, axeResultsHelperMock.object, hTMLElementUtils.object);
+        const testObject = new DrawingController(
+            frameCommunicatorMock.object,
+            axeResultsHelperMock.object,
+            hTMLElementUtils.object,
+        );
 
         testObject.initialize();
         testObject.registerDrawer(configId, drawerMock.object);
@@ -331,8 +397,14 @@ describe('DrawingControllerTest', () => {
     test('drawer already registered', () => {
         const configId = 'stub id';
         const drawerMock = Mock.ofType<Drawer>();
-        const testObject = new DrawingController(frameCommunicatorMock.object, axeResultsHelperMock.object, hTMLElementUtils.object);
+        const testObject = new DrawingController(
+            frameCommunicatorMock.object,
+            axeResultsHelperMock.object,
+            hTMLElementUtils.object,
+        );
         testObject.registerDrawer(configId, drawerMock.object);
-        expect(() => testObject.registerDrawer(configId, drawerMock.object)).toThrowErrorMatchingSnapshot();
+        expect(() =>
+            testObject.registerDrawer(configId, drawerMock.object),
+        ).toThrowErrorMatchingSnapshot();
     });
 });

--- a/src/tests/unit/tests/injected/drawing-initiator.test.ts
+++ b/src/tests/unit/tests/injected/drawing-initiator.test.ts
@@ -4,10 +4,16 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { getDefaultFeatureFlagValues } from '../../../../common/feature-flags';
 import { VisualizationType } from '../../../../common/types/visualization-type';
-import { DrawingController, VisualizationWindowMessage } from '../../../../injected/drawing-controller';
+import {
+    DrawingController,
+    VisualizationWindowMessage,
+} from '../../../../injected/drawing-controller';
 import { DrawingInitiator } from '../../../../injected/drawing-initiator';
 import { AssessmentVisualizationInstance } from '../../../../injected/frameCommunicators/html-element-axe-results-helper';
-import { PropertyBags, VisualizationInstanceProcessorCallback } from '../../../../injected/visualization-instance-processor';
+import {
+    PropertyBags,
+    VisualizationInstanceProcessorCallback,
+} from '../../../../injected/visualization-instance-processor';
 import { DictionaryStringTo } from '../../../../types/common-types';
 
 class DrawingControllerStub extends DrawingController {
@@ -78,7 +84,13 @@ describe('DrawingInitiatorTest', () => {
             })
             .verifiable();
 
-        testObject.enableVisualization(visualizationType, getDefaultFeatureFlagValues(), selectorMap, configId, processorMock.object);
+        testObject.enableVisualization(
+            visualizationType,
+            getDefaultFeatureFlagValues(),
+            selectorMap,
+            configId,
+            processorMock.object,
+        );
 
         verifyAll();
     });
@@ -112,7 +124,13 @@ describe('DrawingInitiatorTest', () => {
 
         drawingControllerMock.setup(x => x.processRequest(It.isAny())).verifiable(Times.never());
 
-        testObject.enableVisualization(visualizationType, featureFlagStoreData, null, step, processorMock.object);
+        testObject.enableVisualization(
+            visualizationType,
+            featureFlagStoreData,
+            null,
+            step,
+            processorMock.object,
+        );
 
         verifyAll();
     });
@@ -136,7 +154,13 @@ describe('DrawingInitiatorTest', () => {
             })
             .verifiable();
 
-        testObject.enableVisualization(visualizationType, getDefaultFeatureFlagValues(), {}, configId, processorMock.object);
+        testObject.enableVisualization(
+            visualizationType,
+            getDefaultFeatureFlagValues(),
+            {},
+            configId,
+            processorMock.object,
+        );
 
         verifyAll();
     });

--- a/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
+++ b/src/tests/unit/tests/injected/element-based-view-model-creator.test.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { UnifiedRule } from 'common/types/store-data/unified-data-interface';
-import { ElementBasedViewModelCreator, GetHighlightedResultInstanceIdsCallback } from 'injected/element-based-view-model-creator';
+import {
+    ElementBasedViewModelCreator,
+    GetHighlightedResultInstanceIdsCallback,
+} from 'injected/element-based-view-model-creator';
 import { GetDecoratedAxeNodeCallback } from 'injected/get-decorated-axe-node';
 import { DecoratedAxeNodeResult } from 'injected/scanner-utils';
 import { cloneDeep } from 'lodash';
@@ -16,19 +19,32 @@ describe('ElementBasedViewModelCreator', () => {
     let cardSelectionData: CardSelectionStoreData;
 
     beforeEach(() => {
-        getDecoratedAxeNodeCallbackMock = Mock.ofType<GetDecoratedAxeNodeCallback>(undefined, MockBehavior.Strict);
-        getHighlightedResultInstanceIdsMock = Mock.ofType<GetHighlightedResultInstanceIdsCallback>(undefined, MockBehavior.Strict);
-        testSubject = new ElementBasedViewModelCreator(getDecoratedAxeNodeCallbackMock.object, getHighlightedResultInstanceIdsMock.object);
+        getDecoratedAxeNodeCallbackMock = Mock.ofType<GetDecoratedAxeNodeCallback>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        getHighlightedResultInstanceIdsMock = Mock.ofType<GetHighlightedResultInstanceIdsCallback>(
+            undefined,
+            MockBehavior.Strict,
+        );
+        testSubject = new ElementBasedViewModelCreator(
+            getDecoratedAxeNodeCallbackMock.object,
+            getHighlightedResultInstanceIdsMock.object,
+        );
 
         cardSelectionData = {} as CardSelectionStoreData;
     });
 
     test('getElementBasedViewModel: rules are null', () => {
-        expect(testSubject.getElementBasedViewModel(null, [], {} as CardSelectionStoreData)).toBeUndefined();
+        expect(
+            testSubject.getElementBasedViewModel(null, [], {} as CardSelectionStoreData),
+        ).toBeUndefined();
     });
 
     test('getElementBasedViewModel: results are null', () => {
-        expect(testSubject.getElementBasedViewModel([], null, {} as CardSelectionStoreData)).toBeUndefined();
+        expect(
+            testSubject.getElementBasedViewModel([], null, {} as CardSelectionStoreData),
+        ).toBeUndefined();
     });
 
     test('getElementBasedViewModel: cardSelectionData are null', () => {
@@ -47,7 +63,9 @@ describe('ElementBasedViewModelCreator', () => {
             }));
 
         const expectedResult = {};
-        expect(testSubject.getElementBasedViewModel([], [unifiedResult], cardSelectionData)).toEqual(expectedResult);
+        expect(
+            testSubject.getElementBasedViewModel([], [unifiedResult], cardSelectionData),
+        ).toEqual(expectedResult);
     });
 
     test('getElementBasedViewModel: no highlighted results', () => {
@@ -60,7 +78,9 @@ describe('ElementBasedViewModelCreator', () => {
             .returns(() => ({ highlightedResultUids: highlightedInstanceIds }));
 
         const expectedResult = {};
-        expect(testSubject.getElementBasedViewModel([], [unifiedResult], cardSelectionData)).toEqual(expectedResult);
+        expect(
+            testSubject.getElementBasedViewModel([], [unifiedResult], cardSelectionData),
+        ).toEqual(expectedResult);
     });
 
     test('getElementBasedViewModel: one element, one result', () => {
@@ -75,7 +95,9 @@ describe('ElementBasedViewModelCreator', () => {
         getHighlightedResultInstanceIdsMock
             .setup(mock => mock(cardSelectionData))
             .returns(() => ({ highlightedResultUids: highlightedInstanceIds }));
-        getDecoratedAxeNodeCallbackMock.setup(mock => mock(unifiedResult, ruleStub, identifierStub)).returns(() => decoratedResultStub);
+        getDecoratedAxeNodeCallbackMock
+            .setup(mock => mock(unifiedResult, ruleStub, identifierStub))
+            .returns(() => decoratedResultStub);
 
         const expectedResult = {
             [identifierStub]: {
@@ -88,7 +110,9 @@ describe('ElementBasedViewModelCreator', () => {
             },
         };
 
-        expect(testSubject.getElementBasedViewModel(unifiedRules, [unifiedResult], cardSelectionData)).toEqual(expectedResult);
+        expect(
+            testSubject.getElementBasedViewModel(unifiedRules, [unifiedResult], cardSelectionData),
+        ).toEqual(expectedResult);
     });
 
     test('getElementBasedViewModel: two results that map to one element', () => {
@@ -138,6 +162,8 @@ describe('ElementBasedViewModelCreator', () => {
             },
         };
 
-        expect(testSubject.getElementBasedViewModel(unifiedRules, unifiedResults, cardSelectionData)).toEqual(expectedResult);
+        expect(
+            testSubject.getElementBasedViewModel(unifiedRules, unifiedResults, cardSelectionData),
+        ).toEqual(expectedResult);
     });
 });

--- a/src/tests/unit/tests/injected/element-finder-by-path.test.ts
+++ b/src/tests/unit/tests/injected/element-finder-by-path.test.ts
@@ -3,7 +3,10 @@
 import { IMock, It, Mock } from 'typemoq';
 
 import { HTMLElementUtils } from '../../../../common/html-element-utils';
-import { ElementFinderByPath, ElementFinderByPathMessage } from '../../../../injected/element-finder-by-path';
+import {
+    ElementFinderByPath,
+    ElementFinderByPathMessage,
+} from '../../../../injected/element-finder-by-path';
 import { ErrorMessageContent } from '../../../../injected/frameCommunicators/error-message-content';
 import { FrameCommunicator } from '../../../../injected/frameCommunicators/frame-communicator';
 import { FrameMessageResponseCallback } from '../../../../injected/frameCommunicators/window-message-handler';
@@ -33,11 +36,16 @@ describe('ElementFinderByPositionTest', () => {
             querySelector: querySelectorMock.object,
         } as HTMLElementUtils;
 
-        testSubject = new TestablePathElementFinder(htmlElementUtilsStub, frameCommunicatorMock.object);
+        testSubject = new TestablePathElementFinder(
+            htmlElementUtilsStub,
+            frameCommunicatorMock.object,
+        );
     });
 
     test('initialize', () => {
-        const responderMock = Mock.ofInstance((result: any, error: ErrorMessageContent, messageSourceWindow: Window) => {});
+        const responderMock = Mock.ofInstance(
+            (result: any, error: ErrorMessageContent, messageSourceWindow: Window) => {},
+        );
         const processRequestPromiseHandlerMock = Mock.ofInstance((successCb, errorCb) => {});
         const processRequestMock = Mock.ofInstance(message => {
             return null;
@@ -54,7 +62,11 @@ describe('ElementFinderByPositionTest', () => {
             then: processRequestPromiseHandlerMock.object,
         } as Promise<string>;
 
-        frameCommunicatorMock.setup(fcm => fcm.subscribe(ElementFinderByPath.findElementByPathCommand, subscribeCallback)).verifiable();
+        frameCommunicatorMock
+            .setup(fcm =>
+                fcm.subscribe(ElementFinderByPath.findElementByPathCommand, subscribeCallback),
+            )
+            .verifiable();
 
         processRequestMock
             .setup(prm => prm(messageStub))
@@ -149,7 +161,10 @@ describe('ElementFinderByPositionTest', () => {
         expect(response).toEqual(snippet);
     });
 
-    function setupQuerySelectorMock(messageStub: ElementFinderByPathMessage, element: HTMLElement): void {
+    function setupQuerySelectorMock(
+        messageStub: ElementFinderByPathMessage,
+        element: HTMLElement,
+    ): void {
         querySelectorMock.setup(em => em(messageStub.path[0])).returns(() => element);
     }
 

--- a/src/tests/unit/tests/injected/element-finder-by-position.test.ts
+++ b/src/tests/unit/tests/injected/element-finder-by-position.test.ts
@@ -5,7 +5,10 @@ import { IMock, It, Mock, MockBehavior } from 'typemoq';
 
 import { SingleElementSelector } from '../../../../common/types/store-data/scoping-store-data';
 import { ClientUtils } from '../../../../injected/client-utils';
-import { ElementFinderByPosition, ElementFinderByPositionMessage } from '../../../../injected/element-finder-by-position';
+import {
+    ElementFinderByPosition,
+    ElementFinderByPositionMessage,
+} from '../../../../injected/element-finder-by-position';
 import { ErrorMessageContent } from '../../../../injected/frameCommunicators/error-message-content';
 import { FrameCommunicator } from '../../../../injected/frameCommunicators/frame-communicator';
 import { FrameMessageResponseCallback } from '../../../../injected/frameCommunicators/window-message-handler';
@@ -69,7 +72,9 @@ describe('ElementFinderByPositionTest', () => {
     });
 
     test('initialize', () => {
-        const responderMock = Mock.ofInstance((result: any, error: ErrorMessageContent, messageSourceWindow: Window) => {});
+        const responderMock = Mock.ofInstance(
+            (result: any, error: ErrorMessageContent, messageSourceWindow: Window) => {},
+        );
         const processRequestPromiseHandlerMock = Mock.ofInstance((successCb, errorCb) => {});
         const processRequestMock = Mock.ofInstance(message => {
             return null;
@@ -87,7 +92,12 @@ describe('ElementFinderByPositionTest', () => {
         } as Q.IPromise<string[]>;
 
         frameCommunicatorMock
-            .setup(fcm => fcm.subscribe(ElementFinderByPosition.findElementByPositionCommand, subscribeCallback))
+            .setup(fcm =>
+                fcm.subscribe(
+                    ElementFinderByPosition.findElementByPositionCommand,
+                    subscribeCallback,
+                ),
+            )
             .verifiable();
 
         processRequestMock
@@ -210,7 +220,10 @@ describe('ElementFinderByPositionTest', () => {
         verifyAll();
     });
 
-    function setupElementsFromPointMock(messageStub: ElementFinderByPositionMessage, elements: HTMLElement[]): void {
+    function setupElementsFromPointMock(
+        messageStub: ElementFinderByPositionMessage,
+        elements: HTMLElement[],
+    ): void {
         elementsFromPointMock
             .setup(em => em(messageStub.x, messageStub.y))
             .returns(() => elements)

--- a/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
+++ b/src/tests/unit/tests/injected/fix-instruction-processor.test.tsx
@@ -10,7 +10,8 @@ describe('FixInstructionProcessor', () => {
     });
 
     test('no background nor foreground on the message', () => {
-        const fixInstruction = 'there is nothing that will trigger the processor to change the fix instruction here';
+        const fixInstruction =
+            'there is nothing that will trigger the processor to change the fix instruction here';
 
         const result = testSubject.process(fixInstruction);
 
@@ -18,7 +19,8 @@ describe('FixInstructionProcessor', () => {
     });
 
     test('foreground color on the message', () => {
-        const fixInstruction = 'color contrast of 2.52 (foreground color: #8a94a8; nothing else to match here)';
+        const fixInstruction =
+            'color contrast of 2.52 (foreground color: #8a94a8; nothing else to match here)';
 
         const result = testSubject.process(fixInstruction);
 
@@ -26,7 +28,8 @@ describe('FixInstructionProcessor', () => {
     });
 
     test('background color on the message', () => {
-        const fixInstruction = 'color contrast of 2.52 (background color: #8a94a8; nothing else to match here)';
+        const fixInstruction =
+            'color contrast of 2.52 (background color: #8a94a8; nothing else to match here)';
 
         const result = testSubject.process(fixInstruction);
 

--- a/src/tests/unit/tests/injected/focus-change-handler.test.ts
+++ b/src/tests/unit/tests/injected/focus-change-handler.test.ts
@@ -4,7 +4,10 @@ import { IMock, It, Mock, Times } from 'typemoq';
 
 import { TargetPageStoreData } from '../../../../injected/client-store-listener';
 import { FocusChangeHandler } from '../../../../injected/focus-change-handler';
-import { ScrollingController, ScrollingWindowMessage } from '../../../../injected/frameCommunicators/scrolling-controller';
+import {
+    ScrollingController,
+    ScrollingWindowMessage,
+} from '../../../../injected/frameCommunicators/scrolling-controller';
 import { TargetPageActionMessageCreator } from '../../../../injected/target-page-action-message-creator';
 
 describe('FocusChangeHandler', () => {
@@ -24,7 +27,10 @@ describe('FocusChangeHandler', () => {
         };
         sampleUid = 'some uid';
 
-        testSubject = new FocusChangeHandler(targetPageActionMessageCreatorMock.object, scrollingControllerMock.object);
+        testSubject = new FocusChangeHandler(
+            targetPageActionMessageCreatorMock.object,
+            scrollingControllerMock.object,
+        );
     });
 
     test('onStoreChange: no target in visualizationStoreData OR cardSelectionStoreData', () => {
@@ -40,8 +46,12 @@ describe('FocusChangeHandler', () => {
             },
         } as TargetPageStoreData;
 
-        targetPageActionMessageCreatorMock.setup(acm => acm.scrollRequested()).verifiable(Times.never());
-        scrollingControllerMock.setup(scm => scm.processRequest(It.isAny())).verifiable(Times.never());
+        targetPageActionMessageCreatorMock
+            .setup(acm => acm.scrollRequested())
+            .verifiable(Times.never());
+        scrollingControllerMock
+            .setup(scm => scm.processRequest(It.isAny()))
+            .verifiable(Times.never());
 
         testSubject.handleFocusChangeWithStoreData(storeData);
 
@@ -59,8 +69,12 @@ describe('FocusChangeHandler', () => {
             },
         } as TargetPageStoreData;
 
-        targetPageActionMessageCreatorMock.setup(acm => acm.scrollRequested()).verifiable(Times.once());
-        scrollingControllerMock.setup(scm => scm.processRequest(sampleMessage)).verifiable(Times.once());
+        targetPageActionMessageCreatorMock
+            .setup(acm => acm.scrollRequested())
+            .verifiable(Times.once());
+        scrollingControllerMock
+            .setup(scm => scm.processRequest(sampleMessage))
+            .verifiable(Times.once());
 
         testSubject.handleFocusChangeWithStoreData(storeData);
 
@@ -88,8 +102,12 @@ describe('FocusChangeHandler', () => {
             },
         } as TargetPageStoreData;
 
-        targetPageActionMessageCreatorMock.setup(acm => acm.scrollRequested()).verifiable(Times.once());
-        scrollingControllerMock.setup(scm => scm.processRequest(sampleMessage)).verifiable(Times.once());
+        targetPageActionMessageCreatorMock
+            .setup(acm => acm.scrollRequested())
+            .verifiable(Times.once());
+        scrollingControllerMock
+            .setup(scm => scm.processRequest(sampleMessage))
+            .verifiable(Times.once());
 
         testSubject.handleFocusChangeWithStoreData(storeData);
 
@@ -114,7 +132,9 @@ describe('FocusChangeHandler', () => {
             },
         } as TargetPageStoreData;
 
-        expect(() => testSubject.handleFocusChangeWithStoreData(storeData)).toThrowError('focused result was not found');
+        expect(() => testSubject.handleFocusChangeWithStoreData(storeData)).toThrowError(
+            'focused result was not found',
+        );
     });
 
     test('onStoreChange: new target and old target are same', () => {
@@ -127,8 +147,12 @@ describe('FocusChangeHandler', () => {
             },
         } as TargetPageStoreData;
 
-        targetPageActionMessageCreatorMock.setup(acm => acm.scrollRequested()).verifiable(Times.once());
-        scrollingControllerMock.setup(scm => scm.processRequest(sampleMessage)).verifiable(Times.once());
+        targetPageActionMessageCreatorMock
+            .setup(acm => acm.scrollRequested())
+            .verifiable(Times.once());
+        scrollingControllerMock
+            .setup(scm => scm.processRequest(sampleMessage))
+            .verifiable(Times.once());
 
         testSubject.handleFocusChangeWithStoreData(storeData);
 
@@ -138,8 +162,12 @@ describe('FocusChangeHandler', () => {
         targetPageActionMessageCreatorMock.reset();
         scrollingControllerMock.reset();
 
-        targetPageActionMessageCreatorMock.setup(acm => acm.scrollRequested()).verifiable(Times.never());
-        scrollingControllerMock.setup(scm => scm.processRequest(It.isAny())).verifiable(Times.never());
+        targetPageActionMessageCreatorMock
+            .setup(acm => acm.scrollRequested())
+            .verifiable(Times.never());
+        scrollingControllerMock
+            .setup(scm => scm.processRequest(It.isAny()))
+            .verifiable(Times.never());
 
         testSubject.handleFocusChangeWithStoreData(storeData);
 

--- a/src/tests/unit/tests/injected/frame-url-finder.test.ts
+++ b/src/tests/unit/tests/injected/frame-url-finder.test.ts
@@ -4,8 +4,15 @@ import { It, Mock, MockBehavior } from 'typemoq';
 
 import { HTMLElementUtils } from '../../../../common/html-element-utils';
 import { WindowUtils } from '../../../../common/window-utils';
-import { FrameUrlFinder, FrameUrlMessage, TargetMessage } from '../../../../injected/frame-url-finder';
-import { FrameCommunicator, MessageRequest } from '../../../../injected/frameCommunicators/frame-communicator';
+import {
+    FrameUrlFinder,
+    FrameUrlMessage,
+    TargetMessage,
+} from '../../../../injected/frame-url-finder';
+import {
+    FrameCommunicator,
+    MessageRequest,
+} from '../../../../injected/frameCommunicators/frame-communicator';
 
 describe('frameUrlFinderTest', () => {
     test('constructor', () => {
@@ -16,7 +23,11 @@ describe('frameUrlFinderTest', () => {
         const frameCommunicatorMock = Mock.ofType(FrameCommunicator, MockBehavior.Strict);
         const testSubject = new FrameUrlFinder(frameCommunicatorMock.object, null, null);
 
-        frameCommunicatorMock.setup(mfc => mfc.subscribe(FrameUrlFinder.GetTargetFrameUrlCommand, testSubject.processRequest)).verifiable();
+        frameCommunicatorMock
+            .setup(mfc =>
+                mfc.subscribe(FrameUrlFinder.GetTargetFrameUrlCommand, testSubject.processRequest),
+            )
+            .verifiable();
 
         testSubject.initialize();
 
@@ -42,7 +53,9 @@ describe('frameUrlFinderTest', () => {
             },
         };
 
-        frameCommunicatorMock.setup(mfc => mfc.sendMessage(It.isValue(sentMessageStub))).verifiable();
+        frameCommunicatorMock
+            .setup(mfc => mfc.sendMessage(It.isValue(sentMessageStub)))
+            .verifiable();
 
         windowUtilsMock
             .setup(mwu => mwu.getTopWindow())
@@ -58,7 +71,11 @@ describe('frameUrlFinderTest', () => {
             })
             .verifiable();
 
-        const testSubject = new FrameUrlFinder(frameCommunicatorMock.object, windowUtilsMock.object, null);
+        const testSubject = new FrameUrlFinder(
+            frameCommunicatorMock.object,
+            windowUtilsMock.object,
+            null,
+        );
         testSubject.processRequest(processRequestMessageStub);
 
         windowUtilsMock.verifyAll();
@@ -81,7 +98,9 @@ describe('frameUrlFinderTest', () => {
             },
         };
 
-        frameCommunicatorMock.setup(mfc => mfc.sendMessage(It.isValue(sentMessageMock))).verifiable();
+        frameCommunicatorMock
+            .setup(mfc => mfc.sendMessage(It.isValue(sentMessageMock)))
+            .verifiable();
 
         htmlUtilsMock
             .setup(mhu => mhu.querySelector('abc'))
@@ -90,7 +109,11 @@ describe('frameUrlFinderTest', () => {
             })
             .verifiable();
 
-        const testSubject = new FrameUrlFinder(frameCommunicatorMock.object, null, htmlUtilsMock.object);
+        const testSubject = new FrameUrlFinder(
+            frameCommunicatorMock.object,
+            null,
+            htmlUtilsMock.object,
+        );
         testSubject.processRequest(processRequestMessageMock);
 
         htmlUtilsMock.verifyAll();

--- a/src/tests/unit/tests/injected/frame-url-message-dispatcher.test.ts
+++ b/src/tests/unit/tests/injected/frame-url-message-dispatcher.test.ts
@@ -12,26 +12,44 @@ describe('FrameUrlMessageDispatcherTest', () => {
     });
 
     test('setTargetFrameUrl', () => {
-        const devToolActionMessageCreatorMock = Mock.ofType(DevToolActionMessageCreator, MockBehavior.Strict);
+        const devToolActionMessageCreatorMock = Mock.ofType(
+            DevToolActionMessageCreator,
+            MockBehavior.Strict,
+        );
         const targetFrameUrlMessage: FrameUrlMessage = {
             frameUrl: 'testUrl',
         };
 
-        devToolActionMessageCreatorMock.setup(acm => acm.setInspectFrameUrl('testUrl')).verifiable();
+        devToolActionMessageCreatorMock
+            .setup(acm => acm.setInspectFrameUrl('testUrl'))
+            .verifiable();
 
-        const testSubject = new FrameUrlMessageDispatcher(devToolActionMessageCreatorMock.object, null);
+        const testSubject = new FrameUrlMessageDispatcher(
+            devToolActionMessageCreatorMock.object,
+            null,
+        );
         testSubject.setTargetFrameUrl(targetFrameUrlMessage);
 
         devToolActionMessageCreatorMock.verifyAll();
     });
 
     test('initialize', () => {
-        const devToolActionMessageCreatorMock = Mock.ofType(DevToolActionMessageCreator, MockBehavior.Strict);
+        const devToolActionMessageCreatorMock = Mock.ofType(
+            DevToolActionMessageCreator,
+            MockBehavior.Strict,
+        );
         const frameCommunicatorMock = Mock.ofType(FrameCommunicator, MockBehavior.Strict);
 
-        const testSubject = new FrameUrlMessageDispatcher(devToolActionMessageCreatorMock.object, frameCommunicatorMock.object);
+        const testSubject = new FrameUrlMessageDispatcher(
+            devToolActionMessageCreatorMock.object,
+            frameCommunicatorMock.object,
+        );
 
-        frameCommunicatorMock.setup(fcm => fcm.subscribe(FrameUrlFinder.SetFrameUrlCommand, testSubject.setTargetFrameUrl)).verifiable();
+        frameCommunicatorMock
+            .setup(fcm =>
+                fcm.subscribe(FrameUrlFinder.SetFrameUrlCommand, testSubject.setTargetFrameUrl),
+            )
+            .verifiable();
 
         testSubject.initialize();
 

--- a/src/tests/unit/tests/injected/frame-url-search-initiator.test.ts
+++ b/src/tests/unit/tests/injected/frame-url-search-initiator.test.ts
@@ -14,8 +14,14 @@ describe('FrameUrlSearchInitiatorTest', () => {
 
     test('listenToStore: state implies to initiate the search for frame url', () => {
         const devToolStoreMock = new StoreMock<DevToolStoreData>();
-        const frameUrlFinderMock = Mock.ofInstance({ processRequest: (message: TargetMessage) => {} }, MockBehavior.Strict);
-        const testSubject = new FrameUrlSearchInitiator(devToolStoreMock.getObject(), frameUrlFinderMock.object as FrameUrlFinder);
+        const frameUrlFinderMock = Mock.ofInstance(
+            { processRequest: (message: TargetMessage) => {} },
+            MockBehavior.Strict,
+        );
+        const testSubject = new FrameUrlSearchInitiator(
+            devToolStoreMock.getObject(),
+            frameUrlFinderMock.object as FrameUrlFinder,
+        );
         const stateStub: DevToolStoreData = {
             isOpen: null,
             inspectElement: ['abc', 'def'],
@@ -25,7 +31,9 @@ describe('FrameUrlSearchInitiatorTest', () => {
         devToolStoreMock.setupAddChangedListener(1);
         devToolStoreMock.setupGetState(stateStub, 1);
 
-        frameUrlFinderMock.setup(icm => icm.processRequest(It.isValue({ target: stateStub.inspectElement }))).verifiable();
+        frameUrlFinderMock
+            .setup(icm => icm.processRequest(It.isValue({ target: stateStub.inspectElement })))
+            .verifiable();
 
         testSubject.listenToStore();
         devToolStoreMock.invokeChangeListener();
@@ -36,8 +44,14 @@ describe('FrameUrlSearchInitiatorTest', () => {
 
     test('listenToStore: frame url is already set; no need to find frame url', () => {
         const devToolStoreMock = new StoreMock<DevToolStoreData>();
-        const frameUrlFinderMock = Mock.ofInstance({ processRequest: (message: TargetMessage) => {} }, MockBehavior.Strict);
-        const testSubject = new FrameUrlSearchInitiator(devToolStoreMock.getObject(), frameUrlFinderMock.object as FrameUrlFinder);
+        const frameUrlFinderMock = Mock.ofInstance(
+            { processRequest: (message: TargetMessage) => {} },
+            MockBehavior.Strict,
+        );
+        const testSubject = new FrameUrlSearchInitiator(
+            devToolStoreMock.getObject(),
+            frameUrlFinderMock.object as FrameUrlFinder,
+        );
         const stateStub: DevToolStoreData = {
             isOpen: null,
             inspectElement: ['abc', 'def'],
@@ -48,7 +62,9 @@ describe('FrameUrlSearchInitiatorTest', () => {
         devToolStoreMock.setupAddChangedListener(1);
         devToolStoreMock.setupGetState(stateStub, 1);
 
-        frameUrlFinderMock.setup(icm => icm.processRequest(It.isValue({ target: stateStub.inspectElement }))).verifiable(Times.never());
+        frameUrlFinderMock
+            .setup(icm => icm.processRequest(It.isValue({ target: stateStub.inspectElement })))
+            .verifiable(Times.never());
 
         testSubject.listenToStore();
         devToolStoreMock.invokeChangeListener();
@@ -59,8 +75,14 @@ describe('FrameUrlSearchInitiatorTest', () => {
 
     test('listenToStore: element is at root; no need for finding frame url', () => {
         const devToolStoreMock = new StoreMock<DevToolStoreData>();
-        const frameUrlFinderMock = Mock.ofInstance({ processRequest: (message: TargetMessage) => {} }, MockBehavior.Strict);
-        const testSubject = new FrameUrlSearchInitiator(devToolStoreMock.getObject(), frameUrlFinderMock.object as FrameUrlFinder);
+        const frameUrlFinderMock = Mock.ofInstance(
+            { processRequest: (message: TargetMessage) => {} },
+            MockBehavior.Strict,
+        );
+        const testSubject = new FrameUrlSearchInitiator(
+            devToolStoreMock.getObject(),
+            frameUrlFinderMock.object as FrameUrlFinder,
+        );
         const stateStub: DevToolStoreData = {
             isOpen: null,
             inspectElement: ['abc'],
@@ -70,7 +92,9 @@ describe('FrameUrlSearchInitiatorTest', () => {
         devToolStoreMock.setupAddChangedListener(1);
         devToolStoreMock.setupGetState(stateStub, 1);
 
-        frameUrlFinderMock.setup(icm => icm.processRequest(It.isValue({ target: stateStub.inspectElement }))).verifiable(Times.never());
+        frameUrlFinderMock
+            .setup(icm => icm.processRequest(It.isValue({ target: stateStub.inspectElement })))
+            .verifiable(Times.never());
 
         testSubject.listenToStore();
         devToolStoreMock.invokeChangeListener();

--- a/src/tests/unit/tests/injected/frameCommunicators/frame-communicator.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/frame-communicator.test.ts
@@ -5,14 +5,8 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { HTMLElementUtils } from '../../../../../common/html-element-utils';
 import { Logger } from '../../../../../common/logging/logger';
-import {
-    FrameCommunicator,
-    MessageRequest,
-} from '../../../../../injected/frameCommunicators/frame-communicator';
-import {
-    FrameMessageResponseCallback,
-    WindowMessageHandler,
-} from '../../../../../injected/frameCommunicators/window-message-handler';
+import { FrameCommunicator, MessageRequest } from '../../../../../injected/frameCommunicators/frame-communicator';
+import { FrameMessageResponseCallback, WindowMessageHandler } from '../../../../../injected/frameCommunicators/window-message-handler';
 import { HTMLCollectionOfBuilder } from '../../../common/html-collection-of-builder';
 import { IsSameObject } from '../../../common/typemoq-helper';
 import { QStub } from '../../../stubs/q-stub';
@@ -48,12 +42,7 @@ describe('FrameCommunicatorTests', () => {
         mockQ = Mock.ofType(QStub) as any;
         const loggerMock = Mock.ofType<Logger>();
 
-        testSubject = new FrameCommunicator(
-            mockWindowMessageHandler.object,
-            mockHtmlElementUtils.object,
-            mockQ.object,
-            loggerMock.object,
-        );
+        testSubject = new FrameCommunicator(mockWindowMessageHandler.object, mockHtmlElementUtils.object, mockQ.object, loggerMock.object);
 
         mockHtmlElementUtils
             .setup(x => x.getAllElementsByTagName('iframe'))
@@ -135,9 +124,9 @@ describe('FrameCommunicatorTests', () => {
     test('verifyDisposeInIframe', () => {
         let disposeCallback: Function;
         const frameRequests: MessageRequest<any>[] = [];
-        const frameRequestCompleteDeferred: Q.Deferred<Q.PromiseState<
-            FrameMessageResponseCallback
-        >[]> = Q.defer<Q.PromiseState<FrameMessageResponseCallback>[]>();
+        const frameRequestCompleteDeferred: Q.Deferred<Q.PromiseState<FrameMessageResponseCallback>[]> = Q.defer<
+            Q.PromiseState<FrameMessageResponseCallback>[]
+        >();
 
         mockWindowMessageHandler
             .setup(x => x.addSubscriber(FrameCommunicator.DisposeCommand, It.isAny()))
@@ -209,9 +198,7 @@ describe('FrameCommunicatorTests', () => {
     test('verifySubscribe', () => {
         const responseCallback = () => {};
 
-        mockWindowMessageHandler
-            .setup(x => x.addSubscriber('command1', responseCallback))
-            .verifiable();
+        mockWindowMessageHandler.setup(x => x.addSubscriber('command1', responseCallback)).verifiable();
 
         testSubject.initialize();
 
@@ -260,10 +247,7 @@ describe('FrameCommunicatorTests', () => {
 
         testSubject.initialize();
 
-        const allFramesExecutedPromise = testSubject.executeRequestForAllFrameRequests(
-            frameRequests,
-            timeoutValue,
-        );
+        const allFramesExecutedPromise = testSubject.executeRequestForAllFrameRequests(frameRequests, timeoutValue);
 
         expect(timeoutDeferred.promise).toEqual(allFramesExecutedPromise);
 
@@ -302,15 +286,7 @@ describe('FrameCommunicatorTests', () => {
         testSubject.initialize();
 
         mockWindowMessageHandler
-            .setup(x =>
-                x.post(
-                    childFrame1Info.window,
-                    FrameCommunicator.PingCommand,
-                    null,
-                    It.isAny(),
-                    undefined,
-                ),
-            )
+            .setup(x => x.post(childFrame1Info.window, FrameCommunicator.PingCommand, null, It.isAny(), undefined))
             .verifiable();
 
         const pingTimeoutDeferred = Q.defer();
@@ -354,9 +330,7 @@ describe('FrameCommunicatorTests', () => {
         testSubject.initialize();
 
         // mock posting ping command
-        mockWindowMessageHandler
-            .setup(x => x.post(It.isAny(), It.isAny(), It.isAny(), It.isAny(), It.isAny()))
-            .verifiable(Times.never());
+        mockWindowMessageHandler.setup(x => x.post(It.isAny(), It.isAny(), It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
 
         const promise = testSubject.sendMessage(frameMessageRequest);
 
@@ -381,15 +355,7 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting ping command
         mockWindowMessageHandler
-            .setup(x =>
-                x.post(
-                    childFrame1Info.window,
-                    FrameCommunicator.PingCommand,
-                    null,
-                    It.isAny(),
-                    undefined,
-                ),
-            )
+            .setup(x => x.post(childFrame1Info.window, FrameCommunicator.PingCommand, null, It.isAny(), undefined))
             .callback((win, command, message, callback) => {
                 pingCallback = callback;
             })
@@ -405,15 +371,7 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting target command
         mockWindowMessageHandler
-            .setup(x =>
-                x.post(
-                    childFrame1Info.window,
-                    windowMessageRequest.command,
-                    windowMessageRequest.message,
-                    It.isAny(),
-                    undefined,
-                ),
-            )
+            .setup(x => x.post(childFrame1Info.window, windowMessageRequest.command, windowMessageRequest.message, It.isAny(), undefined))
             .verifiable();
 
         // mock for the whole request timeout
@@ -459,15 +417,7 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting ping command
         mockWindowMessageHandler
-            .setup(x =>
-                x.post(
-                    childFrame1Info.window,
-                    FrameCommunicator.PingCommand,
-                    null,
-                    It.isAny(),
-                    undefined,
-                ),
-            )
+            .setup(x => x.post(childFrame1Info.window, FrameCommunicator.PingCommand, null, It.isAny(), undefined))
             .callback((win, command, message, callback) => {
                 pingCallback = callback;
             })
@@ -488,15 +438,7 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting target command
         mockWindowMessageHandler
-            .setup(x =>
-                x.post(
-                    childFrame1Info.window,
-                    windowMessageRequest.command,
-                    windowMessageRequest.message,
-                    It.isAny(),
-                    undefined,
-                ),
-            )
+            .setup(x => x.post(childFrame1Info.window, windowMessageRequest.command, windowMessageRequest.message, It.isAny(), undefined))
             .callback((win, command, message, callback) => {
                 commandCallback = callback;
             })
@@ -533,15 +475,7 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting ping command
         mockWindowMessageHandler
-            .setup(x =>
-                x.post(
-                    childFrame1Info.window,
-                    FrameCommunicator.PingCommand,
-                    null,
-                    It.isAny(),
-                    undefined,
-                ),
-            )
+            .setup(x => x.post(childFrame1Info.window, FrameCommunicator.PingCommand, null, It.isAny(), undefined))
             .callback((win, command, message, callback) => {
                 pingCallback = callback;
             })
@@ -564,15 +498,7 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting target command
         mockWindowMessageHandler
-            .setup(x =>
-                x.post(
-                    childFrame1Info.window,
-                    windowMessageRequest.command,
-                    windowMessageRequest.message,
-                    It.isAny(),
-                    undefined,
-                ),
-            )
+            .setup(x => x.post(childFrame1Info.window, windowMessageRequest.command, windowMessageRequest.message, It.isAny(), undefined))
             .callback((win, command, message, callback) => {
                 commandCallback = callback;
             })
@@ -601,10 +527,7 @@ describe('FrameCommunicatorTests', () => {
             message: {},
         };
 
-        childFrame1Info.frameElement.setAttribute(
-            'sandbox',
-            'allow-forms allow-scripts allow-same-origin',
-        );
+        childFrame1Info.frameElement.setAttribute('sandbox', 'allow-forms allow-scripts allow-same-origin');
 
         let pingCallback: Function;
         const commandMsg = {};
@@ -614,15 +537,7 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting ping command
         mockWindowMessageHandler
-            .setup(x =>
-                x.post(
-                    childFrame1Info.window,
-                    FrameCommunicator.PingCommand,
-                    null,
-                    It.isAny(),
-                    undefined,
-                ),
-            )
+            .setup(x => x.post(childFrame1Info.window, FrameCommunicator.PingCommand, null, It.isAny(), undefined))
             .callback((win, command, message, callback) => {
                 pingCallback = callback;
             })
@@ -645,15 +560,7 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting target command
         mockWindowMessageHandler
-            .setup(x =>
-                x.post(
-                    childFrame1Info.window,
-                    frameMessageRequest.command,
-                    frameMessageRequest.message,
-                    It.isAny(),
-                    undefined,
-                ),
-            )
+            .setup(x => x.post(childFrame1Info.window, frameMessageRequest.command, frameMessageRequest.message, It.isAny(), undefined))
             .callback((win, command, message, callback) => {
                 commandCallback = callback;
             })
@@ -681,34 +588,21 @@ describe('FrameCommunicatorTests', () => {
             window: hasWindow ? ({} as Window) : null,
         };
 
-        mockHtmlElementUtils
-            .setup(x => x.getContentWindow(IsSameObject(frameInfo.frameElement)))
-            .returns(() => frameInfo.window);
+        mockHtmlElementUtils.setup(x => x.getContentWindow(IsSameObject(frameInfo.frameElement))).returns(() => frameInfo.window);
 
         return frameInfo;
     }
 
-    function mockSendMessageToFrameCall(): IMock<
-        (frameMessageRequest: MessageRequest<any>) => void
-    > {
-        const sendMessageToFrameStrictMock = Mock.ofInstance(
-            testSubject.sendMessage,
-            MockBehavior.Strict,
-        );
+    function mockSendMessageToFrameCall(): IMock<(frameMessageRequest: MessageRequest<any>) => void> {
+        const sendMessageToFrameStrictMock = Mock.ofInstance(testSubject.sendMessage, MockBehavior.Strict);
         (testSubject.sendMessage as any) = sendMessageToFrameStrictMock.object;
         return sendMessageToFrameStrictMock;
     }
 
     function mockExecuteRequestForAllFrameRequestsCall(): IMock<
-        (
-            frameMessageRequests: MessageRequest<any>[],
-            timeOut: number,
-        ) => Q.IPromise<Q.PromiseState<FrameMessageResponseCallback>[]>
+        (frameMessageRequests: MessageRequest<any>[], timeOut: number) => Q.IPromise<Q.PromiseState<FrameMessageResponseCallback>[]>
     > {
-        const executeForAllFrameRequestsStrictMock = Mock.ofInstance(
-            testSubject.executeRequestForAllFrameRequests,
-            MockBehavior.Strict,
-        );
+        const executeForAllFrameRequestsStrictMock = Mock.ofInstance(testSubject.executeRequestForAllFrameRequests, MockBehavior.Strict);
         (testSubject.executeRequestForAllFrameRequests as any) = executeForAllFrameRequestsStrictMock.object;
         return executeForAllFrameRequestsStrictMock;
     }

--- a/src/tests/unit/tests/injected/frameCommunicators/frame-communicator.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/frame-communicator.test.ts
@@ -5,8 +5,14 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 import { HTMLElementUtils } from '../../../../../common/html-element-utils';
 import { Logger } from '../../../../../common/logging/logger';
-import { FrameCommunicator, MessageRequest } from '../../../../../injected/frameCommunicators/frame-communicator';
-import { FrameMessageResponseCallback, WindowMessageHandler } from '../../../../../injected/frameCommunicators/window-message-handler';
+import {
+    FrameCommunicator,
+    MessageRequest,
+} from '../../../../../injected/frameCommunicators/frame-communicator';
+import {
+    FrameMessageResponseCallback,
+    WindowMessageHandler,
+} from '../../../../../injected/frameCommunicators/window-message-handler';
 import { HTMLCollectionOfBuilder } from '../../../common/html-collection-of-builder';
 import { IsSameObject } from '../../../common/typemoq-helper';
 import { QStub } from '../../../stubs/q-stub';
@@ -42,7 +48,12 @@ describe('FrameCommunicatorTests', () => {
         mockQ = Mock.ofType(QStub) as any;
         const loggerMock = Mock.ofType<Logger>();
 
-        testSubject = new FrameCommunicator(mockWindowMessageHandler.object, mockHtmlElementUtils.object, mockQ.object, loggerMock.object);
+        testSubject = new FrameCommunicator(
+            mockWindowMessageHandler.object,
+            mockHtmlElementUtils.object,
+            mockQ.object,
+            loggerMock.object,
+        );
 
         mockHtmlElementUtils
             .setup(x => x.getAllElementsByTagName('iframe'))
@@ -124,9 +135,9 @@ describe('FrameCommunicatorTests', () => {
     test('verifyDisposeInIframe', () => {
         let disposeCallback: Function;
         const frameRequests: MessageRequest<any>[] = [];
-        const frameRequestCompleteDeferred: Q.Deferred<Q.PromiseState<FrameMessageResponseCallback>[]> = Q.defer<
-            Q.PromiseState<FrameMessageResponseCallback>[]
-        >();
+        const frameRequestCompleteDeferred: Q.Deferred<Q.PromiseState<
+            FrameMessageResponseCallback
+        >[]> = Q.defer<Q.PromiseState<FrameMessageResponseCallback>[]>();
 
         mockWindowMessageHandler
             .setup(x => x.addSubscriber(FrameCommunicator.DisposeCommand, It.isAny()))
@@ -198,7 +209,9 @@ describe('FrameCommunicatorTests', () => {
     test('verifySubscribe', () => {
         const responseCallback = () => {};
 
-        mockWindowMessageHandler.setup(x => x.addSubscriber('command1', responseCallback)).verifiable();
+        mockWindowMessageHandler
+            .setup(x => x.addSubscriber('command1', responseCallback))
+            .verifiable();
 
         testSubject.initialize();
 
@@ -247,7 +260,10 @@ describe('FrameCommunicatorTests', () => {
 
         testSubject.initialize();
 
-        const allFramesExecutedPromise = testSubject.executeRequestForAllFrameRequests(frameRequests, timeoutValue);
+        const allFramesExecutedPromise = testSubject.executeRequestForAllFrameRequests(
+            frameRequests,
+            timeoutValue,
+        );
 
         expect(timeoutDeferred.promise).toEqual(allFramesExecutedPromise);
 
@@ -286,7 +302,15 @@ describe('FrameCommunicatorTests', () => {
         testSubject.initialize();
 
         mockWindowMessageHandler
-            .setup(x => x.post(childFrame1Info.window, FrameCommunicator.PingCommand, null, It.isAny(), undefined))
+            .setup(x =>
+                x.post(
+                    childFrame1Info.window,
+                    FrameCommunicator.PingCommand,
+                    null,
+                    It.isAny(),
+                    undefined,
+                ),
+            )
             .verifiable();
 
         const pingTimeoutDeferred = Q.defer();
@@ -330,7 +354,9 @@ describe('FrameCommunicatorTests', () => {
         testSubject.initialize();
 
         // mock posting ping command
-        mockWindowMessageHandler.setup(x => x.post(It.isAny(), It.isAny(), It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
+        mockWindowMessageHandler
+            .setup(x => x.post(It.isAny(), It.isAny(), It.isAny(), It.isAny(), It.isAny()))
+            .verifiable(Times.never());
 
         const promise = testSubject.sendMessage(frameMessageRequest);
 
@@ -355,7 +381,15 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting ping command
         mockWindowMessageHandler
-            .setup(x => x.post(childFrame1Info.window, FrameCommunicator.PingCommand, null, It.isAny(), undefined))
+            .setup(x =>
+                x.post(
+                    childFrame1Info.window,
+                    FrameCommunicator.PingCommand,
+                    null,
+                    It.isAny(),
+                    undefined,
+                ),
+            )
             .callback((win, command, message, callback) => {
                 pingCallback = callback;
             })
@@ -371,7 +405,15 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting target command
         mockWindowMessageHandler
-            .setup(x => x.post(childFrame1Info.window, windowMessageRequest.command, windowMessageRequest.message, It.isAny(), undefined))
+            .setup(x =>
+                x.post(
+                    childFrame1Info.window,
+                    windowMessageRequest.command,
+                    windowMessageRequest.message,
+                    It.isAny(),
+                    undefined,
+                ),
+            )
             .verifiable();
 
         // mock for the whole request timeout
@@ -417,7 +459,15 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting ping command
         mockWindowMessageHandler
-            .setup(x => x.post(childFrame1Info.window, FrameCommunicator.PingCommand, null, It.isAny(), undefined))
+            .setup(x =>
+                x.post(
+                    childFrame1Info.window,
+                    FrameCommunicator.PingCommand,
+                    null,
+                    It.isAny(),
+                    undefined,
+                ),
+            )
             .callback((win, command, message, callback) => {
                 pingCallback = callback;
             })
@@ -438,7 +488,15 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting target command
         mockWindowMessageHandler
-            .setup(x => x.post(childFrame1Info.window, windowMessageRequest.command, windowMessageRequest.message, It.isAny(), undefined))
+            .setup(x =>
+                x.post(
+                    childFrame1Info.window,
+                    windowMessageRequest.command,
+                    windowMessageRequest.message,
+                    It.isAny(),
+                    undefined,
+                ),
+            )
             .callback((win, command, message, callback) => {
                 commandCallback = callback;
             })
@@ -475,7 +533,15 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting ping command
         mockWindowMessageHandler
-            .setup(x => x.post(childFrame1Info.window, FrameCommunicator.PingCommand, null, It.isAny(), undefined))
+            .setup(x =>
+                x.post(
+                    childFrame1Info.window,
+                    FrameCommunicator.PingCommand,
+                    null,
+                    It.isAny(),
+                    undefined,
+                ),
+            )
             .callback((win, command, message, callback) => {
                 pingCallback = callback;
             })
@@ -498,7 +564,15 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting target command
         mockWindowMessageHandler
-            .setup(x => x.post(childFrame1Info.window, windowMessageRequest.command, windowMessageRequest.message, It.isAny(), undefined))
+            .setup(x =>
+                x.post(
+                    childFrame1Info.window,
+                    windowMessageRequest.command,
+                    windowMessageRequest.message,
+                    It.isAny(),
+                    undefined,
+                ),
+            )
             .callback((win, command, message, callback) => {
                 commandCallback = callback;
             })
@@ -527,7 +601,10 @@ describe('FrameCommunicatorTests', () => {
             message: {},
         };
 
-        childFrame1Info.frameElement.setAttribute('sandbox', 'allow-forms allow-scripts allow-same-origin');
+        childFrame1Info.frameElement.setAttribute(
+            'sandbox',
+            'allow-forms allow-scripts allow-same-origin',
+        );
 
         let pingCallback: Function;
         const commandMsg = {};
@@ -537,7 +614,15 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting ping command
         mockWindowMessageHandler
-            .setup(x => x.post(childFrame1Info.window, FrameCommunicator.PingCommand, null, It.isAny(), undefined))
+            .setup(x =>
+                x.post(
+                    childFrame1Info.window,
+                    FrameCommunicator.PingCommand,
+                    null,
+                    It.isAny(),
+                    undefined,
+                ),
+            )
             .callback((win, command, message, callback) => {
                 pingCallback = callback;
             })
@@ -560,7 +645,15 @@ describe('FrameCommunicatorTests', () => {
 
         // mock posting target command
         mockWindowMessageHandler
-            .setup(x => x.post(childFrame1Info.window, frameMessageRequest.command, frameMessageRequest.message, It.isAny(), undefined))
+            .setup(x =>
+                x.post(
+                    childFrame1Info.window,
+                    frameMessageRequest.command,
+                    frameMessageRequest.message,
+                    It.isAny(),
+                    undefined,
+                ),
+            )
             .callback((win, command, message, callback) => {
                 commandCallback = callback;
             })
@@ -588,21 +681,34 @@ describe('FrameCommunicatorTests', () => {
             window: hasWindow ? ({} as Window) : null,
         };
 
-        mockHtmlElementUtils.setup(x => x.getContentWindow(IsSameObject(frameInfo.frameElement))).returns(() => frameInfo.window);
+        mockHtmlElementUtils
+            .setup(x => x.getContentWindow(IsSameObject(frameInfo.frameElement)))
+            .returns(() => frameInfo.window);
 
         return frameInfo;
     }
 
-    function mockSendMessageToFrameCall(): IMock<(frameMessageRequest: MessageRequest<any>) => void> {
-        const sendMessageToFrameStrictMock = Mock.ofInstance(testSubject.sendMessage, MockBehavior.Strict);
+    function mockSendMessageToFrameCall(): IMock<
+        (frameMessageRequest: MessageRequest<any>) => void
+    > {
+        const sendMessageToFrameStrictMock = Mock.ofInstance(
+            testSubject.sendMessage,
+            MockBehavior.Strict,
+        );
         (testSubject.sendMessage as any) = sendMessageToFrameStrictMock.object;
         return sendMessageToFrameStrictMock;
     }
 
     function mockExecuteRequestForAllFrameRequestsCall(): IMock<
-        (frameMessageRequests: MessageRequest<any>[], timeOut: number) => Q.IPromise<Q.PromiseState<FrameMessageResponseCallback>[]>
+        (
+            frameMessageRequests: MessageRequest<any>[],
+            timeOut: number,
+        ) => Q.IPromise<Q.PromiseState<FrameMessageResponseCallback>[]>
     > {
-        const executeForAllFrameRequestsStrictMock = Mock.ofInstance(testSubject.executeRequestForAllFrameRequests, MockBehavior.Strict);
+        const executeForAllFrameRequestsStrictMock = Mock.ofInstance(
+            testSubject.executeRequestForAllFrameRequests,
+            MockBehavior.Strict,
+        );
         (testSubject.executeRequestForAllFrameRequests as any) = executeForAllFrameRequestsStrictMock.object;
         return executeForAllFrameRequestsStrictMock;
     }

--- a/src/tests/unit/tests/injected/frameCommunicators/html-element-axe-results-helper.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/html-element-axe-results-helper.test.ts
@@ -17,7 +17,10 @@ describe('HtmlElementAxeResultsHelperTest', () => {
     beforeEach(() => {
         mockDocumentElementUtils = Mock.ofType(HTMLElementUtils);
         const loggerMock = Mock.ofType<Logger>();
-        testSubject = new HtmlElementAxeResultsHelper(mockDocumentElementUtils.object, loggerMock.object);
+        testSubject = new HtmlElementAxeResultsHelper(
+            mockDocumentElementUtils.object,
+            loggerMock.object,
+        );
     });
 
     afterEach(() => {
@@ -25,16 +28,27 @@ describe('HtmlElementAxeResultsHelperTest', () => {
     });
 
     test('splitResultsByFrame_ShouldIncludeResultsForMissingFrames', () => {
-        const framesInWindow = HTMLCollectionOfBuilder.create([document.createElement('iframe'), document.createElement('iframe')]);
+        const framesInWindow = HTMLCollectionOfBuilder.create([
+            document.createElement('iframe'),
+            document.createElement('iframe'),
+        ]);
 
-        mockDocumentElementUtils.setup(x => x.getAllElementsByTagName('iframe')).returns(() => framesInWindow);
+        mockDocumentElementUtils
+            .setup(x => x.getAllElementsByTagName('iframe'))
+            .returns(() => framesInWindow);
         const resultsByFrame = testSubject.splitResultsByFrame([]);
 
         expect(resultsByFrame.length).toEqual(3);
         expect(resultsByFrame.filter(result => result.frame == null).length).toEqual(1);
-        expect(resultsByFrame.filter(result => result.frame === framesInWindow[0]).length).toEqual(1);
-        expect(resultsByFrame.filter(result => result.frame === framesInWindow[1]).length).toEqual(1);
-        expect(resultsByFrame.filter(result => result.elementResults.length === 0).length).toEqual(3);
+        expect(resultsByFrame.filter(result => result.frame === framesInWindow[0]).length).toEqual(
+            1,
+        );
+        expect(resultsByFrame.filter(result => result.frame === framesInWindow[1]).length).toEqual(
+            1,
+        );
+        expect(resultsByFrame.filter(result => result.elementResults.length === 0).length).toEqual(
+            3,
+        );
     });
 
     test('splitResultsByFrame_ShouldNotUpdateSelectorForCurrentFrame', () => {
@@ -55,11 +69,17 @@ describe('HtmlElementAxeResultsHelperTest', () => {
             .returns(() => framesInWindow)
             .verifiable();
 
-        const resultsByFrame = testSubject.splitResultsByFrame([currentFrameResultInstance1, currentFrameResultInstance2]);
+        const resultsByFrame = testSubject.splitResultsByFrame([
+            currentFrameResultInstance1,
+            currentFrameResultInstance2,
+        ]);
 
         expect(resultsByFrame.length).toEqual(1);
         expect(resultsByFrame[0].frame).toBeNull();
-        expect(resultsByFrame[0].elementResults).toMatchObject([currentFrameResultInstance1, currentFrameResultInstance2]);
+        expect(resultsByFrame[0].elementResults).toMatchObject([
+            currentFrameResultInstance1,
+            currentFrameResultInstance2,
+        ]);
     });
 
     test('splitResultsByFrame_WithUndefinedTargetIndex_ShouldIncrementTargetIndexByOne', () => {
@@ -148,7 +168,9 @@ describe('HtmlElementAxeResultsHelperTest', () => {
             targetIndex: 5,
         };
 
-        mockDocumentElementUtils.setup(x => x.getAllElementsByTagName('iframe')).returns(() => framesInWindow);
+        mockDocumentElementUtils
+            .setup(x => x.getAllElementsByTagName('iframe'))
+            .returns(() => framesInWindow);
 
         const resultsByFrame = testSubject.splitResultsByFrame([frameResult]);
         const resultsForTargetFrame = resultsByFrame.filter(result => result.frame === frame1)[0];

--- a/src/tests/unit/tests/injected/frameCommunicators/html-element-axe-results-helper.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/html-element-axe-results-helper.test.ts
@@ -17,10 +17,7 @@ describe('HtmlElementAxeResultsHelperTest', () => {
     beforeEach(() => {
         mockDocumentElementUtils = Mock.ofType(HTMLElementUtils);
         const loggerMock = Mock.ofType<Logger>();
-        testSubject = new HtmlElementAxeResultsHelper(
-            mockDocumentElementUtils.object,
-            loggerMock.object,
-        );
+        testSubject = new HtmlElementAxeResultsHelper(mockDocumentElementUtils.object, loggerMock.object);
     });
 
     afterEach(() => {
@@ -28,27 +25,16 @@ describe('HtmlElementAxeResultsHelperTest', () => {
     });
 
     test('splitResultsByFrame_ShouldIncludeResultsForMissingFrames', () => {
-        const framesInWindow = HTMLCollectionOfBuilder.create([
-            document.createElement('iframe'),
-            document.createElement('iframe'),
-        ]);
+        const framesInWindow = HTMLCollectionOfBuilder.create([document.createElement('iframe'), document.createElement('iframe')]);
 
-        mockDocumentElementUtils
-            .setup(x => x.getAllElementsByTagName('iframe'))
-            .returns(() => framesInWindow);
+        mockDocumentElementUtils.setup(x => x.getAllElementsByTagName('iframe')).returns(() => framesInWindow);
         const resultsByFrame = testSubject.splitResultsByFrame([]);
 
         expect(resultsByFrame.length).toEqual(3);
         expect(resultsByFrame.filter(result => result.frame == null).length).toEqual(1);
-        expect(resultsByFrame.filter(result => result.frame === framesInWindow[0]).length).toEqual(
-            1,
-        );
-        expect(resultsByFrame.filter(result => result.frame === framesInWindow[1]).length).toEqual(
-            1,
-        );
-        expect(resultsByFrame.filter(result => result.elementResults.length === 0).length).toEqual(
-            3,
-        );
+        expect(resultsByFrame.filter(result => result.frame === framesInWindow[0]).length).toEqual(1);
+        expect(resultsByFrame.filter(result => result.frame === framesInWindow[1]).length).toEqual(1);
+        expect(resultsByFrame.filter(result => result.elementResults.length === 0).length).toEqual(3);
     });
 
     test('splitResultsByFrame_ShouldNotUpdateSelectorForCurrentFrame', () => {
@@ -69,17 +55,11 @@ describe('HtmlElementAxeResultsHelperTest', () => {
             .returns(() => framesInWindow)
             .verifiable();
 
-        const resultsByFrame = testSubject.splitResultsByFrame([
-            currentFrameResultInstance1,
-            currentFrameResultInstance2,
-        ]);
+        const resultsByFrame = testSubject.splitResultsByFrame([currentFrameResultInstance1, currentFrameResultInstance2]);
 
         expect(resultsByFrame.length).toEqual(1);
         expect(resultsByFrame[0].frame).toBeNull();
-        expect(resultsByFrame[0].elementResults).toMatchObject([
-            currentFrameResultInstance1,
-            currentFrameResultInstance2,
-        ]);
+        expect(resultsByFrame[0].elementResults).toMatchObject([currentFrameResultInstance1, currentFrameResultInstance2]);
     });
 
     test('splitResultsByFrame_WithUndefinedTargetIndex_ShouldIncrementTargetIndexByOne', () => {
@@ -168,9 +148,7 @@ describe('HtmlElementAxeResultsHelperTest', () => {
             targetIndex: 5,
         };
 
-        mockDocumentElementUtils
-            .setup(x => x.getAllElementsByTagName('iframe'))
-            .returns(() => framesInWindow);
+        mockDocumentElementUtils.setup(x => x.getAllElementsByTagName('iframe')).returns(() => framesInWindow);
 
         const resultsByFrame = testSubject.splitResultsByFrame([frameResult]);
         const resultsForTargetFrame = resultsByFrame.filter(result => result.frame === frame1)[0];

--- a/src/tests/unit/tests/injected/frameCommunicators/window-message-handler.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/window-message-handler.test.ts
@@ -5,7 +5,10 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { WindowUtils } from '../../../../../common/window-utils';
 import { ErrorMessageContent } from '../../../../../injected/frameCommunicators/error-message-content';
 import { WindowMessage } from '../../../../../injected/frameCommunicators/window-message';
-import { FrameMessageResponseCallback, WindowMessageHandler } from '../../../../../injected/frameCommunicators/window-message-handler';
+import {
+    FrameMessageResponseCallback,
+    WindowMessageHandler,
+} from '../../../../../injected/frameCommunicators/window-message-handler';
 import { WindowMessageMarshaller } from '../../../../../injected/frameCommunicators/window-message-marshaller';
 
 describe('WindowMessageHandlerTests', () => {
@@ -32,7 +35,10 @@ describe('WindowMessageHandlerTests', () => {
             })
             .verifiable(Times.once());
 
-        testSubject = new WindowMessageHandler(mockWindowUtils.object, mockMessageMarshaller.object);
+        testSubject = new WindowMessageHandler(
+            mockWindowUtils.object,
+            mockMessageMarshaller.object,
+        );
     });
 
     afterEach(() => {
@@ -41,7 +47,9 @@ describe('WindowMessageHandlerTests', () => {
     });
 
     test('shouldNotInitializeMoreThanOnce', () => {
-        mockWindowUtils.setup(x => x.addEventListener(window, 'message', It.isAny(), false)).verifiable(Times.once());
+        mockWindowUtils
+            .setup(x => x.addEventListener(window, 'message', It.isAny(), false))
+            .verifiable(Times.once());
 
         testSubject.initialize();
         testSubject.initialize();
@@ -53,7 +61,9 @@ describe('WindowMessageHandlerTests', () => {
         mockWindowUtils.verifyAll();
         mockWindowUtils.reset();
 
-        mockWindowUtils.setup(x => x.removeEventListener(window, 'message', messageCallback, false)).verifiable(Times.once());
+        mockWindowUtils
+            .setup(x => x.removeEventListener(window, 'message', messageCallback, false))
+            .verifiable(Times.once());
 
         testSubject.dispose();
 
@@ -65,22 +75,38 @@ describe('WindowMessageHandlerTests', () => {
         const targetWindow = {} as Window;
         const sampleMessage = getSampleMessageWithResponseId();
 
-        const createFrameResponderCallbackMock = Mock.ofInstance(testSubject.createFrameResponderCallback);
+        const createFrameResponderCallbackMock = Mock.ofInstance(
+            testSubject.createFrameResponderCallback,
+        );
         (testSubject.createFrameResponderCallback as any) = createFrameResponderCallbackMock.object;
 
         mockMessageMarshaller
-            .setup(x => x.createMessage(sampleMessage.command, sampleMessage.message, sampleMessage.messageId))
+            .setup(x =>
+                x.createMessage(
+                    sampleMessage.command,
+                    sampleMessage.message,
+                    sampleMessage.messageId,
+                ),
+            )
             .returns(() => sampleMessage)
             .verifiable();
 
-        mockWindowUtils.setup(x => x.postMessage(targetWindow, sampleMessage, '*')).verifiable(Times.once());
+        mockWindowUtils
+            .setup(x => x.postMessage(targetWindow, sampleMessage, '*'))
+            .verifiable(Times.once());
 
         createFrameResponderCallbackMock
             .setup(x => x(targetWindow, sampleMessage.command, sampleMessage.messageId))
             .returns(() => () => {});
 
         // sending message to iframe
-        testSubject.post(targetWindow, sampleMessage.command, sampleMessage.message, null, sampleMessage.messageId);
+        testSubject.post(
+            targetWindow,
+            sampleMessage.command,
+            sampleMessage.message,
+            null,
+            sampleMessage.messageId,
+        );
 
         mockWindowUtils.verifyAll();
         mockMessageMarshaller.verifyAll();
@@ -103,14 +129,28 @@ describe('WindowMessageHandlerTests', () => {
         };
 
         mockMessageMarshaller
-            .setup(x => x.createMessage(sampleMessage.command, sampleMessage.message, sampleMessage.messageId))
+            .setup(x =>
+                x.createMessage(
+                    sampleMessage.command,
+                    sampleMessage.message,
+                    sampleMessage.messageId,
+                ),
+            )
             .returns(() => sampleMessage)
             .verifiable();
 
-        mockWindowUtils.setup(x => x.postMessage(targetWindow, sampleMessage, '*')).verifiable(Times.once());
+        mockWindowUtils
+            .setup(x => x.postMessage(targetWindow, sampleMessage, '*'))
+            .verifiable(Times.once());
 
         // sending message to iframe
-        testSubject.post(targetWindow, sampleMessage.command, sampleMessage.message, callback, sampleMessage.messageId);
+        testSubject.post(
+            targetWindow,
+            sampleMessage.command,
+            sampleMessage.message,
+            callback,
+            sampleMessage.messageId,
+        );
 
         mockWindowUtils.verifyAll();
         mockMessageMarshaller.verifyAll();
@@ -120,8 +160,13 @@ describe('WindowMessageHandlerTests', () => {
             data: 'responseMessage',
         } as MessageEvent;
 
-        const responseMessage: WindowMessage = { messageId: 'anotherid', message: '' } as WindowMessage;
-        mockMessageMarshaller.setup(x => x.parseMessage(responseEvent.data)).returns(() => responseMessage);
+        const responseMessage: WindowMessage = {
+            messageId: 'anotherid',
+            message: '',
+        } as WindowMessage;
+        mockMessageMarshaller
+            .setup(x => x.parseMessage(responseEvent.data))
+            .returns(() => responseMessage);
         messageCallback(responseEvent);
 
         expect(isResponseCallbackInvoked).toBe(false);
@@ -148,13 +193,27 @@ describe('WindowMessageHandlerTests', () => {
         };
 
         mockMessageMarshaller
-            .setup(x => x.createMessage(sampleMessage.command, sampleMessage.message, sampleMessage.messageId))
+            .setup(x =>
+                x.createMessage(
+                    sampleMessage.command,
+                    sampleMessage.message,
+                    sampleMessage.messageId,
+                ),
+            )
             .returns(() => sampleMessage);
 
-        mockWindowUtils.setup(x => x.postMessage(targetWindow, sampleMessage, '*')).verifiable(Times.once());
+        mockWindowUtils
+            .setup(x => x.postMessage(targetWindow, sampleMessage, '*'))
+            .verifiable(Times.once());
 
         // sending message to iframe
-        testSubject.post(targetWindow, sampleMessage.command, sampleMessage.message, callback, sampleMessage.messageId);
+        testSubject.post(
+            targetWindow,
+            sampleMessage.command,
+            sampleMessage.message,
+            callback,
+            sampleMessage.messageId,
+        );
 
         mockWindowUtils.verifyAll();
         mockMessageMarshaller.verifyAll();
@@ -164,7 +223,9 @@ describe('WindowMessageHandlerTests', () => {
             data: 'responseMessage',
         } as MessageEvent;
 
-        mockMessageMarshaller.setup(x => x.parseMessage(responseEvent.data)).returns(() => responseMessage);
+        mockMessageMarshaller
+            .setup(x => x.parseMessage(responseEvent.data))
+            .returns(() => responseMessage);
         messageCallback(responseEvent);
 
         expect(isResponseCallbackInvoked).toBe(true);
@@ -189,13 +250,27 @@ describe('WindowMessageHandlerTests', () => {
         };
 
         mockMessageMarshaller
-            .setup(x => x.createMessage(sampleMessage.command, sampleMessage.message, sampleMessage.messageId))
+            .setup(x =>
+                x.createMessage(
+                    sampleMessage.command,
+                    sampleMessage.message,
+                    sampleMessage.messageId,
+                ),
+            )
             .returns(() => sampleMessage);
 
-        mockWindowUtils.setup(x => x.postMessage(targetWindow, sampleMessage, '*')).verifiable(Times.once());
+        mockWindowUtils
+            .setup(x => x.postMessage(targetWindow, sampleMessage, '*'))
+            .verifiable(Times.once());
 
         // sending message to iframe (to register callback)
-        testSubject.post(targetWindow, sampleMessage.command, sampleMessage.message, callback, sampleMessage.messageId);
+        testSubject.post(
+            targetWindow,
+            sampleMessage.command,
+            sampleMessage.message,
+            callback,
+            sampleMessage.messageId,
+        );
 
         mockWindowUtils.verifyAll();
         mockMessageMarshaller.verifyAll();
@@ -208,7 +283,9 @@ describe('WindowMessageHandlerTests', () => {
         // adding subscriber after callback is registered
         testSubject.addSubscriber(sampleMessage.command, callback);
 
-        mockMessageMarshaller.setup(x => x.parseMessage(responseEvent.data)).returns(() => responseMessage);
+        mockMessageMarshaller
+            .setup(x => x.parseMessage(responseEvent.data))
+            .returns(() => responseMessage);
         messageCallback(responseEvent);
 
         expect(isResponseCallbackInvoked).toBe(true);
@@ -239,7 +316,9 @@ describe('WindowMessageHandlerTests', () => {
         });
 
         const responseEvent: MessageEvent = { data: 'responseMessage' } as MessageEvent;
-        mockMessageMarshaller.setup(x => x.parseMessage(responseEvent.data)).returns(() => responseMessage);
+        mockMessageMarshaller
+            .setup(x => x.parseMessage(responseEvent.data))
+            .returns(() => responseMessage);
         messageCallback(responseEvent);
 
         expect(isResponseCallbackInvoked).toBe(true);
@@ -273,10 +352,14 @@ describe('WindowMessageHandlerTests', () => {
             .returns(() => responseMessage)
             .verifiable();
         mockMessageMarshaller
-            .setup(x => x.createMessage(responseMessage.command, sampleError, responseMessage.messageId))
+            .setup(x =>
+                x.createMessage(responseMessage.command, sampleError, responseMessage.messageId),
+            )
             .returns(() => responseMessage)
             .verifiable();
-        mockWindowUtils.setup(x => x.postMessage(responseEvent.source as Window, responseMessage, '*')).verifiable(Times.once());
+        mockWindowUtils
+            .setup(x => x.postMessage(responseEvent.source as Window, responseMessage, '*'))
+            .verifiable(Times.once());
 
         messageCallback(responseEvent);
 
@@ -306,7 +389,9 @@ describe('WindowMessageHandlerTests', () => {
         const responseEvent: MessageEvent = {
             data: 'responseMessage',
         } as MessageEvent;
-        mockMessageMarshaller.setup(x => x.parseMessage(responseEvent.data)).returns(() => responseMessage);
+        mockMessageMarshaller
+            .setup(x => x.parseMessage(responseEvent.data))
+            .returns(() => responseMessage);
 
         messageCallback(responseEvent);
 
@@ -319,13 +404,25 @@ describe('WindowMessageHandlerTests', () => {
         const sampleMessage = getSampleMessageWithResponseId();
         const targetWindow = {} as Window;
 
-        const frameCallback = testSubject.createFrameResponderCallback(targetWindow, sampleMessage.command, sampleMessage.messageId);
+        const frameCallback = testSubject.createFrameResponderCallback(
+            targetWindow,
+            sampleMessage.command,
+            sampleMessage.messageId,
+        );
 
         mockMessageMarshaller
-            .setup(x => x.createMessage(sampleMessage.command, sampleMessage.message, sampleMessage.messageId))
+            .setup(x =>
+                x.createMessage(
+                    sampleMessage.command,
+                    sampleMessage.message,
+                    sampleMessage.messageId,
+                ),
+            )
             .returns(() => sampleMessage)
             .verifiable(Times.once());
-        mockWindowUtils.setup(x => x.postMessage(targetWindow, sampleMessage, '*')).verifiable(Times.once());
+        mockWindowUtils
+            .setup(x => x.postMessage(targetWindow, sampleMessage, '*'))
+            .verifiable(Times.once());
 
         frameCallback(sampleMessage.message, sampleMessage.error, null);
 

--- a/src/tests/unit/tests/injected/frameCommunicators/window-message-handler.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/window-message-handler.test.ts
@@ -5,10 +5,7 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { WindowUtils } from '../../../../../common/window-utils';
 import { ErrorMessageContent } from '../../../../../injected/frameCommunicators/error-message-content';
 import { WindowMessage } from '../../../../../injected/frameCommunicators/window-message';
-import {
-    FrameMessageResponseCallback,
-    WindowMessageHandler,
-} from '../../../../../injected/frameCommunicators/window-message-handler';
+import { FrameMessageResponseCallback, WindowMessageHandler } from '../../../../../injected/frameCommunicators/window-message-handler';
 import { WindowMessageMarshaller } from '../../../../../injected/frameCommunicators/window-message-marshaller';
 
 describe('WindowMessageHandlerTests', () => {
@@ -35,10 +32,7 @@ describe('WindowMessageHandlerTests', () => {
             })
             .verifiable(Times.once());
 
-        testSubject = new WindowMessageHandler(
-            mockWindowUtils.object,
-            mockMessageMarshaller.object,
-        );
+        testSubject = new WindowMessageHandler(mockWindowUtils.object, mockMessageMarshaller.object);
     });
 
     afterEach(() => {
@@ -47,9 +41,7 @@ describe('WindowMessageHandlerTests', () => {
     });
 
     test('shouldNotInitializeMoreThanOnce', () => {
-        mockWindowUtils
-            .setup(x => x.addEventListener(window, 'message', It.isAny(), false))
-            .verifiable(Times.once());
+        mockWindowUtils.setup(x => x.addEventListener(window, 'message', It.isAny(), false)).verifiable(Times.once());
 
         testSubject.initialize();
         testSubject.initialize();
@@ -61,9 +53,7 @@ describe('WindowMessageHandlerTests', () => {
         mockWindowUtils.verifyAll();
         mockWindowUtils.reset();
 
-        mockWindowUtils
-            .setup(x => x.removeEventListener(window, 'message', messageCallback, false))
-            .verifiable(Times.once());
+        mockWindowUtils.setup(x => x.removeEventListener(window, 'message', messageCallback, false)).verifiable(Times.once());
 
         testSubject.dispose();
 
@@ -75,38 +65,22 @@ describe('WindowMessageHandlerTests', () => {
         const targetWindow = {} as Window;
         const sampleMessage = getSampleMessageWithResponseId();
 
-        const createFrameResponderCallbackMock = Mock.ofInstance(
-            testSubject.createFrameResponderCallback,
-        );
+        const createFrameResponderCallbackMock = Mock.ofInstance(testSubject.createFrameResponderCallback);
         (testSubject.createFrameResponderCallback as any) = createFrameResponderCallbackMock.object;
 
         mockMessageMarshaller
-            .setup(x =>
-                x.createMessage(
-                    sampleMessage.command,
-                    sampleMessage.message,
-                    sampleMessage.messageId,
-                ),
-            )
+            .setup(x => x.createMessage(sampleMessage.command, sampleMessage.message, sampleMessage.messageId))
             .returns(() => sampleMessage)
             .verifiable();
 
-        mockWindowUtils
-            .setup(x => x.postMessage(targetWindow, sampleMessage, '*'))
-            .verifiable(Times.once());
+        mockWindowUtils.setup(x => x.postMessage(targetWindow, sampleMessage, '*')).verifiable(Times.once());
 
         createFrameResponderCallbackMock
             .setup(x => x(targetWindow, sampleMessage.command, sampleMessage.messageId))
             .returns(() => () => {});
 
         // sending message to iframe
-        testSubject.post(
-            targetWindow,
-            sampleMessage.command,
-            sampleMessage.message,
-            null,
-            sampleMessage.messageId,
-        );
+        testSubject.post(targetWindow, sampleMessage.command, sampleMessage.message, null, sampleMessage.messageId);
 
         mockWindowUtils.verifyAll();
         mockMessageMarshaller.verifyAll();
@@ -129,28 +103,14 @@ describe('WindowMessageHandlerTests', () => {
         };
 
         mockMessageMarshaller
-            .setup(x =>
-                x.createMessage(
-                    sampleMessage.command,
-                    sampleMessage.message,
-                    sampleMessage.messageId,
-                ),
-            )
+            .setup(x => x.createMessage(sampleMessage.command, sampleMessage.message, sampleMessage.messageId))
             .returns(() => sampleMessage)
             .verifiable();
 
-        mockWindowUtils
-            .setup(x => x.postMessage(targetWindow, sampleMessage, '*'))
-            .verifiable(Times.once());
+        mockWindowUtils.setup(x => x.postMessage(targetWindow, sampleMessage, '*')).verifiable(Times.once());
 
         // sending message to iframe
-        testSubject.post(
-            targetWindow,
-            sampleMessage.command,
-            sampleMessage.message,
-            callback,
-            sampleMessage.messageId,
-        );
+        testSubject.post(targetWindow, sampleMessage.command, sampleMessage.message, callback, sampleMessage.messageId);
 
         mockWindowUtils.verifyAll();
         mockMessageMarshaller.verifyAll();
@@ -164,9 +124,7 @@ describe('WindowMessageHandlerTests', () => {
             messageId: 'anotherid',
             message: '',
         } as WindowMessage;
-        mockMessageMarshaller
-            .setup(x => x.parseMessage(responseEvent.data))
-            .returns(() => responseMessage);
+        mockMessageMarshaller.setup(x => x.parseMessage(responseEvent.data)).returns(() => responseMessage);
         messageCallback(responseEvent);
 
         expect(isResponseCallbackInvoked).toBe(false);
@@ -193,27 +151,13 @@ describe('WindowMessageHandlerTests', () => {
         };
 
         mockMessageMarshaller
-            .setup(x =>
-                x.createMessage(
-                    sampleMessage.command,
-                    sampleMessage.message,
-                    sampleMessage.messageId,
-                ),
-            )
+            .setup(x => x.createMessage(sampleMessage.command, sampleMessage.message, sampleMessage.messageId))
             .returns(() => sampleMessage);
 
-        mockWindowUtils
-            .setup(x => x.postMessage(targetWindow, sampleMessage, '*'))
-            .verifiable(Times.once());
+        mockWindowUtils.setup(x => x.postMessage(targetWindow, sampleMessage, '*')).verifiable(Times.once());
 
         // sending message to iframe
-        testSubject.post(
-            targetWindow,
-            sampleMessage.command,
-            sampleMessage.message,
-            callback,
-            sampleMessage.messageId,
-        );
+        testSubject.post(targetWindow, sampleMessage.command, sampleMessage.message, callback, sampleMessage.messageId);
 
         mockWindowUtils.verifyAll();
         mockMessageMarshaller.verifyAll();
@@ -223,9 +167,7 @@ describe('WindowMessageHandlerTests', () => {
             data: 'responseMessage',
         } as MessageEvent;
 
-        mockMessageMarshaller
-            .setup(x => x.parseMessage(responseEvent.data))
-            .returns(() => responseMessage);
+        mockMessageMarshaller.setup(x => x.parseMessage(responseEvent.data)).returns(() => responseMessage);
         messageCallback(responseEvent);
 
         expect(isResponseCallbackInvoked).toBe(true);
@@ -250,27 +192,13 @@ describe('WindowMessageHandlerTests', () => {
         };
 
         mockMessageMarshaller
-            .setup(x =>
-                x.createMessage(
-                    sampleMessage.command,
-                    sampleMessage.message,
-                    sampleMessage.messageId,
-                ),
-            )
+            .setup(x => x.createMessage(sampleMessage.command, sampleMessage.message, sampleMessage.messageId))
             .returns(() => sampleMessage);
 
-        mockWindowUtils
-            .setup(x => x.postMessage(targetWindow, sampleMessage, '*'))
-            .verifiable(Times.once());
+        mockWindowUtils.setup(x => x.postMessage(targetWindow, sampleMessage, '*')).verifiable(Times.once());
 
         // sending message to iframe (to register callback)
-        testSubject.post(
-            targetWindow,
-            sampleMessage.command,
-            sampleMessage.message,
-            callback,
-            sampleMessage.messageId,
-        );
+        testSubject.post(targetWindow, sampleMessage.command, sampleMessage.message, callback, sampleMessage.messageId);
 
         mockWindowUtils.verifyAll();
         mockMessageMarshaller.verifyAll();
@@ -283,9 +211,7 @@ describe('WindowMessageHandlerTests', () => {
         // adding subscriber after callback is registered
         testSubject.addSubscriber(sampleMessage.command, callback);
 
-        mockMessageMarshaller
-            .setup(x => x.parseMessage(responseEvent.data))
-            .returns(() => responseMessage);
+        mockMessageMarshaller.setup(x => x.parseMessage(responseEvent.data)).returns(() => responseMessage);
         messageCallback(responseEvent);
 
         expect(isResponseCallbackInvoked).toBe(true);
@@ -316,9 +242,7 @@ describe('WindowMessageHandlerTests', () => {
         });
 
         const responseEvent: MessageEvent = { data: 'responseMessage' } as MessageEvent;
-        mockMessageMarshaller
-            .setup(x => x.parseMessage(responseEvent.data))
-            .returns(() => responseMessage);
+        mockMessageMarshaller.setup(x => x.parseMessage(responseEvent.data)).returns(() => responseMessage);
         messageCallback(responseEvent);
 
         expect(isResponseCallbackInvoked).toBe(true);
@@ -352,14 +276,10 @@ describe('WindowMessageHandlerTests', () => {
             .returns(() => responseMessage)
             .verifiable();
         mockMessageMarshaller
-            .setup(x =>
-                x.createMessage(responseMessage.command, sampleError, responseMessage.messageId),
-            )
+            .setup(x => x.createMessage(responseMessage.command, sampleError, responseMessage.messageId))
             .returns(() => responseMessage)
             .verifiable();
-        mockWindowUtils
-            .setup(x => x.postMessage(responseEvent.source as Window, responseMessage, '*'))
-            .verifiable(Times.once());
+        mockWindowUtils.setup(x => x.postMessage(responseEvent.source as Window, responseMessage, '*')).verifiable(Times.once());
 
         messageCallback(responseEvent);
 
@@ -389,9 +309,7 @@ describe('WindowMessageHandlerTests', () => {
         const responseEvent: MessageEvent = {
             data: 'responseMessage',
         } as MessageEvent;
-        mockMessageMarshaller
-            .setup(x => x.parseMessage(responseEvent.data))
-            .returns(() => responseMessage);
+        mockMessageMarshaller.setup(x => x.parseMessage(responseEvent.data)).returns(() => responseMessage);
 
         messageCallback(responseEvent);
 
@@ -404,25 +322,13 @@ describe('WindowMessageHandlerTests', () => {
         const sampleMessage = getSampleMessageWithResponseId();
         const targetWindow = {} as Window;
 
-        const frameCallback = testSubject.createFrameResponderCallback(
-            targetWindow,
-            sampleMessage.command,
-            sampleMessage.messageId,
-        );
+        const frameCallback = testSubject.createFrameResponderCallback(targetWindow, sampleMessage.command, sampleMessage.messageId);
 
         mockMessageMarshaller
-            .setup(x =>
-                x.createMessage(
-                    sampleMessage.command,
-                    sampleMessage.message,
-                    sampleMessage.messageId,
-                ),
-            )
+            .setup(x => x.createMessage(sampleMessage.command, sampleMessage.message, sampleMessage.messageId))
             .returns(() => sampleMessage)
             .verifiable(Times.once());
-        mockWindowUtils
-            .setup(x => x.postMessage(targetWindow, sampleMessage, '*'))
-            .verifiable(Times.once());
+        mockWindowUtils.setup(x => x.postMessage(targetWindow, sampleMessage, '*')).verifiable(Times.once());
 
         frameCallback(sampleMessage.message, sampleMessage.error, null);
 

--- a/src/tests/unit/tests/injected/frameCommunicators/window-message-marshaller.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/window-message-marshaller.test.ts
@@ -4,7 +4,10 @@ import { IMock, Mock } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
 import { WindowMessage } from '../../../../../injected/frameCommunicators/window-message';
-import { MESSAGE_STABLE_SIGNATURE, WindowMessageMarshaller } from '../../../../../injected/frameCommunicators/window-message-marshaller';
+import {
+    MESSAGE_STABLE_SIGNATURE,
+    WindowMessageMarshaller,
+} from '../../../../../injected/frameCommunicators/window-message-marshaller';
 
 describe('WindowMessageMarshallerTests', () => {
     let testSubject: WindowMessageMarshaller;
@@ -202,6 +205,8 @@ describe('WindowMessageMarshallerTests', () => {
         // Using strings instead of strongly typed names to avoid accidentally tool-refactoring the names/values
         // such that this test still passes but our partners break; those partners depend on this *exact* format
         // to distinguish our messages from unknown/assumed-malicious messages.
-        expect(actualMessage['messageStableSignature']).toBe('e467510c-ca1f-47df-ace1-a39f7f0678c9');
+        expect(actualMessage['messageStableSignature']).toBe(
+            'e467510c-ca1f-47df-ace1-a39f7f0678c9',
+        );
     });
 });

--- a/src/tests/unit/tests/injected/frameCommunicators/window-message-marshaller.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/window-message-marshaller.test.ts
@@ -4,10 +4,7 @@ import { IMock, Mock } from 'typemoq';
 
 import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
 import { WindowMessage } from '../../../../../injected/frameCommunicators/window-message';
-import {
-    MESSAGE_STABLE_SIGNATURE,
-    WindowMessageMarshaller,
-} from '../../../../../injected/frameCommunicators/window-message-marshaller';
+import { MESSAGE_STABLE_SIGNATURE, WindowMessageMarshaller } from '../../../../../injected/frameCommunicators/window-message-marshaller';
 
 describe('WindowMessageMarshallerTests', () => {
     let testSubject: WindowMessageMarshaller;
@@ -205,8 +202,6 @@ describe('WindowMessageMarshallerTests', () => {
         // Using strings instead of strongly typed names to avoid accidentally tool-refactoring the names/values
         // such that this test still passes but our partners break; those partners depend on this *exact* format
         // to distinguish our messages from unknown/assumed-malicious messages.
-        expect(actualMessage['messageStableSignature']).toBe(
-            'e467510c-ca1f-47df-ace1-a39f7f0678c9',
-        );
+        expect(actualMessage['messageStableSignature']).toBe('e467510c-ca1f-47df-ace1-a39f7f0678c9');
     });
 });

--- a/src/tests/unit/tests/injected/get-decorated-axe-node.test.ts
+++ b/src/tests/unit/tests/injected/get-decorated-axe-node.test.ts
@@ -45,6 +45,8 @@ describe('GetDecoratedAxeNodeResult', () => {
             }),
         };
 
-        expect(getDecoratedAxeNode(unifiedResult, unifiedRule, selectorStub)).toEqual(expectedResult);
+        expect(getDecoratedAxeNode(unifiedResult, unifiedRule, selectorStub)).toEqual(
+            expectedResult,
+        );
     });
 });

--- a/src/tests/unit/tests/injected/inspect-controller.test.ts
+++ b/src/tests/unit/tests/injected/inspect-controller.test.ts
@@ -3,7 +3,10 @@
 import { InspectMode } from 'background/inspect-modes';
 import { InspectStore } from 'background/stores/inspect-store';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { ConfigurationKey, InspectConfigurationFactory } from '../../../../common/configs/inspect-configuration-factory';
+import {
+    ConfigurationKey,
+    InspectConfigurationFactory,
+} from '../../../../common/configs/inspect-configuration-factory';
 import { InspectStoreData } from '../../../../common/types/store-data/inspect-store-data';
 import { InspectController } from '../../../../injected/inspect-controller';
 import { ScopingListener } from '../../../../injected/scoping-listener';
@@ -15,14 +18,22 @@ describe('InspectControllerTests', () => {
     let inspectConfigurationMock: IMock<InspectConfigurationFactory>;
     let defaultState: InspectMode;
     let onHoverStub: (selector: string[]) => void;
-    let changeInspectModeMock: IMock<(event: React.MouseEvent<HTMLButtonElement> | MouseEvent, inspectMode: InspectMode) => void>;
+    let changeInspectModeMock: IMock<(
+        event: React.MouseEvent<HTMLButtonElement> | MouseEvent,
+        inspectMode: InspectMode,
+    ) => void>;
     let testObject: InspectController;
 
     beforeEach(() => {
         inspectStoreMock = Mock.ofType(InspectStore);
         scopingListenerMock = Mock.ofType(ScopingListener, MockBehavior.Strict);
         inspectConfigurationMock = Mock.ofType(InspectConfigurationFactory, MockBehavior.Strict);
-        changeInspectModeMock = Mock.ofInstance((event: React.MouseEvent<HTMLButtonElement> | MouseEvent, inspectMode: InspectMode) => {});
+        changeInspectModeMock = Mock.ofInstance(
+            (
+                event: React.MouseEvent<HTMLButtonElement> | MouseEvent,
+                inspectMode: InspectMode,
+            ) => {},
+        );
         onHoverStub = () => {};
 
         testObject = new InspectController(
@@ -49,7 +60,9 @@ describe('InspectControllerTests', () => {
 
     test('do not start inspect if inspect store state is null', () => {
         inspectStoreState = null;
-        changeInspectModeMock.setup(sm => sm(It.isAny(), It.isValue(defaultState))).verifiable(Times.once());
+        changeInspectModeMock
+            .setup(sm => sm(It.isAny(), It.isValue(defaultState)))
+            .verifiable(Times.once());
 
         testObject.listenToStore();
         inspectStoreMock.verifyAll();
@@ -65,10 +78,14 @@ describe('InspectControllerTests', () => {
         };
         let sendSelector;
 
-        changeInspectModeMock.setup(sm => sm(It.isAny(), It.isValue(inspectType))).verifiable(Times.once());
+        changeInspectModeMock
+            .setup(sm => sm(It.isAny(), It.isValue(inspectType)))
+            .verifiable(Times.once());
 
         const inspectConfigMock = Mock.ofInstance((event, selector) => {});
-        inspectConfigMock.setup(sm => sm(It.isAny(), It.isValue(givenSelector))).verifiable(Times.once());
+        inspectConfigMock
+            .setup(sm => sm(It.isAny(), It.isValue(givenSelector)))
+            .verifiable(Times.once());
 
         scopingListenerMock
             .setup(sm => sm.start(It.isAny(), onHoverStub))
@@ -98,10 +115,14 @@ describe('InspectControllerTests', () => {
 
         const givenSelector = ['selector'];
 
-        changeInspectModeMock.setup(sm => sm(It.isAny(), It.isValue(defaultState))).verifiable(Times.once());
+        changeInspectModeMock
+            .setup(sm => sm(It.isAny(), It.isValue(defaultState)))
+            .verifiable(Times.once());
 
         const inspectConfigMock = Mock.ofInstance((event, selector) => {});
-        inspectConfigMock.setup(sm => sm(It.isAny(), It.isValue(givenSelector))).verifiable(Times.once());
+        inspectConfigMock
+            .setup(sm => sm(It.isAny(), It.isValue(givenSelector)))
+            .verifiable(Times.once());
 
         scopingListenerMock.setup(sm => sm.stop()).verifiable(Times.never());
 

--- a/src/tests/unit/tests/injected/is-visualization-enabled.test.ts
+++ b/src/tests/unit/tests/injected/is-visualization-enabled.test.ts
@@ -7,7 +7,10 @@ import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { ScanData, VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { IMock, Mock } from 'typemoq';
 
-import { isVisualizationEnabled, IsVisualizationEnabledCallback } from '../../../../injected/is-visualization-enabled';
+import {
+    isVisualizationEnabled,
+    IsVisualizationEnabledCallback,
+} from '../../../../injected/is-visualization-enabled';
 
 describe('isVisualizationEnabled', () => {
     let visualizationConfigurationMock: IMock<VisualizationConfiguration>;
@@ -26,38 +29,78 @@ describe('isVisualizationEnabled', () => {
         scanDataStub = {} as ScanData;
         stepStub = 'some step';
 
-        visualizationConfigurationMock.setup(config => config.getStoreData(visualizationState.tests)).returns(() => scanDataStub);
+        visualizationConfigurationMock
+            .setup(config => config.getStoreData(visualizationState.tests))
+            .returns(() => scanDataStub);
 
         testSubject = isVisualizationEnabled;
     });
 
     test('testStatus is false', () => {
-        visualizationConfigurationMock.setup(config => config.getTestStatus(scanDataStub, stepStub)).returns(() => false);
+        visualizationConfigurationMock
+            .setup(config => config.getTestStatus(scanDataStub, stepStub))
+            .returns(() => false);
 
-        expect(testSubject(visualizationConfigurationMock.object, stepStub, visualizationState, assessmentState, tabState)).toEqual(false);
+        expect(
+            testSubject(
+                visualizationConfigurationMock.object,
+                stepStub,
+                visualizationState,
+                assessmentState,
+                tabState,
+            ),
+        ).toEqual(false);
     });
 
     test('testStatus is true & is not an assessment test', () => {
-        visualizationConfigurationMock.setup(config => config.getTestStatus(scanDataStub, stepStub)).returns(() => true);
-        visualizationConfigurationMock.setup(config => config.testMode).returns(() => TestMode.Adhoc);
+        visualizationConfigurationMock
+            .setup(config => config.getTestStatus(scanDataStub, stepStub))
+            .returns(() => true);
+        visualizationConfigurationMock
+            .setup(config => config.testMode)
+            .returns(() => TestMode.Adhoc);
 
-        expect(testSubject(visualizationConfigurationMock.object, stepStub, visualizationState, assessmentState, tabState)).toEqual(true);
+        expect(
+            testSubject(
+                visualizationConfigurationMock.object,
+                stepStub,
+                visualizationState,
+                assessmentState,
+                tabState,
+            ),
+        ).toEqual(true);
     });
 
     test('testStatus is true & is an assessment test and there is no persisted tab info', () => {
-        visualizationConfigurationMock.setup(config => config.getTestStatus(scanDataStub, stepStub)).returns(() => true);
-        visualizationConfigurationMock.setup(config => config.testMode).returns(() => TestMode.Assessments);
+        visualizationConfigurationMock
+            .setup(config => config.getTestStatus(scanDataStub, stepStub))
+            .returns(() => true);
+        visualizationConfigurationMock
+            .setup(config => config.testMode)
+            .returns(() => TestMode.Assessments);
 
         assessmentState = {
             persistedTabInfo: null,
         } as AssessmentStoreData;
 
-        expect(testSubject(visualizationConfigurationMock.object, stepStub, visualizationState, assessmentState, tabState)).toEqual(true);
+        expect(
+            testSubject(
+                visualizationConfigurationMock.object,
+                stepStub,
+                visualizationState,
+                assessmentState,
+                tabState,
+            ),
+        ).toEqual(true);
     });
 
     test('testStatus is true & is an assessment test and persisted tab does not match tabState', () => {
-        visualizationConfigurationMock.setup(config => config.getTestStatus(scanDataStub, stepStub)).returns(() => true);
-        visualizationConfigurationMock.setup(config => config.testMode).returns(() => TestMode.Assessments);
+        visualizationConfigurationMock
+            .setup(config => config.getTestStatus(scanDataStub, stepStub))
+            .returns(() => true);
+        visualizationConfigurationMock
+            .setup(config => config.testMode)
+            .returns(() => TestMode.Assessments);
 
         assessmentState = {
             persistedTabInfo: {
@@ -69,12 +112,24 @@ describe('isVisualizationEnabled', () => {
             id: 2,
         } as TabStoreData;
 
-        expect(testSubject(visualizationConfigurationMock.object, stepStub, visualizationState, assessmentState, tabState)).toEqual(false);
+        expect(
+            testSubject(
+                visualizationConfigurationMock.object,
+                stepStub,
+                visualizationState,
+                assessmentState,
+                tabState,
+            ),
+        ).toEqual(false);
     });
 
     test('testStatus is true & is an assessment test and persisted tab does match tabState', () => {
-        visualizationConfigurationMock.setup(config => config.getTestStatus(scanDataStub, stepStub)).returns(() => true);
-        visualizationConfigurationMock.setup(config => config.testMode).returns(() => TestMode.Assessments);
+        visualizationConfigurationMock
+            .setup(config => config.getTestStatus(scanDataStub, stepStub))
+            .returns(() => true);
+        visualizationConfigurationMock
+            .setup(config => config.testMode)
+            .returns(() => TestMode.Assessments);
 
         assessmentState = {
             persistedTabInfo: {
@@ -86,6 +141,14 @@ describe('isVisualizationEnabled', () => {
             id: 1,
         } as TabStoreData;
 
-        expect(testSubject(visualizationConfigurationMock.object, stepStub, visualizationState, assessmentState, tabState)).toEqual(true);
+        expect(
+            testSubject(
+                visualizationConfigurationMock.object,
+                stepStub,
+                visualizationState,
+                assessmentState,
+                tabState,
+            ),
+        ).toEqual(true);
     });
 });

--- a/src/tests/unit/tests/injected/layered-details-dialog-component.test.tsx
+++ b/src/tests/unit/tests/injected/layered-details-dialog-component.test.tsx
@@ -6,7 +6,10 @@ import * as React from 'react';
 import { IMock, Mock } from 'typemoq';
 
 import { FeatureFlags } from '../../../../common/feature-flags';
-import { LayeredDetailsDialogComponent, LayeredDetailsDialogProps } from '../../../../injected/layered-details-dialog-component';
+import {
+    LayeredDetailsDialogComponent,
+    LayeredDetailsDialogProps,
+} from '../../../../injected/layered-details-dialog-component';
 import { DictionaryStringTo } from '../../../../types/common-types';
 
 describe('LayeredDetailsDialogComponent', () => {

--- a/src/tests/unit/tests/injected/main-window-context.test.ts
+++ b/src/tests/unit/tests/injected/main-window-context.test.ts
@@ -27,7 +27,9 @@ describe('MainWindowContextTest', () => {
         expect(testSubject.getDevToolStore()).toEqual(devToolStore);
         expect(testSubject.getUserConfigStore()).toEqual(userConfigStore);
         expect(testSubject.getDevToolActionMessageCreator()).toEqual(devToolActionMessageCreator);
-        expect(testSubject.getTargetPageActionMessageCreator()).toEqual(targetPageActionMessageCreator);
+        expect(testSubject.getTargetPageActionMessageCreator()).toEqual(
+            targetPageActionMessageCreator,
+        );
     });
 
     test('save and retrieve from window', () => {
@@ -43,12 +45,24 @@ describe('MainWindowContextTest', () => {
         );
 
         expect(MainWindowContext.getMainWindowContext().getDevToolStore()).toEqual(devToolStore);
-        expect(MainWindowContext.getMainWindowContext().getUserConfigStore()).toEqual(userConfigStore);
-        expect(MainWindowContext.getMainWindowContext().getDevToolActionMessageCreator()).toEqual(devToolActionMessageCreator);
-        expect(MainWindowContext.getMainWindowContext().getTargetPageActionMessageCreator()).toEqual(targetPageActionMessageCreator);
-        expect(MainWindowContext.getMainWindowContext().getUserConfigMessageCreator()).toEqual(userConfigMessageCreator);
-        expect(MainWindowContext.getMainWindowContext().getEnvironmentInfoProvider()).toEqual(environmentInfoProvider);
-        expect(MainWindowContext.getMainWindowContext().getIssueFilingServiceProvider()).toEqual(issueFilingServiceProvider);
+        expect(MainWindowContext.getMainWindowContext().getUserConfigStore()).toEqual(
+            userConfigStore,
+        );
+        expect(MainWindowContext.getMainWindowContext().getDevToolActionMessageCreator()).toEqual(
+            devToolActionMessageCreator,
+        );
+        expect(
+            MainWindowContext.getMainWindowContext().getTargetPageActionMessageCreator(),
+        ).toEqual(targetPageActionMessageCreator);
+        expect(MainWindowContext.getMainWindowContext().getUserConfigMessageCreator()).toEqual(
+            userConfigMessageCreator,
+        );
+        expect(MainWindowContext.getMainWindowContext().getEnvironmentInfoProvider()).toEqual(
+            environmentInfoProvider,
+        );
+        expect(MainWindowContext.getMainWindowContext().getIssueFilingServiceProvider()).toEqual(
+            issueFilingServiceProvider,
+        );
     });
 
     test('getIfNotGiven', () => {
@@ -84,19 +98,39 @@ describe('MainWindowContextTest', () => {
         const mainWindowContextGiven = MainWindowContext.getIfNotGiven(mainWindowContextLocal);
         expect(mainWindowContextGiven.getDevToolStore()).toEqual(devToolStoreLocal);
         expect(mainWindowContextGiven.getUserConfigStore()).toEqual(userConfigStoreLocal);
-        expect(mainWindowContextGiven.getDevToolActionMessageCreator()).toEqual(devToolActionMessageCreatorLocal);
-        expect(mainWindowContextGiven.getTargetPageActionMessageCreator()).toEqual(targetPageActionMessageCreator);
-        expect(mainWindowContextGiven.getUserConfigMessageCreator()).toEqual(userConfigMessageCreatorLocal);
-        expect(mainWindowContextGiven.getEnvironmentInfoProvider()).toEqual(environmentInfoProviderLocal);
-        expect(mainWindowContextGiven.getIssueFilingServiceProvider()).toEqual(issueFilingServiceProviderLocal);
+        expect(mainWindowContextGiven.getDevToolActionMessageCreator()).toEqual(
+            devToolActionMessageCreatorLocal,
+        );
+        expect(mainWindowContextGiven.getTargetPageActionMessageCreator()).toEqual(
+            targetPageActionMessageCreator,
+        );
+        expect(mainWindowContextGiven.getUserConfigMessageCreator()).toEqual(
+            userConfigMessageCreatorLocal,
+        );
+        expect(mainWindowContextGiven.getEnvironmentInfoProvider()).toEqual(
+            environmentInfoProviderLocal,
+        );
+        expect(mainWindowContextGiven.getIssueFilingServiceProvider()).toEqual(
+            issueFilingServiceProviderLocal,
+        );
 
         const mainWindowContextNotGiven = MainWindowContext.getIfNotGiven(null);
         expect(mainWindowContextNotGiven.getDevToolStore()).toEqual(devToolStore);
         expect(mainWindowContextNotGiven.getUserConfigStore()).toEqual(userConfigStore);
-        expect(mainWindowContextNotGiven.getDevToolActionMessageCreator()).toEqual(devToolActionMessageCreator);
-        expect(mainWindowContextNotGiven.getTargetPageActionMessageCreator()).toEqual(targetPageActionMessageCreator);
-        expect(mainWindowContextNotGiven.getUserConfigMessageCreator()).toEqual(userConfigMessageCreator);
-        expect(mainWindowContextNotGiven.getEnvironmentInfoProvider()).toEqual(environmentInfoProvider);
-        expect(mainWindowContextNotGiven.getIssueFilingServiceProvider()).toEqual(issueFilingServiceProvider);
+        expect(mainWindowContextNotGiven.getDevToolActionMessageCreator()).toEqual(
+            devToolActionMessageCreator,
+        );
+        expect(mainWindowContextNotGiven.getTargetPageActionMessageCreator()).toEqual(
+            targetPageActionMessageCreator,
+        );
+        expect(mainWindowContextNotGiven.getUserConfigMessageCreator()).toEqual(
+            userConfigMessageCreator,
+        );
+        expect(mainWindowContextNotGiven.getEnvironmentInfoProvider()).toEqual(
+            environmentInfoProvider,
+        );
+        expect(mainWindowContextNotGiven.getIssueFilingServiceProvider()).toEqual(
+            issueFilingServiceProvider,
+        );
     });
 });

--- a/src/tests/unit/tests/injected/path-snippet-controller.test.ts
+++ b/src/tests/unit/tests/injected/path-snippet-controller.test.ts
@@ -32,7 +32,11 @@ describe('InspectControllerTests', () => {
             then: processRequestPromiseHandlerMock.object,
         };
 
-        testObject = new PathSnippetController(pathSnippetStoreMock.object, elementFinderMock.object, addCorrespondingSnippetMock.object);
+        testObject = new PathSnippetController(
+            pathSnippetStoreMock.object,
+            elementFinderMock.object,
+            addCorrespondingSnippetMock.object,
+        );
     });
 
     afterEach(() => {

--- a/src/tests/unit/tests/injected/scan-incomplete-warning-detector.test.ts
+++ b/src/tests/unit/tests/injected/scan-incomplete-warning-detector.test.ts
@@ -14,7 +14,10 @@ describe('ScanIncompleteWarningDetector', () => {
     beforeEach(() => {
         permissionsStateStoreMock = Mock.ofType<BaseStore<PermissionsStateStoreData>>();
         iframeDetectorMock = Mock.ofType<IframeDetector>();
-        testSubject = new ScanIncompleteWarningDetector(iframeDetectorMock.object, permissionsStateStoreMock.object);
+        testSubject = new ScanIncompleteWarningDetector(
+            iframeDetectorMock.object,
+            permissionsStateStoreMock.object,
+        );
     });
 
     it.each`
@@ -27,7 +30,9 @@ describe('ScanIncompleteWarningDetector', () => {
         'should detect $expectedResults if iframesDetected=$iframesDetected and crossOriginPermissions=$crossOriginPermissions',
         ({ iframesDetected, hasAllUrlAndFilePermissions, expectedResults }) => {
             iframeDetectorMock.setup(m => m.hasIframes()).returns(() => iframesDetected);
-            permissionsStateStoreMock.setup(m => m.getState()).returns(() => ({ hasAllUrlAndFilePermissions }));
+            permissionsStateStoreMock
+                .setup(m => m.getState())
+                .returns(() => ({ hasAllUrlAndFilePermissions }));
 
             expect(testSubject.detectScanIncompleteWarnings()).toStrictEqual(expectedResults);
         },

--- a/src/tests/unit/tests/injected/scanner-utils.test.ts
+++ b/src/tests/unit/tests/injected/scanner-utils.test.ts
@@ -5,7 +5,11 @@ import { ScopingStore } from 'background/stores/global/scoping-store';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { Logger } from '../../../../common/logging/logger';
 import { ScopingStoreData } from '../../../../common/types/store-data/scoping-store-data';
-import { DecoratedAxeNodeResult, HtmlElementAxeResults, ScannerUtils } from '../../../../injected/scanner-utils';
+import {
+    DecoratedAxeNodeResult,
+    HtmlElementAxeResults,
+    ScannerUtils,
+} from '../../../../injected/scanner-utils';
 import { scan } from '../../../../scanner/exposed-apis';
 import { RuleResult, ScanResults } from '../../../../scanner/iruleresults';
 import { ScanOptions } from '../../../../scanner/scan-options';
@@ -47,7 +51,10 @@ describe('ScannerUtilsTest', () => {
 
         const expectedAxeResults: ScanResults = {
             passes: [getSampleRule('rule1', [selectors[0]]), getSampleRule('rule2', selectors)],
-            violations: [getSampleRule('rule1', [selectors[1]]), getSampleRule('rule3', [selectors[0], selectors[1]])],
+            violations: [
+                getSampleRule('rule1', [selectors[1]]),
+                getSampleRule('rule3', [selectors[0], selectors[1]]),
+            ],
             inapplicable: [],
             incomplete: [],
             timestamp: '0',
@@ -85,7 +92,10 @@ describe('ScannerUtilsTest', () => {
 
         const axeResults: ScanResults = {
             passes: [getSampleRule('rule1', [element1Selector]), getSampleRule('rule2', selectors)],
-            violations: [getSampleRule('rule1', [element2Selector]), getSampleRule('rule3', [element1Selector, element2Selector])],
+            violations: [
+                getSampleRule('rule1', [element2Selector]),
+                getSampleRule('rule3', [element1Selector, element2Selector]),
+            ],
             inapplicable: [],
             incomplete: [],
             timestamp: '0',
@@ -104,9 +114,17 @@ describe('ScannerUtilsTest', () => {
             rule3: false,
         };
 
-        verifyElementSelector(selectorMap[element1Selector], element1Selector, expectedElement1RuleResults);
+        verifyElementSelector(
+            selectorMap[element1Selector],
+            element1Selector,
+            expectedElement1RuleResults,
+        );
 
-        verifyElementSelector(selectorMap[element2Selector], element2Selector, expectedElement2RuleResults);
+        verifyElementSelector(
+            selectorMap[element2Selector],
+            element2Selector,
+            expectedElement2RuleResults,
+        );
     });
 
     test('getPassingInstances', () => {
@@ -116,7 +134,10 @@ describe('ScannerUtilsTest', () => {
         const element2Selector = expectedElementSelectors[1];
 
         const axeResults: ScanResults = {
-            passes: [getSampleRule('rule1', [element1Selector]), getSampleRule('rule2', [element1Selector, element2Selector])],
+            passes: [
+                getSampleRule('rule1', [element1Selector]),
+                getSampleRule('rule2', [element1Selector, element2Selector]),
+            ],
             violations: [getSampleRule('rule3', selectors)],
             inapplicable: [],
             incomplete: [],
@@ -136,9 +157,17 @@ describe('ScannerUtilsTest', () => {
             rule2: true,
         };
 
-        verifyElementSelector(selectorMap[element1Selector], element1Selector, expectedElement1RuleResults);
+        verifyElementSelector(
+            selectorMap[element1Selector],
+            element1Selector,
+            expectedElement1RuleResults,
+        );
 
-        verifyElementSelector(selectorMap[element2Selector], element2Selector, expectedElement2RuleResults);
+        verifyElementSelector(
+            selectorMap[element2Selector],
+            element2Selector,
+            expectedElement2RuleResults,
+        );
     });
 
     test('getPassingInstances with separate snippet field', () => {
@@ -148,7 +177,10 @@ describe('ScannerUtilsTest', () => {
         const element2Selector = expectedElementSelectors[1];
 
         const axeResults: ScanResults = {
-            passes: [getSampleRule('rule1', [element1Selector], true), getSampleRule('rule2', [element1Selector, element2Selector])],
+            passes: [
+                getSampleRule('rule1', [element1Selector], true),
+                getSampleRule('rule2', [element1Selector, element2Selector]),
+            ],
             violations: [getSampleRule('rule3', selectors)],
             inapplicable: [],
             incomplete: [],
@@ -168,9 +200,17 @@ describe('ScannerUtilsTest', () => {
             rule2: true,
         };
 
-        verifyElementSelector(selectorMap[element1Selector], element1Selector, expectedElement1RuleResults);
+        verifyElementSelector(
+            selectorMap[element1Selector],
+            element1Selector,
+            expectedElement1RuleResults,
+        );
 
-        verifyElementSelector(selectorMap[element2Selector], element2Selector, expectedElement2RuleResults);
+        verifyElementSelector(
+            selectorMap[element2Selector],
+            element2Selector,
+            expectedElement2RuleResults,
+        );
     });
 
     test('getIncompleteInstances', () => {
@@ -183,7 +223,10 @@ describe('ScannerUtilsTest', () => {
             passes: [getSampleRule('rule1', [element1Selector]), getSampleRule('rule2', selectors)],
             violations: [],
             inapplicable: [],
-            incomplete: [getSampleRule('rule1', [element2Selector]), getSampleRule('rule3', [element1Selector, element2Selector])],
+            incomplete: [
+                getSampleRule('rule1', [element2Selector]),
+                getSampleRule('rule3', [element1Selector, element2Selector]),
+            ],
             timestamp: '0',
             targetPageUrl: 'test url',
             targetPageTitle: 'test title',
@@ -200,9 +243,17 @@ describe('ScannerUtilsTest', () => {
             rule3: undefined,
         };
 
-        verifyElementSelector(selectorMap[element1Selector], element1Selector, expectedElement1RuleResults);
+        verifyElementSelector(
+            selectorMap[element1Selector],
+            element1Selector,
+            expectedElement1RuleResults,
+        );
 
-        verifyElementSelector(selectorMap[element2Selector], element2Selector, expectedElement2RuleResults);
+        verifyElementSelector(
+            selectorMap[element2Selector],
+            element2Selector,
+            expectedElement2RuleResults,
+        );
     });
 
     test('getAllCompletedInstances with IDs', () => {
@@ -210,7 +261,11 @@ describe('ScannerUtilsTest', () => {
             return null;
         });
         const loggerMock = Mock.ofType<Logger>();
-        testSubject = new ScannerUtils(scannerMock.object, loggerMock.object, generateUIDMock.object);
+        testSubject = new ScannerUtils(
+            scannerMock.object,
+            loggerMock.object,
+            generateUIDMock.object,
+        );
 
         generateUIDMock
             .setup(generate => generate())
@@ -259,7 +314,10 @@ describe('ScannerUtilsTest', () => {
 
         const axeResults: ScanResults = {
             passes: [getSampleRule('rule1', [element1Selector]), getSampleRule('rule2', selectors)],
-            violations: [getSampleRule('rule1', [element2Selector]), getSampleRule('rule3', [element1Selector, element2Selector])],
+            violations: [
+                getSampleRule('rule1', [element2Selector]),
+                getSampleRule('rule3', [element1Selector, element2Selector]),
+            ],
             inapplicable: [],
             incomplete: [],
             timestamp: '0',
@@ -307,7 +365,10 @@ describe('ScannerUtilsTest', () => {
                 getSampleRule('rule2', selectors),
                 getSampleRule('rule3', [element2Selector]),
             ],
-            violations: [getSampleRule('rule1', [element3Selector]), getSampleRule('rule3', [element1Selector, element3Selector])],
+            violations: [
+                getSampleRule('rule1', [element3Selector]),
+                getSampleRule('rule3', [element1Selector, element3Selector]),
+            ],
             inapplicable: [],
             incomplete: [],
             timestamp: '0',
@@ -335,9 +396,21 @@ describe('ScannerUtilsTest', () => {
             rule3: false,
         };
 
-        verifyElementSelector(selectorMap[element1Selector], element1Selector, expectedElement1RuleResults);
-        verifyElementSelector(selectorMap[element2Selector], element2Selector, expectedElement2RuleResults);
-        verifyElementSelector(selectorMap[element3Selector], element3Selector, expectedElement3RuleResults);
+        verifyElementSelector(
+            selectorMap[element1Selector],
+            element1Selector,
+            expectedElement1RuleResults,
+        );
+        verifyElementSelector(
+            selectorMap[element2Selector],
+            element2Selector,
+            expectedElement2RuleResults,
+        );
+        verifyElementSelector(
+            selectorMap[element3Selector],
+            element3Selector,
+            expectedElement3RuleResults,
+        );
     });
 
     test('getFingerprint', () => {
@@ -361,7 +434,12 @@ describe('ScannerUtilsTest', () => {
         expect(actual).toEqual(expected);
     });
 
-    function getAxeNodeResult(selector: string, ruleId, status: boolean, includeSnippet?: boolean): DecoratedAxeNodeResult {
+    function getAxeNodeResult(
+        selector: string,
+        ruleId,
+        status: boolean,
+        includeSnippet?: boolean,
+    ): DecoratedAxeNodeResult {
         const axeNodeResult = getSampleNodeResultForSelector(selector, includeSnippet);
 
         return {
@@ -394,7 +472,12 @@ describe('ScannerUtilsTest', () => {
         const ruleResults: DictionaryStringTo<DecoratedAxeNodeResult> = {};
 
         ruleIds.forEach(ruleId => {
-            ruleResults[ruleId] = getAxeNodeResult(selector, ruleId, ruleResultMap[ruleId], includeSnippet);
+            ruleResults[ruleId] = getAxeNodeResult(
+                selector,
+                ruleId,
+                ruleResultMap[ruleId],
+                includeSnippet,
+            );
         });
 
         const ruleResultIds = Object.keys(ruleResults);

--- a/src/tests/unit/tests/injected/scoping-listener.test.ts
+++ b/src/tests/unit/tests/injected/scoping-listener.test.ts
@@ -34,7 +34,10 @@ describe('ScopingListenerTest', () => {
     let onClickProcessRequestPromiseCallback: (path: SingleElementSelector) => void;
     let onClick: (event: MouseEvent) => void;
     let addEventListenerMock: IMock<(event: string, callback: (event: MouseEvent) => void) => void>;
-    let removeEventListenerMock: IMock<(event: string, callback: (event: MouseEvent) => void) => void>;
+    let removeEventListenerMock: IMock<(
+        event: string,
+        callback: (event: MouseEvent) => void,
+    ) => void>;
     let createElementMock: IMock<(tagName: string) => HTMLElement>;
     let dom: Document;
     let elementStub: HTMLElement;
@@ -99,7 +102,12 @@ describe('ScopingListenerTest', () => {
         onInspectClickMock = Mock.ofInstance((eventName, selector) => {});
         onInspectHoverMock = Mock.ofInstance(selector => {});
 
-        testSubject = new TestableScopingListener(elementFinderMock.object, windowUtilsMock.object, shadowUtilsMock.object, dom);
+        testSubject = new TestableScopingListener(
+            elementFinderMock.object,
+            windowUtilsMock.object,
+            shadowUtilsMock.object,
+            dom,
+        );
     });
 
     test("start scope layout container doesn't exist and timeout doesn't exist", () => {
@@ -151,7 +159,10 @@ describe('ScopingListenerTest', () => {
 
     test('stop, scoping container exists', () => {
         const shadowContainerElementStub = {} as HTMLElement;
-        setupShadowContainerMockQuerySelector(`#${ScopingListener.scopeLayoutContainerId}`, shadowContainerElementStub);
+        setupShadowContainerMockQuerySelector(
+            `#${ScopingListener.scopeLayoutContainerId}`,
+            shadowContainerElementStub,
+        );
         shadowContainerMock.setup(scm => scm.removeChild(shadowContainerElementStub)).verifiable();
 
         removeEventListenerMock.setup(re => re('click', testSubject.getOnClick())).verifiable();

--- a/src/tests/unit/tests/injected/scrolling-controller.test.ts
+++ b/src/tests/unit/tests/injected/scrolling-controller.test.ts
@@ -3,8 +3,14 @@
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { HTMLElementUtils } from '../../../../common/html-element-utils';
-import { FrameCommunicator, MessageRequest } from '../../../../injected/frameCommunicators/frame-communicator';
-import { ScrollingController, ScrollingWindowMessage } from '../../../../injected/frameCommunicators/scrolling-controller';
+import {
+    FrameCommunicator,
+    MessageRequest,
+} from '../../../../injected/frameCommunicators/frame-communicator';
+import {
+    ScrollingController,
+    ScrollingWindowMessage,
+} from '../../../../injected/frameCommunicators/scrolling-controller';
 
 describe('ScrollingControllerTest', () => {
     let frameCommunicatorMock: IMock<FrameCommunicator>;
@@ -19,7 +25,9 @@ describe('ScrollingControllerTest', () => {
         let subscribeCallback: (result: any, error: any, responder?: any) => void;
 
         frameCommunicatorMock
-            .setup(fcm => fcm.subscribe(It.isValue(ScrollingController.triggerScrollingCommand), It.isAny()))
+            .setup(fcm =>
+                fcm.subscribe(It.isValue(ScrollingController.triggerScrollingCommand), It.isAny()),
+            )
             .returns((cmd, func) => {
                 subscribeCallback = func;
             })
@@ -37,9 +45,14 @@ describe('ScrollingControllerTest', () => {
             })
             .verifiable(Times.once());
 
-        HTMLElementUtilsMock.setup(h => h.scrollInToView(It.isValue(targetElementStub as any))).verifiable(Times.once());
+        HTMLElementUtilsMock.setup(h =>
+            h.scrollInToView(It.isValue(targetElementStub as any)),
+        ).verifiable(Times.once());
 
-        const testObject = new ScrollingController(frameCommunicatorMock.object, HTMLElementUtilsMock.object);
+        const testObject = new ScrollingController(
+            frameCommunicatorMock.object,
+            HTMLElementUtilsMock.object,
+        );
 
         testObject.initialize();
         subscribeCallback(message, null);
@@ -52,7 +65,9 @@ describe('ScrollingControllerTest', () => {
         let subscribeCallback: (result: any, error: any, responder?: any) => void;
 
         frameCommunicatorMock
-            .setup(fcm => fcm.subscribe(It.isValue(ScrollingController.triggerScrollingCommand), It.isAny()))
+            .setup(fcm =>
+                fcm.subscribe(It.isValue(ScrollingController.triggerScrollingCommand), It.isAny()),
+            )
             .returns((cmd, func) => {
                 subscribeCallback = func;
             })
@@ -78,9 +93,14 @@ describe('ScrollingControllerTest', () => {
             },
         } as MessageRequest<ScrollingWindowMessage>;
 
-        frameCommunicatorMock.setup(fcm => fcm.sendMessage(It.isValue(messageToSend))).verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(fcm => fcm.sendMessage(It.isValue(messageToSend)))
+            .verifiable(Times.once());
 
-        const testObject = new ScrollingController(frameCommunicatorMock.object, HTMLElementUtilsMock.object);
+        const testObject = new ScrollingController(
+            frameCommunicatorMock.object,
+            HTMLElementUtilsMock.object,
+        );
 
         testObject.initialize();
         subscribeCallback(messageToProcess, null);

--- a/src/tests/unit/tests/injected/selector-map-helper.test.ts
+++ b/src/tests/unit/tests/injected/selector-map-helper.test.ts
@@ -15,7 +15,10 @@ import {
     TestStepResult,
 } from '../../../../common/types/store-data/assessment-result-data';
 import { VisualizationType } from '../../../../common/types/visualization-type';
-import { SelectorMapHelper, VisualizationRelatedStoreData } from '../../../../injected/selector-map-helper';
+import {
+    SelectorMapHelper,
+    VisualizationRelatedStoreData,
+} from '../../../../injected/selector-map-helper';
 import { CreateTestAssessmentProvider } from '../../common/test-assessment-provider';
 import { VisualizationScanResultStoreDataBuilder } from '../../common/visualization-scan-result-store-data-builder';
 
@@ -24,11 +27,18 @@ describe('SelectorMapHelperTest', () => {
     let testSubject: SelectorMapHelper;
     let getElementBasedViewModelMock: IMock<GetElementBasedViewModelCallback>;
 
-    const adHocVisualizationTypes = [VisualizationType.Headings, VisualizationType.Landmarks, VisualizationType.Color];
+    const adHocVisualizationTypes = [
+        VisualizationType.Headings,
+        VisualizationType.Landmarks,
+        VisualizationType.Color,
+    ];
     beforeEach(() => {
         assessmentsProvider = CreateTestAssessmentProvider();
         getElementBasedViewModelMock = Mock.ofType<GetElementBasedViewModelCallback>();
-        testSubject = new SelectorMapHelper(assessmentsProvider, getElementBasedViewModelMock.object);
+        testSubject = new SelectorMapHelper(
+            assessmentsProvider,
+            getElementBasedViewModelMock.object,
+        );
     });
 
     test('constructor', () => {
@@ -38,11 +48,15 @@ describe('SelectorMapHelperTest', () => {
     adHocVisualizationTypes.forEach(visualizationType => {
         test(`getSelectorMap: ${VisualizationType[visualizationType]}`, () => {
             const selectorMap = { key1: { target: ['element1'] } };
-            const state = new VisualizationScanResultStoreDataBuilder().withSelectorMap(visualizationType, selectorMap).build();
+            const state = new VisualizationScanResultStoreDataBuilder()
+                .withSelectorMap(visualizationType, selectorMap)
+                .build();
             const storeData: VisualizationRelatedStoreData = {
                 visualizationScanResultStoreData: state,
             } as VisualizationRelatedStoreData;
-            expect(testSubject.getSelectorMap(visualizationType, null, storeData)).toEqual(selectorMap);
+            expect(testSubject.getSelectorMap(visualizationType, null, storeData)).toEqual(
+                selectorMap,
+            );
         });
     });
 
@@ -63,7 +77,9 @@ describe('SelectorMapHelperTest', () => {
             .setup(gebvm => gebvm(rulesStub, resultsStub, storeData.cardSelectionStoreData))
             .returns(() => selectorMap);
 
-        expect(testSubject.getSelectorMap(VisualizationType.Issues, null, storeData)).toEqual(selectorMap);
+        expect(testSubject.getSelectorMap(VisualizationType.Issues, null, storeData)).toEqual(
+            selectorMap,
+        );
     });
 
     test('getState: tabStops', () => {

--- a/src/tests/unit/tests/injected/shadow-initializer.test.ts
+++ b/src/tests/unit/tests/injected/shadow-initializer.test.ts
@@ -48,7 +48,11 @@ describe('ShadowInitializerTests', () => {
             .returns(() => generatedBundleInjectedCssPathFileUrl);
 
         const loggerMock = Mock.ofType<Logger>();
-        testSubject = new ShadowInitializer(browserAdapter.object, htmlElementUtilsMock.object, loggerMock.object);
+        testSubject = new ShadowInitializer(
+            browserAdapter.object,
+            htmlElementUtilsMock.object,
+            loggerMock.object,
+        );
     });
 
     afterEach(() => {
@@ -68,7 +72,9 @@ describe('ShadowInitializerTests', () => {
     });
 
     test('add style data to shadow container', async () => {
-        expect(shadowRoot.querySelectorAll('div#insights-shadow-container style').length).toEqual(0);
+        expect(shadowRoot.querySelectorAll('div#insights-shadow-container style').length).toEqual(
+            0,
+        );
 
         await testSubject.initialize();
 

--- a/src/tests/unit/tests/injected/tab-stops-listener.test.ts
+++ b/src/tests/unit/tests/injected/tab-stops-listener.test.ts
@@ -6,7 +6,10 @@ import { HTMLElementUtils } from '../../../../common/html-element-utils';
 import { WindowUtils } from '../../../../common/window-utils';
 import { VisualizationWindowMessage } from '../../../../injected/drawing-controller';
 import { ErrorMessageContent } from '../../../../injected/frameCommunicators/error-message-content';
-import { FrameCommunicator, MessageRequest } from '../../../../injected/frameCommunicators/frame-communicator';
+import {
+    FrameCommunicator,
+    MessageRequest,
+} from '../../../../injected/frameCommunicators/frame-communicator';
 import { FrameMessageResponseCallback } from '../../../../injected/frameCommunicators/window-message-handler';
 import { ScannerUtils } from '../../../../injected/scanner-utils';
 import { TabStopEvent, TabStopsListener } from '../../../../injected/tab-stops-listener';
@@ -44,9 +47,15 @@ describe('TabStopsListenerTest', () => {
     });
 
     test('initialize', () => {
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
 
         listenerObject.initialize();
         frameCommunicatorMock.verifyAll();
@@ -54,9 +63,15 @@ describe('TabStopsListenerTest', () => {
 
     test('Err: Tab Listener setup in child window', () => {
         windowUtilsMock.setup(w => w.isTopWindow()).returns(() => false);
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
 
         listenerObject.initialize();
         const action = () => {
@@ -69,9 +84,15 @@ describe('TabStopsListenerTest', () => {
         const onStartListenToTabStopsMock = Mock.ofInstance(() => {});
 
         onStartListenToTabStopsMock.setup(o => o()).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
 
         listenerObject.initialize();
         (listenerObject as any).onStartListenToTabStops = onStartListenToTabStopsMock.object;
@@ -85,9 +106,15 @@ describe('TabStopsListenerTest', () => {
         const onStopListenToTabStopsMock = Mock.ofInstance(() => {});
 
         onStopListenToTabStopsMock.setup(o => o()).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.stopListeningCommand, It.isAny())).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.stopListeningCommand, It.isAny())).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.stopListeningCommand, It.isAny())).verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.stopListeningCommand, It.isAny()))
+            .verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.stopListeningCommand, It.isAny()))
+            .verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.stopListeningCommand, It.isAny()))
+            .verifiable(Times.once());
 
         listenerObject.initialize();
         (listenerObject as any).onStopListenToTabStops = onStopListenToTabStopsMock.object;
@@ -104,9 +131,15 @@ describe('TabStopsListenerTest', () => {
                 return [] as any;
             })
             .verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
-        frameCommunicatorMock.setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny())).verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
+            .verifiable(Times.once());
 
         listenerObject.initialize();
         frameCommunicatorMock.verifyAll();
@@ -195,7 +228,9 @@ describe('TabStopsListenerTest', () => {
             })
             .verifiable(Times.once());
 
-        frameCommunicatorMock.setup(f => f.sendMessage(It.isValue(startListenToTabStopsInFrameReqStub))).verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.sendMessage(It.isValue(startListenToTabStopsInFrameReqStub)))
+            .verifiable(Times.once());
 
         frameCommunicatorMock
             .setup(f => f.subscribe(TabStopsListener.startListeningCommand, It.isAny()))
@@ -423,7 +458,9 @@ describe('TabStopsListenerTest', () => {
             )
             .verifiable(Times.once());
 
-        frameCommunicatorMock.setup(f => f.sendMessage(It.isObjectWith(messageStub))).verifiable(Times.once());
+        frameCommunicatorMock
+            .setup(f => f.sendMessage(It.isObjectWith(messageStub)))
+            .verifiable(Times.once());
 
         listenerObject.initialize();
         frameCommunicatorMock.verifyAll();

--- a/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
+++ b/src/tests/unit/tests/injected/target-page-action-message-creator.test.ts
@@ -4,7 +4,10 @@ import { BaseActionPayload } from 'background/actions/action-payloads';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { Mock, Times } from 'typemoq';
 import * as TelemetryEvents from '../../../../common/extension-telemetry-events';
-import { SettingsOpenTelemetryData, TelemetryEventSource } from '../../../../common/extension-telemetry-events';
+import {
+    SettingsOpenTelemetryData,
+    TelemetryEventSource,
+} from '../../../../common/extension-telemetry-events';
 import { Message } from '../../../../common/message';
 import { Messages } from '../../../../common/messages';
 import { TelemetryDataFactory } from '../../../../common/telemetry-data-factory';
@@ -18,7 +21,10 @@ describe('TargetPageActionMessageCreator', () => {
 
     beforeEach(() => {
         dispatcherMock.reset();
-        testSubject = new TargetPageActionMessageCreator(new TelemetryDataFactory(), dispatcherMock.object);
+        testSubject = new TargetPageActionMessageCreator(
+            new TelemetryDataFactory(),
+            dispatcherMock.object,
+        );
     });
 
     it('dispatches message for scrollRequested', () => {
@@ -28,7 +34,10 @@ describe('TargetPageActionMessageCreator', () => {
 
         testSubject.scrollRequested();
 
-        dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(expectedMessage),
+            Times.once(),
+        );
     });
 
     it('sends telemetry for openIssuesDialog', () => {
@@ -40,7 +49,10 @@ describe('TargetPageActionMessageCreator', () => {
 
         testSubject.openIssuesDialog();
 
-        dispatcherMock.verify(dispatcher => dispatcher.sendTelemetry(eventName, eventData), Times.once());
+        dispatcherMock.verify(
+            dispatcher => dispatcher.sendTelemetry(eventName, eventData),
+            Times.once(),
+        );
     });
 
     it('dispatches message for setHoveredOverSelector', () => {
@@ -53,7 +65,10 @@ describe('TargetPageActionMessageCreator', () => {
 
         testSubject.setHoveredOverSelector(selector);
 
-        dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(expectedMessage),
+            Times.once(),
+        );
     });
 
     it('sends telemetry for copyIssueDetailsClicked', () => {
@@ -66,7 +81,10 @@ describe('TargetPageActionMessageCreator', () => {
 
         testSubject.copyIssueDetailsClicked(event);
 
-        dispatcherMock.verify(dispatcher => dispatcher.sendTelemetry(eventName, eventData), Times.once());
+        dispatcherMock.verify(
+            dispatcher => dispatcher.sendTelemetry(eventName, eventData),
+            Times.once(),
+        );
     });
 
     it('dispatches message for openSettingsPanel', () => {
@@ -87,6 +105,9 @@ describe('TargetPageActionMessageCreator', () => {
 
         testSubject.openSettingsPanel(event);
 
-        dispatcherMock.verify(dispatcher => dispatcher.dispatchMessage(expectedMessage), Times.once());
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(expectedMessage),
+            Times.once(),
+        );
     });
 });

--- a/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
+++ b/src/tests/unit/tests/injected/target-page-visualization-updater.test.ts
@@ -8,7 +8,10 @@ import { DrawingInitiator } from 'injected/drawing-initiator';
 import { AssessmentVisualizationInstance } from 'injected/frameCommunicators/html-element-axe-results-helper';
 import { IsVisualizationEnabledCallback } from 'injected/is-visualization-enabled';
 import { SelectorMapHelper } from 'injected/selector-map-helper';
-import { TargetPageVisualizationUpdater, VisualizationSelectorMapContainer } from 'injected/target-page-visualization-updater';
+import {
+    TargetPageVisualizationUpdater,
+    VisualizationSelectorMapContainer,
+} from 'injected/target-page-visualization-updater';
 import { VisualizationNeedsUpdateCallback } from 'injected/visualization-needs-update';
 import { IMock, It, Mock, Times } from 'typemoq';
 import { DictionaryStringTo } from 'types/common-types';
@@ -54,7 +57,9 @@ describe('TargetPageVisualizationUpdater', () => {
         selectorMapHelperMock
             .setup(smhm => smhm.getSelectorMap(visualizationTypeStub, stepKeyStub, storeDataStub))
             .returns(() => selectorMapStub);
-        visualizationConfigurationFactoryMock.setup(vcfm => vcfm.getConfiguration(visualizationTypeStub)).returns(() => configMock.object);
+        visualizationConfigurationFactoryMock
+            .setup(vcfm => vcfm.getConfiguration(visualizationTypeStub))
+            .returns(() => configMock.object);
         configMock.setup(cm => cm.getIdentifier(stepKeyStub)).returns(() => configIdStub);
         isVisualizationEnabledMock
             .setup(vnum =>
@@ -79,9 +84,13 @@ describe('TargetPageVisualizationUpdater', () => {
 
     test('visualization does need not to be updated', () => {
         setupVisualizationNeedsUpdateMock(false);
-        drawingInitiatorMock.setup(dim => dim.disableVisualization(It.isAny(), It.isAny(), It.isAny())).verifiable(Times.never());
         drawingInitiatorMock
-            .setup(dim => dim.enableVisualization(It.isAny(), It.isAny(), It.isAny(), It.isAny(), It.isAny()))
+            .setup(dim => dim.disableVisualization(It.isAny(), It.isAny(), It.isAny()))
+            .verifiable(Times.never());
+        drawingInitiatorMock
+            .setup(dim =>
+                dim.enableVisualization(It.isAny(), It.isAny(), It.isAny(), It.isAny(), It.isAny()),
+            )
             .verifiable(Times.never());
 
         testSubject.updateVisualization(visualizationTypeStub, stepKeyStub, storeDataStub);
@@ -92,7 +101,9 @@ describe('TargetPageVisualizationUpdater', () => {
 
     test('visualization needs to be enabled', () => {
         const visualizationInstanceProcessorStub = () => null;
-        configMock.setup(cm => cm.visualizationInstanceProcessor(stepKeyStub)).returns(() => visualizationInstanceProcessorStub);
+        configMock
+            .setup(cm => cm.visualizationInstanceProcessor(stepKeyStub))
+            .returns(() => visualizationInstanceProcessorStub);
         setupVisualizationNeedsUpdateMock(true);
         drawingInitiatorMock
             .setup(dim =>
@@ -109,20 +120,32 @@ describe('TargetPageVisualizationUpdater', () => {
         testSubject.updateVisualization(visualizationTypeStub, stepKeyStub, storeDataStub);
 
         drawingInitiatorMock.verifyAll();
-        verifyPreviousStates({ [configIdStub]: newVisualizationEnabledStateStub }, { [configIdStub]: selectorMapStub });
+        verifyPreviousStates(
+            { [configIdStub]: newVisualizationEnabledStateStub },
+            { [configIdStub]: selectorMapStub },
+        );
     });
 
     test('visualization needs to be disabled', () => {
         setupVisualizationNeedsUpdateMock(true);
         newVisualizationEnabledStateStub = false;
         drawingInitiatorMock
-            .setup(dim => dim.disableVisualization(visualizationTypeStub, storeDataStub.featureFlagStoreData, configIdStub))
+            .setup(dim =>
+                dim.disableVisualization(
+                    visualizationTypeStub,
+                    storeDataStub.featureFlagStoreData,
+                    configIdStub,
+                ),
+            )
             .verifiable();
 
         testSubject.updateVisualization(visualizationTypeStub, stepKeyStub, storeDataStub);
 
         drawingInitiatorMock.verifyAll();
-        verifyPreviousStates({ [configIdStub]: newVisualizationEnabledStateStub }, { [configIdStub]: selectorMapStub });
+        verifyPreviousStates(
+            { [configIdStub]: newVisualizationEnabledStateStub },
+            { [configIdStub]: selectorMapStub },
+        );
     });
 
     function setupVisualizationNeedsUpdateMock(needsUpdate: boolean): void {

--- a/src/tests/unit/tests/injected/visualization-instance-processor.test.ts
+++ b/src/tests/unit/tests/injected/visualization-instance-processor.test.ts
@@ -1,13 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentVisualizationInstance } from '../../../../injected/frameCommunicators/html-element-axe-results-helper';
-import { PartialTabOrderPropertyBag, TabOrderPropertyBag } from '../../../../injected/tab-order-property-bag';
-import { VisualizationInstanceProcessor, VisualizationPropertyBag } from '../../../../injected/visualization-instance-processor';
+import {
+    PartialTabOrderPropertyBag,
+    TabOrderPropertyBag,
+} from '../../../../injected/tab-order-property-bag';
+import {
+    VisualizationInstanceProcessor,
+    VisualizationPropertyBag,
+} from '../../../../injected/visualization-instance-processor';
 
 describe('VisualizationInstanceProcessorTest', () => {
     test('nullProcessor', () => {
         const instancesStub = [{} as AssessmentVisualizationInstance];
-        expect(VisualizationInstanceProcessor.nullProcessor(instancesStub)).toMatchObject(instancesStub);
+        expect(VisualizationInstanceProcessor.nullProcessor(instancesStub)).toMatchObject(
+            instancesStub,
+        );
     });
 
     test('addOrder', () => {

--- a/src/tests/unit/tests/injected/visualization-state-change-handler.test.ts
+++ b/src/tests/unit/tests/injected/visualization-state-change-handler.test.ts
@@ -21,13 +21,21 @@ describe('VisualizationStateChangeHandler', () => {
         visualizationUpdaterMock = Mock.ofType<UpdateVisualization>();
         storeDataStub = {} as TargetPageStoreData;
         visualizations = [-1, -2];
-        testSubject = new VisualizationStateChangeHandler(visualizations, visualizationUpdaterMock.object, assessmentProviderMock.object);
+        testSubject = new VisualizationStateChangeHandler(
+            visualizations,
+            visualizationUpdaterMock.object,
+            assessmentProviderMock.object,
+        );
     });
 
     test('non-assessment visualizations', () => {
         visualizations.forEach(visualizationType => {
-            assessmentProviderMock.setup(apm => apm.isValidType(visualizationType)).returns(() => false);
-            visualizationUpdaterMock.setup(vum => vum(visualizationType, null, storeDataStub)).verifiable();
+            assessmentProviderMock
+                .setup(apm => apm.isValidType(visualizationType))
+                .returns(() => false);
+            visualizationUpdaterMock
+                .setup(vum => vum(visualizationType, null, storeDataStub))
+                .verifiable();
         });
         testSubject.updateVisualizationsWithStoreData(storeDataStub);
 
@@ -47,10 +55,16 @@ describe('VisualizationStateChangeHandler', () => {
         };
 
         visualizations.forEach(visualizationType => {
-            assessmentProviderMock.setup(apm => apm.isValidType(visualizationType)).returns(() => true);
-            assessmentProviderMock.setup(apm => apm.getStepMap(visualizationType)).returns(() => stepMapStub);
+            assessmentProviderMock
+                .setup(apm => apm.isValidType(visualizationType))
+                .returns(() => true);
+            assessmentProviderMock
+                .setup(apm => apm.getStepMap(visualizationType))
+                .returns(() => stepMapStub);
             forOwn(stepMapStub, step => {
-                visualizationUpdaterMock.setup(vum => vum(visualizationType, step.key, storeDataStub)).verifiable();
+                visualizationUpdaterMock
+                    .setup(vum => vum(visualizationType, step.key, storeDataStub))
+                    .verifiable();
             });
         });
 

--- a/src/tests/unit/tests/injected/visualization-type-drawer-registrar.test.ts
+++ b/src/tests/unit/tests/injected/visualization-type-drawer-registrar.test.ts
@@ -6,7 +6,10 @@ import { IMock, Mock } from 'typemoq';
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
 import { VisualizationType } from '../../../../common/types/visualization-type';
-import { RegisterDrawer, VisualizationTypeDrawerRegistrar } from '../../../../injected/visualization-type-drawer-registrar';
+import {
+    RegisterDrawer,
+    VisualizationTypeDrawerRegistrar,
+} from '../../../../injected/visualization-type-drawer-registrar';
 import { Drawer } from '../../../../injected/visualization/drawer';
 import { DrawerProvider } from '../../../../injected/visualization/drawer-provider';
 
@@ -40,10 +43,14 @@ describe('VisualizationTypeDrawerRegistrar', () => {
     });
 
     test('registerDrawer: non-assessment type', () => {
-        visualizationConfigFactoryMock.setup(mock => mock.getConfiguration(typeStub)).returns(() => configMock.object);
+        visualizationConfigFactoryMock
+            .setup(mock => mock.getConfiguration(typeStub))
+            .returns(() => configMock.object);
         assessmentProviderMock.setup(mock => mock.isValidType(typeStub)).returns(() => false);
         configMock.setup(mock => mock.getIdentifier()).returns(() => identifierStub);
-        configMock.setup(mock => mock.getDrawer(drawerProviderMock.object)).returns(() => drawerStub);
+        configMock
+            .setup(mock => mock.getDrawer(drawerProviderMock.object))
+            .returns(() => drawerStub);
         registerDrawerMock.setup(mock => mock(identifierStub, drawerStub)).verifiable();
 
         testSubject.registerType(typeStub);
@@ -64,13 +71,23 @@ describe('VisualizationTypeDrawerRegistrar', () => {
         };
         const secondIdentifierStub = 'some other id';
 
-        visualizationConfigFactoryMock.setup(mock => mock.getConfiguration(typeStub)).returns(() => configMock.object);
+        visualizationConfigFactoryMock
+            .setup(mock => mock.getConfiguration(typeStub))
+            .returns(() => configMock.object);
         assessmentProviderMock.setup(mock => mock.isValidType(typeStub)).returns(() => true);
         assessmentProviderMock.setup(mock => mock.getStepMap(typeStub)).returns(() => stepMapStub);
-        configMock.setup(mock => mock.getIdentifier(requirementStub.key)).returns(() => identifierStub);
-        configMock.setup(mock => mock.getIdentifier(requirementStubTwo.key)).returns(() => secondIdentifierStub);
-        configMock.setup(mock => mock.getDrawer(drawerProviderMock.object, identifierStub)).returns(() => drawerStub);
-        configMock.setup(mock => mock.getDrawer(drawerProviderMock.object, secondIdentifierStub)).returns(() => drawerStub);
+        configMock
+            .setup(mock => mock.getIdentifier(requirementStub.key))
+            .returns(() => identifierStub);
+        configMock
+            .setup(mock => mock.getIdentifier(requirementStubTwo.key))
+            .returns(() => secondIdentifierStub);
+        configMock
+            .setup(mock => mock.getDrawer(drawerProviderMock.object, identifierStub))
+            .returns(() => drawerStub);
+        configMock
+            .setup(mock => mock.getDrawer(drawerProviderMock.object, secondIdentifierStub))
+            .returns(() => drawerStub);
         registerDrawerMock.setup(mock => mock(identifierStub, drawerStub)).verifiable();
         registerDrawerMock.setup(mock => mock(secondIdentifierStub, drawerStub)).verifiable();
 


### PR DESCRIPTION
#### Description of changes

Adding every subfolder under `src/tests/unit/tests/injected`, this way we keep the PR smaller and apply the desired line width to files directly under `src/tests/unit/tests/injected` but not under any of the subfolders there. Those subfolders will be added in future PRs.

#### Pull request checklist
- [x] Addresses an existing issue: partially addresses #1713
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
