### PR TITLE
fix: sign code for all release channels in one pipeline

### DIFF
--- a/pipeline/unified/sign-release-packages.yaml
+++ b/pipeline/unified/sign-release-packages.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+name: Signing-$(Rev:r)
+
+trigger: none
+
+resources:
+    pipelines:
+        - pipeline: build-unsigned-release-packages
+          source: Accessibility Insights Unified - build-unsigned-release-packages
+          trigger:
+              branches: [master]
+
+jobs:
+    - template: channel/sign-release-packages-for-channel.yaml
+      parameters:
+          unsignedPipelineResource: build-unsigned-release-packages
+          channel: canary
+
+    - template: channel/sign-release-packages-for-channel.yaml
+      parameters:
+          unsignedPipelineResource: build-unsigned-release-packages
+          channel: insider
+
+    - template: channel/sign-release-packages-for-channel.yaml
+      parameters:
+          unsignedPipelineResource: build-unsigned-release-packages
+          channel: production


### PR DESCRIPTION
#### Description of changes

This will fix the issue of having a manually triggered pipeline for insider and production where we don't have control over what is getting signed. Will update the releases to use this pipeline after this is merged and delete the old pipelines in a separate PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
