### PR TITLE
feat(nav-bar-content): re-factored nav link building + added feature flag

### DIFF
--- a/src/DetailsView/components/base-left-nav.tsx
+++ b/src/DetailsView/components/base-left-nav.tsx
@@ -7,15 +7,11 @@ export type onBaseLeftNavItemClick = (
     event: React.MouseEvent<HTMLElement>,
     item: BaseLeftNavLink,
 ) => void;
-export type onBaseLeftNavItemRender = (
-    link: BaseLeftNavLink,
-    renderIcon: (link: BaseLeftNavLink) => JSX.Element,
-) => JSX.Element;
+export type onBaseLeftNavItemRender = (link: BaseLeftNavLink) => JSX.Element;
 
 export type BaseLeftNavProps = {
     selectedKey: string;
     links: BaseLeftNavLink[];
-    renderIcon: (link: BaseLeftNavLink) => JSX.Element;
 };
 
 export interface BaseLeftNavLink extends INavLink {
@@ -45,6 +41,9 @@ export class BaseLeftNav extends React.Component<BaseLeftNavProps> {
                 ]}
                 onRenderLink={this.onRenderLink}
                 onLinkClick={this.onNavLinkClick}
+                styles={{
+                    chevronButton: 'hidden',
+                }}
             />
         );
     }
@@ -59,6 +58,6 @@ export class BaseLeftNav extends React.Component<BaseLeftNavProps> {
     };
 
     protected onRenderLink = (link: BaseLeftNavLink): JSX.Element => {
-        return link.onRenderNavLink(link, this.props.renderIcon);
+        return link.onRenderNavLink(link);
     };
 }

--- a/src/DetailsView/components/left-nav/assessment-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/assessment-left-nav.tsx
@@ -1,20 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { FeatureFlags } from 'common/feature-flags';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import * as React from 'react';
 import { NamedFC } from '../../../common/react/named-fc';
 import { ManualTestStatus, ManualTestStatusData } from '../../../common/types/manual-test-status';
 import { DictionaryStringTo } from '../../../types/common-types';
 import { BaseLeftNav, BaseLeftNavLink } from '../base-left-nav';
-import { LeftNavIndexIcon, LeftNavStatusIcon } from './left-nav-icon';
 import {
     AssessmentLinkBuilderDeps,
     LeftNavLinkBuilder,
     OverviewLinkBuilderDeps,
 } from './left-nav-link-builder';
 import { NavLinkHandler } from './nav-link-handler';
