### PR TITLE
refactor: removes dead css related to old visualization guidance

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -587,51 +587,6 @@ div.insights-file-issue-details-dialog-container {
                 b {
                     font-weight: 600;
                 }
-                .why-vis {
-                    padding-top: 4px;
-                    font-size: 14px;
-                    .ms-Link {
-                        color: $communication-primary;
-                    }
-                }
-                .tab-stops-accessibility-problems-list {
-                    background: $neutral-6;
-                    list-style-type: disc;
-                }
-                .landmarks-legend {
-                    color: $neutral-100;
-                    font-size: 14px;
-                    display: table-cell;
-                    width: 110px;
-                    text-align: center;
-                    font-weight: 400;
-                    padding: 4px;
-                    vertical-align: middle;
-                    &.contentinfo-landmark {
-                        background-color: $landmark-contentinfo;
-                    }
-                    &.main-landmark {
-                        background-color: $landmark-main;
-                    }
-                    &.complementary-landmark {
-                        background-color: $landmark-complementary;
-                    }
-                    &.banner-landmark {
-                        background-color: $landmark-banner;
-                    }
-                    &.region-landmark {
-                        background-color: $landmark-region;
-                    }
-                    &.navigation-landmark {
-                        background-color: $landmark-navigation;
-                    }
-                    &.search-landmark {
-                        background-color: $landmark-search;
-                    }
-                    &.form-landmark {
-                        background-color: $landmark-form;
-                    }
-                }
                 .details-view-toggle {
                     margin-bottom: 0;
                     margin-top: 12px;
@@ -645,12 +600,6 @@ div.insights-file-issue-details-dialog-container {
                     .ms-Toggle-innerContainer {
                         margin: 10px 0px 10px 0px;
                     }
-                }
-                .details-icon-error {
-                    color: $negative-outcome;
-                    padding-right: 0.3em;
-                    padding-bottom: 0.1em;
-                    vertical-align: text-bottom;
                 }
                 .overview {
                     display: flex;


### PR DESCRIPTION
#### Description of changes

None of these classes were found in the repo.

The one related to landmarks does exist but only in content, which has its own styles elsewhere.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
