### PR TITLE
feat(mobile-rule-guidance): Add wcag guidance links

### DIFF
--- a/src/content/link.tsx
+++ b/src/content/link.tsx
@@ -50,7 +50,7 @@ export const link = {
     ]),
     WCAG_2_5_3: guidanceLinkTo('WCAG 2.5.3', 'https://www.w3.org/WAI/WCAG21/Understanding/label-in-name', [guidanceTags.WCAG_2_1]),
     WCAG_2_5_4: guidanceLinkTo('WCAG 2.5.4', 'https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation.html', [guidanceTags.WCAG_2_1]),
-    WCAG_2_5_5: guidanceLinkTo('WCAG 2.5.5', 'https://learningplayer.microsoft.com/activity/S1315002/launch'),
+    WCAG_2_5_5: guidanceLinkTo('WCAG 2.5.5', 'https://www.w3.org/WAI/WCAG21/Understanding/target-size.html'),
     WCAG_3_1_1: guidanceLinkTo('WCAG 3.1.1', 'https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html'),
     WCAG_3_1_2: guidanceLinkTo('WCAG 3.1.2', 'https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html'),
     WCAG_3_2_1: guidanceLinkTo('WCAG 3.2.1', 'https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html'),

--- a/src/content/link.tsx
+++ b/src/content/link.tsx
@@ -50,6 +50,7 @@ export const link = {
     ]),
     WCAG_2_5_3: guidanceLinkTo('WCAG 2.5.3', 'https://www.w3.org/WAI/WCAG21/Understanding/label-in-name', [guidanceTags.WCAG_2_1]),
     WCAG_2_5_4: guidanceLinkTo('WCAG 2.5.4', 'https://www.w3.org/WAI/WCAG21/Understanding/motion-actuation.html', [guidanceTags.WCAG_2_1]),
+    WCAG_2_5_5: guidanceLinkTo('WCAG 2.5.5', 'https://learningplayer.microsoft.com/activity/S1315002/launch'),
     WCAG_3_1_1: guidanceLinkTo('WCAG 3.1.1', 'https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html'),
     WCAG_3_1_2: guidanceLinkTo('WCAG 3.1.2', 'https://www.w3.org/WAI/WCAG21/Understanding/language-of-parts.html'),
     WCAG_3_2_1: guidanceLinkTo('WCAG 3.2.1', 'https://www.w3.org/WAI/WCAG21/Understanding/on-focus.html'),

--- a/src/electron/platform/android/rule-information-provider.ts
+++ b/src/electron/platform/android/rule-information-provider.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { UnifiedFormattableResolution } from 'common/types/store-data/unified-data-interface';
+import { link } from 'content/link';
 import { DictionaryStringTo } from 'types/common-types';
 
 import { RuleResultsData } from './android-scan-results';
