### PR TITLE
feat(threat-model): introduce target page inspector

### DIFF
--- a/src/Devtools/dev-tool-init.ts
+++ b/src/Devtools/dev-tool-init.ts
@@ -1,8 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DevToolsChromeAdapterImpl } from 'background/dev-tools-chrome-adapter';
+import { TargetPageInspector } from 'Devtools/target-page-inspector';
 import { DevToolInitializer } from './dev-tool-initializer';
 
 const browserAdapter = new DevToolsChromeAdapterImpl();
-const devToolInitializer: DevToolInitializer = new DevToolInitializer(browserAdapter);
+const targetPageInspector = new TargetPageInspector(chrome.devtools.inspectedWindow);
+
+const devToolInitializer: DevToolInitializer = new DevToolInitializer(
+    browserAdapter,
+    targetPageInspector,
+);
 devToolInitializer.initialize();

--- a/src/Devtools/dev-tool-initializer.ts
+++ b/src/Devtools/dev-tool-initializer.ts
@@ -5,20 +5,25 @@ import { StoreProxy } from '../common/store-proxy';
 import { StoreNames } from '../common/stores/store-names';
 import { DevToolStoreData } from '../common/types/store-data/dev-tool-store-data';
 import { InspectHandler } from './inspect-handler';
+import { TargetPageInspector } from 'Devtools/target-page-inspector';
 
 export class DevToolInitializer {
-    protected devToolsChromeAdapter: DevToolsChromeAdapter;
-
-    constructor(devToolsChromeAdapter: DevToolsChromeAdapter) {
-        this.devToolsChromeAdapter = devToolsChromeAdapter;
-    }
+    constructor(
+        private readonly devToolsChromeAdapter: DevToolsChromeAdapter,
+        private readonly targetPageInspector: TargetPageInspector,
+    ) {}
 
     public initialize(): void {
         const devtoolsStore = new StoreProxy<DevToolStoreData>(
             StoreNames[StoreNames.DevToolsStore],
             this.devToolsChromeAdapter,
         );
-        const inspectHandler = new InspectHandler(devtoolsStore, this.devToolsChromeAdapter);
+
+        const inspectHandler = new InspectHandler(
+            devtoolsStore,
+            this.devToolsChromeAdapter,
+            this.targetPageInspector,
+        );
 
         inspectHandler.initialize();
     }

--- a/src/Devtools/dev-tool-initializer.ts
+++ b/src/Devtools/dev-tool-initializer.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DevToolsChromeAdapter } from 'background/dev-tools-chrome-adapter';
+import { TargetPageInspector } from 'Devtools/target-page-inspector';
 import { StoreProxy } from '../common/store-proxy';
 import { StoreNames } from '../common/stores/store-names';
 import { DevToolStoreData } from '../common/types/store-data/dev-tool-store-data';
 import { InspectHandler } from './inspect-handler';
