### PR TITLE
feat(Electron 8.x upgrade): Include electron version in build pipeline variable names

### DIFF
--- a/pipeline/unified/build-unsigned-release-packages.yaml
+++ b/pipeline/unified/build-unsigned-release-packages.yaml
@@ -28,8 +28,8 @@ steps:
     - script: yarn build:unified:all --unified-version=$(Build.BuildNumber) --unified-canary-instrumentation-key=$(UnifiedCanaryInstrumentationKey) --unified-insider-instrumentation-key=$(UnifiedInsiderInstrumentationKey) --unified-prod-instrumentation-key=$(UnifiedProdInstrumentationKey)
       displayName: yarn build:unified:all
       env:
-          ELECTRON_MIRROR: $(ELECTRON_MIRROR_VAR)
-          ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR_VAR)
+          ELECTRON_MIRROR: $(ELECTRON_701_MIRROR_VAR)
+          ELECTRON_CUSTOM_DIR: $(ELECTRON_701_CUSTOM_DIR_VAR)
 
     - script: node ./pipeline/scripts/print-file-hash-info.js $(System.DefaultWorkingDirectory)/drop/electron/unified-canary/packed
       displayName: print out canary file hashes

--- a/pipeline/unified/download-electron-mirror.yaml
+++ b/pipeline/unified/download-electron-mirror.yaml
@@ -4,5 +4,5 @@ steps:
     - script: yarn download:electron-mirror
       displayName: download custom electron build
       env:
-          ELECTRON_MIRROR: $(ELECTRON_MIRROR_VAR)
-          ELECTRON_CUSTOM_DIR: $(ELECTRON_CUSTOM_DIR_VAR)
+          ELECTRON_MIRROR: $(ELECTRON_701_MIRROR_VAR)
+          ELECTRON_CUSTOM_DIR: $(ELECTRON_701_CUSTOM_DIR_VAR)


### PR DESCRIPTION
#### Description of changes

This replaces the `ELECTRON_MIRROR_VAR` and `ELECTRON_CUSTOM_DIR_VAR` environment variables with `ELECTRON_701_MIRROR_VAR` and `ELECTRON_701_CUSTOM_DIR_VA`R, respectively. We're doing this to allow the build pipeline to support concurrent versions of Electron as we migrate to 8.x. A similar strategy will be applied to future version migrations.

Note that `ELECTRON_MIRROR` and `ELECTRON_CUSTOM_DIR` are intentionally _not_ changed, since these are the names of the data passed to the build tools.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1710649
- [x] Ran `yarn fastpass`
- [ n/a ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
