### PR TITLE
tools: import missing color-definitions

### DIFF
--- a/src/debug-tools/debug-tools.scss
+++ b/src/debug-tools/debug-tools.scss
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+@import '../common/styles/root-level-only/color-definitions.scss';
+
 body {
     margin: 0px;
 }


### PR DESCRIPTION
#### Description of changes

Adding the missing `color-definitions.scss` import to `debug-tools.scss` to fix some stylings on the debug tools page.

**Before**
![image](https://user-images.githubusercontent.com/2837582/79138943-42445000-7d6a-11ea-8b84-652ae933b2f8.png)

**After**
![02 - after (fixed)](https://user-images.githubusercontent.com/2837582/79138900-2d67bc80-7d6a-11ea-95c0-f15ff55ea718.png)

**Notes**
There is still not full support for high contrast mode on the debug tools, so with this change, the heart icon will change accordingly to high contrast, but the background will stay the same.

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
