### PR TITLE
tool: script to generate change log for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
         "sass-loader": "^8.0.2",
         "script-loader": "0.7.2",
         "serve-static": "^1.13.2",
+        "simple-git": "^1.132.0",
         "source-map-loader": "^0.2.4",
         "spectron": "9.0.0",
         "terser-webpack-plugin": "^2.3.5",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
         "app-builder-lib": "^22.4.0",
         "case-sensitive-paths-webpack-plugin": "^2.3.0",
         "codecov": "^3.6.5",
+        "commander": "^4.1.1",
         "core-js-bundle": "^3.6.4",
         "cross-env": "^7.0.2",
         "css-loader": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "build:package:report": "grunt build-package-report",
         "build:package:ui": "grunt build-package-ui",
         "build:prod": "grunt build-prod",
+        "change-log": "node ./tools/get-change-log-for-release.js",
         "copyright:check": "license-check-and-add check -f copyright-header.config.json",
         "copyright:fix": "license-check-and-add add -f copyright-header.config.json",
         "download:electron-mirror": "node ./pipeline/scripts/download-electron-mirror.js",

--- a/tools/get-change-log-for-release.js
+++ b/tools/get-change-log-for-release.js
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+const gitP = require('simple-git/promise');
+const fs = require('fs');
+const path = require('path');
+
+const main = async () => {
+    const from = 'v2.14.1';
+    const to = 'web@2.15.0';
+    const outputPath = './temp.csv';
+
+    const gitLogs = await getGitLogs(from, to);
+
+    const outputContent = generateOutputContent(gitLogs);
+
+    ensureOutputFileExist(outputPath);
+
+    fs.writeFileSync(outputPath, outputContent);
+};
+
+const getGitLogs = async (from, to) => {
+    const git = gitP();
+
+    const gitLogs = await git.log({ from, to });
+
+    return gitLogs;
+};
+
+const getCommitType = commitMessage => {
+    const separator = ':';
+    const separatorIndex = commitMessage.indexOf(separator);
+
+    if (separatorIndex == -1) {
+        return 'NONE';
+    }
+
+    return commitMessage.substr(0, separatorIndex).trim();
+};
+
+const ensureOutputFileExist = outputPath => {
+    const dir = path.dirname(outputPath);
+
+    fs.mkdirSync(dir, {
+        recursive: true,
+    });
+};
+
+const generateOutputContent = (gitLogs, version) => {
+    const csvLogs = gitLogs.all
+        .map(log => {
+            return {
+                dev: log.author_name,
+                commit: log.hash.substr(0, 7),
+                change: log.message,
+                group: getCommitType(log.message),
+                version,
+                date: log.date,
+            };
+        })
+        .map(log => {
+            // the order here is important, it needs to match the headers order
+            return `,,"${log.dev}","${log.commit}","${log.change}","${log.group}","${log.version}","${log.date}"`;
+        });
+
+    const headers = ['tester', 'verified', 'dev', 'commit', 'change', 'group', 'version', 'date'];
+
+    const headersContent = headers.join(',');
+    return `${headersContent}\n`.concat(csvLogs.join('\n'));
+};
+
+main().catch(console.error);

--- a/tools/get-change-log-for-release.js
+++ b/tools/get-change-log-for-release.js
@@ -73,9 +73,15 @@ const parseCommandLineArguments = () => {
     const program = new commander.Command();
 
     program
-        .requiredOption('-f, --from <commit_hash>', 'starting point to get the logs')
-        .requiredOption('-t, --to <commit_hash>', 'ending point to get the logs')
-        .option('-o, --output <output_path>', 'path to the output file')
+        .requiredOption(
+            '-f, --from <commit_hash or tag>',
+            'Starting point to get the logs. Required.',
+        )
+        .requiredOption('-t, --to <commit_hash or tag>', 'Ending point to get the logs. Required.')
+        .option(
+            '-o, --output <output_path>',
+            'Path to the output file. Default: change-log.<from>-<to>.csv',
+        )
         .parse(process.argv);
 
     return program;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2360,6 +2360,11 @@ commander@^2.12.1, commander@^2.19.0, commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2767,7 +2767,7 @@ debug@2.6.9, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -8642,6 +8642,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+simple-git@^1.132.0:
+  version "1.132.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.132.0.tgz#53ac4c5ec9e74e37c2fd461e23309f22fcdf09b1"
+  integrity sha512-xauHm1YqCTom1sC9eOjfq3/9RKiUA9iPnxBbrY2DdL8l4ADMu0jjM5l5lphQP5YWNqAL2aXC/OeuQ76vHtW5fg==
+  dependencies:
+    debug "^4.0.1"
 
 single-line-log@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
#### Description of changes

Add a small js script to generate a csv file with the changes between to commits/tags.

There are two ways to use it:
```bash
node ./tools/get-change-log-for-release.js [options]
```
or
```bash
yarn change-log [options]
```

And this are the `[options]`
```bash
Usage: get-change-log-for-release [options]

Options:
  -f, --from <commit_hash or tag>  Starting point to get the logs. Required.
  -t, --to <commit_hash or tag>    Ending point to get the logs. Required.
  -o, --output <output_path>       Path to the output file. Default: change-log.<from>-<to>.csv
  -h, --help                       output usage information
```
Here's a snip of the resulting csv file:
```csv
tester,verified,dev,commit,change,group,version,date
,,"dependabot-preview[bot]","356652a","chore(deps-dev): bump @types/chrome from 0.0.98 to 0.0.99 (#2311)","chore(deps-dev)","web@2.15.0","2020-03-06 19:11:04 +0000"
,,"Wahaj","4ca8868","feat(build-release-android): update the API consumption for accessibility insights android service (#2239)","feat(build-release-android)","web@2.15.0","2020-03-06 10:41:08 -0800"
,,"Dan Bjorge","1dd772a","fix: iframe warning "learn more" not pointing to correct FAQ entry (#2310)","fix","web@2.15.0","2020-03-05 19:34:07 -0800"
,,"Sebastian Morales","a6cfa5e","chore: line width for src/tests/unit/tests/popup folder (#2308)","chore","web@2.15.0","2020-03-05 15:10:01 -0800"
,,"Dan Bjorge","8be175b","fix: fit-and-finish for settings/preview/failure instance panels (#2307)","fix","web@2.15.0","2020-03-05 14:44:06 -0800"
```

And here's how it looks in a nice UI (excel or similar)
![image](https://user-images.githubusercontent.com/2837582/76784331-afb38f80-6770-11ea-913c-900bc9448b0b.png)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
