### PR TITLE
chore: log file hashes in unified canary pipeline to help debug signing

### DIFF
--- a/pipeline/scripts/print-file-hash-info.js
+++ b/pipeline/scripts/print-file-hash-info.js
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// In the build loop it can be helpful to know the
+// sha256/512 value of the installer to help debug signing
+const hashUtil = require('app-builder-lib/out/util/hash');
+const fs = require('fs');
+const path = require('path');
+
+const parentDir = process.argv[2];
+
+const printFileInfo = async () => {
+    const entries = fs
+        .readdirSync(parentDir, { withFileTypes: true })
+        .filter(e => e.isFile())
+        .map(e => e.name);
+    for (const f of entries) {
+        console.log(f);
+        const filepath = path.resolve(parentDir, f);
+        const sha256 = await hashUtil.hashFile(filepath, 'sha256', 'base64');
+        const sha512 = await hashUtil.hashFile(filepath, 'sha512', 'base64');
+        console.log(`  sha256 ${sha256}`);
+        console.log(`  sha512 ${sha512}`);
+    }
+};
+
+printFileInfo().catch(err => {
+    console.error(err);
+    process.exit(1);
+});

--- a/pipeline/unified/build-unsigned-release-packages.yaml
+++ b/pipeline/unified/build-unsigned-release-packages.yaml
@@ -31,6 +31,9 @@ steps:
           ELECTRON_MIRROR: $(ELECTRON_MIRROR_VAR)
           ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR_VAR)
 
+    - script: node ./pipeline/scripts/print-file-hash-info.js $(System.DefaultWorkingDirectory)/drop/electron/unified-canary/packed
+      displayName: print out canary file hashes
+
     - template: publish-packed-build-output.yaml
       parameters:
           packedOutputPath: '$(System.DefaultWorkingDirectory)/drop/electron/unified-canary/packed'


### PR DESCRIPTION
#### Description of changes

Sometimes to investigate failures in the canary signing step, it's helpful to know the sha256 of each file we submit to the service. This PR logs the hashes during the build.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
