### PR TITLE
feat(android-report): refactor page title and url into ScanMetaData

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -64,7 +64,7 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
     }
 
     private renderTargetPageInfo(): JSX.Element {
-        const targetPageTitle: string = this.props.tabStoreData.title;
+        const targetPageTitle: string = this.props.scanMetaData.scanTargetData.name;
         const tooltipContent = `Switch to target page: ${targetPageTitle}`;
         const hostStyles: Partial<ITooltipHostStyles> = { root: { display: 'inline-block' } };
         return (

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -64,7 +64,7 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
     }
 
     private renderTargetPageInfo(): JSX.Element {
-        const targetPageTitle: string = this.props.scanMetaData.scanTargetData.name;
+        const targetPageTitle: string = this.props.scanMetaData.targetAppInfo.name;
         const tooltipContent = `Switch to target page: ${targetPageTitle}`;
         const hostStyles: Partial<ITooltipHostStyles> = { root: { display: 'inline-block' } };
         return (

--- a/src/DetailsView/components/report-export-component-factory.tsx
+++ b/src/DetailsView/components/report-export-component-factory.tsx
@@ -14,20 +14,20 @@ export function getReportExportComponentForAssessment(props: CommandBarProps): J
         assessmentStoreData,
         assessmentsProvider,
         featureFlagStoreData,
-        tabStoreData,
+        scanMetaData,
     } = props;
     const reportGenerator = deps.reportGenerator;
     const reportExportComponentProps: ReportExportComponentProps = {
         deps: deps,
         exportResultsType: 'Assessment',
-        pageTitle: tabStoreData.title,
+        pageTitle: scanMetaData.scanTargetData.name,
         scanDate: deps.getCurrentDate(),
         htmlGenerator: description =>
             reportGenerator.generateAssessmentReport(
                 assessmentStoreData,
                 assessmentsProvider,
                 featureFlagStoreData,
-                tabStoreData,
+                scanMetaData.scanTargetData,
                 description,
             ),
         updatePersistedDescription: value =>
@@ -52,20 +52,19 @@ export function getReportExportComponentForFastPass(props: CommandBarProps): JSX
         return null;
     }
 
-    const { deps, tabStoreData } = props;
+    const { deps } = props;
     const scanDate = deps.getDateFromTimestamp(props.scanMetaData.timestamp);
     const reportGenerator = deps.reportGenerator;
 
     const reportExportComponentProps: ReportExportComponentProps = {
         deps: deps,
         scanDate: scanDate,
-        pageTitle: tabStoreData.title,
+        pageTitle: props.scanMetaData.scanTargetData.name,
         exportResultsType: 'AutomatedChecks',
         htmlGenerator: description =>
             reportGenerator.generateFastPassAutomatedChecksReport(
                 scanDate,
-                tabStoreData.title,
-                tabStoreData.url,
+                props.scanMetaData.scanTargetData,
                 props.cardsViewData,
                 description,
                 props.scanMetaData.toolData,

--- a/src/DetailsView/components/report-export-component-factory.tsx
+++ b/src/DetailsView/components/report-export-component-factory.tsx
@@ -20,14 +20,14 @@ export function getReportExportComponentForAssessment(props: CommandBarProps): J
     const reportExportComponentProps: ReportExportComponentProps = {
         deps: deps,
         exportResultsType: 'Assessment',
-        pageTitle: scanMetaData.scanTargetData.name,
+        pageTitle: scanMetaData.targetAppInfo.name,
         scanDate: deps.getCurrentDate(),
         htmlGenerator: description =>
             reportGenerator.generateAssessmentReport(
                 assessmentStoreData,
                 assessmentsProvider,
                 featureFlagStoreData,
-                scanMetaData.scanTargetData,
+                scanMetaData.targetAppInfo,
                 description,
             ),
         updatePersistedDescription: value =>
@@ -59,12 +59,12 @@ export function getReportExportComponentForFastPass(props: CommandBarProps): JSX
     const reportExportComponentProps: ReportExportComponentProps = {
         deps: deps,
         scanDate: scanDate,
-        pageTitle: props.scanMetaData.scanTargetData.name,
+        pageTitle: props.scanMetaData.targetAppInfo.name,
         exportResultsType: 'AutomatedChecks',
         htmlGenerator: description =>
             reportGenerator.generateFastPassAutomatedChecksReport(
                 scanDate,
-                props.scanMetaData.scanTargetData,
+                props.scanMetaData.targetAppInfo,
                 props.cardsViewData,
                 description,
                 props.scanMetaData.toolData,

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -3,7 +3,6 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
-import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
 import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -24,6 +24,7 @@ import { DetailsViewCommandBarDeps } from './components/details-view-command-bar
 import {
     DetailsRightPanelConfiguration,
     DetailsViewContentDeps,
+    RightPanelProps,
 } from './components/details-view-right-panel';
 import { DetailsViewSwitcherNavConfiguration } from './components/details-view-switcher-nav';
 import { IssuesTableHandler } from './components/issues-table-handler';
@@ -59,7 +60,6 @@ export interface DetailsViewBodyProps {
     rightPanelConfiguration: DetailsRightPanelConfiguration;
     switcherNavConfiguration: DetailsViewSwitcherNavConfiguration;
     userConfigurationStoreData: UserConfigurationStoreData;
-    targetAppInfo: TargetAppData;
     cardsViewData: CardsViewModel;
     scanIncompleteWarnings: ScanIncompleteWarningId[];
     scanMetaData: ScanMetaData;
@@ -75,7 +75,7 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
                     <div className="details-view-body-content-pane">
                         {this.getTargetPageHiddenBar()}
                         <div className="view" role="main">
-                            <this.props.rightPanelConfiguration.RightPanel {...this.props} />
+                            {this.renderRightPanel()}
                         </div>
                     </div>
                 </div>
@@ -111,5 +111,14 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
         }
 
         return <TargetPageHiddenBar isTargetPageHidden={tabStoreData.isPageHidden} />;
+    }
+
+    private renderRightPanel(): JSX.Element {
+        const rightPanelProps: RightPanelProps = {
+            targetAppInfo: this.props.scanMetaData.scanTargetData,
+            ...this.props,
+        };
+
+        return <this.props.rightPanelConfiguration.RightPanel {...rightPanelProps} />;
     }
 }

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -115,7 +115,7 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
 
     private renderRightPanel(): JSX.Element {
         const rightPanelProps: RightPanelProps = {
-            targetAppInfo: this.props.scanMetaData.scanTargetData,
+            targetAppInfo: this.props.scanMetaData.targetAppInfo,
             ...this.props,
         };
 

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UnifiedScanResultStore } from 'background/stores/unified-scan-result-store';
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { ScanMetaData } from 'common/types/store-data/scan-meta-data';

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -232,7 +232,6 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
                 userConfigurationStoreData={storeState.userConfigurationStoreData}
                 cardsViewData={cardsViewData}
                 cardSelectionStoreData={storeState.cardSelectionStoreData}
-                targetAppInfo={storeState.unifiedScanResultStoreData.targetAppInfo}
                 scanIncompleteWarnings={
                     storeState.unifiedScanResultStoreData.scanIncompleteWarnings
                 }

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { UnifiedScanResultStore } from 'background/stores/unified-scan-result-store';
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
@@ -195,8 +196,14 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
             this.props.deps.getCardSelectionViewData(this.props.storeState.cardSelectionStoreData),
         );
 
+        const targetAppInfo = {
+            name: this.props.storeState.tabStoreData.title,
+            url: this.props.storeState.tabStoreData.url,
+        };
+
         const scanMetaData: ScanMetaData = {
             timestamp: this.props.storeState.unifiedScanResultStoreData.timestamp,
+            scanTargetData: targetAppInfo,
             toolData: this.props.storeState.unifiedScanResultStoreData.toolInfo,
         };
 

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -203,7 +203,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
 
         const scanMetaData: ScanMetaData = {
             timestamp: this.props.storeState.unifiedScanResultStoreData.timestamp,
-            scanTargetData: targetAppInfo,
+            targetAppInfo: targetAppInfo,
             toolData: this.props.storeState.unifiedScanResultStoreData.toolInfo,
         };
 

--- a/src/common/types/store-data/scan-meta-data.ts
+++ b/src/common/types/store-data/scan-meta-data.ts
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
+
 export type ScanMetaData = {
     timestamp: string;
     toolData: ToolData;
+    scanTargetData: TargetAppData;
 };

--- a/src/common/types/store-data/scan-meta-data.ts
+++ b/src/common/types/store-data/scan-meta-data.ts
@@ -7,5 +7,5 @@ import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 export type ScanMetaData = {
     timestamp: string;
     toolData: ToolData;
-    scanTargetData: TargetAppData;
+    targetAppInfo: TargetAppData;
 };

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -64,7 +64,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
     public render(): JSX.Element {
         const { status } = this.props.scanStoreData;
         if (status === ScanStatus.Failed) {
-            return this.renderLayout(null, null, null, this.renderDeviceDisconnected());
+            return this.renderLayout(null, null, this.renderDeviceDisconnected());
         } else if (status === ScanStatus.Completed) {
             const { unifiedScanResultStoreData, cardSelectionStoreData, deps } = this.props;
             const { rules, results } = unifiedScanResultStoreData;
@@ -77,24 +77,22 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
             const scanMetadata: ScanMetaData = {
                 timestamp: unifiedScanResultStoreData.timestamp,
                 toolData: unifiedScanResultStoreData.toolInfo,
-                scanTargetData: unifiedScanResultStoreData.targetAppInfo,
+                scanTargetData: this.props.unifiedScanResultStoreData.targetAppInfo,
             };
 
             return this.renderLayout(
                 cardsViewData,
-                unifiedScanResultStoreData.targetAppInfo.name,
                 scanMetadata,
                 this.renderResults(cardsViewData),
                 <ScreenshotView viewModel={screenshotViewModel} />,
             );
         } else {
-            return this.renderLayout(null, null, null, this.renderScanningSpinner());
+            return this.renderLayout(null, null, this.renderScanningSpinner());
         }
     }
 
     private renderLayout(
         cardsViewData: CardsViewModel,
-        targetAppName: string,
         scanMetaData: ScanMetaData,
         primaryContent: JSX.Element,
         optionalSidePanel?: JSX.Element,
@@ -117,7 +115,6 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                             scanStoreData={this.props.scanStoreData}
                             featureFlagStoreData={this.props.featureFlagStoreData}
                             cardsViewData={cardsViewData}
-                            targetAppName={targetAppName}
                             scanMetaData={scanMetaData}
                         />
                         <main>

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -77,6 +77,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
             const scanMetadata: ScanMetaData = {
                 timestamp: unifiedScanResultStoreData.timestamp,
                 toolData: unifiedScanResultStoreData.toolInfo,
+                scanTargetData: unifiedScanResultStoreData.targetAppInfo,
             };
 
             return this.renderLayout(

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -77,7 +77,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
             const scanMetadata: ScanMetaData = {
                 timestamp: unifiedScanResultStoreData.timestamp,
                 toolData: unifiedScanResultStoreData.toolInfo,
-                scanTargetData: this.props.unifiedScanResultStoreData.targetAppInfo,
+                targetAppInfo: this.props.unifiedScanResultStoreData.targetAppInfo,
             };
 
             return this.renderLayout(

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -34,7 +34,6 @@ export interface CommandBarProps {
     scanStoreData: ScanStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
     cardsViewData: CardsViewModel;
-    targetAppName: string;
     scanMetaData: ScanMetaData;
 }
 
@@ -42,14 +41,7 @@ export const commandButtonRefreshId = 'command-button-refresh';
 export const commandButtonSettingsId = 'command-button-settings';
 
 export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
-    const {
-        deps,
-        deviceStoreData,
-        featureFlagStoreData,
-        targetAppName,
-        cardsViewData,
-        scanMetaData,
-    } = props;
+    const { deps, deviceStoreData, featureFlagStoreData, cardsViewData, scanMetaData } = props;
     let exportReport = null;
 
     if (scanMetaData != null) {
@@ -57,15 +49,12 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
             <ReportExportComponent
                 deps={deps}
                 exportResultsType={'AutomatedChecks'}
-                pageTitle={targetAppName}
+                pageTitle={scanMetaData.scanTargetData.name}
                 scanDate={deps.getDateFromTimestamp(scanMetaData.timestamp)}
                 htmlGenerator={description =>
                     deps.reportGenerator.generateFastPassAutomatedChecksReport(
                         deps.getDateFromTimestamp(scanMetaData.timestamp),
-                        {
-                            name: targetAppName,
-                            url: null,
-                        },
+                        scanMetaData.scanTargetData,
                         cardsViewData,
                         description,
                         scanMetaData.toolData,

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -49,12 +49,12 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
             <ReportExportComponent
                 deps={deps}
                 exportResultsType={'AutomatedChecks'}
-                pageTitle={scanMetaData.scanTargetData.name}
+                pageTitle={scanMetaData.targetAppInfo.name}
                 scanDate={deps.getDateFromTimestamp(scanMetaData.timestamp)}
                 htmlGenerator={description =>
                     deps.reportGenerator.generateFastPassAutomatedChecksReport(
                         deps.getDateFromTimestamp(scanMetaData.timestamp),
-                        scanMetaData.scanTargetData,
+                        scanMetaData.targetAppInfo,
                         cardsViewData,
                         description,
                         scanMetaData.toolData,

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -62,8 +62,10 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
                 htmlGenerator={description =>
                     deps.reportGenerator.generateFastPassAutomatedChecksReport(
                         deps.getDateFromTimestamp(scanMetaData.timestamp),
-                        targetAppName,
-                        null,
+                        {
+                            name: targetAppName,
+                            url: null,
+                        },
                         cardsViewData,
                         description,
                         scanMetaData.toolData,

--- a/src/reports/assessment-report-html-generator.tsx
+++ b/src/reports/assessment-report-html-generator.tsx
@@ -32,7 +32,7 @@ export class AssessmentReportHtmlGenerator {
         assessmentStoreData: AssessmentStoreData,
         assessmentsProvider: AssessmentsProvider,
         featureFlagStoreData: FeatureFlagStoreData,
-        scanTargetData: TargetAppData,
+        targetAppInfo: TargetAppData,
         description: string,
     ): string {
         const filteredProvider = assessmentsProviderWithFeaturesEnabled(
@@ -43,7 +43,7 @@ export class AssessmentReportHtmlGenerator {
         const modelBuilder = this.assessmentReportModelBuilderFactory.create(
             filteredProvider,
             assessmentStoreData,
-            scanTargetData,
+            targetAppInfo,
             this.dateGetter(),
             this.assessmentDefaultMessageGenerator,
         );

--- a/src/reports/assessment-report-html-generator.tsx
+++ b/src/reports/assessment-report-html-generator.tsx
@@ -5,9 +5,9 @@ import { assessmentsProviderWithFeaturesEnabled } from 'assessments/assessments-
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import * as React from 'react';
 
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import * as bundledStyles from '../DetailsView/bundled-details-view-styles';
 import { AssessmentReportModelBuilderFactory } from './assessment-report-model-builder-factory';
 import * as reportStyles from './assessment-report.styles';
@@ -32,7 +32,7 @@ export class AssessmentReportHtmlGenerator {
         assessmentStoreData: AssessmentStoreData,
         assessmentsProvider: AssessmentsProvider,
         featureFlagStoreData: FeatureFlagStoreData,
-        tabStoreData: TabStoreData,
+        scanTargetData: TargetAppData,
         description: string,
     ): string {
         const filteredProvider = assessmentsProviderWithFeaturesEnabled(
@@ -43,7 +43,7 @@ export class AssessmentReportHtmlGenerator {
         const modelBuilder = this.assessmentReportModelBuilderFactory.create(
             filteredProvider,
             assessmentStoreData,
-            tabStoreData,
+            scanTargetData,
             this.dateGetter(),
             this.assessmentDefaultMessageGenerator,
         );

--- a/src/reports/assessment-report-model-builder-factory.ts
+++ b/src/reports/assessment-report-model-builder-factory.ts
@@ -11,14 +11,14 @@ export class AssessmentReportModelBuilderFactory {
     public create(
         assessmentsProvider: AssessmentsProvider,
         assessmentStoreData: AssessmentStoreData,
-        scanTargetData: TargetAppData,
+        targetAppInfo: TargetAppData,
         reportDate: Date,
         assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator,
     ): AssessmentReportModelBuilder {
         return new AssessmentReportModelBuilder(
             assessmentsProvider,
             assessmentStoreData,
-            scanTargetData,
+            targetAppInfo,
             reportDate,
             assessmentDefaultMessageGenerator,
         );

--- a/src/reports/assessment-report-model-builder-factory.ts
+++ b/src/reports/assessment-report-model-builder-factory.ts
@@ -3,22 +3,22 @@
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
-import { TabStoreData } from 'common/types/store-data/tab-store-data';
 
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { AssessmentReportModelBuilder } from './assessment-report-model-builder';
 
 export class AssessmentReportModelBuilderFactory {
     public create(
         assessmentsProvider: AssessmentsProvider,
         assessmentStoreData: AssessmentStoreData,
-        tabStoreData: TabStoreData,
+        scanTargetData: TargetAppData,
         reportDate: Date,
         assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator,
     ): AssessmentReportModelBuilder {
         return new AssessmentReportModelBuilder(
             assessmentsProvider,
             assessmentStoreData,
-            tabStoreData,
+            scanTargetData,
             reportDate,
             assessmentDefaultMessageGenerator,
         );

--- a/src/reports/assessment-report-model-builder.ts
+++ b/src/reports/assessment-report-model-builder.ts
@@ -12,7 +12,6 @@ import {
     AssessmentStoreData,
     TestStepInstance,
 } from 'common/types/store-data/assessment-result-data';
-import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { find, keys } from 'lodash';
 import { assessmentReportExtensionPoint } from '../DetailsView/extensions/assessment-report-extension-point';

--- a/src/reports/assessment-report-model-builder.ts
+++ b/src/reports/assessment-report-model-builder.ts
@@ -13,6 +13,7 @@ import {
     TestStepInstance,
 } from 'common/types/store-data/assessment-result-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { find, keys } from 'lodash';
 import { assessmentReportExtensionPoint } from '../DetailsView/extensions/assessment-report-extension-point';
 import {
@@ -30,7 +31,7 @@ export class AssessmentReportModelBuilder {
     constructor(
         private readonly assessmentsProvider: AssessmentsProvider,
         private readonly assessmentStoreData: AssessmentStoreData,
-        private readonly tabStoreData: TabStoreData,
+        private readonly scanTargetData: TargetAppData,
         private readonly reportDate: Date,
         private assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator,
     ) {}
@@ -43,8 +44,8 @@ export class AssessmentReportModelBuilder {
         }));
 
         const scanDetails = {
-            targetPage: this.tabStoreData.title,
-            url: this.tabStoreData.url,
+            targetPage: this.scanTargetData.name,
+            url: this.scanTargetData.url,
             reportDate: this.reportDate,
         };
 

--- a/src/reports/assessment-report-model-builder.ts
+++ b/src/reports/assessment-report-model-builder.ts
@@ -31,7 +31,7 @@ export class AssessmentReportModelBuilder {
     constructor(
         private readonly assessmentsProvider: AssessmentsProvider,
         private readonly assessmentStoreData: AssessmentStoreData,
-        private readonly scanTargetData: TargetAppData,
+        private readonly targetAppInfo: TargetAppData,
         private readonly reportDate: Date,
         private assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator,
     ) {}
@@ -44,8 +44,8 @@ export class AssessmentReportModelBuilder {
         }));
 
         const scanDetails = {
-            targetPage: this.scanTargetData.name,
-            url: this.scanTargetData.url,
+            targetPage: this.targetAppInfo.name,
+            url: this.targetAppInfo.url,
             reportDate: this.reportDate,
         };
 

--- a/src/reports/components/assessment-report.tsx
+++ b/src/reports/components/assessment-report.tsx
@@ -20,12 +20,14 @@ export interface AssessmentReportProps {
 
 export class AssessmentReport extends React.Component<AssessmentReportProps> {
     public render(): JSX.Element {
+        const targetAppInfo = {
+            name: this.props.data.scanDetails.targetPage,
+            url: this.props.data.scanDetails.url,
+        };
+
         return (
             <React.Fragment>
-                <HeaderSection
-                    pageTitle={this.props.data.scanDetails.targetPage}
-                    pageUrl={this.props.data.scanDetails.url}
-                />
+                <HeaderSection targetAppInfo={targetAppInfo} />
                 <AssessmentReportBody
                     deps={this.props.deps}
                     data={this.props.data}

--- a/src/reports/components/report-sections/details-section.tsx
+++ b/src/reports/components/report-sections/details-section.tsx
@@ -11,11 +11,11 @@ import { SectionProps } from './report-section-factory';
 
 export type DetailsSectionProps = Pick<
     SectionProps,
-    'pageTitle' | 'pageUrl' | 'description' | 'scanDate' | 'toUtcString'
+    'targetAppInfo' | 'description' | 'scanDate' | 'toUtcString'
 >;
 
 export const DetailsSection = NamedFC<DetailsSectionProps>('DetailsSection', props => {
-    const { pageTitle, pageUrl, description, scanDate, toUtcString } = props;
+    const { targetAppInfo, description, scanDate, toUtcString } = props;
 
     const createListItem = (
         icon: JSX.Element,
@@ -42,8 +42,11 @@ export const DetailsSection = NamedFC<DetailsSectionProps>('DetailsSection', pro
                 {createListItem(
                     <UrlIcon />,
                     'target page url:',
-                    <NewTabLinkWithConfirmationDialog href={pageUrl} title={pageTitle}>
-                        {pageUrl}
+                    <NewTabLinkWithConfirmationDialog
+                        href={targetAppInfo.url}
+                        title={targetAppInfo.name}
+                    >
+                        {targetAppInfo.url}
                     </NewTabLinkWithConfirmationDialog>,
                 )}
                 {createListItem(<DateIcon />, 'scan date:', scanDateUTC)}

--- a/src/reports/components/report-sections/header-section.tsx
+++ b/src/reports/components/report-sections/header-section.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { productName } from 'content/strings/application';
 import { BrandWhite } from 'icons/brand/white/brand-white';
 import * as React from 'react';
@@ -8,28 +9,27 @@ import { NewTabLinkWithConfirmationDialog } from 'reports/components/new-tab-lin
 import * as styles from './header-section.scss';
 
 export interface HeaderSectionProps {
-    pageTitle: string;
-    pageUrl: string;
+    targetAppInfo: TargetAppData;
 }
 
-export const HeaderSection = NamedFC<HeaderSectionProps>(
-    'HeaderSection',
-    ({ pageTitle, pageUrl }) => {
-        return (
-            <header>
-                <div className={styles.reportHeaderBar}>
-                    <BrandWhite />
-                    <div className={styles.headerText}>{productName}</div>
+export const HeaderSection = NamedFC<HeaderSectionProps>('HeaderSection', ({ targetAppInfo }) => {
+    return (
+        <header>
+            <div className={styles.reportHeaderBar}>
+                <BrandWhite />
+                <div className={styles.headerText}>{productName}</div>
+            </div>
+            <div className={styles.reportHeaderCommandBar}>
+                <div className={styles.targetPage}>
+                    Target page:&nbsp;
+                    <NewTabLinkWithConfirmationDialog
+                        href={targetAppInfo.url}
+                        title={targetAppInfo.name}
+                    >
+                        {targetAppInfo.name}
+                    </NewTabLinkWithConfirmationDialog>
                 </div>
-                <div className={styles.reportHeaderCommandBar}>
-                    <div className={styles.targetPage}>
-                        Target page:&nbsp;
-                        <NewTabLinkWithConfirmationDialog href={pageUrl} title={pageTitle}>
-                            {pageTitle}
-                        </NewTabLinkWithConfirmationDialog>
-                    </div>
-                </div>
-            </header>
-        );
-    },
-);
+            </div>
+        </header>
+    );
+});

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -18,8 +18,6 @@ export type SectionDeps = NotApplicableChecksSectionDeps &
 export type SectionProps = {
     deps: SectionDeps;
     fixInstructionProcessor: FixInstructionProcessor;
-    pageTitle: string;
-    pageUrl: string;
     description: string;
     scanDate: Date;
     toolData: ToolData;

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -24,15 +24,15 @@ export class ReportGenerator {
 
     public generateFastPassAutomatedChecksReport(
         scanDate: Date,
-        scanTargetData: TargetAppData,
+        targetAppInfo: TargetAppData,
         cardsViewData: CardsViewModel,
         description: string,
         toolData: ToolData,
     ): string {
         return this.reportHtmlGenerator.generateHtml(
             scanDate,
-            scanTargetData.name,
-            scanTargetData.url,
+            targetAppInfo.name,
+            targetAppInfo.url,
             description,
             cardsViewData,
             toolData,
@@ -43,14 +43,14 @@ export class ReportGenerator {
         assessmentStoreData: AssessmentStoreData,
         assessmentsProvider: AssessmentsProvider,
         featureFlagStoreData: FeatureFlagStoreData,
-        scanTargetData: TargetAppData,
+        targetAppInfo: TargetAppData,
         description: string,
     ): string {
         return this.assessmentReportHtmlGenerator.generateHtml(
             assessmentStoreData,
             assessmentsProvider,
             featureFlagStoreData,
-            scanTargetData,
+            targetAppInfo,
             description,
         );
     }

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -4,8 +4,8 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 
 import { AssessmentReportHtmlGenerator } from './assessment-report-html-generator';
 import { ReportHtmlGenerator } from './report-html-generator';
@@ -24,16 +24,15 @@ export class ReportGenerator {
 
     public generateFastPassAutomatedChecksReport(
         scanDate: Date,
-        pageTitle: string,
-        pageUrl: string,
+        scanTargetData: TargetAppData,
         cardsViewData: CardsViewModel,
         description: string,
         toolData: ToolData,
     ): string {
         return this.reportHtmlGenerator.generateHtml(
             scanDate,
-            pageTitle,
-            pageUrl,
+            scanTargetData.name,
+            scanTargetData.url,
             description,
             cardsViewData,
             toolData,
@@ -44,14 +43,14 @@ export class ReportGenerator {
         assessmentStoreData: AssessmentStoreData,
         assessmentsProvider: AssessmentsProvider,
         featureFlagStoreData: FeatureFlagStoreData,
-        tabStoreData: TabStoreData,
+        scanTargetData: TargetAppData,
         description: string,
     ): string {
         return this.assessmentReportHtmlGenerator.generateHtml(
             assessmentStoreData,
             assessmentsProvider,
             featureFlagStoreData,
-            tabStoreData,
+            scanTargetData,
             description,
         );
     }

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -8,7 +8,7 @@ import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import * as React from 'react';
 
-import { TargetAppData, ToolData } from 'common/types/store-data/unified-data-interface';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { ReportBody, ReportBodyProps } from './components/report-sections/report-body';
 import { ReportCollapsibleContainerControl } from './components/report-sections/report-collapsible-container';
 import {
@@ -32,7 +32,7 @@ export class ReportHtmlGenerator {
     public generateHtml(
         scanDate: Date,
         pageTitle: string,
-        url: string,
+        pageUrl: string,
         description: string,
         cardsViewData: CardsViewModel,
         toolData: ToolData,
@@ -41,7 +41,7 @@ export class ReportHtmlGenerator {
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(<HeadSection />);
         const targetAppInfo = {
             name: pageTitle,
-            url: url,
+            url: pageUrl,
         };
 
         const detailsProps: SectionProps = {

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -8,7 +8,7 @@ import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import * as React from 'react';
 
-import { ToolData } from 'common/types/store-data/unified-data-interface';
+import { TargetAppData, ToolData } from 'common/types/store-data/unified-data-interface';
 import { ReportBody, ReportBodyProps } from './components/report-sections/report-body';
 import { ReportCollapsibleContainerControl } from './components/report-sections/report-collapsible-container';
 import {
@@ -32,17 +32,19 @@ export class ReportHtmlGenerator {
     public generateHtml(
         scanDate: Date,
         pageTitle: string,
-        pageUrl: string,
+        url: string,
         description: string,
         cardsViewData: CardsViewModel,
         toolData: ToolData,
     ): string {
         const HeadSection = this.sectionFactory.HeadSection;
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(<HeadSection />);
+        const scanTargetData = {
+            name: pageTitle,
+            url: url,
+        };
 
         const detailsProps: SectionProps = {
-            pageTitle,
-            pageUrl,
             description,
             scanDate,
             deps: {
@@ -59,6 +61,7 @@ export class ReportHtmlGenerator {
             getCollapsibleScript: this.getCollapsibleScript,
             getGuidanceTagsFromGuidanceLinks: this.getGuidanceTagsFromGuidanceLinks,
             fixInstructionProcessor: this.fixInstructionProcessor,
+            targetAppInfo: scanTargetData,
         } as SectionProps;
 
         const props: ReportBodyProps = {

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -39,7 +39,7 @@ export class ReportHtmlGenerator {
     ): string {
         const HeadSection = this.sectionFactory.HeadSection;
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(<HeadSection />);
-        const scanTargetData = {
+        const targetAppInfo = {
             name: pageTitle,
             url: url,
         };
@@ -61,7 +61,7 @@ export class ReportHtmlGenerator {
             getCollapsibleScript: this.getCollapsibleScript,
             getGuidanceTagsFromGuidanceLinks: this.getGuidanceTagsFromGuidanceLinks,
             fixInstructionProcessor: this.fixInstructionProcessor,
-            targetAppInfo: scanTargetData,
+            targetAppInfo: targetAppInfo,
         } as SectionProps;
 
         const props: ReportBodyProps = {

--- a/src/tests/unit/tests/DetailsView/assessment-report-model-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/assessment-report-model-builder.test.tsx
@@ -44,7 +44,7 @@ describe('AssessmentReportModelBuilderTest', () => {
 
     assessmentsProviderMock.setup(ap => ap.all()).returns(() => assessments);
 
-    const scanTargetData: TargetAppData = {
+    const targetAppInfo: TargetAppData = {
         url: 'url',
         name: 'title',
     };
@@ -56,7 +56,7 @@ describe('AssessmentReportModelBuilderTest', () => {
         return new AssessmentReportModelBuilder(
             assessmentsProviderMock.object,
             assessmentStoreData,
-            scanTargetData,
+            targetAppInfo,
             AssessmentReportBuilderTestHelper.reportDate,
             assessmentDefaultMessageGeneratorMock.object,
         );

--- a/src/tests/unit/tests/DetailsView/assessment-report-model-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/assessment-report-model-builder.test.tsx
@@ -12,9 +12,9 @@ import {
 import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { AssessmentReportModelBuilder } from 'reports/assessment-report-model-builder';
 import { AssessmentStoreData } from '../../../../common/types/store-data/assessment-result-data';
-import { TabStoreData } from '../../../../common/types/store-data/tab-store-data';
 import { AssessmentReportBuilderTestHelper } from './assessment-report-builder-test-helper';
 
 describe('AssessmentReportModelBuilderTest', () => {
@@ -44,13 +44,9 @@ describe('AssessmentReportModelBuilderTest', () => {
 
     assessmentsProviderMock.setup(ap => ap.all()).returns(() => assessments);
 
-    const tabStoreData: TabStoreData = {
+    const scanTargetData: TargetAppData = {
         url: 'url',
-        title: 'title',
-        id: -1,
-        isClosed: false,
-        isChanged: false,
-        isPageHidden: false,
+        name: 'title',
     };
 
     AssessmentReportBuilderTestHelper.setMessageComponent(expectedMessage);
@@ -60,7 +56,7 @@ describe('AssessmentReportModelBuilderTest', () => {
         return new AssessmentReportModelBuilder(
             assessmentsProviderMock.object,
             assessmentStoreData,
-            tabStoreData,
+            scanTargetData,
             AssessmentReportBuilderTestHelper.reportDate,
             assessmentDefaultMessageGeneratorMock.object,
         );

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
+import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import { DetailsViewBodyProps } from 'DetailsView/details-view-body';
@@ -13,7 +14,6 @@ import {
     DetailsViewCommandBar,
     DetailsViewCommandBarProps,
 } from '../../../../../DetailsView/components/details-view-command-bar';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
 
 describe('DetailsViewCommandBar', () => {
     const thePageTitle = 'command-bar-test-tab-title';

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -51,7 +51,7 @@ describe('DetailsViewCommandBar', () => {
             LeftNav: LeftNavStub,
         } as DetailsViewSwitcherNavConfiguration;
         const scanMetaData = {
-            scanTargetData: {
+            targetAppInfo: {
                 name: thePageTitle,
                 url: thePageUrl,
             },

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -13,9 +13,11 @@ import {
     DetailsViewCommandBar,
     DetailsViewCommandBarProps,
 } from '../../../../../DetailsView/components/details-view-command-bar';
+import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
 
 describe('DetailsViewCommandBar', () => {
     const thePageTitle = 'command-bar-test-tab-title';
+    const thePageUrl = 'command-bar-test-url';
 
     let tabStoreData: TabStoreData;
     let startOverComponent: JSX.Element;
@@ -48,6 +50,12 @@ describe('DetailsViewCommandBar', () => {
             StartOverComponentFactory: p => startOverComponent,
             LeftNav: LeftNavStub,
         } as DetailsViewSwitcherNavConfiguration;
+        const scanMetaData = {
+            scanTargetData: {
+                name: thePageTitle,
+                url: thePageUrl,
+            },
+        } as ScanMetaData;
 
         return {
             deps: {
@@ -55,6 +63,7 @@ describe('DetailsViewCommandBar', () => {
             },
             tabStoreData,
             switcherNavConfiguration: switcherNavConfiguration,
+            scanMetaData: scanMetaData,
         } as DetailsViewCommandBarProps;
     }
 

--- a/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
@@ -5,7 +5,6 @@ import { AssessmentStoreData } from 'common/types/store-data/assessment-result-d
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
-import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
@@ -37,7 +36,6 @@ describe('ReportExportComponentPropsFactory', () => {
     let assessmentsProviderMock: IMock<AssessmentsProvider>;
     let featureFlagStoreData: FeatureFlagStoreData;
     let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
-    let tabStoreData: TabStoreData;
     let assessmentStoreData: AssessmentStoreData;
     let reportGeneratorMock: IMock<ReportGenerator>;
     let visualizationScanResultData: VisualizationScanResultData;
@@ -53,7 +51,6 @@ describe('ReportExportComponentPropsFactory', () => {
             DetailsViewActionMessageCreator,
             MockBehavior.Strict,
         );
-        tabStoreData = {} as TabStoreData;
         assessmentStoreData = {
             resultDescription: theDescription,
         } as AssessmentStoreData;
@@ -90,7 +87,6 @@ describe('ReportExportComponentPropsFactory', () => {
         return {
             deps,
             featureFlagStoreData,
-            tabStoreData,
             assessmentStoreData,
             assessmentsProvider: assessmentsProviderMock.object,
             visualizationScanResultData,

--- a/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
@@ -44,7 +44,7 @@ describe('ReportExportComponentPropsFactory', () => {
     let visualizationStoreData: VisualizationStoreData;
     let cardsViewData: CardsViewModel;
     let scanResult: ScanResults;
-    let scanTargetData: TargetAppData;
+    let targetAppInfo: TargetAppData;
     let scanMetaData: ScanMetaData;
 
     beforeEach(() => {
@@ -57,14 +57,14 @@ describe('ReportExportComponentPropsFactory', () => {
         assessmentStoreData = {
             resultDescription: theDescription,
         } as AssessmentStoreData;
-        scanTargetData = {
+        targetAppInfo = {
             name: thePageTitle,
             url: thePageUrl,
         };
         scanMetaData = {
             timestamp: theTimestamp,
             toolData: theToolData,
-            scanTargetData: scanTargetData,
+            targetAppInfo: targetAppInfo,
         } as ScanMetaData;
         assessmentsProviderMock = Mock.ofType<AssessmentsProvider>(undefined, MockBehavior.Loose);
         reportGeneratorMock = Mock.ofType<ReportGenerator>(undefined, MockBehavior.Loose);
@@ -107,7 +107,7 @@ describe('ReportExportComponentPropsFactory', () => {
                     assessmentStoreData,
                     assessmentsProviderMock.object,
                     featureFlagStoreData,
-                    scanTargetData,
+                    targetAppInfo,
                     theDescription,
                 ),
             )
@@ -119,7 +119,7 @@ describe('ReportExportComponentPropsFactory', () => {
             .setup(reportGenerator =>
                 reportGenerator.generateFastPassAutomatedChecksReport(
                     theDate,
-                    scanTargetData,
+                    targetAppInfo,
                     cardsViewData,
                     theDescription,
                     scanMetaData.toolData,

--- a/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
@@ -7,6 +7,7 @@ import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store
 import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
@@ -43,6 +44,7 @@ describe('ReportExportComponentPropsFactory', () => {
     let visualizationStoreData: VisualizationStoreData;
     let cardsViewData: CardsViewModel;
     let scanResult: ScanResults;
+    let scanTargetData: TargetAppData;
     let scanMetaData: ScanMetaData;
 
     beforeEach(() => {
@@ -51,16 +53,18 @@ describe('ReportExportComponentPropsFactory', () => {
             DetailsViewActionMessageCreator,
             MockBehavior.Strict,
         );
-        tabStoreData = {
-            title: thePageTitle,
-            url: thePageUrl,
-        } as TabStoreData;
+        tabStoreData = {} as TabStoreData;
         assessmentStoreData = {
             resultDescription: theDescription,
         } as AssessmentStoreData;
+        scanTargetData = {
+            name: thePageTitle,
+            url: thePageUrl,
+        };
         scanMetaData = {
             timestamp: theTimestamp,
             toolData: theToolData,
+            scanTargetData: scanTargetData,
         } as ScanMetaData;
         assessmentsProviderMock = Mock.ofType<AssessmentsProvider>(undefined, MockBehavior.Loose);
         reportGeneratorMock = Mock.ofType<ReportGenerator>(undefined, MockBehavior.Loose);
@@ -103,7 +107,7 @@ describe('ReportExportComponentPropsFactory', () => {
                     assessmentStoreData,
                     assessmentsProviderMock.object,
                     featureFlagStoreData,
-                    tabStoreData,
+                    scanTargetData,
                     theDescription,
                 ),
             )
@@ -115,8 +119,7 @@ describe('ReportExportComponentPropsFactory', () => {
             .setup(reportGenerator =>
                 reportGenerator.generateFastPassAutomatedChecksReport(
                     theDate,
-                    tabStoreData.title,
-                    tabStoreData.url,
+                    scanTargetData,
                     cardsViewData,
                     theDescription,
                     scanMetaData.toolData,

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -31,6 +31,8 @@ import { TabStoreDataBuilder } from '../../common/tab-store-data-builder';
 import { VisualizationScanResultStoreDataBuilder } from '../../common/visualization-scan-result-store-data-builder';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 import { exampleUnifiedStatusResults } from '../common/components/cards/sample-view-model-data';
+import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 
 describe('DetailsViewBody', () => {
     let selectedTest: VisualizationType;
@@ -43,6 +45,7 @@ describe('DetailsViewBody', () => {
     let props: DetailsViewBodyProps;
     let rightPanelConfig: DetailsRightPanelConfiguration;
     let switcherNavConfig: DetailsViewSwitcherNavConfiguration;
+    let targetAppInfoStub: TargetAppData;
 
     describe('render', () => {
         beforeEach(() => {
@@ -80,6 +83,11 @@ describe('DetailsViewBody', () => {
             scanDataStub = {
                 enabled: false,
             } as ScanData;
+
+            targetAppInfoStub = {
+                name: 'name',
+                url: 'url',
+            } as TargetAppData;
 
             clickHandlerStub = () => {};
 
@@ -127,6 +135,9 @@ describe('DetailsViewBody', () => {
                     visualHelperEnabled: true,
                     allCardsCollapsed: true,
                 },
+                scanMetaData: {
+                    scanTargetData: targetAppInfoStub,
+                } as ScanMetaData,
             } as DetailsViewBodyProps;
         });
 
@@ -152,7 +163,7 @@ describe('DetailsViewBody', () => {
                         <div className="details-view-body-content-pane">
                             {buildTargetPageInfoBar(props)}
                             <div className="view" role="main">
-                                <rightPanelConfig.RightPanel {...props} />
+                                {buildRightPanel(props)}
                             </div>
                         </div>
                     </div>
@@ -200,6 +211,14 @@ describe('DetailsViewBody', () => {
     }
 
     function buildCommandBar(givenProps: DetailsViewBodyProps): JSX.Element {
-        return <switcherNavConfig.CommandBar {...props} />;
+        return <switcherNavConfig.CommandBar {...givenProps} />;
+    }
+
+    function buildRightPanel(givenProps: DetailsViewBodyProps): JSX.Element {
+        const rightPanelProps = {
+            targetAppInfo: givenProps.scanMetaData.scanTargetData,
+            ...givenProps,
+        };
+        return <rightPanelConfig.RightPanel {...rightPanelProps} />;
     }
 });

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -4,6 +4,8 @@ import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
 import { getDefaultFeatureFlagsWeb } from 'common/feature-flags';
+import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewCommandBarDeps } from 'DetailsView/components/details-view-command-bar';
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
@@ -31,8 +33,6 @@ import { TabStoreDataBuilder } from '../../common/tab-store-data-builder';
 import { VisualizationScanResultStoreDataBuilder } from '../../common/visualization-scan-result-store-data-builder';
 import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
 import { exampleUnifiedStatusResults } from '../common/components/cards/sample-view-model-data';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
-import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 
 describe('DetailsViewBody', () => {
     let selectedTest: VisualizationType;

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -136,7 +136,7 @@ describe('DetailsViewBody', () => {
                     allCardsCollapsed: true,
                 },
                 scanMetaData: {
-                    scanTargetData: targetAppInfoStub,
+                    targetAppInfo: targetAppInfoStub,
                 } as ScanMetaData,
             } as DetailsViewBodyProps;
         });
@@ -216,7 +216,7 @@ describe('DetailsViewBody', () => {
 
     function buildRightPanel(givenProps: DetailsViewBodyProps): JSX.Element {
         const rightPanelProps = {
-            targetAppInfo: givenProps.scanMetaData.scanTargetData,
+            targetAppInfo: givenProps.scanMetaData.targetAppInfo,
             ...givenProps,
         };
         return <rightPanelConfig.RightPanel {...rightPanelProps} />;

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -56,6 +56,8 @@ import { DetailsViewContainerPropsBuilder } from './details-view-container-props
 import { StoreMocks } from './store-mocks';
 
 describe('DetailsViewContainer', () => {
+    const pageTitle = 'DetailsViewContainerTest title';
+    const pageUrl = 'http://detailsViewContainerTest/url/';
     let detailsViewActionMessageCreator: IMock<DetailsViewActionMessageCreator>;
     let deps: DetailsViewContainerDeps;
     let getDetailsRightPanelConfiguration: IMock<GetDetailsRightPanelConfiguration>;
@@ -89,7 +91,10 @@ describe('DetailsViewContainer', () => {
             MockBehavior.Strict,
         );
         timestamp = 'timestamp';
-        targetAppInfo = { name: 'app' };
+        targetAppInfo = {
+            name: pageTitle,
+            url: pageUrl,
+        };
         toolData = {
             applicationProperties: { name: 'some app' },
         } as ToolData;
@@ -165,8 +170,8 @@ describe('DetailsViewContainer', () => {
             );
 
             const tabStoreData: TabStoreData = {
-                title: 'DetailsViewContainerTest title',
-                url: 'http://detailsViewContainerTest/url/',
+                title: pageTitle,
+                url: pageUrl,
                 id: 1,
                 isClosed: true,
                 isChanged: false,
@@ -397,7 +402,6 @@ describe('DetailsViewContainer', () => {
                 switcherNavConfiguration={switcherNavConfiguration}
                 userConfigurationStoreData={storeMocks.userConfigurationStoreData}
                 cardsViewData={cardsViewData}
-                targetAppInfo={targetApp}
                 cardSelectionStoreData={storeMocks.cardSelectionStoreData}
                 scanIncompleteWarnings={
                     storeMocks.unifiedScanResultStoreData.scanIncompleteWarnings

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -370,6 +370,11 @@ describe('DetailsViewContainer', () => {
         cardsViewData: CardsViewModel,
         targetApp: TargetAppData,
     ): JSX.Element {
+        const scanMetaData = {
+            timestamp: timestamp,
+            toolData: toolData,
+            scanTargetData: targetApp,
+        };
         return (
             <DetailsViewBody
                 deps={deps}
@@ -397,7 +402,7 @@ describe('DetailsViewContainer', () => {
                 scanIncompleteWarnings={
                     storeMocks.unifiedScanResultStoreData.scanIncompleteWarnings
                 }
-                scanMetaData={{ timestamp, toolData }}
+                scanMetaData={scanMetaData}
             />
         );
     }

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -378,7 +378,7 @@ describe('DetailsViewContainer', () => {
         const scanMetaData = {
             timestamp: timestamp,
             toolData: toolData,
-            scanTargetData: targetApp,
+            targetAppInfo: targetApp,
         };
         return (
             <DetailsViewBody

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
         deviceStoreData={Object {}}
         scanMetaData={
           Object {
-            "scanTargetData": Object {
+            "targetAppInfo": Object {
               "name": "test-target-app-name",
             },
             "timestamp": "test timestamp",

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -55,7 +55,6 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
           Object {
             "scanTargetData": Object {
               "name": "test-target-app-name",
-              "url": undefined,
             },
             "timestamp": "test timestamp",
             "toolData": Object {

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
           Object {
             "scanTargetData": Object {
               "name": "test-target-app-name",
+              "url": undefined,
             },
             "timestamp": "test timestamp",
             "toolData": Object {
@@ -69,7 +70,6 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
             "status": 2,
           }
         }
-        targetAppName="test-target-app-name"
       />
       <main>
         <HeaderSection />
@@ -200,7 +200,6 @@ exports[`AutomatedChecksView renders when status scan <Failed> 1`] = `
             "status": 3,
           }
         }
-        targetAppName={null}
       />
       <main>
         <HeaderSection />
@@ -290,7 +289,6 @@ exports[`AutomatedChecksView renders when status scan <Scanning> 1`] = `
             "status": 1,
           }
         }
-        targetAppName={null}
       />
       <main>
         <HeaderSection />
@@ -380,7 +378,6 @@ exports[`AutomatedChecksView renders when status scan <undefined> 1`] = `
             "status": undefined,
           }
         }
-        targetAppName={null}
       />
       <main>
         <HeaderSection />

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -53,6 +53,9 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
         deviceStoreData={Object {}}
         scanMetaData={
           Object {
+            "scanTargetData": Object {
+              "name": "test-target-app-name",
+            },
             "timestamp": "test timestamp",
             "toolData": Object {
               "applicationProperties": Object {

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
           }
           getExportDescription={[Function]}
           htmlGenerator={[Function]}
-          pageTitle="some target"
+          pageTitle="scan target name"
           scanDate={1970-01-01T00:00:00.000Z}
           updatePersistedDescription={[Function]}
         />
@@ -174,7 +174,7 @@ exports[`CommandBar renders while status is <Default> 1`] = `
           }
           getExportDescription={[Function]}
           htmlGenerator={[Function]}
-          pageTitle="some target"
+          pageTitle="scan target name"
           scanDate={1970-01-01T00:00:00.000Z}
           updatePersistedDescription={[Function]}
         />
@@ -250,7 +250,7 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
           }
           getExportDescription={[Function]}
           htmlGenerator={[Function]}
-          pageTitle="some target"
+          pageTitle="scan target name"
           scanDate={1970-01-01T00:00:00.000Z}
           updatePersistedDescription={[Function]}
         />
@@ -326,7 +326,7 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
           }
           getExportDescription={[Function]}
           htmlGenerator={[Function]}
-          pageTitle="some target"
+          pageTitle="scan target name"
           scanDate={1970-01-01T00:00:00.000Z}
           updatePersistedDescription={[Function]}
         />

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -38,7 +38,7 @@ describe('CommandBar', () => {
         scanMetaDataStub = {
             timestamp: '1234',
             toolData: {} as ToolData,
-            scanTargetData: {
+            targetAppInfo: {
                 name: 'scan target name',
             },
         };

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -38,6 +38,9 @@ describe('CommandBar', () => {
         scanMetaDataStub = {
             timestamp: '1234',
             toolData: {} as ToolData,
+            scanTargetData: {
+                name: 'scan target name',
+            },
         };
         scanDateStub = new Date(0);
         reportGeneratorMock = Mock.ofType(ReportGenerator);

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -62,7 +62,6 @@ describe('CommandBar', () => {
                     status: ScanStatus.Scanning,
                 },
                 cardsViewData: cardsViewDataStub,
-                targetAppName: 'some target',
                 featureFlagStoreData: featureFlagStoreDataStub,
                 scanMetaData: scanMetaDataStub,
             } as CommandBarProps;
@@ -83,7 +82,6 @@ describe('CommandBar', () => {
                     status: ScanStatus.Scanning,
                 },
                 cardsViewData: cardsViewDataStub,
-                targetAppName: 'some target',
                 featureFlagStoreData: featureFlagStoreDataStub,
                 scanMetaData: null,
             } as CommandBarProps;
@@ -107,7 +105,6 @@ describe('CommandBar', () => {
                     status: ScanStatus[status],
                 },
                 cardsViewData: cardsViewDataStub,
-                targetAppName: 'some target',
                 featureFlagStoreData: featureFlagStoreDataStub,
                 scanMetaData: scanMetaDataStub,
             } as CommandBarProps;
@@ -143,7 +140,6 @@ describe('CommandBar', () => {
                     status: ScanStatus.Default,
                 },
                 cardsViewData: cardsViewDataStub,
-                targetAppName: 'some target',
                 featureFlagStoreData: featureFlagStoreDataStub,
                 scanMetaData: scanMetaDataStub,
             } as CommandBarProps;
@@ -171,7 +167,6 @@ describe('CommandBar', () => {
                     status: ScanStatus.Default,
                 },
                 cardsViewData: cardsViewDataStub,
-                targetAppName: 'some target',
                 featureFlagStoreData: featureFlagStoreDataStub,
                 scanMetaData: scanMetaDataStub,
             } as CommandBarProps;

--- a/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
@@ -3,7 +3,7 @@
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import {
     AssessmentReportHtmlGenerator,
@@ -31,7 +31,7 @@ describe('AssessmentReportHtmlGenerator', () => {
         const assessmentsProvider = CreateTestAssessmentProviderWithFeatureFlag();
         const assessmentStoreData: AssessmentStoreData = { stub: 'assessmentStoreData' } as any;
         const featureFlagStoreData: FeatureFlagStoreData = { stub: 'featureFlagStoreData' } as any;
-        const tabStoreData: TabStoreData = { stub: 'tabStoreData' } as any;
+        const scanTargetData: TargetAppData = { stub: 'scanTargetData' } as any;
         const description = 'generateHtml-description';
 
         const deps: AssessmentReportHtmlGeneratorDeps = {
@@ -77,7 +77,7 @@ describe('AssessmentReportHtmlGenerator', () => {
                 f.create(
                     It.isAny(),
                     assessmentStoreData,
-                    tabStoreData,
+                    scanTargetData,
                     testDate,
                     assessmentDefaultMessageGenerator,
                 ),
@@ -105,7 +105,7 @@ describe('AssessmentReportHtmlGenerator', () => {
             assessmentStoreData,
             assessmentsProvider,
             featureFlagStoreData,
-            tabStoreData,
+            scanTargetData,
             description,
         );
 

--- a/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/assessment-report-html-generator.test.tsx
@@ -31,7 +31,7 @@ describe('AssessmentReportHtmlGenerator', () => {
         const assessmentsProvider = CreateTestAssessmentProviderWithFeatureFlag();
         const assessmentStoreData: AssessmentStoreData = { stub: 'assessmentStoreData' } as any;
         const featureFlagStoreData: FeatureFlagStoreData = { stub: 'featureFlagStoreData' } as any;
-        const scanTargetData: TargetAppData = { stub: 'scanTargetData' } as any;
+        const targetAppInfo: TargetAppData = { stub: 'targetAppInfo' } as any;
         const description = 'generateHtml-description';
 
         const deps: AssessmentReportHtmlGeneratorDeps = {
@@ -77,7 +77,7 @@ describe('AssessmentReportHtmlGenerator', () => {
                 f.create(
                     It.isAny(),
                     assessmentStoreData,
-                    scanTargetData,
+                    targetAppInfo,
                     testDate,
                     assessmentDefaultMessageGenerator,
                 ),
@@ -105,7 +105,7 @@ describe('AssessmentReportHtmlGenerator', () => {
             assessmentStoreData,
             assessmentsProvider,
             featureFlagStoreData,
-            scanTargetData,
+            targetAppInfo,
             description,
         );
 

--- a/src/tests/unit/tests/reports/assessment-report-model-builder-factory.test.ts
+++ b/src/tests/unit/tests/reports/assessment-report-model-builder-factory.test.ts
@@ -12,21 +12,21 @@ describe('AssessmentReportModelBuilderFactory', () => {
 
         const assessmentStoreData: AssessmentStoreData = { stub: 'assessmentStoreData' } as any;
         const assessmentsProvider: AssessmentsProvider = { stub: 'assessmentsProvider' } as any;
-        const scanTargetData: TargetAppData = { stub: 'scanTargetData' } as any;
+        const targetAppInfo: TargetAppData = { stub: 'targetAppInfo' } as any;
         const reportDate = new Date(2018, 9, 19, 10, 53);
         const assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator = new AssessmentDefaultMessageGenerator();
 
         const actual = testSubject.create(
             assessmentsProvider,
             assessmentStoreData,
-            scanTargetData,
+            targetAppInfo,
             reportDate,
             assessmentDefaultMessageGenerator,
         );
 
         expect((actual as any).assessmentStoreData).toBe(assessmentStoreData);
         expect((actual as any).assessmentsProvider).toBe(assessmentsProvider);
-        expect((actual as any).scanTargetData).toBe(scanTargetData);
+        expect((actual as any).targetAppInfo).toBe(targetAppInfo);
         expect((actual as any).reportDate).toBe(reportDate);
     });
 });

--- a/src/tests/unit/tests/reports/assessment-report-model-builder-factory.test.ts
+++ b/src/tests/unit/tests/reports/assessment-report-model-builder-factory.test.ts
@@ -3,7 +3,7 @@
 import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
-import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { AssessmentReportModelBuilderFactory } from 'reports/assessment-report-model-builder-factory';
 
 describe('AssessmentReportModelBuilderFactory', () => {
@@ -12,21 +12,21 @@ describe('AssessmentReportModelBuilderFactory', () => {
 
         const assessmentStoreData: AssessmentStoreData = { stub: 'assessmentStoreData' } as any;
         const assessmentsProvider: AssessmentsProvider = { stub: 'assessmentsProvider' } as any;
-        const tabStoreData: TabStoreData = { stub: 'tabStoreData' } as any;
+        const scanTargetData: TargetAppData = { stub: 'scanTargetData' } as any;
         const reportDate = new Date(2018, 9, 19, 10, 53);
         const assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator = new AssessmentDefaultMessageGenerator();
 
         const actual = testSubject.create(
             assessmentsProvider,
             assessmentStoreData,
-            tabStoreData,
+            scanTargetData,
             reportDate,
             assessmentDefaultMessageGenerator,
         );
 
         expect((actual as any).assessmentStoreData).toBe(assessmentStoreData);
         expect((actual as any).assessmentsProvider).toBe(assessmentsProvider);
-        expect((actual as any).tabStoreData).toBe(tabStoreData);
+        expect((actual as any).scanTargetData).toBe(scanTargetData);
         expect((actual as any).reportDate).toBe(reportDate);
     });
 });

--- a/src/tests/unit/tests/reports/components/__snapshots__/assessment-report.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/__snapshots__/assessment-report.test.tsx.snap
@@ -3,8 +3,12 @@
 exports[`AssessmentReport render 1`] = `
 <React.Fragment>
   <HeaderSection
-    pageTitle="title"
-    pageUrl="url"
+    targetAppInfo={
+      Object {
+        "name": "title",
+        "url": "url",
+      }
+    }
   />
   <AssessmentReportBody
     data={

--- a/src/tests/unit/tests/reports/components/report-sections/details-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/details-section.test.tsx
@@ -25,8 +25,10 @@ describe('DetailsSection', () => {
 
         const props: DetailsSectionProps = {
             scanDate,
-            pageTitle: 'page-title',
-            pageUrl: 'https://page-url/',
+            targetAppInfo: {
+                name: 'page-title',
+                url: 'https://page-url/',
+            },
             description,
             environmentInfo: {
                 browserSpec: 'environment-version',

--- a/src/tests/unit/tests/reports/components/report-sections/header-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/header-section.test.tsx
@@ -6,7 +6,11 @@ import { HeaderSection } from 'reports/components/report-sections/header-section
 
 describe('HeaderSection', () => {
     it('renders', () => {
-        const wrapper = shallow(<HeaderSection pageUrl="url://page" pageTitle="page-title" />);
+        const targetAppInfo = {
+            name: 'page-title',
+            url: 'url://page',
+        };
+        const wrapper = shallow(<HeaderSection targetAppInfo={targetAppInfo} />);
         expect(wrapper.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -26,7 +26,7 @@ describe('ReportGenerator', () => {
     const toolDataStub: ToolData = {
         applicationProperties: { name: 'some app' },
     } as ToolData;
-    const scanTargetData = {
+    const targetAppInfo = {
         name: title,
         url: url,
     };
@@ -65,7 +65,7 @@ describe('ReportGenerator', () => {
         );
         const actual = testObject.generateFastPassAutomatedChecksReport(
             date,
-            scanTargetData,
+            targetAppInfo,
             cardsViewDataStub,
             description,
             toolDataStub,
@@ -87,7 +87,7 @@ describe('ReportGenerator', () => {
                     assessmentStoreData,
                     assessmentsProvider,
                     featureFlagStoreData,
-                    scanTargetData,
+                    targetAppInfo,
                     assessmentDescription,
                 ),
             )
@@ -103,7 +103,7 @@ describe('ReportGenerator', () => {
             assessmentStoreData,
             assessmentsProvider,
             featureFlagStoreData,
-            scanTargetData,
+            targetAppInfo,
             assessmentDescription,
         );
 

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -26,6 +26,10 @@ describe('ReportGenerator', () => {
     const toolDataStub: ToolData = {
         applicationProperties: { name: 'some app' },
     } as ToolData;
+    const scanTargetData = {
+        name: title,
+        url: url,
+    };
 
     let dataBuilderMock: IMock<ReportHtmlGenerator>;
     let nameBuilderMock: IMock<ReportNameGenerator>;
@@ -61,8 +65,7 @@ describe('ReportGenerator', () => {
         );
         const actual = testObject.generateFastPassAutomatedChecksReport(
             date,
-            title,
-            url,
+            scanTargetData,
             cardsViewDataStub,
             description,
             toolDataStub,
@@ -84,7 +87,7 @@ describe('ReportGenerator', () => {
                     assessmentStoreData,
                     assessmentsProvider,
                     featureFlagStoreData,
-                    tabStoreData,
+                    scanTargetData,
                     assessmentDescription,
                 ),
             )
@@ -100,7 +103,7 @@ describe('ReportGenerator', () => {
             assessmentStoreData,
             assessmentsProvider,
             featureFlagStoreData,
-            tabStoreData,
+            scanTargetData,
             assessmentDescription,
         );
 

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -3,7 +3,6 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { AssessmentReportHtmlGenerator } from 'reports/assessment-report-html-generator';
 import { ReportGenerator } from 'reports/report-generator';
@@ -78,7 +77,6 @@ describe('ReportGenerator', () => {
         const assessmentStoreData: AssessmentStoreData = { stub: 'assessmentStoreData' } as any;
         const assessmentsProvider: AssessmentsProvider = { stub: 'assessmentsProvider' } as any;
         const featureFlagStoreData: FeatureFlagStoreData = { stub: 'featureFlagStoreData' } as any;
-        const tabStoreData: TabStoreData = { stub: 'tabStoreData' } as any;
         const assessmentDescription = 'generateAssessmentHtml-description';
 
         assessmentReportHtmlGeneratorMock

--- a/src/tests/unit/tests/reports/report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/report-html-generator.test.tsx
@@ -63,8 +63,10 @@ describe('ReportHtmlGenerator', () => {
             } as SectionDeps,
             fixInstructionProcessor: fixInstructionProcessorMock.object,
             sectionFactory: sectionFactoryMock.object as ReportBodySectionFactory,
-            pageTitle,
-            pageUrl,
+            targetAppInfo: {
+                name: pageTitle,
+                url: pageUrl,
+            },
             description,
             scanDate,
             toolData,


### PR DESCRIPTION
#### Description of changes

- Add TargetAppInfo (containing name and url) to ScanMetaData
- Consume in report sections (header and details) and name generator
- Remove dependencies on tabStoreData which are no longer needed
- Remove duplicate targetAppInfo in DetailsViewContainer

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
