### PR TITLE
refactor(side-panel): open scoping panel as a side panel

### DIFF
--- a/src/background/actions/details-view-action-creator.ts
+++ b/src/background/actions/details-view-action-creator.ts
@@ -5,6 +5,7 @@ import { DetailsViewController } from 'background/details-view-controller';
 import { SidePanel } from 'background/stores/side-panel';
 import {
     PREVIEW_FEATURES_OPEN,
+    SCOPING_OPEN,
     SETTINGS_PANEL_CLOSE,
     SETTINGS_PANEL_OPEN,
 } from 'common/extension-telemetry-events';
@@ -42,6 +43,10 @@ export class DetailsViewActionCreator {
             this.onOpenSidePanel.bind(this, 'PreviewFeatures'),
         );
         this.interpreter.registerTypeToPayloadCallback(
+            Messages.Scoping.OpenPanel,
+            this.onOpenSidePanel.bind(this, 'Scoping'),
+        );
+        this.interpreter.registerTypeToPayloadCallback(
             Messages.SettingsPanel.ClosePanel,
             this.onCloseSettingsPanel,
         );
@@ -58,6 +63,7 @@ export class DetailsViewActionCreator {
     private sidePanelToOpenPanelTelemetryEventName: SidePanelToOpenPanelTelemetryEventName = {
         Settings: SETTINGS_PANEL_OPEN,
         PreviewFeatures: PREVIEW_FEATURES_OPEN,
+        Scoping: SCOPING_OPEN,
     };
 
     private onOpenSidePanel = async (

--- a/src/background/actions/scoping-actions.ts
+++ b/src/background/actions/scoping-actions.ts
@@ -9,7 +9,6 @@ export interface ScopingPayload extends BaseActionPayload {
 }
 
 export class ScopingActions {
-    public readonly openScopingPanel = new Action<void>();
     public readonly closeScopingPanel = new Action<void>();
     public readonly addSelector = new Action<ScopingPayload>();
     public readonly deleteSelector = new Action<ScopingPayload>();

--- a/src/background/actions/scoping-panel-action-creator.ts
+++ b/src/background/actions/scoping-panel-action-creator.ts
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { SCOPING_CLOSE, SCOPING_OPEN } from 'common/extension-telemetry-events';
-import { createDefaultLogger } from 'common/logging/default-logger';
-import { Logger } from 'common/logging/logger';
+import { SCOPING_CLOSE } from 'common/extension-telemetry-events';
 import { Messages } from 'common/messages';
-import { ExtensionDetailsViewController } from '../extension-details-view-controller';
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { BaseActionPayload } from './action-payloads';
@@ -15,24 +12,12 @@ export class ScopingPanelActionCreator {
         private readonly interpreter: Interpreter,
         private readonly scopingActions: ScopingActions,
         private readonly telemetryEventHandler: TelemetryEventHandler,
-        private readonly detailsViewController: ExtensionDetailsViewController,
-        private readonly logger: Logger = createDefaultLogger(),
     ) {}
 
     public registerCallbacks(): void {
-        this.interpreter.registerTypeToPayloadCallback(
-            Messages.Scoping.OpenPanel,
-            (payload, tabId) => this.onOpenScopingPanel(payload, tabId),
-        );
         this.interpreter.registerTypeToPayloadCallback(Messages.Scoping.ClosePanel, payload =>
             this.onCloseScopingPanel(payload),
         );
-    }
-
-    private async onOpenScopingPanel(payload: BaseActionPayload, tabId: number): Promise<void> {
-        this.scopingActions.openScopingPanel.invoke(null);
-        await this.detailsViewController.showDetailsView(tabId).catch(this.logger.error);
-        this.telemetryEventHandler.publishTelemetry(SCOPING_OPEN, payload);
     }
 
     private onCloseScopingPanel(payload: BaseActionPayload): void {

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -47,7 +47,6 @@ export class DetailsViewStore extends BaseStoreImpl<DetailsViewStoreData> {
             this.onClose('isPreviewFeaturesOpen'),
         );
 
-        this.scopingActions.openScopingPanel.addListener(() => this.onOpen('isScopingOpen'));
         this.scopingActions.closeScopingPanel.addListener(() => this.onClose('isScopingOpen'));
 
         this.detailsViewActions.closeSettingsPanel.addListener(() =>
@@ -72,6 +71,7 @@ export class DetailsViewStore extends BaseStoreImpl<DetailsViewStoreData> {
     private sidePanelToStateKey: SidePanelToStoreKey = {
         Settings: 'isSettingsOpen',
         PreviewFeatures: 'isPreviewFeaturesOpen',
+        Scoping: 'isScopingOpen',
     };
 
     private onOpenSidePanel = (sidePanel: SidePanel) => {

--- a/src/background/stores/side-panel.ts
+++ b/src/background/stores/side-panel.ts
@@ -2,4 +2,4 @@
 // Licensed under the MIT License.
 
 // There will be more SidePanel types as we keep refactoring.
-export type SidePanel = 'Settings' | 'PreviewFeatures';
+export type SidePanel = 'Settings' | 'PreviewFeatures' | 'Scoping';

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -117,7 +117,6 @@ export class TabContextFactory {
             interpreter,
             actionsHub.scopingActions,
             this.telemetryEventHandler,
-            detailsViewController,
         );
         const contentActionCreator = new ContentActionCreator(
             interpreter,

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -14,6 +14,7 @@ import {
     SETTINGS_PANEL_OPEN,
     TelemetryEventSource,
     TriggeredBy,
+    SCOPING_OPEN,
 } from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
 import { Logger } from 'common/logging/logger';
@@ -60,6 +61,7 @@ describe('DetailsViewActionCreatorTest', () => {
             messageFriendlyName                     | actualMessage                         | sidePanel            | telemetryEventName
             ${'Messages.SettingsPanel.OpenPanel'}   | ${Messages.SettingsPanel.OpenPanel}   | ${'Settings'}        | ${SETTINGS_PANEL_OPEN}
             ${'Messages.PreviewFeatures.OpenPanel'} | ${Messages.PreviewFeatures.OpenPanel} | ${'PreviewFeatures'} | ${PREVIEW_FEATURES_OPEN}
+            ${'Messages.Scoping.OpenPanel'}         | ${Messages.Scoping.OpenPanel}         | ${'Scoping'}         | ${SCOPING_OPEN}
         `('$messageFriendlyName', ({ actualMessage, sidePanel, telemetryEventName }) => {
             beforeEach(() => {
                 openSidePanelMock = createActionMock<SidePanel>(sidePanel);

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -10,11 +10,11 @@ import { SidePanel } from 'background/stores/side-panel';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
 import {
     PREVIEW_FEATURES_OPEN,
+    SCOPING_OPEN,
     SETTINGS_PANEL_CLOSE,
     SETTINGS_PANEL_OPEN,
     TelemetryEventSource,
     TriggeredBy,
-    SCOPING_OPEN,
 } from 'common/extension-telemetry-events';
 import { Action } from 'common/flux/action';
 import { Logger } from 'common/logging/logger';

--- a/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/scoping-panel-action-creator.test.ts
@@ -3,14 +3,10 @@
 import { BaseActionPayload } from 'background/actions/action-payloads';
 import { ScopingActions } from 'background/actions/scoping-actions';
 import { ScopingPanelActionCreator } from 'background/actions/scoping-panel-action-creator';
-import { ExtensionDetailsViewController } from 'background/extension-details-view-controller';
 import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
-import { SCOPING_CLOSE, SCOPING_OPEN } from 'common/extension-telemetry-events';
-import { Action } from 'common/flux/action';
-import { Logger } from 'common/logging/logger';
+import { SCOPING_CLOSE } from 'common/extension-telemetry-events';
 import { Messages } from 'common/messages';
-import { tick } from 'tests/unit/common/tick';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 import {
     createActionMock,
@@ -19,7 +15,6 @@ import {
 
 describe('ScopingPanelActionCreatorTest', () => {
     let telemetryEventHandlerMock: IMock<TelemetryEventHandler>;
-    let detailsViewControllerStrictMock: IMock<ExtensionDetailsViewController>;
     let actionsMocks: IMock<ScopingActions>;
     let interpreterMock: IMock<Interpreter>;
 
@@ -27,69 +22,6 @@ describe('ScopingPanelActionCreatorTest', () => {
 
     beforeEach(() => {
         telemetryEventHandlerMock = Mock.ofType(TelemetryEventHandler, MockBehavior.Strict);
-        detailsViewControllerStrictMock = Mock.ofType<ExtensionDetailsViewController>(
-            undefined,
-            MockBehavior.Strict,
-        );
-    });
-
-    describe('handles OpenPanel message', () => {
-        const tabId = -1;
-        const payload: BaseActionPayload = {};
-
-        let openScopingPanelMock: IMock<Action<void>>;
-        let loggerMock: IMock<Logger>;
-
-        beforeEach(() => {
-            openScopingPanelMock = createActionMock(null);
-            actionsMocks = createActionsMock('openScopingPanel', openScopingPanelMock.object);
-            interpreterMock = createInterpreterMock(Messages.Scoping.OpenPanel, payload, tabId);
-            telemetryEventHandlerMock
-                .setup(handler => handler.publishTelemetry(SCOPING_OPEN, payload))
-                .verifiable(Times.once());
-            loggerMock = Mock.ofType<Logger>();
-
-            testObject = new ScopingPanelActionCreator(
-                interpreterMock.object,
-                actionsMocks.object,
-                telemetryEventHandlerMock.object,
-                detailsViewControllerStrictMock.object,
-                loggerMock.object,
-            );
-        });
-
-        it('when showDetailsView succeed', async () => {
-            detailsViewControllerStrictMock
-                .setup(controller => controller.showDetailsView(tabId))
-                .returns(() => Promise.resolve())
-                .verifiable(Times.once());
-
-            testObject.registerCallbacks();
-
-            await tick();
-
-            openScopingPanelMock.verifyAll();
-            telemetryEventHandlerMock.verifyAll();
-            detailsViewControllerStrictMock.verifyAll();
-        });
-
-        it('logs the error when showDetailsView fail', async () => {
-            const errorMessage = 'error on showDetailsView';
-
-            detailsViewControllerStrictMock
-                .setup(controller => controller.showDetailsView(tabId))
-                .returns(() => Promise.reject(errorMessage))
-                .verifiable(Times.once());
-
-            testObject.registerCallbacks();
-
-            await tick();
-
-            openScopingPanelMock.verifyAll();
-            telemetryEventHandlerMock.verifyAll();
-            detailsViewControllerStrictMock.verifyAll();
-            loggerMock.verify(logger => logger.error(errorMessage), Times.once());
-        });
     });
 
     test('handles ClosePanel message', () => {
@@ -107,7 +39,6 @@ describe('ScopingPanelActionCreatorTest', () => {
             interpreterMock.object,
             actionsMocks.object,
             telemetryEventHandlerMock.object,
-            detailsViewControllerStrictMock.object,
         );
 
         testObject.registerCallbacks();

--- a/src/tests/unit/tests/background/stores/details-view-store.test.ts
+++ b/src/tests/unit/tests/background/stores/details-view-store.test.ts
@@ -64,10 +64,9 @@ describe('DetailsViewStoreTest', () => {
 
         const expectedState = new DetailsViewStoreDataBuilder().withScopingOpen(true).build();
 
-        createStoreTesterForScopingActions('openScopingPanel').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        createStoreTesterForSidePanelActions('openSidePanel')
+            .withActionParam('Scoping')
+            .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     test('onCloseScoping', () => {


### PR DESCRIPTION
#### Description of changes

Following up from previews PRs (#2313, #2420, #2424), updating how we handle opening the scoping panel to use the new side panel logic.

Out of scope:
- updating other panels to use the side panel logic (content panel, add failure instance, etc)
- updating how we close side panel
Those will come on future PRs

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
