### PR TITLE
test: update setHighContrastMode to wait for userConfig controller

### DIFF
--- a/src/tests/electron/common/view-controllers/app-controller.ts
+++ b/src/tests/electron/common/view-controllers/app-controller.ts
@@ -44,6 +44,8 @@ export class AppController {
     }
 
     public async setHighContrastMode(enableHighContrast: boolean): Promise<void> {
+        await this.waitForUserConfigurationInitializer();
+
         await this.app.webContents.executeJavaScript(
             `window.insightsUserConfiguration.setHighContrastMode(${enableHighContrast})`,
         );
@@ -70,6 +72,14 @@ export class AppController {
     }
 
     public async setTelemetryState(enableTelemetry: boolean): Promise<void> {
+        await this.waitForUserConfigurationInitializer();
+
+        await this.app.webContents.executeJavaScript(
+            `window.insightsUserConfiguration.setTelemetryState(${enableTelemetry})`,
+        );
+    }
+
+    private async waitForUserConfigurationInitializer(): Promise<void> {
         await this.client.waitUntil(
             async () => {
                 const executeOutput = await this.client.executeAsync(done => {
@@ -80,10 +90,6 @@ export class AppController {
             },
             DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS,
             'was expecting window.insightsUserConfiguration to be defined',
-        );
-
-        await this.app.webContents.executeJavaScript(
-            `window.insightsUserConfiguration.setTelemetryState(${enableTelemetry})`,
         );
     }
 }


### PR DESCRIPTION
#### Description of changes

This attempts to fix a unified e2e reliability issue of the form ([example](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=74210&view=ms.vss-test-web.build-test-results-tab&runId=2247790&resultId=100021&paneView=debug)):

```
Error: An error occurred while executing user supplied JavaScript.
    at executeAsync(<Function>, "window.insightsUserConfiguration.setHighContrastMode(false)", , "require") - D:\a\1\s\node_modules\spectron\lib\api.js:393:17
```

This happens inconsistently and I don't have a local repro to verify exactly what the exception is, but my suspicion is that it might be invoking this bit of script before the insightsUserConfiguration controller is initialized, so this updates the code to wait for it like we already do for `setTelemetryState`.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
