### PR TITLE
fix: auditory cues to convey information are WCAG 1.1.1 not 1.3.3

### DIFF
--- a/src/assessments/color/test-steps/auditory-cues.tsx
+++ b/src/assessments/color/test-steps/auditory-cues.tsx
@@ -40,5 +40,5 @@ export const AuditoryCues: Requirement = {
     howToTest: auditoryCuesHowToTest,
     isManual: true,
     ...content,
-    guidanceLinks: [link.WCAG_1_3_3],
+    guidanceLinks: [link.WCAG_1_1_1],
 };

--- a/src/content/test/sensory/guidance.tsx
+++ b/src/content/test/sensory/guidance.tsx
@@ -62,7 +62,7 @@ export const guidance = create(({ Markup, Link }) => (
                     </li>
                 </ul>
                 <h3>
-                    Don't use audio as the only means of conveying information. (<Link.WCAG_1_3_3 />)
+                    Don't use audio as the only means of conveying information. (<Link.WCAG_1_1_1 />)
                 </h3>
                 <ul>
                     <li>Convey the same information visually, such as through text or icons.</li>

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -28346,10 +28346,10 @@ exports[`Guidance Content pages test/sensory/guidance matches the snapshot 1`] =
               Don't use audio as the only means of conveying information. (
               <a
                 class="ms-Link insights-link root-000"
-                href="https://www.w3.org/WAI/WCAG21/Understanding/sensory-characteristics.html"
+                href="https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html"
                 target="_blank"
               >
-                WCAG 1.3.3
+                WCAG 1.1.1
               </a>
               )
             </h3>


### PR DESCRIPTION
WCAG 2.1 1.3.3. is only scope to *instructions* that describe other things based on sensory characteristics. The use of audio alone as a cue is not a failure of 1.3.3, but of 1.1.1. Audio-only cues are
non-text content (and time-based media, though relatively short ones). This may not be immediately clear/obvious from the normative wording of the SC (nor the current normative definition of "non-text content"
which gives only visual examples), but referring to 1.1.1 Understanding https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html see example 8:

> An e-learning application
>
> An e-learning application uses sound effects to indicate whether or not the answers are correct. The chime sound indicates that the answer is correct and the beep sound indicates that the answer is incorrect.
> A text description is also included so that people who can't hear or understand the sound understand whether the answer is correct or incorrect.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [X] Ran `yarn fastpass`
- [N/A] Added/updated relevant unit test(s) (and ran `yarn test`)
- [N/A] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [X] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS
