### PR TITLE
refactor: debug tools to use WithStoreSubscription

### DIFF
--- a/src/debug-tools/components/debug-tools-view.tsx
+++ b/src/debug-tools/components/debug-tools-view.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    withStoreSubscription,
+    WithStoreSubscriptionDeps,
+} from 'common/components/with-store-subscription';
+import { NamedFC } from 'common/react/named-fc';
+import { StoresTree, StoresTreeState } from 'debug-tools/components/stores-tree';
+import * as React from 'react';
+
+export type DebugToolsViewState = StoresTreeState;
+
+export type DebugToolsViewDeps = WithStoreSubscriptionDeps<DebugToolsViewState>;
+
+export interface DebugToolsViewProps {
+    deps: DebugToolsViewDeps;
+    storeState: DebugToolsViewState;
+}
+
+export const DebugTools = NamedFC<DebugToolsViewProps>('DebugToolsView', ({ deps, storeState }) => {
+    return <StoresTree deps={deps} state={storeState} />;
+});
+
+export const DebugToolsView = withStoreSubscription<DebugToolsViewProps, DebugToolsViewState>(
+    DebugTools,
+);

--- a/src/debug-tools/components/stores-tree.tsx
+++ b/src/debug-tools/components/stores-tree.tsx
@@ -1,8 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BaseStore } from 'common/base-store';
-import { StoreActionMessageCreator } from 'common/message-creators/store-action-message-creator';
-import { forEach, isEmpty } from 'lodash';
+import { NamedFC } from 'common/react/named-fc';
+import { ClientStoresHub } from 'common/stores/client-stores-hub';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
+import { ScopingStoreData } from 'common/types/store-data/scoping-store-data';
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { forEach } from 'lodash';
 import {
     DetailsRow,
     FocusZone,
@@ -14,17 +18,6 @@ import {
     Spinner,
 } from 'office-ui-fabric-react';
 import * as React from 'react';
-
-export type StoresTreeProps = {
-    global: BaseStore<any>[];
-    storeActionMessageCreator: StoreActionMessageCreator;
-};
-
-export type StoresTreeState = {
-    global: {
-        [storeId: string]: any;
-    };
-};
 
 export const columns: IColumn[] = [
     {
@@ -42,98 +35,88 @@ export const columns: IColumn[] = [
     },
 ];
 
-export class StoresTree extends React.Component<StoresTreeProps, StoresTreeState> {
-    private selection = new Selection();
-    private selectionMode = SelectionMode.none;
-    private compact = true;
-
-    constructor(props: StoresTreeProps) {
-        super(props);
-        this.state = {
-            global: {},
-        };
-    }
-
-    public componentDidMount(): void {
-        this.props.global.forEach(store => {
-            store.addChangedListener(() => {
-                this.setState({
-                    global: {
-                        ...this.state.global,
-                        [store.getId()]: store.getState(),
-                    },
-                });
-            });
-        });
-
-        this.props.storeActionMessageCreator.getAllStates();
-    }
-
-    public render(): JSX.Element {
-        const global = this.state.global;
-
-        if (isEmpty(global)) {
-            return <Spinner label="loading..." />;
-        }
-
-        const groups = [];
-        let items = [];
-
-        let instanceCount: number = 0;
-
-        forEach(global, (storeState, storeKey) => {
-            const stateKeys = Object.keys(storeState);
-
-            const currentGroup = {
-                key: storeKey,
-                name: storeKey,
-                startIndex: instanceCount,
-                count: stateKeys.length,
-            };
-
-            groups.push(currentGroup);
-
-            const currentGroupItems = stateKeys.map(key => {
-                return {
-                    key,
-                    value: storeState[key],
-                };
-            });
-
-            items = items.concat(currentGroupItems);
-
-            instanceCount += currentGroupItems.length;
-        });
-
-        this.selection.setItems(items);
-
-        const onRenderCell = (nestingDepth: number, item: any, itemIndex: number): JSX.Element => {
-            return (
-                <DetailsRow
-                    columns={columns}
-                    groupNestingDepth={nestingDepth}
-                    item={item}
-                    itemIndex={itemIndex}
-                    selection={this.selection}
-                    selectionMode={this.selectionMode}
-                    compact={this.compact}
-                />
-            );
-        };
-
-        return (
-            <FocusZone>
-                <SelectionZone selection={this.selection} selectionMode={this.selectionMode}>
-                    <GroupedList
-                        items={items}
-                        onRenderCell={onRenderCell}
-                        selection={this.selection}
-                        selectionMode={this.selectionMode}
-                        groups={groups}
-                        compact={this.compact}
-                    />
-                </SelectionZone>
-            </FocusZone>
-        );
-    }
+export interface StoresTreeState {
+    featureFlagStoreData: FeatureFlagStoreData;
+    scopingStoreData: ScopingStoreData;
+    userConfigurationStoreData: UserConfigurationStoreData;
+    permissionsStateStoreData: PermissionsStateStoreData;
 }
+
+export type StoresTreeDeps = {
+    storesHub: ClientStoresHub<StoresTreeState>;
+};
+
+export interface StoresTreeProps {
+    deps: StoresTreeDeps;
+    state: StoresTreeState;
+}
+
+export const StoresTree = NamedFC<StoresTreeProps>('StoresTree', ({ deps, state }) => {
+    const { storesHub } = deps;
+
+    if (!storesHub.hasStoreData()) {
+        return <Spinner label="loading..." />;
+    }
+
+    const compact = true;
+    const selection = new Selection();
+    const selectionMode = SelectionMode.none;
+
+    const groups = [];
+    let items = [];
+
+    let instanceCount: number = 0;
+
+    forEach(state, (storeState, storeKey) => {
+        const stateKeys = Object.keys(storeState);
+
+        const currentGroup = {
+            key: storeKey,
+            name: storeKey,
+            startIndex: instanceCount,
+            count: stateKeys.length,
+        };
+
+        groups.push(currentGroup);
+
+        const currentGroupItems = stateKeys.map(key => {
+            return {
+                key,
+                value: storeState[key],
+            };
+        });
+
+        items = items.concat(currentGroupItems);
+
+        instanceCount += currentGroupItems.length;
+    });
+
+    const onRenderCell = (nestingDepth: number, item: any, itemIndex: number): JSX.Element => {
+        return (
+            <DetailsRow
+                columns={columns}
+                groupNestingDepth={nestingDepth}
+                item={item}
+                itemIndex={itemIndex}
+                selection={selection}
+                selectionMode={selectionMode}
+                compact={compact}
+            />
+        );
+    };
+
+    return (
+        <FocusZone>
+            <SelectionZone selection={selection} selectionMode={selectionMode}>
+                <GroupedList
+                    items={items}
+                    onRenderCell={onRenderCell}
+                    selection={selection}
+                    selectionMode={selectionMode}
+                    groups={groups}
+                    compact={compact}
+                />
+            </SelectionZone>
+        </FocusZone>
+    );
+});

--- a/src/debug-tools/components/stores-tree.tsx
+++ b/src/debug-tools/components/stores-tree.tsx
@@ -12,11 +12,11 @@ import {
     FocusZone,
     GroupedList,
     IColumn,
+    IGroup,
     Selection,
     SelectionMode,
     SelectionZone,
     Spinner,
-    IGroup,
 } from 'office-ui-fabric-react';
 import * as React from 'react';
 

--- a/src/debug-tools/components/stores-tree.tsx
+++ b/src/debug-tools/components/stores-tree.tsx
@@ -16,6 +16,7 @@ import {
     SelectionMode,
     SelectionZone,
     Spinner,
+    IGroup,
 } from 'office-ui-fabric-react';
 import * as React from 'react';
 
@@ -62,7 +63,7 @@ export const StoresTree = NamedFC<StoresTreeProps>('StoresTree', ({ deps, state 
     const selection = new Selection();
     const selectionMode = SelectionMode.none;
 
-    const groups = [];
+    const groups: IGroup[] = [];
     let items = [];
 
     let instanceCount: number = 0;
@@ -70,7 +71,7 @@ export const StoresTree = NamedFC<StoresTreeProps>('StoresTree', ({ deps, state 
     forEach(state, (storeState, storeKey) => {
         const stateKeys = Object.keys(storeState);
 
-        const currentGroup = {
+        const currentGroup: IGroup = {
             key: storeKey,
             name: storeKey,
             startIndex: instanceCount,

--- a/src/debug-tools/initializer/debug-tools-init.tsx
+++ b/src/debug-tools/initializer/debug-tools-init.tsx
@@ -8,12 +8,17 @@ import { createDefaultLogger } from 'common/logging/default-logger';
 import { RemoteActionMessageDispatcher } from 'common/message-creators/remote-action-message-dispatcher';
 import { StoreActionMessageCreatorFactory } from 'common/message-creators/store-action-message-creator-factory';
 import { StoreProxy } from 'common/store-proxy';
+import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { StoreNames } from 'common/stores/store-names';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { ScopingStoreData } from 'common/types/store-data/scoping-store-data';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
-import { StoresTree, StoresTreeProps } from 'debug-tools/components/stores-tree';
+import {
+    DebugToolsView,
+    DebugToolsViewDeps,
+    DebugToolsViewState,
+} from 'debug-tools/components/debug-tools-view';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
@@ -24,8 +29,10 @@ export const initializeDebugTools = () => {
     const stores = createStoreProxies(browserAdapter);
     const storeActionMessageCreator = getStoreActionMessageCreator(browserAdapter, stores);
 
-    const props = {
-        global: stores,
+    const storesHub = new BaseClientStoresHub<DebugToolsViewState>(stores);
+
+    const props: DebugToolsViewDeps = {
+        storesHub,
         storeActionMessageCreator,
     };
 
@@ -67,10 +74,10 @@ const getStoreActionMessageCreator = (browserAdapter: BrowserAdapter, stores: Ba
     return storeActionMessageCreatorFactory.fromStores(stores);
 };
 
-const render = (props: StoresTreeProps) => {
+const render = (deps: DebugToolsViewDeps) => {
     const container = document.querySelector('#debug-tools-container');
 
-    ReactDOM.render(<StoresTree {...props} />, container);
+    ReactDOM.render(<DebugToolsView deps={deps} />, container);
 };
 
 initializeDebugTools();

--- a/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DebugToolsView renders 1`] = `
+<StoresTree
+  deps={
+    Object {
+      "storesHub": null,
+    }
+  }
+  state={
+    Object {
+      "userConfigurationStoreData": Object {
+        "isFirstTime": true,
+      },
+    }
+  }
+/>
+`;

--- a/src/tests/unit/tests/debug-tools/components/__snapshots__/stores-tree.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/__snapshots__/stores-tree.test.tsx.snap
@@ -1,21 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StoresTree handles store updates by updating the state: after update 1`] = `
-Object {
-  "global": Object {
-    "test-store-id": Object {
-      "value": "1",
-    },
-  },
-}
-`;
-
-exports[`StoresTree handles store updates by updating the state: before update 1`] = `
-Object {
-  "global": Object {},
-}
-`;
-
 exports[`StoresTree renders each row properly 1`] = `
 <StyledDetailsRowBase
   columns={
@@ -52,26 +36,12 @@ exports[`StoresTree renders each row properly 1`] = `
       "_exemptedIndices": Object {},
       "_getKey": [Function],
       "_isModal": false,
-      "_items": Array [
-        Object {
-          "key": "0",
-          "value": "1",
-        },
-        Object {
-          "key": "0",
-          "value": "2",
-        },
-      ],
-      "_keyToIndexMap": Object {
-        "0": 1,
-      },
+      "_items": Array [],
+      "_keyToIndexMap": Object {},
       "_onSelectionChanged": undefined,
       "_selectedItems": null,
       "_unselectableCount": 0,
-      "_unselectableIndices": Object {
-        "0": false,
-        "1": false,
-      },
+      "_unselectableIndices": Object {},
       "count": 0,
       "mode": 2,
     }
@@ -82,13 +52,13 @@ exports[`StoresTree renders each row properly 1`] = `
 
 exports[`StoresTree renders the value column properly 1`] = `"{\\"first\\":1,\\"second\\":\\"2\\",\\"third\\":true,\\"fourth\\":[4],\\"fifth\\":{\\"sixth\\":\\"6\\"}}"`;
 
-exports[`StoresTree renders with NO global state 1`] = `
+exports[`StoresTree renders with no data from the state 1`] = `
 <StyledSpinnerBase
   label="loading..."
 />
 `;
 
-exports[`StoresTree renders with global state 1`] = `
+exports[`StoresTree renders with proper data from the stores 1`] = `
 <FocusZone
   direction={2}
   isCircularNavigation={false}
@@ -104,26 +74,12 @@ exports[`StoresTree renders with global state 1`] = `
         "_exemptedIndices": Object {},
         "_getKey": [Function],
         "_isModal": false,
-        "_items": Array [
-          Object {
-            "key": "0",
-            "value": "1",
-          },
-          Object {
-            "key": "0",
-            "value": "2",
-          },
-        ],
-        "_keyToIndexMap": Object {
-          "0": 1,
-        },
+        "_items": Array [],
+        "_keyToIndexMap": Object {},
         "_onSelectionChanged": undefined,
         "_selectedItems": null,
         "_unselectableCount": 0,
-        "_unselectableIndices": Object {
-          "0": false,
-          "1": false,
-        },
+        "_unselectableIndices": Object {},
         "count": 0,
         "mode": 2,
       }
@@ -135,28 +91,32 @@ exports[`StoresTree renders with global state 1`] = `
       groups={
         Array [
           Object {
-            "count": 1,
-            "key": "first",
-            "name": "first",
+            "count": 2,
+            "key": "userConfigurationStoreData",
+            "name": "userConfigurationStoreData",
             "startIndex": 0,
           },
           Object {
             "count": 1,
-            "key": "second",
-            "name": "second",
-            "startIndex": 1,
+            "key": "permissionsStateStoreData",
+            "name": "permissionsStateStoreData",
+            "startIndex": 2,
           },
         ]
       }
       items={
         Array [
           Object {
-            "key": "0",
-            "value": "1",
+            "key": "enableTelemetry",
+            "value": true,
           },
           Object {
-            "key": "0",
-            "value": "2",
+            "key": "isFirstTime",
+            "value": false,
+          },
+          Object {
+            "key": "hasAllUrlAndFilePermissions",
+            "value": true,
           },
         ]
       }
@@ -170,26 +130,12 @@ exports[`StoresTree renders with global state 1`] = `
           "_exemptedIndices": Object {},
           "_getKey": [Function],
           "_isModal": false,
-          "_items": Array [
-            Object {
-              "key": "0",
-              "value": "1",
-            },
-            Object {
-              "key": "0",
-              "value": "2",
-            },
-          ],
-          "_keyToIndexMap": Object {
-            "0": 1,
-          },
+          "_items": Array [],
+          "_keyToIndexMap": Object {},
           "_onSelectionChanged": undefined,
           "_selectedItems": null,
           "_unselectableCount": 0,
-          "_unselectableIndices": Object {
-            "0": false,
-            "1": false,
-          },
+          "_unselectableIndices": Object {},
           "count": 0,
           "mode": 2,
         }

--- a/src/tests/unit/tests/debug-tools/components/debug-tools-view.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/debug-tools-view.test.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import {
+    DebugTools,
+    DebugToolsViewDeps,
+    DebugToolsViewState,
+} from 'debug-tools/components/debug-tools-view';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('DebugToolsView', () => {
+    it('renders', () => {
+        const deps = {
+            storesHub: null,
+        } as DebugToolsViewDeps;
+
+        const storeState = {
+            userConfigurationStoreData: {
+                isFirstTime: true,
+            } as UserConfigurationStoreData,
+        } as DebugToolsViewState;
+
+        const wrapped = shallow(<DebugTools deps={deps} storeState={storeState} />);
+
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Currently, the main react component in the debug tools is in charge off listening to the stores and re-render when there are updates. 

This PR refactors this behavior by leveraging `WithStoreSubscription` and adding a new component in charge of being the top-level container component.

**Notes** there are no actual changes on the UI/UX 

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
