### PR TITLE
fix: avoid extra horizontal scroll bar in fastpass automated checks "no failures" view

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -502,10 +502,8 @@ div.insights-file-issue-details-dialog-container {
                 min-width: 600px;
                 height: auto;
             }
-            .ms-MessageBar {
-                padding-left: 24px;
-            }
             .ms-MessageBar-icon i {
+                margin-left: 12px;
                 color: $secondary-text;
             }
             .view {

--- a/src/tests/end-to-end/test-resources/clean.html
+++ b/src/tests/end-to-end/test-resources/clean.html
@@ -1,0 +1,15 @@
+<!--
+Copyright (c) Microsoft Corporation. All rights reserved.
+Licensed under the MIT License.
+-->
+<html lang="en">
+    <head>
+        <title>Page with no automated check failures</title>
+    </head>
+    <body>
+        <main>
+            <h1>Content</h1>
+            <p>This page has no automated checks failures.</p>
+        </main>
+    </body>
+</html>


### PR DESCRIPTION
#### Description of changes

The left-padding we were adding to our "target page hidden" message bar was interacting poorly with the container for the main panel, causing the size of the whole panel to over-expand by the padding amount. This resolves that issue by replacing the padding on the message bar with some margin in the content of the message bar.

This PR also includes a new "clean.html" test page with no automated checks faliures that I used to test the change.

Before:
![screenshot before this PR with extra scrollbar and a white vertical stripe on right of main panel content](https://user-images.githubusercontent.com/376284/77701503-b19d0000-6f73-11ea-94d7-6b1d038f69f7.png)

After (same size/zoom):
![screenshot after this PR without extra scrollbars or white vertical stripe](https://user-images.githubusercontent.com/376284/77701492-ab0e8880-6f73-11ea-96bc-40d9b8e803fe.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2215
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
