### PR TITLE
fix: minor styling issues in semantics requirements

### DIFF
--- a/src/assessments/semantics/test-steps/css-content.tsx
+++ b/src/assessments/semantics/test-steps/css-content.tsx
@@ -16,8 +16,8 @@ const cssContentHowToTest: JSX.Element = (
     <div>
         <p>
             The visual helper for this requirement highlights content inserted in the page using CSS{' '}
-            <Markup.Code>:before</Markup.Code> or <Markup.Code>:after</Markup.Code>. This procedure
-            uses the{' '}
+            <Markup.CodeTerm>:before</Markup.CodeTerm> or <Markup.CodeTerm>:after</Markup.CodeTerm>.
+            This procedure uses the{' '}
             <NewTabLink href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">
                 Web Developer
             </NewTabLink>{' '}
@@ -88,8 +88,8 @@ const cssContentHowToTest: JSX.Element = (
 
 const cssContentDescription: JSX.Element = (
     <span>
-        Meaningful content must not be implemented using only CSS <Markup.Code>:before</Markup.Code>{' '}
-        or <Markup.Code>:after</Markup.Code>.
+        Meaningful content must not be implemented using only CSS{' '}
+        <Markup.CodeTerm>:before</Markup.CodeTerm> or <Markup.CodeTerm>:after</Markup.CodeTerm>.
     </span>
 );
 

--- a/src/assessments/semantics/test-steps/css-content.tsx
+++ b/src/assessments/semantics/test-steps/css-content.tsx
@@ -16,7 +16,7 @@ const cssContentHowToTest: JSX.Element = (
     <div>
         <p>
             The visual helper for this requirement highlights content inserted in the page using CSS{' '}
-            <Markup.Term>:before</Markup.Term> or <Markup.Term>:after</Markup.Term>. This procedure
+            <Markup.Code>:before</Markup.Code> or <Markup.Code>:after</Markup.Code>. This procedure
             uses the{' '}
             <NewTabLink href="https://chrome.google.com/webstore/detail/web-developer/bfbameneiokkgbdmiekhjnmfkcnldhhm">
                 Web Developer
@@ -88,8 +88,8 @@ const cssContentHowToTest: JSX.Element = (
 
 const cssContentDescription: JSX.Element = (
     <span>
-        Meaningful content must not be implemented using only CSS <Markup.Term>:before</Markup.Term>{' '}
-        or <Markup.Term>:after</Markup.Term>.
+        Meaningful content must not be implemented using only CSS <Markup.Code>:before</Markup.Code>{' '}
+        or <Markup.Code>:after</Markup.Code>.
     </span>
 );
 

--- a/src/assessments/semantics/test-steps/headers-attribute.tsx
+++ b/src/assessments/semantics/test-steps/headers-attribute.tsx
@@ -41,7 +41,7 @@ const headersAttributeHowToTest: JSX.Element = (
                 <ol>
                     <li>
                         Each header cell (<Markup.Tag tagName="th" /> element(s)) must have an{' '}
-                        <Markup.Code>id</Markup.Code> attribute.
+                        <Markup.CodeTerm>id</Markup.CodeTerm> attribute.
                     </li>
                     <li>
                         Each data cell's <Markup.CodeTerm>headers</Markup.CodeTerm> attribute must

--- a/src/assessments/semantics/test-steps/headers-attribute.tsx
+++ b/src/assessments/semantics/test-steps/headers-attribute.tsx
@@ -41,7 +41,7 @@ const headersAttributeHowToTest: JSX.Element = (
                 <ol>
                     <li>
                         Each header cell (<Markup.Tag tagName="th" /> element(s)) must have an{' '}
-                        <Markup.Term>id</Markup.Term> attribute.
+                        <Markup.Code>id</Markup.Code> attribute.
                     </li>
                     <li>
                         Each data cell's <Markup.CodeTerm>headers</Markup.CodeTerm> attribute must

--- a/src/content/test/semantics/headers.tsx
+++ b/src/content/test/semantics/headers.tsx
@@ -76,7 +76,7 @@ export const infoAndExamples = create(({ Markup, Link }) => (
             </table>`}
             passText={
                 <p>
-                    Using <Markup.Term>{`<th>`}</Markup.Term> elements for headers identifies them correctly to assistive technologies. All
+                    Using <Markup.Code>{`<th>`}</Markup.Code> elements for headers identifies them correctly to assistive technologies. All
                     users can distinguish between column headers and data cells.
                 </p>
             }

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -25959,9 +25959,11 @@ exports[`Guidance Content pages test/semantics/headers/infoAndExamples matches t
           </div>
           <p>
             Using 
-            <strong>
+            <span
+              class="insights-code"
+            >
               &lt;th&gt;
-            </strong>
+            </span>
              elements for headers identifies them correctly to assistive technologies. All users can distinguish between column headers and data cells.
           </p>
         </div>


### PR DESCRIPTION
#### Description of changes

Addresses issues from #2583

1. Fixes CSS content styling of `:before` and `:after` selectors:

**before (left) vs after (right)**:
![screenshot comparing before and after fix](https://user-images.githubusercontent.com/376284/80763274-02fc5a00-8af3-11ea-8349-17c74e02d20b.png)

2. Fixes styling on `<th>` in description of pass example in Headers info and examples

**before (left) vs after (right)**:
![screenshot comparing before and after fix](https://user-images.githubusercontent.com/376284/80763710-fe847100-8af3-11ea-89ec-d30e3808fa1b.png)

3. Fixes styling on `id` attribute in Header attributes how to fix text:

**before (left) vs after (right)**:
![screenshot comparing before and after fix](https://user-images.githubusercontent.com/376284/80763860-4efbce80-8af4-11ea-93f5-a8a24578d54c.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2583
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
