### PR TITLE
feat(android-report): fixed body color and summary section ordering

### DIFF
--- a/src/electron/views/root-container/components/root-container.scss
+++ b/src/electron/views/root-container/components/root-container.scss
@@ -7,8 +7,11 @@ body {
     margin: 0px;
     height: 100%;
     width: 100%;
-    background-color: $neutral-0;
     font-family: $fontFamily;
+}
+
+#root-container {
+    background-color: $neutral-0;
 }
 
 button {

--- a/src/electron/views/root-container/components/root-container.scss
+++ b/src/electron/views/root-container/components/root-container.scss
@@ -10,7 +10,7 @@ body {
     font-family: $fontFamily;
 }
 
-#root-container {
+:global(#root-container) {
     background-color: $neutral-0;
 }
 

--- a/src/reports/components/report-sections/summary-section.tsx
+++ b/src/reports/components/report-sections/summary-section.tsx
@@ -45,6 +45,6 @@ export const AllOutcomesSummarySection = NamedFC<SummarySectionProps>(
 export const PassFailSummarySection = NamedFC<SummarySectionProps>(
     'PassFailSummarySection',
     props => {
-        return <BaseSummarySection {...props} outcomeTypesShown={['pass', 'fail']} />;
+        return <BaseSummarySection {...props} outcomeTypesShown={['fail', 'pass']} />;
     },
 );

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/summary-section.test.tsx.snap
@@ -193,8 +193,8 @@ exports[`SummarySection PassFailSummarySection renders BaseSummarySection with o
   cardsViewData={Object {}}
   outcomeTypesShown={
     Array [
-      "pass",
       "fail",
+      "pass",
     ]
   }
 />


### PR DESCRIPTION
#### Description of changes

Before vs After:
![image](https://user-images.githubusercontent.com/32555133/79287175-c801f180-7e77-11ea-9e05-1305bc1a4dae.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
