### PR TITLE
chore: add first-time-dialog test for electron

### DIFF
--- a/src/tests/electron/tests/first-time-dialog.test.ts
+++ b/src/tests/electron/tests/first-time-dialog.test.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { createApplication } from 'tests/electron/common/create-application';
+import { scanForAccessibilityIssues } from 'tests/electron/common/scan-for-accessibility-issues';
+import { AppController } from 'tests/electron/common/view-controllers/app-controller';
+import { DeviceConnectionDialogController } from 'tests/electron/common/view-controllers/device-connection-dialog-controller';
+
+describe('first time dialog', () => {
+    let app: AppController;
+    let dialog: DeviceConnectionDialogController;
+
+    beforeEach(async () => {
+        app = await createApplication({ suppressFirstTimeDialog: false });
+        dialog = await app.openDeviceConnectionDialog();
+    });
+
+    afterEach(async () => {
+        dialog = null;
+        if (app != null) {
+            await app.stop();
+        }
+    });
+
+    it.each([true, false])(
+        'should pass accessibility validation with highContrastMode=%s',
+        async highContrastMode => {
+            await app.setHighContrastMode(highContrastMode);
+            await app.waitForHighContrastMode(highContrastMode);
+
+            const violations = await scanForAccessibilityIssues(dialog);
+            expect(violations).toStrictEqual([]);
+        },
+    );
+});


### PR DESCRIPTION
#### Description of changes

This PR follows up on #2327 by adding an a11y end-to-end test for the first-time-dialog in unified. It's helpful to have the e2e test for both web & unified because of layering scenarios that don't show up in the web test, such as the issue in https://github.com/microsoft/accessibility-insights-web/issues/2316

alternative implementations:
- fully fold the `first-time-dialog` into `DeviceConnectionDialogController` by adding an explicit `dismissTelemetryDialog()` method. Remove the existing `suppressFirstTimeDialog` flag in `createApplication`. This would collapse this new e2e test file with the existing `device-connection-dialog` tests, reducing the number of times we need to restart the app
- move `this.waitForSelector(CommonSelectors.rootContainer)` into `AppController` and similarly refactor it and/or `scanForAccessibilityIssues` so that this test file doesn't have to touch `DeviceConnectionDialogController` at all 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
