### PR TITLE
feat(threat-model): enable tslint rule for no dangerous html property

### DIFF
--- a/src/reports/assessment-report-html-generator.tsx
+++ b/src/reports/assessment-report-html-generator.tsx
@@ -50,6 +50,7 @@ export class AssessmentReportHtmlGenerator {
 
         const model = modelBuilder.getReportModelData();
 
+        // tslint:disable: react-no-dangerous-html
         const reportElement = (
             <React.Fragment>
                 <head>

--- a/src/reports/components/report-head.tsx
+++ b/src/reports/components/report-head.tsx
@@ -8,6 +8,7 @@ import * as bundledStyles from '../../DetailsView/bundled-details-view-styles';
 import * as reportStyles from '../automated-checks-report.styles';
 
 export const ReportHead = NamedFC('ReportHead', () => {
+    // tslint:disable: react-no-dangerous-html
     return (
         <head>
             <meta charSet="UTF-8" />

--- a/src/reports/components/report-sections/results-container.tsx
+++ b/src/reports/components/report-sections/results-container.tsx
@@ -9,6 +9,7 @@ export type ResultsContainerProps = Pick<SectionProps, 'getCollapsibleScript'>;
 export const ResultsContainer = NamedFC<ResultsContainerProps>(
     'ResultsContainer',
     ({ children, getCollapsibleScript }) => {
+        // tslint:disable: react-no-dangerous-html
         return (
             <>
                 <div className="results-container">{children}</div>

--- a/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
@@ -43,6 +43,7 @@ describe('AssessmentReportHtmlGenerator', () => {
         const modelBuilderMock = Mock.ofType(AssessmentReportModelBuilder, MockBehavior.Strict);
         const model: ReportModel = { stub: 'model' } as any;
 
+        // tslint:disable: react-no-dangerous-html
         const expectedComponent = (
             <React.Fragment>
                 <head>

--- a/tslint.json
+++ b/tslint.json
@@ -81,6 +81,7 @@
         "react-a11y-role": true,
         "react-a11y-role-has-required-aria-props": true,
         "react-a11y-role-supports-aria-props": true,
+        "react-no-dangerous-html": true,
         "semicolon": [true, "always", "ignore-bound-class-methods"],
         "switch-default": true,
         "trailing-comma": [


### PR DESCRIPTION
#### Description of changes

As part of our threat model follow up, we need to handle our usages of `dangerouslySetInnerHtml`. That means remove them or somehow account for them (in the sense of: let's not add more usages and make it clear where and why we are using it).

There is a microsoft contrib tslint rule to catch uses of `dangerouslySetInnerHtml`. In this PR I'm enabling that and grandfathering the current usages of this property through our code.

I do thing there is more we can do to actually remove this usages, so we can either have this PR as a backup plan, or we can go ahead (so we have the tslint rule and no more usages are introduce) and fix what we can later (still during this feature).

**Note** this PR will fail tslint check as it depends on another PR where I was able to remove one of the usages.

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1697429
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
