### PR TITLE
chore: capitalize ScanMetadata consistently

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -13,7 +13,7 @@ import { ITooltipHostStyles, Link, TooltipHost } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { AssessmentStoreData } from '../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { TabStoreData } from '../../common/types/store-data/tab-store-data';
@@ -46,7 +46,7 @@ export interface DetailsViewCommandBarProps {
     visualizationScanResultData: VisualizationScanResultData;
     cardsViewData: CardsViewModel;
     switcherNavConfiguration: DetailsViewSwitcherNavConfiguration;
-    scanMetadata: ScanMetaData;
+    scanMetadata: ScanMetadata;
 }
 
 export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBarProps> {

--- a/src/DetailsView/components/details-view-command-bar.tsx
+++ b/src/DetailsView/components/details-view-command-bar.tsx
@@ -46,7 +46,7 @@ export interface DetailsViewCommandBarProps {
     visualizationScanResultData: VisualizationScanResultData;
     cardsViewData: CardsViewModel;
     switcherNavConfiguration: DetailsViewSwitcherNavConfiguration;
-    scanMetaData: ScanMetaData;
+    scanMetadata: ScanMetaData;
 }
 
 export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBarProps> {
@@ -64,7 +64,7 @@ export class DetailsViewCommandBar extends React.Component<DetailsViewCommandBar
     }
 
     private renderTargetPageInfo(): JSX.Element {
-        const targetPageTitle: string = this.props.scanMetaData.targetAppInfo.name;
+        const targetPageTitle: string = this.props.scanMetadata.targetAppInfo.name;
         const tooltipContent = `Switch to target page: ${targetPageTitle}`;
         const hostStyles: Partial<ITooltipHostStyles> = { root: { display: 'inline-block' } };
         return (

--- a/src/DetailsView/components/report-export-component-factory.tsx
+++ b/src/DetailsView/components/report-export-component-factory.tsx
@@ -14,20 +14,20 @@ export function getReportExportComponentForAssessment(props: CommandBarProps): J
         assessmentStoreData,
         assessmentsProvider,
         featureFlagStoreData,
-        scanMetaData,
+        scanMetadata,
     } = props;
     const reportGenerator = deps.reportGenerator;
     const reportExportComponentProps: ReportExportComponentProps = {
         deps: deps,
         reportExportFormat: 'Assessment',
-        pageTitle: scanMetaData.targetAppInfo.name,
+        pageTitle: scanMetadata.targetAppInfo.name,
         scanDate: deps.getCurrentDate(),
         htmlGenerator: description =>
             reportGenerator.generateAssessmentReport(
                 assessmentStoreData,
                 assessmentsProvider,
                 featureFlagStoreData,
-                scanMetaData.targetAppInfo,
+                scanMetadata.targetAppInfo,
                 description,
             ),
         updatePersistedDescription: value =>
@@ -53,20 +53,20 @@ export function getReportExportComponentForFastPass(props: CommandBarProps): JSX
     }
 
     const { deps } = props;
-    const scanDate = deps.getDateFromTimestamp(props.scanMetaData.timestamp);
+    const scanDate = deps.getDateFromTimestamp(props.scanMetadata.timestamp);
     const reportGenerator = deps.reportGenerator;
 
     const reportExportComponentProps: ReportExportComponentProps = {
         deps: deps,
         scanDate: scanDate,
-        pageTitle: props.scanMetaData.targetAppInfo.name,
+        pageTitle: props.scanMetadata.targetAppInfo.name,
         reportExportFormat: 'AutomatedChecks',
         htmlGenerator: description =>
             reportGenerator.generateFastPassAutomatedChecksReport(
                 scanDate,
                 props.cardsViewData,
                 description,
-                props.scanMetaData,
+                props.scanMetadata,
             ),
         updatePersistedDescription: () => null,
         getExportDescription: () => '',

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -7,7 +7,7 @@ import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-
 import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';
 
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { VisualizationConfigurationFactory } from '../common/configs/visualization-configuration-factory';
 import { DropdownClickHandler } from '../common/dropdown-click-handler';
 import { AssessmentStoreData } from '../common/types/store-data/assessment-result-data';
@@ -61,7 +61,7 @@ export interface DetailsViewBodyProps {
     userConfigurationStoreData: UserConfigurationStoreData;
     cardsViewData: CardsViewModel;
     scanIncompleteWarnings: ScanIncompleteWarningId[];
-    scanMetadata: ScanMetaData;
+    scanMetadata: ScanMetadata;
 }
 
 export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -61,7 +61,7 @@ export interface DetailsViewBodyProps {
     userConfigurationStoreData: UserConfigurationStoreData;
     cardsViewData: CardsViewModel;
     scanIncompleteWarnings: ScanIncompleteWarningId[];
-    scanMetaData: ScanMetaData;
+    scanMetadata: ScanMetaData;
 }
 
 export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
@@ -114,7 +114,7 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
 
     private renderRightPanel(): JSX.Element {
         const rightPanelProps: RightPanelProps = {
-            targetAppInfo: this.props.scanMetaData.targetAppInfo,
+            targetAppInfo: this.props.scanMetadata.targetAppInfo,
             ...this.props,
         };
 

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -206,7 +206,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
             url: this.props.storeState.tabStoreData.url,
         };
 
-        const scanMetaData: ScanMetaData = {
+        const scanMetadata: ScanMetaData = {
             timestamp: this.props.storeState.unifiedScanResultStoreData.timestamp,
             targetAppInfo: targetAppInfo,
             toolData: this.props.storeState.unifiedScanResultStoreData.toolInfo,
@@ -240,7 +240,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
                 scanIncompleteWarnings={
                     storeState.unifiedScanResultStoreData.scanIncompleteWarnings
                 }
-                scanMetaData={scanMetaData}
+                scanMetadata={scanMetadata}
             />
         );
     }

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -3,7 +3,7 @@
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { ISelection, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 
@@ -206,7 +206,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
             url: this.props.storeState.tabStoreData.url,
         };
 
-        const scanMetadata: ScanMetaData = {
+        const scanMetadata: ScanMetadata = {
             timestamp: this.props.storeState.unifiedScanResultStoreData.timestamp,
             targetAppInfo: targetAppInfo,
             toolData: this.props.storeState.unifiedScanResultStoreData.toolInfo,

--- a/src/common/types/store-data/scan-meta-data.ts
+++ b/src/common/types/store-data/scan-meta-data.ts
@@ -4,7 +4,7 @@ import { ToolData } from 'common/types/store-data/unified-data-interface';
 
 import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 
-export type ScanMetaData = {
+export type ScanMetadata = {
     timestamp: string;
     toolData: ToolData;
     targetAppInfo: TargetAppData;

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -104,7 +104,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
 
     private renderLayout(
         cardsViewData: CardsViewModel,
-        scanMetaData: ScanMetaData,
+        scanMetadata: ScanMetaData,
         primaryContent: JSX.Element,
         optionalSidePanel?: JSX.Element,
     ): JSX.Element {
@@ -126,7 +126,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                             scanStoreData={this.props.scanStoreData}
                             featureFlagStoreData={this.props.featureFlagStoreData}
                             cardsViewData={cardsViewData}
-                            scanMetaData={scanMetaData}
+                            scanMetadata={scanMetadata}
                         />
                         <main>
                             <HeaderSection />

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -8,7 +8,7 @@ import { CardSelectionStoreData } from 'common/types/store-data/card-selection-s
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { DetailsViewStoreData } from 'common/types/store-data/details-view-store-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { UnifiedScanResultStoreData } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { CardsView, CardsViewDeps } from 'DetailsView/components/cards-view';
@@ -84,7 +84,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
                 highlightedResultUids,
             );
 
-            const scanMetadata: ScanMetaData = {
+            const scanMetadata: ScanMetadata = {
                 timestamp: unifiedScanResultStoreData.timestamp,
                 toolData: unifiedScanResultStoreData.toolInfo,
                 targetAppInfo: this.props.unifiedScanResultStoreData.targetAppInfo,
@@ -104,7 +104,7 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
 
     private renderLayout(
         cardsViewData: CardsViewModel,
-        scanMetadata: ScanMetaData,
+        scanMetadata: ScanMetadata,
         primaryContent: JSX.Element,
         optionalSidePanel?: JSX.Element,
     ): JSX.Element {

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -34,29 +34,29 @@ export interface CommandBarProps {
     scanStoreData: ScanStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
     cardsViewData: CardsViewModel;
-    scanMetaData: ScanMetaData;
+    scanMetadata: ScanMetaData;
 }
 
 export const commandButtonRefreshId = 'command-button-refresh';
 export const commandButtonSettingsId = 'command-button-settings';
 
 export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
-    const { deps, deviceStoreData, featureFlagStoreData, cardsViewData, scanMetaData } = props;
+    const { deps, deviceStoreData, featureFlagStoreData, cardsViewData, scanMetadata } = props;
     let exportReport = null;
 
-    if (scanMetaData != null) {
+    if (scanMetadata != null) {
         exportReport = (
             <ReportExportComponent
                 deps={deps}
                 reportExportFormat={'AutomatedChecks'}
-                pageTitle={scanMetaData.targetAppInfo.name}
-                scanDate={deps.getDateFromTimestamp(scanMetaData.timestamp)}
+                pageTitle={scanMetadata.targetAppInfo.name}
+                scanDate={deps.getDateFromTimestamp(scanMetadata.timestamp)}
                 htmlGenerator={description =>
                     deps.reportGenerator.generateFastPassAutomatedChecksReport(
-                        deps.getDateFromTimestamp(scanMetaData.timestamp),
+                        deps.getDateFromTimestamp(scanMetadata.timestamp),
                         cardsViewData,
                         description,
-                        scanMetaData,
+                        scanMetadata,
                     )
                 }
                 updatePersistedDescription={() => null}

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -5,7 +5,7 @@ import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { NamedFC } from 'common/react/named-fc';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import {
     ReportExportComponent,
     ReportExportComponentDeps,
@@ -34,7 +34,7 @@ export interface CommandBarProps {
     scanStoreData: ScanStoreData;
     featureFlagStoreData: FeatureFlagStoreData;
     cardsViewData: CardsViewModel;
-    scanMetadata: ScanMetaData;
+    scanMetadata: ScanMetadata;
 }
 
 export const commandButtonRefreshId = 'command-button-refresh';

--- a/src/electron/views/report/unified-details-section.tsx
+++ b/src/electron/views/report/unified-details-section.tsx
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import {
     makeDetailsSectionFC,
     ScanDetailInfo,
 } from 'reports/components/report-sections/make-details-section-fc';
 
-export function createDeviceNameItemInfo(scanMetadata: ScanMetaData): ScanDetailInfo {
+export function createDeviceNameItemInfo(scanMetadata: ScanMetadata): ScanDetailInfo {
     return {
         label: 'connected device name:',
         content: `${scanMetadata.deviceName} - ${scanMetadata.targetAppInfo.name}`,

--- a/src/electron/views/report/unified-details-section.tsx
+++ b/src/electron/views/report/unified-details-section.tsx
@@ -7,10 +7,10 @@ import {
     ScanDetailInfo,
 } from 'reports/components/report-sections/make-details-section-fc';
 
-export function createDeviceNameItemInfo(scanMetaData: ScanMetaData): ScanDetailInfo {
+export function createDeviceNameItemInfo(scanMetadata: ScanMetaData): ScanDetailInfo {
     return {
         label: 'connected device name:',
-        content: `${scanMetaData.deviceName} - ${scanMetaData.targetAppInfo.name}`,
+        content: `${scanMetadata.deviceName} - ${scanMetadata.targetAppInfo.name}`,
     };
 }
 

--- a/src/reports/components/report-sections/details-section.tsx
+++ b/src/reports/components/report-sections/details-section.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import * as React from 'react';
 import { NewTabLinkWithConfirmationDialog } from 'reports/components/new-tab-link-confirmation-dialog';
 import {
@@ -9,7 +9,7 @@ import {
     ScanDetailInfo,
 } from 'reports/components/report-sections/make-details-section-fc';
 
-export function getUrlItemInfo(scanMetadata: ScanMetaData): ScanDetailInfo {
+export function getUrlItemInfo(scanMetadata: ScanMetadata): ScanDetailInfo {
     return {
         label: 'target page url:',
         content: (

--- a/src/reports/components/report-sections/footer-text-props.ts
+++ b/src/reports/components/report-sections/footer-text-props.ts
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 
-export type FooterTextProps = { scanMetadata: ScanMetaData };
+export type FooterTextProps = { scanMetadata: ScanMetadata };

--- a/src/reports/components/report-sections/make-details-section-fc.tsx
+++ b/src/reports/components/report-sections/make-details-section-fc.tsx
@@ -21,7 +21,7 @@ export type ScanDetailInfo = {
 };
 
 export function makeDetailsSectionFC(
-    getDisplayedScanTargetInfo: (scanMetaData: ScanMetaData) => ScanDetailInfo,
+    getDisplayedScanTargetInfo: (scanMetadata: ScanMetaData) => ScanDetailInfo,
 ): ReactFCWithDisplayName<DetailsSectionProps> {
     return NamedFC<DetailsSectionProps>('DetailsSection', props => {
         const { scanMetadata, description, scanDate, toUtcString } = props;

--- a/src/reports/components/report-sections/make-details-section-fc.tsx
+++ b/src/reports/components/report-sections/make-details-section-fc.tsx
@@ -5,7 +5,7 @@ import { CommentIcon } from 'common/icons/comment-icon';
 import { DateIcon } from 'common/icons/date-icon';
 import { UrlIcon } from 'common/icons/url-icon';
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { isEmpty } from 'lodash';
 import * as React from 'react';
 import { SectionProps } from './report-section-factory';
@@ -21,7 +21,7 @@ export type ScanDetailInfo = {
 };
 
 export function makeDetailsSectionFC(
-    getDisplayedScanTargetInfo: (scanMetadata: ScanMetaData) => ScanDetailInfo,
+    getDisplayedScanTargetInfo: (scanMetadata: ScanMetadata) => ScanDetailInfo,
 ): ReactFCWithDisplayName<DetailsSectionProps> {
     return NamedFC<DetailsSectionProps>('DetailsSection', props => {
         const { scanMetadata, description, scanDate, toUtcString } = props;

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -5,7 +5,7 @@ import { FixInstructionProcessor } from 'common/components/fix-instruction-proce
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
 import { ReactFCWithDisplayName } from 'common/react/named-fc';
 
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { CardsViewModel } from '../../../common/types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../../common/types/store-data/user-configuration-store';
@@ -27,7 +27,7 @@ export type SectionProps = {
     cardsViewData: CardsViewModel;
     userConfigurationStoreData: UserConfigurationStoreData;
     shouldAlertFailuresCount?: boolean;
-    scanMetadata: ScanMetaData;
+    scanMetadata: ScanMetadata;
     targetAppInfo: TargetAppData;
 };
 

--- a/src/reports/package/axe-results-report.ts
+++ b/src/reports/package/axe-results-report.ts
@@ -8,7 +8,7 @@ import { convertScanResultsToUnifiedResults } from 'injected/adapters/scan-resul
 import { convertScanResultsToUnifiedRules } from 'injected/adapters/scan-results-to-unified-rules';
 import { ResultDecorator } from 'scanner/result-decorator';
 
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { ReportHtmlGenerator } from '../report-html-generator';
 import AccessibilityInsightsReport from './accessibilityInsightsReport';
 
@@ -54,7 +54,7 @@ export class AxeResultsReport implements AccessibilityInsightsReport.Report {
             url: results.url,
         };
 
-        const scanMetadata: ScanMetaData = {
+        const scanMetadata: ScanMetadata = {
             targetAppInfo: targetAppInfo,
             toolData: this.toolInfo,
             timestamp: null,

--- a/src/reports/report-generator.ts
+++ b/src/reports/report-generator.ts
@@ -4,7 +4,7 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { AssessmentReportHtmlGenerator } from './assessment-report-html-generator';
 import { ReportHtmlGenerator } from './report-html-generator';
@@ -25,7 +25,7 @@ export class ReportGenerator {
         scanDate: Date,
         cardsViewData: CardsViewModel,
         description: string,
-        scanMetadata: ScanMetaData,
+        scanMetadata: ScanMetadata,
     ): string {
         return this.reportHtmlGenerator.generateHtml(
             scanDate,

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -8,7 +8,7 @@ import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import * as React from 'react';
 
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { ReportBody, ReportBodyProps } from './components/report-sections/report-body';
 import { ReportCollapsibleContainerControl } from './components/report-sections/report-collapsible-container';
 import {
@@ -33,7 +33,7 @@ export class ReportHtmlGenerator {
         scanDate: Date,
         description: string,
         cardsViewData: CardsViewModel,
-        scanMetadata: ScanMetaData,
+        scanMetadata: ScanMetadata,
     ): string {
         const HeadSection = this.sectionFactory.HeadSection;
         const headMarkup: string = this.reactStaticRenderer.renderToStaticMarkup(<HeadSection />);

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -50,7 +50,7 @@ describe('DetailsViewCommandBar', () => {
             StartOverComponentFactory: p => startOverComponent,
             LeftNav: LeftNavStub,
         } as DetailsViewSwitcherNavConfiguration;
-        const scanMetaData = {
+        const scanMetadata = {
             targetAppInfo: {
                 name: thePageTitle,
                 url: thePageUrl,
@@ -63,7 +63,7 @@ describe('DetailsViewCommandBar', () => {
             },
             tabStoreData,
             switcherNavConfiguration: switcherNavConfiguration,
-            scanMetaData: scanMetaData,
+            scanMetadata: scanMetadata,
         } as DetailsViewCommandBarProps;
     }
 

--- a/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/details-view-command-bar.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC, ReactFCWithDisplayName } from 'common/react/named-fc';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { DetailsViewSwitcherNavConfiguration } from 'DetailsView/components/details-view-switcher-nav';
 import { DetailsViewBodyProps } from 'DetailsView/details-view-body';
@@ -55,7 +55,7 @@ describe('DetailsViewCommandBar', () => {
                 name: thePageTitle,
                 url: thePageUrl,
             },
-        } as ScanMetaData;
+        } as ScanMetadata;
 
         return {
             deps: {

--- a/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
@@ -4,7 +4,7 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { VisualizationScanResultData } from 'common/types/store-data/visualization-scan-result-data';
@@ -43,7 +43,7 @@ describe('ReportExportComponentPropsFactory', () => {
     let cardsViewData: CardsViewModel;
     let scanResult: ScanResults;
     let targetAppInfo: TargetAppData;
-    let scanMetadata: ScanMetaData;
+    let scanMetadata: ScanMetadata;
 
     beforeEach(() => {
         featureFlagStoreData = {};
@@ -62,7 +62,7 @@ describe('ReportExportComponentPropsFactory', () => {
             timestamp: theTimestamp,
             toolData: theToolData,
             targetAppInfo: targetAppInfo,
-        } as ScanMetaData;
+        } as ScanMetadata;
         assessmentsProviderMock = Mock.ofType<AssessmentsProvider>(undefined, MockBehavior.Loose);
         reportGeneratorMock = Mock.ofType<ReportGenerator>(undefined, MockBehavior.Loose);
         cardsViewData = null;

--- a/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component-factory.test.tsx
@@ -43,7 +43,7 @@ describe('ReportExportComponentPropsFactory', () => {
     let cardsViewData: CardsViewModel;
     let scanResult: ScanResults;
     let targetAppInfo: TargetAppData;
-    let scanMetaData: ScanMetaData;
+    let scanMetadata: ScanMetaData;
 
     beforeEach(() => {
         featureFlagStoreData = {};
@@ -58,7 +58,7 @@ describe('ReportExportComponentPropsFactory', () => {
             name: thePageTitle,
             url: thePageUrl,
         };
-        scanMetaData = {
+        scanMetadata = {
             timestamp: theTimestamp,
             toolData: theToolData,
             targetAppInfo: targetAppInfo,
@@ -92,7 +92,7 @@ describe('ReportExportComponentPropsFactory', () => {
             visualizationScanResultData,
             visualizationStoreData,
             cardsViewData,
-            scanMetaData,
+            scanMetadata,
         } as DetailsViewCommandBarProps;
     }
 
@@ -117,7 +117,7 @@ describe('ReportExportComponentPropsFactory', () => {
                     theDate,
                     cardsViewData,
                     theDescription,
-                    scanMetaData,
+                    scanMetadata,
                 ),
             )
             .returns(() => theGeneratorOutput);

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -135,7 +135,7 @@ describe('DetailsViewBody', () => {
                     visualHelperEnabled: true,
                     allCardsCollapsed: true,
                 },
-                scanMetaData: {
+                scanMetadata: {
                     targetAppInfo: targetAppInfoStub,
                 } as ScanMetaData,
             } as DetailsViewBodyProps;
@@ -216,7 +216,7 @@ describe('DetailsViewBody', () => {
 
     function buildRightPanel(givenProps: DetailsViewBodyProps): JSX.Element {
         const rightPanelProps = {
-            targetAppInfo: givenProps.scanMetaData.targetAppInfo,
+            targetAppInfo: givenProps.scanMetadata.targetAppInfo,
             ...givenProps,
         };
         return <rightPanelConfig.RightPanel {...rightPanelProps} />;

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
 
 import { getDefaultFeatureFlagsWeb } from 'common/feature-flags';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewCommandBarDeps } from 'DetailsView/components/details-view-command-bar';
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
@@ -137,7 +137,7 @@ describe('DetailsViewBody', () => {
                 },
                 scanMetadata: {
                     targetAppInfo: targetAppInfoStub,
-                } as ScanMetaData,
+                } as ScanMetadata,
             } as DetailsViewBodyProps;
         });
 

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -385,7 +385,7 @@ describe('DetailsViewContainer', () => {
         cardsViewData: CardsViewModel,
         targetApp: TargetAppData,
     ): JSX.Element {
-        const scanMetaData = {
+        const scanMetadata = {
             timestamp: timestamp,
             toolData: toolData,
             targetAppInfo: targetApp,
@@ -416,7 +416,7 @@ describe('DetailsViewContainer', () => {
                 scanIncompleteWarnings={
                     storeMocks.unifiedScanResultStoreData.scanIncompleteWarnings
                 }
-                scanMetaData={scanMetaData}
+                scanMetadata={scanMetadata}
             />
         );
     }

--- a/src/tests/unit/tests/electron/report/unified-details-section.test.tsx
+++ b/src/tests/unit/tests/electron/report/unified-details-section.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { createDeviceNameItemInfo } from 'electron/views/report/unified-details-section';
 
@@ -15,7 +15,7 @@ describe('UnifiedDetailsSection', () => {
         const scanMetadata = {
             targetAppInfo,
             deviceName,
-        } as ScanMetaData;
+        } as ScanMetadata;
         const expectedResult = {
             label: 'connected device name:',
             content: `${deviceName} - ${appName}`,

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
           }
         }
         deviceStoreData={Object {}}
-        scanMetaData={
+        scanMetadata={
           Object {
             "deviceName": "TEST DEVICE",
             "targetAppInfo": Object {
@@ -200,7 +200,7 @@ exports[`AutomatedChecksView renders when status scan <Failed> 1`] = `
             "connectedDevice": "TEST DEVICE",
           }
         }
-        scanMetaData={null}
+        scanMetadata={null}
         scanStoreData={
           Object {
             "status": 3,
@@ -292,7 +292,7 @@ exports[`AutomatedChecksView renders when status scan <Scanning> 1`] = `
             "connectedDevice": "TEST DEVICE",
           }
         }
-        scanMetaData={null}
+        scanMetadata={null}
         scanStoreData={
           Object {
             "status": 1,
@@ -384,7 +384,7 @@ exports[`AutomatedChecksView renders when status scan <undefined> 1`] = `
             "connectedDevice": "TEST DEVICE",
           }
         }
-        scanMetaData={null}
+        scanMetadata={null}
         scanStoreData={
           Object {
             "status": undefined,

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -26,7 +26,7 @@ describe('CommandBar', () => {
     let getDateFromTimestampMock: IMock<(timestamp: string) => Date>;
     let cardsViewDataStub: CardsViewModel;
     let reportGeneratorMock: IMock<ReportGenerator>;
-    let scanMetaDataStub: ScanMetaData;
+    let scanMetadataStub: ScanMetaData;
     let scanDateStub: Date;
 
     beforeEach(() => {
@@ -35,7 +35,7 @@ describe('CommandBar', () => {
         };
         getDateFromTimestampMock = Mock.ofInstance((_: string) => null as Date);
         cardsViewDataStub = {} as CardsViewModel;
-        scanMetaDataStub = {
+        scanMetadataStub = {
             timestamp: '1234',
             toolData: {} as ToolData,
             targetAppInfo: {
@@ -46,7 +46,7 @@ describe('CommandBar', () => {
         reportGeneratorMock = Mock.ofType(ReportGenerator);
 
         getDateFromTimestampMock
-            .setup(mock => mock(scanMetaDataStub.timestamp))
+            .setup(mock => mock(scanMetadataStub.timestamp))
             .returns(() => scanDateStub);
     });
 
@@ -63,7 +63,7 @@ describe('CommandBar', () => {
                 },
                 cardsViewData: cardsViewDataStub,
                 featureFlagStoreData: featureFlagStoreDataStub,
-                scanMetaData: scanMetaDataStub,
+                scanMetadata: scanMetadataStub,
             } as CommandBarProps;
 
             const rendered = shallow(<CommandBar {...props} />);
@@ -83,7 +83,7 @@ describe('CommandBar', () => {
                 },
                 cardsViewData: cardsViewDataStub,
                 featureFlagStoreData: featureFlagStoreDataStub,
-                scanMetaData: null,
+                scanMetadata: null,
             } as CommandBarProps;
             const rendered = shallow(<CommandBar {...props} />);
 
@@ -106,7 +106,7 @@ describe('CommandBar', () => {
                 },
                 cardsViewData: cardsViewDataStub,
                 featureFlagStoreData: featureFlagStoreDataStub,
-                scanMetaData: scanMetaDataStub,
+                scanMetadata: scanMetadataStub,
             } as CommandBarProps;
 
             const rendered = shallow(<CommandBar {...props} />);
@@ -141,7 +141,7 @@ describe('CommandBar', () => {
                 },
                 cardsViewData: cardsViewDataStub,
                 featureFlagStoreData: featureFlagStoreDataStub,
-                scanMetaData: scanMetaDataStub,
+                scanMetadata: scanMetadataStub,
             } as CommandBarProps;
 
             const rendered = mount(<CommandBar {...props} />);
@@ -168,7 +168,7 @@ describe('CommandBar', () => {
                 },
                 cardsViewData: cardsViewDataStub,
                 featureFlagStoreData: featureFlagStoreDataStub,
-                scanMetaData: scanMetaDataStub,
+                scanMetadata: scanMetadataStub,
             } as CommandBarProps;
 
             const rendered = mount(<CommandBar {...props} />);

--- a/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/command-bar.test.tsx
@@ -4,7 +4,7 @@ import { DropdownClickHandler } from 'common/dropdown-click-handler';
 import { EnumHelper } from 'common/enum-helper';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-creator';
 import { ScanStatus } from 'electron/flux/types/scan-status';
@@ -26,7 +26,7 @@ describe('CommandBar', () => {
     let getDateFromTimestampMock: IMock<(timestamp: string) => Date>;
     let cardsViewDataStub: CardsViewModel;
     let reportGeneratorMock: IMock<ReportGenerator>;
-    let scanMetadataStub: ScanMetaData;
+    let scanMetadataStub: ScanMetadata;
     let scanDateStub: Date;
 
     beforeEach(() => {

--- a/src/tests/unit/tests/reports/components/report-sections/details-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/details-section.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import * as React from 'react';
 import { getUrlItemInfo } from 'reports/components/report-sections/details-section';
 
@@ -14,7 +14,7 @@ describe('DetailsSection', () => {
                 name: appName,
                 url: url,
             },
-        } as ScanMetaData;
+        } as ScanMetadata;
         const expectedLabel = 'target page url:';
 
         const urlItemInfo = getUrlItemInfo(scanMetadata);

--- a/src/tests/unit/tests/reports/components/report-sections/footer-text-for-unified.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/footer-text-for-unified.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -21,7 +21,7 @@ describe('FooterText', () => {
         };
         const scanMetadata = {
             toolData,
-        } as ScanMetaData;
+        } as ScanMetadata;
 
         const footerWrapper = shallow(<FooterTextForUnified {...{ scanMetadata }} />);
         expect(footerWrapper.getElement()).toMatchSnapshot();

--- a/src/tests/unit/tests/reports/components/report-sections/footer-text.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/footer-text.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -21,7 +21,7 @@ describe('FooterText', () => {
         };
         const scanMetadata = {
             toolData,
-        } as ScanMetaData;
+        } as ScanMetadata;
 
         const footerWrapper = shallow(<FooterText {...{ scanMetadata }} />);
         expect(footerWrapper.getElement()).toMatchSnapshot();

--- a/src/tests/unit/tests/reports/components/report-sections/make-details-section-fc.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/make-details-section-fc.test.tsx
@@ -30,13 +30,13 @@ describe('makeDetailsSection', () => {
         content: 'item content',
     };
     let toUtcStringMock: IMock<(date: Date) => string>;
-    let getDisplayedScanTargetInfoMock: IMock<(scanMetaData: ScanMetaData) => ScanDetailInfo>;
+    let getDisplayedScanTargetInfoMock: IMock<(scanMetadata: ScanMetaData) => ScanDetailInfo>;
 
     beforeEach(() => {
         toUtcStringMock = Mock.ofInstance(DateProvider.getUTCStringFromDate, MockBehavior.Strict);
         toUtcStringMock.setup(getter => getter(scanDate)).returns(() => '2018-03-12 11:24 PM UTC');
         getDisplayedScanTargetInfoMock = Mock.ofType<
-            (scanMetaData: ScanMetaData) => ScanDetailInfo
+            (scanMetadata: ScanMetaData) => ScanDetailInfo
         >();
         getDisplayedScanTargetInfoMock
             .setup(g => g(scanMetadata))

--- a/src/tests/unit/tests/reports/components/report-sections/make-details-section-fc.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/make-details-section-fc.test.tsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import * as React from 'react';
 
 import { DateProvider } from 'common/date-provider';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import {
     DetailsSectionProps,
     makeDetailsSectionFC,
@@ -24,19 +24,19 @@ describe('makeDetailsSection', () => {
     const scanMetadata = {
         targetAppInfo,
         deviceName,
-    } as ScanMetaData;
+    } as ScanMetadata;
     const displayedScanTargetInfo: ScanDetailInfo = {
         label: 'item label',
         content: 'item content',
     };
     let toUtcStringMock: IMock<(date: Date) => string>;
-    let getDisplayedScanTargetInfoMock: IMock<(scanMetadata: ScanMetaData) => ScanDetailInfo>;
+    let getDisplayedScanTargetInfoMock: IMock<(scanMetadata: ScanMetadata) => ScanDetailInfo>;
 
     beforeEach(() => {
         toUtcStringMock = Mock.ofInstance(DateProvider.getUTCStringFromDate, MockBehavior.Strict);
         toUtcStringMock.setup(getter => getter(scanDate)).returns(() => '2018-03-12 11:24 PM UTC');
         getDisplayedScanTargetInfoMock = Mock.ofType<
-            (scanMetadata: ScanMetaData) => ScanDetailInfo
+            (scanMetadata: ScanMetadata) => ScanDetailInfo
         >();
         getDisplayedScanTargetInfoMock
             .setup(g => g(scanMetadata))

--- a/src/tests/unit/tests/reports/package/footer-text-for-service.test.tsx
+++ b/src/tests/unit/tests/reports/package/footer-text-for-service.test.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { shallow } from 'enzyme';
 import * as React from 'react';
@@ -21,7 +21,7 @@ describe('FooterTextForService', () => {
         };
         const scanMetadata = {
             toolData,
-        } as ScanMetaData;
+        } as ScanMetadata;
 
         const FooterText = FooterTextForService('ClientService');
 

--- a/src/tests/unit/tests/reports/report-generator.test.ts
+++ b/src/tests/unit/tests/reports/report-generator.test.ts
@@ -3,7 +3,7 @@
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { AssessmentStoreData } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { AssessmentReportHtmlGenerator } from 'reports/assessment-report-html-generator';
 import { ReportGenerator } from 'reports/report-generator';
@@ -30,10 +30,10 @@ describe('ReportGenerator', () => {
         name: title,
         url: url,
     };
-    const scanMetadataStub: ScanMetaData = {
+    const scanMetadataStub: ScanMetadata = {
         toolData: toolDataStub,
         targetAppInfo: targetAppInfo,
-    } as ScanMetaData;
+    } as ScanMetadata;
 
     let dataBuilderMock: IMock<ReportHtmlGenerator>;
     let nameBuilderMock: IMock<ReportNameGenerator>;

--- a/src/tests/unit/tests/reports/report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/report-html-generator.test.tsx
@@ -5,7 +5,7 @@ import { FixInstructionProcessor } from 'common/components/fix-instruction-proce
 import { NullComponent } from 'common/components/null-component';
 import { DateProvider } from 'common/date-provider';
 import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-guidance-links';
-import { ScanMetaData } from 'common/types/store-data/scan-meta-data';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import * as React from 'react';
 import {
@@ -60,7 +60,7 @@ describe('ReportHtmlGenerator', () => {
         const scanMetadata = {
             toolData: toolData,
             targetAppInfo: targetAppInfo,
-        } as ScanMetaData;
+        } as ScanMetadata;
 
         const sectionProps: ReportBodyProps = {
             deps: {


### PR DESCRIPTION
#### Description of changes

some props have a property called scanMetaData, while some capitalize it as scanMetadata. This will standardize all variables with this name to scanMetadata.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
