### PR TITLE
refactor(android-report): get ToolData from scan instead of environment when generating report

### DIFF
--- a/src/DetailsView/components/report-export-component-factory.tsx
+++ b/src/DetailsView/components/report-export-component-factory.tsx
@@ -67,6 +67,7 @@ export function getReportExportComponentForFastPass(props: CommandBarProps): JSX
                 tabStoreData.url,
                 props.cardsViewData,
                 description,
+                props.scanMetaData.toolData,
             ),
         updatePersistedDescription: () => null,
         getExportDescription: () => '',

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
 import { ISelection, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
+
 import { ThemeDeps } from '../common/components/theme';
 import {
     withStoreSubscription,
@@ -193,8 +195,9 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
             this.props.deps.getCardSelectionViewData(this.props.storeState.cardSelectionStoreData),
         );
 
-        const scanMetaData = {
+        const scanMetaData: ScanMetaData = {
             timestamp: this.props.storeState.unifiedScanResultStoreData.timestamp,
+            toolData: this.props.storeState.unifiedScanResultStoreData.toolInfo,
         };
 
         return (

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -296,7 +296,6 @@ if (isNaN(tabId) === false) {
             const reportHtmlGenerator = new ReportHtmlGenerator(
                 AutomatedChecksReportSectionFactory,
                 reactStaticRenderer,
-                environmentInfoProvider.getToolData(),
                 getDefaultAddListenerForCollapsibleSection,
                 DateProvider.getUTCStringFromDate,
                 GetGuidanceTagsFromGuidanceLinks,

--- a/src/common/types/store-data/scan-meta-data.ts
+++ b/src/common/types/store-data/scan-meta-data.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 
 export type ScanMetaData = {
     timestamp: string;
+    toolData: ToolData;
 };

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -7,6 +7,7 @@ import { CardSelectionStoreData } from 'common/types/store-data/card-selection-s
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { DetailsViewStoreData } from 'common/types/store-data/details-view-store-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { CardsView, CardsViewDeps } from 'DetailsView/components/cards-view';
@@ -63,7 +64,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
     public render(): JSX.Element {
         const { status } = this.props.scanStoreData;
         if (status === ScanStatus.Failed) {
-            return this.renderLayout(null, null, this.renderDeviceDisconnected());
+            return this.renderLayout(null, null, null, this.renderDeviceDisconnected());
         } else if (status === ScanStatus.Completed) {
             const { unifiedScanResultStoreData, cardSelectionStoreData, deps } = this.props;
             const { rules, results } = unifiedScanResultStoreData;
@@ -73,21 +74,27 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                 unifiedScanResultStoreData,
                 cardSelectionViewData.highlightedResultUids,
             );
+            const scanMetadata: ScanMetaData = {
+                timestamp: unifiedScanResultStoreData.timestamp,
+                toolData: unifiedScanResultStoreData.toolInfo,
+            };
 
             return this.renderLayout(
                 cardsViewData,
                 unifiedScanResultStoreData.targetAppInfo.name,
+                scanMetadata,
                 this.renderResults(cardsViewData),
                 <ScreenshotView viewModel={screenshotViewModel} />,
             );
         } else {
-            return this.renderLayout(null, null, this.renderScanningSpinner());
+            return this.renderLayout(null, null, null, this.renderScanningSpinner());
         }
     }
 
     private renderLayout(
         cardsViewData: CardsViewModel,
         targetAppName: string,
+        scanMetaData: ScanMetaData,
         primaryContent: JSX.Element,
         optionalSidePanel?: JSX.Element,
     ): JSX.Element {
@@ -110,6 +117,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                             featureFlagStoreData={this.props.featureFlagStoreData}
                             cardsViewData={cardsViewData}
                             targetAppName={targetAppName}
+                            scanMetaData={scanMetaData}
                         />
                         <main>
                             <HeaderSection />

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -5,6 +5,7 @@ import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { NamedFC } from 'common/react/named-fc';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
 import {
     ReportExportComponent,
     ReportExportComponentDeps,
@@ -23,7 +24,7 @@ import * as styles from './command-bar.scss';
 export type CommandBarDeps = {
     scanActionCreator: ScanActionCreator;
     dropdownClickHandler: DropdownClickHandler;
-    getCurrentDate: () => Date;
+    getDateFromTimestamp: (timestamp: string) => Date;
     reportGenerator: ReportGenerator;
 } & ReportExportComponentDeps;
 
@@ -34,28 +35,37 @@ export interface CommandBarProps {
     featureFlagStoreData: FeatureFlagStoreData;
     cardsViewData: CardsViewModel;
     targetAppName: string;
+    scanMetaData: ScanMetaData;
 }
 
 export const commandButtonRefreshId = 'command-button-refresh';
 export const commandButtonSettingsId = 'command-button-settings';
 
 export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
-    const { deps, deviceStoreData, featureFlagStoreData, targetAppName, cardsViewData } = props;
+    const {
+        deps,
+        deviceStoreData,
+        featureFlagStoreData,
+        targetAppName,
+        cardsViewData,
+        scanMetaData,
+    } = props;
 
-    const currentDate = deps.getCurrentDate();
+    const scanDate = deps.getDateFromTimestamp(scanMetaData.timestamp);
     const exportReport = (
         <ReportExportComponent
             deps={deps}
             exportResultsType={'AutomatedChecks'}
             pageTitle={targetAppName}
-            scanDate={currentDate}
+            scanDate={scanDate}
             htmlGenerator={description =>
                 deps.reportGenerator.generateFastPassAutomatedChecksReport(
-                    currentDate,
+                    scanDate,
                     targetAppName,
                     null,
                     cardsViewData,
                     description,
+                    scanMetaData.toolData,
                 )
             }
             updatePersistedDescription={() => null}

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -50,28 +50,30 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
         cardsViewData,
         scanMetaData,
     } = props;
+    let exportReport = null;
 
-    const scanDate = deps.getDateFromTimestamp(scanMetaData.timestamp);
-    const exportReport = (
-        <ReportExportComponent
-            deps={deps}
-            exportResultsType={'AutomatedChecks'}
-            pageTitle={targetAppName}
-            scanDate={scanDate}
-            htmlGenerator={description =>
-                deps.reportGenerator.generateFastPassAutomatedChecksReport(
-                    scanDate,
-                    targetAppName,
-                    null,
-                    cardsViewData,
-                    description,
-                    scanMetaData.toolData,
-                )
-            }
-            updatePersistedDescription={() => null}
-            getExportDescription={() => ''}
-        />
-    );
+    if (scanMetaData != null) {
+        exportReport = (
+            <ReportExportComponent
+                deps={deps}
+                exportResultsType={'AutomatedChecks'}
+                pageTitle={targetAppName}
+                scanDate={deps.getDateFromTimestamp(scanMetaData.timestamp)}
+                htmlGenerator={description =>
+                    deps.reportGenerator.generateFastPassAutomatedChecksReport(
+                        deps.getDateFromTimestamp(scanMetaData.timestamp),
+                        targetAppName,
+                        null,
+                        cardsViewData,
+                        description,
+                        scanMetaData.toolData,
+                    )
+                }
+                updatePersistedDescription={() => null}
+                getExportDescription={() => ''}
+            />
+        );
+    }
 
     return (
         <section className={styles.commandBar} aria-label="command bar">

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -365,10 +365,6 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
         const reportHtmlGenerator = new ReportHtmlGenerator(
             UnifiedReportSectionFactory,
             new ReactStaticRenderer(),
-            {
-                applicationProperties: { name: 'Android app', version: '0.0.1' },
-                scanEngineProperties: { name: 'axe-android', version: '0.0.1' },
-            }, // stubbed values for the moment
             getDefaultAddListenerForCollapsibleSection,
             DateProvider.getUTCStringFromDate,
             GetGuidanceTagsFromGuidanceLinks,
@@ -406,7 +402,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             documentManipulator,
             reportGenerator: reportGenerator,
             fileURLProvider: new FileURLProvider(new WindowUtils(), provideBlob),
-            getCurrentDate: DateProvider.getCurrentDate,
+            getDateFromTimestamp: DateProvider.getDateFromTimestamp,
         };
 
         window.insightsUserConfiguration = new UserConfigurationController(interpreter);

--- a/src/reports/package/axe-results-report.ts
+++ b/src/reports/package/axe-results-report.ts
@@ -2,10 +2,12 @@
 // Licensed under the MIT License.
 import { CardSelectionViewData } from 'common/get-card-selection-view-data';
 import { getCardViewData } from 'common/rule-based-view-model-provider';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { UUIDGenerator } from 'common/uid-generator';
 import { convertScanResultsToUnifiedResults } from 'injected/adapters/scan-results-to-unified-results';
 import { convertScanResultsToUnifiedRules } from 'injected/adapters/scan-results-to-unified-rules';
 import { ResultDecorator } from 'scanner/result-decorator';
+
 import { ReportHtmlGenerator } from '../report-html-generator';
 import AccessibilityInsightsReport from './accessibilityInsightsReport';
 
@@ -22,6 +24,7 @@ export class AxeResultsReport implements AccessibilityInsightsReport.Report {
     constructor(
         private readonly deps: AxeResultsReportDeps,
         private readonly parameters: AccessibilityInsightsReport.AxeReportParameters,
+        private readonly toolInfo: ToolData,
     ) { }
 
     public asHTML(): string {
@@ -51,6 +54,7 @@ export class AxeResultsReport implements AccessibilityInsightsReport.Report {
             results.url,
             description,
             cardsViewModel,
+            this.toolInfo,
         );
 
         return html;

--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -56,7 +56,6 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
     const reportHtmlGenerator = new ReportHtmlGenerator(
         sectionFactory,
         reactStaticRenderer,
-        environmentInfoProvider.getToolData(),
         getDefaultAddListenerForCollapsibleSection,
         DateProvider.getUTCStringFromDate,
         GetGuidanceTagsFromGuidanceLinks,
@@ -83,7 +82,7 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
         getUUID: generateUID,
     };
 
-    return new AxeResultsReport(deps, parameters);
+    return new AxeResultsReport(deps, parameters, environmentInfoProvider.getToolData());
 };
 
 export const reporterFactory: ReporterFactory = () => {

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -5,6 +5,8 @@ import { AssessmentStoreData } from 'common/types/store-data/assessment-result-d
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
+
 import { AssessmentReportHtmlGenerator } from './assessment-report-html-generator';
 import { ReportHtmlGenerator } from './report-html-generator';
 import { ReportNameGenerator } from './report-name-generator';
@@ -26,6 +28,7 @@ export class ReportGenerator {
         pageUrl: string,
         cardsViewData: CardsViewModel,
         description: string,
+        toolData: ToolData,
     ): string {
         return this.reportHtmlGenerator.generateHtml(
             scanDate,
@@ -33,6 +36,7 @@ export class ReportGenerator {
             pageUrl,
             description,
             cardsViewData,
+            toolData,
         );
     }
 

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -22,7 +22,6 @@ export class ReportHtmlGenerator {
     constructor(
         private readonly sectionFactory: ReportSectionFactory,
         private readonly reactStaticRenderer: ReactStaticRenderer,
-        private readonly toolData: ToolData,
         private readonly getCollapsibleScript: () => string,
         private readonly utcDateConverter: (scanDate: Date) => string,
         private readonly getGuidanceTagsFromGuidanceLinks: GetGuidanceTagsFromGuidanceLinks,
@@ -36,6 +35,7 @@ export class ReportHtmlGenerator {
         pageUrl: string,
         description: string,
         cardsViewData: CardsViewModel,
+        toolData: ToolData,
     ): string {
         const HeadSection = this.sectionFactory.HeadSection;
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(<HeadSection />);
@@ -54,7 +54,7 @@ export class ReportHtmlGenerator {
                 cardsVisualizationModifierButtons: NullComponent,
             } as SectionDeps,
             cardsViewData: cardsViewData,
-            toolData: this.toolData,
+            toolData: toolData,
             toUtcString: this.utcDateConverter,
             getCollapsibleScript: this.getCollapsibleScript,
             getGuidanceTagsFromGuidanceLinks: this.getGuidanceTagsFromGuidanceLinks,

--- a/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
@@ -6,6 +6,7 @@ import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -26,6 +27,7 @@ import { IMock, Mock, MockBehavior } from 'typemoq';
 describe('ReportExportComponentPropsFactory', () => {
     const theDate = new Date(2019, 2, 12, 9, 0);
     const theTimestamp = 'test timestamp';
+    const theToolData: ToolData = { applicationProperties: { name: 'some app' } } as ToolData;
     const thePageTitle = 'command-bar-test-tab-title';
     const theDescription = 'test description';
     const theGeneratorOutput = 'generator output';
@@ -58,7 +60,8 @@ describe('ReportExportComponentPropsFactory', () => {
         } as AssessmentStoreData;
         scanMetaData = {
             timestamp: theTimestamp,
-        };
+            toolData: theToolData,
+        } as ScanMetaData;
         assessmentsProviderMock = Mock.ofType<AssessmentsProvider>(undefined, MockBehavior.Loose);
         reportGeneratorMock = Mock.ofType<ReportGenerator>(undefined, MockBehavior.Loose);
         cardsViewData = null;
@@ -116,6 +119,7 @@ describe('ReportExportComponentPropsFactory', () => {
                     tabStoreData.url,
                     cardsViewData,
                     theDescription,
+                    scanMetaData.toolData,
                 ),
             )
             .returns(() => theGeneratorOutput);

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -15,6 +15,7 @@ import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import {
     TargetAppData,
+    ToolData,
     UnifiedResult,
     UnifiedRule,
     UnifiedScanResultStoreData,
@@ -47,6 +48,7 @@ import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/detai
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import { DetailsViewStoreDataBuilder } from '../../common/details-view-store-data-builder';
 import { TabStoreDataBuilder } from '../../common/tab-store-data-builder';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
@@ -61,7 +63,8 @@ describe('DetailsViewContainer', () => {
     let getCardViewDataMock: IMock<GetCardViewData>;
     let getCardSelectionViewDataMock: IMock<GetCardSelectionViewData>;
     let targetAppInfo: TargetAppData;
-    const timestamp = 'timestamp';
+    let timestamp: string;
+    let toolData: ToolData;
 
     beforeEach(() => {
         detailsViewActionMessageCreator = Mock.ofType<DetailsViewActionMessageCreator>();
@@ -85,7 +88,11 @@ describe('DetailsViewContainer', () => {
             (storeData: CardSelectionStoreData) => null,
             MockBehavior.Strict,
         );
+        timestamp = 'timestamp';
         targetAppInfo = { name: 'app' };
+        toolData = {
+            applicationProperties: { name: 'some app' },
+        } as ToolData;
         deps = {
             detailsViewActionMessageCreator: detailsViewActionMessageCreator.object,
             getDetailsRightPanelConfiguration: getDetailsRightPanelConfiguration.object,
@@ -390,7 +397,7 @@ describe('DetailsViewContainer', () => {
                 scanIncompleteWarnings={
                     storeMocks.unifiedScanResultStoreData.scanIncompleteWarnings
                 }
-                scanMetaData={{ timestamp: timestamp }}
+                scanMetaData={{ timestamp, toolData }}
             />
         );
     }
@@ -523,6 +530,7 @@ describe('DetailsViewContainer', () => {
             rules: [],
             targetAppInfo: targetAppInfo,
             timestamp: timestamp,
+            toolInfo: toolData,
         };
 
         const storeMocks = new StoreMocks()

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -51,6 +51,16 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
           }
         }
         deviceStoreData={Object {}}
+        scanMetaData={
+          Object {
+            "timestamp": "test timestamp",
+            "toolData": Object {
+              "applicationProperties": Object {
+                "name": "some app",
+              },
+            },
+          }
+        }
         scanStoreData={
           Object {
             "status": 2,
@@ -181,6 +191,7 @@ exports[`AutomatedChecksView renders when status scan <Failed> 1`] = `
             "connectedDevice": "TEST DEVICE",
           }
         }
+        scanMetaData={null}
         scanStoreData={
           Object {
             "status": 3,
@@ -270,6 +281,7 @@ exports[`AutomatedChecksView renders when status scan <Scanning> 1`] = `
             "connectedDevice": "TEST DEVICE",
           }
         }
+        scanMetaData={null}
         scanStoreData={
           Object {
             "status": 1,
@@ -359,6 +371,7 @@ exports[`AutomatedChecksView renders when status scan <undefined> 1`] = `
             "connectedDevice": "TEST DEVICE",
           }
         }
+        scanMetaData={null}
         scanStoreData={
           Object {
             "status": undefined,

--- a/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/automated-checks-view.test.tsx
@@ -12,6 +12,7 @@ import {
     CardsViewModel,
 } from 'common/types/store-data/card-view-model';
 import {
+    ToolData,
     UnifiedResult,
     UnifiedRule,
     UnifiedScanResultStoreData,
@@ -66,6 +67,11 @@ describe('AutomatedChecksView', () => {
 
         it('when status scan <Completed>', () => {
             const cardSelectionStoreData = {} as CardSelectionStoreData;
+            const timeStampStub = 'test timestamp';
+            const toolDataStub: ToolData = {
+                applicationProperties: { name: 'some app' },
+            } as ToolData;
+
             const cardSelectionViewDataStub = {
                 highlightedResultUids: ['highlighted-uid-1'],
             } as CardSelectionViewData;
@@ -77,6 +83,8 @@ describe('AutomatedChecksView', () => {
                 },
                 rules: rulesStub,
                 results: resultsStub,
+                toolInfo: toolDataStub,
+                timestamp: timeStampStub,
             };
             const ruleResultsByStatusStub = {
                 fail: [{ id: 'test-fail-id' } as CardRuleResult],

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
         <ReportExportComponent
           deps={
             Object {
-              "getCurrentDate": [Function],
+              "getDateFromTimestamp": [Function],
               "reportGenerator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "assessmentReportHtmlGenerator": undefined,
@@ -44,6 +44,7 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
           getExportDescription={[Function]}
           htmlGenerator={[Function]}
           pageTitle="some target"
+          scanDate={1970-01-01T00:00:00.000Z}
           updatePersistedDescription={[Function]}
         />
       }
@@ -100,7 +101,7 @@ exports[`CommandBar renders while status is <Default> 1`] = `
         <ReportExportComponent
           deps={
             Object {
-              "getCurrentDate": [Function],
+              "getDateFromTimestamp": [Function],
               "reportGenerator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "assessmentReportHtmlGenerator": undefined,
@@ -114,6 +115,7 @@ exports[`CommandBar renders while status is <Default> 1`] = `
           getExportDescription={[Function]}
           htmlGenerator={[Function]}
           pageTitle="some target"
+          scanDate={1970-01-01T00:00:00.000Z}
           updatePersistedDescription={[Function]}
         />
       }
@@ -170,7 +172,7 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
         <ReportExportComponent
           deps={
             Object {
-              "getCurrentDate": [Function],
+              "getDateFromTimestamp": [Function],
               "reportGenerator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "assessmentReportHtmlGenerator": undefined,
@@ -184,6 +186,7 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
           getExportDescription={[Function]}
           htmlGenerator={[Function]}
           pageTitle="some target"
+          scanDate={1970-01-01T00:00:00.000Z}
           updatePersistedDescription={[Function]}
         />
       }
@@ -240,7 +243,7 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
         <ReportExportComponent
           deps={
             Object {
-              "getCurrentDate": [Function],
+              "getDateFromTimestamp": [Function],
               "reportGenerator": proxy {
                 "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
                 "assessmentReportHtmlGenerator": undefined,
@@ -254,6 +257,7 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
           getExportDescription={[Function]}
           htmlGenerator={[Function]}
           pageTitle="some target"
+          scanDate={1970-01-01T00:00:00.000Z}
           updatePersistedDescription={[Function]}
         />
       }

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`CommandBar renders does not create report export when scan metadata is null 1`] = `
+<section
+  aria-label="command bar"
+  className="commandBar"
+>
+  <div
+    className="items"
+  >
+    <CustomizedActionButton
+      className="menuItemButton"
+      data-automation-id="command-button-refresh"
+      disabled={true}
+      iconProps={
+        Object {
+          "className": "buttonIcon",
+          "iconName": "Refresh",
+        }
+      }
+      onClick={[Function]}
+      text="Start over"
+    />
+  </div>
+  <div
+    className="farItems"
+  >
+    <FlaggedComponent
+      enableJSXElement={null}
+      featureFlag="exportReport"
+      featureFlagStoreData={
+        Object {
+          "somefeatureflag": true,
+        }
+      }
+    />
+    <CustomizedActionButton
+      ariaLabel="settings"
+      className="menuItemButton"
+      data-automation-id="command-button-settings"
+      iconProps={
+        Object {
+          "className": "buttonIcon",
+          "iconName": "Gear",
+        }
+      }
+      onClick={[Function]}
+    />
+  </div>
+</section>
+`;
+
 exports[`CommandBar renders while status is <Completed> 1`] = `
 <section
   aria-label="command bar"

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -4,6 +4,8 @@ import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { EnumHelper } from 'common/enum-helper';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import {
@@ -21,17 +23,28 @@ import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('CommandBar', () => {
     let featureFlagStoreDataStub: FeatureFlagStoreData;
-    let getCurrentDateMock: IMock<() => Date>;
+    let getDateFromTimestampMock: IMock<(timestamp: string) => Date>;
     let cardsViewDataStub: CardsViewModel;
     let reportGeneratorMock: IMock<ReportGenerator>;
+    let scanMetaDataStub: ScanMetaData;
+    let scanDateStub: Date;
 
     beforeEach(() => {
         featureFlagStoreDataStub = {
             somefeatureflag: true,
         };
-        getCurrentDateMock = Mock.ofInstance(() => null as Date);
+        getDateFromTimestampMock = Mock.ofInstance((_: string) => null as Date);
         cardsViewDataStub = {} as CardsViewModel;
+        scanMetaDataStub = {
+            timestamp: '1234',
+            toolData: {} as ToolData,
+        };
+        scanDateStub = new Date(0);
         reportGeneratorMock = Mock.ofType(ReportGenerator);
+
+        getDateFromTimestampMock
+            .setup(mock => mock(scanMetaDataStub.timestamp))
+            .returns(() => scanDateStub);
     });
 
     describe('renders', () => {
@@ -39,7 +52,7 @@ describe('CommandBar', () => {
             const props = {
                 deps: {
                     scanActionCreator: null,
-                    getCurrentDate: getCurrentDateMock.object,
+                    getDateFromTimestamp: getDateFromTimestampMock.object,
                     reportGenerator: reportGeneratorMock.object,
                 } as CommandBarDeps,
                 scanStoreData: {
@@ -48,6 +61,7 @@ describe('CommandBar', () => {
                 cardsViewData: cardsViewDataStub,
                 targetAppName: 'some target',
                 featureFlagStoreData: featureFlagStoreDataStub,
+                scanMetaData: scanMetaDataStub,
             } as CommandBarProps;
 
             const rendered = shallow(<CommandBar {...props} />);
@@ -63,7 +77,7 @@ describe('CommandBar', () => {
             const props = {
                 deps: {
                     scanActionCreator: null,
-                    getCurrentDate: getCurrentDateMock.object,
+                    getDateFromTimestamp: getDateFromTimestampMock.object,
                     reportGenerator: reportGeneratorMock.object,
                 },
                 scanStoreData: {
@@ -72,6 +86,7 @@ describe('CommandBar', () => {
                 cardsViewData: cardsViewDataStub,
                 targetAppName: 'some target',
                 featureFlagStoreData: featureFlagStoreDataStub,
+                scanMetaData: scanMetaDataStub,
             } as CommandBarProps;
 
             const rendered = shallow(<CommandBar {...props} />);
@@ -95,7 +110,7 @@ describe('CommandBar', () => {
             const props = {
                 deps: {
                     scanActionCreator: scanActionCreatorMock.object,
-                    getCurrentDate: getCurrentDateMock.object,
+                    getDateFromTimestamp: getDateFromTimestampMock.object,
                     reportGenerator: reportGeneratorMock.object,
                 },
                 deviceStoreData: {
@@ -107,6 +122,7 @@ describe('CommandBar', () => {
                 cardsViewData: cardsViewDataStub,
                 targetAppName: 'some target',
                 featureFlagStoreData: featureFlagStoreDataStub,
+                scanMetaData: scanMetaDataStub,
             } as CommandBarProps;
 
             const rendered = mount(<CommandBar {...props} />);
@@ -125,7 +141,7 @@ describe('CommandBar', () => {
             const props = {
                 deps: {
                     dropdownClickHandler: dropdownClickHandlerMock.object,
-                    getCurrentDate: getCurrentDateMock.object,
+                    getDateFromTimestamp: getDateFromTimestampMock.object,
                     reportGenerator: reportGeneratorMock.object,
                 },
                 scanStoreData: {
@@ -134,6 +150,7 @@ describe('CommandBar', () => {
                 cardsViewData: cardsViewDataStub,
                 targetAppName: 'some target',
                 featureFlagStoreData: featureFlagStoreDataStub,
+                scanMetaData: scanMetaDataStub,
             } as CommandBarProps;
 
             const rendered = mount(<CommandBar {...props} />);

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -69,6 +69,26 @@ describe('CommandBar', () => {
             expect(rendered.getElement()).toMatchSnapshot();
         });
 
+        it('does not create report export when scan metadata is null', () => {
+            const props = {
+                deps: {
+                    scanActionCreator: null,
+                    getDateFromTimestamp: getDateFromTimestampMock.object,
+                    reportGenerator: reportGeneratorMock.object,
+                } as CommandBarDeps,
+                scanStoreData: {
+                    status: ScanStatus.Scanning,
+                },
+                cardsViewData: cardsViewDataStub,
+                targetAppName: 'some target',
+                featureFlagStoreData: featureFlagStoreDataStub,
+                scanMetaData: null,
+            } as CommandBarProps;
+            const rendered = shallow(<CommandBar {...props} />);
+
+            expect(rendered.getElement()).toMatchSnapshot();
+        });
+
         const notScanningStatuses = EnumHelper.getNumericValues<ScanStatus>(ScanStatus)
             .filter(status => status !== ScanStatus.Scanning)
             .map(status => ScanStatus[status]);

--- a/src/tests/unit/tests/reports/package/axe-results-report.test.ts
+++ b/src/tests/unit/tests/reports/package/axe-results-report.test.ts
@@ -3,7 +3,7 @@
 import { AxeResults } from 'axe-core';
 import { getCardViewData } from 'common/rule-based-view-model-provider';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
-import { UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
+import { ToolData, UnifiedResult, UnifiedRule } from 'common/types/store-data/unified-data-interface';
 import { generateUID } from 'common/uid-generator';
 import { convertScanResultsToUnifiedResults } from 'injected/adapters/scan-results-to-unified-results';
 import { convertScanResultsToUnifiedRules } from 'injected/adapters/scan-results-to-unified-rules';
@@ -19,6 +19,9 @@ describe('AxeResultReport', () => {
     const url = 'https://the.page';
     const pageTitle = 'PAGE_TITLE';
     const description = 'DESCRIPTION';
+    const toolDataStub: ToolData = {
+        applicationProperties: { name: 'some app' },
+    } as ToolData;
 
     const results = {
         timestamp: reportDateTime.toISOString(),
@@ -61,7 +64,7 @@ describe('AxeResultReport', () => {
     const expectedHTML = '<div>The Report!</div>';
     const mockReportHtmlGenerator = Mock.ofType<ReportHtmlGenerator>(null, MockBehavior.Strict);
     mockReportHtmlGenerator
-        .setup(gen => gen.generateHtml(reportDateTime, pageTitle, url, description, mockCardsViewModel.object))
+        .setup(gen => gen.generateHtml(reportDateTime, pageTitle, url, description, mockCardsViewModel.object, toolDataStub))
         .returns(() => expectedHTML);
 
     const deps: AxeResultsReportDeps = {
@@ -74,7 +77,7 @@ describe('AxeResultReport', () => {
     };
 
     it('returns HTML', () => {
-        const report = new AxeResultsReport(deps, parameters);
+        const report = new AxeResultsReport(deps, parameters, toolDataStub);
 
         const html = report.asHTML();
 

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -4,6 +4,7 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { AssessmentReportHtmlGenerator } from 'reports/assessment-report-html-generator';
 import { ReportGenerator } from 'reports/report-generator';
 import { ReportHtmlGenerator } from 'reports/report-html-generator';
@@ -22,6 +23,9 @@ describe('ReportGenerator', () => {
         visualHelperEnabled: true,
         allCardsCollapsed: true,
     };
+    const toolDataStub: ToolData = {
+        applicationProperties: { name: 'some app' },
+    } as ToolData;
 
     let dataBuilderMock: IMock<ReportHtmlGenerator>;
     let nameBuilderMock: IMock<ReportNameGenerator>;
@@ -40,11 +44,12 @@ describe('ReportGenerator', () => {
         dataBuilderMock
             .setup(builder =>
                 builder.generateHtml(
-                    It.isValue(date),
-                    It.isValue(title),
-                    It.isValue(url),
-                    It.isValue(description),
-                    It.isValue(cardsViewDataStub),
+                    date,
+                    title,
+                    url,
+                    description,
+                    cardsViewDataStub,
+                    toolDataStub,
                 ),
             )
             .returns(() => 'returned-data');
@@ -60,6 +65,7 @@ describe('ReportGenerator', () => {
             url,
             cardsViewDataStub,
             description,
+            toolDataStub,
         );
 
         expect(actual).toMatchSnapshot();

--- a/src/tests/unit/tests/reports/report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/report-html-generator.test.tsx
@@ -5,6 +5,7 @@ import { FixInstructionProcessor } from 'common/components/fix-instruction-proce
 import { NullComponent } from 'common/components/null-component';
 import { DateProvider } from 'common/date-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import {
     ReportBody,
@@ -20,7 +21,6 @@ import { ReactStaticRenderer } from 'reports/react-static-renderer';
 import { ReportHtmlGenerator } from 'reports/report-html-generator';
 import { It, Mock, MockBehavior, Times } from 'typemoq';
 
-import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { exampleUnifiedStatusResults } from '../common/components/cards/sample-view-model-data';
 
 describe('ReportHtmlGenerator', () => {
@@ -95,7 +95,6 @@ describe('ReportHtmlGenerator', () => {
         const testObject = new ReportHtmlGenerator(
             sectionFactoryMock.object,
             rendererMock.object,
-            toolData,
             getScriptMock.object,
             getUTCStringFromDateStub,
             getGuidanceTagsStub,
@@ -103,11 +102,18 @@ describe('ReportHtmlGenerator', () => {
             getPropertyConfigurationStub,
         );
 
-        const actual = testObject.generateHtml(scanDate, pageTitle, pageUrl, description, {
-            cards: exampleUnifiedStatusResults,
-            visualHelperEnabled: true,
-            allCardsCollapsed: true,
-        });
+        const actual = testObject.generateHtml(
+            scanDate,
+            pageTitle,
+            pageUrl,
+            description,
+            {
+                cards: exampleUnifiedStatusResults,
+                visualHelperEnabled: true,
+                allCardsCollapsed: true,
+            },
+            toolData,
+        );
 
         expect(actual).toMatchSnapshot();
     });


### PR DESCRIPTION
#### Description of changes

This ensures that toolData is used from the unified scan result store instead of whichever environment the current running code is in.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
