### PR TITLE
feat(nav-bar-content): create new links for reflow left nav

### DIFF
--- a/src/DetailsView/components/left-nav/assessment-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/assessment-left-nav.tsx
@@ -48,6 +48,11 @@ export type onTestRequirementClick = (
     item: TestRequirementLeftNavLink,
 ) => void;
 
+export type onTestGettingStartedClick = (
+    event: React.MouseEvent<HTMLElement>,
+    item: TestGettingStartedNavLink,
+) => void;
+
 export const AssessmentLeftNav = NamedFC<AssessmentLeftNavProps>('AssessmentLeftNav', props => {
     const { deps, selectedKey, assessmentsProvider, assessmentsData, featureFlagStoreData } = props;
 
@@ -65,7 +70,14 @@ export const AssessmentLeftNav = NamedFC<AssessmentLeftNavProps>('AssessmentLeft
     );
 
     if (featureFlagStoreData[FeatureFlags.reflowUI]) {
-        links = links;
+        links = links.concat(
+            leftNavLinkBuilder.buildReflowAssessmentTestLinks(
+                deps,
+                assessmentsProvider,
+                assessmentsData,
+                1,
+            ),
+        );
     } else {
         links = links.concat(
             leftNavLinkBuilder.buildAssessmentTestLinks(

--- a/src/DetailsView/components/left-nav/getting-started-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/getting-started-nav-link.tsx
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { NamedFC } from 'common/react/named-fc';
+import * as React from 'react';
+
+export type GettingStartedNavLinkProps = {};
+
+export const GettingStartedNavLink = NamedFC<GettingStartedNavLinkProps>(
+    'GettingStartedNavLink',
+    _ => {
+        return <span className="getting-started">Getting Started</span>;
+    },
+);

--- a/src/common/types/store-data/assessment-result-data.ts
+++ b/src/common/types/store-data/assessment-result-data.ts
@@ -10,6 +10,8 @@ export type TestStepInstance = UserCapturedInstance & GeneratedAssessmentInstanc
 export type RequirementName = string;
 export type GettingStarted = 'getting-started';
 
+export const gettingStartedSubview: GettingStarted = 'getting-started';
+
 export type PersistedTabInfo = Tab & {
     appRefreshed: boolean;
 };

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/assessment-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/assessment-left-nav.test.tsx.snap
@@ -23,6 +23,9 @@ exports[`AssessmentLeftNav renders with reflow feature flag enabled 1`] = `
       Object {
         "status": 1,
       },
+      Object {
+        "status": 1,
+      },
     ]
   }
   selectedKey="some key"

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/getting-started-nav-link.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/getting-started-nav-link.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GettingStartedNavLink renders 1`] = `
+<span
+  className="getting-started"
+>
+  Getting Started
+</span>
+`;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-link-builder.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-link-builder.test.tsx.snap
@@ -86,6 +86,392 @@ exports[`LeftNavBuilder buildAssessmentTestLinks should build links for assessme
 />
 `;
 
+exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: getting started nav link render 1`] = `<GettingStartedNavLink />`;
+
+exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: getting started nav link render 2`] = `<GettingStartedNavLink />`;
+
+exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: requirement nav link render 1`] = `
+<TestViewLeftNavLink
+  link={
+    Object {
+      "displayedIndex": "-1.1",
+      "forceAnchor": true,
+      "iconProps": Object {
+        "className": "hidden",
+      },
+      "index": 1,
+      "key": "requirement-key-1",
+      "name": "requirement-name-1",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "status": -2,
+      "testType": 1,
+      "title": "-1.1: requirement-name-1 (passed)",
+      "url": "",
+    }
+  }
+  renderIcon={[Function]}
+/>
+`;
+
+exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: requirement nav link render 2`] = `
+<TestViewLeftNavLink
+  link={
+    Object {
+      "displayedIndex": "0.1",
+      "forceAnchor": true,
+      "iconProps": Object {
+        "className": "hidden",
+      },
+      "index": 1,
+      "key": "requirement-key-1",
+      "name": "requirement-name-1",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "status": -2,
+      "testType": 1,
+      "title": "0.1: requirement-name-1 (passed)",
+      "url": "",
+    }
+  }
+  renderIcon={[Function]}
+/>
+`;
+
+exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: requirement nav link render icon 1`] = `
+<LeftNavStatusIcon
+  item={
+    <TestViewLeftNavLink
+      link={
+        Object {
+          "displayedIndex": "-1.1",
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 1,
+          "key": "requirement-key-1",
+          "name": "requirement-name-1",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "status": -2,
+          "testType": 1,
+          "title": "-1.1: requirement-name-1 (passed)",
+          "url": "",
+        }
+      }
+      renderIcon={[Function]}
+    />
+  }
+/>
+`;
+
+exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: requirement nav link render icon 2`] = `
+<LeftNavStatusIcon
+  item={
+    <TestViewLeftNavLink
+      link={
+        Object {
+          "displayedIndex": "0.1",
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 1,
+          "key": "requirement-key-1",
+          "name": "requirement-name-1",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "status": -2,
+          "testType": 1,
+          "title": "0.1: requirement-name-1 (passed)",
+          "url": "",
+        }
+      }
+      renderIcon={[Function]}
+    />
+  }
+/>
+`;
+
+exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: test nav link render 1`] = `
+<TestViewLeftNavLink
+  link={
+    Object {
+      "forceAnchor": true,
+      "iconProps": Object {
+        "className": "hidden",
+      },
+      "index": -1,
+      "isExpanded": true,
+      "key": "Issues",
+      "links": Array [
+        Object {
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 0,
+          "key": "getting-started",
+          "name": "Getting Started",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "testType": 1,
+          "url": "",
+        },
+        Object {
+          "displayedIndex": "-1.1",
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 1,
+          "key": "requirement-key-1",
+          "name": "requirement-name-1",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "status": -2,
+          "testType": 1,
+          "title": "-1.1: requirement-name-1 (passed)",
+          "url": "",
+        },
+        Object {
+          "displayedIndex": "-1.2",
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 2,
+          "key": "requirement-key-2",
+          "name": "requirement-name-2",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "status": -2,
+          "testType": 1,
+          "title": "-1.2: requirement-name-2 (passed)",
+          "url": "",
+        },
+      ],
+      "name": "some title",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "status": -2,
+      "title": "-1: some title (passed)",
+      "url": "",
+    }
+  }
+  renderIcon={[Function]}
+/>
+`;
+
+exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: test nav link render 2`] = `
+<TestViewLeftNavLink
+  link={
+    Object {
+      "forceAnchor": true,
+      "iconProps": Object {
+        "className": "hidden",
+      },
+      "index": 0,
+      "isExpanded": true,
+      "key": "Issues",
+      "links": Array [
+        Object {
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 0,
+          "key": "getting-started",
+          "name": "Getting Started",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "testType": 1,
+          "url": "",
+        },
+        Object {
+          "displayedIndex": "0.1",
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 1,
+          "key": "requirement-key-1",
+          "name": "requirement-name-1",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "status": -2,
+          "testType": 1,
+          "title": "0.1: requirement-name-1 (passed)",
+          "url": "",
+        },
+        Object {
+          "displayedIndex": "0.2",
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 2,
+          "key": "requirement-key-2",
+          "name": "requirement-name-2",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "status": -2,
+          "testType": 1,
+          "title": "0.2: requirement-name-2 (passed)",
+          "url": "",
+        },
+      ],
+      "name": "some title",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "status": -2,
+      "title": "0: some title (passed)",
+      "url": "",
+    }
+  }
+  renderIcon={[Function]}
+/>
+`;
+
+exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: test nav link render icon 1`] = `
+<LeftNavStatusIcon
+  item={
+    Object {
+      "forceAnchor": true,
+      "iconProps": Object {
+        "className": "hidden",
+      },
+      "index": -1,
+      "isExpanded": true,
+      "key": "Issues",
+      "links": Array [
+        Object {
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 0,
+          "key": "getting-started",
+          "name": "Getting Started",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "testType": 1,
+          "url": "",
+        },
+        Object {
+          "displayedIndex": "-1.1",
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 1,
+          "key": "requirement-key-1",
+          "name": "requirement-name-1",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "status": -2,
+          "testType": 1,
+          "title": "-1.1: requirement-name-1 (passed)",
+          "url": "",
+        },
+        Object {
+          "displayedIndex": "-1.2",
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 2,
+          "key": "requirement-key-2",
+          "name": "requirement-name-2",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "status": -2,
+          "testType": 1,
+          "title": "-1.2: requirement-name-2 (passed)",
+          "url": "",
+        },
+      ],
+      "name": "some title",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "status": -2,
+      "title": "-1: some title (passed)",
+      "url": "",
+    }
+  }
+/>
+`;
+
+exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: test nav link render icon 2`] = `
+<LeftNavStatusIcon
+  item={
+    Object {
+      "forceAnchor": true,
+      "iconProps": Object {
+        "className": "hidden",
+      },
+      "index": 0,
+      "isExpanded": true,
+      "key": "Issues",
+      "links": Array [
+        Object {
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 0,
+          "key": "getting-started",
+          "name": "Getting Started",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "testType": 1,
+          "url": "",
+        },
+        Object {
+          "displayedIndex": "0.1",
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 1,
+          "key": "requirement-key-1",
+          "name": "requirement-name-1",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "status": -2,
+          "testType": 1,
+          "title": "0.1: requirement-name-1 (passed)",
+          "url": "",
+        },
+        Object {
+          "displayedIndex": "0.2",
+          "forceAnchor": true,
+          "iconProps": Object {
+            "className": "hidden",
+          },
+          "index": 2,
+          "key": "requirement-key-2",
+          "name": "requirement-name-2",
+          "onClickNavLink": [Function],
+          "onRenderNavLink": [Function],
+          "status": -2,
+          "testType": 1,
+          "title": "0.2: requirement-name-2 (passed)",
+          "url": "",
+        },
+      ],
+      "name": "some title",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "status": -2,
+      "title": "0: some title (passed)",
+      "url": "",
+    }
+  }
+/>
+`;
+
 exports[`LeftNavBuilder buildOverviewLink should build overview link 1`] = `
 <OverviewLeftNavLink
   link={

--- a/src/tests/unit/tests/DetailsView/components/left-nav/assessment-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/assessment-left-nav.test.tsx
@@ -4,7 +4,7 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { FeatureFlags } from 'common/feature-flags';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, Mock } from 'typemoq';
+import { IMock, Mock, MockBehavior } from 'typemoq';
 import {
     ManualTestStatus,
     ManualTestStatusData,
@@ -31,7 +31,7 @@ describe('AssessmentLeftNav', () => {
     beforeEach(() => {
         assessmentsDataStub = {};
         assessmentsProviderStub = {} as AssessmentsProvider;
-        leftNavLinkBuilderMock = Mock.ofType(LeftNavLinkBuilder);
+        leftNavLinkBuilderMock = Mock.ofType(LeftNavLinkBuilder, MockBehavior.Strict);
         navLinkHandlerMock = {
             onOverviewClick: () => {},
             onAssessmentTestClick: (x, y) => {},
@@ -63,6 +63,28 @@ describe('AssessmentLeftNav', () => {
                 ),
             )
             .returns(() => linkStub);
+    });
+
+    it('renders with reflow feature flag enabled', () => {
+        props.featureFlagStoreData[FeatureFlags.reflowUI] = true;
+
+        leftNavLinkBuilderMock
+            .setup(lnlbm =>
+                lnlbm.buildReflowAssessmentTestLinks(
+                    deps,
+                    assessmentsProviderStub,
+                    assessmentsDataStub,
+                    1,
+                ),
+            )
+            .returns(() => [linkStub]);
+
+        const actual = shallow(<AssessmentLeftNav {...props} />);
+        expect(actual.getElement()).toMatchSnapshot();
+    });
+
+    it('renders with reflow feature flag disabled', () => {
+        props.featureFlagStoreData[FeatureFlags.reflowUI] = false;
 
         leftNavLinkBuilderMock
             .setup(lnlbm =>
@@ -75,16 +97,7 @@ describe('AssessmentLeftNav', () => {
                 ),
             )
             .returns(() => [linkStub]);
-    });
 
-    it('renders with reflow feature flag enabled', () => {
-        props.featureFlagStoreData[FeatureFlags.reflowUI] = true;
-        const actual = shallow(<AssessmentLeftNav {...props} />);
-        expect(actual.getElement()).toMatchSnapshot();
-    });
-
-    it('renders with reflow feature flag disabled', () => {
-        props.featureFlagStoreData[FeatureFlags.reflowUI] = false;
         const actual = shallow(<AssessmentLeftNav {...props} />);
         expect(actual.getElement()).toMatchSnapshot();
     });

--- a/src/tests/unit/tests/DetailsView/components/left-nav/getting-started-nav-link.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/getting-started-nav-link.test.tsx
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { GettingStartedNavLink } from 'DetailsView/components/left-nav/getting-started-nav-link';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('GettingStartedNavLink', () => {
+    test('renders', () => {
+        const renderedTestObject = shallow(<GettingStartedNavLink />);
+        expect(renderedTestObject.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

This creates a new "duplicate" function on the left nav link builder to create the links for reflow (links now have tests, requirements, and getting started).

Ideally, I'd like to re-factor the left nav link builder but felt that the old link building didn't require it (i.e. fastpass) but this does. Additionally, I don't know how much I want to break up the responsibility of creating the link objects themselves: it's largely just composition and there are few branches of logic. I'd like to move out some of inner small components to separate modules though, as they allow for their own logic/have own responsibility.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
