### PR TITLE
feat(nav-bar-content): use AssessmentViewUpdateHandler in ReflowAssessmentView

### DIFF
--- a/src/DetailsView/components/assessment-test-view.tsx
+++ b/src/DetailsView/components/assessment-test-view.tsx
@@ -73,6 +73,7 @@ export const AssessmentTestView = NamedFC<AssessmentTestViewProps>(
                     currentTarget={currentTarget}
                     prevTarget={prevTarget}
                     assessmentTestResult={assessmentTestResult}
+                    isEnabled={isEnabled}
                 />
             );
         };

--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -2,6 +2,10 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
+import {
+    AssessmentViewUpdateHandler,
+    AssessmentViewUpdateHandlerDeps,
+} from 'DetailsView/components/assessment-view-update-handler';
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { Tab } from '../../common/itab';
 import {
@@ -12,7 +16,10 @@ import {
 import { GettingStartedView } from './getting-started-view';
 import { TargetChangeDialog, TargetChangeDialogDeps } from './target-change-dialog';
 
-export type ReflowAssessmentViewDeps = TargetChangeDialogDeps;
+export type ReflowAssessmentViewDeps = {
+    assessmentViewUpdateHandler: AssessmentViewUpdateHandler;
+} & AssessmentViewUpdateHandlerDeps &
+    TargetChangeDialogDeps;
 
 export interface ReflowAssessmentViewProps {
     deps: ReflowAssessmentViewDeps;
@@ -21,6 +28,7 @@ export interface ReflowAssessmentViewProps {
     currentTarget: Tab;
     prevTarget: PersistedTabInfo;
     assessmentTestResult: AssessmentTestResult;
+    isEnabled: boolean;
 }
 
 export class ReflowAssessmentView extends React.Component<ReflowAssessmentViewProps> {
@@ -37,6 +45,18 @@ export class ReflowAssessmentView extends React.Component<ReflowAssessmentViewPr
             );
         }
         return null;
+    }
+
+    public componentDidMount(): void {
+        this.props.deps.assessmentViewUpdateHandler.onMount(this.props);
+    }
+
+    public componentDidUpdate(prevProps: ReflowAssessmentViewProps): void {
+        this.props.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
+    }
+
+    public componentWillUnmount(): void {
+        this.props.deps.assessmentViewUpdateHandler.onUnmount(this.props);
     }
 
     private renderTargetChangeDialog(): JSX.Element {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-test-view.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`AssessmentTestView assessment view, isScanning is false 1`] = `
             "detailsViewActionMessageCreator": Object {},
           }
         }
+        isEnabled={false}
       />
     }
     featureFlag="reflowUI"
@@ -184,6 +185,7 @@ exports[`AssessmentTestView assessment view, isScanning is true 1`] = `
             "detailsViewActionMessageCreator": Object {},
           }
         }
+        isEnabled={false}
       />
     }
     featureFlag="reflowUI"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
@@ -1,10 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssessmentViewTest render for gettting started 1`] = `
-"<div>
-  <TargetChangeDialog deps={{...}} prevTab={{...}} newTab={{...}} />
-  <GettingStartedView gettingStartedContent={{...}} />
-</div>"
+<div>
+  <TargetChangeDialog
+    deps={
+      Object {
+        "assessmentViewUpdateHandler": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        },
+      }
+    }
+    newTab={
+      Object {
+        "id": 5,
+      }
+    }
+    prevTab={
+      Object {
+        "id": 4,
+      }
+    }
+  />
+  <GettingStartedView
+    gettingStartedContent={
+      <h1>
+        Hello
+      </h1>
+    }
+  />
+</div>
 `;
 
-exports[`AssessmentViewTest render for requirement 1`] = `""`;
+exports[`AssessmentViewTest render for requirement 1`] = `null`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
@@ -1,28 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssessmentViewTest render for gettting started 1`] = `
-<div>
-  <TargetChangeDialog
-    deps={Object {}}
-    newTab={
-      Object {
-        "id": 5,
-      }
-    }
-    prevTab={
-      Object {
-        "id": 4,
-      }
-    }
-  />
-  <GettingStartedView
-    gettingStartedContent={
-      <h1>
-        Hello
-      </h1>
-    }
-  />
-</div>
+"<div>
+  <TargetChangeDialog deps={{...}} prevTab={{...}} newTab={{...}} />
+  <GettingStartedView gettingStartedContent={{...}} />
+</div>"
 `;
 
