### PR TITLE
refactor(left-nav-content): rename some cases of select test-step/requirement to select test subview

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -21,9 +21,8 @@ import {
 import { FeatureFlagPayload } from 'background/actions/feature-flag-actions';
 import { SupportedMouseEvent } from 'common/telemetry-data-factory';
 import * as React from 'react';
-
-import { ReportExportFormat } from '../../common/extension-telemetry-events';
 import * as TelemetryEvents from '../../common/extension-telemetry-events';
+import { ReportExportFormat } from '../../common/extension-telemetry-events';
 import { Message } from '../../common/message';
 import { DevToolActionMessageCreator } from '../../common/message-creators/dev-tool-action-message-creator';
 import { Messages } from '../../common/messages';

--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -13,7 +13,7 @@ import {
     OnDetailsViewOpenPayload,
     OnDetailsViewPivotSelected,
     RemoveFailureInstancePayload,
-    SelectRequirementPayload,
+    SelectTestSubviewPayload,
     SetAllUrlsPermissionStatePayload,
     SwitchToTargetTabPayload,
     ToggleActionPayload,
@@ -164,13 +164,13 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         selectedRequirement: string,
         visualizationType: VisualizationType,
     ): void {
-        const payload: SelectRequirementPayload = {
+        const payload: SelectTestSubviewPayload = {
             telemetry: this.telemetryFactory.forSelectRequirement(
                 event,
                 visualizationType,
                 selectedRequirement,
             ),
-            selectedRequirement: selectedRequirement,
+            selectedTestSubview: selectedRequirement,
             selectedTest: visualizationType,
         };
 

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -29,8 +29,8 @@ export interface BaseActionPayload {
     telemetry?: TelemetryData;
 }
 
-export interface SelectRequirementPayload extends BaseActionPayload {
-    selectedRequirement: string;
+export interface SelectTestSubviewPayload extends BaseActionPayload {
+    selectedTestSubview: string;
     selectedTest: VisualizationType;
 }
 

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -9,7 +9,6 @@ import {
     ScanUpdatePayload,
 } from 'injected/analyzers/analyzer';
 import { capitalize } from 'lodash';
-
 import { Interpreter } from '../interpreter';
 import { TelemetryEventHandler } from '../telemetry/telemetry-event-handler';
 import {

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -23,7 +23,7 @@ import {
     EditFailureInstancePayload,
     OnDetailsViewOpenPayload,
     RemoveFailureInstancePayload,
-    SelectRequirementPayload,
+    SelectTestSubviewPayload,
     ToggleActionPayload,
 } from './action-payloads';
 import { AssessmentActions } from './assessment-actions';
@@ -40,7 +40,7 @@ export class AssessmentActionCreator {
     public registerCallbacks(): void {
         this.interpreter.registerTypeToPayloadCallback(
             AssessmentMessages.SelectTestRequirement,
-            this.onSelectTestStep,
+            this.onSelectTestRequirement,
         );
         this.interpreter.registerTypeToPayloadCallback(
             getStoreStateMessage(StoreNames.AssessmentStore),
@@ -225,8 +225,8 @@ export class AssessmentActionCreator {
         this.assessmentActions.getCurrentState.invoke(null);
     };
 
-    private onSelectTestStep = (payload: SelectRequirementPayload): void => {
-        this.assessmentActions.selectRequirement.invoke(payload);
+    private onSelectTestRequirement = (payload: SelectTestSubviewPayload): void => {
+        this.assessmentActions.selectTestSubview.invoke(payload);
         this.telemetryEventHandler.publishTelemetry(TelemetryEvents.SELECT_REQUIREMENT, payload);
     };
 

--- a/src/background/actions/assessment-actions.ts
+++ b/src/background/actions/assessment-actions.ts
@@ -15,13 +15,13 @@ import {
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
     RemoveFailureInstancePayload,
-    SelectRequirementPayload,
+    SelectTestSubviewPayload,
     ToggleActionPayload,
     UpdateSelectedDetailsViewPayload,
 } from './action-payloads';
 
 export class AssessmentActions {
-    public readonly selectRequirement = new Action<SelectRequirementPayload>();
+    public readonly selectTestSubview = new Action<SelectTestSubviewPayload>();
     public readonly changeInstanceStatus = new Action<ChangeInstanceStatusPayload>();
     public readonly changeRequirementStatus = new Action<ChangeRequirementStatusPayload>();
     public readonly addFailureInstance = new Action<AddFailureInstancePayload>();

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -22,7 +22,7 @@ import {
 } from 'injected/analyzers/analyzer';
 import { forEach, isEmpty } from 'lodash';
 import { DictionaryStringTo } from 'types/common-types';
-import { AddResultDescriptionPayload, SelectRequirementPayload } from '../actions/action-payloads';
+import { AddResultDescriptionPayload, SelectTestSubviewPayload } from '../actions/action-payloads';
 import { AssessmentDataConverter } from '../assessment-data-converter';
 import { InitialAssessmentStoreDataGenerator } from '../initial-assessment-store-data-generator';
 import {
@@ -106,7 +106,7 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.assessmentActions.scanUpdate.addListener(this.onScanUpdate);
         this.assessmentActions.resetData.addListener(this.onResetData);
         this.assessmentActions.resetAllAssessmentsData.addListener(this.onResetAllAssessmentsData);
-        this.assessmentActions.selectRequirement.addListener(this.onSelectTestStep);
+        this.assessmentActions.selectTestSubview.addListener(this.onSelectTestSubview);
         this.assessmentActions.changeInstanceStatus.addListener(this.onChangeInstanceStatus);
         this.assessmentActions.changeRequirementStatus.addListener(this.onChangeStepStatus);
         this.assessmentActions.undoRequirementStatusChange.addListener(this.onUndoStepStatusChange);
@@ -363,9 +363,9 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onSelectTestStep = (payload: SelectRequirementPayload): void => {
+    private onSelectTestSubview = (payload: SelectTestSubviewPayload): void => {
         this.state.assessmentNavState.selectedTestType = payload.selectedTest;
-        this.state.assessmentNavState.selectedTestSubview = payload.selectedRequirement;
+        this.state.assessmentNavState.selectedTestSubview = payload.selectedTestSubview;
         this.emitChanged();
     };
 

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -151,7 +151,7 @@ describe('DetailsViewActionMessageCreatorTest', () => {
             messageType: Messages.Assessment.SelectTestRequirement,
             payload: {
                 telemetry: telemetry,
-                selectedRequirement: selectedRequirement,
+                selectedTestSubview: selectedRequirement,
                 selectedTest: view,
             },
         };

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -29,7 +29,6 @@ import {
     ScanUpdatePayload,
 } from 'injected/analyzers/analyzer';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
-
 import {
     createActionMock,
     createInterpreterMock,

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -10,7 +10,7 @@ import {
     EditFailureInstancePayload,
     OnDetailsViewOpenPayload,
     RemoveFailureInstancePayload,
-    SelectRequirementPayload,
+    SelectTestSubviewPayload,
     ToggleActionPayload,
 } from 'background/actions/action-payloads';
 import { AssessmentActionCreator } from 'background/actions/assessment-action-creator';
@@ -527,13 +527,13 @@ describe('AssessmentActionCreatorTest', () => {
     });
 
     it('handles SelectTestRequirement message', () => {
-        const payload: SelectRequirementPayload = {
-            selectedRequirement: 'test-requirement',
+        const payload: SelectTestSubviewPayload = {
+            selectedTestSubview: 'test-requirement',
             ...telemetryOnlyPayload,
-        } as SelectRequirementPayload;
+        } as SelectTestSubviewPayload;
 
         const selectRequirementMock = createActionMock(payload);
-        const actionsMock = createActionsMock('selectRequirement', selectRequirementMock.object);
+        const actionsMock = createActionsMock('selectTestSubview', selectRequirementMock.object);
         const interpreterMock = createInterpreterMock(
             AssessmentMessages.SelectTestRequirement,
             payload,

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -10,7 +10,7 @@ import {
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
     RemoveFailureInstancePayload,
-    SelectRequirementPayload,
+    SelectTestSubviewPayload,
     ToggleActionPayload,
     UpdateSelectedDetailsViewPayload,
 } from 'background/actions/action-payloads';
@@ -667,14 +667,14 @@ describe('AssessmentStoreTest', () => {
             .withSelectedTestSubview(requirement)
             .build();
 
-        const payload: SelectRequirementPayload = {
-            selectedRequirement: requirement,
+        const payload: SelectTestSubviewPayload = {
+            selectedTestSubview: requirement,
             selectedTest: visualizationType,
         };
 
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
 
-        createStoreTesterForAssessmentActions('selectRequirement')
+        createStoreTesterForAssessmentActions('selectTestSubview')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, finalState);
     });


### PR DESCRIPTION
#### Description of changes

Renaming methods to select test sub view where necessary: basically in the action and action creator. We will have a future PR that will have separate calls for selectRequirement and selectGettingStarted that will eventually funnel into the selectSubview action.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [.] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [.] (UI changes only) Added screenshots/GIFs to description above
- [.] (UI changes only) Verified usability with NVDA/JAWS
