### PR TITLE
feat(nav-bar-content): Putting Reflow Assessment View behind a feature flag

### DIFF
--- a/src/DetailsView/components/assessment-test-view.tsx
+++ b/src/DetailsView/components/assessment-test-view.tsx
@@ -19,6 +19,9 @@ import { TabStoreData } from '../../common/types/store-data/tab-store-data';
 import { VisualizationStoreData } from '../../common/types/store-data/visualization-store-data';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
 import { AssessmentView, AssessmentViewDeps } from './assessment-view';
+import { FeatureFlags } from 'common/feature-flags';
+import { ReflowAssessmentView } from 'DetailsView/components/reflow-assessment-view';
+import { FlaggedComponent } from 'common/components/flagged-component';
 
 export type AssessmentTestViewDeps = AssessmentViewDeps &
     ScanIncompleteWarningDeps & {
@@ -60,14 +63,21 @@ export const AssessmentTestView = NamedFC<AssessmentTestViewProps>(
             assessmentNavState.selectedTestType,
             assessmentData,
         );
-        return (
-            <>
-                <ScanIncompleteWarning
+
+        const renderReflowAssessmentView = (): JSX.Element => {
+            return (
+                <ReflowAssessmentView
                     deps={deps}
-                    warnings={assessmentData.scanIncompleteWarnings}
-                    warningConfiguration={props.switcherNavConfiguration.warningConfiguration}
-                    test={assessmentNavState.selectedTestType}
+                    assessmentNavState={assessmentNavState}
+                    assessmentData={assessmentData}
+                    currentTarget={currentTarget}
+                    prevTarget={prevTarget}
+                    assessmentTestResult={assessmentTestResult}
                 />
+            );
+        };
+        const renderAssessmentView = (): JSX.Element => {
+            return (
                 <AssessmentView
                     deps={deps}
                     isScanning={isScanning}
@@ -82,6 +92,23 @@ export const AssessmentTestView = NamedFC<AssessmentTestViewProps>(
                     featureFlagStoreData={props.featureFlagStoreData}
                     pathSnippetStoreData={props.pathSnippetStoreData}
                     switcherNavConfiguration={props.switcherNavConfiguration}
+                />
+            );
+        };
+
+        return (
+            <>
+                <ScanIncompleteWarning
+                    deps={deps}
+                    warnings={assessmentData.scanIncompleteWarnings}
+                    warningConfiguration={props.switcherNavConfiguration.warningConfiguration}
+                    test={assessmentNavState.selectedTestType}
+                />
+                <FlaggedComponent
+                    enableJSXElement={renderReflowAssessmentView()}
+                    disableJSXElement={renderAssessmentView()}
+                    featureFlag={FeatureFlags.reflowUI}
+                    featureFlagStoreData={props.featureFlagStoreData}
                 />
             </>
         );

--- a/src/DetailsView/components/assessment-test-view.tsx
+++ b/src/DetailsView/components/assessment-test-view.tsx
@@ -9,6 +9,9 @@ import {
 } from 'DetailsView/components/scan-incomplete-warning';
 import * as React from 'react';
 
+import { FlaggedComponent } from 'common/components/flagged-component';
+import { FeatureFlags } from 'common/feature-flags';
+import { ReflowAssessmentView } from 'DetailsView/components/reflow-assessment-view';
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { VisualizationConfiguration } from '../../common/configs/visualization-configuration';
 import { NamedFC } from '../../common/react/named-fc';
@@ -19,9 +22,6 @@ import { TabStoreData } from '../../common/types/store-data/tab-store-data';
 import { VisualizationStoreData } from '../../common/types/store-data/visualization-store-data';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
 import { AssessmentView, AssessmentViewDeps } from './assessment-view';
-import { FeatureFlags } from 'common/feature-flags';
-import { ReflowAssessmentView } from 'DetailsView/components/reflow-assessment-view';
-import { FlaggedComponent } from 'common/components/flagged-component';
 
 export type AssessmentTestViewDeps = AssessmentViewDeps &
     ScanIncompleteWarningDeps & {

--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -1,110 +1,45 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
-import { AssessmentsProvider } from 'assessments/types/assessments-provider';
-import { AssessmentViewUpdateHandler } from 'DetailsView/components/assessment-view-update-handler';
-import * as styles from 'DetailsView/components/assessment-view.scss';
 import * as React from 'react';
-import { ContentLink, ContentLinkDeps } from 'views/content/content-link';
-import { ContentPageComponent } from 'views/content/content-page';
+import { ContentLinkDeps } from 'views/content/content-link';
 
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
-import { CollapsibleComponent } from '../../common/components/collapsible-component';
-import { reactExtensionPoint } from '../../common/extensibility/react-extension-point';
 import { Tab } from '../../common/itab';
 import {
     AssessmentData,
     AssessmentNavState,
     PersistedTabInfo,
 } from '../../common/types/store-data/assessment-result-data';
-import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
-import { PathSnippetStoreData } from '../../common/types/store-data/path-snippet-store-data';
-import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
-import { DetailsViewExtensionPoint } from '../extensions/details-view-extension-point';
-import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
-import { GettingStartedView, GettingStartedViewProps } from './getting-started-view';
+import { GettingStartedView } from './getting-started-view';
 import { TargetChangeDialog, TargetChangeDialogDeps } from './target-change-dialog';
-import { TestStepView, TestStepViewDeps } from './test-step-view';
-import { TestStepNavDeps, TestStepsNav } from './test-steps-nav';
 
 export type WithAssessmentTestResult = { assessmentTestResult: AssessmentTestResult };
-export const AssessmentViewMainContentExtensionPoint = reactExtensionPoint<
-    WithAssessmentTestResult
->('AssessmentViewMainContentExtensionPoint');
 
-export type AssessmentViewDeps = ContentLinkDeps &
-    TestStepViewDeps &
-    TestStepNavDeps &
-    TargetChangeDialogDeps & {
-        detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-        assessmentsProvider: AssessmentsProvider;
-        assessmentViewUpdateHandler: AssessmentViewUpdateHandler;
-        detailsViewExtensionPoint: DetailsViewExtensionPoint;
-    };
+export type ReflowAssessmentViewDeps = ContentLinkDeps & TargetChangeDialogDeps;
 
-export interface AssessmentViewProps {
-    deps: AssessmentViewDeps;
-    isScanning: boolean;
-    isEnabled: boolean;
+export interface ReflowAssessmentViewProps {
+    deps: ReflowAssessmentViewDeps;
     assessmentNavState: AssessmentNavState;
-    assessmentInstanceTableHandler: AssessmentInstanceTableHandler;
     assessmentData: AssessmentData;
     currentTarget: Tab;
     prevTarget: PersistedTabInfo;
-    assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator;
     assessmentTestResult: AssessmentTestResult;
-    featureFlagStoreData: FeatureFlagStoreData;
-    pathSnippetStoreData: PathSnippetStoreData;
 }
 
-export class ReflowAssessmentView extends React.Component<AssessmentViewProps> {
-    public static readonly requirementsTitle: string = 'Requirements';
-
-    private deps: AssessmentViewDeps;
-
-    constructor(props: AssessmentViewProps) {
-        super(props);
-        this.deps = props.deps;
-        this.state = {
-            isStartOverDialogOpen: false,
-        };
-    }
-
+export class ReflowAssessmentView extends React.Component<ReflowAssessmentViewProps> {
     public render(): JSX.Element {
         const { assessmentTestResult } = this.props;
-        const { extensions } = assessmentTestResult.definition;
-        const extPointProps = { extensions, assessmentTestResult };
-        return (
-            <div className={styles.assessmentContent}>
-                {this.renderTargetChangeDialog()}
-                {this.renderTitle(
-                    assessmentTestResult.definition.title,
-                    assessmentTestResult.definition.guidance,
-                )}
-                {this.renderGettingStarted(assessmentTestResult.definition.gettingStarted)}
-                <AssessmentViewMainContentExtensionPoint.component {...extPointProps}>
-                    {this.renderRequirements()}
-                    {this.renderMainContent(assessmentTestResult)}
-                </AssessmentViewMainContentExtensionPoint.component>
-            </div>
-        );
-    }
-
-    public componentDidMount(): void {
-        this.deps.assessmentViewUpdateHandler.onMount(this.props);
-    }
-
-    public componentDidUpdate(prevProps: AssessmentViewProps): void {
-        this.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
-
-        const { assessmentTestResult } = this.props;
-        this.deps.detailsViewExtensionPoint
-            .apply(assessmentTestResult.definition.extensions)
-            .onAssessmentViewUpdate(prevProps, this.props);
-    }
-
-    public componentWillUnmount(): void {
-        this.deps.assessmentViewUpdateHandler.onUnmount(this.props);
+        if (this.props.assessmentNavState.selectedTestSubview === 'getting-started') {
+            return (
+                <div>
+                    {this.renderTargetChangeDialog()}
+                    <GettingStartedView
+                        gettingStartedContent={assessmentTestResult.definition.gettingStarted}
+                    />
+                </div>
+            );
+        }
+        return null;
     }
 
     private renderTargetChangeDialog(): JSX.Element {
@@ -115,94 +50,5 @@ export class ReflowAssessmentView extends React.Component<AssessmentViewProps> {
                 newTab={this.props.currentTarget}
             />
         );
-    }
-
-    private renderTitle(title: string, content?: ContentPageComponent): JSX.Element {
-        return (
-            <div className={styles.assessmentTitle}>
-                <h1 className={styles.assessmentHeader}>
-                    {title} <ContentLink deps={this.deps} reference={content} iconName="info" />
-                </h1>
-            </div>
-        );
-    }
-
-    private renderGettingStarted(gettingStarted: JSX.Element): JSX.Element {
-        return (
-            <CollapsibleComponent
-                header={<h2>Getting Started</h2>}
-                content={gettingStarted}
-                containerClassName={styles.assessmentGettingStartedContainer}
-            />
-        );
-    }
-
-    private renderRequirements(): JSX.Element {
-        return (
-            <div className={styles.assessmentRequirementsTitle}>
-                <h2 className={styles.assessmentRequirements}>
-                    {ReflowAssessmentView.requirementsTitle}
-                </h2>
-            </div>
-        );
-    }
-
-    private renderMainContent(assessmentTestResult: AssessmentTestResult): JSX.Element {
-        if (this.props.assessmentNavState.selectedTestSubview === 'getting-started') {
-            const props: GettingStartedViewProps = {
-                gettingStartedContent: (
-                    <div>
-                        Could pass the getting started content for the requirement as part of props
-                    </div>
-                ),
-            };
-            return (
-                <div className={styles.detailsViewAssessmentContent}>
-                    <GettingStartedView {...props} />
-                </div>
-            );
-        } else {
-            const selectedRequirement = assessmentTestResult.getRequirementResult(
-                this.props.assessmentNavState.selectedTestSubview,
-            );
-            const isStepScanned = selectedRequirement.data.isStepScanned;
-            return (
-                <div className={styles.detailsViewAssessmentContent}>
-                    <div className={styles.testStepsNavContainer}>
-                        <TestStepsNav
-                            deps={this.props.deps}
-                            ariaLabel={ReflowAssessmentView.requirementsTitle}
-                            selectedTest={assessmentTestResult.visualizationType}
-                            selectedTestStep={selectedRequirement.definition.key}
-                            stepStatus={this.props.assessmentData.testStepStatus}
-                        />
-                    </div>
-                    <div className={styles.testStepViewContainer}>
-                        <TestStepView
-                            deps={this.deps}
-                            isScanning={this.props.isScanning}
-                            testStep={selectedRequirement.definition}
-                            renderStaticContent={selectedRequirement.definition.renderStaticContent}
-                            instancesMap={this.props.assessmentData.generatedAssessmentInstancesMap}
-                            assessmentNavState={this.props.assessmentNavState}
-                            assessmentInstanceTableHandler={
-                                this.props.assessmentInstanceTableHandler
-                            }
-                            manualTestStepResultMap={
-                                this.props.assessmentData.manualTestStepResultMap
-                            }
-                            assessmentsProvider={this.props.deps.assessmentsProvider}
-                            isStepEnabled={this.props.isEnabled}
-                            isStepScanned={isStepScanned}
-                            assessmentDefaultMessageGenerator={
-                                this.props.assessmentDefaultMessageGenerator
-                            }
-                            featureFlagStoreData={this.props.featureFlagStoreData}
-                            pathSnippetStoreData={this.props.pathSnippetStoreData}
-                        />
-                    </div>
-                </div>
-            );
-        }
     }
 }

--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -1,0 +1,208 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { AssessmentViewUpdateHandler } from 'DetailsView/components/assessment-view-update-handler';
+import * as styles from 'DetailsView/components/assessment-view.scss';
+import * as React from 'react';
+import { ContentLink, ContentLinkDeps } from 'views/content/content-link';
+import { ContentPageComponent } from 'views/content/content-page';
+
+import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
+import { CollapsibleComponent } from '../../common/components/collapsible-component';
+import { reactExtensionPoint } from '../../common/extensibility/react-extension-point';
+import { Tab } from '../../common/itab';
+import {
+    AssessmentData,
+    AssessmentNavState,
+    PersistedTabInfo,
+} from '../../common/types/store-data/assessment-result-data';
+import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
+import { PathSnippetStoreData } from '../../common/types/store-data/path-snippet-store-data';
+import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
+import { DetailsViewExtensionPoint } from '../extensions/details-view-extension-point';
+import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
+import { GettingStartedView, GettingStartedViewProps } from './getting-started-view';
+import { TargetChangeDialog, TargetChangeDialogDeps } from './target-change-dialog';
+import { TestStepView, TestStepViewDeps } from './test-step-view';
+import { TestStepNavDeps, TestStepsNav } from './test-steps-nav';
+
+export type WithAssessmentTestResult = { assessmentTestResult: AssessmentTestResult };
+export const AssessmentViewMainContentExtensionPoint = reactExtensionPoint<
+    WithAssessmentTestResult
+>('AssessmentViewMainContentExtensionPoint');
+
+export type AssessmentViewDeps = ContentLinkDeps &
+    TestStepViewDeps &
+    TestStepNavDeps &
+    TargetChangeDialogDeps & {
+        detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+        assessmentsProvider: AssessmentsProvider;
+        assessmentViewUpdateHandler: AssessmentViewUpdateHandler;
+        detailsViewExtensionPoint: DetailsViewExtensionPoint;
+    };
+
+export interface AssessmentViewProps {
+    deps: AssessmentViewDeps;
+    isScanning: boolean;
+    isEnabled: boolean;
+    assessmentNavState: AssessmentNavState;
+    assessmentInstanceTableHandler: AssessmentInstanceTableHandler;
+    assessmentData: AssessmentData;
+    currentTarget: Tab;
+    prevTarget: PersistedTabInfo;
+    assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator;
+    assessmentTestResult: AssessmentTestResult;
+    featureFlagStoreData: FeatureFlagStoreData;
+    pathSnippetStoreData: PathSnippetStoreData;
+}
+
+export class ReflowAssessmentView extends React.Component<AssessmentViewProps> {
+    public static readonly requirementsTitle: string = 'Requirements';
+
+    private deps: AssessmentViewDeps;
+
+    constructor(props: AssessmentViewProps) {
+        super(props);
+        this.deps = props.deps;
+        this.state = {
+            isStartOverDialogOpen: false,
+        };
+    }
+
+    public render(): JSX.Element {
+        const { assessmentTestResult } = this.props;
+        const { extensions } = assessmentTestResult.definition;
+        const extPointProps = { extensions, assessmentTestResult };
+        return (
+            <div className={styles.assessmentContent}>
+                {this.renderTargetChangeDialog()}
+                {this.renderTitle(
+                    assessmentTestResult.definition.title,
+                    assessmentTestResult.definition.guidance,
+                )}
+                {this.renderGettingStarted(assessmentTestResult.definition.gettingStarted)}
+                <AssessmentViewMainContentExtensionPoint.component {...extPointProps}>
+                    {this.renderRequirements()}
+                    {this.renderMainContent(assessmentTestResult)}
+                </AssessmentViewMainContentExtensionPoint.component>
+            </div>
+        );
+    }
+
+    public componentDidMount(): void {
+        this.deps.assessmentViewUpdateHandler.onMount(this.props);
+    }
+
+    public componentDidUpdate(prevProps: AssessmentViewProps): void {
+        this.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
+
+        const { assessmentTestResult } = this.props;
+        this.deps.detailsViewExtensionPoint
+            .apply(assessmentTestResult.definition.extensions)
+            .onAssessmentViewUpdate(prevProps, this.props);
+    }
+
+    public componentWillUnmount(): void {
+        this.deps.assessmentViewUpdateHandler.onUnmount(this.props);
+    }
+
+    private renderTargetChangeDialog(): JSX.Element {
+        return (
+            <TargetChangeDialog
+                deps={this.props.deps}
+                prevTab={this.props.prevTarget}
+                newTab={this.props.currentTarget}
+            />
+        );
+    }
+
+    private renderTitle(title: string, content?: ContentPageComponent): JSX.Element {
+        return (
+            <div className={styles.assessmentTitle}>
+                <h1 className={styles.assessmentHeader}>
+                    {title} <ContentLink deps={this.deps} reference={content} iconName="info" />
+                </h1>
+            </div>
+        );
+    }
+
+    private renderGettingStarted(gettingStarted: JSX.Element): JSX.Element {
+        return (
+            <CollapsibleComponent
+                header={<h2>Getting Started</h2>}
+                content={gettingStarted}
+                containerClassName={styles.assessmentGettingStartedContainer}
+            />
+        );
+    }
+
+    private renderRequirements(): JSX.Element {
+        return (
+            <div className={styles.assessmentRequirementsTitle}>
+                <h2 className={styles.assessmentRequirements}>
+                    {ReflowAssessmentView.requirementsTitle}
+                </h2>
+            </div>
+        );
+    }
+
+    private renderMainContent(assessmentTestResult: AssessmentTestResult): JSX.Element {
+        if (this.props.assessmentNavState.selectedTestSubview === 'getting-started') {
+            const props: GettingStartedViewProps = {
+                gettingStartedContent: (
+                    <div>
+                        Could pass the getting started content for the requirement as part of props
+                    </div>
+                ),
+            };
+            return (
+                <div className={styles.detailsViewAssessmentContent}>
+                    <GettingStartedView {...props} />
+                </div>
+            );
+        } else {
+            const selectedRequirement = assessmentTestResult.getRequirementResult(
+                this.props.assessmentNavState.selectedTestSubview,
+            );
+            const isStepScanned = selectedRequirement.data.isStepScanned;
+            return (
+                <div className={styles.detailsViewAssessmentContent}>
+                    <div className={styles.testStepsNavContainer}>
+                        <TestStepsNav
+                            deps={this.props.deps}
+                            ariaLabel={ReflowAssessmentView.requirementsTitle}
+                            selectedTest={assessmentTestResult.visualizationType}
+                            selectedTestStep={selectedRequirement.definition.key}
+                            stepStatus={this.props.assessmentData.testStepStatus}
+                        />
+                    </div>
+                    <div className={styles.testStepViewContainer}>
+                        <TestStepView
+                            deps={this.deps}
+                            isScanning={this.props.isScanning}
+                            testStep={selectedRequirement.definition}
+                            renderStaticContent={selectedRequirement.definition.renderStaticContent}
+                            instancesMap={this.props.assessmentData.generatedAssessmentInstancesMap}
+                            assessmentNavState={this.props.assessmentNavState}
+                            assessmentInstanceTableHandler={
+                                this.props.assessmentInstanceTableHandler
+                            }
+                            manualTestStepResultMap={
+                                this.props.assessmentData.manualTestStepResultMap
+                            }
+                            assessmentsProvider={this.props.deps.assessmentsProvider}
+                            isStepEnabled={this.props.isEnabled}
+                            isStepScanned={isStepScanned}
+                            assessmentDefaultMessageGenerator={
+                                this.props.assessmentDefaultMessageGenerator
+                            }
+                            featureFlagStoreData={this.props.featureFlagStoreData}
+                            pathSnippetStoreData={this.props.pathSnippetStoreData}
+                        />
+                    </div>
+                </div>
+            );
+        }
+    }
+}

--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-import { ContentLinkDeps } from 'views/content/content-link';
 
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { Tab } from '../../common/itab';
@@ -13,9 +12,7 @@ import {
 import { GettingStartedView } from './getting-started-view';
 import { TargetChangeDialog, TargetChangeDialogDeps } from './target-change-dialog';
 
-export type WithAssessmentTestResult = { assessmentTestResult: AssessmentTestResult };
-
-export type ReflowAssessmentViewDeps = ContentLinkDeps & TargetChangeDialogDeps;
+export type ReflowAssessmentViewDeps = TargetChangeDialogDeps;
 
 export interface ReflowAssessmentViewProps {
     deps: ReflowAssessmentViewDeps;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-test-view.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`AssessmentTestView assessment view, isScanning is false 1`] = `
 "<Fragment>
   <ScanIncompleteWarning deps={{...}} warnings={[undefined]} warningConfiguration={{...}} test={-1} />
-  <AssessmentView deps={{...}} isScanning={false} isEnabled={false} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} assessmentData={{...}} currentTarget={{...}} prevTarget={[undefined]} assessmentDefaultMessageGenerator={[undefined]} assessmentTestResult={{...}} featureFlagStoreData={{...}} pathSnippetStoreData={{...}} switcherNavConfiguration={{...}} />
+  <FlaggedComponent enableJSXElement={{...}} disableJSXElement={{...}} featureFlag=\\"reflowUI\\" featureFlagStoreData={{...}} />
 </Fragment>"
 `;
 
 exports[`AssessmentTestView assessment view, isScanning is true 1`] = `
 "<Fragment>
   <ScanIncompleteWarning deps={{...}} warnings={[undefined]} warningConfiguration={{...}} test={-1} />
-  <AssessmentView deps={{...}} isScanning={true} isEnabled={false} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} assessmentData={{...}} currentTarget={{...}} prevTarget={[undefined]} assessmentDefaultMessageGenerator={[undefined]} assessmentTestResult={{...}} featureFlagStoreData={{...}} pathSnippetStoreData={{...}} switcherNavConfiguration={{...}} />
+  <FlaggedComponent enableJSXElement={{...}} disableJSXElement={{...}} featureFlag=\\"reflowUI\\" featureFlagStoreData={{...}} />
 </Fragment>"
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
@@ -1,54 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssessmentViewTest render for gettting started 1`] = `
-"<div className=\\"assessmentContent\\">
+"<div>
   <TargetChangeDialog deps={{...}} prevTab={{...}} newTab={{...}} />
-  <div className=\\"assessmentTitle\\">
-    <h1 className=\\"assessmentHeader\\">
-      assessment 1
-       
-      <ContentLink deps={{...}} reference={[Function]} iconName=\\"info\\" />
-    </h1>
-  </div>
-  <CollapsibleComponent header={{...}} content={{...}} containerClassName=\\"assessmentGettingStartedContainer\\" />
-  <AssessmentViewMainContentExtensionPoint extensions={[undefined]} assessmentTestResult={{...}}>
-    <div className=\\"assessmentRequirementsTitle\\">
-      <h2 className=\\"assessmentRequirements\\">
-        Requirements
-      </h2>
-    </div>
-    <div className=\\"detailsViewAssessmentContent\\">
-      <GettingStartedView gettingStartedContent={{...}} />
-    </div>
-  </AssessmentViewMainContentExtensionPoint>
+  <GettingStartedView gettingStartedContent={[undefined]} />
 </div>"
 `;
 
-exports[`AssessmentViewTest render for requirement 1`] = `
-"<div className=\\"assessmentContent\\">
-  <TargetChangeDialog deps={{...}} prevTab={{...}} newTab={{...}} />
-  <div className=\\"assessmentTitle\\">
-    <h1 className=\\"assessmentHeader\\">
-      assessment 1
-       
-      <ContentLink deps={{...}} reference={[Function]} iconName=\\"info\\" />
-    </h1>
-  </div>
-  <CollapsibleComponent header={{...}} content={{...}} containerClassName=\\"assessmentGettingStartedContainer\\" />
-  <AssessmentViewMainContentExtensionPoint extensions={[undefined]} assessmentTestResult={{...}}>
-    <div className=\\"assessmentRequirementsTitle\\">
-      <h2 className=\\"assessmentRequirements\\">
-        Requirements
-      </h2>
-    </div>
-    <div className=\\"detailsViewAssessmentContent\\">
-      <div className=\\"testStepsNavContainer\\">
-        <TestStepsNav deps={{...}} ariaLabel=\\"Requirements\\" selectedTest={-1} selectedTestStep=\\"assessment-1-step-1\\" stepStatus={{...}} />
-      </div>
-      <div className=\\"testStepViewContainer\\">
-        <TestStepView deps={{...}} isScanning={false} testStep={{...}} renderStaticContent={[undefined]} instancesMap={{...}} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} manualTestStepResultMap={{...}} assessmentsProvider={{...}} isStepEnabled={false} isStepScanned={false} assessmentDefaultMessageGenerator={{...}} featureFlagStoreData={{...}} pathSnippetStoreData={{...}} />
-      </div>
-    </div>
-  </AssessmentViewMainContentExtensionPoint>
-</div>"
-`;
+exports[`AssessmentViewTest render for requirement 1`] = `""`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AssessmentViewTest render for gettting started 1`] = `
+"<div className=\\"assessmentContent\\">
+  <TargetChangeDialog deps={{...}} prevTab={{...}} newTab={{...}} />
+  <div className=\\"assessmentTitle\\">
+    <h1 className=\\"assessmentHeader\\">
+      assessment 1
+       
+      <ContentLink deps={{...}} reference={[Function]} iconName=\\"info\\" />
+    </h1>
+  </div>
+  <CollapsibleComponent header={{...}} content={{...}} containerClassName=\\"assessmentGettingStartedContainer\\" />
+  <AssessmentViewMainContentExtensionPoint extensions={[undefined]} assessmentTestResult={{...}}>
+    <div className=\\"assessmentRequirementsTitle\\">
+      <h2 className=\\"assessmentRequirements\\">
+        Requirements
+      </h2>
+    </div>
+    <div className=\\"detailsViewAssessmentContent\\">
+      <GettingStartedView gettingStartedContent={{...}} />
+    </div>
+  </AssessmentViewMainContentExtensionPoint>
+</div>"
+`;
+
+exports[`AssessmentViewTest render for requirement 1`] = `
+"<div className=\\"assessmentContent\\">
+  <TargetChangeDialog deps={{...}} prevTab={{...}} newTab={{...}} />
+  <div className=\\"assessmentTitle\\">
+    <h1 className=\\"assessmentHeader\\">
+      assessment 1
+       
+      <ContentLink deps={{...}} reference={[Function]} iconName=\\"info\\" />
+    </h1>
+  </div>
+  <CollapsibleComponent header={{...}} content={{...}} containerClassName=\\"assessmentGettingStartedContainer\\" />
+  <AssessmentViewMainContentExtensionPoint extensions={[undefined]} assessmentTestResult={{...}}>
+    <div className=\\"assessmentRequirementsTitle\\">
+      <h2 className=\\"assessmentRequirements\\">
+        Requirements
+      </h2>
+    </div>
+    <div className=\\"detailsViewAssessmentContent\\">
+      <div className=\\"testStepsNavContainer\\">
+        <TestStepsNav deps={{...}} ariaLabel=\\"Requirements\\" selectedTest={-1} selectedTestStep=\\"assessment-1-step-1\\" stepStatus={{...}} />
+      </div>
+      <div className=\\"testStepViewContainer\\">
+        <TestStepView deps={{...}} isScanning={false} testStep={{...}} renderStaticContent={[undefined]} instancesMap={{...}} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} manualTestStepResultMap={{...}} assessmentsProvider={{...}} isStepEnabled={false} isStepScanned={false} assessmentDefaultMessageGenerator={{...}} featureFlagStoreData={{...}} pathSnippetStoreData={{...}} />
+      </div>
+    </div>
+  </AssessmentViewMainContentExtensionPoint>
+</div>"
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
@@ -1,10 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssessmentViewTest render for gettting started 1`] = `
-"<div>
-  <TargetChangeDialog deps={{...}} prevTab={{...}} newTab={{...}} />
-  <GettingStartedView gettingStartedContent={[undefined]} />
-</div>"
+<div>
+  <TargetChangeDialog
+    deps={Object {}}
+    newTab={
+      Object {
+        "id": 5,
+      }
+    }
+    prevTab={
+      Object {
+        "id": 4,
+      }
+    }
+  />
+  <GettingStartedView
+    gettingStartedContent={
+      <h1>
+        Hello
+      </h1>
+    }
+  />
+</div>
 `;
 
-exports[`AssessmentViewTest render for requirement 1`] = `""`;
+exports[`AssessmentViewTest render for requirement 1`] = `null`;

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Assessment } from 'assessments/types/iassessment';
 import { AssessmentTestResult } from 'common/assessment/assessment-test-result';
 import { AssessmentData } from 'common/types/store-data/assessment-result-data';
 import { shallow } from 'enzyme';
@@ -17,30 +16,34 @@ describe('AssessmentViewTest', () => {
     test('render for requirement', () => {
         const props = generateProps('requirement');
         const rendered = shallow(<ReflowAssessmentView {...props} />);
-        expect(rendered.debug()).toMatchSnapshot();
+        expect(rendered.getElement()).toMatchSnapshot();
     });
 
     test('render for gettting started', () => {
         const props = generateProps('getting-started');
         const rendered = shallow(<ReflowAssessmentView {...props} />);
-        expect(rendered.debug()).toMatchSnapshot();
+        expect(rendered.getElement()).toMatchSnapshot();
     });
 
     function generateProps(subview: string): ReflowAssessmentViewProps {
-        const assessmentMock = Mock.ofType<Assessment>();
         const assessmentDataMock = Mock.ofType<AssessmentData>();
-        const assessmentTestResultMock = Mock.ofType<AssessmentTestResult>();
+
+        const assessmentTestResultStub: AssessmentTestResult = {
+            definition: {
+                gettingStarted: <h1>Hello</h1>,
+            },
+        } as AssessmentTestResult;
 
         const reflowProps = {
             deps: {} as ReflowAssessmentViewDeps,
-            prevTarget: {},
-            currentTarget: {},
+            prevTarget: { id: 4 },
+            currentTarget: { id: 5 },
             assessmentNavState: {
                 selectedTestSubview: subview,
-                selectedTestType: assessmentMock.object.visualizationType,
+                selectedTestType: -1,
             },
             assessmentData: assessmentDataMock.object,
-            assessmentTestResult: assessmentTestResultMock.object,
+            assessmentTestResult: assessmentTestResultStub,
         } as ReflowAssessmentViewProps;
         return reflowProps;
     }

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { AssessmentViewPropsBuilder } from 'tests/unit/tests/DetailsView/components/assessment-view-props-builder';
+import { Mock, Times } from 'typemoq';
+
+import { VisualizationType } from '../../../../../common/types/visualization-type';
+import {
+    AssessmentViewProps,
+    ReflowAssessmentView,
+} from '../../../../../DetailsView/components/reflow-assessment-view';
+import { CreateTestAssessmentProvider } from '../../../common/test-assessment-provider';
+
+describe('AssessmentViewTest', () => {
+    const assessmentsProvider = CreateTestAssessmentProvider();
+    const assessmentDefaultMessageGenerator = new AssessmentDefaultMessageGenerator();
+    let builder: AssessmentViewPropsBuilder;
+
+    beforeEach(() => {
+        builder = new AssessmentViewPropsBuilder(
+            assessmentsProvider,
+            assessmentDefaultMessageGenerator,
+        );
+    });
+
+    test('constructor', () => {
+        const testObject = new ReflowAssessmentView({} as AssessmentViewProps);
+        expect(testObject).toBeInstanceOf(React.Component);
+    });
+
+    test('render for requirement', () => {
+        const props = builder.buildProps();
+
+        const rendered = shallow(<ReflowAssessmentView {...props} />);
+        expect(rendered.debug()).toMatchSnapshot();
+    });
+
+    test('render for gettting started', () => {
+        const props = builder.buildProps();
+        props.assessmentNavState.selectedTestSubview = 'getting-started';
+
+        const rendered = shallow(<ReflowAssessmentView {...props} />);
+        expect(rendered.debug()).toMatchSnapshot();
+    });
+
+    test('componentDidMount', () => {
+        const props = builder.buildProps();
+        builder.updateHandlerMock.setup(u => u.onMount(props)).verifiable(Times.once());
+
+        const testObject = new ReflowAssessmentView(props);
+
+        testObject.componentDidMount();
+        builder.verifyAll();
+    });
+
+    test('componentDidUpdate', () => {
+        const prevProps = buildPrevProps();
+        const props = builder.buildProps();
+        const onAssessmentViewUpdateMock = Mock.ofInstance(
+            (previousProps: AssessmentViewProps, currentProps: AssessmentViewProps) => {},
+        );
+
+        builder.updateHandlerMock.setup(u => u.update(prevProps, props)).verifiable(Times.once());
+        builder.detailsViewExtensionPointMock
+            .setup(d => d.apply(props.assessmentTestResult.definition.extensions))
+            .returns(() => {
+                return { onAssessmentViewUpdate: onAssessmentViewUpdateMock.object };
+            })
+            .verifiable(Times.once());
+        onAssessmentViewUpdateMock.setup(o => o(prevProps, props)).verifiable(Times.once());
+
+        const testObject = new ReflowAssessmentView(props);
+
+        testObject.componentDidUpdate(prevProps);
+
+        builder.verifyAll();
+        onAssessmentViewUpdateMock.verifyAll();
+    });
+
+    test('componentWillUnmount', () => {
+        const props = builder.buildProps();
+        builder.updateHandlerMock.setup(u => u.onUnmount(props)).verifiable(Times.once());
+
+        const testObject = new ReflowAssessmentView(props);
+
+        testObject.componentWillUnmount();
+        builder.verifyAll();
+    });
+
+    function buildPrevProps(): AssessmentViewProps {
+        const prevStep = 'prevStep';
+        const prevTest = -100 as VisualizationType;
+        const prevProps = builder.buildProps();
+        prevProps.assessmentNavState.selectedTestSubview = prevStep;
+        prevProps.assessmentNavState.selectedTestType = prevTest;
+        return prevProps;
+    }
+});


### PR DESCRIPTION
#### Description of changes
Updated AssessmentTestView so it shows the reflow-assessment-view component when the reflowUI flag is enabled. Updated the related test. 

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [X] Ran `yarn fastpass`
- [X] Added/updated relevant unit test(s) (and ran `yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [N/A] (UI changes only) Verified usability with NVDA/JAWS
