### PR TITLE
fix: Allow DEV_MODE to work from elevated command prompt

### DIFF
--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -89,6 +89,8 @@ const createWindow = () => {
 
 const enableDevMode = (window: BrowserWindow) => {
     if (process.env.DEV_MODE === 'true') {
+        const devTools = new BrowserWindow();
+        window.webContents.setDevToolsWebContents(devTools.webContents);
         window.webContents.openDevTools({
             mode: 'detach',
         });


### PR DESCRIPTION
#### Description of changes

Electron's openDevTools has issues when running inside an elevated command prompt. This is discussed at https://github.com/electron/electron/issues/20069. The fix is to call setDevToolsWebContents, as called out in https://github.com/electron/electron/issues/20069#issuecomment-586642795 (and several subsequent comments indicate that this worked for them, as well). We don't bother to wait for the main window to report ready. but it doesn't seem to do any harm.

Tested by running with `DEV_MODE=true` from both elevated and non-elevated command prompts. Before the change, devTools opened only from the non-elevated command prompt. After the change, devTools open from both.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
