### PR TITLE
fix: resize for export dialog in android

### DIFF
--- a/src/DetailsView/components/export-dialog.scss
+++ b/src/DetailsView/components/export-dialog.scss
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+.export-dialog {
+    max-width: 640px;
+    width: 50%;
+    min-width: 320px !important;
+    user-select: text;
+}

--- a/src/DetailsView/components/export-dialog.tsx
+++ b/src/DetailsView/components/export-dialog.tsx
@@ -11,6 +11,7 @@ import { ReportExportFormat } from '../../common/extension-telemetry-events';
 import { FileURLProvider } from '../../common/file-url-provider';
 import { NamedFC } from '../../common/react/named-fc';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
+import * as styles from './export-dialog.scss';
 
 export interface ExportDialogProps {
     deps: ExportDialogDeps;
@@ -124,7 +125,7 @@ export const ExportDialog = NamedFC<ExportDialogProps>('ExportDialog', props => 
             }}
             modalProps={{
                 isBlocking: false,
-                containerClassName: 'insights-dialog-main-override',
+                containerClassName: styles.exportDialog,
             }}
         >
             <TextField

--- a/src/electron/views/renderer-global-styles.scss
+++ b/src/electron/views/renderer-global-styles.scss
@@ -13,7 +13,7 @@
 
 //  Required as GenericDialog is not using css-modules. Once that is done, this can be removed.
 .insights-dialog-main-override {
-    max-width: 25%;
-    width: 25%;
+    max-width: 640px;
+    width: 50%;
     min-width: 320px !important;
 }

--- a/src/electron/views/renderer-global-styles.scss
+++ b/src/electron/views/renderer-global-styles.scss
@@ -10,10 +10,3 @@
 .ms-Fabric {
     color: $primary-text;
 }
-
-//  Required as GenericDialog is not using css-modules. Once that is done, this can be removed.
-.insights-dialog-main-override {
-    max-width: 640px;
-    width: 50%;
-    min-width: 320px !important;
-}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/export-dialog.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`ExportDialog renders with open false 1`] = `
   hidden={true}
   modalProps={
     Object {
-      "containerClassName": "insights-dialog-main-override",
+      "containerClassName": "exportDialog",
       "isBlocking": false,
     }
   }
@@ -104,7 +104,7 @@ exports[`ExportDialog renders with open true 1`] = `
   hidden={false}
   modalProps={
     Object {
-      "containerClassName": "insights-dialog-main-override",
+      "containerClassName": "exportDialog",
       "isBlocking": false,
     }
   }


### PR DESCRIPTION
#### Description of changes

Increases the size of the export dialog scale factor (while setting a max-width that might make sense).

Note: moved to using css modules after realizing the telemetry dialog was effected by the changes. I checked to see what styles were being applied with the override css class and realized it was about the same as what I was already doing. Hence, it made sense to reduce an instance of that and move to css modules here.

Gif of what that looks like:
![exportdialogresize](https://user-images.githubusercontent.com/32555133/80419729-7fdaca00-888e-11ea-9252-c9d2af59bcdc.gif)

Here it is in Web:
![exportdialogresize_web](https://user-images.githubusercontent.com/32555133/80542516-f5fc3100-8961-11ea-9204-94e392cadb15.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
