### PR TITLE
test(unified): attempted fix for unified-settings-panel test mispositioned click

### DIFF
--- a/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
+++ b/src/tests/electron/common/view-controllers/automated-checks-view-controller.ts
@@ -39,6 +39,7 @@ export class AutomatedChecksViewController extends ViewController {
         await this.waitForSelector(AutomatedChecksViewSelectors.settingsButton);
         await this.click(AutomatedChecksViewSelectors.settingsButton);
         await this.waitForSelector(settingsPanelSelectors.settingsPanel);
+        await this.waitForMilliseconds(750); // Allow for fabric's panel animation to settle
     }
 
     public async setToggleState(toggleSelector: string, newState: boolean): Promise<void> {

--- a/src/tests/electron/common/view-controllers/view-controller.ts
+++ b/src/tests/electron/common/view-controllers/view-controller.ts
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as fs from 'fs';
-import { DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS } from 'tests/electron/setup/timeouts';
+import {
+    DEFAULT_CLICK_HOVER_DELAY_MS,
+    DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS,
+} from 'tests/electron/setup/timeouts';
 import * as WebDriverIO from 'webdriverio';
 import { screenshotOnError } from '../../../end-to-end/common/screenshot-on-error';
 
@@ -38,6 +41,15 @@ export abstract class ViewController {
                 `was expecting element by selector ${selector} to disappear`,
             ),
         );
+    }
+
+    // You should avoid using this in most cases!
+    //
+    // This should only be used for cases where the product's intended functionality involves a
+    // time-based delay (eg, a UI element animates in before becoming active), NOT sprinkled in
+    // randomly in the hopes that it improves reliability.
+    public async waitForMilliseconds(durationInMilliseconds: number): Promise<void> {
+        await this.client.pause(durationInMilliseconds);
     }
 
     public async click(selector: string): Promise<void> {

--- a/src/tests/electron/common/view-controllers/view-controller.ts
+++ b/src/tests/electron/common/view-controllers/view-controller.ts
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as fs from 'fs';
-import {
-    DEFAULT_CLICK_HOVER_DELAY_MS,
-    DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS,
-} from 'tests/electron/setup/timeouts';
+import { DEFAULT_WAIT_FOR_ELEMENT_TO_BE_VISIBLE_TIMEOUT_MS } from 'tests/electron/setup/timeouts';
 import * as WebDriverIO from 'webdriverio';
 import { screenshotOnError } from '../../../end-to-end/common/screenshot-on-error';
 


### PR DESCRIPTION
#### Description of changes

This PR attempts to fix the following class of unified e2e flakiness ([example](https://dev.azure.com/ms/accessibility-insights-web/_build/results?buildId=74651&view=logs&j=5ca0a2fb-3894-5dc8-ae91-49e140341ffc&t=e3a7ed4b-97f0-5ad9-e559-3ac0c9f4f59d)):

```
FAIL electron tests src/tests/electron/tests/unified-settings-panel.test.ts (30.64s)
  ● Console

    console.log src/tests/end-to-end/common/screenshot-on-error.ts:14
      Screenshot file is located at: /Users/runner/runners/2.166.3/work/1/s/test-results/e2e/failure-screenshots/1ba4b7a7-6b32-4d89-a963-0ce7e0d3d78b.png

  ● AutomatedChecksView -> Settings Panel › High Contrast Mode toggle › should apply the appropriate CSS style when High Contrast Mode setting is toggled

    element click intercepted: Element <button id="enable-high-contrast-mode" class="ms-Toggle-background pill-154" type="button" role="switch" aria-checked="false" aria-label="Enable high contrast" data-is-focusable="true">...</button> is not clickable at point (1136, 400). Other element would receive the click: <label for="enable-high-contrast-mode" class="ms-Label ms-Toggle-stateText text-156" id="enable-high-contrast-mode-stateText">...</label>

      at new RuntimeError (node_modules/webdriverio/build/lib/utils/ErrorHandler.js:143:12)
      at Request._callback (node_modules/webdriverio/build/lib/utils/RequestHandler.js:318:39)
      at Request.self.callback (node_modules/request/request.js:185:22)
      at Request.<anonymous> (node_modules/request/request.js:1161:10)
      at IncomingMessage.<anonymous> (node_modules/request/request.js:1083:12)
```

The hypothesis here is that the "element is not clickable at expected position" error is probably happening because it's trying to click on the panel element while the panel hasn't finished animating in yet, so the attempted solution adds a delay corresponding to the panel animation time.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