-import { FeatureFlags } from 'common/feature-flags';
 
 export type AssessmentLeftNavDeps = {
     leftNavLinkBuilder: LeftNavLinkBuilder;
@@ -39,14 +38,6 @@ export const AssessmentLeftNav = NamedFC<AssessmentLeftNavProps>('AssessmentLeft
 
     const { navLinkHandler, leftNavLinkBuilder } = deps;
 
-    const renderAssessmentIcon = (link: AssessmentLeftNavLink) => {
-        if (link.status === ManualTestStatus.UNKNOWN) {
-            return <LeftNavIndexIcon item={link} />;
-        }
-
-        return <LeftNavStatusIcon item={link} />;
-    };
-
     let links = [];
     links.push(
         leftNavLinkBuilder.buildOverviewLink(
@@ -59,15 +50,7 @@ export const AssessmentLeftNav = NamedFC<AssessmentLeftNavProps>('AssessmentLeft
     );
 
     if (featureFlagStoreData[FeatureFlags.reflowUI]) {
-        links = links.concat(
-            leftNavLinkBuilder.buildAssessmentTestLinks(
-                deps,
-                navLinkHandler.onAssessmentTestClick,
-                assessmentsProvider,
-                assessmentsData,
-                1,
-            ),
-        );
+        links = links;
     } else {
         links = links.concat(
             leftNavLinkBuilder.buildAssessmentTestLinks(
@@ -80,7 +63,5 @@ export const AssessmentLeftNav = NamedFC<AssessmentLeftNavProps>('AssessmentLeft
         );
     }
 
-    return (
-        <BaseLeftNav renderIcon={renderAssessmentIcon} selectedKey={selectedKey} links={links} />
-    );
+    return <BaseLeftNav selectedKey={selectedKey} links={links} />;
 });

--- a/src/DetailsView/components/left-nav/assessment-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/assessment-left-nav.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
-
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import * as React from 'react';
 import { NamedFC } from '../../../common/react/named-fc';
 import { ManualTestStatus, ManualTestStatusData } from '../../../common/types/manual-test-status';
 import { DictionaryStringTo } from '../../../types/common-types';
@@ -14,6 +14,7 @@ import {
     OverviewLinkBuilderDeps,
 } from './left-nav-link-builder';
 import { NavLinkHandler } from './nav-link-handler';
+import { FeatureFlags } from 'common/feature-flags';
 
 export type AssessmentLeftNavDeps = {
     leftNavLinkBuilder: LeftNavLinkBuilder;
@@ -26,6 +27,7 @@ export type AssessmentLeftNavProps = {
     selectedKey: string;
     assessmentsProvider: AssessmentsProvider;
     assessmentsData: DictionaryStringTo<ManualTestStatusData>;
+    featureFlagStoreData: FeatureFlagStoreData;
 };
 
 export type AssessmentLeftNavLink = {
@@ -33,7 +35,7 @@ export type AssessmentLeftNavLink = {
 } & BaseLeftNavLink;
 
 export const AssessmentLeftNav = NamedFC<AssessmentLeftNavProps>('AssessmentLeftNav', props => {
-    const { deps, selectedKey, assessmentsProvider, assessmentsData } = props;
+    const { deps, selectedKey, assessmentsProvider, assessmentsData, featureFlagStoreData } = props;
 
     const { navLinkHandler, leftNavLinkBuilder } = deps;
 
@@ -55,15 +57,28 @@ export const AssessmentLeftNav = NamedFC<AssessmentLeftNavProps>('AssessmentLeft
             0,
         ),
     );
-    links = links.concat(
-        leftNavLinkBuilder.buildAssessmentTestLinks(
-            deps,
-            navLinkHandler.onAssessmentTestClick,
-            assessmentsProvider,
-            assessmentsData,
-            1,
-        ),
-    );
+
+    if (featureFlagStoreData[FeatureFlags.reflowUI]) {
+        links = links.concat(
+            leftNavLinkBuilder.buildAssessmentTestLinks(
+                deps,
+                navLinkHandler.onAssessmentTestClick,
+                assessmentsProvider,
+                assessmentsData,
+                1,
+            ),
+        );
+    } else {
+        links = links.concat(
+            leftNavLinkBuilder.buildAssessmentTestLinks(
+                deps,
+                navLinkHandler.onAssessmentTestClick,
+                assessmentsProvider,
+                assessmentsData,
+                1,
+            ),
+        );
+    }
 
     return (
         <BaseLeftNav renderIcon={renderAssessmentIcon} selectedKey={selectedKey} links={links} />

--- a/src/DetailsView/components/left-nav/details-view-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.tsx
@@ -51,13 +51,14 @@ export const DetailsViewLeftNav = NamedFC<DetailsViewLeftNavProps>('DetailsViewL
     const leftNav: JSX.Element = (
         <div className="left-nav main-nav">
             <switcherNavConfiguration.LeftNav
-                {...props}
+                deps={deps}
                 assessmentsProvider={filteredProvider}
                 selectedKey={selectedKey}
                 assessmentsData={mapValues(
                     assessmentStoreData.assessments,
                     data => data.testStepStatus,
                 )}
+                featureFlagStoreData={featureFlagStoreData}
             />
         </div>
     );

--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { Assessment } from 'assessments/types/iassessment';
+import { Requirement } from 'assessments/types/requirement';
+import { AssessmentLeftNavLink } from 'DetailsView/components/left-nav/assessment-left-nav';
+import { LeftNavIndexIcon, LeftNavStatusIcon } from 'DetailsView/components/left-nav/left-nav-icon';
 import { map } from 'lodash';
 import * as React from 'react';
-
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { OutcomeTypeSemantic } from 'reports/components/outcome-type';
 import { RequirementOutcomeStats } from 'reports/components/requirement-outcome-type';
 import { GetAssessmentSummaryModelFromProviderAndStatusData } from 'reports/get-assessment-summary-model';
@@ -53,7 +56,7 @@ export class LeftNavLinkBuilder {
             'Overview',
             'Overview',
             index,
-            (l, ri) => <OverviewLeftNavLink link={l} renderIcon={ri} />,
+            l => <OverviewLeftNavLink link={l} />,
             onLinkClick,
         );
 
@@ -93,7 +96,7 @@ export class LeftNavLinkBuilder {
                 name,
                 VisualizationType[assessment.visualizationType],
                 index,
-                (l, ri) => <TestViewLeftNavLink link={l} renderIcon={ri} />,
+                l => <TestViewLeftNavLink link={l} renderIcon={this.renderAssessmentTestIcon} />,
                 onLinkClick,
             );
 
@@ -110,6 +113,14 @@ export class LeftNavLinkBuilder {
         return testLinks;
     }
 
+    private renderAssessmentTestIcon: onBaseLeftNavItemRender = (link: AssessmentLeftNavLink) => {
+        if (link.status === ManualTestStatus.UNKNOWN) {
+            return <LeftNavIndexIcon item={link} />;
+        }
+
+        return <LeftNavStatusIcon item={link} />;
+    };
+
     public buildVisualizationConfigurationLink(
         configuration: VisualizationConfiguration,
         onLinkClick: onBaseLeftNavItemClick,
@@ -122,12 +133,16 @@ export class LeftNavLinkBuilder {
             displayableData.title,
             VisualizationType[visualizationType],
             index,
-            (l, ri) => <TestViewLeftNavLink link={l} renderIcon={ri} />,
+            l => <TestViewLeftNavLink link={l} renderIcon={this.renderVisualizationIcon} />,
             onLinkClick,
         );
 
         return link;
     }
+
+    private renderVisualizationIcon: onBaseLeftNavItemRender = link => (
+        <LeftNavIndexIcon item={link} />
+    );
 
     private buildLink(
         name: string,

--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -1,8 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { Assessment } from 'assessments/types/iassessment';
-import { Requirement } from 'assessments/types/requirement';
 import { AssessmentLeftNavLink } from 'DetailsView/components/left-nav/assessment-left-nav';
 import { LeftNavIndexIcon, LeftNavStatusIcon } from 'DetailsView/components/left-nav/left-nav-icon';
 import { map } from 'lodash';

--- a/src/DetailsView/components/left-nav/overview-left-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/overview-left-nav-link.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import { NamedFC } from '../../../common/react/named-fc';
 import { BaseLeftNavLinkProps } from '../base-left-nav';
 
-export const OverviewLeftNavLink = NamedFC<BaseLeftNavLinkProps>(
+export const OverviewLeftNavLink = NamedFC<Pick<BaseLeftNavLinkProps, 'link'>>(
     'OverviewLeftNavLink',
     ({ link }) => {
         return (

--- a/src/DetailsView/components/left-nav/visualization-based-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/visualization-based-left-nav.tsx
@@ -1,12 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-
 import { VisualizationConfigurationFactory } from '../../../common/configs/visualization-configuration-factory';
 import { NamedFC } from '../../../common/react/named-fc';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { BaseLeftNav, onBaseLeftNavItemClick } from '../base-left-nav';
-import { LeftNavIndexIcon } from './left-nav-icon';
 import {
     AssessmentLinkBuilderDeps,
     LeftNavLinkBuilder,

--- a/src/DetailsView/components/left-nav/visualization-based-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/visualization-based-left-nav.tsx
@@ -46,12 +46,6 @@ export const VisualizationBasedLeftNav = NamedFC<VisualizationBasedLeftNavProps>
             );
         });
 
-        return (
-            <BaseLeftNav
-                renderIcon={link => <LeftNavIndexIcon item={link} />}
-                selectedKey={selectedKey}
-                links={links}
-            />
-        );
+        return <BaseLeftNav selectedKey={selectedKey} links={links} />;
     },
 );

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/base-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/base-left-nav.test.tsx.snap
@@ -15,5 +15,10 @@ exports[`BaseLeftNav should render 1`] = `
   onLinkClick={[Function]}
   onRenderLink={[Function]}
   selectedKey="some key"
+  styles={
+    Object {
+      "chevronButton": "hidden",
+    }
+  }
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/base-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/base-left-nav.test.tsx
@@ -8,6 +8,7 @@ import {
     BaseLeftNav,
     BaseLeftNavLink,
     BaseLeftNavProps,
+    onBaseLeftNavItemRender,
 } from '../../../../../DetailsView/components/base-left-nav';
 
 class TestableBaseLeftNav extends BaseLeftNav {
@@ -60,23 +61,16 @@ describe('BaseLeftNav', () => {
     });
 
     it('render side-effect: onRenderLink with item', () => {
-        const props = {
-            renderIcon: _ => null,
-        } as BaseLeftNavProps;
+        const props = {} as BaseLeftNavProps;
         const actual = new TestableBaseLeftNav(props);
         const elemnentStub = {} as JSX.Element;
-        const onRenderNavLinkMock = Mock.ofInstance(
-            (link, renderIcon) => null,
-            MockBehavior.Strict,
-        );
+        const onRenderNavLinkMock = Mock.ofType<onBaseLeftNavItemRender>(null, MockBehavior.Strict);
         const itemStub = {
             onRenderNavLink: onRenderNavLinkMock.object,
         } as BaseLeftNavLink;
         const onRenderLinkCallback = actual.getOnRenderLink();
 
-        onRenderNavLinkMock
-            .setup(ocnlm => ocnlm(itemStub, props.renderIcon))
-            .returns(() => elemnentStub);
+        onRenderNavLinkMock.setup(ocnlm => ocnlm(itemStub)).returns(() => elemnentStub);
 
         expect(onRenderLinkCallback(itemStub)).toEqual(elemnentStub);
     });

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/assessment-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/assessment-left-nav.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`AssessmentLeftNav render with index icon 1`] = `
+exports[`AssessmentLeftNav renders with reflow feature flag disabled 1`] = `
 <BaseLeftNav
   links={
     Array [
@@ -12,38 +12,19 @@ exports[`AssessmentLeftNav render with index icon 1`] = `
       },
     ]
   }
-  renderIcon={[Function]}
   selectedKey="some key"
 />
 `;
 
-exports[`AssessmentLeftNav render with index icon 2`] = `
-<span
-  className="index-circle"
-/>
-`;
-
-exports[`AssessmentLeftNav render with status icon 1`] = `
+exports[`AssessmentLeftNav renders with reflow feature flag enabled 1`] = `
 <BaseLeftNav
   links={
     Array [
       Object {
-        "status": -1,
-      },
-      Object {
-        "status": -1,
+        "status": 1,
       },
     ]
   }
-  renderIcon={[Function]}
   selectedKey="some key"
-/>
-`;
-
-exports[`AssessmentLeftNav render with status icon 2`] = `
-<StatusIcon
-  className="dark-gray"
-  level="test"
-  status={-1}
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/details-view-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/details-view-left-nav.test.tsx.snap
@@ -5,15 +5,6 @@ exports[`DetailsViewLeftNav should render from switcher nav 1`] = `
   className="left-nav main-nav"
 >
   <test
-    assessmentStoreData={
-      Object {
-        "assessments": Object {
-          "x": Object {
-            "testStepStatus": Object {},
-          },
-        },
-      }
-    }
     assessmentsData={
       Object {
         "x": Object {},
@@ -27,18 +18,7 @@ exports[`DetailsViewLeftNav should render from switcher nav 1`] = `
       }
     }
     featureFlagStoreData={Object {}}
-    rightPanelConfiguration={
-      Object {
-        "GetLeftNavSelectedKey": [Function],
-      }
-    }
     selectedKey="some key"
-    selectedTest={-1}
-    switcherNavConfiguration={
-      Object {
-        "LeftNav": [Function],
-      }
-    }
   />
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-link-builder.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-link-builder.test.tsx.snap
@@ -23,6 +23,27 @@ exports[`LeftNavBuilder buildAssessmentTestLinks should build links for assessme
 `;
 
 exports[`LeftNavBuilder buildAssessmentTestLinks should build links for assessments 2`] = `
+<LeftNavStatusIcon
+  item={
+    Object {
+      "forceAnchor": true,
+      "iconProps": Object {
+        "className": "hidden",
+      },
+      "index": -1,
+      "key": "Issues",
+      "name": "some title",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "status": -2,
+      "title": "-1: some title (passed)",
+      "url": "",
+    }
+  }
+/>
+`;
+
+exports[`LeftNavBuilder buildAssessmentTestLinks should build links for assessments 3`] = `
 <TestViewLeftNavLink
   link={
     Object {
@@ -44,6 +65,27 @@ exports[`LeftNavBuilder buildAssessmentTestLinks should build links for assessme
 />
 `;
 
+exports[`LeftNavBuilder buildAssessmentTestLinks should build links for assessments 4`] = `
+<LeftNavStatusIcon
+  item={
+    Object {
+      "forceAnchor": true,
+      "iconProps": Object {
+        "className": "hidden",
+      },
+      "index": 0,
+      "key": "Issues",
+      "name": "some title",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "status": -2,
+      "title": "0: some title (passed)",
+      "url": "",
+    }
+  }
+/>
+`;
+
 exports[`LeftNavBuilder buildOverviewLink should build overview link 1`] = `
 <OverviewLeftNavLink
   link={
@@ -62,7 +104,6 @@ exports[`LeftNavBuilder buildOverviewLink should build overview link 1`] = `
       "url": "",
     }
   }
-  renderIcon={[Function]}
 />
 `;
 
@@ -83,5 +124,24 @@ exports[`LeftNavBuilder buildVisualizationConfigurationLink should build link us
     }
   }
   renderIcon={[Function]}
+/>
+`;
+
+exports[`LeftNavBuilder buildVisualizationConfigurationLink should build link using configuration 2`] = `
+<LeftNavIndexIcon
+  item={
+    Object {
+      "forceAnchor": true,
+      "iconProps": Object {
+        "className": "hidden",
+      },
+      "index": -1,
+      "key": "Issues",
+      "name": "some title",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "url": "",
+    }
+  }
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/visualization-based-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/visualization-based-left-nav.test.tsx.snap
@@ -8,13 +8,6 @@ exports[`VisualizationBasedLeftNav renders with index icon 1`] = `
       Object {},
     ]
   }
-  renderIcon={[Function]}
   selectedKey="some key"
-/>
-`;
-
-exports[`VisualizationBasedLeftNav renders with index icon 2`] = `
-<span
-  className="index-circle"
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/assessment-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/assessment-left-nav.test.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { FeatureFlags } from 'common/feature-flags';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock } from 'typemoq';
-
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import {
     ManualTestStatus,
     ManualTestStatusData,
@@ -18,7 +18,6 @@ import {
 import { LeftNavLinkBuilder } from '../../../../../../DetailsView/components/left-nav/left-nav-link-builder';
 import { NavLinkHandler } from '../../../../../../DetailsView/components/left-nav/nav-link-handler';
 import { DictionaryStringTo } from '../../../../../../types/common-types';
-import { FeatureFlags } from 'common/feature-flags';
 
 describe('AssessmentLeftNav', () => {
     let linkStub: AssessmentLeftNavLink;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/assessment-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/assessment-left-nav.test.tsx
@@ -18,6 +18,7 @@ import {
 import { LeftNavLinkBuilder } from '../../../../../../DetailsView/components/left-nav/left-nav-link-builder';
 import { NavLinkHandler } from '../../../../../../DetailsView/components/left-nav/nav-link-handler';
 import { DictionaryStringTo } from '../../../../../../types/common-types';
+import { FeatureFlags } from 'common/feature-flags';
 
 describe('AssessmentLeftNav', () => {
     let linkStub: AssessmentLeftNavLink;
@@ -49,6 +50,7 @@ describe('AssessmentLeftNav', () => {
             leftNavLinkBuilder: leftNavLinkBuilderMock.object,
             assessmentsProvider: assessmentsProviderStub,
             assessmentsData: assessmentsDataStub,
+            featureFlagStoreData: {},
         };
 
         leftNavLinkBuilderMock
@@ -76,22 +78,15 @@ describe('AssessmentLeftNav', () => {
             .returns(() => [linkStub]);
     });
 
-    it('render with index icon', () => {
+    it('renders with reflow feature flag enabled', () => {
+        props.featureFlagStoreData[FeatureFlags.reflowUI] = true;
         const actual = shallow(<AssessmentLeftNav {...props} />);
-        const renderIcon: (link: AssessmentLeftNavLink) => JSX.Element = actual.prop('renderIcon');
-        const renderedIcon = shallow(renderIcon(linkStub));
-
         expect(actual.getElement()).toMatchSnapshot();
-        expect(renderedIcon.getElement()).toMatchSnapshot();
     });
 
-    it('render with status icon', () => {
-        linkStub.status = -1;
+    it('renders with reflow feature flag disabled', () => {
+        props.featureFlagStoreData[FeatureFlags.reflowUI] = false;
         const actual = shallow(<AssessmentLeftNav {...props} />);
-        const renderIcon: (link: AssessmentLeftNavLink) => JSX.Element = actual.prop('renderIcon');
-        const renderedIcon = shallow(renderIcon(linkStub));
-
         expect(actual.getElement()).toMatchSnapshot();
-        expect(renderedIcon.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
@@ -25,6 +25,7 @@ import {
     LeftNavLinkBuilderDeps,
 } from '../../../../../../DetailsView/components/left-nav/left-nav-link-builder';
 import { DictionaryStringTo } from '../../../../../../types/common-types';
+import { shallow } from 'enzyme';
 
 describe('LeftNavBuilder', () => {
     let deps: LeftNavLinkBuilderDeps;
@@ -33,7 +34,6 @@ describe('LeftNavBuilder', () => {
     let assessmentsDataStub: DictionaryStringTo<ManualTestStatusData>;
     let testSubject: LeftNavLinkBuilder;
     let getAssessmentSummaryModelFromProviderAndStatusDataMock: IMock<GetAssessmentSummaryModelFromProviderAndStatusData>;
-    let renderIconStub: (link: BaseLeftNavLink) => JSX.Element;
     let getStatusForTestMock: IMock<(stats: RequirementOutcomeStats) => ManualTestStatus>;
     let outcomeTypeFromTestStatusMock: IMock<(testStatus: ManualTestStatus) => OutcomeTypeSemantic>;
     let outcomeStatsFromManualTestStatusMock: IMock<(
@@ -51,7 +51,6 @@ describe('LeftNavBuilder', () => {
             MockBehavior.Strict,
         );
         assessmentsDataStub = {};
-        renderIconStub = _ => null;
 
         deps = {
             getStatusForTest: getStatusForTestMock.object,
@@ -102,8 +101,8 @@ describe('LeftNavBuilder', () => {
                 percentComplete: expectedPercentComplete,
             };
 
-            expect(isMatch(actual, expected)).toBeTruthy();
-            expect(actual.onRenderNavLink(actual, renderIconStub)).toMatchSnapshot();
+            expect(actual).toMatchObject(expected);
+            expect(actual.onRenderNavLink(actual)).toMatchSnapshot();
         });
     });
 
@@ -137,8 +136,10 @@ describe('LeftNavBuilder', () => {
                 onClickNavLink: onLinkClickMock.object,
             };
 
-            expect(isMatch(actual, expected)).toBeTruthy();
-            expect(actual.onRenderNavLink(actual, renderIconStub)).toMatchSnapshot();
+            const navLink = actual.onRenderNavLink(actual);
+            expect(actual).toMatchObject(expected);
+            expect(navLink).toMatchSnapshot();
+            expect(navLink.props['renderIcon'](actual)).toMatchSnapshot();
         });
     });
 
@@ -198,8 +199,11 @@ describe('LeftNavBuilder', () => {
                         narratorStatusStub.pastTense
                     })`,
                 };
-                expect(isMatch(actual, expected)).toBeTruthy();
-                expect(actual.onRenderNavLink(actual, renderIconStub)).toMatchSnapshot();
+
+                const navLink = actual.onRenderNavLink(actual);
+                expect(actual).toMatchObject(expected);
+                expect(navLink).toMatchSnapshot();
+                expect(navLink.props['renderIcon'](actual)).toMatchSnapshot();
             });
         });
     });

--- a/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { isMatch } from 'lodash';
-import { IMock, Mock, MockBehavior } from 'typemoq';
-
 import { AssessmentsProviderImpl } from 'assessments/assessments-provider';
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { Assessment } from 'assessments/types/iassessment';
@@ -10,22 +7,19 @@ import { OverviewSummaryReportModel } from 'reports/assessment-report-model';
 import { OutcomeTypeSemantic } from 'reports/components/outcome-type';
 import { RequirementOutcomeStats } from 'reports/components/requirement-outcome-type';
 import { GetAssessmentSummaryModelFromProviderAndStatusData } from 'reports/get-assessment-summary-model';
+import { IMock, Mock, MockBehavior } from 'typemoq';
 import { VisualizationConfiguration } from '../../../../../../common/configs/visualization-configuration';
 import {
     ManualTestStatus,
     ManualTestStatusData,
 } from '../../../../../../common/types/manual-test-status';
 import { VisualizationType } from '../../../../../../common/types/visualization-type';
-import {
-    BaseLeftNavLink,
-    onBaseLeftNavItemClick,
-} from '../../../../../../DetailsView/components/base-left-nav';
+import { onBaseLeftNavItemClick } from '../../../../../../DetailsView/components/base-left-nav';
 import {
     LeftNavLinkBuilder,
     LeftNavLinkBuilderDeps,
 } from '../../../../../../DetailsView/components/left-nav/left-nav-link-builder';
 import { DictionaryStringTo } from '../../../../../../types/common-types';
-import { shallow } from 'enzyme';
 
 describe('LeftNavBuilder', () => {
     let deps: LeftNavLinkBuilderDeps;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/visualization-based-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/visualization-based-left-nav.test.tsx
@@ -69,10 +69,7 @@ describe('VisualizationBasedLeftNav', () => {
 
     it('renders with index icon', () => {
         const actual = shallow(<VisualizationBasedLeftNav {...props} />);
-        const renderIcon: (link: BaseLeftNavLink) => JSX.Element = actual.prop('renderIcon');
-        const renderedIcon = shallow(renderIcon(linkStub));
 
         expect(actual.getElement()).toMatchSnapshot();
-        expect(renderedIcon.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/left-nav/visualization-based-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/visualization-based-left-nav.test.tsx
@@ -3,7 +3,6 @@
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
-
 import { VisualizationConfiguration } from '../../../../../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../../../../../common/configs/visualization-configuration-factory';
 import { VisualizationType } from '../../../../../../common/types/visualization-type';


### PR DESCRIPTION
#### Description of changes

This PR does two things:

1. Adds a feature flag to assessment left nav for the reflow UI (currently will only show Overview link).
2. Refactors the renderIcon link responsibility to the nav-link-builder. This will be leveraged in a future PR where the types of links being built dictate how the icon is rendered (and not on a assessment vs fastpass level, as it is now).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