-import { TargetPageInspector } from 'Devtools/target-page-inspector';
 
 export class DevToolInitializer {
     constructor(

--- a/src/Devtools/inspect-handler.ts
+++ b/src/Devtools/inspect-handler.ts
@@ -1,22 +1,18 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DevToolsChromeAdapter } from 'background/dev-tools-chrome-adapter';
+import { TargetPageInspector } from 'Devtools/target-page-inspector';
 import { BaseStore } from '../common/base-store';
 import { ConnectionNames } from '../common/constants/connection-names';
 import { DevToolsOpenMessage } from '../common/types/dev-tools-open-message';
 import { DevToolStoreData } from '../common/types/store-data/dev-tool-store-data';
 
 export class InspectHandler {
-    private devToolsStore: BaseStore<DevToolStoreData>;
-    private devToolsChromeAdapter: DevToolsChromeAdapter;
-
     constructor(
-        devToolsStore: BaseStore<DevToolStoreData>,
-        devToolsChromeAdapter: DevToolsChromeAdapter,
-    ) {
-        this.devToolsStore = devToolsStore;
-        this.devToolsChromeAdapter = devToolsChromeAdapter;
-    }
+        private readonly devToolsStore: BaseStore<DevToolStoreData>,
+        private readonly devToolsChromeAdapter: DevToolsChromeAdapter,
+        private readonly targetPageInspector: TargetPageInspector,
+    ) {}
 
     public initialize(): void {
         this.devToolsStore.addChangedListener(() => {
@@ -27,12 +23,8 @@ export class InspectHandler {
                 state.inspectElement &&
                 (state.inspectElement.length === 1 || state.frameUrl)
             ) {
-                this.devToolsChromeAdapter.executeScriptInInspectedWindow(
-                    "inspect(document.querySelector('" +
-                        state.inspectElement[state.inspectElement.length - 1] +
-                        "'))",
-                    state.frameUrl,
-                );
+                const selector = state.inspectElement[state.inspectElement.length - 1];
+                this.targetPageInspector.inspectElement(selector, state.frameUrl);
             }
         });
 

--- a/src/Devtools/target-page-inspector.ts
+++ b/src/Devtools/target-page-inspector.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+export class TargetPageInspector {
+    constructor(private readonly inspectedWindow: typeof chrome.devtools.inspectedWindow) {}
+
+    public inspectElement(selector: string, frameUrl: string): void {
+        const sanitizedSelector = this.sanitizeSelector(selector);
+
+        const script = `inspect(document.querySelector(${sanitizedSelector}))`;
+
+        this.inspectedWindow.eval(script, { frameURL: frameUrl } as any);
+    }
+
+    private sanitizeSelector = (selector: any): string => {
+        if (typeof selector !== 'string') {
+            throw new Error('selector is not a string');
+        }
+
+        // stringify the string selector allow us to handle quote escaping
+        return JSON.stringify(selector);
+    };
+}

--- a/src/Devtools/target-page-inspector.ts
+++ b/src/Devtools/target-page-inspector.ts
@@ -16,7 +16,7 @@ export class TargetPageInspector {
             throw new Error('selector is not a string');
         }
 
-        // stringify the string selector allow us to handle quote escaping
+        // handles scaping the quotes safely
         return JSON.stringify(selector);
     };
 }

--- a/src/background/dev-tools-chrome-adapter.ts
+++ b/src/background/dev-tools-chrome-adapter.ts
@@ -5,15 +5,10 @@ import { ChromeAdapter } from '../common/browser-adapters/chrome-adapter';
 
 export interface DevToolsChromeAdapter extends BrowserAdapter {
     getInspectedWindowTabId(): number;
-    executeScriptInInspectedWindow(script: string, frameUrl: string): void;
 }
 
 export class DevToolsChromeAdapterImpl extends ChromeAdapter implements DevToolsChromeAdapter {
     public getInspectedWindowTabId(): number {
         return chrome.devtools.inspectedWindow.tabId;
-    }
-
-    public executeScriptInInspectedWindow(script: string, frameUrl: string): void {
-        chrome.devtools.inspectedWindow.eval(script, { frameURL: frameUrl } as any);
     }
 }

--- a/src/tests/unit/mock-helpers/dev-tools-chrome-adapter-mock.ts
+++ b/src/tests/unit/mock-helpers/dev-tools-chrome-adapter-mock.ts
@@ -65,17 +65,6 @@ export class DevToolsChromeAdapterMock {
         return this;
     }
 
-    public setupExecuteScriptInInspectedWindow(
-        script: string,
-        frameUrl: string,
-    ): DevToolsChromeAdapterMock {
-        this.underlyingMock
-            .setup(x => x.executeScriptInInspectedWindow(It.isValue(script), frameUrl))
-            .verifiable(Times.once());
-
-        return this;
-    }
-
     public verifyAll(): void {
         this.underlyingMock.verifyAll();
     }

