### PR TITLE
feat(threat-model): create LinkScriptProvider to add event listener on target page links

### DIFF
--- a/src/reports/components/report-sections/link-script-provider.tsx
+++ b/src/reports/components/report-sections/link-script-provider.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const addEventListenerForLink = (doc: Document) => {
+    const targetPageLink = doc.getElementById('target-page-link');
+
+    targetPageLink.addEventListener('click', event => {
+        const result = confirm(
+            'Are you sure you want to navigate away from the Accessibility Insights report?\n' +
+                'This link will open the target page in a new tab.\n\nPress OK to continue or ' +
+                'Cancel to stay on the current page.',
+        );
+
+        if (result === false) {
+            event.preventDefault();
+        }
+    });
+};
+
+export const getAddListenerForLink = (code: string | Function): string =>
+    `(${String(code)})(document)`;
+
+export const getDefaultAddListenerForLink = (): string =>
+    getAddListenerForLink(addEventListenerForLink);

--- a/src/reports/components/report-sections/link-script-provider.tsx
+++ b/src/reports/components/report-sections/link-script-provider.tsx
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-export const addEventListenerForLink = (doc: Document) => {
+export type ConfirmType = (message?: string) => boolean;
+
+export const addEventListenerForLink = (doc: Document, confirmCallback: ConfirmType) => {
     const targetPageLink = doc.getElementById('target-page-link');
 
     targetPageLink.addEventListener('click', event => {
-        const result = confirm(
+        const result = confirmCallback(
             'Are you sure you want to navigate away from the Accessibility Insights report?\n' +
                 'This link will open the target page in a new tab.\n\nPress OK to continue or ' +
                 'Cancel to stay on the current page.',
@@ -18,7 +20,7 @@ export const addEventListenerForLink = (doc: Document) => {
 };
 
 export const getAddListenerForLink = (code: string | Function): string =>
-    `(${String(code)})(document)`;
+    `(${String(code)})(document, confirm)`;
 
 export const getDefaultAddListenerForLink = (): string =>
     getAddListenerForLink(addEventListenerForLink);

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/link-script-provider.test.ts.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/link-script-provider.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LinkScriptProvider getAddListenerForLink matches content 1`] = `"(this is test code)(document)"`;

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/link-script-provider.test.ts.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/link-script-provider.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LinkScriptProvider getAddListenerForLink matches content 1`] = `"(this is test code)(document)"`;
+exports[`LinkScriptProvider getAddListenerForLink matches content 1`] = `"(this is test code)(document, confirm)"`;

--- a/src/tests/unit/tests/reports/components/report-sections/link-script-provider.test.ts
+++ b/src/tests/unit/tests/reports/components/report-sections/link-script-provider.test.ts
@@ -3,6 +3,7 @@
 import { isFunction } from 'lodash';
 import {
     addEventListenerForLink,
+    ConfirmType,
     getAddListenerForLink,
 } from 'reports/components/report-sections/link-script-provider';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
@@ -22,16 +23,51 @@ describe('LinkScriptProvider', () => {
         it('adds listener for click event on target-page-link', () => {
             const targetPageLinkMock = Mock.ofType<HTMLElement>();
             const docMock = Mock.ofType<Document>(undefined, MockBehavior.Strict);
+            const confirmMock = Mock.ofType<ConfirmType>();
+
             docMock
                 .setup(doc => doc.getElementById('target-page-link'))
                 .returns(() => targetPageLinkMock.object);
 
-            addEventListenerForLink(docMock.object);
+            targetPageLinkMock
+                .setup(link => link.addEventListener('click', It.isAny()))
+                .verifiable(Times.once());
 
-            targetPageLinkMock.verify(
-                link => link.addEventListener('click', It.is(isFunction)),
-                Times.once(),
-            );
+            addEventListenerForLink(docMock.object, confirmMock.object);
+
+            targetPageLinkMock.verifyAll();
         });
+        it.each([true, false])(
+            'listener calls confirm and triggers proper event when confirm result is %s',
+            isConfirmed => {
+                const targetPageLinkMock = Mock.ofType<HTMLElement>();
+                const docMock = Mock.ofType<Document>(undefined, MockBehavior.Strict);
+                const confirmMock = Mock.ofType<ConfirmType>();
+                const eventMock = Mock.ofType<Event>();
+
+                docMock
+                    .setup(doc => doc.getElementById('target-page-link'))
+                    .returns(() => targetPageLinkMock.object);
+
+                confirmMock
+                    .setup(confirmCallback => confirmCallback(It.isAnyString()))
+                    .returns(() => isConfirmed)
+                    .verifiable(Times.once());
+
+                const times: Times = isConfirmed ? Times.never() : Times.once();
+                eventMock.setup(event => event.preventDefault()).verifiable(times);
+
+                let clickListener: Function;
+                targetPageLinkMock
+                    .setup(link => link.addEventListener('click', It.isAny()))
+                    .callback((_, listener) => (clickListener = listener));
+
+                addEventListenerForLink(docMock.object, confirmMock.object);
+                clickListener(eventMock.object);
+
+                confirmMock.verifyAll();
+                eventMock.verifyAll();
+            },
+        );
     });
 });

--- a/src/tests/unit/tests/reports/components/report-sections/link-script-provider.test.ts
+++ b/src/tests/unit/tests/reports/components/report-sections/link-script-provider.test.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isFunction } from 'lodash';
 import {
     addEventListenerForLink,
     ConfirmType,

--- a/src/tests/unit/tests/reports/components/report-sections/link-script-provider.test.ts
+++ b/src/tests/unit/tests/reports/components/report-sections/link-script-provider.test.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { isFunction } from 'lodash';
+import {
+    addEventListenerForLink,
+    getAddListenerForLink,
+} from 'reports/components/report-sections/link-script-provider';
+import { It, Mock, MockBehavior, Times } from 'typemoq';
+
+describe('LinkScriptProvider', () => {
+    describe('getAddListenerForLink', () => {
+        it('matches content', () => {
+            const code = 'this is test code';
+
+            const result = getAddListenerForLink(code);
+
+            expect(result).toMatchSnapshot();
+        });
+    });
+
+    describe('addEventListenerForLink', () => {
+        it('adds listener for click event on target-page-link', () => {
+            const targetPageLinkMock = Mock.ofType<HTMLElement>();
+            const docMock = Mock.ofType<Document>(undefined, MockBehavior.Strict);
+            docMock
+                .setup(doc => doc.getElementById('target-page-link'))
+                .returns(() => targetPageLinkMock.object);
+
+            addEventListenerForLink(docMock.object);
+
+            targetPageLinkMock.verify(
+                link => link.addEventListener('click', It.is(isFunction)),
+                Times.once(),
+            );
+        });
+    });
+});


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

Created LinkScriptProvider that adds an event listener to the "click" event on elements with the `target-page-link` id in the generated HTML report. The event handler prompts the browser to generate a confirmation dialog, where selecting OK opens the target page in a new tab, and selecting Cancel prevents the target page from being opened.

Added relevant unit tests. There is no unit test for `getDefaultAddListenerForLink` because the snapshot text representation is a bit confusing (see `collapsible-script-provider.tsx` for similar issue).

Note: To keep this PR small, I will add the event listeners to the target page links in future PRs. As a result, there are currently no changes to UI.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Partially addresses an existing issue: # 1521197
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
