### PR TITLE
chore: fix web-e2e-reliability linux failures in fetching cypress/base:12.16.3 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # We use Puppeteer, not Cypress; however, Cypress's docker images are up to date baselines that already contain both node and
 # the system dependencies required to run headful Chromium, so we use them to avoid the performance hit of having our own
 # build agents running apt-get for all those dependencies.
-FROM cypress/base:12.16.3
+FROM cypress/base:12
 
 RUN npm install -g yarn@1.22.4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@
 # build agents running apt-get for all those dependencies.
 FROM cypress/base:12.16.1
 
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+    libgbm1 \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN npm install -g yarn@1.22.4
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # We use Puppeteer, not Cypress; however, Cypress's docker images are up to date baselines that already contain both node and
 # the system dependencies required to run headful Chromium, so we use them to avoid the performance hit of having our own
 # build agents running apt-get for all those dependencies.
-FROM cypress/base:12
+FROM cypress/base:12.16.1
 
 RUN npm install -g yarn@1.22.4
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/Microsoft/accessibility-insights-web"
     },
     "engines": {
-        "node": ">=12.16.3",
+        "node": ">=12.16.1",
         "yarn": "^1.22.4"
     },
     "scripts": {

--- a/pipeline/e2e-reliability.yaml
+++ b/pipeline/e2e-reliability.yaml
@@ -12,6 +12,7 @@ pr:
     paths:
         include:
             - src/tests/end-to-end/
+            - Dockerfile
 
 jobs:
     - template: ./e2e-job-per-environment.yaml


### PR DESCRIPTION
#### Description of changes

Cypress hasn't released a 12.16.3 image yet; downgrading our Dockerfile base to use the most recent available node LTS version, updating our package.json engine requirements to allow the looser version, and updating our e2e-reliability config to trigger automatically for future Dockerfile changes to avoid this class of regression in future version updates.

Should fix issues seen in, for example, this [web-e2e-reliability build](https://dev.azure.com/accessibility-insights/accessibility-insights-web/_build/results?buildId=9045&view=results) from #2654

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
