### PR TITLE
refactor: start cleaning up css for test step view

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -294,11 +294,6 @@ div.insights-file-issue-details-dialog-container {
                     padding-top: 0px;
                     display: inline-block;
                 }
-                .test-guidance-links-group {
-                    align-items: flex-end;
-                    display: flex;
-                    flex-direction: column;
-                }
             }
             .visual-helper {
                 display: flex;
@@ -321,28 +316,6 @@ div.insights-file-issue-details-dialog-container {
             .test-step-instructions-header {
                 font-size: 14px;
                 font-weight: $normalTitleFontWeight;
-            }
-            .test-step-instructions {
-                font-family: $fontFamily;
-                p,
-                ol,
-                li {
-                    margin: 5px 0px;
-                }
-                ol {
-                    -webkit-padding-start: 16px;
-                }
-                ol ol {
-                    list-style-type: lower-alpha;
-                }
-                ol ol ol {
-                    list-style-type: lower-roman;
-                }
-            }
-            .test-step-instances-header {
-                font-size: 15px;
-                font-weight: normal;
-                padding-top: 15px;
             }
             .no-matching-elements {
                 font-weight: bold;

--- a/src/DetailsView/components/test-step-view.scss
+++ b/src/DetailsView/components/test-step-view.scss
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+@import '../../common/styles/common.scss';
+
+.test-step-instructions {
+    font-family: $fontFamily;
+    p,
+    ol,
+    li {
+        margin: 5px 0px;
+    }
+    ol {
+        -webkit-padding-start: 16px;
+    }
+    ol ol {
+        list-style-type: lower-alpha;
+    }
+    ol ol ol {
+        list-style-type: lower-roman;
+    }
+}
+
+.test-step-instructions-header {
+    font-size: 14px;
+    font-weight: $normalTitleFontWeight;
+}

--- a/src/DetailsView/components/test-step-view.tsx
+++ b/src/DetailsView/components/test-step-view.tsx
@@ -1,26 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
-import * as React from 'react';
-
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Requirement, VisualHelperToggleConfig } from 'assessments/types/requirement';
-import { ContentPanelButton, ContentPanelButtonDeps } from 'views/content/content-panel-button';
-import { CollapsibleComponent } from '../../common/components/collapsible-component';
-import { GuidanceTags, GuidanceTagsDeps } from '../../common/components/guidance-tags';
+import { CollapsibleComponent } from 'common/components/collapsible-component';
+import { GuidanceTags, GuidanceTagsDeps } from 'common/components/guidance-tags';
 import {
     AssessmentNavState,
     GeneratedAssessmentInstance,
     ManualTestStepResult,
-} from '../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { PathSnippetStoreData } from '../../common/types/store-data/path-snippet-store-data';
-import { DictionaryStringTo } from '../../types/common-types';
+} from 'common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { PathSnippetStoreData } from 'common/types/store-data/path-snippet-store-data';
+import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { DictionaryStringTo } from 'types/common-types';
+import { ContentPanelButton, ContentPanelButtonDeps } from 'views/content/content-panel-button';
+
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
 import { AssessmentInstanceTable } from './assessment-instance-table';
 import { ManualTestStepView } from './manual-test-step-view';
+import * as styles from './test-step-view.scss';
 
 export type TestStepViewDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
@@ -66,9 +67,9 @@ export class TestStepView extends React.Component<TestStepViewProps> {
                 </div>
                 {this.renderVisualHelperToggle()}
                 <CollapsibleComponent
-                    header={<h4 className="test-step-instructions-header">How to test</h4>}
+                    header={<h4 className={styles.testStepInstructionsHeader}>How to test</h4>}
                     content={this.props.testStep.howToTest}
-                    contentClassName={'test-step-instructions'}
+                    contentClassName={styles.testStepInstructions}
                 />
                 {this.renderTable()}
             </div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/test-step-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/test-step-view.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`TestStepViewTest render snapshot matches with manual false and scanning
       Info &amp; examples
     </ContentPanelButton>
   </div>
-  <CollapsibleComponent header={{...}} content={{...}} contentClassName=\\"test-step-instructions\\" />
+  <CollapsibleComponent header={{...}} content={{...}} contentClassName=\\"testStepInstructions\\" />
   <div role=\\"alert\\" aria-live=\\"polite\\" aria-label=\\"Scan Complete\\" />
   <h3 className=\\"test-step-instances-header\\">
     Instances
@@ -31,7 +31,7 @@ exports[`TestStepViewTest render, variable part for assisted test 1`] = `
       Info &amp; examples
     </ContentPanelButton>
   </div>
-  <CollapsibleComponent header={{...}} content={{...}} contentClassName=\\"test-step-instructions\\" />
+  <CollapsibleComponent header={{...}} content={{...}} contentClassName=\\"testStepInstructions\\" />
   <h3 className=\\"test-step-instances-header\\">
     Instances
   </h3>

--- a/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
@@ -1,20 +1,20 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as Enzyme from 'enzyme';
-import * as React from 'react';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
 import { Requirement } from 'assessments/types/requirement';
-import { CollapsibleComponent } from '../../../../../common/components/collapsible-component';
-import { ManualTestStatus } from '../../../../../common/types/manual-test-status';
-import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { AssessmentInstanceTable } from '../../../../../DetailsView/components/assessment-instance-table';
-import { AssessmentVisualizationEnabledToggle } from '../../../../../DetailsView/components/assessment-visualization-enabled-toggle';
-import { ManualTestStepView } from '../../../../../DetailsView/components/manual-test-step-view';
-import { TestStepView, TestStepViewProps } from '../../../../../DetailsView/components/test-step-view';
-import { AssessmentInstanceTableHandler } from '../../../../../DetailsView/handlers/assessment-instance-table-handler';
-import { BaseDataBuilder } from '../../../common/base-data-builder';
+import { CollapsibleComponent } from 'common/components/collapsible-component';
+import { ManualTestStatus } from 'common/types/manual-test-status';
+import { VisualizationType } from 'common/types/visualization-type';
+import { AssessmentInstanceTable } from 'DetailsView/components/assessment-instance-table';
+import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
+import { ManualTestStepView } from 'DetailsView/components/manual-test-step-view';
+import { TestStepView, TestStepViewProps } from 'DetailsView/components/test-step-view';
+import * as styles from 'DetailsView/components/test-step-view.scss';
+import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
+import * as Enzyme from 'enzyme';
+import * as React from 'react';
+import { BaseDataBuilder } from 'tests/unit/common/base-data-builder';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 let getVisualHelperToggleMock: IMock<(provider, props) => {}>;
 
@@ -48,8 +48,8 @@ describe('TestStepViewTest', () => {
 
         expect(testInstructions.exists()).toBeTruthy();
         expect(props.testStep.howToTest).toEqual(testInstructions.prop('content'));
-        expect(testInstructions.prop('contentClassName')).toBe('test-step-instructions');
-        expect(testInstructions.prop('header')).toEqual(<h4 className="test-step-instructions-header">How to test</h4>);
+        expect(testInstructions.prop('contentClassName')).toBe(styles.testStepInstructions);
+        expect(testInstructions.prop('header')).toEqual(<h4 className={styles.testStepInstructionsHeader}>How to test</h4>);
     });
 
     test('render spinner for non-manual tests', () => {


### PR DESCRIPTION
#### Description of changes

Removes some dead css and _starts_ the process for more work in this component.

The reason I did not continue and do more was due to conflicts with detailsview.scss that would require me to use more !important styles. I want to look into how I can just not use those styles from detailsview.scss instead.

CSS remains unchanged:
![image](https://user-images.githubusercontent.com/32555133/76476371-0f034f80-63bf-11ea-878f-daa66a8734d3.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
