### PR TITLE
fix: add anchor to aria practices presentation_role links

### DIFF
--- a/src/content/test/semantics/guidance.tsx
+++ b/src/content/test/semantics/guidance.tsx
@@ -158,7 +158,7 @@ export const guidance = create(({ Markup, Link }) => (
         </Markup.Links>
         <h4>Additional guidance</h4>
         <Markup.Links>
-            <Markup.HyperLink href="https://www.w3.org/TR/wai-aria-practices-1.1/">
+            <Markup.HyperLink href="https://www.w3.org/TR/wai-aria-practices-1.1/#presentation_role">
                 Intentionally Hiding Semantics with the Presentation Role
             </Markup.HyperLink>
         </Markup.Links>

--- a/src/content/test/semantics/table-semantics.tsx
+++ b/src/content/test/semantics/table-semantics.tsx
@@ -153,7 +153,7 @@ export const infoAndExamples = createWithTitle(
             </Markup.Links>
             <h3>Additional guidance</h3>
             <Markup.Links>
-                <Markup.HyperLink href="https://www.w3.org/TR/wai-aria-practices-1.1/">
+                <Markup.HyperLink href="https://www.w3.org/TR/wai-aria-practices-1.1/#presentation_role">
                     Intentionally Hiding Semantics with the Presentation Role
                 </Markup.HyperLink>
             </Markup.Links>

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -25474,7 +25474,7 @@ exports[`Guidance Content pages test/semantics/guidance matches the snapshot 1`]
       >
         <a
           class="ms-Link insights-link root-000"
-          href="https://www.w3.org/TR/wai-aria-practices-1.1/"
+          href="https://www.w3.org/TR/wai-aria-practices-1.1/#presentation_role"
           target="_blank"
         >
           Intentionally Hiding Semantics with the Presentation Role
@@ -27821,7 +27821,7 @@ exports[`Guidance Content pages test/semantics/tableSemantics/infoAndExamples ma
       >
         <a
           class="ms-Link insights-link root-000"
-          href="https://www.w3.org/TR/wai-aria-practices-1.1/"
+          href="https://www.w3.org/TR/wai-aria-practices-1.1/#presentation_role"
           target="_blank"
         >
           Intentionally Hiding Semantics with the Presentation Role


### PR DESCRIPTION
#### Description of changes

We had a link in 2 places of the form:

```tsx
<Markup.HyperLink href="https://www.w3.org/TR/wai-aria-practices-1.1/">
    Intentionally Hiding Semantics with the Presentation Role
</Markup.HyperLink>
```

...linking to the top-level document instead of the specific section labeled by the link text. This fixes both spots where we have a link of that format to use the anchor to the specific indicated section.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
