### PR TITLE
refactor(side-panel): close settings panel as a side panel

### DIFF
--- a/src/background/actions/details-view-action-creator.ts
+++ b/src/background/actions/details-view-action-creator.ts
@@ -19,7 +19,7 @@ import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import { BaseActionPayload } from './action-payloads';
 import { DetailsViewActions } from './details-view-actions';
 
-type SidePanelToOpenPanelTelemetryEventName = {
+type SidePanelToTelemetryEventName = {
     [P in SidePanel]: string;
 };
 
@@ -48,7 +48,7 @@ export class DetailsViewActionCreator {
         );
         this.interpreter.registerTypeToPayloadCallback(
             Messages.SettingsPanel.ClosePanel,
-            this.onCloseSettingsPanel,
+            this.onCloseSidePanel.bind(this, 'Settings'),
         );
         this.interpreter.registerTypeToPayloadCallback(
             getStoreStateMessage(StoreNames.DetailsViewStore),
@@ -60,7 +60,7 @@ export class DetailsViewActionCreator {
         );
     }
 
-    private sidePanelToOpenPanelTelemetryEventName: SidePanelToOpenPanelTelemetryEventName = {
+    private sidePanelToOpenPanelTelemetryEventName: SidePanelToTelemetryEventName = {
         Settings: SETTINGS_PANEL_OPEN,
         PreviewFeatures: PREVIEW_FEATURES_OPEN,
         Scoping: SCOPING_OPEN,
@@ -78,9 +78,17 @@ export class DetailsViewActionCreator {
         this.telemetryEventHandler.publishTelemetry(eventName, payload);
     };
 
-    private onCloseSettingsPanel = (payload: BaseActionPayload): void => {
-        this.detailsViewActions.closeSettingsPanel.invoke(null);
-        this.telemetryEventHandler.publishTelemetry(SETTINGS_PANEL_CLOSE, payload);
+    private sidePanelToClosePanelTelemetryEventName: SidePanelToTelemetryEventName = {
+        Settings: SETTINGS_PANEL_CLOSE,
+        PreviewFeatures: null, // not supported here yet,
+        Scoping: null, // not supported here yet
+    };
+
+    private onCloseSidePanel = (panel: SidePanel, payload: BaseActionPayload): void => {
+        this.sidePanelActions.closeSidePanel.invoke(panel);
+
+        const eventName = this.sidePanelToClosePanelTelemetryEventName[panel];
+        this.telemetryEventHandler.publishTelemetry(eventName, payload);
     };
 
     private onSetDetailsViewRightContentPanel = (

--- a/src/background/actions/details-view-actions.ts
+++ b/src/background/actions/details-view-actions.ts
@@ -8,5 +8,4 @@ export class DetailsViewActions {
         DetailsViewRightContentPanelType
     >();
     public readonly getCurrentState = new Action();
-    public readonly closeSettingsPanel = new Action();
 }

--- a/src/background/actions/side-panel-actions.ts
+++ b/src/background/actions/side-panel-actions.ts
@@ -5,4 +5,5 @@ import { Action } from 'common/flux/action';
 
 export class SidePanelActions {
     public readonly openSidePanel = new Action<SidePanel>();
+    public readonly closeSidePanel = new Action<SidePanel>();
 }

--- a/src/background/stores/details-view-store.ts
+++ b/src/background/stores/details-view-store.ts
@@ -49,10 +49,6 @@ export class DetailsViewStore extends BaseStoreImpl<DetailsViewStoreData> {
 
         this.scopingActions.closeScopingPanel.addListener(() => this.onClose('isScopingOpen'));
 
-        this.detailsViewActions.closeSettingsPanel.addListener(() =>
-            this.onClose('isSettingsOpen'),
-        );
-
         this.contentActions.openContentPanel.addListener(contentPayload =>
             this.onOpen('isContentOpen', state => (state.contentPath = contentPayload.contentPath)),
         );
@@ -66,6 +62,7 @@ export class DetailsViewStore extends BaseStoreImpl<DetailsViewStoreData> {
         this.detailsViewActions.getCurrentState.addListener(this.onGetCurrentState);
 
         this.sidePanelActions.openSidePanel.addListener(this.onOpenSidePanel);
+        this.sidePanelActions.closeSidePanel.addListener(this.onCloseSidePanel);
     }
 
     private sidePanelToStateKey: SidePanelToStoreKey = {
@@ -95,6 +92,12 @@ export class DetailsViewStore extends BaseStoreImpl<DetailsViewStoreData> {
         }
 
         this.emitChanged();
+    };
+
+    private onCloseSidePanel = (sidePanel: SidePanel) => {
+        const stateKey = this.sidePanelToStateKey[sidePanel];
+
+        this.onClose(stateKey);
     };
 
     private onClose = (

--- a/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/details-view-action-creator.test.ts
@@ -133,11 +133,12 @@ describe('DetailsViewActionCreatorTest', () => {
     });
 
     it('handles SettingsPanel.ClosePanel message', () => {
-        const closeSettingsPanelMock = createActionMock<void>(null);
-        const detailsViewActionsMock = createDetailsViewActionsMock(
-            'closeSettingsPanel',
-            closeSettingsPanelMock.object,
+        const closeSidePanelMock = createActionMock<SidePanel>('Settings');
+        const sidePanelActionsMock = createSidePanelActionsMock(
+            'closeSidePanel',
+            closeSidePanelMock.object,
         );
+
         const interpreterMock = createInterpreterMock(
             Messages.SettingsPanel.ClosePanel,
             defaultBasePayload,
@@ -145,15 +146,15 @@ describe('DetailsViewActionCreatorTest', () => {
 
         const testObject = new DetailsViewActionCreator(
             interpreterMock.object,
-            detailsViewActionsMock.object,
             null,
+            sidePanelActionsMock.object,
             detailsViewControllerMock.object,
             telemetryEventHandlerMock.object,
         );
 
         testObject.registerCallback();
 
-        closeSettingsPanelMock.verifyAll();
+        closeSidePanelMock.verifyAll();
         telemetryEventHandlerMock.verify(
             handler => handler.publishTelemetry(SETTINGS_PANEL_CLOSE, defaultBasePayload),
             Times.once(),

--- a/src/tests/unit/tests/background/stores/details-view-store.test.ts
+++ b/src/tests/unit/tests/background/stores/details-view-store.test.ts
@@ -87,10 +87,9 @@ describe('DetailsViewStoreTest', () => {
             .withSettingPanelState(false)
             .build();
 
-        createStoreTesterForDetailsViewActions('closeSettingsPanel').testListenerToBeCalledOnce(
-            initialState,
-            expectedState,
-        );
+        createStoreTesterForSidePanelActions('closeSidePanel')
+            .withActionParam('Settings')
+            .testListenerToBeCalledOnce(initialState, expectedState);
     });
 
     test('onOpenContent', () => {


### PR DESCRIPTION
#### Description of changes

Following up from previews PRs (#2313, #2420, #2424, #2427), updating how we handle closing the settings panel to use the new side panel logic.

Out of scope:
- updating other panels to use the side panel logic (content panel, add failure instance, etc)
Those will come on future PRs

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
