### PR TITLE
feat(android-report): minor improvements to passed section

### DIFF
--- a/src/reports/components/report-sections/full-rule-header.tsx
+++ b/src/reports/components/report-sections/full-rule-header.tsx
@@ -6,9 +6,8 @@ import { NewTabLink } from 'common/components/new-tab-link';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { NamedFC } from 'common/react/named-fc';
 import { CardRuleResult } from 'common/types/store-data/card-view-model';
-import { kebabCase } from 'lodash';
+import { isEmpty, kebabCase } from 'lodash';
 import * as React from 'react';
-
 import { InstanceOutcomeType } from '../instance-outcome-type';
 import { OutcomeChip } from '../outcome-chip';
 import { outcomeTypeSemantics } from '../outcome-type';
@@ -44,21 +43,29 @@ export const FullRuleHeader = NamedFC<FullRuleHeaderProps>('FullRuleHeader', pro
     const renderRuleLink = () => {
         const ruleId = cardResult.id;
         const ruleUrl = cardResult.url;
-        return (
-            <span className="rule-details-id">
-                <NewTabLink
-                    href={ruleUrl}
-                    aria-label={`rule ${ruleId}`}
-                    aria-describedby={ariaDescribedBy}
-                >
-                    {ruleId}
-                </NewTabLink>
-            </span>
+        const displayedRule = ruleUrl ? (
+            <NewTabLink
+                href={ruleUrl}
+                aria-label={`rule ${ruleId}`}
+                aria-describedby={ariaDescribedBy}
+            >
+                {ruleId}
+            </NewTabLink>
+        ) : (
+            <>{ruleId}</>
         );
+        return <span className="rule-details-id">{displayedRule}</span>;
     };
 
     const renderGuidanceLinks = () => {
-        return <GuidanceLinks links={cardResult.guidance} />;
+        if (isEmpty(cardResult.guidance)) {
+            return null;
+        }
+        return (
+            <>
+                (<GuidanceLinks links={cardResult.guidance} />)
+            </>
+        );
     };
 
     const renderDescription = () => {
@@ -77,8 +84,9 @@ export const FullRuleHeader = NamedFC<FullRuleHeaderProps>('FullRuleHeader', pro
         <>
             <div className="rule-detail">
                 <div>
-                    {renderCountBadge()} {renderRuleLink()}: {renderDescription()} (
-                    {renderGuidanceLinks()}){renderGuidanceTags()}
+                    {renderCountBadge()} {renderRuleLink()}: {renderDescription()}
+                    {renderGuidanceLinks()}
+                    {renderGuidanceTags()}
                 </div>
             </div>
         </>

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/full-rule-header.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/full-rule-header.test.tsx.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`FullRuleHeader guidance links and the containing parenthesis are not rendered without guidance 1`] = `
+<React.Fragment>
+  <div
+    className="rule-detail"
+  >
+    <div>
+      <span
+        aria-hidden="true"
+      >
+        <OutcomeChip
+          count={1}
+          outcomeType="fail"
+        />
+      </span>
+       
+      <span
+        className="rule-details-id"
+      >
+        <NewTabLink
+          aria-describedby="failed-rule-rule id-description"
+          aria-label="rule rule id"
+          href="url://help.url"
+        >
+          rule id
+        </NewTabLink>
+      </span>
+      : 
+      <span
+        className="rule-details-description"
+        id="failed-rule-rule id-description"
+      >
+        rule description
+      </span>
+      <GuidanceTags
+        deps={Object {}}
+        links={null}
+      />
+    </div>
+  </div>
+</React.Fragment>
+`;
+
 exports[`FullRuleHeader renders, outcomeType = fail 1`] = `
 <React.Fragment>
   <div
@@ -33,22 +75,24 @@ exports[`FullRuleHeader renders, outcomeType = fail 1`] = `
       >
         rule description
       </span>
-       (
-      <GuidanceLinks
-        links={
-          Array [
-            Object {
-              "href": "url://guidance-01.link",
-              "text": "guidance-01",
-            },
-            Object {
-              "href": "url://guidance-02.link",
-              "text": "guidance-02",
-            },
-          ]
-        }
-      />
-      )
+      <React.Fragment>
+        (
+        <GuidanceLinks
+          links={
+            Array [
+              Object {
+                "href": "url://guidance-01.link",
+                "text": "guidance-01",
+              },
+              Object {
+                "href": "url://guidance-02.link",
+                "text": "guidance-02",
+              },
+            ]
+          }
+        />
+        )
+      </React.Fragment>
       <GuidanceTags
         deps={Object {}}
         links={
@@ -94,22 +138,24 @@ exports[`FullRuleHeader renders, outcomeType = inapplicable 1`] = `
       >
         rule description
       </span>
-       (
-      <GuidanceLinks
-        links={
-          Array [
-            Object {
-              "href": "url://guidance-01.link",
-              "text": "guidance-01",
-            },
-            Object {
-              "href": "url://guidance-02.link",
-              "text": "guidance-02",
-            },
-          ]
-        }
-      />
-      )
+      <React.Fragment>
+        (
+        <GuidanceLinks
+          links={
+            Array [
+              Object {
+                "href": "url://guidance-01.link",
+                "text": "guidance-01",
+              },
+              Object {
+                "href": "url://guidance-02.link",
+                "text": "guidance-02",
+              },
+            ]
+          }
+        />
+        )
+      </React.Fragment>
       <GuidanceTags
         deps={Object {}}
         links={
@@ -155,8 +201,26 @@ exports[`FullRuleHeader renders, outcomeType = pass 1`] = `
       >
         rule description
       </span>
-       (
-      <GuidanceLinks
+      <React.Fragment>
+        (
+        <GuidanceLinks
+          links={
+            Array [
+              Object {
+                "href": "url://guidance-01.link",
+                "text": "guidance-01",
+              },
+              Object {
+                "href": "url://guidance-02.link",
+                "text": "guidance-02",
+              },
+            ]
+          }
+        />
+        )
+      </React.Fragment>
+      <GuidanceTags
+        deps={Object {}}
         links={
           Array [
             Object {
@@ -170,7 +234,58 @@ exports[`FullRuleHeader renders, outcomeType = pass 1`] = `
           ]
         }
       />
-      )
+    </div>
+  </div>
+</React.Fragment>
+`;
+
+exports[`FullRuleHeader ruleId is displayed as text when there is no url provided for a link 1`] = `
+<React.Fragment>
+  <div
+    className="rule-detail"
+  >
+    <div>
+      <span
+        aria-hidden="true"
+      >
+        <OutcomeChip
+          count={1}
+          outcomeType="fail"
+        />
+      </span>
+       
+      <span
+        className="rule-details-id"
+      >
+        <React.Fragment>
+          rule id
+        </React.Fragment>
+      </span>
+      : 
+      <span
+        className="rule-details-description"
+        id="failed-rule-rule id-description"
+      >
+        rule description
+      </span>
+      <React.Fragment>
+        (
+        <GuidanceLinks
+          links={
+            Array [
+              Object {
+                "href": "url://guidance-01.link",
+                "text": "guidance-01",
+              },
+              Object {
+                "href": "url://guidance-02.link",
+                "text": "guidance-02",
+              },
+            ]
+          }
+        />
+        )
+      </React.Fragment>
       <GuidanceTags
         deps={Object {}}
         links={

--- a/src/tests/unit/tests/reports/components/report-sections/full-rule-header.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/full-rule-header.test.tsx
@@ -11,29 +11,60 @@ import {
 } from 'reports/components/report-sections/full-rule-header';
 
 describe('FullRuleHeader', () => {
-    const depsStub = {} as FullRuleHeaderDeps;
-    const rule: CardRuleResult = {
-        url: 'url://help.url',
-        id: 'rule id',
-        description: 'rule description',
-        guidance: [
-            {
-                href: 'url://guidance-01.link',
-                text: 'guidance-01',
-            },
-            {
-                href: 'url://guidance-02.link',
-                text: 'guidance-02',
-            },
-        ],
-        nodes: [{}],
-    } as CardRuleResult;
+    let depsStub: FullRuleHeaderDeps;
+    let rule: CardRuleResult;
+
+    beforeEach(() => {
+        depsStub = {} as FullRuleHeaderDeps;
+        rule = {
+            url: 'url://help.url',
+            id: 'rule id',
+            description: 'rule description',
+            guidance: [
+                {
+                    href: 'url://guidance-01.link',
+                    text: 'guidance-01',
+                },
+                {
+                    href: 'url://guidance-02.link',
+                    text: 'guidance-02',
+                },
+            ],
+            nodes: [{}],
+        } as CardRuleResult;
+    });
 
     it.each(allInstanceOutcomeTypes)('renders, outcomeType = %s', outcomeType => {
         const props: FullRuleHeaderProps = {
             deps: depsStub,
             cardRuleResult: rule,
             outcomeType,
+        };
+
+        const wrapped = shallow(<FullRuleHeader {...props} />);
+
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+
+    test('guidance links and the containing parenthesis are not rendered without guidance', () => {
+        rule.guidance = null;
+        const props: FullRuleHeaderProps = {
+            deps: depsStub,
+            cardRuleResult: rule,
+            outcomeType: 'fail',
+        };
+
+        const wrapped = shallow(<FullRuleHeader {...props} />);
+
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+
+    test('ruleId is displayed as text when there is no url provided for a link', () => {
+        rule.url = null;
+        const props: FullRuleHeaderProps = {
+            deps: depsStub,
+            cardRuleResult: rule,
+            outcomeType: 'fail',
         };
 
         const wrapped = shallow(<FullRuleHeader {...props} />);


### PR DESCRIPTION
#### Description of changes

A couple changes:
1. Rules are not rendered as links when there is no url in passed/not-applicable section.
2. Rules that do not have guidance will not have empty parenthesis where that guidance link would go.

These changes apply to Web and the not applicable section as well. However, since we do not show that yet and both changes will not realistically be shown in Web, it doesn't "really" apply, if that makes sense. As in, no user should see them but since they are shared components, they changes are there.

Before on the left, After on the right:
![image](https://user-images.githubusercontent.com/32555133/79268623-ee139b80-7e4f-11ea-9027-ca4785ca1a9a.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
