### PR TITLE
fix: disabled visual helper toggles read confusingly for AT users

### DIFF
--- a/src/DetailsView/components/base-visual-helper-toggle.tsx
+++ b/src/DetailsView/components/base-visual-helper-toggle.tsx
@@ -23,13 +23,15 @@ export abstract class BaseVisualHelperToggle extends React.Component<VisualHelpe
         return (
             <div className="visual-helper">
                 <div className="visual-helper-text">{visualHelperText}</div>
-                <VisualizationToggle
-                    checked={isChecked}
-                    disabled={isDisabled}
-                    onClick={onClick}
-                    className="visual-helper-toggle"
-                    visualizationName={visualHelperText}
-                />
+                <div aria-hidden={isDisabled} /* disabledMessage supersedes it; see #682 */>
+                    <VisualizationToggle
+                        checked={isChecked}
+                        disabled={isDisabled}
+                        onClick={onClick}
+                        className="visual-helper-toggle"
+                        visualizationName={visualHelperText}
+                    />
+                </div>
                 {disabledMessage}
             </div>
         );

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/restart-scan-visual-helper-toggle.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/restart-scan-visual-helper-toggle.test.tsx.snap
@@ -9,13 +9,17 @@ exports[`RestartScanVisualHelperToggleTest onClick: step enabled = false 1`] = `
   >
     Visual helper
   </div>
-  <VisualizationToggle
-    checked={false}
-    className="visual-helper-toggle"
-    disabled={false}
-    onClick={[Function]}
-    visualizationName="Visual helper"
-  />
+  <div
+    aria-hidden={false}
+  >
+    <VisualizationToggle
+      checked={false}
+      className="visual-helper-toggle"
+      disabled={false}
+      onClick={[Function]}
+      visualizationName="Visual helper"
+    />
+  </div>
 </div>
 `;
 
@@ -28,13 +32,17 @@ exports[`RestartScanVisualHelperToggleTest onClick: step enabled = true 1`] = `
   >
     Visual helper
   </div>
-  <VisualizationToggle
-    checked={true}
-    className="visual-helper-toggle"
-    disabled={false}
-    onClick={[Function]}
-    visualizationName="Visual helper"
-  />
+  <div
+    aria-hidden={false}
+  >
+    <VisualizationToggle
+      checked={true}
+      className="visual-helper-toggle"
+      disabled={false}
+      onClick={[Function]}
+      visualizationName="Visual helper"
+    />
+  </div>
 </div>
 `;
 
@@ -47,12 +55,16 @@ exports[`RestartScanVisualHelperToggleTest render 1`] = `
   >
     Visual helper
   </div>
-  <VisualizationToggle
-    checked={true}
-    className="visual-helper-toggle"
-    disabled={false}
-    onClick={[Function]}
-    visualizationName="Visual helper"
-  />
+  <div
+    aria-hidden={false}
+  >
+    <VisualizationToggle
+      checked={true}
+      className="visual-helper-toggle"
+      disabled={false}
+      onClick={[Function]}
+      visualizationName="Visual helper"
+    />
+  </div>
 </div>
 `;

--- a/src/tests/unit/tests/assessments/automated-checks/__snapshots__/automated-checks-visualization-toggle.test.tsx.snap
+++ b/src/tests/unit/tests/assessments/automated-checks/__snapshots__/automated-checks-visualization-toggle.test.tsx.snap
@@ -9,13 +9,17 @@ exports[`AutomatedChecksVisualizationToggle render with disabled message 1`] = `
   >
     Visual helper
   </div>
-  <VisualizationToggle
-    checked={false}
-    className="visual-helper-toggle"
-    disabled={true}
-    onClick={[Function]}
-    visualizationName="Visual helper"
-  />
+  <div
+    aria-hidden={true}
+  >
+    <VisualizationToggle
+      checked={false}
+      className="visual-helper-toggle"
+      disabled={true}
+      onClick={[Function]}
+      visualizationName="Visual helper"
+    />
+  </div>
   <span
     className="no-matching-elements"
   >
@@ -33,13 +37,17 @@ exports[`AutomatedChecksVisualizationToggle render: toggle disabled when there a
   >
     Visual helper
   </div>
-  <VisualizationToggle
-    checked={false}
-    className="visual-helper-toggle"
-    disabled={true}
-    onClick={[Function]}
-    visualizationName="Visual helper"
-  />
+  <div
+    aria-hidden={true}
+  >
+    <VisualizationToggle
+      checked={false}
+      className="visual-helper-toggle"
+      disabled={true}
+      onClick={[Function]}
+      visualizationName="Visual helper"
+    />
+  </div>
   <span
     className="no-matching-elements"
   >
@@ -57,12 +65,16 @@ exports[`AutomatedChecksVisualizationToggle render: toggle not disabled 1`] = `
   >
     Visual helper
   </div>
-  <VisualizationToggle
-    checked={false}
-    className="visual-helper-toggle"
-    disabled={false}
-    onClick={[Function]}
-    visualizationName="Visual helper"
-  />
+  <div
+    aria-hidden={false}
+  >
+    <VisualizationToggle
+      checked={false}
+      className="visual-helper-toggle"
+      disabled={false}
+      onClick={[Function]}
+      visualizationName="Visual helper"
+    />
+  </div>
 </div>
 `;


### PR DESCRIPTION
#### Description of changes

Per #682, the proposed resolution to make the Visual Helper toggles read more pleasantly for AT users was:

> After discussion with @ferBonnin ; the want from this issue is that whenever the visual helper is disabled; AT should not be reading the state of it. 
> It should just say for example: 
> ```
> Visual Helper
> No matching/failing instances were found
> ```

This PR achieves that by `aria-hidden`ing the toggle and its on/off label using a new wrapping `<div>` when the toggle is disabled. The new wrapper element is required because Office Fabric only applies `aria-hidden` props passed to a `Toggle` to the actual `<button>` element representing the toggle, not to the On/Off label, and we want it applied to both.

Verified that the desired reading occurs in NVDA and JAWS, verified no visual change vs canary in either the disabled or enabled states.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #682
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a, no visual change] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
