### PR TITLE
tools: add debug tools telemetry client and listener

### DIFF
--- a/src/background/telemetry/debug-tools-telemetry-client.ts
+++ b/src/background/telemetry/debug-tools-telemetry-client.ts
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TelemetryClient } from 'background/telemetry/telemetry-client';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { ConnectionNames } from 'common/constants/connection-names';
+
+export class DebugToolsTelemetryClient implements TelemetryClient {
+    private connections: chrome.runtime.Port[] = [];
+
+    constructor(private readonly browserAdapter: BrowserAdapter) {}
+
+    public initialize(): void {
+        this.browserAdapter.addListenerOnConnect((connection: chrome.runtime.Port) => {
+            if (connection.name !== ConnectionNames.debugToolsTelemetry) {
+                return;
+            }
+
+            connection.onDisconnect.addListener(() => {
+                this.connections = this.connections.filter(current => current !== connection);
+            });
+
+            this.connections.push(connection);
+        });
+    }
+
+    public enableTelemetry(): void {
+        // no op as we always want to send telemetry to the debug tools page (if there is a connection)
+    }
+
+    public disableTelemetry(): void {
+        // no op as we always want to send telemetry to the debug tools page (if there is a connection)
+    }
+
+    public trackEvent(name: string, properties?: Object): void {
+        if (this.connections.length === 0) {
+            return;
+        }
+
+        this.connections.forEach(connection =>
+            connection.postMessage({
+                name,
+                properties,
+            }),
+        );
+    }
+}

--- a/src/background/telemetry/debug-tools-telemetry-client.ts
+++ b/src/background/telemetry/debug-tools-telemetry-client.ts
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ApplicationTelemetryDataFactory } from 'background/telemetry/application-telemetry-data-factory';
 import { TelemetryClient } from 'background/telemetry/telemetry-client';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { ConnectionNames } from 'common/constants/connection-names';
