### PR TITLE
tools: telemetry viewer

### DIFF
--- a/src/debug-tools/components/telemetry-viewer/telemetry-common-fields.scss
+++ b/src/debug-tools/components/telemetry-viewer/telemetry-common-fields.scss
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.container {
+    display: grid;
+    grid-template-columns: 7em auto;
+    column-gap: 1em;
+
+    > strong {
+        justify-self: end;
+    }
+}

--- a/src/debug-tools/components/telemetry-viewer/telemetry-common-fields.tsx
+++ b/src/debug-tools/components/telemetry-viewer/telemetry-common-fields.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { DebugToolsTelemetryMessage } from 'debug-tools/controllers/telemetry-listener';
+import * as React from 'react';
+import * as styles from './telemetry-common-fields.scss';
+
+export type TelemetryCommonFieldsProps = Pick<
+    DebugToolsTelemetryMessage,
+    'applicationBuild' | 'applicationName' | 'applicationVersion' | 'installationId'
+>;
+
+export const TelemetryCommonFields = NamedFC<TelemetryCommonFieldsProps>(
+    'TelemetryCommonFields',
+    ({ applicationBuild, applicationName, applicationVersion, installationId }) => (
+        <div className={styles.container}>
+            <strong>Build:</strong>
+            <span>{applicationBuild}</span>
+            <strong>Name:</strong>
+            <span>{applicationName}</span>
+            <strong>Version:</strong>
+            <span>{applicationVersion}</span>
+            <strong>Installation Id:</strong>
+            <span>{installationId}</span>
+        </div>
+    ),
+);

--- a/src/debug-tools/components/telemetry-viewer/telemetry-messages-list.tsx
+++ b/src/debug-tools/components/telemetry-viewer/telemetry-messages-list.tsx
@@ -7,15 +7,20 @@ import * as moment from 'moment';
 import { DetailsList, IColumn } from 'office-ui-fabric-react';
 import * as React from 'react';
 
