### PR TITLE
fix: 1.4.10 Reflow is not solely about text

### DIFF
--- a/src/assessments/text-legibility/test-steps/reflow.tsx
+++ b/src/assessments/text-legibility/test-steps/reflow.tsx
@@ -9,7 +9,7 @@ import * as content from 'content/test/text-legibility/reflow';
 import { ManualTestRecordYourResults } from '../../common/manual-test-record-your-results';
 
 const reflowDescription: JSX.Element = (
-    <span>Text content must be visible without having to scroll in two dimensions.</span>
+    <span>Content must be visible without having to scroll in two dimensions.</span>
 );
 
 const reflowHowToTest: JSX.Element = (

--- a/src/content/test/text-legibility/reflow.tsx
+++ b/src/content/test/text-legibility/reflow.tsx
@@ -4,7 +4,7 @@ import { create, React } from '../../common';
 
 export const infoAndExamples = create(({ Markup }) => (
     <>
-        <p>Text content must be visible without having to scroll both vertically and horizontally.</p>
+        <p>Content must be visible without having to scroll both vertically and horizontally.</p>
 
         <h2>Why it matters</h2>
         <p>

--- a/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
+++ b/src/tests/end-to-end/tests/content/__snapshots__/guidance-content.test.ts.snap
@@ -31675,7 +31675,7 @@ exports[`Guidance Content pages test/textLegibility/reflow/infoAndExamples match
       class="content"
     >
       <p>
-        Text content must be visible without having to scroll both vertically and horizontally.
+        Content must be visible without having to scroll both vertically and horizontally.
       </p>
       <h2>
         Why it matters


### PR DESCRIPTION
Normatively, 1.4.10 is scoped to all content, not just text. While the principal concern of the SC is indeed text, it applies in equal measure to other types of content/mixed content.
Admittedly, the normative wording is a bit wooly/omits certain extra scenarios (i.e. that the primary concern is that blocks of text are legible without tow-dimensional scrolling, rather than an outright
ban on two-dimensional scrolling ... see for instance https://github.com/w3c/wcag/issues/668), but one things it does not do is explicitly limit this to just the text portion of content.

> Success Criterion 1.4.10 Reflow (Level AA): *Content* can be presented without loss of information or functionality [...]
(emphasis on "Content", not "Text" or "Text content")

https://www.w3.org/WAI/WCAG21/Understanding/reflow.html

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [n/a] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
