### PR TITLE
fix(android-report): sets minimum width for export dialog to 320px

### DIFF
--- a/src/electron/views/renderer-global-styles.scss
+++ b/src/electron/views/renderer-global-styles.scss
@@ -15,4 +15,5 @@
 .insights-dialog-main-override {
     max-width: 25%;
     width: 25%;
+    min-width: 500px !important;
 }

--- a/src/electron/views/renderer-global-styles.scss
+++ b/src/electron/views/renderer-global-styles.scss
@@ -15,5 +15,5 @@
 .insights-dialog-main-override {
     max-width: 25%;
     width: 25%;
-    min-width: 500px !important;
+    min-width: 320px !important;
 }


### PR DESCRIPTION
#### Description of changes

Sets a min width to match web. Looks like this:

![image](https://user-images.githubusercontent.com/32555133/80132496-a2987600-8550-11ea-92c7-fa0dfda17334.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
