### PR TITLE
fix(android-report): minor style fix + minor text change to footer text

### DIFF
--- a/src/electron/views/report/unified-report-section-factory.ts
+++ b/src/electron/views/report/unified-report-section-factory.ts
@@ -8,7 +8,6 @@ import { ContentContainer } from 'reports/components/report-sections/content-con
 import { DetailsSection } from 'reports/components/report-sections/details-section';
 import { FooterTextForUnified } from 'reports/components/report-sections/footer-text-for-unified';
 import { HeaderSection } from 'reports/components/report-sections/header-section';
-import { NotApplicableChecksSection } from 'reports/components/report-sections/not-applicable-checks-section';
 import { PassedChecksSection } from 'reports/components/report-sections/passed-checks-section';
 import { ReportFooter } from 'reports/components/report-sections/report-footer';
 import { ReportSectionFactory } from 'reports/components/report-sections/report-section-factory';

--- a/src/electron/views/report/unified-report-section-factory.ts
+++ b/src/electron/views/report/unified-report-section-factory.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FailedInstancesSection } from 'common/components/cards/failed-instances-section';
+import { NullComponent } from 'common/components/null-component';
 import { UnifiedReportHead } from 'electron/views/report/unified-report-head';
 import { BodySection } from 'reports/components/report-sections/body-section';
 import { ContentContainer } from 'reports/components/report-sections/content-container';
@@ -26,7 +27,7 @@ export const UnifiedReportSectionFactory: ReportSectionFactory = {
     ResultsContainer,
     FailedInstancesSection,
     PassedChecksSection,
-    NotApplicableChecksSection,
+    NotApplicableChecksSection: NullComponent,
     FooterSection: ReportFooter,
     FooterText: FooterTextForUnified,
 };

--- a/src/electron/views/root-container/components/root-container.scss
+++ b/src/electron/views/root-container/components/root-container.scss
@@ -7,7 +7,6 @@ body {
     margin: 0px;
     height: 100%;
     width: 100%;
-    overflow: hidden;
     background-color: $neutral-0;
     font-family: $fontFamily;
 }

--- a/src/reports/components/report-sections/footer-text-for-unified.tsx
+++ b/src/reports/components/report-sections/footer-text-for-unified.tsx
@@ -11,7 +11,7 @@ export const FooterTextForUnified = NamedFC<FooterTextProps>(
         return (
             <>
                 This automated checks result was generated using{' '}
-                {`${toolData.applicationProperties.name} ${toolData.applicationProperties.version} (axe-core ${toolData.scanEngineProperties.version})`}
+                {`${toolData.applicationProperties.name} ${toolData.applicationProperties.version} (${toolData.scanEngineProperties.name} ${toolData.scanEngineProperties.version})`}
                 , a tool that helps debug and find accessibility issues earlier. Get more
                 information & download this tool at <ToolLink />.
             </>

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/footer-text-for-unified.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/footer-text-for-unified.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`FooterText renders 1`] = `
 <React.Fragment>
   This automated checks result was generated using
    
-  app-name app-version (axe-core engine-version)
+  app-name app-version (engine-name engine-version)
   , a tool that helps debug and find accessibility issues earlier. Get more information & download this tool at 
   <ToolLink />
   .


### PR DESCRIPTION
#### Description of changes

Minor changes to:
1. Make the report scrollable in android.
2. Remove the Not Applicable rules component
3. Modify the text in footer to use tool data scan engine name.

Screenshot:
![image](https://user-images.githubusercontent.com/32555133/79028502-0aa88e80-7b45-11ea-9806-0a7cccc309a8.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
