### PR TITLE
chore: fix webpack transitive dependency resolution

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,6 +82,7 @@ const commonConfig = {
         rules: [tsRule, scssRule(true)],
     },
     resolve: {
+        // It is important that src is absolute but node_modules is relative. See #2520
         modules: [path.resolve(__dirname, './src'), 'node_modules'],
         extensions: ['.tsx', '.ts', '.js'],
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -82,7 +82,7 @@ const commonConfig = {
         rules: [tsRule, scssRule(true)],
     },
     resolve: {
-        modules: [path.resolve(__dirname, './src'), path.resolve(__dirname, 'node_modules')],
+        modules: [path.resolve(__dirname, './src'), 'node_modules'],
         extensions: ['.tsx', '.ts', '.js'],
     },
     plugins: commonPlugins,


### PR DESCRIPTION
#### Description of changes

This PR fixes a very subtle but very serious issue in our webpack module resolution config.

Background: when you run `yarn install`, it uses an algorithm similar to the following to populate `/node_modules`:
* Scan the full dependency tree, downloading all required versions of all packages to a local cache (outside of `/node_modules`)
* For each direct dependency, put the directly dependent version in `/node_modules/package-name/`
* For each transitive dependency not already in `/node_modules/transitive-dep`, use an implementation-defined algorithm to pick one version of the transitive dependency (chosen by some combination of "most frequently used" and "used closest to the root of the dependency tree), and put that version in `/node_modules/transitive-dep`
* For each version-dep pair not already in `/node_modules`, put a copy of it in `/node_modules/parent-dep/node_modules/child-dep/` for each parent that requires it.
* Repeat recursively

This algorithm means that when a transitive dependency writes `require('child-dep')`, the correct resolution behavior is to prefer versions of `child-dep` in `node_modules` folders inside the individual `parent-dep`'s folder, and fall back to ancestor `node_modules` folders if the `parent-dep` folder wasn't given its own copy of `child-dep`.

That resolution behavior is the normal behavior for node or webpack when told to accept a relative directory path (typically, `"node_modules"`) as a candidate for module resolution.

However, **our** webpack config contains a subtle bug where we don't tell webpack to resolve against `'node_modules'`, but instead say to use `path.resolve(__dirname, 'node_modules')`. This is an important distinction; it means that webpack will **ignore** more specific versions yarn has provided for use as descendant dependencies and instead **always** use the version at the root, even if it doesn't match a parent dependency's version requirement.

Previously, we haven't noticed this because this error doesn't usually cause build breaks; the yarn algorithm means there always exists **some** version of every transitive dep in the root level `node_modules` folder, just maybe not a version the parent-dep expects. In #2507, we got very very lucky and hit a build error for this. We have no idea what other mystery runtime errors we might have ever seen based on this issue.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: no, but see [this comment](https://github.com/microsoft/accessibility-insights-web/pull/2507#issuecomment-616762675) in #2507
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
