### PR TITLE
fix: new Headers and Header attributes reqs not using new panel titles

### DIFF
--- a/src/content/test/semantics/headers-attribute.tsx
+++ b/src/content/test/semantics/headers-attribute.tsx
@@ -1,43 +1,47 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { create, React } from '../../common';
+import { createWithTitle, React } from '../../common';
 
-export const infoAndExamples = create(({ Markup, Link }) => (
-    <>
-        <h1>Headers attribute</h1>
-        <p>
-            The <Markup.Code>headers</Markup.Code> attribute of a <Markup.Code>{`<td>`}</Markup.Code> element must reference the correct{' '}
-            <Markup.Code>{`<th>`}</Markup.Code> element(s).
-        </p>
+export const infoAndExamples = createWithTitle(
+    {
+        pageTitle: 'Headers attribute',
+    },
+    ({ Markup }) => (
+        <>
+            <p>
+                The <Markup.Code>headers</Markup.Code> attribute of a <Markup.Code>{`<td>`}</Markup.Code> element must reference the correct{' '}
+                <Markup.Code>{`<th>`}</Markup.Code> element(s).
+            </p>
 
-        <h2>Why it matters</h2>
-        <p>
-            When assistive technologies describe data tables, they mention both the data cells and their programmatically-related header
-            cells. When incorrect header cells are reported, users are likely to find the table confusing.
-        </p>
+            <h2>Why it matters</h2>
+            <p>
+                When assistive technologies describe data tables, they mention both the data cells and their programmatically-related header
+                cells. When incorrect header cells are reported, users are likely to find the table confusing.
+            </p>
 
-        <h2>How to fix</h2>
-        <ul>
-            <li>
-                Good: Modify the <Markup.Code>headers</Markup.Code> attribute of the <Markup.Code>{`<td>`}</Markup.Code> element(s) to match
-                the <Markup.Code>id</Markup.Code> attribute of the correct <Markup.Code>{`<th>`}</Markup.Code> element(s), or
-            </li>
-            <li>
-                Better: Eliminate multi-level headings and define headers using <Markup.Code>scope</Markup.Code> attributes.
-            </li>
-        </ul>
-        <p />
+            <h2>How to fix</h2>
+            <ul>
+                <li>
+                    Good: Modify the <Markup.Code>headers</Markup.Code> attribute of the <Markup.Code>{`<td>`}</Markup.Code> element(s) to
+                    match the <Markup.Code>id</Markup.Code> attribute of the correct <Markup.Code>{`<th>`}</Markup.Code> element(s), or
+                </li>
+                <li>
+                    Better: Eliminate multi-level headings and define headers using <Markup.Code>scope</Markup.Code> attributes.
+                </li>
+            </ul>
+            <p />
 
-        <h2>Example</h2>
-        <Markup.PassFail
-            failText={
-                <p>
-                    This complex data table has two levels of headers. Three of the data cells' <Markup.Code>headers</Markup.Code>{' '}
-                    attributes should refer to both levels, but incorrectly refer to only the top-level header. Assistive technologies will
-                    announce only "Faculty" as the header for those data cells. Some users will find it difficult to understand the table.
-                </p>
-            }
-            failExample={`<table border="1">
+            <h2>Example</h2>
+            <Markup.PassFail
+                failText={
+                    <p>
+                        This complex data table has two levels of headers. Three of the data cells' <Markup.Code>headers</Markup.Code>{' '}
+                        attributes should refer to both levels, but incorrectly refer to only the top-level header. Assistive technologies
+                        will announce only "Faculty" as the header for those data cells. Some users will find it difficult to understand the
+                        table.
+                    </p>
+                }
+                failExample={`<table border="1">
             <tr>
             <th rowspan="2" id="s">Students</th>
             <th colspan="3" id="f">Faculty</th>
@@ -54,13 +58,14 @@ export const infoAndExamples = create(({ Markup, Link }) => (
             <td [headers="f"]>5</td>
             </tr>
             </table> `}
-            passText={
-                <p>
-                    All data cells refer to the correct headers. Assistive technologies will announce both header levels where appropriate:
-                    "Faculty Teachers," "Faculty Assistants," and "Faculty Observers". Everyone can interpret the table correctly.
-                </p>
-            }
-            passExample={`<table border="1">
+                passText={
+                    <p>
+                        All data cells refer to the correct headers. Assistive technologies will announce both header levels where
+                        appropriate: "Faculty Teachers," "Faculty Assistants," and "Faculty Observers". Everyone can interpret the table
+                        correctly.
+                    </p>
+                }
+                passExample={`<table border="1">
             <tr>
             <th rowspan="2" id="s">Students</th>
             <th colspan="3" id="f">Faculty</th>
@@ -77,41 +82,43 @@ export const infoAndExamples = create(({ Markup, Link }) => (
             <td [headers="f f3"]>5</td>
             </tr>
             </table>`}
-        />
+            />
 
-        <h2>More examples</h2>
-        <h3>WCAG success criteria</h3>
-        <Markup.Links>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html">
-                Understanding Success Criterion 1.3.1
-            </Markup.HyperLink>
-        </Markup.Links>
+            <h2>More examples</h2>
+            <h3>WCAG success criteria</h3>
+            <Markup.Links>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html">
+                    Understanding Success Criterion 1.3.1
+                </Markup.HyperLink>
+            </Markup.Links>
 
-        <h3>Sufficient techniques</h3>
-        <Markup.Links>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H51">
-                Using table markup to present tabular information
-            </Markup.HyperLink>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H63">
-                Using the scope attribute to associate header cells and data cells in data tables
-            </Markup.HyperLink>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H43">
-                Using id and headers attributes to associate data cells with header cells in data tables
-            </Markup.HyperLink>
-        </Markup.Links>
+            <h3>Sufficient techniques</h3>
+            <Markup.Links>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H51">
+                    Using table markup to present tabular information
+                </Markup.HyperLink>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H63">
+                    Using the scope attribute to associate header cells and data cells in data tables
+                </Markup.HyperLink>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H43">
+                    Using id and headers attributes to associate data cells with header cells in data tables
+                </Markup.HyperLink>
+            </Markup.Links>
 
-        <h3>Common failures</h3>
-        <Markup.Links>
-            <Markup.HyperLink href="https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/F90">
-                Failure of Success Criterion 1.3.1 for incorrectly associating table headers and content via the headers and id attributes
-            </Markup.HyperLink>
-        </Markup.Links>
+            <h3>Common failures</h3>
+            <Markup.Links>
+                <Markup.HyperLink href="https://www.w3.org/TR/2016/NOTE-WCAG20-TECHS-20161007/F90">
+                    Failure of Success Criterion 1.3.1 for incorrectly associating table headers and content via the headers and id
+                    attributes
+                </Markup.HyperLink>
+            </Markup.Links>
 
-        <h3>Additional guidance</h3>
-        <Markup.Links>
-            <Markup.HyperLink href="https://www.w3.org/WAI/tutorials/tables/">
-                Tables Concepts – Tables – WAI Web Accessibility Tutorials
-            </Markup.HyperLink>
-        </Markup.Links>
-    </>
-));
+            <h3>Additional guidance</h3>
+            <Markup.Links>
+                <Markup.HyperLink href="https://www.w3.org/WAI/tutorials/tables/">
+                    Tables Concepts – Tables – WAI Web Accessibility Tutorials
+                </Markup.HyperLink>
+            </Markup.Links>
+        </>
+    ),
+);

--- a/src/content/test/semantics/headers.tsx
+++ b/src/content/test/semantics/headers.tsx
@@ -1,62 +1,65 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { create, React } from '../../common';
+import { createWithTitle, React } from '../../common';
 
-export const infoAndExamples = create(({ Markup, Link }) => (
-    <>
-        <h1>Headers</h1>
-        <p>Coded headers must be used correctly.</p>
+export const infoAndExamples = createWithTitle(
+    {
+        pageTitle: 'Headers',
+    },
+    ({ Markup }) => (
+        <>
+            <p>Coded headers must be used correctly.</p>
 
-        <h2>Why it matters</h2>
-        <p>
-            When assistive technologies encounter a <Markup.Emphasis>data</Markup.Emphasis> table, they report the data cells and their
-            coded headers in a way that shows they are related. When a <Markup.Emphasis>data</Markup.Emphasis> table has no coded headers,
-            assistive technologies can't report these relationships. When a <Markup.Emphasis>layout</Markup.Emphasis> table has coded
-            headers, assistive technologies report relationships between cells that don't actually exist. Some users are likely to find the
-            table's content confusing.
-        </p>
+            <h2>Why it matters</h2>
+            <p>
+                When assistive technologies encounter a <Markup.Emphasis>data</Markup.Emphasis> table, they report the data cells and their
+                coded headers in a way that shows they are related. When a <Markup.Emphasis>data</Markup.Emphasis> table has no coded
+                headers, assistive technologies can't report these relationships. When a <Markup.Emphasis>layout</Markup.Emphasis> table has
+                coded headers, assistive technologies report relationships between cells that don't actually exist. Some users are likely to
+                find the table's content confusing.
+            </p>
 
-        <h2>How to fix</h2>
-        <p>
-            Add programmatically identified headers to every data table:
-            <ol>
-                <li>
-                    If the table has only one row or one column of headers, use <Markup.Code>{`<th>`}</Markup.Code> elements for header
-                    cells and <Markup.Code>{`<td>`}</Markup.Code> elements for data cells.
-                </li>
-                <li>
-                    If the table has both row and column headers, add <Markup.Code>scope="row"</Markup.Code> or{' '}
-                    <Markup.Code>scope="column"</Markup.Code> to each header cell.
-                </li>
-                <li>
-                    If the table has headers that span multiple rows or columns, add <Markup.Code>colgroup</Markup.Code> or{' '}
-                    <Markup.Code>rowgroup</Markup.Code> and <Markup.Code>span</Markup.Code> attributes to each header cell.
-                </li>
-                <li>
-                    If the table has multi-level headers (not recommended):
-                    <ol>
-                        <li>
-                            Provide an <Markup.Code>id</Markup.Code> for each header cell.
-                        </li>
-                        <li>
-                            For each data cell, provide a <Markup.Code>headers</Markup.Code> attribute that references the correct header
-                            cell(s).{' '}
-                        </li>
-                    </ol>
-                </li>
-            </ol>
-        </p>
+            <h2>How to fix</h2>
+            <p>
+                Add programmatically identified headers to every data table:
+                <ol>
+                    <li>
+                        If the table has only one row or one column of headers, use <Markup.Code>{`<th>`}</Markup.Code> elements for header
+                        cells and <Markup.Code>{`<td>`}</Markup.Code> elements for data cells.
+                    </li>
+                    <li>
+                        If the table has both row and column headers, add <Markup.Code>scope="row"</Markup.Code> or{' '}
+                        <Markup.Code>scope="column"</Markup.Code> to each header cell.
+                    </li>
+                    <li>
+                        If the table has headers that span multiple rows or columns, add <Markup.Code>colgroup</Markup.Code> or{' '}
+                        <Markup.Code>rowgroup</Markup.Code> and <Markup.Code>span</Markup.Code> attributes to each header cell.
+                    </li>
+                    <li>
+                        If the table has multi-level headers (not recommended):
+                        <ol>
+                            <li>
+                                Provide an <Markup.Code>id</Markup.Code> for each header cell.
+                            </li>
+                            <li>
+                                For each data cell, provide a <Markup.Code>headers</Markup.Code> attribute that references the correct
+                                header cell(s).{' '}
+                            </li>
+                        </ol>
+                    </li>
+                </ol>
+            </p>
 
-        <h2>Example</h2>
+            <h2>Example</h2>
 
-        <Markup.PassFail
-            failText={
-                <p>
-                    Because this data table has no programmatically-identified headers, assistive technologies will report the headers as
-                    data cells. Some users will find the table difficult to understand.
-                </p>
-            }
-            failExample={`<table>
+            <Markup.PassFail
+                failText={
+                    <p>
+                        Because this data table has no programmatically-identified headers, assistive technologies will report the headers
+                        as data cells. Some users will find the table difficult to understand.
+                    </p>
+                }
+                failExample={`<table>
             <tr>
             [<td>]Park name[</th>]
             [<td>]Location[</th>]
@@ -74,13 +77,13 @@ export const infoAndExamples = create(({ Markup, Link }) => (
             <td>Des Moines, WA<td>
             </tr>
             </table>`}
-            passText={
-                <p>
-                    Using <Markup.Term>{`<th>`}</Markup.Term> elements for headers identifies them correctly to assistive technologies. All
-                    users can distinguish between column headers and data cells.
-                </p>
-            }
-            passExample={`<table>
+                passText={
+                    <p>
+                        Using <Markup.Term>{`<th>`}</Markup.Term> elements for headers identifies them correctly to assistive technologies.
+                        All users can distinguish between column headers and data cells.
+                    </p>
+                }
+                passExample={`<table>
             <tr>
             [<th>]Park name[</th>]
             [<th>]Location[</th>]
@@ -98,41 +101,42 @@ export const infoAndExamples = create(({ Markup, Link }) => (
             <td>Des Moines, WA<td>
             </tr>
             </table>`}
-        />
+            />
 
-        <h2>More examples</h2>
-        <h3>WCAG success criteria</h3>
-        <Markup.Links>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html">
-                Understanding Success Criterion 1.3.1
-            </Markup.HyperLink>
-        </Markup.Links>
+            <h2>More examples</h2>
+            <h3>WCAG success criteria</h3>
+            <Markup.Links>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html">
+                    Understanding Success Criterion 1.3.1
+                </Markup.HyperLink>
+            </Markup.Links>
 
-        <h3>Sufficient techniques</h3>
-        <Markup.Links>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H51">
-                Using table markup to present tabular information
-            </Markup.HyperLink>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H63">
-                Using the scope attribute to associate header cells and data cells in data tables
-            </Markup.HyperLink>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H43">
-                Using id and headers attributes to associate data cells with header cells in data tables
-            </Markup.HyperLink>
-        </Markup.Links>
+            <h3>Sufficient techniques</h3>
+            <Markup.Links>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H51">
+                    Using table markup to present tabular information
+                </Markup.HyperLink>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H63">
+                    Using the scope attribute to associate header cells and data cells in data tables
+                </Markup.HyperLink>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/html/H43">
+                    Using id and headers attributes to associate data cells with header cells in data tables
+                </Markup.HyperLink>
+            </Markup.Links>
 
-        <h3>Common failures</h3>
-        <Markup.Links>
-            <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F91">
-                Failure of Success Criterion 1.3.1 for not correctly marking up table headers{' '}
-            </Markup.HyperLink>
-        </Markup.Links>
+            <h3>Common failures</h3>
+            <Markup.Links>
+                <Markup.HyperLink href="https://www.w3.org/WAI/WCAG21/Techniques/failures/F91">
+                    Failure of Success Criterion 1.3.1 for not correctly marking up table headers{' '}
+                </Markup.HyperLink>
+            </Markup.Links>
 
-        <h3>Additional guidance</h3>
-        <Markup.Links>
-            <Markup.HyperLink href="https://www.w3.org/WAI/tutorials/tables/">
-                Tables Concepts – Tables – WAI Web Accessibility Tutorials
-            </Markup.HyperLink>
-        </Markup.Links>
-    </>
-));
+            <h3>Additional guidance</h3>
+            <Markup.Links>
+                <Markup.HyperLink href="https://www.w3.org/WAI/tutorials/tables/">
+                    Tables Concepts – Tables – WAI Web Accessibility Tutorials
+                </Markup.HyperLink>
+            </Markup.Links>
+        </>
+    ),
+);

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -25699,9 +25699,6 @@ exports[`Guidance Content pages test/semantics/headers/infoAndExamples matches t
     <div
       class="content"
     >
-      <h1>
-        Headers
-      </h1>
       <p>
         Coded headers must be used correctly.
       </p>
@@ -26133,9 +26130,6 @@ exports[`Guidance Content pages test/semantics/headersAttribute/infoAndExamples 
     <div
       class="content"
     >
-      <h1>
-        Headers attribute
-      </h1>
       <p>
         The 
         <span


### PR DESCRIPTION
#### Description of changes

This fixes a silent merge conflict between the feature work adding the new header/header attributes requirements and #2572

Verified that no other infoAndExamples content is affected similarly.

I'd like to add a test case to prevent this class of issue, but scoping that to a later PR to unblock respinning 2.18.1

**before (left) vs after (right):**
![image](https://user-images.githubusercontent.com/376284/80764547-c716c400-8af5-11ea-9b72-7a5cbfe76e9b.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
