### PR TITLE
feat(usage-data): record initial usage data upon extension entry points

### DIFF
--- a/src/background/actions/popup-action-creator.ts
+++ b/src/background/actions/popup-action-creator.ts
@@ -2,9 +2,9 @@
 // Licensed under the MIT License.
 import { POPUP_INITIALIZED } from 'common/extension-telemetry-events';
 import { Messages } from 'common/messages';
-
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
+import { UsageLogger } from '../usage-logger';
 import { PopupInitializedPayload } from './action-payloads';
 import { TabActions } from './tab-actions';
 
@@ -13,6 +13,7 @@ export class PopupActionCreator {
         private readonly interpreter: Interpreter,
         private readonly tabActions: TabActions,
         private readonly telemetryEventHandler: TelemetryEventHandler,
+        private readonly usageLogger: UsageLogger,
     ) {}
 
     public registerCallbacks(): void {
@@ -21,6 +22,7 @@ export class PopupActionCreator {
             (payload: PopupInitializedPayload) => {
                 this.telemetryEventHandler.publishTelemetry(POPUP_INITIALIZED, payload);
                 this.tabActions.newTabCreated.invoke(payload.tab);
+                this.usageLogger.record();
             },
         );
     }

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -5,6 +5,7 @@ import { Assessments } from 'assessments/assessments';
 import { AxeInfo } from '../common/axe-info';
 import { ChromeAdapter } from '../common/browser-adapters/chrome-adapter';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
+import { DateProvider } from '../common/date-provider';
 import { EnvironmentInfoProvider } from '../common/environment-info-provider';
 import { getIndexedDBStore } from '../common/indexedDB/get-indexeddb-store';
 import { IndexedDBAPI, IndexedDBUtil } from '../common/indexedDB/indexedDB';
@@ -34,9 +35,8 @@ import { getTelemetryClient } from './telemetry/telemetry-client-provider';
 import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
 import { TelemetryLogger } from './telemetry/telemetry-logger';
 import { TelemetryStateListener } from './telemetry/telemetry-state-listener';
+import { UsageLogger } from './usage-logger';
 import { cleanKeysFromStorage } from './user-stored-data-cleaner';
-import { UsageLogger } from 'background/usage-logger';
-import { DateProvider } from 'common/date-provider';
 
 declare var window: Window & InsightsWindowExtensions;
 
@@ -79,7 +79,6 @@ async function initialize(): Promise<void> {
     );
 
     const usageLogger = new UsageLogger(browserAdapter, DateProvider.getCurrentDate, logger);
-    usageLogger.record();
 
     const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
 
@@ -134,6 +133,7 @@ async function initialize(): Promise<void> {
         globalContext.stores.userConfigurationStore,
         browserAdapter,
         logger,
+        usageLogger,
     );
     keyboardShortcutHandler.initialize();
 
@@ -158,6 +158,7 @@ async function initialize(): Promise<void> {
         targetTabController,
         promiseFactory,
         logger,
+        usageLogger,
     );
 
     const targetPageController = new TargetPageController(

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -78,7 +78,7 @@ async function initialize(): Promise<void> {
         browserAdapter,
     );
 
-    const usageLogger = new UsageLogger(browserAdapter, DateProvider.getUTCDate, logger);
+    const usageLogger = new UsageLogger(browserAdapter, DateProvider.getCurrentDate, logger);
     usageLogger.record();
 
     const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);

--- a/src/background/background-init.ts
+++ b/src/background/background-init.ts
@@ -35,6 +35,8 @@ import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
 import { TelemetryLogger } from './telemetry/telemetry-logger';
 import { TelemetryStateListener } from './telemetry/telemetry-state-listener';
 import { cleanKeysFromStorage } from './user-stored-data-cleaner';
+import { UsageLogger } from 'background/usage-logger';
+import { DateProvider } from 'common/date-provider';
 
 declare var window: Window & InsightsWindowExtensions;
 
@@ -75,6 +77,9 @@ async function initialize(): Promise<void> {
         AppInsights,
         browserAdapter,
     );
+
+    const usageLogger = new UsageLogger(browserAdapter, DateProvider.getUTCDate, logger);
+    usageLogger.record();
 
     const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
 

