### PR TITLE
refactor(side-panel): open preview feature panel as side panel

### DIFF
--- a/src/background/actions/action-creator.ts
+++ b/src/background/actions/action-creator.ts
@@ -130,10 +130,6 @@ export class ActionCreator {
         );
 
         this.interpreter.registerTypeToPayloadCallback(
-            Messages.PreviewFeatures.OpenPanel,
-            this.onOpenPreviewFeaturesPanel,
-        );
-        this.interpreter.registerTypeToPayloadCallback(
             Messages.PreviewFeatures.ClosePanel,
             this.onClosePreviewFeaturesPanel,
         );
@@ -239,17 +235,6 @@ export class ActionCreator {
             payload.scanIncompleteWarnings,
         );
         await this.targetTabController.showTargetTab(tabId, payload.testType, payload.key);
-    };
-
-    private onOpenPreviewFeaturesPanel = async (
-        payload: BaseActionPayload,
-        tabId: number,
-    ): Promise<void> => {
-        this.previewFeaturesActions.openPreviewFeatures.invoke(null);
-        await this.detailsViewController
-            .showDetailsView(tabId)
-            .catch(e => this.logger.error(e.message));
-        this.telemetryEventHandler.publishTelemetry(TelemetryEvents.PREVIEW_FEATURES_OPEN, payload);
     };
 
     private onClosePreviewFeaturesPanel = (payload: BaseActionPayload): void => {

--- a/src/background/actions/details-view-action-creator.ts
+++ b/src/background/actions/details-view-action-creator.ts
@@ -3,7 +3,11 @@
 import { SidePanelActions } from 'background/actions/side-panel-actions';
 import { DetailsViewController } from 'background/details-view-controller';
 import { SidePanel } from 'background/stores/side-panel';
-import { SETTINGS_PANEL_CLOSE, SETTINGS_PANEL_OPEN } from 'common/extension-telemetry-events';
+import {
+    PREVIEW_FEATURES_OPEN,
+    SETTINGS_PANEL_CLOSE,
+    SETTINGS_PANEL_OPEN,
+} from 'common/extension-telemetry-events';
 import { createDefaultLogger } from 'common/logging/default-logger';
 import { Logger } from 'common/logging/logger';
 import { getStoreStateMessage, Messages } from 'common/messages';
@@ -49,6 +53,7 @@ export class DetailsViewActionCreator {
 
     private sidePanelToOpenPanelTelemetryEventName: SidePanelToOpenPanelTelemetryEventName = {
         Settings: SETTINGS_PANEL_OPEN,
+        PreviewFeatures: PREVIEW_FEATURES_OPEN,
     };
 
     private onOpenSidePanel = async (

--- a/src/background/actions/details-view-action-creator.ts
+++ b/src/background/actions/details-view-action-creator.ts
@@ -38,6 +38,10 @@ export class DetailsViewActionCreator {
             this.onOpenSidePanel.bind(this, 'Settings'),
         );
         this.interpreter.registerTypeToPayloadCallback(
+            Messages.PreviewFeatures.OpenPanel,
+            this.onOpenSidePanel.bind(this, 'PreviewFeatures'),
+        );
+        this.interpreter.registerTypeToPayloadCallback(
             Messages.SettingsPanel.ClosePanel,
             this.onCloseSettingsPanel,
         );

--- a/src/background/actions/preview-features-actions.ts
+++ b/src/background/actions/preview-features-actions.ts
@@ -3,6 +3,5 @@
 import { Action } from 'common/flux/action';
 
 export class PreviewFeaturesActions {
-    public readonly openPreviewFeatures = new Action<void>();
     public readonly closePreviewFeatures = new Action<void>();
 }

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { SidePanelActions } from 'background/actions/side-panel-actions';
-import { SidePanel, SidePanelToStoreKey } from 'background/stores/side-panel';
+import { SidePanel } from 'background/stores/side-panel';
 import { StoreNames } from 'common/stores/store-names';
 import { CurrentPanel } from 'common/types/store-data/current-panel';
 import { DetailsViewStoreData } from 'common/types/store-data/details-view-store-data';
@@ -11,6 +11,10 @@ import { DetailsViewActions } from '../actions/details-view-actions';
 import { ScopingActions } from '../actions/scoping-actions';
 import { PreviewFeaturesActions } from './../actions/preview-features-actions';
 import { BaseStoreImpl } from './base-store-impl';
+
+type SidePanelToStoreKey = {
+    [P in SidePanel]: keyof DetailsViewStoreData['currentPanel'];
+};
 
 export class DetailsViewStore extends BaseStoreImpl<DetailsViewStoreData> {
     constructor(

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -43,9 +43,6 @@ export class DetailsViewStore extends BaseStoreImpl<DetailsViewStoreData> {
     }
 
     protected addActionListeners(): void {
-        this.previewFeaturesActions.openPreviewFeatures.addListener(() =>
-            this.onOpen('isPreviewFeaturesOpen'),
-        );
         this.previewFeaturesActions.closePreviewFeatures.addListener(() =>
             this.onClose('isPreviewFeaturesOpen'),
         );

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -74,6 +74,7 @@ export class DetailsViewStore extends BaseStoreImpl<DetailsViewStoreData> {
 
     private sidePanelToStateKey: SidePanelToStoreKey = {
         Settings: 'isSettingsOpen',
+        PreviewFeatures: 'isPreviewFeaturesOpen',
     };
 
     private onOpenSidePanel = (sidePanel: SidePanel) => {

--- a/src/background/stores/side-panel.ts
+++ b/src/background/stores/side-panel.ts
@@ -1,10 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { DetailsViewStoreData } from 'common/types/store-data/details-view-store-data';
 
 // There will be more SidePanel types as we keep refactoring.
 export type SidePanel = 'Settings';
-
-export type SidePanelToStoreKey = {
-    [P in SidePanel]: keyof DetailsViewStoreData['currentPanel'];
-};

--- a/src/background/stores/side-panel.ts
+++ b/src/background/stores/side-panel.ts
@@ -2,4 +2,4 @@
 // Licensed under the MIT License.
 
 // There will be more SidePanel types as we keep refactoring.
-export type SidePanel = 'Settings';
+export type SidePanel = 'Settings' | 'PreviewFeatures';

--- a/src/tests/unit/tests/background/actions/action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/action-creator.test.ts
@@ -855,59 +855,6 @@ describe('ActionCreatorTest', () => {
         validator.verifyAll();
     });
 
-    describe('registerCallback for onOpenPreviewFeaturesPanel', () => {
-        const tabId = 1;
-        const actionName = 'openPreviewFeatures';
-        const telemetryData: BaseTelemetryData = {
-            triggeredBy: 'stub triggered by' as TriggeredBy,
-            source: testSource,
-        };
-
-        const telemetryInfo = {
-            telemetryData,
-        };
-
-        it('open preview features panel, shows the details view and send telemetry', async () => {
-            const validator = new ActionCreatorValidator()
-                .setupRegistrationCallback(PreviewFeaturesMessage.OpenPanel, [telemetryInfo, tabId])
-                .setupActionOnPreviewFeaturesActions(actionName)
-                .setupTelemetrySend(TelemetryEvents.PREVIEW_FEATURES_OPEN, telemetryInfo, tabId)
-                .setupShowDetailsView(tabId, Promise.resolve())
-                .setupPreviewFeaturesActionWithInvokeParameter(actionName, null);
-
-            const actionCreator = validator.buildActionCreator();
-
-            actionCreator.registerCallbacks();
-
-            await tick();
-
-            validator.verifyAll();
-        });
-
-        it('propagate errors showing the details view to the logger', async () => {
-            const showDetailsViewErrorMessage = 'error on showDetailsView ';
-
-            const validator = new ActionCreatorValidator()
-                .setupRegistrationCallback(PreviewFeaturesMessage.OpenPanel, [telemetryInfo, tabId])
-                .setupActionOnPreviewFeaturesActions(actionName)
-                .setupTelemetrySend(TelemetryEvents.PREVIEW_FEATURES_OPEN, telemetryInfo, tabId)
-                .setupShowDetailsView(
-                    tabId,
-                    Promise.reject({ message: showDetailsViewErrorMessage }),
-                )
-                .setupLogError(showDetailsViewErrorMessage)
-                .setupPreviewFeaturesActionWithInvokeParameter(actionName, null);
-
-            const actionCreator = validator.buildActionCreator();
-
-            actionCreator.registerCallbacks();
-
-            await tick();
-
-            validator.verifyAll();
-        });
-    });
-
     test('registerCallback for switch focus back to target', () => {
         const pivot = DetailsViewPivotType.fastPass;
         const updatePivotActionName = 'updateSelectedPivot';

--- a/src/tests/unit/tests/background/stores/details-view-store.test.ts
+++ b/src/tests/unit/tests/background/stores/details-view-store.test.ts
@@ -40,10 +40,9 @@ describe('DetailsViewStoreTest', () => {
             .withPreviewFeaturesOpen(true)
             .build();
 
-        createStoreTesterForPreviewFeatureActions('openPreviewFeatures').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        createStoreTesterForSidePanelActions('openSidePanel')
+            .withActionParam('PreviewFeatures')
+            .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     test('onClosePreviewFeatures', () => {


### PR DESCRIPTION
#### Description of changes

Following up from previews PRs (#2313, #2420), updating how we handle opening the preview feature panel to use the new side panel logic.

Out of scope:
- updating other panels to use the side panel logic (content panel, add failure instance, etc)
- updating how we close side panel
Those will come on future PRs

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