-export type DateFormatter = (timestampe: number) => string;
-export type TelemetryMessagesListProps = {
-    items: DebugToolsTelemetryMessage[];
+export type DateFormatter = (timestamp: number) => string;
+
+export type TelemetryMessagesListDeps = {
     dateFormatter: DateFormatter;
+};
+
+export type TelemetryMessagesListProps = {
+    deps: TelemetryMessagesListDeps;
+    items: DebugToolsTelemetryMessage[];
 };
 
 export const TelemetryMessagesList = NamedFC<TelemetryMessagesListProps>(
     'TelemetryMessagesList',
-    ({ items, dateFormatter }) => {
+    ({ items, deps }) => {
         const columns: IColumn[] = [
             {
                 key: 'date',
@@ -24,7 +29,7 @@ export const TelemetryMessagesList = NamedFC<TelemetryMessagesListProps>(
                 isResizable: true,
                 minWidth: 100,
                 maxWidth: 130,
-                onRender: item => onRenderTimestamp(item, dateFormatter),
+                onRender: item => onRenderTimestamp(item, deps.dateFormatter),
             },
             {
                 key: 'eventName',

--- a/src/debug-tools/components/telemetry-viewer/telemetry-messages-list.tsx
+++ b/src/debug-tools/components/telemetry-viewer/telemetry-messages-list.tsx
@@ -7,13 +7,15 @@ import * as moment from 'moment';
 import { DetailsList, IColumn } from 'office-ui-fabric-react';
 import * as React from 'react';
 
+export type DateFormatter = (timestampe: number) => string;
 export type TelemetryMessagesListProps = {
     items: DebugToolsTelemetryMessage[];
+    dateFormatter: DateFormatter;
 };
 
 export const TelemetryMessagesList = NamedFC<TelemetryMessagesListProps>(
     'TelemetryMessagesList',
-    ({ items }) => {
+    ({ items, dateFormatter }) => {
         const columns: IColumn[] = [
             {
                 key: 'date',
@@ -22,7 +24,7 @@ export const TelemetryMessagesList = NamedFC<TelemetryMessagesListProps>(
                 isResizable: true,
                 minWidth: 100,
                 maxWidth: 130,
-                onRender: onRenderTimestamp,
+                onRender: item => onRenderTimestamp(item, dateFormatter),
             },
             {
                 key: 'eventName',
@@ -77,7 +79,11 @@ export const onRenderCustomProperties = (
     return <span>{toRender}</span>;
 };
 
-export const onRenderTimestamp = (item: DebugToolsTelemetryMessage): JSX.Element => {
-    const dateString = moment(item.timestamp).format('YYYY-MMM-DD HH:mm:ss.S');
-    return <span>{dateString}</span>;
-};
+export const onRenderTimestamp = (
+    item: DebugToolsTelemetryMessage,
+    dateFormatter: DateFormatter,
+): JSX.Element => <span>{dateFormatter(item.timestamp)}</span>;
+
+export const defaultDateFormatter: DateFormatter = timestamp =>
+    // untested line: moment is sensitive to the host machine time zone
+    moment(timestamp).format('YYYY-MMM-DD HH:mm:ss.S');

--- a/src/debug-tools/components/telemetry-viewer/telemetry-messages-list.tsx
+++ b/src/debug-tools/components/telemetry-viewer/telemetry-messages-list.tsx
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { DebugToolsTelemetryMessage } from 'debug-tools/controllers/telemetry-listener';
+import { isEmpty } from 'lodash';
+import * as moment from 'moment';
+import { DetailsList, IColumn } from 'office-ui-fabric-react';
+import * as React from 'react';
+
+export type TelemetryMessagesListProps = {
+    items: DebugToolsTelemetryMessage[];
+};
+
+export const TelemetryMessagesList = NamedFC<TelemetryMessagesListProps>(
+    'TelemetryMessagesList',
+    ({ items }) => {
+        const columns: IColumn[] = [
+            {
+                key: 'date',
+                name: 'date & time',
+                fieldName: 'timestamp',
+                isResizable: true,
+                minWidth: 100,
+                maxWidth: 130,
+                onRender: onRenderTimestamp,
+            },
+            {
+                key: 'eventName',
+                name: 'event name',
+                fieldName: 'name',
+                isResizable: true,
+                minWidth: 100,
+                maxWidth: 130,
+            },
+            {
+                key: 'source',
+                name: 'source',
+                fieldName: 'source',
+                isResizable: true,
+                minWidth: 100,
+                maxWidth: 100,
+            },
+            {
+                key: 'triggeredBy',
+                name: 'triggeredBy',
+                fieldName: 'triggeredBy',
+                isResizable: true,
+                minWidth: 100,
+                maxWidth: 100,
+            },
+            {
+                key: 'customProperties',
+                name: 'custom properties',
+                fieldName: 'customProperties',
+                isResizable: true,
+                minWidth: 100,
+                onRender: onRenderCustomProperties.bind(null, 'customProperties'),
+            },
+        ];
+
+        return <DetailsList items={items} columns={columns} />;
+    },
+);
+
+export const onRenderCustomProperties = (
+    propertyName: keyof DebugToolsTelemetryMessage,
+    item: DebugToolsTelemetryMessage,
+): JSX.Element => {
+    const propertyValue = item[propertyName];
+
+    let toRender = '-';
+
+    if (!isEmpty(propertyValue)) {
+        toRender = JSON.stringify(propertyValue);
+    }
+
+    return <span>{toRender}</span>;
+};
+
+export const onRenderTimestamp = (item: DebugToolsTelemetryMessage): JSX.Element => {
+    const dateString = moment(item.timestamp).format('YYYY-MMM-DD HH:mm:ss.S');
+    return <span>{dateString}</span>;
+};

--- a/src/debug-tools/components/telemetry-viewer/telemetry-viewer.tsx
+++ b/src/debug-tools/components/telemetry-viewer/telemetry-viewer.tsx
@@ -1,7 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TelemetryCommonFields } from 'debug-tools/components/telemetry-viewer/telemetry-common-fields';
-import { TelemetryMessagesList } from 'debug-tools/components/telemetry-viewer/telemetry-messages-list';
+import {
+    TelemetryMessagesList,
+    TelemetryMessagesListDeps,
+} from 'debug-tools/components/telemetry-viewer/telemetry-messages-list';
 import {
     DebugToolsTelemetryMessage,
     TelemetryListener,
@@ -10,7 +13,7 @@ import * as React from 'react';
 
 export type TelemetryViewerDeps = {
     telemetryListener: TelemetryListener;
-};
+} & TelemetryMessagesListDeps;
 
 export interface TelemetryViewerProps {
     deps: TelemetryViewerDeps;
@@ -79,7 +82,7 @@ export class TelemetryViewer extends React.Component<TelemetryViewerProps, Telem
     }
 
     private renderTelemetryMessagesList = () => (
-        <TelemetryMessagesList items={this.state.telemetryMessages} />
+        <TelemetryMessagesList deps={this.props.deps} items={this.state.telemetryMessages} />
     );
 
     private onTelemetryMessage = (telemetryMessage: DebugToolsTelemetryMessage) => {

--- a/src/debug-tools/components/telemetry-viewer/telemetry-viewer.tsx
+++ b/src/debug-tools/components/telemetry-viewer/telemetry-viewer.tsx
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TelemetryCommonFields } from 'debug-tools/components/telemetry-viewer/telemetry-common-fields';
+import { TelemetryMessagesList } from 'debug-tools/components/telemetry-viewer/telemetry-messages-list';
+import {
+    DebugToolsTelemetryMessage,
+    TelemetryListener,
+} from 'debug-tools/controllers/telemetry-listener';
+import * as React from 'react';
+
+export type TelemetryViewerDeps = {
+    telemetryListener: TelemetryListener;
+};
+
+export interface TelemetryViewerProps {
+    deps: TelemetryViewerDeps;
+}
+
+interface TelemetryViewerState {
+    telemetryMessages: DebugToolsTelemetryMessage[];
+}
+
+export class TelemetryViewer extends React.Component<TelemetryViewerProps, TelemetryViewerState> {
+    constructor(props: TelemetryViewerProps) {
+        super(props);
+
+        this.state = {
+            telemetryMessages: [],
+        };
+    }
+
+    public componentDidMount(): void {
+        this.props.deps.telemetryListener.addListener(this.onTelemetryMessage);
+    }
+
+    public render(): JSX.Element {
+        if (this.state.telemetryMessages.length === 0) {
+            return (
+                <>
+                    {this.renderTitle()}
+                    {this.renderNoMessages()}
+                </>
+            );
+        }
+
+        return (
+            <>
+                {this.renderTitle()}
+                {this.renderCommonFields()}
+                {this.renderTelemetryMessagesList()}
+            </>
+        );
+    }
+
+    private renderTitle = () => <h1>Telemetry Viewer</h1>;
+
+    private renderNoMessages = () => (
+        <span>No telemetry messages yet. Use the extension to see something here.</span>
+    );
+
+    private renderCommonFields(): JSX.Element {
+        const lastMessage = this.state.telemetryMessages[0];
+
+        const {
+            applicationBuild,
+            applicationName,
+            applicationVersion,
+            installationId,
+        } = lastMessage;
+
+        const props = {
+            applicationBuild,
+            applicationName,
+            applicationVersion,
+            installationId,
+        };
+
+        return <TelemetryCommonFields {...props} />;
+    }
+
+    private renderTelemetryMessagesList = () => (
+        <TelemetryMessagesList items={this.state.telemetryMessages} />
+    );
+
+    private onTelemetryMessage = (telemetryMessage: DebugToolsTelemetryMessage) => {
+        this.setState({
+            telemetryMessages: [telemetryMessage, ...this.state.telemetryMessages],
+        });
+    };
+}

--- a/src/debug-tools/controllers/telemetry-listener.ts
+++ b/src/debug-tools/controllers/telemetry-listener.ts
@@ -2,12 +2,35 @@
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { ConnectionNames } from 'common/constants/connection-names';
-import { Logger } from 'common/logging/logger';
+
+export type DebugToolsTelemetryMessage = {
+    timestamp: number;
+    name: string;
+    source: string;
+    triggeredBy: string;
+    applicationVersion: string;
+    applicationName: string;
+    applicationBuild: string;
+    installationId: string;
+    customProperties: {
+        [name: string]: string;
+    };
+};
+
+export type DebugToolsTelemetryMessageListener = (
+    telemetryMessage: DebugToolsTelemetryMessage,
+) => void;
+
+type GetDate = () => Date;
 
 export class TelemetryListener {
     private connection: chrome.runtime.Port;
+    private listeners: DebugToolsTelemetryMessageListener[] = [];
 
-    constructor(private readonly browserAdapter: BrowserAdapter, private readonly logger: Logger) {}
+    constructor(
+        private readonly browserAdapter: BrowserAdapter,
+        private readonly getDate: GetDate,
+    ) {}
 
     public initialize(): void {
         this.connection = this.browserAdapter.connect({
@@ -18,10 +41,46 @@ export class TelemetryListener {
     }
 
     private onTelemetryMessage = (telemetryMessage: any) => {
-        this.logger.log('GOT TELEMETRY', telemetryMessage);
+        this.listeners.forEach(listener =>
+            listener(convertToDebugToolTelemetryMessage(telemetryMessage, this.getDate)),
+        );
     };
+
+    public addListener(listener: DebugToolsTelemetryMessageListener): void {
+        this.listeners.push(listener);
+    }
 
     public dispose(): void {
         this.connection.disconnect();
     }
+}
+
+function convertToDebugToolTelemetryMessage(
+    telemetryMessage: any,
+    getDate: GetDate,
+): DebugToolsTelemetryMessage {
+    const { name, properties } = telemetryMessage;
+
+    const {
+        source,
+        triggeredBy,
+        applicationVersion,
+        applicationName,
+        applicationBuild,
+        installationId,
+        // tslint:disable-next-line: trailing-comma
+        ...rest
+    } = properties;
+
+    return {
+        timestamp: getDate().getTime(),
+        name,
+        source,
+        triggeredBy,
+        applicationVersion,
+        applicationName,
+        applicationBuild,
+        installationId,
+        customProperties: rest,
+    };
 }

--- a/src/debug-tools/initializer/debug-tools-init.tsx
+++ b/src/debug-tools/initializer/debug-tools-init.tsx
@@ -3,6 +3,7 @@
 import { BaseStore } from 'common/base-store';
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { ChromeAdapter } from 'common/browser-adapters/chrome-adapter';
+import { DateProvider } from 'common/date-provider';
 import { initializeFabricIcons } from 'common/fabric-icons';
 import { createDefaultLogger } from 'common/logging/default-logger';
 import { RemoteActionMessageDispatcher } from 'common/message-creators/remote-action-message-dispatcher';
@@ -33,13 +34,14 @@ export const initializeDebugTools = () => {
 
     const storesHub = new BaseClientStoresHub<DebugToolsViewState>(stores);
 
-    const telemetryListener = new TelemetryListener(browserAdapter, createDefaultLogger());
+    const telemetryListener = new TelemetryListener(browserAdapter, DateProvider.getCurrentDate);
     telemetryListener.initialize();
 
     const props: DebugToolsViewDeps = {
         storesHub,
         storeActionMessageCreator,
         textContent,
+        telemetryListener,
     };
 
     render(props);

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-common-fields.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-common-fields.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TelemetryCommonFields renders and match snapshot 1`] = `
+<div
+  className="container"
+>
+  <strong>
+    Build:
+  </strong>
+  <span>
+    test-app-build
+  </span>
+  <strong>
+    Name:
+  </strong>
+  <span>
+    test-app-name
+  </span>
+  <strong>
+    Version:
+  </strong>
+  <span>
+    test-app-version
+  </span>
+  <strong>
+    Installation Id:
+  </strong>
+  <span>
+    test-installation-id
+  </span>
+</div>
+`;

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-messages-list.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-messages-list.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`TelemetryMessagesList custom renderers onRenderCustomProperties when th
 exports[`TelemetryMessagesList custom renderers onRenderTimestamp matches snapshot 1`] = `
 <React.Fragment>
   <span>
-    1969-Dec-31 16:00:00.0
+    formatted-datetime
   </span>
 </React.Fragment>
 `;

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-messages-list.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-messages-list.test.tsx.snap
@@ -1,0 +1,93 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TelemetryMessagesList custom renderers onRenderCustomProperties when custom properties is present 1`] = `
+<React.Fragment>
+  <span>
+    {"key1":"value1","key2":"value2"}
+  </span>
+</React.Fragment>
+`;
+
+exports[`TelemetryMessagesList custom renderers onRenderCustomProperties when there is not custom properties 1`] = `
+<React.Fragment>
+  <span>
+    -
+  </span>
+</React.Fragment>
+`;
+
+exports[`TelemetryMessagesList custom renderers onRenderTimestamp matches snapshot 1`] = `
+<React.Fragment>
+  <span>
+    1969-Dec-31 16:00:00.0
+  </span>
+</React.Fragment>
+`;
+
+exports[`TelemetryMessagesList renders and matches snapshot 1`] = `
+<StyledWithViewportComponent
+  columns={
+    Array [
+      Object {
+        "fieldName": "timestamp",
+        "isResizable": true,
+        "key": "date",
+        "maxWidth": 130,
+        "minWidth": 100,
+        "name": "date & time",
+        "onRender": [Function],
+      },
+      Object {
+        "fieldName": "name",
+        "isResizable": true,
+        "key": "eventName",
+        "maxWidth": 130,
+        "minWidth": 100,
+        "name": "event name",
+      },
+      Object {
+        "fieldName": "source",
+        "isResizable": true,
+        "key": "source",
+        "maxWidth": 100,
+        "minWidth": 100,
+        "name": "source",
+      },
+      Object {
+        "fieldName": "triggeredBy",
+        "isResizable": true,
+        "key": "triggeredBy",
+        "maxWidth": 100,
+        "minWidth": 100,
+        "name": "triggeredBy",
+      },
+      Object {
+        "fieldName": "customProperties",
+        "isResizable": true,
+        "key": "customProperties",
+        "minWidth": 100,
+        "name": "custom properties",
+        "onRender": [Function],
+      },
+    ]
+  }
+  items={
+    Array [
+      Object {
+        "applicationBuild": "test-app-build",
+        "applicationName": "test-app-name",
+        "applicationVersion": "test-app-version",
+        "customProperties": Object {
+          "key1": "value1",
+          "key2": "value2",
+        },
+        "installationId": "test-installation-id",
+        "name": "test-name",
+        "source": "test-source",
+        "timestamp": 1,
+        "triggeredBy": "test-triggered-by",
+      },
+    ]
+  }
+/>
+`;

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-messages-list.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-messages-list.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`TelemetryMessagesList custom renderers onRenderCustomProperties when th
 </React.Fragment>
 `;
 
-exports[`TelemetryMessagesList custom renderers onRenderTimestamp matches snapshot 1`] = `
+exports[`TelemetryMessagesList custom renderers onRenderTimestamp (from the column onRender) matches snapshot 1`] = `
 <React.Fragment>
   <span>
     formatted-datetime

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-viewer.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-viewer.test.tsx.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TelemetryViewer renders when there are no telemetry messages 1`] = `
+<React.Fragment>
+  <h1>
+    Telemetry Viewer
+  </h1>
+  <span>
+    No telemetry messages yet. Use the extension to see something here.
+  </span>
+</React.Fragment>
+`;
+
+exports[`TelemetryViewer renders when there is at least one telemetry message 1`] = `
+<React.Fragment>
+  <h1>
+    Telemetry Viewer
+  </h1>
+  <TelemetryCommonFields
+    applicationBuild="test-application-build"
+    applicationName="test-application-name"
+    applicationVersion="test-application-version"
+    installationId="test-installation-id"
+  />
+  <TelemetryMessagesList
+    items={
+      Array [
+        Object {
+          "applicationBuild": "test-application-build",
+          "applicationName": "test-application-name",
+          "applicationVersion": "test-application-version",
+          "installationId": "test-installation-id",
+          "key": "value",
+        },
+      ]
+    }
+  />
+</React.Fragment>
+`;

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-viewer.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/__snapshots__/telemetry-viewer.test.tsx.snap
@@ -23,6 +23,17 @@ exports[`TelemetryViewer renders when there is at least one telemetry message 1`
     installationId="test-installation-id"
   />
   <TelemetryMessagesList
+    deps={
+      Object {
+        "telemetryListener": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "browserAdapter": undefined,
+          "getDate": undefined,
+          "listeners": Array [],
+          "onTelemetryMessage": [Function],
+        },
+      }
+    }
     items={
       Array [
         Object {

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-common-fields.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-common-fields.test.tsx
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    TelemetryCommonFields,
+    TelemetryCommonFieldsProps,
+} from 'debug-tools/components/telemetry-viewer/telemetry-common-fields';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('TelemetryCommonFields', () => {
+    const props: TelemetryCommonFieldsProps = {
+        applicationBuild: 'test-app-build',
+        applicationName: 'test-app-name',
+        applicationVersion: 'test-app-version',
+        installationId: 'test-installation-id',
+    };
+
+    it('renders and match snapshot', () => {
+        const wrapped = shallow(<TelemetryCommonFields {...props} />);
+
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-messages-list.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-messages-list.test.tsx
@@ -40,7 +40,9 @@ describe('TelemetryMessagesList', () => {
 
         props = {
             items: getItems(),
-            dateFormatter: dateFormatterMock.object,
+            deps: {
+                dateFormatter: dateFormatterMock.object,
+            },
         };
     });
 

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-messages-list.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-messages-list.test.tsx
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import {
+    onRenderCustomProperties,
+    TelemetryMessagesList,
+    onRenderTimestamp,
+} from 'debug-tools/components/telemetry-viewer/telemetry-messages-list';
+import { DebugToolsTelemetryMessage } from 'debug-tools/controllers/telemetry-listener';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('TelemetryMessagesList', () => {
+    const getItems: () => DebugToolsTelemetryMessage[] = () => [
+        {
+            applicationBuild: 'test-app-build',
+            applicationName: 'test-app-name',
+            applicationVersion: 'test-app-version',
+            customProperties: {
+                key1: 'value1',
+                key2: 'value2',
+            },
+            installationId: 'test-installation-id',
+            name: 'test-name',
+            source: 'test-source',
+            timestamp: 1,
+            triggeredBy: 'test-triggered-by',
+        },
+    ];
+
+    it('renders and matches snapshot', () => {
+        const wrapped = shallow(<TelemetryMessagesList items={getItems()} />);
+
+        expect(wrapped.getElement()).toMatchSnapshot();
+    });
+
+    describe('custom renderers', () => {
+        type Renderer = () => JSX.Element;
+        type WrapperProps = { renderer: Renderer };
+        const Wrapper = NamedFC<WrapperProps>('Wrapper', ({ renderer }) => <>{renderer()}</>);
+
+        let item: DebugToolsTelemetryMessage;
+
+        beforeEach(() => {
+            item = getItems().pop();
+        });
+
+        describe('onRenderTimestamp', () => {
+            const testSubject = onRenderTimestamp;
+
+            it('matches snapshot', () => {
+                const wrapped = shallow(<Wrapper renderer={() => testSubject(item)} />);
+
+                expect(wrapped.getElement()).toMatchSnapshot();
+            });
+        });
+
+        describe('onRenderCustomProperties', () => {
+            const testSubject = onRenderCustomProperties;
+
+            it('when there is not custom properties', () => {
+                delete item.customProperties;
+
+                const wrapped = shallow(
+                    <Wrapper renderer={() => testSubject('customProperties', item)} />,
+                );
+
+                expect(wrapped.getElement()).toMatchSnapshot();
+            });
+
+            it('when custom properties is present', () => {
+                const wrapped = shallow(
+                    <Wrapper renderer={() => testSubject('customProperties', item)} />,
+                );
+
+                expect(wrapped.getElement()).toMatchSnapshot();
+            });
+        });
+    });
+});

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-messages-list.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-messages-list.test.tsx
@@ -3,8 +3,8 @@
 import { NamedFC } from 'common/react/named-fc';
 import {
     onRenderCustomProperties,
-    TelemetryMessagesList,
     onRenderTimestamp,
+    TelemetryMessagesList,
 } from 'debug-tools/components/telemetry-viewer/telemetry-messages-list';
 import { DebugToolsTelemetryMessage } from 'debug-tools/controllers/telemetry-listener';
 import { shallow } from 'enzyme';

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-viewer.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-viewer.test.tsx
@@ -19,11 +19,11 @@ describe('TelemetryViewer', () => {
     let props: TelemetryViewerProps;
 
     beforeEach(() => {
-        telemetryListenerMock = Mock.ofType<TelemetryListener>();
+        telemetryListenerMock = Mock.ofType<TelemetryListener>(TelemetryListener);
 
         deps = {
             telemetryListener: telemetryListenerMock.object,
-        };
+        } as TelemetryViewerDeps;
 
         props = { deps };
     });

--- a/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-viewer.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/telemetry-viewer/telemetry-viewer.test.tsx
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import {
+    TelemetryViewer,
+    TelemetryViewerDeps,
+    TelemetryViewerProps,
+} from 'debug-tools/components/telemetry-viewer/telemetry-viewer';
+import { TelemetryListener } from 'debug-tools/controllers/telemetry-listener';
+import { shallow } from 'enzyme';
+import { isFunction } from 'lodash';
+import * as React from 'react';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+describe('TelemetryViewer', () => {
+    let telemetryListenerMock: IMock<TelemetryListener>;
+
+    let deps: TelemetryViewerDeps;
+    let props: TelemetryViewerProps;
+
+    beforeEach(() => {
+        telemetryListenerMock = Mock.ofType<TelemetryListener>();
+
+        deps = {
+            telemetryListener: telemetryListenerMock.object,
+        };
+
+        props = { deps };
+    });
+
+    it('add listner for telemetry messages', () => {
+        shallow(<TelemetryViewer {...props} />);
+
+        telemetryListenerMock.verify(
+            listener => listener.addListener(It.is(isFunction)),
+            Times.once(),
+        );
+    });
+
+    describe('renders', () => {
+        it('when there are no telemetry messages', () => {
+            const wrapped = shallow(<TelemetryViewer {...props} />);
+
+            expect(wrapped.getElement()).toMatchSnapshot();
+        });
+
+        it('when there is at least one telemetry message', () => {
+            let callback: Function;
+
+            telemetryListenerMock
+                .setup(listener => listener.addListener(It.is(isFunction)))
+                .callback(l => (callback = l));
+
+            const wrapped = shallow(<TelemetryViewer {...props} />);
+
+            callback({
+                key: 'value',
+                applicationBuild: 'test-application-build',
+                applicationName: 'test-application-name',
+                applicationVersion: 'test-application-version',
+                installationId: 'test-installation-id',
+            });
+
+            expect(wrapped.getElement()).toMatchSnapshot();
+        });
+    });
+});


### PR DESCRIPTION
#### Description of changes

Adding a new section (not hook up yet though) to be able to visualize telemetry events from the extension, displaying them on a list (`<DetailsList>` to be more precise).

**no telemetry messages yet**
![01 - no telemetry messages yet](https://user-images.githubusercontent.com/2837582/79700406-3664fc00-824a-11ea-844a-5ee35d62944e.png)

**telemetry message on a list**
![02 - with telemetry messages on display](https://user-images.githubusercontent.com/2837582/79700411-3c5add00-824a-11ea-8b58-6208fa3c9d78.png)

**Future work**
- There is a missing styling on the content border. I think we do have a small (5px maybe) border around the content (except for the header itself). I'd like to adjust that styling as part of a future hook up PR
- Hook up the view into the debug tools container so it actually shows up. I didn't want to include that part in this PR as it will introduce a new UI piece (probably a nav bar so the user can navigate between the different sections)
- Filtering events
- Better visualization for custom properties
- Start/stop registering events: currently, the telemetry messages are stored on an array on the viewer's state. I was a little concerned about RAM usage as there is no limit at the amount of messages the state will keep. I though it may be nice to add a start/stop feature and/or maybe put a maximum size to the array but left both options out for now

#### Pull request checklist
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
