### PR TITLE
chore: fail the grunt publish task if it resolves with 'BadUploadResult'

### DIFF
--- a/deploy/Gruntfile.js
+++ b/deploy/Gruntfile.js
@@ -44,6 +44,11 @@ module.exports = function(grunt) {
                 },
             },
             onError: e => grunt.fail.fatal(e.errorMsg),
+            onExtensionPublished: info => {
+                if (!info.success) {
+                    grunt.fail.fatal(JSON.stringify(info));
+                }
+            },
         },
     });
 


### PR DESCRIPTION
#### Description of changes

Similar to #2058, this PR fails the grunt task if the webstore publish fails. A recent error we saw in our publish step results from this [line](https://github.com/c301/grunt-webstore-upload/blob/c62cce2191cd8717de08ba670bbc4c1be2dbbc61/tasks/webstore_upload.js#L651) - however, the library does not call the `onError` callback in this case. Instead, we wait for the upload result [here](https://github.com/c301/grunt-webstore-upload/blob/c62cce2191cd8717de08ba670bbc4c1be2dbbc61/tasks/webstore_upload.js#L374) and fail the task ourselves if needed. To test this, I added the grunt options `fakeUpload` / `fakeBadPublish`, and manually removed some required checks for appId / other options I didn't have set up locally.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
