### PR TITLE
refactor: rename exportReport feature flag

### DIFF
--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -138,7 +138,7 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
             />
             <DialogFooter>
                 <FlaggedComponent
-                    featureFlag={FeatureFlags.exportReport}
+                    featureFlag={FeatureFlags.exportReportOptions}
                     featureFlagStoreData={props.featureFlagStoreData}
                     enableJSXElement={getMultiOptionExportButton()}
                     disableJSXElement={getSingleExportToHtmlButton()}

--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -14,7 +14,7 @@ export class FeatureFlags {
     public static readonly manualInstanceDetails = 'manualInstanceDetails';
     public static readonly debugTools = 'debugTools';
 
-    public static readonly exportReport = 'exportReport';
+    public static readonly exportReportOptions = 'exportReportOptions';
 }
 
 export interface FeatureFlagDetail {
@@ -102,7 +102,7 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
             forceDefault: false,
         },
         {
-            id: FeatureFlags.exportReport,
+            id: FeatureFlags.exportReportOptions,
             defaultValue: false,
             displayableName: 'More export options',
             displayableDescription: 'Enables exporting reports to external services',

--- a/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
+++ b/src/tests/end-to-end/tests/details-view/__snapshots__/preview-features.test.ts.snap
@@ -104,7 +104,7 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
                           aria-label="More export options"
                           class="ms-Toggle-background pill-000"
                           data-is-focusable="true"
-                          id="exportReport"
+                          id="exportReportOptions"
                           role="switch"
                           type="button"
                         >
@@ -114,8 +114,8 @@ exports[`Details View -> Preview Features Panel should match content in snapshot
                         </button>
                         <label
                           class="ms-Label ms-Toggle-stateText text-000"
-                          for="exportReport"
-                          id="exportReport-stateText"
+                          for="exportReportOptions"
+                          id="exportReportOptions-stateText"
                         >
                           Off
                         </label>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
@@ -85,7 +85,7 @@ exports[`ExportDialog renders with open false 1`] = `
           />
         </React.Fragment>
       }
-      featureFlag="exportReport"
+      featureFlag="exportReportOptions"
       featureFlagStoreData={Object {}}
     />
   </StyledDialogFooterBase>
@@ -154,7 +154,7 @@ exports[`ExportDialog renders with open true 1`] = `
           />
         </React.Fragment>
       }
-      featureFlag="exportReport"
+      featureFlag="exportReportOptions"
       featureFlagStoreData={Object {}}
     />
   </StyledDialogFooterBase>

--- a/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/export-dialog.test.tsx
@@ -172,7 +172,7 @@ describe('ExportDialog', () => {
                 .returns(() => [CodePenReportExportService])
                 .verifiable(Times.exactly(2));
 
-            props.featureFlagStoreData[FeatureFlags.exportReport] = true;
+            props.featureFlagStoreData[FeatureFlags.exportReportOptions] = true;
 
             const wrapper = shallow(<ExportDialog {...props} />);
 

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -25,7 +25,7 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.showInstanceVisibility]: false,
             [FeatureFlags.manualInstanceDetails]: false,
             [FeatureFlags.debugTools]: false,
-            [FeatureFlags.exportReport]: false,
+            [FeatureFlags.exportReportOptions]: false,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);

--- a/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
+++ b/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { FeatureFlagDefaultsHelper } from 'common/feature-flag-defaults-helper';
+import { getAllFeatureFlagDetails } from 'common/feature-flags';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import {
     getAllFeatureFlagDetailsUnified,
@@ -80,6 +81,20 @@ describe('FeatureFlagsTest', () => {
         forEach(details, detail => {
             expect(detail.displayableName.length > 0).toBeTruthy();
             expect(detail.displayableDescription.length > 0).toBeTruthy();
+        });
+    });
+
+    test('web and electron feature flags with matching names should have the same purpose', () => {
+        const unifiedDetails = getAllFeatureFlagDetailsUnified();
+        const webDetails = getAllFeatureFlagDetails();
+
+        unifiedDetails.forEach(unifiedDetail => {
+            const matchingWebDetail = webDetails.find(
+                webDetail => webDetail.id === unifiedDetail.id,
+            );
+            if (matchingWebDetail !== undefined) {
+                expect(unifiedDetail.displayableName).toEqual(matchingWebDetail.displayableName);
+            }
         });
     });
 });

--- a/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
+++ b/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
@@ -94,6 +94,9 @@ describe('FeatureFlagsTest', () => {
             );
             if (matchingWebDetail !== undefined) {
                 expect(unifiedDetail.displayableName).toEqual(matchingWebDetail.displayableName);
+                expect(unifiedDetail.displayableDescription).toEqual(
+                    matchingWebDetail.displayableDescription,
+                );
             }
         });
     });


### PR DESCRIPTION
#### Description of changes

The feature flag on web to enable exporting to CodePen currently has the same name as the feature flag to enable the export report button in electron. As a result, turning on this feature flag in electron automatically also enables exporting to CodePen, which we do not want. This PR renames the CodePen feature flag from exportReport to exportReportOptions

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
