### PR TITLE
tools: add header to debug tools page

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,6 +114,12 @@ module.exports = function(grunt) {
                         dest: path.join(extensionPath, 'common/styles/'),
                         expand: true,
                     },
+                    {
+                        cwd: './dist/src/debug-tools',
+                        src: '*.css',
+                        dest: path.join(extensionPath, 'debug-tools'),
+                        expand: true,
+                    },
                 ],
             },
             'package-report': {

--- a/src/debug-tools/components/debug-tools-view.tsx
+++ b/src/debug-tools/components/debug-tools-view.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { HeaderDeps, Header } from 'common/components/header';
+import { Header, HeaderDeps } from 'common/components/header';
 import {
     withStoreSubscription,
     WithStoreSubscriptionDeps,

--- a/src/debug-tools/components/debug-tools-view.tsx
+++ b/src/debug-tools/components/debug-tools-view.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { HeaderDeps, Header } from 'common/components/header';
 import {
     withStoreSubscription,
     WithStoreSubscriptionDeps,
@@ -10,7 +11,7 @@ import * as React from 'react';
 
 export type DebugToolsViewState = StoresTreeState;
 
-export type DebugToolsViewDeps = WithStoreSubscriptionDeps<DebugToolsViewState>;
+export type DebugToolsViewDeps = WithStoreSubscriptionDeps<DebugToolsViewState> & HeaderDeps;
 
 export interface DebugToolsViewProps {
     deps: DebugToolsViewDeps;
@@ -18,7 +19,12 @@ export interface DebugToolsViewProps {
 }
 
 export const DebugTools = NamedFC<DebugToolsViewProps>('DebugToolsView', ({ deps, storeState }) => {
-    return <StoresTree deps={deps} state={storeState} />;
+    return (
+        <>
+            <Header deps={deps} />
+            <StoresTree deps={deps} state={storeState} />
+        </>
+    );
 });
 
 export const DebugToolsView = withStoreSubscription<DebugToolsViewProps, DebugToolsViewState>(

--- a/src/debug-tools/debug-tools.html
+++ b/src/debug-tools/debug-tools.html
@@ -7,6 +7,7 @@ Licensed under the MIT License.
         <meta charset="utf-8" />
         <link rel="stylesheet" type="text/css" href="../common/styles/fabric.min.css" />
         <link rel="stylesheet" type="text/css" href="../bundle/debugTools.css" />
+        <link rel="stylesheet" type="text/css" href="./debug-tools.css" />
     </head>
     <body>
         <div id="debug-tools-container"></div>

--- a/src/debug-tools/debug-tools.html
+++ b/src/debug-tools/debug-tools.html
@@ -6,6 +6,7 @@ Licensed under the MIT License.
     <head>
         <meta charset="utf-8" />
         <link rel="stylesheet" type="text/css" href="../common/styles/fabric.min.css" />
+        <link rel="stylesheet" type="text/css" href="../bundle/debugTools.css" />
     </head>
     <body>
         <div id="debug-tools-container"></div>

--- a/src/debug-tools/debug-tools.scss
+++ b/src/debug-tools/debug-tools.scss
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+body {
+    margin: 0px;
+}

--- a/src/debug-tools/initializer/debug-tools-init.tsx
+++ b/src/debug-tools/initializer/debug-tools-init.tsx
@@ -14,6 +14,7 @@ import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store
 import { PermissionsStateStoreData } from 'common/types/store-data/permissions-state-store-data';
 import { ScopingStoreData } from 'common/types/store-data/scoping-store-data';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { textContent } from 'content/strings/text-content';
 import {
     DebugToolsView,
     DebugToolsViewDeps,
@@ -34,6 +35,7 @@ export const initializeDebugTools = () => {
     const props: DebugToolsViewDeps = {
         storesHub,
         storeActionMessageCreator,
+        textContent,
     };
 
     render(props);

--- a/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
@@ -1,18 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`DebugToolsView renders 1`] = `
-<StoresTree
-  deps={
-    Object {
-      "storesHub": null,
+<React.Fragment>
+  <Header
+    deps={
+      Object {
+        "storesHub": null,
+      }
     }
-  }
-  state={
-    Object {
-      "userConfigurationStoreData": Object {
-        "isFirstTime": true,
-      },
+  />
+  <StoresTree
+    deps={
+      Object {
+        "storesHub": null,
+      }
     }
-  }
-/>
+    state={
+      Object {
+        "userConfigurationStoreData": Object {
+          "isFirstTime": true,
+        },
+      }
+    }
+  />
+</React.Fragment>
 `;


### PR DESCRIPTION
#### Description of changes

Add the extension header to the debug tools page. Also, remove body margins.

![image](https://user-images.githubusercontent.com/2837582/76885514-96781500-683c-11ea-8401-09fc096ac5b3.png)

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
