### PR TITLE
chore(build-break): switch condition for CG/Notice gen to variable-based

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -71,7 +71,7 @@ jobs:
 
           - task: ComponentGovernanceComponentDetection@0
             displayName: 'dependency detection (Component Governance)'
-            condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+            condition: and(succeeded(), eq(variables['GenerateReleaseNoticeFile'], 'true'))
             inputs:
                 detectorsFilter: Yarn
                 ignoreDirectories: 'drop,dist,extension,node_modules'
@@ -80,7 +80,7 @@ jobs:
 
           - task: msospo.ospo-extension.8d7f9abb-6896-461d-9e25-4f74ed65ddb2.notice@0
             displayName: 'generate NOTICE.html file'
-            condition: and(succeeded(), in(variables['Build.Reason'], 'IndividualCI', 'BatchedCI'))
+            condition: and(succeeded(), eq(variables['GenerateReleaseNoticeFile'], 'true'))
             inputs:
                 outputfile: '$(System.DefaultWorkingDirectory)/src/NOTICE.html'
                 outputformat: html


### PR DESCRIPTION
#### Description of changes

This switches the conditional for when our PR/CI builds run CG/Notice generation to allow us to avoid running it in the public devops instance (where CG is not enabled) and instead run it only in the private instance using a build variable I've just added to the private CI build.

Addresses [this public CI build failure](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=8287&view=logs&j=a131156f-3b43-553f-e7ad-02c8341f7440&t=b775a80b-db19-5e1f-518a-020944e6f74d)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
