### PR TITLE
chore: update build agents to latest hosted vmImages

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -14,7 +14,7 @@ jobs:
     - job: 'unit_tests_and_lints'
 
       pool:
-          vmImage: 'macOS-10.14'
+          vmImage: 'macOS-10.15'
 
       steps:
           - template: pipeline/install-node-prerequisites.yaml
@@ -65,7 +65,7 @@ jobs:
 
     - job: 'publish_build_drops'
       pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-18.04'
       steps:
           - template: pipeline/install-node-prerequisites.yaml
 
@@ -99,7 +99,7 @@ jobs:
 
     - job: 'e2e_mac_web_unified'
       pool:
-          vmImage: macOS-10.14
+          vmImage: macOS-10.15
       steps:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/e2e-test-from-agent.yaml
@@ -109,7 +109,7 @@ jobs:
 
     - job: 'e2e_linux_unified'
       pool:
-          vmImage: ubuntu-16.04
+          vmImage: ubuntu-18.04
       steps:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/unified/unified-e2e-test-linux.yaml
@@ -117,7 +117,7 @@ jobs:
 
     - job: 'e2e_windows_unified'
       pool:
-          vmImage: windows-latest
+          vmImage: windows-2019
       steps:
           - template: pipeline/install-node-prerequisites.yaml
           - template: pipeline/unified/unified-e2e-test-interactive.yaml

--- a/pipeline/build-all-job-per-environment.yaml
+++ b/pipeline/build-all-job-per-environment.yaml
@@ -3,8 +3,8 @@
 parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2019'
-    macImage: 'macOS-10.14'
-    linuxImage: 'ubuntu-16.04'
+    macImage: 'macOS-10.15'
+    linuxImage: 'ubuntu-18.04'
 
 jobs:
     - job: 'build_all_windows${{ parameters.jobNameSuffix }}'

--- a/pipeline/build-package.template.yaml
+++ b/pipeline/build-package.template.yaml
@@ -8,7 +8,7 @@ jobs:
     - job: 'build_and_publish_package'
 
       pool:
-          vmImage: 'macOS-10.14'
+          vmImage: 'macOS-10.15'
 
       steps:
           - template: install-node-prerequisites.yaml

--- a/pipeline/e2e-job-per-environment.yaml
+++ b/pipeline/e2e-job-per-environment.yaml
@@ -4,8 +4,8 @@
 parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2019'
-    macImage: 'macOS-10.14'
-    linuxImage: 'ubuntu-16.04'
+    macImage: 'macOS-10.15'
+    linuxImage: 'ubuntu-18.04'
 
 jobs:
     - job: 'e2e_tests_windows${{ parameters.jobNameSuffix }}'

--- a/pipeline/unified/build-unsigned-release-packages.yaml
+++ b/pipeline/unified/build-unsigned-release-packages.yaml
@@ -10,8 +10,8 @@ trigger: none
 strategy:
     matrix:
         windows: { vmImage: 'windows-latest', platform: 'windows' }
-        mac: { vmImage: 'macOS-10.14', platform: 'mac' }
-        linux: { vmImage: 'ubuntu-16.04', platform: 'linux' }
+        mac: { vmImage: 'macOS-10.15', platform: 'mac' }
+        linux: { vmImage: 'ubuntu-18.04', platform: 'linux' }
 
 pool:
     vmImage: $(vmImage)

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -8,7 +8,7 @@ parameters:
 jobs:
     - job: ${{ parameters.signedArtifactName }}
       pool:
-          vmImage: 'ubuntu-16.04'
+          vmImage: 'ubuntu-18.04'
       steps:
           - template: ../../install-node-prerequisites.yaml
 

--- a/pipeline/unified/channel/sign-release-package-mac.yaml
+++ b/pipeline/unified/channel/sign-release-package-mac.yaml
@@ -11,7 +11,7 @@ jobs:
           unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
           unsignedArtifactName: ${{ parameters.unsignedArtifactName }}
           signedArtifactName: ${{ parameters.signedArtifactName }}
-          vmImage: macOS-10.14
+          vmImage: macOS-10.15
           filePattern: '*.dmg, *.zip'
           platform: mac
           inlineSignParams: |

--- a/pipeline/unified/channel/sign-release-package-windows.yaml
+++ b/pipeline/unified/channel/sign-release-package-windows.yaml
@@ -11,7 +11,7 @@ jobs:
           unsignedPipelineResource: ${{ parameters.unsignedPipelineResource }}
           unsignedArtifactName: ${{ parameters.unsignedArtifactName }}
           signedArtifactName: ${{ parameters.signedArtifactName }}
-          vmImage: windows-latest
+          vmImage: windows-2019
           filePattern: '*.exe, *.dll'
           platform: windows
           inlineSignParams: |

--- a/pipeline/unified/unified-e2e-job-per-environment.yaml
+++ b/pipeline/unified/unified-e2e-job-per-environment.yaml
@@ -4,8 +4,8 @@
 parameters:
     jobNameSuffix: ''
     windowsImage: 'windows-2019'
-    macImage: 'macOS-10.14'
-    linuxImage: 'ubuntu-16.04'
+    macImage: 'macOS-10.15'
+    linuxImage: 'ubuntu-18.04'
 
 jobs:
     - job: 'electron_e2e_tests_windows${{ parameters.jobNameSuffix }}'


### PR DESCRIPTION
#### Description of changes

Our mac and linux build agents were both outdated, and our windows images were inconsistent (sometimes specifying the auto-updating latest image, sometimes the pinned version like we use elsewhere). This updates all build agents in all yaml pipeline definitions to use a pinned version corresponding to the latest available vmImage (per [DevOps docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops))

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
