### PR TITLE
fix: link the versioned electron vars to the pipeline

### DIFF
--- a/pipeline/unified/download-electron-mirror.yaml
+++ b/pipeline/unified/download-electron-mirror.yaml
@@ -4,5 +4,5 @@ steps:
     - script: yarn download:electron-mirror
       displayName: download custom electron build
       env:
-          ELECTRON_MIRROR: $(ELECTRON_822_MIRROR_VAR)
-          ELECTRON_CUSTOM_DIR: $(ELECTRON_822_CUSTOM_DIR_VAR)
+          ELECTRON_MIRROR_VAR: $(ELECTRON_822_MIRROR_VAR)
+          ELECTRON_CUSTOM_DIR_VAR: $(ELECTRON_822_CUSTOM_DIR_VAR)


### PR DESCRIPTION
#### Description of changes

The code in `download-electron-mirror.js` used a different var name than what we passed in: https://github.com/microsoft/accessibility-insights-web/blob/8449c2d84b00b8323ee49835b0a4e2b882fd2d8a/pipeline/scripts/download-electron-mirror.js#L20

This was fine because the pipeline had both pairs, but they should match up so we can remove the extra pair in the pipeline. This will leave us with just 1 pair (except for during an upgrde, where we'll temporarily have the old and new vars defined).

The most recent update to @electron/get provides a custom URL resolution function, so I have a separate branch trying to leverage that to simplify this further.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
