### PR TITLE
chore: remove obsolete property from test assessment data provider

### DIFF
--- a/src/tests/unit/common/test-assessment-provider.tsx
+++ b/src/tests/unit/common/test-assessment-provider.tsx
@@ -9,7 +9,6 @@ import { ContentPage } from 'views/content/content-page';
 import { RequirementComparer } from '../../../common/assessment/requirement-comparer';
 import { AssessmentVisualizationConfiguration } from '../../../common/configs/assessment-visualization-configuration';
 import { FeatureFlags } from '../../../common/feature-flags';
-import { ManualTestStatus } from '../../../common/types/manual-test-status';
 import { AssessmentData } from '../../../common/types/store-data/assessment-result-data';
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { RequirementLink } from '../../../DetailsView/components/requirement-link';
@@ -137,7 +136,6 @@ const automatedAssessment = {
             isManual: null,
             guidanceLinks: [],
             columnsConfig: [],
-            defaultInstanceStatus: ManualTestStatus.FAIL,
             renderInstanceTableHeader: () => null,
             getInstanceStatusColumns: () => [],
             renderRequirementDescription: renderRequirementDescription,
@@ -150,7 +148,6 @@ const automatedAssessment = {
             isManual: null,
             guidanceLinks: [],
             columnsConfig: [],
-            defaultInstanceStatus: ManualTestStatus.FAIL,
             renderInstanceTableHeader: () => null,
             getInstanceStatusColumns: () => [],
             renderRequirementDescription: renderRequirementDescription,


### PR DESCRIPTION
#### Description of changes

Our `test-assessment-provider` helper was still including a property (`defaultInstanceStatus`) in test AssessmentData which was removed in the production type some time ago and is no longer used. This removes the obsolete property.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
