### PR TITLE
fix: improvement to alignment w/ outcome chip in reports result title section.

### DIFF
--- a/src/common/components/cards/result-section-title.scss
+++ b/src/common/components/cards/result-section-title.scss
@@ -12,13 +12,9 @@
     margin-bottom: 8px;
 
     :global(.outcome-chip) {
-        :global(.count) {
-            line-height: 11px;
-        }
-
         &:global(.outcome-chip-fail) {
             :global(.count) {
-                line-height: 13px;
+                line-height: 11px;
             }
 
             svg {
@@ -35,6 +31,6 @@
 
     .outcome-chip-container {
         display: flex;
-        margin-top: 2px;
+        height: 16px;
     }
 }


### PR DESCRIPTION
#### Description of changes

This doesn't fix all the alignment issues (and that's tough to do due to this being rendered differently in each scenario) but it does improve the situation quite a bit.

Automated Checks in Web Before vs After (left to right):
![image](https://user-images.githubusercontent.com/32555133/79285818-7ce5df80-7e73-11ea-86c1-74f2bc5e701d.png)

Automated Checks Report in Web Before vs After
![image](https://user-images.githubusercontent.com/32555133/79285857-9edf6200-7e73-11ea-8c05-aa3ed5c570e9.png)

Automated Checks in Unified Before vs After:
![image](https://user-images.githubusercontent.com/32555133/79286016-24fba880-7e74-11ea-8b07-e1a789c7d41e.png)
![image](https://user-images.githubusercontent.com/32555133/79285977-02698f80-7e74-11ea-8102-516c993d90d1.png)

Automated Checks Report in Unified Before vs After:
![image](https://user-images.githubusercontent.com/32555133/79286117-6f7d2500-7e74-11ea-8425-0ec6d50e26f6.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
