### PR TITLE
fix: remove wcag link and replace it with best practice in headings assessment guidance

### DIFF
--- a/src/content/test/headings/guidance.tsx
+++ b/src/content/test/headings/guidance.tsx
@@ -55,9 +55,7 @@ export const guidance = create(({ Markup, Link }) => (
                     <li>Programmatic heading levels should match their visual appearance (like size and boldness).</li>
                 </ul>
 
-                <h3>
-                    Use exactly one top-level heading. (<Link.WCAG_1_3_1 />){' '}
-                </h3>
+                <h3>Use exactly one top-level heading. (best practice) </h3>
                 <ul>
                     <li>
                         Top-level (<Markup.Code>h1</Markup.Code>) headings should give an overall description of the page content.

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -8745,15 +8745,7 @@ exports[`Guidance Content pages test/headings/guidance matches the snapshot 1`] 
               </li>
             </ul>
             <h3>
-              Use exactly one top-level heading. (
-              <a
-                class="ms-Link insights-link root-000"
-                href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships"
-                target="_blank"
-              >
-                WCAG 1.3.1
-              </a>
-              ) 
+              Use exactly one top-level heading. (best practice) 
             </h3>
             <ul>
               <li>


### PR DESCRIPTION
#### Description of changes

Remove the `WCAG 1.3.1` link from headings guidance.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2444 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS


#### Screenshot

<img width="567" alt="Screen Shot 2020-04-12 at 3 17 05 PM" src="https://user-images.githubusercontent.com/4496335/79081322-3789ac80-7cd1-11ea-9774-25888a65161a.png">