@@ -14,18 +15,21 @@ export class RuleInformationProvider {
             ColorContrast: new RuleInformation(
                 'ColorContrast',
                 'Text elements must have sufficient contrast against the background.',
+                [link.WCAG_1_4_3],
                 this.getColorContrastUnifiedFormattableResolution,
                 this.includeColorContrastResult,
             ),
             TouchSizeWcag: new RuleInformation(
                 'TouchSizeWcag',
                 'Touch inputs must have a sufficient target size.',
+                [link.WCAG_1_3_1, link.WCAG_3_3_2],
                 this.getTouchSizeUnifiedFormattableResolution,
                 this.includeAllResults,
             ),
             ActiveViewName: new RuleInformation(
                 'ActiveViewName',
                 "Active views must have a name that's available to assistive technologies.",
+                [link.WCAG_2_5_5],
                 () =>
                     this.buildUnifiedFormattableResolution(
                         'The view is active but has no name available to assistive technologies. Provide a name for the view using its contentDescription, hint, labelFor, or text attribute (depending on the view type)',
@@ -36,6 +40,7 @@ export class RuleInformationProvider {
             ImageViewName: new RuleInformation(
                 'ImageViewName',
                 'Meaningful images must have alternate text.',
+                [link.WCAG_1_1_1],
                 () =>
                     this.buildUnifiedFormattableResolution(
                         'The image has no alternate text and is not identified as decorative. If the image conveys meaningful content, provide alternate text using the contentDescription attribute. If the image is decorative, give it an empty contentDescription, or set its isImportantForAccessibility attribute to false.',
@@ -46,6 +51,7 @@ export class RuleInformationProvider {
             EditTextValue: new RuleInformation(
                 'EditTextValue',
                 'EditText elements must expose their entered text value to assistive technologies',
+                [link.WCAG_4_1_2],
                 () =>
                     this.buildUnifiedFormattableResolution(
                         "The element's contentDescription overrides the text value required by assistive technologies. Remove the element’s contentDescription attribute.",

--- a/src/electron/platform/android/rule-information.ts
+++ b/src/electron/platform/android/rule-information.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import { UnifiedFormattableResolution } from 'common/types/store-data/unified-data-interface';
+import { GuidanceLink } from 'scanner/rule-to-links-mappings';
+
 import { RuleResultsData } from './android-scan-results';
 
 export type GetUnifiedFormattableResolutionDelegate = (
@@ -14,6 +15,7 @@ export class RuleInformation {
     constructor(
         readonly ruleId: string,
         readonly ruleDescription: string,
+        readonly guidance: GuidanceLink[],
         readonly getUnifiedFormattableResolutionDelegate: GetUnifiedFormattableResolutionDelegate,
         readonly includeThisResultDelegate: IncludeThisResultDelegate,
     ) {}

--- a/src/electron/platform/android/scan-results-to-unified-rules.ts
+++ b/src/electron/platform/android/scan-results-to-unified-rules.ts
@@ -49,6 +49,6 @@ function createUnifiedRuleFromRuleResult(
         id: ruleInformation.ruleId,
         description: ruleInformation.ruleDescription,
         url: null,
-        guidance: [],
+        guidance: ruleInformation.guidance,
     };
 }

--- a/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-rules.test.ts.snap
+++ b/src/tests/unit/tests/electron/platform/android/__snapshots__/scan-results-to-unified-rules.test.ts.snap
@@ -30,7 +30,13 @@ exports[`ScanResultsToUnifiedRules ScanResults with a mix of supported rules, un
 Array [
   Object {
     "description": "This describes Rule #3",
-    "guidance": Array [],
+    "guidance": Array [
+      Object {
+        "href": "https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html",
+        "tags": undefined,
+        "text": "WCAG 1.1.1",
+      },
+    ],
     "id": "Rule #3",
     "uid": "gguid-mock-stub",
     "url": null,

--- a/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/rule-information.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import { UnifiedFormattableResolution } from 'common/types/store-data/unified-data-interface';
+import { link } from 'content/link';
 import { RuleResultsData } from 'electron/platform/android/android-scan-results';
 import {
     GetUnifiedFormattableResolutionDelegate,
@@ -20,16 +20,28 @@ describe('RuleInformation', () => {
 
     test('RuleId works correctly', () => {
         for (const ruleId of testInputs) {
-            const ruleInformation = new RuleInformation(ruleId, null, null, failIfCalled);
+            const ruleInformation = new RuleInformation(ruleId, null, null, null, failIfCalled);
             expect(ruleId === ruleInformation.ruleId);
         }
     });
 
     test('RuleDescription works correctly', () => {
         for (const ruleDescription of testInputs) {
-            const ruleInformation = new RuleInformation(null, ruleDescription, null, failIfCalled);
+            const ruleInformation = new RuleInformation(
+                null,
+                ruleDescription,
+                null,
+                null,
+                failIfCalled,
+            );
             expect(ruleDescription === ruleInformation.ruleDescription);
         }
+    });
+
+    test('guidance works correctly', () => {
+        const guidance = [link.WCAG_1_1_1];
+        const ruleInformation = new RuleInformation(null, null, guidance, null, failIfCalled);
+        expect(ruleInformation.guidance).toEqual(guidance);
     });
 
     test('GetUnifiedResolution works correctly', () => {
@@ -53,6 +65,7 @@ describe('RuleInformation', () => {
                 .returns(() => expectedUnifiedFormattableResolution);
 
             const ruleInformation = new RuleInformation(
+                null,
                 null,
                 null,
                 getUnifiedFormattableResolutionDelegateMock.object,
@@ -82,6 +95,7 @@ describe('RuleInformation', () => {
             includeThisResultMock.setup(func => func(testData)).returns(() => expectedResult);
 
             const ruleInformation = new RuleInformation(
+                null,
                 null,
                 null,
                 null,

--- a/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-helpers.ts
@@ -8,6 +8,7 @@ import {
     ViewElementData,
 } from 'electron/platform/android/android-scan-results';
 import { RuleInformation } from 'electron/platform/android/rule-information';
+import { GuidanceLink } from './../../../../../../scanner/rule-to-links-mappings';
 
 export function buildScanResultsObject(
     deviceName: string = null,
@@ -111,11 +112,13 @@ export function buildViewElement(
 
 export function buildRuleInformation(
     ruleId: string,
+    guidance: GuidanceLink[] = [],
     includeResults: boolean = true,
 ): RuleInformation {
     return {
         ruleId: ruleId,
         ruleDescription: 'This describes ' + ruleId,
+        guidance,
         getUnifiedFormattableResolutionDelegate: r => {
             expect('getUnifiedResolution').toBe('This code should never execute');
             return null;

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-results.test.ts
@@ -36,7 +36,7 @@ describe('ScanResultsToUnifiedResults', () => {
         const ruleInformation1: RuleInformation = buildRuleInformation(ruleId1);
         const ruleInformation2: RuleInformation = buildRuleInformation(ruleId2);
         const ruleInformation3: RuleInformation = buildRuleInformation(ruleId3);
-        const ruleInformation4: RuleInformation = buildRuleInformation(ruleId4, false);
+        const ruleInformation4: RuleInformation = buildRuleInformation(ruleId4, [], false);
 
         ruleInformationProviderMock = Mock.ofType<RuleInformationProviderType>();
         ruleInformationProviderMock

--- a/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-rules.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/scan-results-to-unified-rules.test.ts
@@ -1,10 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
-import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
-
 import { UnifiedRule } from 'common/types/store-data/unified-data-interface';
 import { generateUID } from 'common/uid-generator';
+import { link } from 'content/link';
 import {
     AndroidScanResults,
     RuleResultsData,
@@ -12,6 +10,8 @@ import {
 import { RuleInformation } from 'electron/platform/android/rule-information';
 import { RuleInformationProviderType } from 'electron/platform/android/rule-information-provider-type';
 import { convertScanResultsToUnifiedRules } from 'electron/platform/android/scan-results-to-unified-rules';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
 import {
     buildRuleInformation,
     buildRuleResultObject,
@@ -73,8 +73,12 @@ describe('ScanResultsToUnifiedRules', () => {
 
         const ruleInformation1: RuleInformation = buildRuleInformation(ruleId1);
         const ruleInformation2: RuleInformation = buildRuleInformation(ruleId2);
-        const ruleInformation3: RuleInformation = buildRuleInformation(ruleId3);
-        const ruleInformation4: RuleInformation = buildRuleInformation(ruleId4, false);
+        const ruleInformation3: RuleInformation = buildRuleInformation(ruleId3, [link.WCAG_1_1_1]);
+        const ruleInformation4: RuleInformation = buildRuleInformation(
+            ruleId4,
+            [link.WCAG_1_2_1],
+            false,
+        );
 
         ruleInformationProviderMock = Mock.ofType<RuleInformationProviderType>();
         ruleInformationProviderMock


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

Since the rule link is still not available yet, so only the wcag links would be added as of this PR. Confirmed with Fer that this is ok.
screenshot for the new rule UI:
 
![image](https://user-images.githubusercontent.com/15974344/81353766-ce524a80-907e-11ea-87c5-cc5fdd1fa618.png)



#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
