### PR TITLE
feat(line-breaks): Improve formatting of instances added manually

### DIFF
--- a/src/reports/assessment-report.scss
+++ b/src/reports/assessment-report.scss
@@ -111,6 +111,7 @@ header {
     font-family: $fontFamily;
     vertical-align: top;
     word-break: break-all;
+    white-space: pre-line;
 }
 
 .instance-key {


### PR DESCRIPTION
#### Description of changes
Improve formatting of instances added manually/copied from the Nu HTML checker by adding the white-space: pre-line

Before:
<img width="640" alt="before" src="https://user-images.githubusercontent.com/35084583/81019437-82ec3200-8e1b-11ea-83b7-61a2fe254ebb.png">

After:
<img width="640" alt="after" src="https://user-images.githubusercontent.com/35084583/81019475-95ff0200-8e1b-11ea-9fa9-a91afc70417f.png">

I believe this could be further enhanced, but that would be a larger task since the class modified here is used throughout the report and not just the "Parse" section as described in the 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #822 
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