@@ -7,7 +8,10 @@ import { ConnectionNames } from 'common/constants/connection-names';
 export class DebugToolsTelemetryClient implements TelemetryClient {
     private connections: chrome.runtime.Port[] = [];
 
-    constructor(private readonly browserAdapter: BrowserAdapter) {}
+    constructor(
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly telemetryDataFactory: ApplicationTelemetryDataFactory,
+    ) {}
 
     public initialize(): void {
         this.browserAdapter.addListenerOnConnect((connection: chrome.runtime.Port) => {
@@ -36,10 +40,15 @@ export class DebugToolsTelemetryClient implements TelemetryClient {
             return;
         }
 
+        const finalProperties = {
+            ...properties,
+            ...this.telemetryDataFactory.getData(),
+        };
+
         this.connections.forEach(connection =>
             connection.postMessage({
                 name,
-                properties,
+                properties: finalProperties,
             }),
         );
     }

--- a/src/background/telemetry/telemetry-client-provider.ts
+++ b/src/background/telemetry/telemetry-client-provider.ts
@@ -11,41 +11,42 @@ import { InstallDataGenerator } from '../install-data-generator';
 import { InstallationData } from '../installation-data';
 import { AppInsightsTelemetryClient } from './app-insights-telemetry-client';
 import { ApplicationTelemetryDataFactory } from './application-telemetry-data-factory';
-import { ConsoleTelemetryClient } from './console-telemetry-client';
 import { TelemetryClient } from './telemetry-client';
-import { TelemetryLogger } from './telemetry-logger';
 
 export const getTelemetryClient = (
-    applicationName: string,
-    installationData: InstallationData,
-    appDataAdapter: AppDataAdapter,
-    logger: TelemetryLogger,
+    applicationTelemetryDataFactory: ApplicationTelemetryDataFactory,
     appInsights: Microsoft.ApplicationInsights.IAppInsights,
-    storageAdapter: StorageAdapter,
+    baseClients: TelemetryClient[],
 ): TelemetryClient => {
+    const clients = [...baseClients];
+
+    const appInsightsInstrumentationKey = config.getOption('appInsightsInstrumentationKey');
+
+    if (appInsightsInstrumentationKey != null) {
+        clients.push(new AppInsightsTelemetryClient(appInsights, applicationTelemetryDataFactory));
+    }
+
+    return new MultiplexingTelemetryClient(clients);
+};
+
+export const getApplicationTelemetryDataFactory = (
+    installationData: InstallationData,
+    storageAdapter: StorageAdapter,
+    appDataAdapter: AppDataAdapter,
+    applicationName: string,
+) => {
     const installDataGenerator = new InstallDataGenerator(
         installationData,
         generateUID,
         DateProvider.getCurrentDate,
         storageAdapter,
     );
+
     const applicationBuildGenerator = new ApplicationBuildGenerator();
-    const coreTelemetryDataFactory = new ApplicationTelemetryDataFactory(
+    return new ApplicationTelemetryDataFactory(
         appDataAdapter.getVersion(),
         applicationName,
         applicationBuildGenerator.getBuild(),
         installDataGenerator,
     );
-
-    const clients: TelemetryClient[] = [
-        new ConsoleTelemetryClient(coreTelemetryDataFactory, logger),
-    ];
-
-    const appInsightsInstrumentationKey = config.getOption('appInsightsInstrumentationKey');
-
-    if (appInsightsInstrumentationKey != null) {
-        clients.push(new AppInsightsTelemetryClient(appInsights, coreTelemetryDataFactory));
-    }
-
-    return new MultiplexingTelemetryClient(clients);
 };

--- a/src/common/constants/connection-names.ts
+++ b/src/common/constants/connection-names.ts
@@ -2,4 +2,5 @@
 // Licensed under the MIT License.
 export class ConnectionNames {
     public static readonly devTools: string = 'insights-dev-tools';
+    public static readonly debugToolsTelemetry: string = 'insights-debug-tools-telemetry';
 }

--- a/src/debug-tools/controllers/telemetry-listener.ts
+++ b/src/debug-tools/controllers/telemetry-listener.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { ConnectionNames } from 'common/constants/connection-names';
+import { Logger } from 'common/logging/logger';
+
+export class TelemetryListener {
+    private connection: chrome.runtime.Port;
+
+    constructor(private readonly browserAdapter: BrowserAdapter, private readonly logger: Logger) {}
+
+    public initialize(): void {
+        this.connection = this.browserAdapter.connect({
+            name: ConnectionNames.debugToolsTelemetry,
+        });
+
+        this.connection.onMessage.addListener(this.onTelemetryMessage);
+    }
+
+    private onTelemetryMessage = (telemetryMessage: any) => {
+        this.logger.log('GOT TELEMETRY', telemetryMessage);
+    };
+
+    public dispose(): void {
+        this.connection.disconnect();
+    }
+}

--- a/src/debug-tools/initializer/debug-tools-init.tsx
+++ b/src/debug-tools/initializer/debug-tools-init.tsx
@@ -20,6 +20,7 @@ import {
     DebugToolsViewDeps,
     DebugToolsViewState,
 } from 'debug-tools/components/debug-tools-view';
+import { TelemetryListener } from 'debug-tools/controllers/telemetry-listener';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 
@@ -31,6 +32,9 @@ export const initializeDebugTools = () => {
     const storeActionMessageCreator = getStoreActionMessageCreator(browserAdapter, stores);
 
     const storesHub = new BaseClientStoresHub<DebugToolsViewState>(stores);
+
+    const telemetryListener = new TelemetryListener(browserAdapter, createDefaultLogger());
+    telemetryListener.initialize();
 
     const props: DebugToolsViewDeps = {
         storesHub,

--- a/src/tests/unit/tests/background/telemetry/debug-tools-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/debug-tools-telemetry-client.test.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import {
-    ApplicationTelemetryDataFactory,
     ApplicationTelemetryData,
+    ApplicationTelemetryDataFactory,
 } from 'background/telemetry/application-telemetry-data-factory';
 import { DebugToolsTelemetryClient } from 'background/telemetry/debug-tools-telemetry-client';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';

--- a/src/tests/unit/tests/background/telemetry/debug-tools-telemetry-client.test.ts
+++ b/src/tests/unit/tests/background/telemetry/debug-tools-telemetry-client.test.ts
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DebugToolsTelemetryClient } from 'background/telemetry/debug-tools-telemetry-client';
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { ConnectionNames } from 'common/constants/connection-names';
+import { isFunction, times } from 'lodash';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+describe('DebugToolsTelemetryClient', () => {
+    type Port = chrome.runtime.Port;
+    type OnDisconnect = Port['onDisconnect'];
+    type AddListener = OnDisconnect['addListener'];
+
+    const connectionsCountProperty = 'connections.length';
+
+    let browserAdapterMock: IMock<BrowserAdapter>;
+    let portMock: IMock<Port>;
+
+    let testSubject: DebugToolsTelemetryClient;
+
+    beforeEach(() => {
+        browserAdapterMock = Mock.ofType<BrowserAdapter>();
+        portMock = Mock.ofType<Port>();
+
+        testSubject = new DebugToolsTelemetryClient(browserAdapterMock.object);
+    });
+
+    describe('initialize', () => {
+        it('no op for NON debug tools telemetry connection name', () => {
+            browserAdapterMock
+                .setup(adapter => adapter.addListenerOnConnect(It.is(isFunction)))
+                .callback(listener => listener(portMock.object));
+
+            portMock.setup(port => port.name).returns(() => 'not-the-on-i-am-looking-for');
+
+            testSubject.initialize();
+
+            portMock.verify(port => port.onDisconnect, Times.never());
+
+            expect(testSubject).toHaveProperty(connectionsCountProperty, 0);
+        });
+
+        it.each([1, 3, 4, 7])(
+            'handles new debug tools telemetry connections (total connection count %s)',
+            connectionsCount => {
+                let onConnectListener: Function;
+
+                browserAdapterMock
+                    .setup(adapter => adapter.addListenerOnConnect(It.is(isFunction)))
+                    .callback(listener => (onConnectListener = listener));
+
+                portMock
+                    .setup(port => port.name)
+                    .returns(() => ConnectionNames.debugToolsTelemetry);
+
+                const onDisconnectMock = Mock.ofType<OnDisconnect>();
+
+                portMock.setup(port => port.onDisconnect).returns(() => onDisconnectMock.object);
+
+                testSubject.initialize();
+
+                times(connectionsCount, () => onConnectListener(portMock.object));
+
+                onDisconnectMock.verify(
+                    onDisconnect => onDisconnect.addListener(It.is(isFunction)),
+                    Times.exactly(connectionsCount),
+                );
+
+                expect(testSubject).toHaveProperty(connectionsCountProperty, connectionsCount);
+            },
+        );
+    });
+
+    describe('enableTelemetry', () => {
+        beforeEach(() => {
+            testSubject = new DebugToolsTelemetryClient(null);
+        });
+
+        it('no op, no side effects', () => {
+            const action = () => testSubject.enableTelemetry();
+
+            expect(action).not.toThrow();
+        });
+    });
+
+    describe('disableTelemetry', () => {
+        beforeEach(() => {
+            testSubject = new DebugToolsTelemetryClient(null);
+        });
+
+        it('no op, no side effects', () => {
+            const action = () => testSubject.disableTelemetry();
+
+            expect(action).not.toThrow();
+        });
+    });
+
+    describe('trackEvent', () => {
+        const eventName = 'test-event-name';
+        const eventProperties = { testProperty: 'testValue' };
+
+        it('is no op when there are no connections', () => {
+            testSubject = new DebugToolsTelemetryClient(null);
+
+            const action = () => testSubject.trackEvent(eventName, eventProperties);
+
+            expect(action).not.toThrow();
+        });
+
+        it('post a message to every tracked connection', () => {
+            const connectionsCount = 3;
+            let onConnectListener: Function;
+
+            browserAdapterMock
+                .setup(adapter => adapter.addListenerOnConnect(It.is(isFunction)))
+                .callback(listener => (onConnectListener = listener));
+
+            const onDisconnectMock = Mock.ofType<OnDisconnect>();
+
+            const portMocks: IMock<Port>[] = [];
+
+            for (let portIndex = 0; portIndex < connectionsCount; portIndex++) {
+                const mock = Mock.ofType<Port>();
+                mock.setup(port => port.name).returns(() => ConnectionNames.debugToolsTelemetry);
+                mock.setup(port => port.onDisconnect).returns(() => onDisconnectMock.object);
+
+                portMocks.push(mock);
+            }
+
+            testSubject.initialize();
+
+            times(connectionsCount, callIndex => onConnectListener(portMocks[callIndex].object));
+
+            expect(testSubject).toHaveProperty(connectionsCountProperty, connectionsCount);
+
+            testSubject.trackEvent(eventName, eventProperties);
+
+            portMocks.forEach(mock => {
+                mock.verify(
+                    port =>
+                        port.postMessage(
+                            It.isValue({
+                                name: eventName,
+                                properties: eventProperties,
+                            }),
+                        ),
+                    Times.once(),
+                );
+            });
+        });
+    });
+
+    it('handles onDisconnect events for existing, tracked connections', () => {
+        const connectionsCount = 3;
+        let onConnectListener: Function;
+
+        browserAdapterMock
+            .setup(adapter => adapter.addListenerOnConnect(It.is(isFunction)))
+            .callback(listener => (onConnectListener = listener));
+
+        const onDisconnectListeners: Function[] = [];
+        const onDisconnectMock = Mock.ofType<OnDisconnect>();
+        onDisconnectMock
+            .setup(onDisconnect => onDisconnect.addListener(It.is(isFunction)))
+            .callback(listener => onDisconnectListeners.push(listener));
+
+        const portMocks: IMock<Port>[] = [];
+
+        for (let portIndex = 0; portIndex < connectionsCount; portIndex++) {
+            const mock = Mock.ofType<Port>();
+            mock.setup(port => port.name).returns(() => ConnectionNames.debugToolsTelemetry);
+            mock.setup(port => port.onDisconnect).returns(() => onDisconnectMock.object);
+
+            portMocks.push(mock);
+        }
+
+        testSubject.initialize();
+
+        times(connectionsCount, callIndex => onConnectListener(portMocks[callIndex].object));
+
+        expect(testSubject).toHaveProperty(connectionsCountProperty, connectionsCount);
+        expect(onDisconnectListeners).toHaveLength(connectionsCount);
+
+        onDisconnectListeners.forEach((disconnectionListener, disconnectionIndex) => {
+            disconnectionListener();
+            expect(testSubject).toHaveProperty(
+                connectionsCountProperty,
+                connectionsCount - (disconnectionIndex + 1),
+            );
+        });
+    });
+});

--- a/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
@@ -1,8 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { InstallationData } from 'background/installation-data';
+import { ApplicationTelemetryDataFactory } from 'background/telemetry/application-telemetry-data-factory';
 import { MultiplexingTelemetryClient } from 'background/telemetry/multiplexing-telemetry-client';
-import { getTelemetryClient } from 'background/telemetry/telemetry-client-provider';
+import { TelemetryClient } from 'background/telemetry/telemetry-client';
+import {
+    getApplicationTelemetryDataFactory,
+    getTelemetryClient,
+} from 'background/telemetry/telemetry-client-provider';
 import { TelemetryLogger } from 'background/telemetry/telemetry-logger';
 import { AppDataAdapter } from 'common/browser-adapters/app-data-adapter';
 import { StorageAdapter } from 'common/browser-adapters/storage-adapter';
@@ -10,51 +15,65 @@ import { configMutator } from 'common/configuration';
 import { Mock } from 'typemoq';
 
 describe('TelemetryClientProvider', () => {
-    const installationData: InstallationData = {
-        id: 'test-id',
-        month: 9,
-        year: 2019,
-    };
+    describe('getTelemetryClient', () => {
+        const baseClients = [
+            Mock.ofType<TelemetryClient>().object,
+            Mock.ofType<TelemetryClient>().object,
+        ];
 
-    const applicationName = 'test application name';
+        const baseClientsCount = baseClients.length;
 
-    beforeEach(() => configMutator.reset());
+        beforeEach(() => configMutator.reset());
 
-    afterAll(() => configMutator.reset());
+        afterAll(() => configMutator.reset());
 
-    it('builds a telemetry client using the instrumentation key', () => {
-        configMutator.setOption('appInsightsInstrumentationKey', 'test-key');
+        it('builds a telemetry client using the instrumentation key', () => {
+            configMutator.setOption('appInsightsInstrumentationKey', 'test-key');
 
-        const appAdapterMock = Mock.ofType<AppDataAdapter>();
+            const appAdapterMock = Mock.ofType<AppDataAdapter>();
 
-        appAdapterMock.setup(adapter => adapter.getVersion()).returns(() => 'test');
+            appAdapterMock.setup(adapter => adapter.getVersion()).returns(() => 'test');
 
-        const result = getTelemetryClient(
-            applicationName,
-            installationData,
-            appAdapterMock.object,
-            Mock.ofType<TelemetryLogger>().object,
-            Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>().object,
-            Mock.ofType<StorageAdapter>().object,
-        );
+            const result = getTelemetryClient(
+                Mock.ofType<ApplicationTelemetryDataFactory>().object,
+                Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>().object,
+                baseClients,
+            );
 
-        expect(result).toBeInstanceOf(MultiplexingTelemetryClient);
-        expect(result).toHaveProperty('wrappedClients.length', 2);
+            expect(result).toBeInstanceOf(MultiplexingTelemetryClient);
+            expect(result).toHaveProperty('wrappedClients.length', baseClientsCount + 1);
+        });
+
+        it('builds a telemetry client when there is no instrumentation key', () => {
+            configMutator.setOption('appInsightsInstrumentationKey', null);
+
+            const result = getTelemetryClient(
+                Mock.ofType<ApplicationTelemetryDataFactory>().object,
+                Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>().object,
+                baseClients,
+            );
+
+            expect(result).toBeInstanceOf(MultiplexingTelemetryClient);
+            expect(result).toHaveProperty('wrappedClients.length', baseClientsCount);
+        });
     });
 
-    it('builds a telemetry client when there is no instrumentation key', () => {
-        configMutator.setOption('appInsightsInstrumentationKey', null);
+    it('build an application telemetry data factory', () => {
+        const installationData: InstallationData = {
+            id: 'test-id',
+            month: 9,
+            year: 2019,
+        };
 
-        const result = getTelemetryClient(
-            applicationName,
+        const applicationName = 'test application name';
+
+        const result = getApplicationTelemetryDataFactory(
             installationData,
-            Mock.ofType<AppDataAdapter>().object,
-            Mock.ofType<TelemetryLogger>().object,
-            Mock.ofType<Microsoft.ApplicationInsights.IAppInsights>().object,
             Mock.ofType<StorageAdapter>().object,
+            Mock.ofType<AppDataAdapter>().object,
+            applicationName,
         );
 
-        expect(result).toBeInstanceOf(MultiplexingTelemetryClient);
-        expect(result).toHaveProperty('wrappedClients.length', 1);
+        expect(result).toBeInstanceOf(ApplicationTelemetryDataFactory);
     });
 });

--- a/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
+++ b/src/tests/unit/tests/background/telemetry/telemetry-client-provider.test.ts
@@ -8,7 +8,6 @@ import {
     getApplicationTelemetryDataFactory,
     getTelemetryClient,
 } from 'background/telemetry/telemetry-client-provider';
-import { TelemetryLogger } from 'background/telemetry/telemetry-logger';
 import { AppDataAdapter } from 'common/browser-adapters/app-data-adapter';
 import { StorageAdapter } from 'common/browser-adapters/storage-adapter';
 import { configMutator } from 'common/configuration';

--- a/src/tests/unit/tests/debug-tools/controllers/telemetry-listener.test.ts
+++ b/src/tests/unit/tests/debug-tools/controllers/telemetry-listener.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
+import { ConnectionNames } from 'common/constants/connection-names';
+import { Logger } from 'common/logging/logger';
+import { TelemetryListener } from 'debug-tools/controllers/telemetry-listener';
+import { isFunction } from 'lodash';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+describe('TelemetryListener', () => {
+    type Port = chrome.runtime.Port;
+    type OnMessage = Port['onMessage'];
+
+    let onMessageMock: IMock<OnMessage>;
+    let connectionMock: IMock<Port>;
+    let browserAdapterMock: IMock<BrowserAdapter>;
+    let loggerMock: IMock<Logger>;
+
+    let testSubject: TelemetryListener;
+
+    beforeEach(() => {
+        onMessageMock = Mock.ofType<OnMessage>();
+
+        connectionMock = Mock.ofType<Port>();
+        connectionMock
+            .setup(connection => connection.onMessage)
+            .returns(() => onMessageMock.object);
+
+        browserAdapterMock = Mock.ofType<BrowserAdapter>();
+
+        browserAdapterMock
+            .setup(adapter =>
+                adapter.connect(
+                    It.isValue({
+                        name: ConnectionNames.debugToolsTelemetry,
+                    }),
+                ),
+            )
+            .returns(() => connectionMock.object);
+
+        loggerMock = Mock.ofType<Logger>();
+
+        testSubject = new TelemetryListener(browserAdapterMock.object, loggerMock.object);
+    });
+
+    it('handles incoming messages', () => {
+        let messageListener: Function;
+
+        onMessageMock
+            .setup(onMessage => onMessage.addListener(It.is(isFunction)))
+            .callback(listener => (messageListener = listener));
+
+        testSubject.initialize();
+
+        const telemetryMessage = { testKey: 'testValue' };
+        messageListener(telemetryMessage);
+
+        loggerMock.verify(logger => logger.log('GOT TELEMETRY', telemetryMessage), Times.once());
+    });
+
+    it('close the connection', () => {
+        testSubject.initialize();
+
+        testSubject.dispose();
+
+        connectionMock.verify(connection => connection.disconnect(), Times.once());
+    });
+});


### PR DESCRIPTION
#### Description of changes

This PR introduces most (maybe all) of the piping needed to send and consume telemetry events on the debug tools.

The implementation relies on chrome API's that allows us to more explicitly establish a communication channel between different context (in this case, the background and the debug tools page). This allow for more fine-grained control.

There is no UI being added on this PR so to keep it more or less simple. The way to check it is working is to open the debug tools tab and inspect the page; the console will show all the telemetry events being trigger by the extension.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
