### PR TITLE
fix: go to overview when restarting assessment

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -500,12 +500,18 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
 
     public startOverAllAssessments = (event: React.MouseEvent<any>): void => {
         const telemetry = this.telemetryFactory.fromDetailsView(event);
-        const payload: BaseActionPayload = {
+        const setDetailsViewRightContentPanelPayload: DetailsViewRightContentPanelType = 'Overview';
+        const startOverAllAssessmentsActionPayload: BaseActionPayload = {
             telemetry: telemetry,
         };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
+            payload: setDetailsViewRightContentPanelPayload,
+        });
         this.dispatcher.dispatchMessage({
             messageType: Messages.Assessment.StartOverAllAssessments,
-            payload,
+            payload: startOverAllAssessmentsActionPayload,
         });
     };
 

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -380,11 +380,15 @@ describe('DetailsViewActionMessageCreatorTest', () => {
             source: TelemetryEventSource.DetailsView,
         };
 
-        const expectedMessage = {
+        const expectedMessageToStartOverAllAssessments = {
             messageType: Messages.Assessment.StartOverAllAssessments,
             payload: {
                 telemetry,
             },
+        };
+        const expectedMessageToSetDetailsViewRightContentPanel = {
+            messageType: Messages.Visualizations.DetailsView.SetDetailsViewRightContentPanel,
+            payload: 'Overview',
         };
 
         telemetryFactoryMock.setup(tf => tf.fromDetailsView(event)).returns(() => telemetry);
@@ -392,7 +396,15 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         testSubject.startOverAllAssessments(event);
 
         dispatcherMock.verify(
-            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            dispatcher =>
+                dispatcher.dispatchMessage(It.isValue(expectedMessageToStartOverAllAssessments)),
+            Times.once(),
+        );
+        dispatcherMock.verify(
+            dispatcher =>
+                dispatcher.dispatchMessage(
+                    It.isValue(expectedMessageToSetDetailsViewRightContentPanel),
+                ),
             Times.once(),
         );
     });


### PR DESCRIPTION
#### Description of changes

simply sets the right content panel to be overview when starting over the entire assessment.


![startovertooverview](https://user-images.githubusercontent.com/32555133/79811066-94b4dc00-8329-11ea-8fdf-0866bcd9519b.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2418 
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
