### PR TITLE
fix: update wording in assessment report footer from Axe to axe-core to match FastPass's

### DIFF
--- a/src/reports/components/assessment-report-footer.tsx
+++ b/src/reports/components/assessment-report-footer.tsx
@@ -14,8 +14,9 @@ export class AssessmentReportFooter extends React.Component<AssessmentReportFoot
         return (
             <footer className="report-footer">
                 This assessment report was generated using {title} {this.props.extensionVersion}{' '}
-                (Axe {this.props.axeVersion}), a tool that helps debug and find accessibility issues
-                earlier on {this.props.chromeVersion}. Get more information & download this tool at{' '}
+                (axe-core {this.props.axeVersion}), a tool that helps debug and find accessibility
+                issues earlier on {this.props.chromeVersion}. Get more information & download this
+                tool at{' '}
                 <a
                     href="http://aka.ms/AccessibilityInsights"
                     className="link report-footer-link"

--- a/src/tests/unit/tests/reports/components/__snapshots__/assessment-report-footer.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/assessment-report-footer.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`AssessmentReportFooter renders 1`] = `
    
   test-extension-version
    
-  (Axe 
+  (axe-core 
   axeVersion
   ), a tool that helps debug and find accessibility issues earlier on 
   chromeVersion


### PR DESCRIPTION
#### Description of changes

This is a sister change to #2348, updating the assessment report similarly to how it updated the FastPass report (changing how we refer to the axe-core version that generated the report from "Axe 1.2.3" to "axe-core 1.2.3").

![screenshot of updated report with axe-core text circled](https://user-images.githubusercontent.com/376284/77955942-e36cda00-7285-11ea-8367-adceeb46de17.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
