### PR TITLE
feat(threat-model): remove usage of dangerouslySetInnerHtml on popup view

### DIFF
--- a/src/popup/components/popup-view.tsx
+++ b/src/popup/components/popup-view.tsx
@@ -192,16 +192,26 @@ export class PopupView extends React.Component<PopupViewProps> {
             <div className="ms-Fabric unsupported-url-info-panel">
                 {this.renderDefaultHeader()}
                 <div className="ms-Grid main-section">
-                    <div
-                        className="launch-panel-general-container"
-                        dangerouslySetInnerHTML={{
-                            __html: DisplayableStrings.urlNotScannable.join('</br>'),
-                        }}
-                    />
+                    <div className="launch-panel-general-container">
+                        <>{this.getUrlNotScannableMessage()}</>
+                    </div>
                 </div>
             </div>
         );
     }
+
+    private getUrlNotScannableMessage = () => {
+        let keyIndex = 0;
+        const result = DisplayableStrings.urlNotScannable.reduce(
+            (r, current) =>
+                r.concat(<span key={keyIndex++}>{current}</span>, <br key={keyIndex++}></br>),
+            [],
+        );
+
+        result.pop();
+
+        return result;
+    };
 
     private renderUnsupportedMsgPanelForFileUrl(): JSX.Element {
         const props: FileUrlUnsupportedMessagePanelProps = {

--- a/src/popup/components/popup-view.tsx
+++ b/src/popup/components/popup-view.tsx
@@ -208,6 +208,8 @@ export class PopupView extends React.Component<PopupViewProps> {
             [],
         );
 
+        // the reduce function above adds an extra <br> element
+        // calling pop to remove it before returning
         result.pop();
 
         return result;

--- a/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
+++ b/src/tests/unit/tests/popup/components/__snapshots__/popup-view.test.tsx.snap
@@ -59,12 +59,17 @@ exports[`PopupView renderFailureMsgPanelForChromeUrl 1`] = `
   >
     <div
       className="launch-panel-general-container"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Accessibility Insights for Web can't run on this URL.</br>You'll need to go to a different page.",
-        }
-      }
-    />
+    >
+      <React.Fragment>
+        <span>
+          Accessibility Insights for Web can't run on this URL.
+        </span>
+        <br />
+        <span>
+          You'll need to go to a different page.
+        </span>
+      </React.Fragment>
+    </div>
   </div>
 </div>
 `;

--- a/src/tests/unit/tests/popup/components/popup-view.test.tsx
+++ b/src/tests/unit/tests/popup/components/popup-view.test.tsx
@@ -1,27 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { NewTabLink } from 'common/components/new-tab-link';
+import { DropdownClickHandler } from 'common/dropdown-click-handler';
+import { StoreActionMessageCreatorImpl } from 'common/message-creators/store-action-message-creator-impl';
+import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
+import { LaunchPanelStoreData } from 'common/types/store-data/launch-panel-store-data';
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { shallow } from 'enzyme';
-import * as React from 'react';
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-import { BrowserAdapter } from '../../../../../common/browser-adapters/browser-adapter';
-import { NewTabLink } from '../../../../../common/components/new-tab-link';
-import { DropdownClickHandler } from '../../../../../common/dropdown-click-handler';
-import { StoreActionMessageCreatorImpl } from '../../../../../common/message-creators/store-action-message-creator-impl';
-import { BaseClientStoresHub } from '../../../../../common/stores/base-client-stores-hub';
-import { LaunchPanelStoreData } from '../../../../../common/types/store-data/launch-panel-store-data';
-import { UserConfigurationStoreData } from '../../../../../common/types/store-data/user-configuration-store';
-import { PopupActionMessageCreator } from '../../../../../popup/actions/popup-action-message-creator';
-import { LaunchPanelHeader } from '../../../../../popup/components/launch-panel-header';
+import { PopupActionMessageCreator } from 'popup/actions/popup-action-message-creator';
+import { LaunchPanelHeader } from 'popup/components/launch-panel-header';
 import {
     LaunchPanelType,
     PopupView,
     PopupViewControllerDeps,
     PopupViewControllerState,
     PopupViewProps,
-} from '../../../../../popup/components/popup-view';
-import { DiagnosticViewClickHandler } from '../../../../../popup/handlers/diagnostic-view-toggle-click-handler';
-import { PopupViewControllerHandler } from '../../../../../popup/handlers/popup-view-controller-handler';
-import { LaunchPadRowConfigurationFactory } from '../../../../../popup/launch-pad-row-configuration-factory';
+} from 'popup/components/popup-view';
+import { DiagnosticViewClickHandler } from 'popup/handlers/diagnostic-view-toggle-click-handler';
+import { PopupViewControllerHandler } from 'popup/handlers/popup-view-controller-handler';
+import { LaunchPadRowConfigurationFactory } from 'popup/launch-pad-row-configuration-factory';
+import * as React from 'react';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { BaseDataBuilder } from '../../../common/base-data-builder';
 import { IsSameObject } from '../../../common/typemoq-helper';
 


### PR DESCRIPTION
#### Description of changes

As part of our threat model follow up, we need to handle our usages of `dangerouslySetInnerHtml`. That means remove them or somehow account for them (in the sense of: let's not add more usages and make it clear where and why we are using it).

In this case, it was possible to remove the usage of `dangerouslySetInnerHtml` and replace it with "normal" react code.

**Note** there is no actual change on the UI/UX

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1697429
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
