### PR TITLE
refactor: use scanMetadata in HeaderSection for automated checks report

### DIFF
--- a/src/reports/components/report-sections/automated-checks-header-section.tsx
+++ b/src/reports/components/report-sections/automated-checks-header-section.tsx
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
+import * as React from 'react';
+import { HeaderSection } from 'reports/components/report-sections/header-section';
+
+export interface AutomatedChecksHeaderSectionProps {
+    scanMetadata: ScanMetadata;
+}
+
+export const AutomatedChecksHeaderSection = NamedFC<AutomatedChecksHeaderSectionProps>(
+    'AutomatedChecksHeaderSection',
+    ({ scanMetadata }) => {
+        return <HeaderSection targetAppInfo={scanMetadata.targetAppInfo} />;
+    },
+);

--- a/src/reports/components/report-sections/automated-checks-report-section-factory.tsx
+++ b/src/reports/components/report-sections/automated-checks-report-section-factory.tsx
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 import { FailedInstancesSection } from 'common/components/cards/failed-instances-section';
 import { ReportHead } from 'reports/components/report-head';
+import { AutomatedChecksHeaderSection } from 'reports/components/report-sections/automated-checks-header-section';
 import { BodySection } from './body-section';
 import { ContentContainer } from './content-container';
 import { DetailsSection } from './details-section';
 import { FooterText } from './footer-text';
-import { HeaderSection } from './header-section';
 import { NotApplicableChecksSection } from './not-applicable-checks-section';
 import { PassedChecksSection } from './passed-checks-section';
 import { ReportFooter } from './report-footer';
@@ -19,7 +19,7 @@ export const AutomatedChecksReportSectionFactory: ReportSectionFactory = {
     HeadSection: ReportHead,
     BodySection,
     ContentContainer,
-    HeaderSection,
+    HeaderSection: AutomatedChecksHeaderSection,
     TitleSection,
     SummarySection: AllOutcomesSummarySection,
     DetailsSection,

--- a/src/reports/components/report-sections/report-section-factory.tsx
+++ b/src/reports/components/report-sections/report-section-factory.tsx
@@ -6,7 +6,6 @@ import { GetGuidanceTagsFromGuidanceLinks } from 'common/get-guidance-tags-from-
 import { ReactFCWithDisplayName } from 'common/react/named-fc';
 
 import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
-import { TargetAppData } from 'common/types/store-data/unified-data-interface';
 import { CardsViewModel } from '../../../common/types/store-data/card-view-model';
 import { UserConfigurationStoreData } from '../../../common/types/store-data/user-configuration-store';
 import { NotApplicableChecksSectionDeps } from './not-applicable-checks-section';
@@ -28,7 +27,6 @@ export type SectionProps = {
     userConfigurationStoreData: UserConfigurationStoreData;
     shouldAlertFailuresCount?: boolean;
     scanMetadata: ScanMetadata;
-    targetAppInfo: TargetAppData;
 };
 
 export type ReportSectionFactory = {

--- a/src/reports/report-html-generator.tsx
+++ b/src/reports/report-html-generator.tsx
@@ -55,7 +55,6 @@ export class ReportHtmlGenerator {
             getGuidanceTagsFromGuidanceLinks: this.getGuidanceTagsFromGuidanceLinks,
             fixInstructionProcessor: this.fixInstructionProcessor,
             scanMetadata,
-            targetAppInfo: scanMetadata.targetAppInfo,
         } as SectionProps;
 
         const props: ReportBodyProps = {

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/automated-checks-header-section.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/automated-checks-header-section.test.tsx.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AutomatedChecksHeaderSection renders 1`] = `
+<HeaderSection
+  targetAppInfo={
+    Object {
+      "name": "page-title",
+      "url": "url://page",
+    }
+  }
+/>
+`;

--- a/src/tests/unit/tests/reports/components/report-sections/automated-checks-header-section.test.tsx
+++ b/src/tests/unit/tests/reports/components/report-sections/automated-checks-header-section.test.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { ScanMetadata } from 'common/types/store-data/scan-meta-data';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { AutomatedChecksHeaderSection } from 'reports/components/report-sections/automated-checks-header-section';
+
+describe('AutomatedChecksHeaderSection', () => {
+    it('renders', () => {
+        const targetAppInfo = {
+            name: 'page-title',
+            url: 'url://page',
+        };
+        const scanMetadata = {
+            targetAppInfo,
+        } as ScanMetadata;
+        const wrapper = shallow(<AutomatedChecksHeaderSection scanMetadata={scanMetadata} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/reports/report-html-generator.test.tsx
+++ b/src/tests/unit/tests/reports/report-html-generator.test.tsx
@@ -84,7 +84,6 @@ describe('ReportHtmlGenerator', () => {
                 allCardsCollapsed: true,
             },
             scanMetadata,
-            targetAppInfo,
         } as ReportBodyProps;
 
         const headElement: JSX.Element = <NullComponent />;


### PR DESCRIPTION
#### Description of changes

- Create a wrapper around HeaderSection that takes scanMetadata instead of targetAppInfo (AutomatedChecksHeaderSection)
- Use AutomatedChecksHeaderSection in automated checks report
- Remove targetAppInfo from SectionProps

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
