### PR TITLE
fix: using document.body instead of querying for body selector

### DIFF
--- a/src/common/html-element-utils.ts
+++ b/src/common/html-element-utils.ts
@@ -18,6 +18,10 @@ export class HTMLElementUtils {
         return this.dom.getElementsByTagName(tagName);
     }
 
+    public getBody(): HTMLElement {
+        return this.dom.body;
+    }
+
     public querySelector(selector: string): Element {
         return this.dom.querySelector(selector);
     }

--- a/src/injected/details-dialog-handler.ts
+++ b/src/injected/details-dialog-handler.ts
@@ -141,7 +141,7 @@ export class DetailsDialogHandler {
 
         const modal = shadowRoot.querySelector('.insights-dialog-main-override-shadow');
         if (modal != null) {
-            this.htmlElementUtils.getBody();
+            this.htmlElementUtils.getBody().classList.add('insights-modal');
             modal.addEventListener('click', ev => {
                 if (modal === ev.target) {
                     this.closeWindow(shadowRoot);

--- a/src/injected/details-dialog-handler.ts
+++ b/src/injected/details-dialog-handler.ts
@@ -218,7 +218,7 @@ export class DetailsDialogHandler {
         if (dialogContainer) {
             dialogContainer.parentNode.removeChild(dialogContainer);
         }
-        const body = this.htmlElementUtils.querySelector('body');
+        const body = this.htmlElementUtils.getBody();
         body.classList.remove(...['insights-modal']);
     }
 }

--- a/src/injected/details-dialog-handler.ts
+++ b/src/injected/details-dialog-handler.ts
@@ -141,7 +141,7 @@ export class DetailsDialogHandler {
 
         const modal = shadowRoot.querySelector('.insights-dialog-main-override-shadow');
         if (modal != null) {
-            document.body.classList.add('insights-modal');
+            this.htmlElementUtils.getBody();
             modal.addEventListener('click', ev => {
                 if (modal === ev.target) {
                     this.closeWindow(shadowRoot);

--- a/src/injected/visualization/center-position-calculator.ts
+++ b/src/injected/visualization/center-position-calculator.ts
@@ -31,7 +31,7 @@ export class CenterPositionCalculator {
         }
 
         const myDocument = this.drawerUtils.getDocumentElement();
-        const body = myDocument.querySelector('body');
+        const body = myDocument.body;
 
         const bodyStyle = this.windowUtils.getComputedStyle(body);
         const docStyle = this.windowUtils.getComputedStyle(myDocument.documentElement);
@@ -80,7 +80,7 @@ export class CenterPositionCalculator {
         );
 
         const myDocument = this.drawerUtils.getDocumentElement();
-        const body = myDocument.querySelector('body');
+        const body = myDocument.body;
 
         const bodyStyle = this.windowUtils.getComputedStyle(body);
         const docStyle = this.windowUtils.getComputedStyle(myDocument.documentElement);

--- a/src/injected/visualization/highlight-box-drawer.ts
+++ b/src/injected/visualization/highlight-box-drawer.ts
@@ -64,7 +64,7 @@ export class HighlightBoxDrawer extends BaseDrawer {
 
     protected createHighlightElement(element: Element, data: HtmlElementAxeResults): HTMLElement {
         const currentDom = this.drawerUtils.getDocumentElement();
-        const body = currentDom.querySelector('body');
+        const body = currentDom.body;
         const bodyStyle = this.windowUtils.getComputedStyle(body);
 
         let drawerConfig = HighlightBoxDrawer.defaultConfiguration;

--- a/src/injected/visualization/highlight-visualization.tsx
+++ b/src/injected/visualization/highlight-visualization.tsx
@@ -33,7 +33,7 @@ export const HighlightVisualization = NamedFC<HighlightVisualizationProps>(
 
         const highlightElements: JSX.Element[] = [];
         const currentDom = drawerUtils.getDocumentElement();
-        const body = currentDom.querySelector('body');
+        const body = currentDom.body;
         const bodyStyle = windowUtils.getComputedStyle(body);
         const docStyle = windowUtils.getComputedStyle(currentDom.documentElement);
 

--- a/src/injected/visualization/root-container-creator.ts
+++ b/src/injected/visualization/root-container-creator.ts
@@ -9,6 +9,6 @@ export class RootContainerCreator {
         this.htmlElementUtils.deleteAllElements(`#${id}`);
         const root = document.createElement('div');
         root.id = id;
-        this.htmlElementUtils.querySelector('body').appendChild(root);
+        this.htmlElementUtils.getBody().appendChild(root);
     }
 }

--- a/src/injected/visualization/svg-drawer.ts
+++ b/src/injected/visualization/svg-drawer.ts
@@ -159,7 +159,7 @@ export class SVGDrawer extends BaseDrawer {
 
     private setSVGSize(): void {
         const doc = this.drawerUtils.getDocumentElement();
-        const body = doc.querySelector('body');
+        const body = doc.body;
         const bodyStyle = this.windowUtils.getComputedStyle(body);
         const docStyle = this.windowUtils.getComputedStyle(doc.documentElement);
 

--- a/src/tests/unit/tests/common/html-element-utils.test.ts
+++ b/src/tests/unit/tests/common/html-element-utils.test.ts
@@ -50,6 +50,20 @@ describe('HTMLElementUtilsTest', () => {
         expect(result).toEqual(expectedElement);
     });
 
+    test('getBody', () => {
+        const expectedBody = 'body stub' as any;
+
+        const dom = {
+            body: expectedBody,
+        } as any;
+
+        const testObject = new HTMLElementUtils(dom);
+
+        const result = testObject.getBody();
+
+        expect(result).toEqual(expectedBody);
+    });
+
     test('querySelector', () => {
         const selector = 'selector';
 

--- a/src/tests/unit/tests/injected/details-dialog-handler.test.ts
+++ b/src/tests/unit/tests/injected/details-dialog-handler.test.ts
@@ -18,7 +18,7 @@ describe('DetailsDialogHandlerTest', () => {
     let container: Element;
     let detailsDialog: Element;
     let containerParent: Element;
-    let body: Element;
+    let body: HTMLElement;
     let featureFlagStoreData: DictionaryStringTo<boolean>;
     let detailsDialogMock: IMock<DetailsDialog>;
 
@@ -506,7 +506,7 @@ describe('DetailsDialogHandlerTest', () => {
             .verifiable(Times.once());
 
         htmlElementUtilsMock
-            .setup(x => x.querySelector('body'))
+            .setup(x => x.getBody())
             .returns(() => body)
             .verifiable(Times.once());
 
@@ -618,7 +618,7 @@ describe('DetailsDialogHandlerTest', () => {
             .verifiable(Times.once());
 
         htmlElementUtilsMock
-            .setup(x => x.querySelector('body'))
+            .setup(x => x.getBody())
             .returns(() => body)
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/injected/visualization/center-position-calculator.test.ts
+++ b/src/tests/unit/tests/injected/visualization/center-position-calculator.test.ts
@@ -13,7 +13,6 @@ import { DrawerUtilsMockBuilder } from './drawer-utils-mock-builder';
 describe('CenterPositionCalculatorTest', () => {
     let windowUtilsMock: IMock<WindowUtils>;
     let tabbableElementsHelperMock: IMock<TabbableElementsHelper>;
-    let querySelectorMock: IMock<any>;
     let documentMock;
     const bodyStub = { bodyStub: true } as any;
     const styleStub = { styleStub: true } as any;
@@ -21,10 +20,9 @@ describe('CenterPositionCalculatorTest', () => {
     beforeEach(() => {
         windowUtilsMock = Mock.ofType(WindowUtils);
         tabbableElementsHelperMock = Mock.ofType(TabbableElementsHelper);
-        querySelectorMock = Mock.ofInstance(() => HTMLElement);
         documentMock = {
             documentElement: { docElement: true },
-            querySelector: querySelectorMock.object,
+            body: bodyStub,
         };
     });
 
@@ -46,7 +44,6 @@ describe('CenterPositionCalculatorTest', () => {
             y: 12,
         };
 
-        setupDefaultQuerySelectorMock();
         setupDefaultWindowUtilsMock();
         const drawerUtilsMock = new DrawerUtilsMockBuilder(documentMock, styleStub)
             .setupGetContainerOffset(10)
@@ -60,7 +57,6 @@ describe('CenterPositionCalculatorTest', () => {
         );
 
         drawerUtilsMock.verifyAll();
-        querySelectorMock.verifyAll();
         windowUtilsMock.verifyAll();
     });
 
@@ -76,7 +72,6 @@ describe('CenterPositionCalculatorTest', () => {
         const area: HTMLElement = dom.querySelector('#id1') as HTMLElement;
         const map: HTMLMapElement = dom.querySelector('#map1') as HTMLMapElement;
 
-        setupDefaultQuerySelectorMock();
         setupDefaultWindowUtilsMock();
         const drawerUtilsMock = new DrawerUtilsMockBuilder(documentMock, styleStub)
             .setupIsOutsideOfDocument(true)
@@ -90,7 +85,6 @@ describe('CenterPositionCalculatorTest', () => {
         expect(centerPositionCalculator.getElementCenterPosition(area)).toBeNull();
 
         drawerUtilsMock.verifyAll();
-        querySelectorMock.verifyAll();
         windowUtilsMock.verifyAll();
     });
 
@@ -109,7 +103,6 @@ describe('CenterPositionCalculatorTest', () => {
         const area: HTMLElement = dom.querySelector('#id1') as HTMLElement;
         const map: HTMLMapElement = dom.querySelector('#map1') as HTMLMapElement;
 
-        setupDefaultQuerySelectorMock();
         setupDefaultWindowUtilsMock();
 
         const drawerUtilsMock = new DrawerUtilsMockBuilder(dom, styleStub)
@@ -124,7 +117,6 @@ describe('CenterPositionCalculatorTest', () => {
         expect(centerPositionCalculator.getElementCenterPosition(area)).toEqual(expectedPosition);
 
         drawerUtilsMock.verifyAll();
-        querySelectorMock.verifyAll();
         windowUtilsMock.verifyAll();
     });
 
@@ -149,7 +141,6 @@ describe('CenterPositionCalculatorTest', () => {
 
         setupDefaultTabbableElementsHelperMock(area, map, img);
 
-        setupDefaultQuerySelectorMock();
         setupDefaultWindowUtilsMock();
 
         const centerPositionCalculator = createCenterPositionCalculator(drawerUtilsMock.object);
@@ -157,7 +148,6 @@ describe('CenterPositionCalculatorTest', () => {
         expect(centerPositionCalculator.getElementCenterPosition(area)).toEqual(expectedPosition);
 
         drawerUtilsMock.verifyAll();
-        querySelectorMock.verifyAll();
         windowUtilsMock.verifyAll();
     });
 
@@ -181,7 +171,6 @@ describe('CenterPositionCalculatorTest', () => {
             .setupGetContainerSizeNeverCall()
             .build();
 
-        setupDefaultQuerySelectorMock();
         setupDefaultWindowUtilsMock();
         setupDefaultTabbableElementsHelperMock(area, map, img);
 
@@ -190,7 +179,6 @@ describe('CenterPositionCalculatorTest', () => {
         expect(centerPositionCalculator.getElementCenterPosition(area)).toEqual(expectedPosition);
 
         drawerUtilsMock.verifyAll();
-        querySelectorMock.verifyAll();
         windowUtilsMock.verifyAll();
     });
 
@@ -214,7 +202,6 @@ describe('CenterPositionCalculatorTest', () => {
             .setupGetContainerSizeNeverCall()
             .build();
 
-        setupDefaultQuerySelectorMock();
         setupDefaultWindowUtilsMock();
         setupDefaultTabbableElementsHelperMock(area, map, img);
 
@@ -223,7 +210,6 @@ describe('CenterPositionCalculatorTest', () => {
         expect(centerPositionCalculator.getElementCenterPosition(area)).toEqual(expectedPosition);
 
         drawerUtilsMock.verifyAll();
-        querySelectorMock.verifyAll();
         windowUtilsMock.verifyAll();
     });
 
@@ -247,7 +233,6 @@ describe('CenterPositionCalculatorTest', () => {
             .setupGetContainerSizeNeverCall()
             .build();
 
-        setupDefaultQuerySelectorMock();
         setupDefaultWindowUtilsMock();
         setupDefaultTabbableElementsHelperMock(area, map, img);
 
@@ -256,7 +241,6 @@ describe('CenterPositionCalculatorTest', () => {
         expect(centerPositionCalculator.getElementCenterPosition(area)).toEqual(expectedPosition);
 
         drawerUtilsMock.verifyAll();
-        querySelectorMock.verifyAll();
         windowUtilsMock.verifyAll();
     });
 
@@ -268,7 +252,6 @@ describe('CenterPositionCalculatorTest', () => {
             .setupGetContainerOffsetNeverCall()
             .build();
 
-        setupDefaultQuerySelectorMock();
         setupDefaultWindowUtilsMock();
 
         const centerPositionCalculator = createCenterPositionCalculator(drawerUtilsMock.object);
@@ -276,7 +259,6 @@ describe('CenterPositionCalculatorTest', () => {
         expect(centerPositionCalculator.getElementCenterPosition(element)).toBeNull();
 
         drawerUtilsMock.verifyAll();
-        querySelectorMock.verifyAll();
         windowUtilsMock.verifyAll();
     });
 
@@ -295,7 +277,6 @@ describe('CenterPositionCalculatorTest', () => {
         const area: HTMLElement = dom.querySelector('#id1') as HTMLElement;
         const map: HTMLMapElement = dom.querySelector('#map1') as HTMLMapElement;
 
-        setupDefaultQuerySelectorMock();
         setupDefaultWindowUtilsMock();
 
         const drawerUtilsMock = new DrawerUtilsMockBuilder(dom, styleStub)
@@ -310,13 +291,8 @@ describe('CenterPositionCalculatorTest', () => {
         expect(centerPositionCalculator.getElementCenterPosition(area)).toEqual(expectedPosition);
 
         drawerUtilsMock.verifyAll();
-        querySelectorMock.verifyAll();
         windowUtilsMock.verifyAll();
     });
-
-    function setupDefaultQuerySelectorMock(): void {
-        querySelectorMock.setup(q => q('body')).returns(selector => bodyStub);
-    }
 
     function setupDefaultWindowUtilsMock(): void {
         windowUtilsMock

--- a/src/tests/unit/tests/injected/visualization/highlight-visualization.test.tsx
+++ b/src/tests/unit/tests/injected/visualization/highlight-visualization.test.tsx
@@ -52,7 +52,7 @@ describe('HighlightVisualization', () => {
         drawerUtilsMock
             .setup(drawerUtils => drawerUtils.getDocumentElement())
             .returns(() => documentMock.object);
-        documentMock.setup(document => document.querySelector('body')).returns(() => bodyStub);
+        documentMock.setup(document => document.body).returns(() => bodyStub);
         windowUtilsMock
             .setup(windowUtils => windowUtils.getComputedStyle(bodyStub))
             .returns(() => bodyStyleStub);

--- a/src/tests/unit/tests/injected/visualization/root-container-creator.test.ts
+++ b/src/tests/unit/tests/injected/visualization/root-container-creator.test.ts
@@ -14,7 +14,7 @@ describe(RootContainerCreator, () => {
         htmlElementUtilsMock = Mock.ofType(HTMLElementUtils);
 
         bodyStub = document.createElement('body');
-        htmlElementUtilsMock.setup(h => h.querySelector('body')).returns(() => bodyStub);
+        htmlElementUtilsMock.setup(h => h.getBody()).returns(() => bodyStub);
     });
 
     it('should create root container', () => {


### PR DESCRIPTION
#### Description of changes

This is an alternative to the PR (#2373) that using the html element. This is safer than querying for the body selector as it [also includes frameset elements](https://developer.mozilla.org/en-US/docs/Web/API/Document/body).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1107
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
