### PR TITLE
feat(android-report): match export report dialog width to with web (25%)

### DIFF
--- a/src/electron/views/renderer-global-styles.scss
+++ b/src/electron/views/renderer-global-styles.scss
@@ -10,3 +10,9 @@
 .ms-Fabric {
     color: $primary-text;
 }
+
+//  Required as GenericDialog is not using css-modules. Once that is done, this can be removed.
+.insights-dialog-main-override {
+    max-width: 25%;
+    width: 25%;
+}


### PR DESCRIPTION
#### Description of changes


![image](https://user-images.githubusercontent.com/32555133/79287745-a0138d80-7e79-11ea-8c54-04cc2fa65f3a.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
