### PR TITLE
feat(nav-bar-content): Narrow down props used by AssessmentViewUpdateHandler

### DIFF
--- a/src/DetailsView/components/assessment-view-update-handler.ts
+++ b/src/DetailsView/components/assessment-view-update-handler.ts
@@ -1,6 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { AssessmentViewProps } from 'DetailsView/components/assessment-view';
+import { AssessmentsProvider } from 'assessments/types/assessments-provider';
+import { Tab } from 'common/itab';
+import {
+    AssessmentData,
+    AssessmentNavState,
+    PersistedTabInfo,
+} from 'common/types/store-data/assessment-result-data';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { reactExtensionPoint } from '../../common/extensibility/react-extension-point';
 import { VisualizationType } from '../../common/types/visualization-type';
@@ -10,18 +17,35 @@ export const AssessmentViewMainContentExtensionPoint = reactExtensionPoint<
     WithAssessmentTestResult
 >('AssessmentViewMainContentExtensionPoint');
 
+export interface AssessmentViewUpdateHandlerDeps {
+    detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+    assessmentsProvider: AssessmentsProvider;
+}
+
+export interface AssessmentViewUpdateHandlerProps {
+    deps: AssessmentViewUpdateHandlerDeps;
+    assessmentNavState: AssessmentNavState;
+    assessmentData: AssessmentData;
+    isEnabled: boolean;
+    currentTarget: Tab;
+    prevTarget: PersistedTabInfo;
+}
+
 export class AssessmentViewUpdateHandler {
     public static readonly requirementsTitle: string = 'Requirements';
 
-    public onMount(props: AssessmentViewProps): void {
+    public onMount(props: AssessmentViewUpdateHandlerProps): void {
         this.enableSelectedStepVisualHelper(props);
     }
 
-    public onUnmount(props: AssessmentViewProps): void {
+    public onUnmount(props: AssessmentViewUpdateHandlerProps): void {
         this.disableVisualHelpersForSelectedTest(props);
     }
 
-    public update(prevProps: AssessmentViewProps, currentProps: AssessmentViewProps): void {
+    public update(
+        prevProps: AssessmentViewUpdateHandlerProps,
+        currentProps: AssessmentViewUpdateHandlerProps,
+    ): void {
         if (this.isStepSwitched(prevProps, currentProps)) {
             this.disableVisualHelpersForSelectedTest(prevProps);
             this.enableSelectedStepVisualHelper(currentProps);
@@ -31,7 +55,10 @@ export class AssessmentViewUpdateHandler {
         }
     }
 
-    private enableSelectedStepVisualHelper(props: AssessmentViewProps, sendTelemetry = true): void {
+    private enableSelectedStepVisualHelper(
+        props: AssessmentViewUpdateHandlerProps,
+        sendTelemetry = true,
+    ): void {
         const test = props.assessmentNavState.selectedTestType;
         const step = props.assessmentNavState.selectedTestSubview;
         if (this.visualHelperDisabledByDefault(props, test, step) || this.isTargetChanged(props)) {
@@ -49,13 +76,13 @@ export class AssessmentViewUpdateHandler {
         }
     }
 
-    private isTargetChanged(props: AssessmentViewProps): boolean {
+    private isTargetChanged(props: AssessmentViewUpdateHandlerProps): boolean {
         return props.prevTarget != null && props.prevTarget.id !== props.currentTarget.id;
     }
 
     private isStepSwitched(
-        prevProps: AssessmentViewProps,
-        currentProps: AssessmentViewProps,
+        prevProps: AssessmentViewUpdateHandlerProps,
+        currentProps: AssessmentViewUpdateHandlerProps,
     ): boolean {
         return (
             prevProps.assessmentNavState.selectedTestSubview !==
@@ -64,14 +91,14 @@ export class AssessmentViewUpdateHandler {
     }
 
     private visualHelperDisabledByDefault(
-        props: AssessmentViewProps,
+        props: AssessmentViewUpdateHandlerProps,
         test: VisualizationType,
         step: string,
     ): boolean {
         return props.deps.assessmentsProvider.getStep(test, step).doNotScanByDefault === true;
     }
 
-    private disableVisualHelpersForSelectedTest(props: AssessmentViewProps): void {
+    private disableVisualHelpersForSelectedTest(props: AssessmentViewUpdateHandlerProps): void {
         const test = props.assessmentNavState.selectedTestType;
         props.deps.detailsViewActionMessageCreator.disableVisualHelpersForTest(test);
     }

--- a/src/DetailsView/components/assessment-view.tsx
+++ b/src/DetailsView/components/assessment-view.tsx
@@ -22,7 +22,6 @@ import {
 } from '../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../common/types/store-data/feature-flag-store-data';
 import { PathSnippetStoreData } from '../../common/types/store-data/path-snippet-store-data';
-import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { DetailsViewExtensionPoint } from '../extensions/details-view-extension-point';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
 import { TargetChangeDialog, TargetChangeDialogDeps } from './target-change-dialog';

--- a/src/DetailsView/components/assessment-view.tsx
+++ b/src/DetailsView/components/assessment-view.tsx
@@ -7,7 +7,10 @@ import * as React from 'react';
 import { ContentLink, ContentLinkDeps } from 'views/content/content-link';
 import { ContentPageComponent } from 'views/content/content-page';
 
-import { AssessmentViewUpdateHandler } from 'DetailsView/components/assessment-view-update-handler';
+import {
+    AssessmentViewUpdateHandler,
+    AssessmentViewUpdateHandlerDeps,
+} from 'DetailsView/components/assessment-view-update-handler';
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { CollapsibleComponent } from '../../common/components/collapsible-component';
 import { reactExtensionPoint } from '../../common/extensibility/react-extension-point';
@@ -34,8 +37,8 @@ export const AssessmentViewMainContentExtensionPoint = reactExtensionPoint<
 export type AssessmentViewDeps = ContentLinkDeps &
     TestStepViewDeps &
     TestStepNavDeps &
-    TargetChangeDialogDeps & {
-        detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+    TargetChangeDialogDeps &
+    AssessmentViewUpdateHandlerDeps & {
         assessmentsProvider: AssessmentsProvider;
         assessmentViewUpdateHandler: AssessmentViewUpdateHandler;
         detailsViewExtensionPoint: DetailsViewExtensionPoint;

--- a/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
@@ -1,175 +1,226 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { It, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
-import { AssessmentDefaultMessageGenerator } from 'assessments/assessment-default-message-generator';
-import { AssessmentViewUpdateHandler } from 'DetailsView/components/assessment-view-update-handler';
+import { ManualTestStatus } from 'common/types/manual-test-status';
+import { AssessmentData } from 'common/types/store-data/assessment-result-data';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import {
+    AssessmentViewUpdateHandler,
+    AssessmentViewUpdateHandlerDeps,
+    AssessmentViewUpdateHandlerProps,
+} from 'DetailsView/components/assessment-view-update-handler';
 import { CreateTestAssessmentProvider } from 'tests/unit/common/test-assessment-provider';
-import { AssessmentViewPropsBuilder } from 'tests/unit/tests/DetailsView/components/assessment-view-props-builder';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
-import { AssessmentViewProps } from '../../../../../DetailsView/components/assessment-view';
 
 describe('AssessmentViewTest', () => {
     const assessmentsProvider = CreateTestAssessmentProvider();
     const firstAssessment = assessmentsProvider.all()[0];
     const stepName = firstAssessment.requirements[0].key;
-    const assessmentDefaultMessageGenerator = new AssessmentDefaultMessageGenerator();
-    let builder: AssessmentViewPropsBuilder;
+    let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
+    let isEnabled: boolean;
 
     let testObject: AssessmentViewUpdateHandler;
 
     beforeEach(() => {
-        builder = new AssessmentViewPropsBuilder(
-            assessmentsProvider,
-            assessmentDefaultMessageGenerator,
-        );
+        isEnabled = false;
+        detailsViewActionMessageCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
         testObject = new AssessmentViewUpdateHandler();
     });
 
     describe('onMount', () => {
         test('enable assessment by default according to config', () => {
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a =>
                     a.enableVisualHelper(firstAssessment.visualizationType, stepName, true, true),
                 )
                 .verifiable(Times.once());
-            const props = builder.buildProps();
+            const props = buildProps();
 
             testObject.onMount(props);
-            builder.verifyAll();
+
+            detailsViewActionMessageCreatorMock.verifyAll();
         });
 
         test('avoid enabling assessment by default according to config', () => {
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a => a.enableVisualHelper(It.isAny(), It.isAny(), It.isAny()))
                 .verifiable(Times.never());
-            const props = builder.buildProps();
+            const props = buildProps();
             setStepNotToScanByDefault(props);
 
             testObject.onMount(props);
-            builder.verifyAll();
+            detailsViewActionMessageCreatorMock.verifyAll();
         });
 
         test('do not rescan because step already scanned', () => {
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a =>
                     a.enableVisualHelper(firstAssessment.visualizationType, stepName, false, true),
                 )
                 .verifiable(Times.once());
-            const props = builder.buildProps({ selector: {} }, false, true);
+            const props = buildProps({ selector: {} }, false, true);
 
             testObject.onMount(props);
-            builder.verifyAll();
+            detailsViewActionMessageCreatorMock.verifyAll();
         });
 
         test('already enabled', () => {
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a =>
                     a.enableVisualHelper(firstAssessment.visualizationType, stepName, false),
                 )
                 .verifiable(Times.never());
-            const props = builder.setIsEnabled(true).buildProps({ selector: {} });
+            isEnabled = true;
+            const props = buildProps({ selector: {} });
 
             testObject.onMount(props);
-            builder.verifyAll();
+            detailsViewActionMessageCreatorMock.verifyAll();
         });
     });
 
     describe('update', () => {
         test('no step change', () => {
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a =>
                     a.enableVisualHelper(firstAssessment.visualizationType, stepName, true, false),
                 )
                 .verifiable(Times.once());
 
-            const props = builder.buildProps();
-            const prevProps = builder.buildProps();
+            const props = buildProps();
+            const prevProps = buildProps();
 
             testObject.update(prevProps, props);
 
-            builder.verifyAll();
+            detailsViewActionMessageCreatorMock.verifyAll();
         });
 
         test('step changed', () => {
             const prevStep = 'prevStep';
             const prevTest = -100 as VisualizationType;
-            const prevProps = builder.buildProps();
-            const props = builder.buildProps();
+            const prevProps = buildProps();
+            const props = buildProps();
             prevProps.assessmentNavState.selectedTestSubview = prevStep;
             prevProps.assessmentNavState.selectedTestType = prevTest;
 
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a =>
                     a.enableVisualHelper(firstAssessment.visualizationType, stepName, true, true),
                 )
                 .verifiable(Times.once());
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a => a.disableVisualHelpersForTest(prevTest))
                 .verifiable(Times.once());
 
             testObject.update(prevProps, props);
 
-            builder.verifyAll();
+            detailsViewActionMessageCreatorMock.verifyAll();
         });
 
         test('do not enable because target changed', () => {
             const prevStep = 'prevStep';
             const prevTest = -100 as VisualizationType;
-            const prevProps = builder.buildProps({}, true);
-            const props = builder.buildProps({}, true);
+            const prevProps = buildProps({}, true);
+            const props = buildProps({}, true);
             prevProps.assessmentNavState.selectedTestSubview = prevStep;
             prevProps.assessmentNavState.selectedTestType = prevTest;
 
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a => a.enableVisualHelper(firstAssessment.visualizationType, stepName, true))
                 .verifiable(Times.never());
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a => a.disableVisualHelpersForTest(prevTest))
                 .verifiable(Times.once());
 
             testObject.update(prevProps, props);
 
-            builder.verifyAll();
+            detailsViewActionMessageCreatorMock.verifyAll();
         });
 
         test('step changed, but the step is configured not enabled by default', () => {
             const prevStep = 'prevStep';
             const prevTest = -100 as VisualizationType;
             const newStep = assessmentsProvider.all()[0].requirements[1].key;
-            const prevProps = builder.buildProps();
-            const props = builder.buildProps();
+            const prevProps = buildProps();
+            const props = buildProps();
             prevProps.assessmentNavState.selectedTestSubview = prevStep;
             prevProps.assessmentNavState.selectedTestType = prevTest;
             props.assessmentNavState.selectedTestSubview = newStep;
 
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a => a.enableVisualHelper(firstAssessment.visualizationType, stepName, true))
                 .verifiable(Times.never());
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a => a.disableVisualHelpersForTest(prevTest))
                 .verifiable(Times.once());
 
             testObject.update(prevProps, props);
 
-            builder.verifyAll();
+            detailsViewActionMessageCreatorMock.verifyAll();
         });
     });
 
     describe('onUnmount', () => {
         test('componentWillUnmount', () => {
-            builder.detailsViewActionMessageCreatorMock
+            detailsViewActionMessageCreatorMock
                 .setup(a => a.disableVisualHelpersForTest(firstAssessment.visualizationType))
                 .verifiable(Times.once());
 
-            const props = builder.buildProps();
+            const props = buildProps();
 
             testObject.onUnmount(props);
-            builder.verifyAll();
+            detailsViewActionMessageCreatorMock.verifyAll();
         });
     });
 
-    function setStepNotToScanByDefault(props: AssessmentViewProps): void {
+    function setStepNotToScanByDefault(props: AssessmentViewUpdateHandlerProps): void {
         props.assessmentNavState.selectedTestSubview = assessmentsProvider.all()[0].requirements[1].key;
+    }
+
+    function buildProps(
+        generatedAssessmentInstancesMap = {},
+        isTargetChanged = false,
+        isStepScanned = false,
+    ): AssessmentViewUpdateHandlerProps {
+        const deps: AssessmentViewUpdateHandlerDeps = {
+            detailsViewActionMessageCreator: detailsViewActionMessageCreatorMock.object,
+            assessmentsProvider,
+        };
+        const assessment = assessmentsProvider.all()[0];
+        const firstStep = assessment.requirements[0];
+        const anotherTarget = {
+            id: 2,
+            url: '2',
+            title: '2',
+        };
+        const prevTarget = {
+            id: 1,
+            url: '1',
+            title: '2',
+            appRefreshed: false,
+        };
+        const assessmentNavState = {
+            selectedTestSubview: firstStep.key,
+            selectedTestType: assessment.visualizationType,
+        };
+        const assessmentData = {
+            testStepStatus: {
+                [firstStep.key]: {
+                    stepFinalResult: ManualTestStatus.UNKNOWN,
+                    isStepScanned: isStepScanned,
+                },
+            },
+            generatedAssessmentInstancesMap: generatedAssessmentInstancesMap,
+            manualTestStepResultMap: {},
+        } as AssessmentData;
+
+        return {
+            deps,
+            prevTarget,
+            currentTarget: isTargetChanged ? anotherTarget : prevTarget,
+            isEnabled,
+            assessmentNavState,
+            assessmentData,
+        };
     }
 });


### PR DESCRIPTION
#### Description of changes

Make AssessmentViewUpdateHandler only depend on the props and deps that it uses, instead of taking in all of AssessmentViewProps (especially since the new AssessmentView will likely have different props)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
