### PR TITLE
feat(nav-bar-content): updating selectedTestStep to selectedTestSubview

### DIFF
--- a/src/DetailsView/components/assessment-instance-table.tsx
+++ b/src/DetailsView/components/assessment-instance-table.tsx
@@ -80,7 +80,7 @@ export class AssessmentInstanceTable extends React.Component<AssessmentInstanceT
         );
         const defaultMessageComponent = getDefaultMessage(
             this.props.instancesMap,
-            this.props.assessmentNavState.selectedTestStep,
+            this.props.assessmentNavState.selectedTestSubview,
         );
 
         if (defaultMessageComponent) {
@@ -123,7 +123,7 @@ export class AssessmentInstanceTable extends React.Component<AssessmentInstanceT
     public renderDefaultInstanceTableHeader(items: AssessmentInstanceRowData[]): JSX.Element {
         const disabled = !this.isAnyInstanceStatusUnknown(
             items,
-            this.props.assessmentNavState.selectedTestStep,
+            this.props.assessmentNavState.selectedTestSubview,
         );
 
         return (
@@ -149,7 +149,7 @@ export class AssessmentInstanceTable extends React.Component<AssessmentInstanceT
     protected onPassUnmarkedInstances = (): void => {
         this.props.assessmentInstanceTableHandler.passUnmarkedInstances(
             this.props.assessmentNavState.selectedTestType,
-            this.props.assessmentNavState.selectedTestStep,
+            this.props.assessmentNavState.selectedTestSubview,
         );
     };
 }

--- a/src/DetailsView/components/assessment-table-column-config-handler.tsx
+++ b/src/DetailsView/components/assessment-table-column-config-handler.tsx
@@ -65,7 +65,7 @@ export class AssessmentTableColumnConfigHandler {
         let allColumns: IColumn[] = [];
         const stepConfig = this.assessmentProvider.getStep(
             assessmentNavState.selectedTestType,
-            assessmentNavState.selectedTestStep,
+            assessmentNavState.selectedTestSubview,
         );
 
         if (hasVisualHelper) {
@@ -89,7 +89,7 @@ export class AssessmentTableColumnConfigHandler {
     private getCustomColumns(assessmentNavState: AssessmentNavState): IColumn[] {
         const stepConfig = this.assessmentProvider.getStep(
             assessmentNavState.selectedTestType,
-            assessmentNavState.selectedTestStep,
+            assessmentNavState.selectedTestSubview,
         );
 
         const customColumns = stepConfig.columnsConfig.map(columnConfig => {

--- a/src/DetailsView/components/assessment-test-view.tsx
+++ b/src/DetailsView/components/assessment-test-view.tsx
@@ -48,7 +48,7 @@ export const AssessmentTestView = NamedFC<AssessmentTestViewProps>(
         const prevTarget = props.assessmentStoreData.persistedTabInfo;
         const isEnabled = props.configuration.getTestStatus(
             scanData,
-            assessmentNavState.selectedTestStep,
+            assessmentNavState.selectedTestSubview,
         );
         const currentTarget = {
             id: props.tabStoreData.id,

--- a/src/DetailsView/components/assessment-view.tsx
+++ b/src/DetailsView/components/assessment-view.tsx
@@ -109,7 +109,7 @@ export class AssessmentView extends React.Component<AssessmentViewProps> {
 
     private enableSelectedStepVisualHelper(sendTelemetry = true): void {
         const test = this.props.assessmentNavState.selectedTestType;
-        const step = this.props.assessmentNavState.selectedTestStep;
+        const step = this.props.assessmentNavState.selectedTestSubview;
         if (this.visualHelperDisabledByDefault(test, step) || this.isTargetChanged()) {
             return;
         }
@@ -134,8 +134,8 @@ export class AssessmentView extends React.Component<AssessmentViewProps> {
 
     private isStepSwitched(prevProps: AssessmentViewProps): boolean {
         return (
-            prevProps.assessmentNavState.selectedTestStep !==
-            this.props.assessmentNavState.selectedTestStep
+            prevProps.assessmentNavState.selectedTestSubview !==
+            this.props.assessmentNavState.selectedTestSubview
         );
     }
 
@@ -193,7 +193,7 @@ export class AssessmentView extends React.Component<AssessmentViewProps> {
 
     private renderMainContent(assessmentTestResult: AssessmentTestResult): JSX.Element {
         const selectedRequirement = assessmentTestResult.getRequirementResult(
-            this.props.assessmentNavState.selectedTestStep,
+            this.props.assessmentNavState.selectedTestSubview,
         );
         const isStepScanned = selectedRequirement.data.isStepScanned;
 

--- a/src/DetailsView/components/assessment-visualization-enabled-toggle.tsx
+++ b/src/DetailsView/components/assessment-visualization-enabled-toggle.tsx
@@ -23,14 +23,14 @@ export class AssessmentVisualizationEnabledToggle extends BaseVisualHelperToggle
                 ),
             ),
             this.props.assessmentNavState.selectedTestType,
-            this.props.assessmentNavState.selectedTestStep,
+            this.props.assessmentNavState.selectedTestSubview,
         );
     };
 
     private isAnyInstanceVisible(instances: GeneratedAssessmentInstance<{}, {}>[]): boolean {
         return instances.some(
             instance =>
-                instance.testStepResults[this.props.assessmentNavState.selectedTestStep]
+                instance.testStepResults[this.props.assessmentNavState.selectedTestSubview]
                     .isVisualizationEnabled,
         );
     }

--- a/src/DetailsView/components/base-visual-helper-toggle.tsx
+++ b/src/DetailsView/components/base-visual-helper-toggle.tsx
@@ -47,7 +47,7 @@ export abstract class BaseVisualHelperToggle extends React.Component<VisualHelpe
         assessmentNavState,
         instancesMap: DictionaryStringTo<GeneratedAssessmentInstance>,
     ): GeneratedAssessmentInstance<{}, {}>[] {
-        const selectedTestStep = assessmentNavState.selectedTestStep;
+        const selectedTestStep = assessmentNavState.selectedTestSubview;
 
         return filter(instancesMap, instance => {
             if (instance == null) {

--- a/src/DetailsView/components/base-visual-helper-toggle.tsx
+++ b/src/DetailsView/components/base-visual-helper-toggle.tsx
@@ -47,7 +47,7 @@ export abstract class BaseVisualHelperToggle extends React.Component<VisualHelpe
         assessmentNavState,
         instancesMap: DictionaryStringTo<GeneratedAssessmentInstance>,
     ): GeneratedAssessmentInstance<{}, {}>[] {
-        const selectedTestStep = assessmentNavState.selectedTestSubview;
+        const selectedTestSubview = assessmentNavState.selectedTestSubview;
 
         return filter(instancesMap, instance => {
             if (instance == null) {
@@ -56,8 +56,8 @@ export abstract class BaseVisualHelperToggle extends React.Component<VisualHelpe
 
             const testStepKeys = keys(instance.testStepResults);
             return (
-                includes(testStepKeys, selectedTestStep) &&
-                instance.testStepResults[selectedTestStep] != null
+                includes(testStepKeys, selectedTestSubview) &&
+                instance.testStepResults[selectedTestSubview] != null
             );
         });
     }

--- a/src/DetailsView/components/restart-scan-visual-helper-toggle.tsx
+++ b/src/DetailsView/components/restart-scan-visual-helper-toggle.tsx
@@ -16,12 +16,12 @@ export class RestartScanVisualHelperToggle extends BaseVisualHelperToggle {
         if (this.props.isStepEnabled) {
             this.props.deps.detailsViewActionMessageCreator.disableVisualHelper(
                 this.props.assessmentNavState.selectedTestType,
-                this.props.assessmentNavState.selectedTestStep,
+                this.props.assessmentNavState.selectedTestSubview,
             );
         } else {
             this.props.deps.detailsViewActionMessageCreator.enableVisualHelper(
                 this.props.assessmentNavState.selectedTestType,
-                this.props.assessmentNavState.selectedTestStep,
+                this.props.assessmentNavState.selectedTestSubview,
             );
         }
     };

--- a/src/DetailsView/components/start-over-component-factory.tsx
+++ b/src/DetailsView/components/start-over-component-factory.tsx
@@ -13,7 +13,7 @@ export function getStartOverComponentForAssessment(props: CommandBarProps): JSX.
         deps: deps,
         testName: test.title,
         test: selectedTest,
-        requirementKey: props.assessmentStoreData.assessmentNavState.selectedTestStep,
+        requirementKey: props.assessmentStoreData.assessmentNavState.selectedTestSubview,
         rightPanelConfiguration: props.rightPanelConfiguration,
     };
 

--- a/src/DetailsView/components/test-step-view.tsx
+++ b/src/DetailsView/components/test-step-view.tsx
@@ -81,7 +81,7 @@ export class TestStepView extends React.Component<TestStepViewProps> {
             return (
                 <ManualTestStepView
                     test={this.props.assessmentNavState.selectedTestType}
-                    step={this.props.assessmentNavState.selectedTestStep}
+                    step={this.props.assessmentNavState.selectedTestSubview}
                     manualTestStepResultMap={this.props.manualTestStepResultMap}
                     assessmentInstanceTableHandler={this.props.assessmentInstanceTableHandler}
                     assessmentsProvider={this.props.assessmentsProvider}
@@ -126,7 +126,7 @@ export class TestStepView extends React.Component<TestStepViewProps> {
     private getSelectedStep(): Readonly<Requirement> {
         return this.props.assessmentsProvider.getStep(
             this.props.assessmentNavState.selectedTestType,
-            this.props.assessmentNavState.selectedTestStep,
+            this.props.assessmentNavState.selectedTestSubview,
         );
     }
 

--- a/src/DetailsView/handlers/assessment-instance-table-handler.tsx
+++ b/src/DetailsView/handlers/assessment-instance-table-handler.tsx
@@ -108,7 +108,7 @@ export class AssessmentInstanceTableHandler {
             const key = instanceKeys[keyIndex];
             const instance = instancesMap[key];
             if (
-                !instance.testStepResults[assessmentNavState.selectedTestStep]
+                !instance.testStepResults[assessmentNavState.selectedTestSubview]
                     .isVisualizationEnabled
             ) {
                 allEnabled = false;
@@ -153,7 +153,7 @@ export class AssessmentInstanceTableHandler {
         key: string,
         assessmentNavState: AssessmentNavState,
     ): JSX.Element => {
-        const step = assessmentNavState.selectedTestStep;
+        const step = assessmentNavState.selectedTestSubview;
         const test = assessmentNavState.selectedTestType;
         return (
             <TestStatusChoiceGroup
@@ -173,7 +173,7 @@ export class AssessmentInstanceTableHandler {
         key: string,
         assessmentNavState: AssessmentNavState,
     ): JSX.Element => {
-        const step = assessmentNavState.selectedTestStep;
+        const step = assessmentNavState.selectedTestSubview;
         const test = assessmentNavState.selectedTestType;
 
         return (
@@ -221,7 +221,9 @@ export class AssessmentInstanceTableHandler {
         assessmentNavState: AssessmentNavState,
     ): string[] {
         return Object.keys(instancesMap).filter(key => {
-            return instancesMap[key].testStepResults[assessmentNavState.selectedTestStep] != null;
+            return (
+                instancesMap[key].testStepResults[assessmentNavState.selectedTestSubview] != null
+            );
         });
     }
 }

--- a/src/DetailsView/handlers/master-checkbox-config-provider.ts
+++ b/src/DetailsView/handlers/master-checkbox-config-provider.ts
@@ -46,7 +46,7 @@ export class MasterCheckBoxConfigProvider {
             this.detailsViewActionMessageCreator.changeAssessmentVisualizationStateForAll(
                 !allEnabled,
                 assessmentNavState.selectedTestType,
-                assessmentNavState.selectedTestStep,
+                assessmentNavState.selectedTestSubview,
             );
         };
     };

--- a/src/assessments/automated-checks/automated-checks-visualization-enabled-toggle.tsx
+++ b/src/assessments/automated-checks/automated-checks-visualization-enabled-toggle.tsx
@@ -17,7 +17,7 @@ export class AutomatedChecksVisualizationToggle extends AssessmentVisualizationE
     protected isDisabled(
         passingOrFailingInstances: GeneratedAssessmentInstance<{}, {}>[],
     ): boolean {
-        const selectedTestStep = this.props.assessmentNavState.selectedTestStep;
+        const selectedTestStep = this.props.assessmentNavState.selectedTestSubview;
         if (isEmpty(passingOrFailingInstances)) {
             return true;
         }

--- a/src/background/initial-assessment-store-data-generator.ts
+++ b/src/background/initial-assessment-store-data-generator.ts
@@ -37,7 +37,7 @@ export class InitialAssessmentStoreDataGenerator {
             persistedTabInfo: targetTab,
             assessmentNavState: {
                 selectedTestType: selectedTestType,
-                selectedTestStep: selectedTestStep,
+                selectedTestSubview: selectedTestStep,
             },
             assessments: this.constructInitialDataForAssessment(persistedTests),
             resultDescription: resultDescription,

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -167,7 +167,7 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
             payload.detailsViewType != null
         ) {
             this.state.assessmentNavState.selectedTestType = payload.detailsViewType;
-            this.state.assessmentNavState.selectedTestStep = this.getDefaultTestStepForTest(
+            this.state.assessmentNavState.selectedTestSubview = this.getDefaultTestStepForTest(
                 payload.detailsViewType,
             );
             this.emitChanged();
@@ -365,7 +365,7 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
 
     private onSelectTestStep = (payload: SelectRequirementPayload): void => {
         this.state.assessmentNavState.selectedTestType = payload.selectedTest;
-        this.state.assessmentNavState.selectedTestStep = payload.selectedRequirement;
+        this.state.assessmentNavState.selectedTestSubview = payload.selectedRequirement;
         this.emitChanged();
     };
 
@@ -414,7 +414,7 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
             this.generateDefaultState(),
         );
         this.state.assessments[test.key] = defaultTestStatus;
-        this.state.assessmentNavState.selectedTestStep = test.requirements[0].key;
+        this.state.assessmentNavState.selectedTestSubview = test.requirements[0].key;
         this.emitChanged();
     };
 

--- a/src/common/types/store-data/assessment-result-data.ts
+++ b/src/common/types/store-data/assessment-result-data.ts
@@ -7,6 +7,8 @@ import { ManualTestStatus, ManualTestStatusData } from '../manual-test-status';
 import { VisualizationType } from '../visualization-type';
 
 export type TestStepInstance = UserCapturedInstance & GeneratedAssessmentInstance;
+export type RequirementName = string;
+export type GettingStarted = 'getting-started';
 
 export type PersistedTabInfo = Tab & {
     appRefreshed: boolean;
@@ -63,7 +65,7 @@ export interface TestStepResult {
 }
 
 export interface AssessmentNavState {
-    selectedTestStep: string;
+    selectedTestStep: RequirementName | GettingStarted;
     selectedTestType: VisualizationType;
 }
 

--- a/src/common/types/store-data/assessment-result-data.ts
+++ b/src/common/types/store-data/assessment-result-data.ts
@@ -65,7 +65,7 @@ export interface TestStepResult {
 }
 
 export interface AssessmentNavState {
-    selectedTestStep: RequirementName | GettingStarted;
+    selectedTestSubview: RequirementName | GettingStarted;
     selectedTestType: VisualizationType;
 }
 

--- a/src/tests/unit/common/assessment-store-data-builder.ts
+++ b/src/tests/unit/common/assessment-store-data-builder.ts
@@ -66,7 +66,7 @@ export class AssessmentsStoreDataBuilder extends BaseDataBuilder<AssessmentStore
         return this;
     }
 
-    public withSelectedTestStep(step: string): AssessmentsStoreDataBuilder {
+    public withSelectedTestSubview(step: string): AssessmentsStoreDataBuilder {
         this.data.assessmentNavState.selectedTestSubview = step;
         return this;
     }

--- a/src/tests/unit/common/assessment-store-data-builder.ts
+++ b/src/tests/unit/common/assessment-store-data-builder.ts
@@ -42,7 +42,7 @@ export class AssessmentsStoreDataBuilder extends BaseDataBuilder<AssessmentStore
         const stubData: AssessmentStoreData = {
             persistedTabInfo: null,
             assessments: {},
-            assessmentNavState: { selectedTestType: null, selectedTestStep: null },
+            assessmentNavState: { selectedTestType: null, selectedTestSubview: null },
             resultDescription: '',
         };
 
@@ -67,7 +67,7 @@ export class AssessmentsStoreDataBuilder extends BaseDataBuilder<AssessmentStore
     }
 
     public withSelectedTestStep(step: string): AssessmentsStoreDataBuilder {
-        this.data.assessmentNavState.selectedTestStep = step;
+        this.data.assessmentNavState.selectedTestSubview = step;
         return this;
     }
 

--- a/src/tests/unit/common/visual-helper-toggle-config-builder.ts
+++ b/src/tests/unit/common/visual-helper-toggle-config-builder.ts
@@ -22,7 +22,7 @@ export class VisualHelperToggleConfigBuilder extends BaseDataBuilder<VisualHelpe
                 detailsViewActionMessageCreator: null,
             },
             assessmentNavState: {
-                selectedTestStep: this.stepKey,
+                selectedTestSubview: this.stepKey,
                 selectedTestType: -1 as VisualizationType,
             },
             instancesMap: {

--- a/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-instance-table.test.tsx
@@ -197,7 +197,7 @@ describe('AssessmentInstanceTable', () => {
                     .setup(a =>
                         a.passUnmarkedInstances(
                             props.assessmentNavState.selectedTestType,
-                            props.assessmentNavState.selectedTestStep,
+                            props.assessmentNavState.selectedTestSubview,
                         ),
                     )
                     .verifiable(Times.once());
@@ -220,7 +220,7 @@ describe('AssessmentInstanceTable', () => {
             instancesMap: instancesMap,
             columnConfiguration: [],
             assessmentNavState: {
-                selectedTestStep: selectedTestStep,
+                selectedTestSubview: selectedTestStep,
                 selectedTestType: 1,
             },
             assessmentInstanceTableHandler: assessmentInstanceTableHandler,

--- a/src/tests/unit/tests/DetailsView/components/assessment-table-column-config-handler.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-table-column-config-handler.test.tsx
@@ -28,7 +28,7 @@ describe('AssessmentTableColumnConfigHandlerTest', () => {
         const step = assessment.requirements[0];
         const navState: AssessmentNavState = {
             selectedTestType: assessment.visualizationType,
-            selectedTestStep: step.key,
+            selectedTestSubview: step.key,
         };
 
         const baseConfig = {
@@ -64,7 +64,7 @@ describe('AssessmentTableColumnConfigHandlerTest', () => {
         const step = assessment.requirements[0];
         const navState: AssessmentNavState = {
             selectedTestType: assessment.visualizationType,
-            selectedTestStep: step.key,
+            selectedTestSubview: step.key,
         };
 
         const baseConfig = {
@@ -92,7 +92,7 @@ describe('AssessmentTableColumnConfigHandlerTest', () => {
         const step = assessment.requirements[0];
         const navState: AssessmentNavState = {
             selectedTestType: assessment.visualizationType,
-            selectedTestStep: step.key,
+            selectedTestSubview: step.key,
         };
 
         masterCheckboxConfigProviderMock

--- a/src/tests/unit/tests/DetailsView/components/assessment-test-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-test-view.test.tsx
@@ -66,7 +66,7 @@ describe('AssessmentTestView', () => {
         assessmentStoreDataStub = {
             assessmentNavState: {
                 selectedTestType: selectedTest,
-                selectedTestStep: selectedTestStep,
+                selectedTestSubview: selectedTestStep,
             },
         } as AssessmentStoreData;
 

--- a/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
@@ -119,7 +119,7 @@ describe('AssessmentViewTest', () => {
         );
         const prevProps = builder.buildProps();
         const props = builder.buildProps();
-        prevProps.assessmentNavState.selectedTestStep = prevStep;
+        prevProps.assessmentNavState.selectedTestSubview = prevStep;
         prevProps.assessmentNavState.selectedTestType = prevTest;
 
         builder.detailsViewActionMessageCreatorMock
@@ -147,7 +147,7 @@ describe('AssessmentViewTest', () => {
         );
         const prevProps = builder.buildProps({}, true);
         const props = builder.buildProps({}, true);
-        prevProps.assessmentNavState.selectedTestStep = prevStep;
+        prevProps.assessmentNavState.selectedTestSubview = prevStep;
         prevProps.assessmentNavState.selectedTestType = prevTest;
 
         builder.detailsViewActionMessageCreatorMock
@@ -174,9 +174,9 @@ describe('AssessmentViewTest', () => {
         );
         const prevProps = builder.buildProps();
         const props = builder.buildProps();
-        prevProps.assessmentNavState.selectedTestStep = prevStep;
+        prevProps.assessmentNavState.selectedTestSubview = prevStep;
         prevProps.assessmentNavState.selectedTestType = prevTest;
-        props.assessmentNavState.selectedTestStep = newStep;
+        props.assessmentNavState.selectedTestSubview = newStep;
 
         builder.detailsViewActionMessageCreatorMock
             .setup(a => a.enableVisualHelper(firstAssessment.visualizationType, stepName, true))
@@ -243,7 +243,7 @@ describe('AssessmentViewTest', () => {
     });
 
     function setStepNotToScanByDefault(props: AssessmentViewProps): void {
-        props.assessmentNavState.selectedTestStep = assessmentsProvider.all()[0].requirements[1].key;
+        props.assessmentNavState.selectedTestSubview = assessmentsProvider.all()[0].requirements[1].key;
     }
 });
 
@@ -299,7 +299,7 @@ class AssessmentViewPropsBuilder {
             appRefreshed: false,
         };
         const assessmentNavState = {
-            selectedTestStep: firstStep.key,
+            selectedTestSubview: firstStep.key,
             selectedTestType: assessment.visualizationType,
         };
         const assessmentData = {

--- a/src/tests/unit/tests/DetailsView/components/assessment-visualization-enabled-toggle.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-visualization-enabled-toggle.test.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as Enzyme from 'enzyme';
-import { forEach } from 'lodash';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 import {
@@ -157,7 +156,7 @@ describe('AssessmentVisualizationEnabledToggle', () => {
                 acm.changeAssessmentVisualizationStateForAll(
                     true,
                     props.assessmentNavState.selectedTestType,
-                    props.assessmentNavState.selectedTestStep,
+                    props.assessmentNavState.selectedTestSubview,
                 ),
             )
             .verifiable(Times.once());
@@ -182,7 +181,7 @@ describe('AssessmentVisualizationEnabledToggle', () => {
                 acm.changeAssessmentVisualizationStateForAll(
                     false,
                     props.assessmentNavState.selectedTestType,
-                    props.assessmentNavState.selectedTestStep,
+                    props.assessmentNavState.selectedTestSubview,
                 ),
             )
             .verifiable(Times.once());
@@ -200,9 +199,7 @@ describe('AssessmentVisualizationEnabledToggle', () => {
 
         const actualProps = visualizationToggle.props();
 
-        forEach(expectedProps, (value, key) => {
-            expect(actualProps[key]).toEqual(value);
-        });
+        expect(actualProps).toMatchObject(expectedProps);
     }
 
     function getDefaultVisualizationTogglePropsBuilder(): VisualizationTogglePropsBuilder {

--- a/src/tests/unit/tests/DetailsView/components/restart-scan-visual-helper-toggle.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/restart-scan-visual-helper-toggle.test.tsx
@@ -64,7 +64,7 @@ describe('RestartScanVisualHelperToggleTest', () => {
                 return stepIsEnabled
                     ? acm.disableVisualHelper(
                           props.assessmentNavState.selectedTestType,
-                          props.assessmentNavState.selectedTestStep,
+                          props.assessmentNavState.selectedTestSubview,
                       )
                     : acm.enableVisualHelper(props.assessmentNavState.selectedTestType, stepKey);
             })

--- a/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-component-factory.test.tsx
@@ -76,7 +76,7 @@ describe('StartOverComponentFactory', () => {
         assessmentStoreData = {
             assessmentNavState: {
                 selectedTestType,
-                selectedTestStep: theTestStep,
+                selectedTestSubview: theTestStep,
             } as AssessmentNavState,
         } as AssessmentStoreData;
 

--- a/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
@@ -141,7 +141,7 @@ describe('TestStepViewTest', () => {
     ): void {
         const view = wrapper.find(ManualTestStepView);
         expect(view.exists()).toBe(true);
-        expect(props.assessmentNavState.selectedTestStep).toEqual(view.prop('step'));
+        expect(props.assessmentNavState.selectedTestSubview).toEqual(view.prop('step'));
         expect(props.assessmentNavState.selectedTestType).toEqual(view.prop('test'));
         expect(props.manualTestStepResultMap).toEqual(view.prop('manualTestStepResultMap'));
         expect(props.assessmentInstanceTableHandler).toEqual(
@@ -207,7 +207,7 @@ class TestStepViewPropsBuilder extends BaseDataBuilder<TestStepViewProps> {
                 },
             })
             .with('assessmentNavState', {
-                selectedTestStep: 'headingFunction',
+                selectedTestSubview: 'headingFunction',
                 selectedTestType: VisualizationType.HeadingsAssessment,
             })
             .with('assessmentsProvider', assessmentsProviderMock.object)

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -92,7 +92,7 @@ describe('DetailsViewBody', () => {
 
             const assessmentStoreData = {
                 assessmentNavState: {
-                    selectedTestStep: 'sample test step',
+                    selectedTestSubview: 'sample test step',
                 } as AssessmentNavState,
                 assessments: {
                     assessment: {

--- a/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
+++ b/src/tests/unit/tests/DetailsView/handlers/assessment-instance-table-handler.test.tsx
@@ -68,7 +68,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
             },
         };
         const assessmentNavState: AssessmentNavState = {
-            selectedTestStep: 'step1',
+            selectedTestSubview: 'step1',
             selectedTestType: 5,
         };
 
@@ -134,7 +134,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
             description: 'des',
         };
         const assessmentNavState: AssessmentNavState = {
-            selectedTestStep: 'step1',
+            selectedTestSubview: 'step1',
             selectedTestType: 5,
         };
 
@@ -146,7 +146,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
         const rows = testSubject.createCapturedInstanceTableItems(
             [instance],
             assessmentNavState.selectedTestType,
-            assessmentNavState.selectedTestStep,
+            assessmentNavState.selectedTestSubview,
             featureFlagStoreData,
             pathSnippetStoreData,
         );
@@ -160,7 +160,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
         const instanceActionButtons: JSX.Element = (
             <AssessmentInstanceEditAndRemoveControl
                 test={assessmentNavState.selectedTestType}
-                step={assessmentNavState.selectedTestStep}
+                step={assessmentNavState.selectedTestSubview}
                 id={instance.id}
                 currentInstance={currentInstance}
                 onRemove={detailsViewActionMessageCreatorMock.object.removeFailureInstance}
@@ -190,7 +190,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
             html: 'saved instance',
         };
         const assessmentNavState: AssessmentNavState = {
-            selectedTestStep: 'step1',
+            selectedTestSubview: 'step1',
             selectedTestType: 5,
         };
 
@@ -202,7 +202,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
         const rows = testSubject.createCapturedInstanceTableItems(
             [instance],
             assessmentNavState.selectedTestType,
-            assessmentNavState.selectedTestStep,
+            assessmentNavState.selectedTestSubview,
             featureFlagStoreData,
             pathSnippetStoreData,
         );
@@ -216,7 +216,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
         const instanceActionButtons: JSX.Element = (
             <AssessmentInstanceEditAndRemoveControl
                 test={assessmentNavState.selectedTestType}
-                step={assessmentNavState.selectedTestStep}
+                step={assessmentNavState.selectedTestSubview}
                 id={instance.id}
                 currentInstance={currentInstance}
                 onRemove={detailsViewActionMessageCreatorMock.object.removeFailureInstance}
@@ -241,7 +241,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
     test('getColumnConfigs', () => {
         const navState: AssessmentNavState = {
             selectedTestType: VisualizationType.HeadingsAssessment,
-            selectedTestStep: 'step',
+            selectedTestSubview: 'step',
         };
         const instanceMap = {
             selector1: {
@@ -376,7 +376,7 @@ describe('AssessmentInstanceTableHandlerTest', () => {
         } as GeneratedAssessmentInstance;
 
         const assessmentNavState: AssessmentNavState = {
-            selectedTestStep: 'step1',
+            selectedTestSubview: 'step1',
             selectedTestType: 5,
         };
 

--- a/src/tests/unit/tests/DetailsView/handlers/master-check-box-config-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/handlers/master-check-box-config-handler.test.ts
@@ -12,7 +12,7 @@ describe('MasterCheckBoxConfigProviderTest', () => {
         const allEnabled = true;
         const navState: AssessmentNavState = {
             selectedTestType: VisualizationType.HeadingsAssessment,
-            selectedTestStep: '',
+            selectedTestSubview: '',
         };
         const detailsViewActionMessageCreatorMock = Mock.ofType(DetailsViewActionMessageCreator);
         detailsViewActionMessageCreatorMock
@@ -20,7 +20,7 @@ describe('MasterCheckBoxConfigProviderTest', () => {
                 acm.changeAssessmentVisualizationStateForAll(
                     false,
                     navState.selectedTestType,
-                    navState.selectedTestStep,
+                    navState.selectedTestSubview,
                 ),
             )
             .verifiable(Times.once());
@@ -43,7 +43,7 @@ describe('MasterCheckBoxConfigProviderTest', () => {
         const allEnabled = false;
         const navState: AssessmentNavState = {
             selectedTestType: VisualizationType.HeadingsAssessment,
-            selectedTestStep: '',
+            selectedTestSubview: '',
         };
 
         const provider = new MasterCheckBoxConfigProvider(null);

--- a/src/tests/unit/tests/assessments/automated-checks/automated-checks-visualization-toggle.test.tsx
+++ b/src/tests/unit/tests/assessments/automated-checks/automated-checks-visualization-toggle.test.tsx
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { AutomatedChecksVisualizationToggle } from 'assessments/automated-checks/automated-checks-visualization-enabled-toggle';
 import { shallow, ShallowWrapper } from 'enzyme';
-import { forEach } from 'lodash';
 import * as React from 'react';
 import { IMock, Mock } from 'typemoq';
 import {
@@ -121,9 +120,7 @@ describe('AutomatedChecksVisualizationToggle', () => {
 
         const actualProps = visualizationToggle.props();
 
-        forEach(expectedProps, (value, key) => {
-            expect(actualProps[key]).toEqual(value);
-        });
+        expect(actualProps).toMatchObject(expectedProps);
     }
 
     function assertSnapshotMatch(wrapper: ShallowWrapper): void {

--- a/src/tests/unit/tests/background/__snapshots__/initial-assessment-store-data-generator.test.ts.snap
+++ b/src/tests/unit/tests/background/__snapshots__/initial-assessment-store-data-generator.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`InitialAssessmentStoreDataGenerator.generateInitialState generates the pinned default state from assessmentsProvider data when no persistedData is provided 1`] = `
 Object {
   "assessmentNavState": Object {
-    "selectedTestStep": "assessment-1-step-1",
+    "selectedTestSubview": "assessment-1-step-1",
     "selectedTestType": -1,
   },
   "assessments": Object {

--- a/src/tests/unit/tests/background/initial-assessment-store-data-generator.test.ts
+++ b/src/tests/unit/tests/background/initial-assessment-store-data-generator.test.ts
@@ -133,7 +133,7 @@ describe('InitialAssessmentStoreDataGenerator.generateInitialState', () => {
         ({ selectedTestStep, selectedTestType }) => {
             const generatedState = generator.generateInitialState({
                 assessmentNavState: {
-                    selectedTestStep,
+                    selectedTestSubview: selectedTestStep,
                     selectedTestType,
                 },
             } as AssessmentStoreData);

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -664,7 +664,7 @@ describe('AssessmentStoreTest', () => {
             assessmentDataConverterMock.object,
         )
             .withSelectedTestType(visualizationType)
-            .withSelectedTestStep(requirement)
+            .withSelectedTestSubview(requirement)
             .build();
 
         const payload: SelectRequirementPayload = {
@@ -1473,7 +1473,7 @@ describe('AssessmentStoreTest', () => {
             assessmentsProvider,
             assessmentDataConverterMock.object,
         )
-            .withSelectedTestStep('step')
+            .withSelectedTestSubview('step')
             .withSelectedTestType(VisualizationType.Color)
             .build();
 
@@ -1481,7 +1481,7 @@ describe('AssessmentStoreTest', () => {
             assessmentsProvider,
             assessmentDataConverterMock.object,
         )
-            .withSelectedTestStep(requirementKey)
+            .withSelectedTestSubview(requirementKey)
             .withSelectedTestType(testType)
             .build();
 
@@ -1504,7 +1504,7 @@ describe('AssessmentStoreTest', () => {
             assessmentsProvider,
             assessmentDataConverterMock.object,
         )
-            .withSelectedTestStep('step')
+            .withSelectedTestSubview('step')
             .withSelectedTestType(selectedTest)
             .build();
 
@@ -1512,7 +1512,7 @@ describe('AssessmentStoreTest', () => {
             assessmentsProvider,
             assessmentDataConverterMock.object,
         )
-            .withSelectedTestStep('step')
+            .withSelectedTestSubview('step')
             .withSelectedTestType(selectedTest)
             .build();
 
@@ -1534,7 +1534,7 @@ describe('AssessmentStoreTest', () => {
             assessmentsProvider,
             assessmentDataConverterMock.object,
         )
-            .withSelectedTestStep('step')
+            .withSelectedTestSubview('step')
             .withSelectedTestType(VisualizationType.Color)
             .build();
 
@@ -1542,7 +1542,7 @@ describe('AssessmentStoreTest', () => {
             assessmentsProvider,
             assessmentDataConverterMock.object,
         )
-            .withSelectedTestStep('step')
+            .withSelectedTestSubview('step')
             .withSelectedTestType(VisualizationType.Color)
             .build();
 
@@ -1645,7 +1645,7 @@ describe('AssessmentStoreTest', () => {
                 manualTestStepResultMap: {},
                 testStepStatus: {},
             })
-            .withSelectedTestStep(selectedRequirement)
+            .withSelectedTestSubview(selectedRequirement)
             .build();
     }
 

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -169,7 +169,7 @@ describe('AssessmentStoreTest', () => {
             },
             assessmentNavState: {
                 selectedTestType: expectedTestType,
-                selectedTestStep: expectedTestStep,
+                selectedTestSubview: expectedTestStep,
             },
             resultDescription: '',
         };
@@ -185,7 +185,7 @@ describe('AssessmentStoreTest', () => {
             assessments: {},
             assessmentNavState: {
                 selectedTestType: expectedTestType,
-                selectedTestStep: expectedTestStep,
+                selectedTestSubview: expectedTestStep,
             },
             resultDescription: '',
         };


### PR DESCRIPTION
#### Description of changes
As part of this feature, we are now treating "Getting Started" instructions for each assessment to be a subview like the test steps. `selectedTestStep` was renamed to `selectedTestSubview`, which accounts for the fact that there will be two categories of subviews: either a requirement or getting started. PR also includes changes for introducing types for each subview. 

With the renaming, all files that referenced `assessmentNavState` needed to be updated

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [N/A] Addresses an existing issue: #0000
- [X] Ran `yarn fastpass`
- [X] Added/updated relevant unit test(s) (and ran `yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [N/A] (UI changes only) Verified usability with NVDA/JAWS
