### PR TITLE
fix: should not initialize fabric icons more than once

### DIFF
--- a/src/reports/package/reporter-factory.ts
+++ b/src/reports/package/reporter-factory.ts
@@ -85,8 +85,9 @@ const axeResultsReportGenerator = (parameters: AxeReportParameters) => {
     return new AxeResultsReport(deps, parameters, environmentInfoProvider.getToolData());
 };
 
+initializeFabricIcons();
+
 export const reporterFactory: ReporterFactory = () => {
-    initializeFabricIcons();
 
     return new Reporter(axeResultsReportGenerator);
 };


### PR DESCRIPTION
If we call reporterFactory() multiple times, office fabric gives the below warning in console:
_Some icons were re-registered. Applications should only call registerIcons for any given icon once. Redefining what an icon is may have unintended consequences. Duplicates include:
add, back, calculatorAddition, cancel, cat, checkBox, checkMark, chevronDown, chevronDownMed, chevronRight (+ 40 more)_

#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