-exports[`AssessmentViewTest render for requirement 1`] = `null`;
+exports[`AssessmentViewTest render for requirement 1`] = `""`;

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -17,19 +17,19 @@ describe('AssessmentViewTest', () => {
     let updateHandlerMock: IMock<AssessmentViewUpdateHandler>;
 
     beforeEach(() => {
-        updateHandlerMock = Mock.ofType<AssessmentViewUpdateHandler>();
+        updateHandlerMock = Mock.ofType(AssessmentViewUpdateHandler);
     });
 
     test('render for requirement', () => {
         const props = generateProps('requirement');
         const rendered = shallow(<ReflowAssessmentView {...props} />);
-        expect(rendered.debug()).toMatchSnapshot();
+        expect(rendered.getElement()).toMatchSnapshot();
     });
 
     test('render for gettting started', () => {
         const props = generateProps('getting-started');
         const rendered = shallow(<ReflowAssessmentView {...props} />);
-        expect(rendered.debug()).toMatchSnapshot();
+        expect(rendered.getElement()).toMatchSnapshot();
     });
 
     test('componentDidMount', () => {

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -4,8 +4,9 @@ import { AssessmentTestResult } from 'common/assessment/assessment-test-result';
 import { AssessmentData } from 'common/types/store-data/assessment-result-data';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Mock } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 
+import { AssessmentViewUpdateHandler } from 'DetailsView/components/assessment-view-update-handler';
 import {
     ReflowAssessmentView,
     ReflowAssessmentViewDeps,
@@ -13,16 +14,53 @@ import {
 } from '../../../../../DetailsView/components/reflow-assessment-view';
 
 describe('AssessmentViewTest', () => {
+    let updateHandlerMock: IMock<AssessmentViewUpdateHandler>;
+
+    beforeEach(() => {
+        updateHandlerMock = Mock.ofType<AssessmentViewUpdateHandler>();
+    });
+
     test('render for requirement', () => {
         const props = generateProps('requirement');
         const rendered = shallow(<ReflowAssessmentView {...props} />);
-        expect(rendered.getElement()).toMatchSnapshot();
+        expect(rendered.debug()).toMatchSnapshot();
     });
 
     test('render for gettting started', () => {
         const props = generateProps('getting-started');
         const rendered = shallow(<ReflowAssessmentView {...props} />);
-        expect(rendered.getElement()).toMatchSnapshot();
+        expect(rendered.debug()).toMatchSnapshot();
+    });
+
+    test('componentDidMount', () => {
+        const props = generateProps('requirement');
+        updateHandlerMock.setup(u => u.onMount(props)).verifiable(Times.once());
+        const testObject = new ReflowAssessmentView(props);
+
+        testObject.componentDidMount();
+
+        updateHandlerMock.verifyAll();
+    });
+
+    test('componentWillUnmount', () => {
+        const props = generateProps('requirement');
+        updateHandlerMock.setup(u => u.onUnmount(props)).verifiable(Times.once());
+        const testObject = new ReflowAssessmentView(props);
+
+        testObject.componentWillUnmount();
+
+        updateHandlerMock.verifyAll();
+    });
+
+    test('componentDidUpdate', () => {
+        const prevProps = generateProps('requirement1');
+        const props = generateProps('requirement2');
+        updateHandlerMock.setup(u => u.update(prevProps, props)).verifiable(Times.once());
+        const testObject = new ReflowAssessmentView(props);
+
+        testObject.componentDidUpdate(prevProps);
+
+        updateHandlerMock.verifyAll();
     });
 
     function generateProps(subview: string): ReflowAssessmentViewProps {
@@ -35,7 +73,9 @@ describe('AssessmentViewTest', () => {
         } as AssessmentTestResult;
 
         const reflowProps = {
-            deps: {} as ReflowAssessmentViewDeps,
+            deps: {
+                assessmentViewUpdateHandler: updateHandlerMock.object,
+            } as ReflowAssessmentViewDeps,
             prevTarget: { id: 4 },
             currentTarget: { id: 5 },
             assessmentNavState: {


### PR DESCRIPTION
#### Description of changes

Hook up the update handler to the new ReflowAssessmentView (enables updates from changing target page, scanning pages, enabling visual helpers, etc.)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