--- a/src/tests/unit/tests/DevTools/inspect-handler.test.ts
+++ b/src/tests/unit/tests/DevTools/inspect-handler.test.ts
@@ -1,28 +1,31 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { IMock, It, Mock } from 'typemoq';
-
-import { ConnectionNames } from '../../../../common/constants/connection-names';
-import { DevToolStoreData } from '../../../../common/types/store-data/dev-tool-store-data';
-import { InspectHandler } from '../../../../Devtools/inspect-handler';
+import { ConnectionNames } from 'common/constants/connection-names';
+import { DevToolStoreData } from 'common/types/store-data/dev-tool-store-data';
+import { InspectHandler } from 'Devtools/inspect-handler';
+import { TargetPageInspector } from 'Devtools/target-page-inspector';
+import { IMock, It, Mock, Times } from 'typemoq';
 import { DevToolsChromeAdapterMock } from '../../mock-helpers/dev-tools-chrome-adapter-mock';
 import { StoreMock } from '../../mock-helpers/store-mock';
 import { PortStub } from '../../stubs/port-stub';
 
-describe('InspectHandlerTests', () => {
-    let testObjec: InspectHandler;
+describe('InspectHandler', () => {
+    let testSubject: InspectHandler;
     let devToolsChromeAdapterMock: DevToolsChromeAdapterMock;
     let devtoolsStoreProxyMock: StoreMock<DevToolStoreData>;
     let backgrountConnectionMock: IMock<chrome.runtime.Port>;
+    let targetPageInspectorMock: IMock<TargetPageInspector>;
     const inspectedWindowId = 12;
 
     beforeEach(() => {
         devToolsChromeAdapterMock = new DevToolsChromeAdapterMock();
         devtoolsStoreProxyMock = new StoreMock<DevToolStoreData>();
+        targetPageInspectorMock = Mock.ofType<TargetPageInspector>();
         backgrountConnectionMock = Mock.ofType(PortStub);
-        testObjec = new InspectHandler(
+        testSubject = new InspectHandler(
             devtoolsStoreProxyMock.getObject(),
             devToolsChromeAdapterMock.getObject(),
+            targetPageInspectorMock.object,
         );
 
         devToolsChromeAdapterMock.setUpConnect(
@@ -38,7 +41,7 @@ describe('InspectHandlerTests', () => {
             .verifiable();
         devToolsChromeAdapterMock.setupGetInspectedWindowTabId(inspectedWindowId);
 
-        testObjec.initialize();
+        testSubject.initialize();
 
         devtoolsStoreProxyMock.verifyAll();
         devToolsChromeAdapterMock.verifyAll();
@@ -49,7 +52,7 @@ describe('InspectHandlerTests', () => {
         devtoolsStoreProxyMock.setupAddChangedListener();
         devtoolsStoreProxyMock.setupGetState(null);
         devToolsChromeAdapterMock.setupGetInspectedWindowTabId(inspectedWindowId);
-        testObjec.initialize();
+        testSubject.initialize();
 
         devtoolsStoreProxyMock.invokeChangeListener();
 
@@ -65,7 +68,7 @@ describe('InspectHandlerTests', () => {
         devtoolsStoreProxyMock.setupAddChangedListener();
         devtoolsStoreProxyMock.setupGetState(state);
         devToolsChromeAdapterMock.setupGetInspectedWindowTabId(inspectedWindowId);
-        testObjec.initialize();
+        testSubject.initialize();
 
         devtoolsStoreProxyMock.invokeChangeListener();
 
@@ -82,16 +85,16 @@ describe('InspectHandlerTests', () => {
         devtoolsStoreProxyMock.setupGetState(state);
         devToolsChromeAdapterMock.setupGetInspectedWindowTabId(inspectedWindowId);
 
-        devToolsChromeAdapterMock.setupExecuteScriptInInspectedWindow(
-            "inspect(document.querySelector('#testElement'))",
-            null,
-        );
-        testObjec.initialize();
+        targetPageInspectorMock
+            .setup(inspector => inspector.inspectElement('#testElement', null))
+            .verifiable(Times.once());
+
+        testSubject.initialize();
 
         devtoolsStoreProxyMock.invokeChangeListener();
 
         devtoolsStoreProxyMock.verifyAll();
-        devToolsChromeAdapterMock.verifyAll();
+        targetPageInspectorMock.verifyAll();
     });
 
     test('initialize - inspect on state change: target not at parent level with frame url provided', () => {
@@ -103,16 +106,16 @@ describe('InspectHandlerTests', () => {
         devtoolsStoreProxyMock.setupGetState(state);
         devToolsChromeAdapterMock.setupGetInspectedWindowTabId(inspectedWindowId);
 
-        devToolsChromeAdapterMock.setupExecuteScriptInInspectedWindow(
-            "inspect(document.querySelector('test'))",
-            'testUrl',
-        );
-        testObjec.initialize();
+        targetPageInspectorMock
+            .setup(inspector => inspector.inspectElement('test', 'testUrl'))
+            .verifiable(Times.once());
+
+        testSubject.initialize();
 
         devtoolsStoreProxyMock.invokeChangeListener();
 
         devtoolsStoreProxyMock.verifyAll();
-        devToolsChromeAdapterMock.verifyAll();
+        targetPageInspectorMock.verifyAll();
     });
 
     test("initialize - don't inspect if inspect element length > 1 and frame Url not set", () => {
@@ -124,7 +127,7 @@ describe('InspectHandlerTests', () => {
         devtoolsStoreProxyMock.setupGetState(state);
         devToolsChromeAdapterMock.setupGetInspectedWindowTabId(inspectedWindowId);
 
-        testObjec.initialize();
+        testSubject.initialize();
         devtoolsStoreProxyMock.invokeChangeListener();
 
         devtoolsStoreProxyMock.verifyAll();

--- a/src/tests/unit/tests/DevTools/target-page-inspector.test.ts
+++ b/src/tests/unit/tests/DevTools/target-page-inspector.test.ts
@@ -60,6 +60,7 @@ describe('TargetPageInspector', () => {
         'calls eval through the inspected window, with selector = %s',
         actualSelector => {
             // we need to define a inspect function so we can actually evaluate the script
+            // tslint:disable-next-line: no-unused-variable
             function inspect(): void {
                 // no op on purpose
             }

--- a/src/tests/unit/tests/DevTools/target-page-inspector.test.ts
+++ b/src/tests/unit/tests/DevTools/target-page-inspector.test.ts
@@ -50,12 +50,12 @@ describe('TargetPageInspector', () => {
         'div:not(.awesome)',
         'div::after',
         '#result;button',
-        `body"); throw new Error("should not throw this error`,
-        `body'); throw new Error('should not throw this error`,
+        `body")); throw new Error("should not throw this error"); (("" === "`,
+        `body')); throw new Error('should not throw this error'); (('' === '`,
     ];
 
     it.each(selectors)(
-        'calls eval through the inspected window, with safe selector = %s',
+        'calls eval through the inspected window, with selector = %s',
         actualSelector => {
             // we need to define a inspect function so we can actually evaluate the script
             function inspect(): void {
@@ -94,9 +94,9 @@ describe('TargetPageInspector', () => {
     );
 
     it('throws for a non string selector value', () => {
-        const unsafeSelector = { description: 'this is not a string' } as any;
+        const notAnStringSelector = { description: 'this is not a string' } as any;
 
-        const act = () => testSubject.inspectElement(unsafeSelector, testFrameUrl);
+        const act = () => testSubject.inspectElement(notAnStringSelector, testFrameUrl);
 
         inspectedWindowMock.verify(
             inspected => inspected.eval(It.isAny(), It.isAny()),

--- a/src/tests/unit/tests/DevTools/target-page-inspector.test.ts
+++ b/src/tests/unit/tests/DevTools/target-page-inspector.test.ts
@@ -50,8 +50,10 @@ describe('TargetPageInspector', () => {
         'div:not(.awesome)',
         'div::after',
         '#result;button',
-        `body")); throw new Error("should not throw this error"); (("" === "`,
-        `body')); throw new Error('should not throw this error'); (('' === '`,
+        `body")); throw new Error("should not throw this error") //`,
+        `body')); throw new Error('should not throw this error') //`,
+        'body`)); throw new Error(`should not throw this error`) //',
+        `body\\')); throw new Error("should not throw this error") //`,
     ];
 
     it.each(selectors)(

--- a/src/tests/unit/tests/DevTools/target-page-inspector.test.ts
+++ b/src/tests/unit/tests/DevTools/target-page-inspector.test.ts
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TargetPageInspector } from 'Devtools/target-page-inspector';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+describe('TargetPageInspector', () => {
+    type InspectedWindow = typeof chrome.devtools.inspectedWindow;
+
+    let inspectedWindowMock: IMock<InspectedWindow>;
+    let testSubject: TargetPageInspector;
+
+    const testFrameUrl = 'test-frame-url';
+
+    beforeEach(() => {
+        inspectedWindowMock = Mock.ofType<InspectedWindow>();
+        testSubject = new TargetPageInspector(inspectedWindowMock.object);
+    });
+
+    const safeSelectors = [
+        '#id-selector',
+        '.class-selector',
+        'article > p',
+        'article h2',
+        'article ~ h2',
+        'article + h2',
+        'li:last-child',
+        'input:checked + label',
+        'a[target]',
+        'a[href*="login"]',
+        'a[href^="https://"]',
+        'a[href$=".pdf"]',
+        'a[rel~="tag"]',
+        'a[lang|="en"]',
+        'li:nth-child(3n)',
+        'div:not(.awesome)',
+        'div::after',
+        '#result;button',
+    ];
+
+    it.each(safeSelectors)('calls eval on the target page with selector = %s', safeSelector => {
+        const expectedScript =
+            'inspect(document.querySelector(' + JSON.stringify(safeSelector) + '))';
+
+        testSubject.inspectElement(safeSelector, testFrameUrl);
+
+        inspectedWindowMock.verify(
+            inspected => inspected.eval(expectedScript, { frameURL: testFrameUrl } as any),
+            Times.once(),
+        );
+    });
+
+    it('throws for a non string selector value', () => {
+        const unsafeSelector = { description: 'this is not a string' } as any;
+
+        const act = () => testSubject.inspectElement(unsafeSelector, testFrameUrl);
+
+        inspectedWindowMock.verify(
+            inspected => inspected.eval(It.isAny(), It.isAny()),
+            Times.never(),
+        );
+
+        expect(act).toThrow('selector is not a string');
+    });
+
+    it('properly handles quotes', () => {
+        const unsafeSelector = `body'); alert('xss`; // this is an attempt to run arbitrary js code
+
+        const expectedScript =
+            'inspect(document.querySelector(' + JSON.stringify(unsafeSelector) + '))';
+
+        testSubject.inspectElement(unsafeSelector, testFrameUrl);
+
+        inspectedWindowMock.verify(
+            inspected => inspected.eval(expectedScript, { frameURL: testFrameUrl } as any),
+            Times.once(),
+        );
+    });
+});


### PR DESCRIPTION
#### Description of changes

As part of our threat model follow up we need to assess our usage of javascript `eval`(which we don't have any and we do have a tslint rule to catch this). While looking at our code base, I found we are using `chrome.devtools.inspectedWindow.eval` (this allow the user to inspect an element we marked as failing an automated check, directly from the target page's details dialog).

While we are using this `eval` API only to call `inspect`, we are implementing this in a way we can pass any script to `eval` (not only `inspect`) which is not necessary and also a opens the door for some security risks.

In this PR:
- Change the API so the user cannot pass just any script; the new API is specific for inspect, the user can pass a selector
- Run some basic sanitization on the input (the selector) as a malicious attack can still try to use this user input to try and run arbitrary code.

**Discussion**
This new API is not bullet proof; it's not close to be perfect neither. This is a starting point in case we start hearing about security concerns with concrete examples on how to exploit this on our extension. 

#### Pull request checklist
- [x] Addresses an existing issue: part of WI # 1697428
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). Check workflow guide at: `<rootDir>/docs/workflow.md`
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
