### PR TITLE
test: try removing null setters in e2e test cleanup

### DIFF
--- a/src/tests/electron/tests/automated-checks-view.test.ts
+++ b/src/tests/electron/tests/automated-checks-view.test.ts
@@ -23,7 +23,6 @@ describe('AutomatedChecksView', () => {
     });
 
     afterEach(async () => {
-        automatedChecksView = null;
         if (app != null) {
             await app.stop();
         }

--- a/src/tests/electron/tests/device-connection-dialog.test.ts
+++ b/src/tests/electron/tests/device-connection-dialog.test.ts
@@ -16,7 +16,6 @@ describe('device connection dialog', () => {
     });
 
     afterEach(async () => {
-        dialog = null;
         if (app != null) {
             await app.stop();
         }

--- a/src/tests/electron/tests/unified-settings-panel.test.ts
+++ b/src/tests/electron/tests/unified-settings-panel.test.ts
@@ -19,7 +19,6 @@ describe('AutomatedChecksView -> Settings Panel', () => {
     });
 
     afterEach(async () => {
-        automatedChecksView = null;
         if (app != null) {
             await app.stop();
         }


### PR DESCRIPTION
#### Description of changes

This PR removes `dialog = null` setters in our e2e tests. While the electron BrowserWindow should be set to null upon close per docs [here](https://github.com/electron/electron/blob/master/docs/api/browser-window.md#event-closed), it doesn't seem clear that this is related. In this PR check, the electron-e2e-reliability build had 3 (out of 18) failures that seemed to match existing e2e flakiness symptoms.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
