### PR TITLE
feat(android-report): created/re-factored summary section for unified report

### DIFF
--- a/src/electron/views/report/unified-report-section-factory.ts
+++ b/src/electron/views/report/unified-report-section-factory.ts
@@ -12,7 +12,7 @@ import { PassedChecksSection } from 'reports/components/report-sections/passed-c
 import { ReportFooter } from 'reports/components/report-sections/report-footer';
 import { ReportSectionFactory } from 'reports/components/report-sections/report-section-factory';
 import { ResultsContainer } from 'reports/components/report-sections/results-container';
-import { SummarySection } from 'reports/components/report-sections/summary-section';
+import { PassFailSummarySection } from 'reports/components/report-sections/summary-section';
 import { TitleSection } from 'reports/components/report-sections/title-section';
 
 export const UnifiedReportSectionFactory: ReportSectionFactory = {
@@ -21,7 +21,7 @@ export const UnifiedReportSectionFactory: ReportSectionFactory = {
     ContentContainer,
     HeaderSection,
     TitleSection,
-    SummarySection,
+    SummarySection: PassFailSummarySection,
     DetailsSection,
     ResultsContainer,
     FailedInstancesSection,

--- a/src/reports/components/report-sections/automated-checks-report-section-factory.tsx
+++ b/src/reports/components/report-sections/automated-checks-report-section-factory.tsx
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { FailedInstancesSection } from 'common/components/cards/failed-instances-section';
 import { ReportHead } from 'reports/components/report-head';
-
 import { BodySection } from './body-section';
 import { ContentContainer } from './content-container';
 import { DetailsSection } from './details-section';
@@ -13,7 +12,7 @@ import { PassedChecksSection } from './passed-checks-section';
 import { ReportFooter } from './report-footer';
 import { ReportSectionFactory } from './report-section-factory';
 import { ResultsContainer } from './results-container';
-import { SummarySection } from './summary-section';
+import { AllOutcomesSummarySection } from './summary-section';
 import { TitleSection } from './title-section';
 
 export const AutomatedChecksReportSectionFactory: ReportSectionFactory = {
@@ -22,7 +21,7 @@ export const AutomatedChecksReportSectionFactory: ReportSectionFactory = {
     ContentContainer,
     HeaderSection,
     TitleSection,
-    SummarySection,
+    SummarySection: AllOutcomesSummarySection,
     DetailsSection,
     ResultsContainer,
     FailedInstancesSection,

--- a/src/reports/components/report-sections/summary-section.tsx
+++ b/src/reports/components/report-sections/summary-section.tsx
@@ -8,8 +8,11 @@ import { OutcomeSummaryBar } from '../outcome-summary-bar';
 import { SectionProps } from './report-section-factory';
 
 export type SummarySectionProps = Pick<SectionProps, 'cardsViewData'>;
+export type BaseSummarySectionProps = {
+    outcomeTypesShown: InstanceOutcomeType[];
+} & SummarySectionProps;
 
-export const SummarySection = NamedFC<SummarySectionProps>('SummarySection', props => {
+export const BaseSummarySection = NamedFC<BaseSummarySectionProps>('BaseSummarySection', props => {
     const { cards } = props.cardsViewData;
 
     const countSummary: { [type in InstanceOutcomeType]: number } = {
@@ -26,8 +29,22 @@ export const SummarySection = NamedFC<SummarySectionProps>('SummarySection', pro
             <OutcomeSummaryBar
                 outcomeStats={countSummary}
                 iconStyleInverted={true}
-                allOutcomeTypes={allInstanceOutcomeTypes}
+                allOutcomeTypes={props.outcomeTypesShown}
             />
         </div>
     );
 });
+
+export const AllOutcomesSummarySection = NamedFC<SummarySectionProps>(
+    'AllOutcomesSummarySection',
+    props => {
+        return <BaseSummarySection {...props} outcomeTypesShown={allInstanceOutcomeTypes} />;
+    },
+);
+
+export const PassFailSummarySection = NamedFC<SummarySectionProps>(
+    'PassFailSummarySection',
+    props => {
+        return <BaseSummarySection {...props} outcomeTypesShown={['pass', 'fail']} />;
+    },
+);

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-section.test.tsx.snap
@@ -1,6 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SummarySection failure only 1`] = `
+exports[`SummarySection AllOutcomesSummarySection renders BaseSummarySection with all outcome types 1`] = `
+<BaseSummarySection
+  cardsViewData={Object {}}
+  outcomeTypesShown={
+    Array [
+      "fail",
+      "pass",
+      "inapplicable",
+    ]
+  }
+/>
+`;
+
+exports[`SummarySection BaseSummarySection: failure only 1`] = `
 <div
   className="summary-section"
 >
@@ -10,9 +23,7 @@ exports[`SummarySection failure only 1`] = `
   <OutcomeSummaryBar
     allOutcomeTypes={
       Array [
-        "fail",
         "pass",
-        "inapplicable",
       ]
     }
     iconStyleInverted={true}
@@ -27,7 +38,7 @@ exports[`SummarySection failure only 1`] = `
 </div>
 `;
 
-exports[`SummarySection failures + not applicable + passes 1`] = `
+exports[`SummarySection BaseSummarySection: failures + not applicable + passes 1`] = `
 <div
   className="summary-section"
 >
@@ -37,9 +48,7 @@ exports[`SummarySection failures + not applicable + passes 1`] = `
   <OutcomeSummaryBar
     allOutcomeTypes={
       Array [
-        "fail",
         "pass",
-        "inapplicable",
       ]
     }
     iconStyleInverted={true}
@@ -54,7 +63,7 @@ exports[`SummarySection failures + not applicable + passes 1`] = `
 </div>
 `;
 
-exports[`SummarySection failures + not applicable only 1`] = `
+exports[`SummarySection BaseSummarySection: failures + not applicable only 1`] = `
 <div
   className="summary-section"
 >
@@ -64,9 +73,7 @@ exports[`SummarySection failures + not applicable only 1`] = `
   <OutcomeSummaryBar
     allOutcomeTypes={
       Array [
-        "fail",
         "pass",
-        "inapplicable",
       ]
     }
     iconStyleInverted={true}
@@ -81,7 +88,7 @@ exports[`SummarySection failures + not applicable only 1`] = `
 </div>
 `;
 
-exports[`SummarySection failures + passes only 1`] = `
+exports[`SummarySection BaseSummarySection: failures + passes only 1`] = `
 <div
   className="summary-section"
 >
@@ -91,9 +98,7 @@ exports[`SummarySection failures + passes only 1`] = `
   <OutcomeSummaryBar
     allOutcomeTypes={
       Array [
-        "fail",
         "pass",
-        "inapplicable",
       ]
     }
     iconStyleInverted={true}
@@ -108,7 +113,7 @@ exports[`SummarySection failures + passes only 1`] = `
 </div>
 `;
 
-exports[`SummarySection not applicable + passes only 1`] = `
+exports[`SummarySection BaseSummarySection: not applicable + passes only 1`] = `
 <div
   className="summary-section"
 >
@@ -118,9 +123,7 @@ exports[`SummarySection not applicable + passes only 1`] = `
   <OutcomeSummaryBar
     allOutcomeTypes={
       Array [
-        "fail",
         "pass",
-        "inapplicable",
       ]
     }
     iconStyleInverted={true}
@@ -135,7 +138,7 @@ exports[`SummarySection not applicable + passes only 1`] = `
 </div>
 `;
 
-exports[`SummarySection not applicable only 1`] = `
+exports[`SummarySection BaseSummarySection: not applicable only 1`] = `
 <div
   className="summary-section"
 >
@@ -145,9 +148,7 @@ exports[`SummarySection not applicable only 1`] = `
   <OutcomeSummaryBar
     allOutcomeTypes={
       Array [
-        "fail",
         "pass",
-        "inapplicable",
       ]
     }
     iconStyleInverted={true}
@@ -162,7 +163,7 @@ exports[`SummarySection not applicable only 1`] = `
 </div>
 `;
 
-exports[`SummarySection passes only 1`] = `
+exports[`SummarySection BaseSummarySection: passes only 1`] = `
 <div
   className="summary-section"
 >
@@ -172,9 +173,7 @@ exports[`SummarySection passes only 1`] = `
   <OutcomeSummaryBar
     allOutcomeTypes={
       Array [
-        "fail",
         "pass",
-        "inapplicable",
       ]
     }
     iconStyleInverted={true}
@@ -187,4 +186,16 @@ exports[`SummarySection passes only 1`] = `
     }
   />
 </div>
+`;
+
+exports[`SummarySection PassFailSummarySection renders BaseSummarySection with only pass and failed outcome types 1`] = `
+<BaseSummarySection
+  cardsViewData={Object {}}
+  outcomeTypesShown={
+    Array [
+      "pass",
+      "fail",
+    ]
+  }
+/>
 `;

--- a/src/tests/unit/tests/reports/components/report-sections/summary-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/summary-section.test.tsx
@@ -3,8 +3,11 @@
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { InstanceOutcomeType } from 'reports/components/instance-outcome-type';
 import {
-    SummarySection,
+    AllOutcomesSummarySection,
+    BaseSummarySection,
+    PassFailSummarySection,
     SummarySectionProps,
 } from 'reports/components/report-sections/summary-section';
 
@@ -12,7 +15,7 @@ describe('SummarySection', () => {
     const noViolations = [];
     const noPasses = [];
     const noNonApplicable = [];
-
+    const outcomeTypes: InstanceOutcomeType[] = ['pass'];
     const violations = [
         {
             nodes: [{}],
@@ -96,12 +99,32 @@ describe('SummarySection', () => {
         ],
     ];
 
-    it.each(scenarios)('%s', (_, cardsViewData) => {
+    it.each(scenarios)('BaseSummarySection: %s', (_, cardsViewData) => {
         const props: SummarySectionProps = {
             cardsViewData: cardsViewData,
         };
-        const wrapper = shallow(<SummarySection {...props} />);
+        const wrapper = shallow(<BaseSummarySection {...props} outcomeTypesShown={outcomeTypes} />);
 
         expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    describe('AllOutcomesSummarySection', () => {
+        test('renders BaseSummarySection with all outcome types', () => {
+            const props: SummarySectionProps = {
+                cardsViewData: {} as CardsViewModel,
+            };
+            const wrapper = shallow(<AllOutcomesSummarySection {...props} />);
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
+    });
+
+    describe('PassFailSummarySection', () => {
+        test('renders BaseSummarySection with only pass and failed outcome types', () => {
+            const props: SummarySectionProps = {
+                cardsViewData: {} as CardsViewModel,
+            };
+            const wrapper = shallow(<PassFailSummarySection {...props} />);
+            expect(wrapper.getElement()).toMatchSnapshot();
+        });
     });
 });


### PR DESCRIPTION
#### Description of changes

Simply made the outcome types a prop on the summary section as is and made two versions of the component used by the different reports.

Screenshot (left: web, right: unified)
![image](https://user-images.githubusercontent.com/32555133/79156680-28b20100-7d88-11ea-9aad-bf35833d5ee2.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
