### PR TITLE
chore: fix a few unnecessary spacings in info and examples content

### DIFF
--- a/src/content/test/multimedia/captions.tsx
+++ b/src/content/test/multimedia/captions.tsx
@@ -28,18 +28,15 @@ export const infoAndExamples = createWithTitle(
             <h2>How to fix</h2>
             <ul>
                 <li>
-                    {' '}
                     If captions are missing, add them.
                     <ul>
-                        <li>Use closed captions (visible on demand) if possible. </li>
+                        <li>Use closed captions (visible on demand) if possible.</li>
                         <li>
-                            {' '}
-                            Use open captions (always visible) if your media player or hosting provider doesn't support closed captions.{' '}
+                            Use open captions (always visible) if your media player or hosting provider doesn't support closed captions.
                         </li>
                     </ul>
                 </li>
                 <li>
-                    {' '}
                     Make sure the captions provide an accurate and complete description of the audio content:
                     <ul>
                         <li>Include all speech.</li>

--- a/src/content/test/native-widgets/cues.tsx
+++ b/src/content/test/native-widgets/cues.tsx
@@ -25,9 +25,7 @@ export const infoAndExamples = createWithTitle(
                 </li>
                 <li>
                     The <Markup.Term>readonly</Markup.Term> attribute is supported by <Markup.Code>{`<textarea>`}</Markup.Code> elements and
-                    by
-                    {' ' + ''}
-                    <Markup.Code>{`<input>`}</Markup.Code> elements that accept text input. A read-only widget is non-editable, but it is
+                    by <Markup.Code>{`<input>`}</Markup.Code> elements that accept text input. A read-only widget is non-editable, but it is
                     focusable, and users can select its text.
                 </li>
                 <li>

--- a/src/content/test/pointer-motion/pointer-cancellation.tsx
+++ b/src/content/test/pointer-motion/pointer-cancellation.tsx
@@ -19,13 +19,12 @@ export const infoAndExamples = createWithTitle(
             <h2>How to fix</h2>
             <p>For any function that can be operated using a single pointer, make sure at least one of the following is true:</p>
             <ul>
-                <li> The down event doesn't trigger any part of the function, or</li>
+                <li>The down event doesn't trigger any part of the function, or</li>
                 <li>
-                    {' '}
                     The down event initiates the function, which is completed only on the up event, and users can abort or undo the
                     function, or
                 </li>
-                <li> The down event completes the function, and the up event reverses the outcome of the preceding down event.</li>
+                <li>The down event completes the function, and the up event reverses the outcome of the preceding down event.</li>
             </ul>
             <h2>Example</h2>
             <Markup.PassFail

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -17852,18 +17852,18 @@ exports[`Guidance Content pages test/multimedia/captions/infoAndExamples matches
       </h2>
       <ul>
         <li>
-           If captions are missing, add them.
+          If captions are missing, add them.
           <ul>
             <li>
-              Use closed captions (visible on demand) if possible. 
+              Use closed captions (visible on demand) if possible.
             </li>
             <li>
-               Use open captions (always visible) if your media player or hosting provider doesn't support closed captions. 
+              Use open captions (always visible) if your media player or hosting provider doesn't support closed captions.
             </li>
           </ul>
         </li>
         <li>
-           Make sure the captions provide an accurate and complete description of the audio content:
+          Make sure the captions provide an accurate and complete description of the audio content:
           <ul>
             <li>
               Include all speech.
@@ -23070,13 +23070,13 @@ exports[`Guidance Content pages test/pointerMotion/pointerCancellation/infoAndEx
       </p>
       <ul>
         <li>
-           The down event doesn't trigger any part of the function, or
+          The down event doesn't trigger any part of the function, or
         </li>
         <li>
-           The down event initiates the function, which is completed only on the up event, and users can abort or undo the function, or
+          The down event initiates the function, which is completed only on the up event, and users can abort or undo the function, or
         </li>
         <li>
-           The down event completes the function, and the up event reverses the outcome of the preceding down event.
+          The down event completes the function, and the up event reverses the outcome of the preceding down event.
         </li>
       </ul>
       <h2>


### PR DESCRIPTION
#### Description of changes

During the review of #2572, I noticed a few places where there were unnecessary `{' '}`s lingering. This PR removes them.

Verified that there are no visual/reading changes to the affected content.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
