### PR TITLE
fix: install rename in linux signing pipeline

### DIFF
--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -48,7 +48,7 @@ jobs:
                         }
                     ]
 
-          - script: 'rename "s/\.AppImage$/.sig/" $(System.DefaultWorkingDirectory)/detachedSignature/*.AppImage'
+          - script: 'sudo apt-get install rename; rename "s/\.AppImage$/.sig/" $(System.DefaultWorkingDirectory)/detachedSignature/*.AppImage'
             displayName: 'Change signature file extension to sig'
 
           - task: CopyFiles@2

--- a/pipeline/unified/channel/sign-release-package-linux.yaml
+++ b/pipeline/unified/channel/sign-release-package-linux.yaml
@@ -48,7 +48,10 @@ jobs:
                         }
                     ]
 
-          - script: 'sudo apt-get install rename; rename "s/\.AppImage$/.sig/" $(System.DefaultWorkingDirectory)/detachedSignature/*.AppImage'
+          - script: 'sudo apt-get install rename'
+            displayName: 'Install rename'
+
+          - script: 'rename "s/\.AppImage$/.sig/" $(System.DefaultWorkingDirectory)/detachedSignature/*.AppImage'
             displayName: 'Change signature file extension to sig'
 
           - task: CopyFiles@2


### PR DESCRIPTION
#### Description of changes

Signing pipeline is currently failing because the rename command is not installed by default on the new ubuntu vm images

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
