### PR TITLE
chore: set default vscode eol to match prettier settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,7 @@
     ],
     "editor.tabSize": 4,
     "html.format.endWithNewline": true,
+    "files.eol": "\n",
     "files.insertFinalNewline": true,
     "prettier.requireConfig": true,
     "editor.formatOnSave": true,


### PR DESCRIPTION
#### Description of changes

Updates our project VS Code EOL setting to match prettier config, to avoid issues where "format on save" does the wrong thing by default on windows machines.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
