### PR TITLE
feat(android-report): enable android report feature flag

### DIFF
--- a/src/electron/common/unified-feature-flags.ts
+++ b/src/electron/common/unified-feature-flags.ts
@@ -29,11 +29,11 @@ export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
         },
         {
             id: UnifiedFeatureFlags.exportReport,
-            defaultValue: false,
+            defaultValue: true,
             displayableName: 'Show export report button',
             displayableDescription: 'Show the export report button on the automated checks window',
             isPreviewFeature: false,
-            forceDefault: false,
+            forceDefault: true,
         },
     ];
 }

--- a/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
+++ b/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
@@ -22,7 +22,7 @@ describe('FeatureFlagsTest', () => {
         const expectedValues: FeatureFlagStoreData = {
             [UnifiedFeatureFlags.logTelemetryToConsole]: false,
             [UnifiedFeatureFlags.showAllFeatureFlags]: false,
-            [UnifiedFeatureFlags.exportReport]: false,
+            [UnifiedFeatureFlags.exportReport]: true,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
#### Description of changes

enables the FF for unified/android report.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
