### PR TITLE
fix: missing space in table semantics how to test text

### DIFF
--- a/src/assessments/semantics/test-steps/table-semantics.tsx
+++ b/src/assessments/semantics/test-steps/table-semantics.tsx
@@ -58,8 +58,8 @@ const tableSemanticsHowToTest: JSX.Element = (
                     <li>
                         A <Markup.Tag tagName="table" /> element that serves as a layout table{' '}
                         <Markup.Emphasis>must be</Markup.Emphasis> marked with{' '}
-                        <Markup.CodeTerm>role="presentation"</Markup.CodeTerm> or
-                        <Markup.CodeTerm>role="none"</Markup.CodeTerm>.
+                        <Markup.CodeTerm>role="presentation"</Markup.CodeTerm>
+                        or <Markup.CodeTerm>role="none"</Markup.CodeTerm>.
                     </li>
                 </ol>
             </li>

--- a/src/assessments/semantics/test-steps/table-semantics.tsx
+++ b/src/assessments/semantics/test-steps/table-semantics.tsx
@@ -52,14 +52,14 @@ const tableSemanticsHowToTest: JSX.Element = (
                     <li>
                         A <Markup.Tag tagName="table" /> element that serves as a data table{' '}
                         <Markup.Emphasis>must not be</Markup.Emphasis> marked with{' '}
-                        <Markup.CodeTerm>role="presentation"</Markup.CodeTerm>
-                        or <Markup.CodeTerm>role="none"</Markup.CodeTerm>.
+                        <Markup.CodeTerm>role="presentation"</Markup.CodeTerm> or{' '}
+                        <Markup.CodeTerm>role="none"</Markup.CodeTerm>.
                     </li>
                     <li>
                         A <Markup.Tag tagName="table" /> element that serves as a layout table{' '}
                         <Markup.Emphasis>must be</Markup.Emphasis> marked with{' '}
-                        <Markup.CodeTerm>role="presentation"</Markup.CodeTerm>
-                        or <Markup.CodeTerm>role="none"</Markup.CodeTerm>.
+                        <Markup.CodeTerm>role="presentation"</Markup.CodeTerm> or{' '}
+                        <Markup.CodeTerm>role="none"</Markup.CodeTerm>.
                     </li>
                 </ol>
             </li>


### PR DESCRIPTION
#### Description of changes

There's a space missing between "or" and "`role="none"`" in table semantics how to fix 4.b.:

**before**
![screenshot of issue](https://user-images.githubusercontent.com/376284/80760957-91baa800-8aee-11ea-8c3c-8847933861c1.png)

**after**
![screenshot of same text with fix](https://user-images.githubusercontent.com/376284/80761410-5ff61100-8aef-11ea-9d8b-0bcb39905030.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
