### PR TITLE
feat(android-report): add exportReport feature flag for unified

### DIFF
--- a/src/electron/common/unified-feature-flags.ts
+++ b/src/electron/common/unified-feature-flags.ts
@@ -5,6 +5,7 @@ import { FeatureFlagDetail } from 'common/feature-flags';
 export class UnifiedFeatureFlags {
     public static readonly logTelemetryToConsole = 'logTelemetryToConsole';
     public static readonly showAllFeatureFlags = 'showAllFeatureFlags';
+    public static readonly exportReport = 'exportReport';
 }
 
 export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
@@ -23,6 +24,14 @@ export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
             defaultValue: false,
             displayableName: 'Show all feature flags',
             displayableDescription: 'Show all feature flags in the Preview Features panel.',
+            isPreviewFeature: false,
+            forceDefault: false,
+        },
+        {
+            id: UnifiedFeatureFlags.exportReport,
+            defaultValue: false,
+            displayableName: 'Show export report button',
+            displayableDescription: 'Show the export report button on the automated checks window',
             isPreviewFeature: false,
             forceDefault: false,
         },

--- a/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
+++ b/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
@@ -21,6 +21,7 @@ describe('FeatureFlagsTest', () => {
         const expectedValues: FeatureFlagStoreData = {
             [UnifiedFeatureFlags.logTelemetryToConsole]: false,
             [UnifiedFeatureFlags.showAllFeatureFlags]: false,
+            [UnifiedFeatureFlags.exportReport]: false,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Description of changes

Add `exportReport` feature flag to hide the new export report functionality on AI-Android.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
