### PR TITLE
chore: avoid tests using both async and done (breaks in jest-circus 26)

### DIFF
--- a/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/base-analyzer.test.ts
@@ -9,7 +9,7 @@ import { AnalyzerConfiguration } from 'injected/analyzers/analyzer';
 import { BaseAnalyzer } from 'injected/analyzers/base-analyzer';
 import { ScanIncompleteWarningDetector } from 'injected/scan-incomplete-warning-detector';
 
-describe('BaseAnalyzerTest', () => {
+describe('BaseAnalyzer', () => {
     let testSubject: BaseAnalyzer;
     let configStub: AnalyzerConfiguration;
     let sendMessageMock: IMock<(message) => void>;
@@ -32,7 +32,7 @@ describe('BaseAnalyzerTest', () => {
         );
     });
 
-    test('analyze', async done => {
+    test('analyze', (done: () => void) => {
         const resultsStub = {};
         const scanIncompleteWarnings: ScanIncompleteWarningId[] = [
             'missing-required-cross-origin-permissions',

--- a/src/tests/unit/tests/injected/analyzers/batched-rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/batched-rule-analyzer.test.ts
@@ -81,7 +81,7 @@ describe('BatchedRuleAnalyzer', () => {
             .returns(() => []);
     });
 
-    test('analyze', async done => {
+    test('analyze', (done: () => void) => {
         testGetResults(done);
     });
 

--- a/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/rule-analyzer.test.ts
@@ -87,7 +87,7 @@ describe('RuleAnalyzer', () => {
             .returns(() => []);
     });
 
-    test('analyze', async done => {
+    test('analyze', (done: () => void) => {
         testGetResults(done);
     });
 

--- a/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
+++ b/src/tests/unit/tests/injected/analyzers/tab-stops-analyzer.test.ts
@@ -14,7 +14,7 @@ import { TabStopsAnalyzer } from '../../../../../injected/analyzers/tab-stops-an
 import { TabStopEvent, TabStopsListener } from '../../../../../injected/tab-stops-listener';
 import { itIsFunction } from '../../../common/it-is-function';
 
-describe('TabStopsAnalyzerTests', () => {
+describe('TabStopsAnalyzer', () => {
     let windowUtilsMock: IMock<WindowUtils>;
     let sendMessageMock: IMock<(message) => void>;
     let configStub: FocusAnalyzerConfiguration;
@@ -54,7 +54,7 @@ describe('TabStopsAnalyzerTests', () => {
         typeStub = -1 as VisualizationType;
     });
 
-    test('analyze', async (completeSignal: () => void) => {
+    test('analyze', (done: () => void) => {
         const tabEventStub: TabStopEvent = {
             target: ['selector'],
             html: 'test',
@@ -87,7 +87,7 @@ describe('TabStopsAnalyzerTests', () => {
         setupSendMessageMock(expectedOnProgressMessage, () => {
             verifyAll();
             expect((testSubject as any).onTabbedTimeoutId).toBeNull();
-            completeSignal();
+            done();
         });
 
         testSubject.analyze();

--- a/src/tests/unit/tests/injected/frameCommunicators/frame-communicator.test.ts
+++ b/src/tests/unit/tests/injected/frameCommunicators/frame-communicator.test.ts
@@ -26,7 +26,7 @@ interface FrameInfo {
     window: Window;
 }
 
-describe('FrameCommunicatorTests', () => {
+describe('FrameCommunicator', () => {
     let testSubject: FrameCommunicator;
 
     let childFrame1Info: FrameInfo;
@@ -92,7 +92,7 @@ describe('FrameCommunicatorTests', () => {
         mockWindowMessageHandler.verifyAll();
     });
 
-    test('verifyDispose', async done => {
+    test('verifyDispose', (done: () => void) => {
         const frameRequests: MessageRequest<any>[] = [];
         const frameRequestCompleteDeferred: Q.Deferred<any> = Q.defer<any>();
         const framesCompletedData = {};
@@ -271,7 +271,7 @@ describe('FrameCommunicatorTests', () => {
         sendMessageToFrameStrictMock.verifyAll();
     });
 
-    test('SendMessageToFrame should not throw if window does not exist for frame', async done => {
+    test('SendMessageToFrame should not throw if window does not exist for frame', (done: () => void) => {
         const frameMessageRequest: MessageRequest<any> = {
             command: 'command1',
             frame: childFrameWithoutWindowInfo.frameElement,
@@ -292,7 +292,7 @@ describe('FrameCommunicatorTests', () => {
         });
     });
 
-    test('SendMessageToWindow should timeout If frame doesnt respond for ping', async done => {
+    test("SendMessageToWindow should timeout if frame doesn't respond to ping", (done: () => void) => {
         const windowMessageRequest: MessageRequest<any> = {
             command: 'command1',
             win: childFrame1Info.window,
@@ -342,7 +342,7 @@ describe('FrameCommunicatorTests', () => {
         pingTimeoutDeferred.reject({});
     });
 
-    test('SendMessageToFrame should rejected if frmae is sandboxed', async done => {
+    test('SendMessageToFrame should rejected if frame is sandboxed', (done: () => void) => {
         const frameMessageRequest: MessageRequest<any> = {
             command: 'command1',
             frame: childFrame1Info.frameElement,
@@ -367,7 +367,7 @@ describe('FrameCommunicatorTests', () => {
         });
     });
 
-    test("SendMessageToWindow should timeout If frame doesn't respond for command", async done => {
+    test("SendMessageToWindow should timeout if frame doesn't respond to command", (done: () => void) => {
         const windowMessageRequest: MessageRequest<any> = {
             command: 'command1',
             win: childFrame1Info.window,
@@ -444,7 +444,7 @@ describe('FrameCommunicatorTests', () => {
         requestTimeoutDeferred.reject({});
     });
 
-    test('SendMessageToWindow should handle for error response of command from iframe', async done => {
+    test('SendMessageToWindow should handle for error response of command from iframe', (done: () => void) => {
         const windowMessageRequest: MessageRequest<any> = {
             command: 'command1',
             win: childFrame1Info.window,
@@ -519,7 +519,7 @@ describe('FrameCommunicatorTests', () => {
         pingDeferered.resolve({});
     });
 
-    test('SendMessageToWindow should handle for success response of command from iframe', async done => {
+    test('SendMessageToWindow should handle for success response of command from iframe', (done: () => void) => {
         const windowMessageRequest: MessageRequest<any> = {
             command: 'command1',
             win: childFrame1Info.window,
@@ -594,7 +594,7 @@ describe('FrameCommunicatorTests', () => {
         pingDeferered.resolve({});
     });
 
-    test('SendMessageToFrame should handle sandboxed iframe with allow-scripts', async done => {
+    test('SendMessageToFrame should handle sandboxed iframe with allow-scripts', (done: () => void) => {
         const frameMessageRequest: MessageRequest<any> = {
             command: 'command1',
             frame: childFrame1Info.frameElement,


### PR DESCRIPTION
#### Description of changes

`jest-circus` 26 includes a breaking change that disallows test cases from trying to mix patterns and by simultaneously accepting a done parameter and returning a promise (it only supports one or the other at a time).

This PR fixes the cases where we were doing this (via extraneous async keywords, in all cases), unblocking #2622 ([build with corresponding failures](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=8802&view=ms.vss-test-web.build-test-results-tab)).

Also cleaned up some minor naming issues I noticed while making the changes.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