--- a/src/background/keyboard-shortcut-handler.ts
+++ b/src/background/keyboard-shortcut-handler.ts
@@ -20,6 +20,7 @@ import { DictionaryStringTo } from '../types/common-types';
 import { VisualizationTogglePayload } from './actions/action-payloads';
 import { UserConfigurationStore } from './stores/global/user-configuration-store';
 import { TabToContextMap } from './tab-context';
+import { UsageLogger } from './usage-logger';
 
 const VisualizationMessages = Messages.Visualizations;
 
@@ -37,6 +38,7 @@ export class KeyboardShortcutHandler {
         private userConfigurationStore: UserConfigurationStore,
         private commandsAdapter: CommandsAdapter,
         private logger: Logger,
+        private usageLogger: UsageLogger,
     ) {}
 
     public initialize(): void {
@@ -51,6 +53,7 @@ export class KeyboardShortcutHandler {
                 return;
             }
 
+            this.usageLogger.record();
             const currentTab = await this.queryCurrentActiveTab();
 
             if (!currentTab) {

--- a/src/background/tab-context-factory.ts
+++ b/src/background/tab-context-factory.ts
@@ -29,6 +29,7 @@ import { TabContextStoreHub } from './stores/tab-context-store-hub';
 import { TabContext } from './tab-context';
 import { TargetTabController } from './target-tab-controller';
 import { TelemetryEventHandler } from './telemetry/telemetry-event-handler';
+import { UsageLogger } from './usage-logger';
 
 export class TabContextFactory {
     constructor(
@@ -37,6 +38,7 @@ export class TabContextFactory {
         private targetTabController: TargetTabController,
         private readonly promiseFactory: PromiseFactory,
         private readonly logger: Logger,
+        private readonly usageLogger: UsageLogger,
     ) {}
 
     public createTabContext(
@@ -91,6 +93,7 @@ export class TabContextFactory {
             interpreter,
             actionsHub.tabActions,
             this.telemetryEventHandler,
+            this.usageLogger,
         );
         const devToolsActionCreator = new DevToolsActionCreator(
             interpreter,

--- a/src/background/usage-logger.ts
+++ b/src/background/usage-logger.ts
@@ -1,5 +1,5 @@
-import { StorageAdapter } from 'common/browser-adapters/storage-adapter';
-import { Logger } from 'common/logging/logger';
+import { StorageAdapter } from '../common/browser-adapters/storage-adapter';
+import { Logger } from '../common/logging/logger';
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.

--- a/src/background/usage-logger.ts
+++ b/src/background/usage-logger.ts
@@ -9,7 +9,7 @@ export const USAGE_KEY: string = 'ADA_IS_A_COOL_CAT';
 export class UsageLogger {
     constructor(
         private storageAdapter: StorageAdapter,
-        private utcDateGetter: () => Date,
+        private dateGetter: () => Date,
         private logger: Logger,
     ) {}
 
@@ -17,7 +17,7 @@ export class UsageLogger {
         this.storageAdapter
             .setUserData({
                 usageData: {
-                    lastUsageDateTime: this.utcDateGetter().toISOString(),
+                    lastUsageDateTime: this.dateGetter().toISOString(),
                     magic: USAGE_KEY,
                 },
             })

--- a/src/background/usage-logger.ts
+++ b/src/background/usage-logger.ts
@@ -1,8 +1,7 @@
-import { StorageAdapter } from '../common/browser-adapters/storage-adapter';
-import { Logger } from '../common/logging/logger';
-
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { StorageAdapter } from '../common/browser-adapters/storage-adapter';
+import { Logger } from '../common/logging/logger';
 
 export const USAGE_KEY: string = 'ADA_IS_A_COOL_CAT';
 
@@ -18,7 +17,7 @@ export class UsageLogger {
             .setUserData({
                 usageData: {
                     lastUsageDateTime: this.dateGetter().toISOString(),
-                    magic: USAGE_KEY,
+                    usageKey: USAGE_KEY,
                 },
             })
             .catch(this.logger.error);

--- a/src/background/usage-logger.ts
+++ b/src/background/usage-logger.ts
@@ -1,0 +1,26 @@
+import { StorageAdapter } from 'common/browser-adapters/storage-adapter';
+import { Logger } from 'common/logging/logger';
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+export const USAGE_KEY: string = 'ADA_IS_A_COOL_CAT';
+
+export class UsageLogger {
+    constructor(
+        private storageAdapter: StorageAdapter,
+        private utcDateGetter: () => Date,
+        private logger: Logger,
+    ) {}
+
+    public record(): void {
+        this.storageAdapter
+            .setUserData({
+                usageData: {
+                    lastUsageDateTime: this.utcDateGetter().toISOString(),
+                    magic: USAGE_KEY,
+                },
+            })
+            .catch(this.logger.error);
+    }
+}

--- a/src/common/date-provider.ts
+++ b/src/common/date-provider.ts
@@ -11,21 +11,6 @@ export class DateProvider {
         return new Date();
     }
 
-    public static getUTCDate(): Date {
-        const date = new Date();
-        return new Date(
-            Date.UTC(
-                date.getUTCFullYear(),
-                date.getMonth(),
-                date.getDate(),
-                date.getHours(),
-                date.getMinutes(),
-                date.getSeconds(),
-                date.getMilliseconds(),
-            ),
-        );
-    }
-
     public static getUTCStringFromDate(date: Date): string {
         return utc(date.toISOString()).format('YYYY-MM-DD h:mm A z');
     }

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -139,7 +139,6 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             AppInsights,
             storageAdapter,
         );
-
         const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
         const platformInfo = new PlatformInfo(process);
 

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -91,7 +91,6 @@ import {
     RootContainerRendererDeps,
 } from './root-container/root-container-renderer';
 import { screenshotViewModelProvider } from './screenshot/screenshot-view-model-provider';
-import { UsageLogger } from 'background/usage-logger';
 
 declare var window: Window & {
     insightsUserConfiguration: UserConfigurationController;
@@ -140,9 +139,6 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             AppInsights,
             storageAdapter,
         );
-
-        const usageLogger = new UsageLogger(storageAdapter, DateProvider.getUTCDate, logger);
-        usageLogger.record();
 
         const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
         const platformInfo = new PlatformInfo(process);

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -91,6 +91,7 @@ import {
     RootContainerRendererDeps,
 } from './root-container/root-container-renderer';
 import { screenshotViewModelProvider } from './screenshot/screenshot-view-model-provider';
+import { UsageLogger } from 'background/usage-logger';
 
 declare var window: Window & {
     insightsUserConfiguration: UserConfigurationController;
@@ -139,6 +140,10 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             AppInsights,
             storageAdapter,
         );
+
+        const usageLogger = new UsageLogger(storageAdapter, DateProvider.getUTCDate, logger);
+        usageLogger.record();
+
         const telemetryEventHandler = new TelemetryEventHandler(telemetryClient);
         const platformInfo = new PlatformInfo(process);
 

--- a/src/tests/unit/common/date-provider.test.tsx
+++ b/src/tests/unit/common/date-provider.test.tsx
@@ -13,11 +13,6 @@ describe('DateProviderTest', () => {
         expect(date.getTime()).toEqual(new Date(date).getTime());
     });
 
-    test('getUTCDate', () => {
-        const UTCDate = DateProvider.getUTCDate();
-        expect(UTCDate.getTime()).toEqual(new Date(UTCDate).getTime());
-    });
-
     const differentTimeZonesDates = [
         'Thu May 30 2019 16:57:54 GMT-0700 (Pacific Daylight Time)',
         'Thu May 30 2019 18:57:54 GMT-0500 (Central Standard Time)',

--- a/src/tests/unit/tests/background/actions/popup-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/popup-action-creator.test.ts
@@ -4,6 +4,7 @@ import { PopupInitializedPayload } from 'background/actions/action-payloads';
 import { PopupActionCreator } from 'background/actions/popup-action-creator';
 import { TabActions } from 'background/actions/tab-actions';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { UsageLogger } from 'background/usage-logger';
 import {
     POPUP_INITIALIZED,
     TelemetryEventSource,
@@ -35,10 +36,13 @@ describe('PopupActionCreator', () => {
         const actionsMock = createTabActionsMock('newTabCreated', actionMock.object);
         const interpreterMock = createInterpreterMock(Messages.Popup.Initialized, payload);
         const telemetryEventHandlerMock = Mock.ofType<TelemetryEventHandler>();
+        const usageLoggerMock = Mock.ofType<UsageLogger>();
+
         const testSubject = new PopupActionCreator(
             interpreterMock.object,
             actionsMock.object,
             telemetryEventHandlerMock.object,
+            usageLoggerMock.object,
         );
 
         testSubject.registerCallbacks();
@@ -48,6 +52,7 @@ describe('PopupActionCreator', () => {
             tp => tp.publishTelemetry(POPUP_INITIALIZED, payload),
             Times.once(),
         );
+        usageLoggerMock.verify(m => m.record(), Times.once());
     });
 
     function createTabActionsMock<ActionName extends keyof TabActions>(

--- a/src/tests/unit/tests/background/keyboard-shortcut-handler.test.ts
+++ b/src/tests/unit/tests/background/keyboard-shortcut-handler.test.ts
@@ -6,6 +6,7 @@ import { UserConfigurationStore } from 'background/stores/global/user-configurat
 import { TabContextStoreHub } from 'background/stores/tab-context-store-hub';
 import { VisualizationStore } from 'background/stores/visualization-store';
 import { TabContext, TabToContextMap } from 'background/tab-context';
+import { UsageLogger } from 'background/usage-logger';
 import { BaseStore } from 'common/base-store';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { CommandsAdapter } from 'common/browser-adapters/commands-adapter';
@@ -34,6 +35,7 @@ describe('KeyboardShortcutHandler', () => {
     let visualizationStoreMock: IMock<BaseStore<VisualizationStoreData>>;
     let interpreterMock: IMock<Interpreter>;
     let loggerMock: IMock<Logger>;
+    let usageLoggerMock: IMock<UsageLogger>;
 
     let commandCallback: (commandId: string) => Promise<void>;
     let existingTabId: number;
@@ -102,7 +104,7 @@ describe('KeyboardShortcutHandler', () => {
             });
 
         loggerMock = Mock.ofType<Logger>();
-
+        usageLoggerMock = Mock.ofType<UsageLogger>();
         testSubject = new KeyboardShortcutHandler(
             tabToContextMap,
             browserAdapterMock.object,
@@ -113,6 +115,7 @@ describe('KeyboardShortcutHandler', () => {
             userConfigurationStoreMock.object,
             commandsAdapterMock.object,
             loggerMock.object,
+            usageLoggerMock.object,
         );
 
         testSubject.initialize();
@@ -178,6 +181,7 @@ describe('KeyboardShortcutHandler', () => {
                 },
             });
 
+            usageLoggerMock.verify(m => m.record(), Times.once());
             interpreterMock.verifyAll();
         },
     );
@@ -215,6 +219,7 @@ describe('KeyboardShortcutHandler', () => {
                 },
             });
 
+            usageLoggerMock.verify(m => m.record(), Times.once());
             interpreterMock.verifyAll();
         },
     );
@@ -234,6 +239,7 @@ describe('KeyboardShortcutHandler', () => {
 
             await commandCallback(configuration.chromeCommand);
 
+            usageLoggerMock.verify(m => m.record(), Times.once());
             notificationCreatorMock.verifyAll();
         },
     );
@@ -252,6 +258,7 @@ describe('KeyboardShortcutHandler', () => {
 
             await commandCallback(configuration.chromeCommand);
 
+            usageLoggerMock.verify(m => m.record(), Times.once());
             notificationCreatorMock.verifyAll();
         },
     );
@@ -261,6 +268,7 @@ describe('KeyboardShortcutHandler', () => {
 
         await commandCallback('unknown-command');
 
+        usageLoggerMock.verify(m => m.record(), Times.once());
         interpreterMock.verifyAll();
     });
 
@@ -271,6 +279,7 @@ describe('KeyboardShortcutHandler', () => {
 
         await commandCallback(getArbitraryValidChromeCommand());
 
+        usageLoggerMock.verify(m => m.record(), Times.never());
         interpreterMock.verifyAll();
     });
 
@@ -282,6 +291,7 @@ describe('KeyboardShortcutHandler', () => {
 
         await commandCallback(getArbitraryValidChromeCommand());
 
+        usageLoggerMock.verify(m => m.record(), Times.once());
         interpreterMock.verifyAll();
     });
 
@@ -299,6 +309,7 @@ describe('KeyboardShortcutHandler', () => {
 
         await commandCallback(configuration.chromeCommand);
 
+        usageLoggerMock.verify(m => m.record(), Times.once());
         interpreterMock.verifyAll();
     });
 
@@ -309,6 +320,7 @@ describe('KeyboardShortcutHandler', () => {
 
         await commandCallback(getArbitraryValidChromeCommand());
 
+        usageLoggerMock.verify(m => m.record(), Times.once());
         interpreterMock.verifyAll();
     });
 
@@ -328,6 +340,7 @@ describe('KeyboardShortcutHandler', () => {
 
             await commandCallback(getArbitraryValidChromeCommand());
 
+            usageLoggerMock.verify(m => m.record(), Times.once());
             notificationCreatorMock.verifyAll();
         },
     );

--- a/src/tests/unit/tests/background/tab-context-factory.test.ts
+++ b/src/tests/unit/tests/background/tab-context-factory.test.ts
@@ -16,6 +16,7 @@ import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-hand
 import { Logger } from 'common/logging/logger';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 import { UnifiedScanResultStore } from '../../../../background/stores/unified-scan-result-store';
+import { UsageLogger } from '../../../../background/usage-logger';
 import { BrowserAdapter } from '../../../../common/browser-adapters/browser-adapter';
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
@@ -33,10 +34,12 @@ describe('TabContextFactoryTest', () => {
     let mockDetailsViewController: IMock<ExtensionDetailsViewController>;
     let mockBrowserAdapter: IMock<BrowserAdapter>;
     let mockLogger: IMock<Logger>;
+    let mockUsageLogger: IMock<UsageLogger>;
 
     beforeEach(() => {
         mockBrowserAdapter = Mock.ofType<BrowserAdapter>();
         mockLogger = Mock.ofType<Logger>();
+        mockUsageLogger = Mock.ofType<UsageLogger>();
         mockDetailsViewController = Mock.ofType<ExtensionDetailsViewController>();
     });
 
@@ -90,6 +93,7 @@ describe('TabContextFactoryTest', () => {
             targetTabControllerMock.object,
             promiseFactoryMock.object,
             mockLogger.object,
+            mockUsageLogger.object,
         );
 
         const tabContext = testObject.createTabContext(

--- a/src/tests/unit/tests/background/usage-logger.test.ts
+++ b/src/tests/unit/tests/background/usage-logger.test.ts
@@ -1,7 +1,7 @@
 import { USAGE_KEY, UsageLogger } from 'background/usage-logger';
 import { StorageAdapter } from 'common/browser-adapters/storage-adapter';
 import { Logger } from 'common/logging/logger';
-import { It, Mock, MockBehavior, Times, IMock } from 'typemoq';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
@@ -24,7 +24,7 @@ describe('UsageLoggerTest', () => {
         dateGetterMock = Mock.ofInstance(() => dateStub, MockBehavior.Strict);
         dateGetterMock.setup(m => m()).returns(_ => dateStub);
     });
-    /*
+
     it('sets current time', () => {
         const usageLogger = new UsageLogger(
             storageAdapterMock.object,
@@ -61,5 +61,5 @@ describe('UsageLoggerTest', () => {
 
         storageAdapterMock.verifyAll();
         loggerMock.verifyAll();
-    });*/
+    });
 });

--- a/src/tests/unit/tests/background/usage-logger.test.ts
+++ b/src/tests/unit/tests/background/usage-logger.test.ts
@@ -1,0 +1,65 @@
+import { USAGE_KEY, UsageLogger } from 'background/usage-logger';
+import { StorageAdapter } from 'common/browser-adapters/storage-adapter';
+import { Logger } from 'common/logging/logger';
+import { It, Mock, MockBehavior, Times, IMock } from 'typemoq';
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+describe('UsageLoggerTest', () => {
+    let storageAdapterMock: IMock<StorageAdapter>;
+    let dateGetterMock: IMock<() => Date>;
+    let loggerMock: IMock<Logger>;
+
+    const dateStub = { toISOString: () => 'time' } as Date;
+    const expected = {
+        usageData: {
+            lastUsageDateTime: 'time',
+            magic: USAGE_KEY,
+        },
+    };
+
+    beforeEach(() => {
+        storageAdapterMock = Mock.ofType<StorageAdapter>(undefined, MockBehavior.Strict);
+        loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
+        dateGetterMock = Mock.ofInstance(() => dateStub, MockBehavior.Strict);
+        dateGetterMock.setup(m => m()).returns(_ => dateStub);
+    });
+    /*
+    it('sets current time', () => {
+        const usageLogger = new UsageLogger(
+            storageAdapterMock.object,
+            dateGetterMock.object,
+            loggerMock.object,
+        );
+
+        storageAdapterMock
+            .setup(m => m.setUserData(It.isValue(expected)))
+            .returns(_ => Promise.resolve());
+
+        loggerMock.setup(l => l.error()).verifiable(Times.never());
+
+        usageLogger.record();
+
+        storageAdapterMock.verifyAll();
+        loggerMock.verifyAll();
+    });
+
+    it('routes to logger if promise rejected', () => {
+        const usageLogger = new UsageLogger(
+            storageAdapterMock.object,
+            dateGetterMock.object,
+            loggerMock.object,
+        );
+
+        storageAdapterMock
+            .setup(m => m.setUserData(It.isValue(expected)))
+            .returns(_ => Promise.reject());
+
+        loggerMock.setup(l => l.error()).verifiable(Times.once());
+
+        usageLogger.record();
+
+        storageAdapterMock.verifyAll();
+        loggerMock.verifyAll();
+    });*/
+});

--- a/src/tests/unit/tests/background/usage-logger.test.ts
+++ b/src/tests/unit/tests/background/usage-logger.test.ts
@@ -19,8 +19,8 @@ describe('UsageLoggerTest', () => {
     };
 
     beforeEach(() => {
+        loggerMock = Mock.ofType<Logger>();
         storageAdapterMock = Mock.ofType<StorageAdapter>(undefined, MockBehavior.Strict);
-        loggerMock = Mock.ofType<Logger>(undefined, MockBehavior.Strict);
         dateGetterMock = Mock.ofInstance(() => dateStub, MockBehavior.Strict);
         dateGetterMock.setup(m => m()).returns(_ => dateStub);
     });
@@ -36,15 +36,13 @@ describe('UsageLoggerTest', () => {
             .setup(m => m.setUserData(It.isValue(expected)))
             .returns(_ => Promise.resolve());
 
-        loggerMock.setup(l => l.error()).verifiable(Times.never());
-
         usageLogger.record();
 
         storageAdapterMock.verifyAll();
-        loggerMock.verifyAll();
     });
 
     it('routes to logger if promise rejected', () => {
+        const errorMessage = 'errorMessage';
         const usageLogger = new UsageLogger(
             storageAdapterMock.object,
             dateGetterMock.object,
@@ -53,13 +51,11 @@ describe('UsageLoggerTest', () => {
 
         storageAdapterMock
             .setup(m => m.setUserData(It.isValue(expected)))
-            .returns(_ => Promise.reject());
-
-        loggerMock.setup(l => l.error()).verifiable(Times.once());
+            .returns(_ => Promise.reject({ message: errorMessage }));
 
         usageLogger.record();
 
         storageAdapterMock.verifyAll();
-        loggerMock.verifyAll();
+        loggerMock.verify(l => l.error(errorMessage), Times.once());
     });
 });

--- a/src/tests/unit/tests/background/usage-logger.test.ts
+++ b/src/tests/unit/tests/background/usage-logger.test.ts
@@ -14,7 +14,7 @@ describe('UsageLoggerTest', () => {
     const expected = {
         usageData: {
             lastUsageDateTime: 'time',
-            magic: USAGE_KEY,
+            usageKey: USAGE_KEY,
         },
     };
 


### PR DESCRIPTION
#### Description of changes

This is an initial iteration of #2375 that sets the last-used-time. The intent is to set this data often enough to capture meaningful usage (e.g. popup opened, keyboard shortcuts). This excludes approaches that run in background-init.ts (background script also runs upon install & updates). 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
