### PR TITLE
feat(nav-bar-content): handle getting started in AssessmentViewUpdateHandler

### DIFF
--- a/src/DetailsView/components/assessment-test-view.tsx
+++ b/src/DetailsView/components/assessment-test-view.tsx
@@ -73,7 +73,6 @@ export const AssessmentTestView = NamedFC<AssessmentTestViewProps>(
                     currentTarget={currentTarget}
                     prevTarget={prevTarget}
                     assessmentTestResult={assessmentTestResult}
-                    selectedRequirementIsEnabled={selectedRequirementIsEnabled}
                 />
             );
         };

--- a/src/DetailsView/components/assessment-view-update-handler.ts
+++ b/src/DetailsView/components/assessment-view-update-handler.ts
@@ -5,6 +5,7 @@ import { Tab } from 'common/itab';
 import {
     AssessmentData,
     AssessmentNavState,
+    gettingStartedSubview,
     PersistedTabInfo,
 } from 'common/types/store-data/assessment-result-data';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
@@ -61,7 +62,11 @@ export class AssessmentViewUpdateHandler {
     ): void {
         const test = props.assessmentNavState.selectedTestType;
         const step = props.assessmentNavState.selectedTestSubview;
-        if (this.visualHelperDisabledByDefault(props, test, step) || this.isTargetChanged(props)) {
+        if (
+            step === gettingStartedSubview ||
+            this.visualHelperDisabledByDefault(props, test, step) ||
+            this.isTargetChanged(props)
+        ) {
             return;
         }
 
@@ -100,6 +105,9 @@ export class AssessmentViewUpdateHandler {
 
     private disableVisualHelpersForSelectedTest(props: AssessmentViewUpdateHandlerProps): void {
         const test = props.assessmentNavState.selectedTestType;
-        props.deps.detailsViewActionMessageCreator.disableVisualHelpersForTest(test);
+        const subview = props.assessmentNavState.selectedTestSubview;
+        if (subview !== gettingStartedSubview) {
+            props.deps.detailsViewActionMessageCreator.disableVisualHelpersForTest(test);
+        }
     }
 }

--- a/src/DetailsView/components/assessment-view-update-handler.ts
+++ b/src/DetailsView/components/assessment-view-update-handler.ts
@@ -27,7 +27,7 @@ export interface AssessmentViewUpdateHandlerProps {
     deps: AssessmentViewUpdateHandlerDeps;
     assessmentNavState: AssessmentNavState;
     assessmentData: AssessmentData;
-    selectedRequirementIsEnabled: boolean;
+    isStepEnabled: boolean;
     currentTarget: Tab;
     prevTarget: PersistedTabInfo;
 }
@@ -71,7 +71,7 @@ export class AssessmentViewUpdateHandler {
         }
 
         const isStepNotScanned = !props.assessmentData.testStepStatus[step].isStepScanned;
-        if (props.selectedRequirementIsEnabled === false || isStepNotScanned) {
+        if (props.isStepEnabled === false || isStepNotScanned) {
             props.deps.detailsViewActionMessageCreator.enableVisualHelper(
                 test,
                 step,

--- a/src/DetailsView/components/assessment-view-update-handler.ts
+++ b/src/DetailsView/components/assessment-view-update-handler.ts
@@ -5,7 +5,6 @@ import { Tab } from 'common/itab';
 import {
     AssessmentData,
     AssessmentNavState,
-    gettingStartedSubview,
     PersistedTabInfo,
 } from 'common/types/store-data/assessment-result-data';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
@@ -62,11 +61,7 @@ export class AssessmentViewUpdateHandler {
     ): void {
         const test = props.assessmentNavState.selectedTestType;
         const step = props.assessmentNavState.selectedTestSubview;
-        if (
-            step === gettingStartedSubview ||
-            this.visualHelperDisabledByDefault(props, test, step) ||
-            this.isTargetChanged(props)
-        ) {
+        if (this.visualHelperDisabledByDefault(props, test, step) || this.isTargetChanged(props)) {
             return;
         }
 
@@ -105,9 +100,6 @@ export class AssessmentViewUpdateHandler {
 
     private disableVisualHelpersForSelectedTest(props: AssessmentViewUpdateHandlerProps): void {
         const test = props.assessmentNavState.selectedTestType;
-        const subview = props.assessmentNavState.selectedTestSubview;
-        if (subview !== gettingStartedSubview) {
-            props.deps.detailsViewActionMessageCreator.disableVisualHelpersForTest(test);
-        }
+        props.deps.detailsViewActionMessageCreator.disableVisualHelpersForTest(test);
     }
 }

--- a/src/DetailsView/components/assessment-view-update-handler.ts
+++ b/src/DetailsView/components/assessment-view-update-handler.ts
@@ -26,7 +26,7 @@ export interface AssessmentViewUpdateHandlerProps {
     deps: AssessmentViewUpdateHandlerDeps;
     assessmentNavState: AssessmentNavState;
     assessmentData: AssessmentData;
-    isStepEnabled: boolean;
+    isRequirementEnabled: boolean;
     currentTarget: Tab;
     prevTarget: PersistedTabInfo;
 }
@@ -65,12 +65,12 @@ export class AssessmentViewUpdateHandler {
             return;
         }
 
-        const isStepNotScanned = !props.assessmentData.testStepStatus[step].isStepScanned;
-        if (props.isStepEnabled === false || isStepNotScanned) {
+        const isRequirementNotScanned = !props.assessmentData.testStepStatus[step].isStepScanned;
+        if (props.isRequirementEnabled === false || isRequirementNotScanned) {
             props.deps.detailsViewActionMessageCreator.enableVisualHelper(
                 test,
                 step,
-                isStepNotScanned,
+                isRequirementNotScanned,
                 sendTelemetry,
             );
         }

--- a/src/DetailsView/components/assessment-view.tsx
+++ b/src/DetailsView/components/assessment-view.tsx
@@ -92,21 +92,11 @@ export class AssessmentView extends React.Component<AssessmentViewProps> {
         );
     }
 
-    public componentDidMount(): void {
-        this.deps.assessmentViewUpdateHandler.onMount(this.props);
-    }
-
     public componentDidUpdate(prevProps: AssessmentViewProps): void {
-        this.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
-
         const { assessmentTestResult } = this.props;
         this.deps.detailsViewExtensionPoint
             .apply(assessmentTestResult.definition.extensions)
             .onAssessmentViewUpdate(prevProps, this.props);
-    }
-
-    public componentWillUnmount(): void {
-        this.deps.assessmentViewUpdateHandler.onUnmount(this.props);
     }
 
     private renderTargetChangeDialog(): JSX.Element {
@@ -184,6 +174,9 @@ export class AssessmentView extends React.Component<AssessmentViewProps> {
                         }
                         featureFlagStoreData={this.props.featureFlagStoreData}
                         pathSnippetStoreData={this.props.pathSnippetStoreData}
+                        assessmentData={this.props.assessmentData}
+                        currentTarget={this.props.currentTarget}
+                        prevTarget={this.props.prevTarget}
                     />
                 </div>
             </div>

--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -47,18 +47,6 @@ export class ReflowAssessmentView extends React.Component<ReflowAssessmentViewPr
         return null;
     }
 
-    // public componentDidMount(): void {
-    //     this.props.deps.assessmentViewUpdateHandler.onMount(this.props);
-    // }
-
-    // public componentDidUpdate(prevProps: ReflowAssessmentViewProps): void {
-    //     this.props.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
-    // }
-
-    // public componentWillUnmount(): void {
-    //     this.props.deps.assessmentViewUpdateHandler.onUnmount(this.props);
-    // }
-
     private renderTargetChangeDialog(): JSX.Element {
         return (
             <TargetChangeDialog

--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -29,7 +29,7 @@ export type ReflowAssessmentViewProps = {
     currentTarget: Tab;
     prevTarget: PersistedTabInfo;
     assessmentTestResult: AssessmentTestResult;
-} & AssessmentViewUpdateHandlerProps;
+};
 
 export class ReflowAssessmentView extends React.Component<ReflowAssessmentViewProps> {
     public render(): JSX.Element {
@@ -47,17 +47,17 @@ export class ReflowAssessmentView extends React.Component<ReflowAssessmentViewPr
         return null;
     }
 
-    public componentDidMount(): void {
-        this.props.deps.assessmentViewUpdateHandler.onMount(this.props);
-    }
+    // public componentDidMount(): void {
+    //     this.props.deps.assessmentViewUpdateHandler.onMount(this.props);
+    // }
 
-    public componentDidUpdate(prevProps: ReflowAssessmentViewProps): void {
-        this.props.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
-    }
+    // public componentDidUpdate(prevProps: ReflowAssessmentViewProps): void {
+    //     this.props.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
+    // }
 
-    public componentWillUnmount(): void {
-        this.props.deps.assessmentViewUpdateHandler.onUnmount(this.props);
-    }
+    // public componentWillUnmount(): void {
+    //     this.props.deps.assessmentViewUpdateHandler.onUnmount(this.props);
+    // }
 
     private renderTargetChangeDialog(): JSX.Element {
         return (

--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -5,7 +5,6 @@ import * as React from 'react';
 import {
     AssessmentViewUpdateHandler,
     AssessmentViewUpdateHandlerDeps,
-    AssessmentViewUpdateHandlerProps,
 } from 'DetailsView/components/assessment-view-update-handler';
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { Tab } from '../../common/itab';

--- a/src/DetailsView/components/test-step-view.tsx
+++ b/src/DetailsView/components/test-step-view.tsx
@@ -6,9 +6,11 @@ import { Requirement, VisualHelperToggleConfig } from 'assessments/types/require
 import { CollapsibleComponent } from 'common/components/collapsible-component';
 import { GuidanceTags, GuidanceTagsDeps } from 'common/components/guidance-tags';
 import {
+    AssessmentData,
     AssessmentNavState,
     GeneratedAssessmentInstance,
     ManualTestStepResult,
+    PersistedTabInfo,
 } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { PathSnippetStoreData } from 'common/types/store-data/path-snippet-store-data';
@@ -17,6 +19,7 @@ import * as React from 'react';
 import { DictionaryStringTo } from 'types/common-types';
 import { ContentPanelButton, ContentPanelButtonDeps } from 'views/content/content-panel-button';
 
+import { Tab } from 'common/itab';
 import {
     AssessmentViewUpdateHandler,
     AssessmentViewUpdateHandlerDeps,
@@ -50,7 +53,10 @@ export type TestStepViewProps = {
     assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator;
     featureFlagStoreData: FeatureFlagStoreData;
     pathSnippetStoreData: PathSnippetStoreData;
-} & AssessmentViewUpdateHandlerProps;
+    assessmentData: AssessmentData;
+    currentTarget: Tab;
+    prevTarget: PersistedTabInfo;
+};
 
 export class TestStepView extends React.Component<TestStepViewProps> {
     public render(): JSX.Element {
@@ -85,15 +91,31 @@ export class TestStepView extends React.Component<TestStepViewProps> {
     }
 
     public componentDidMount(): void {
-        this.props.deps.assessmentViewUpdateHandler.onMount(this.props);
+        this.props.deps.assessmentViewUpdateHandler.onMount(this.getUpdateHandlerProps(this.props));
     }
 
     public componentDidUpdate(prevProps: TestStepViewProps): void {
-        this.props.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
+        this.props.deps.assessmentViewUpdateHandler.update(
+            this.getUpdateHandlerProps(prevProps),
+            this.getUpdateHandlerProps(this.props),
+        );
     }
 
     public componentWillUnmount(): void {
-        this.props.deps.assessmentViewUpdateHandler.onUnmount(this.props);
+        this.props.deps.assessmentViewUpdateHandler.onUnmount(
+            this.getUpdateHandlerProps(this.props),
+        );
+    }
+
+    private getUpdateHandlerProps(props: TestStepViewProps): AssessmentViewUpdateHandlerProps {
+        return {
+            deps: props.deps,
+            isRequirementEnabled: props.isStepEnabled,
+            assessmentNavState: props.assessmentNavState,
+            assessmentData: props.assessmentData,
+            prevTarget: props.prevTarget,
+            currentTarget: props.currentTarget,
+        };
     }
 
     private renderTable(): JSX.Element {

--- a/src/DetailsView/components/test-step-view.tsx
+++ b/src/DetailsView/components/test-step-view.tsx
@@ -17,6 +17,11 @@ import * as React from 'react';
 import { DictionaryStringTo } from 'types/common-types';
 import { ContentPanelButton, ContentPanelButtonDeps } from 'views/content/content-panel-button';
 
+import {
+    AssessmentViewUpdateHandler,
+    AssessmentViewUpdateHandlerDeps,
+    AssessmentViewUpdateHandlerProps,
+} from 'DetailsView/components/assessment-view-update-handler';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
 import { AssessmentInstanceTable } from './assessment-instance-table';
@@ -25,10 +30,12 @@ import * as styles from './test-step-view.scss';
 
 export type TestStepViewDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
+    assessmentViewUpdateHandler: AssessmentViewUpdateHandler;
 } & ContentPanelButtonDeps &
-    GuidanceTagsDeps;
+    GuidanceTagsDeps &
+    AssessmentViewUpdateHandlerDeps;
 
-export interface TestStepViewProps {
+export type TestStepViewProps = {
     deps: TestStepViewDeps;
     isStepEnabled: boolean;
     isStepScanned: boolean;
@@ -43,7 +50,7 @@ export interface TestStepViewProps {
     assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator;
     featureFlagStoreData: FeatureFlagStoreData;
     pathSnippetStoreData: PathSnippetStoreData;
-}
+} & AssessmentViewUpdateHandlerProps;
 
 export class TestStepView extends React.Component<TestStepViewProps> {
     public render(): JSX.Element {
@@ -75,6 +82,18 @@ export class TestStepView extends React.Component<TestStepViewProps> {
                 {this.renderTable()}
             </div>
         );
+    }
+
+    public componentDidMount(): void {
+        this.props.deps.assessmentViewUpdateHandler.onMount(this.props);
+    }
+
+    public componentDidUpdate(prevProps: TestStepViewProps): void {
+        this.props.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
+    }
+
+    public componentWillUnmount(): void {
+        this.props.deps.assessmentViewUpdateHandler.onUnmount(this.props);
     }
 
     private renderTable(): JSX.Element {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-test-view.test.tsx.snap
@@ -88,7 +88,6 @@ exports[`AssessmentTestView assessment view, isScanning is false 1`] = `
             "detailsViewActionMessageCreator": Object {},
           }
         }
-        selectedRequirementIsEnabled={false}
       />
     }
     featureFlag="reflowUI"
@@ -185,7 +184,6 @@ exports[`AssessmentTestView assessment view, isScanning is true 1`] = `
             "detailsViewActionMessageCreator": Object {},
           }
         }
-        selectedRequirementIsEnabled={false}
       />
     }
     featureFlag="reflowUI"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-view.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`AssessmentViewTest render 1`] = `
         <TestStepsNav deps={{...}} ariaLabel=\\"Requirements\\" selectedTest={-1} selectedTestStep=\\"assessment-1-step-1\\" stepStatus={{...}} />
       </div>
       <div className=\\"testStepViewContainer\\">
-        <TestStepView deps={{...}} isScanning={false} testStep={{...}} renderStaticContent={[undefined]} instancesMap={{...}} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} manualTestStepResultMap={{...}} assessmentsProvider={{...}} isStepEnabled={false} isStepScanned={false} assessmentDefaultMessageGenerator={{...}} featureFlagStoreData={{...}} pathSnippetStoreData={{...}} />
+        <TestStepView deps={{...}} isScanning={false} testStep={{...}} renderStaticContent={[undefined]} instancesMap={{...}} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} manualTestStepResultMap={{...}} assessmentsProvider={{...}} isStepEnabled={false} isStepScanned={false} assessmentDefaultMessageGenerator={{...}} featureFlagStoreData={{...}} pathSnippetStoreData={{...}} assessmentData={{...}} currentTarget={{...}} prevTarget={{...}} />
       </div>
     </div>
   </AssessmentViewMainContentExtensionPoint>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
@@ -3,13 +3,7 @@
 exports[`AssessmentViewTest render for gettting started 1`] = `
 <div>
   <TargetChangeDialog
-    deps={
-      Object {
-        "assessmentViewUpdateHandler": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        },
-      }
-    }
+    deps={Object {}}
     newTab={
       Object {
         "id": 5,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/test-step-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/test-step-view.test.tsx.snap
@@ -5,9 +5,9 @@ exports[`TestStepViewTest render snapshot matches with manual false and scanning
   <div className=\\"test-step-title-container\\">
     <h3 className=\\"test-step-view-title\\">
       Test Step Test Name
-      <GuidanceTags deps={[undefined]} links={{...}} />
+      <GuidanceTags deps={{...}} links={{...}} />
     </h3>
-    <ContentPanelButton deps={[undefined]} reference={[undefined]} iconName=\\"info\\" contentTitle=\\"Test Step Test Name\\">
+    <ContentPanelButton deps={{...}} reference={[undefined]} iconName=\\"info\\" contentTitle=\\"Test Step Test Name\\">
       Info &amp; examples
     </ContentPanelButton>
   </div>
@@ -25,9 +25,9 @@ exports[`TestStepViewTest render, variable part for assisted test 1`] = `
   <div className=\\"test-step-title-container\\">
     <h3 className=\\"test-step-view-title\\">
       Test Step Test Name
-      <GuidanceTags deps={[undefined]} links={{...}} />
+      <GuidanceTags deps={{...}} links={{...}} />
     </h3>
-    <ContentPanelButton deps={[undefined]} reference={[undefined]} iconName=\\"info\\" contentTitle=\\"Test Step Test Name\\">
+    <ContentPanelButton deps={{...}} reference={[undefined]} iconName=\\"info\\" contentTitle=\\"Test Step Test Name\\">
       Info &amp; examples
     </ContentPanelButton>
   </div>

--- a/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
@@ -18,12 +18,12 @@ describe('AssessmentViewTest', () => {
     const firstAssessment = assessmentsProvider.all()[0];
     const stepName = firstAssessment.requirements[0].key;
     let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
-    let isStepEnabled: boolean;
+    let isRequirementEnabled: boolean;
 
     let testObject: AssessmentViewUpdateHandler;
 
     beforeEach(() => {
-        isStepEnabled = false;
+        isRequirementEnabled = false;
         detailsViewActionMessageCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
         testObject = new AssessmentViewUpdateHandler();
     });
@@ -71,7 +71,7 @@ describe('AssessmentViewTest', () => {
                     a.enableVisualHelper(firstAssessment.visualizationType, stepName, false),
                 )
                 .verifiable(Times.never());
-            isStepEnabled = true;
+            isRequirementEnabled = true;
             const props = buildProps({ selector: {} });
 
             testObject.onMount(props);
@@ -218,7 +218,7 @@ describe('AssessmentViewTest', () => {
             deps,
             prevTarget,
             currentTarget: isTargetChanged ? anotherTarget : prevTarget,
-            isStepEnabled: isStepEnabled,
+            isRequirementEnabled: isRequirementEnabled,
             assessmentNavState,
             assessmentData,
         };

--- a/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
@@ -162,7 +162,7 @@ describe('AssessmentViewTest', () => {
             detailsViewActionMessageCreatorMock.verifyAll();
         });
 
-        test('do not enable for getting started view', () => {
+        test('do not enable visual helper for getting started view', () => {
             const prevStep = 'prevStep';
             const prevTest = -100 as VisualizationType;
             const prevProps = buildProps();
@@ -184,7 +184,7 @@ describe('AssessmentViewTest', () => {
             detailsViewActionMessageCreatorMock.verifyAll();
         });
 
-        test('do not disable for getting started view', () => {
+        test('do not disable visual helper for getting started view', () => {
             const prevProps = buildProps();
             const props = buildProps();
             prevProps.assessmentNavState.selectedTestSubview = gettingStartedSubview;

--- a/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
@@ -3,10 +3,7 @@
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { ManualTestStatus } from 'common/types/manual-test-status';
-import {
-    AssessmentData,
-    gettingStartedSubview,
-} from 'common/types/store-data/assessment-result-data';
+import { AssessmentData } from 'common/types/store-data/assessment-result-data';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import {
     AssessmentViewUpdateHandler,
@@ -156,48 +153,6 @@ describe('AssessmentViewTest', () => {
             detailsViewActionMessageCreatorMock
                 .setup(a => a.disableVisualHelpersForTest(prevTest))
                 .verifiable(Times.once());
-
-            testObject.update(prevProps, props);
-
-            detailsViewActionMessageCreatorMock.verifyAll();
-        });
-
-        test('do not enable visual helper for getting started view', () => {
-            const prevStep = 'prevStep';
-            const prevTest = -100 as VisualizationType;
-            const prevProps = buildProps();
-            const props = buildProps();
-            props.assessmentNavState.selectedTestSubview = gettingStartedSubview;
-            props.assessmentNavState.selectedTestType = null;
-            prevProps.assessmentNavState.selectedTestSubview = prevStep;
-            prevProps.assessmentNavState.selectedTestType = prevTest;
-
-            detailsViewActionMessageCreatorMock
-                .setup(a => a.enableVisualHelper(It.isAny(), It.isAny(), It.isAny()))
-                .verifiable(Times.never());
-            detailsViewActionMessageCreatorMock
-                .setup(a => a.disableVisualHelpersForTest(prevTest))
-                .verifiable(Times.once());
-
-            testObject.update(prevProps, props);
-
-            detailsViewActionMessageCreatorMock.verifyAll();
-        });
-
-        test('do not disable visual helper for getting started view', () => {
-            const prevProps = buildProps();
-            const props = buildProps();
-            prevProps.assessmentNavState.selectedTestSubview = gettingStartedSubview;
-            prevProps.assessmentNavState.selectedTestType = null;
-
-            detailsViewActionMessageCreatorMock
-                .setup(a =>
-                    a.enableVisualHelper(firstAssessment.visualizationType, stepName, true, true),
-                )
-                .verifiable(Times.once());
-            detailsViewActionMessageCreatorMock
-                .setup(a => a.disableVisualHelpersForTest(It.isAny()))
-                .verifiable(Times.never());
 
             testObject.update(prevProps, props);
 

--- a/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
@@ -3,7 +3,10 @@
 import { IMock, It, Mock, Times } from 'typemoq';
 
 import { ManualTestStatus } from 'common/types/manual-test-status';
-import { AssessmentData } from 'common/types/store-data/assessment-result-data';
+import {
+    AssessmentData,
+    gettingStartedSubview,
+} from 'common/types/store-data/assessment-result-data';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import {
     AssessmentViewUpdateHandler,
@@ -153,6 +156,48 @@ describe('AssessmentViewTest', () => {
             detailsViewActionMessageCreatorMock
                 .setup(a => a.disableVisualHelpersForTest(prevTest))
                 .verifiable(Times.once());
+
+            testObject.update(prevProps, props);
+
+            detailsViewActionMessageCreatorMock.verifyAll();
+        });
+
+        test('do not enable for getting started view', () => {
+            const prevStep = 'prevStep';
+            const prevTest = -100 as VisualizationType;
+            const prevProps = buildProps();
+            const props = buildProps();
+            props.assessmentNavState.selectedTestSubview = gettingStartedSubview;
+            props.assessmentNavState.selectedTestType = null;
+            prevProps.assessmentNavState.selectedTestSubview = prevStep;
+            prevProps.assessmentNavState.selectedTestType = prevTest;
+
+            detailsViewActionMessageCreatorMock
+                .setup(a => a.enableVisualHelper(It.isAny(), It.isAny(), It.isAny()))
+                .verifiable(Times.never());
+            detailsViewActionMessageCreatorMock
+                .setup(a => a.disableVisualHelpersForTest(prevTest))
+                .verifiable(Times.once());
+
+            testObject.update(prevProps, props);
+
+            detailsViewActionMessageCreatorMock.verifyAll();
+        });
+
+        test('do not disable for getting started view', () => {
+            const prevProps = buildProps();
+            const props = buildProps();
+            prevProps.assessmentNavState.selectedTestSubview = gettingStartedSubview;
+            prevProps.assessmentNavState.selectedTestType = null;
+
+            detailsViewActionMessageCreatorMock
+                .setup(a =>
+                    a.enableVisualHelper(firstAssessment.visualizationType, stepName, true, true),
+                )
+                .verifiable(Times.once());
+            detailsViewActionMessageCreatorMock
+                .setup(a => a.disableVisualHelpersForTest(It.isAny()))
+                .verifiable(Times.never());
 
             testObject.update(prevProps, props);
 

--- a/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
@@ -21,12 +21,12 @@ describe('AssessmentViewTest', () => {
     const firstAssessment = assessmentsProvider.all()[0];
     const stepName = firstAssessment.requirements[0].key;
     let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
-    let selectedRequirementIsEnabled: boolean;
+    let isStepEnabled: boolean;
 
     let testObject: AssessmentViewUpdateHandler;
 
     beforeEach(() => {
-        selectedRequirementIsEnabled = false;
+        isStepEnabled = false;
         detailsViewActionMessageCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
         testObject = new AssessmentViewUpdateHandler();
     });
@@ -74,7 +74,7 @@ describe('AssessmentViewTest', () => {
                     a.enableVisualHelper(firstAssessment.visualizationType, stepName, false),
                 )
                 .verifiable(Times.never());
-            selectedRequirementIsEnabled = true;
+            isStepEnabled = true;
             const props = buildProps({ selector: {} });
 
             testObject.onMount(props);
@@ -263,7 +263,7 @@ describe('AssessmentViewTest', () => {
             deps,
             prevTarget,
             currentTarget: isTargetChanged ? anotherTarget : prevTarget,
-            selectedRequirementIsEnabled: selectedRequirementIsEnabled,
+            isStepEnabled: isStepEnabled,
             assessmentNavState,
             assessmentData,
         };

--- a/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
@@ -37,16 +37,6 @@ describe('AssessmentViewTest', () => {
         expect(rendered.debug()).toMatchSnapshot();
     });
 
-    test('componentDidMount', () => {
-        const props = builder.buildProps();
-        builder.updateHandlerMock.setup(u => u.onMount(props)).verifiable(Times.once());
-
-        const testObject = new AssessmentView(props);
-
-        testObject.componentDidMount();
-        builder.verifyAll();
-    });
-
     test('componentDidUpdate', () => {
         const prevProps = buildPrevProps();
         const props = builder.buildProps();
@@ -54,7 +44,6 @@ describe('AssessmentViewTest', () => {
             (previousProps: AssessmentViewProps, currentProps: AssessmentViewProps) => {},
         );
 
-        builder.updateHandlerMock.setup(u => u.update(prevProps, props)).verifiable(Times.once());
         builder.detailsViewExtensionPointMock
             .setup(d => d.apply(props.assessmentTestResult.definition.extensions))
             .returns(() => {
@@ -69,16 +58,6 @@ describe('AssessmentViewTest', () => {
 
         builder.verifyAll();
         onAssessmentViewUpdateMock.verifyAll();
-    });
-
-    test('componentWillUnmount', () => {
-        const props = builder.buildProps();
-        builder.updateHandlerMock.setup(u => u.onUnmount(props)).verifiable(Times.once());
-
-        const testObject = new AssessmentView(props);
-
-        testObject.componentWillUnmount();
-        builder.verifyAll();
     });
 
     function buildPrevProps(): AssessmentViewProps {

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -32,36 +32,36 @@ describe('AssessmentViewTest', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    test('componentDidMount', () => {
-        const props = generateProps('requirement');
-        updateHandlerMock.setup(u => u.onMount(props)).verifiable(Times.once());
-        const testObject = new ReflowAssessmentView(props);
+    // test('componentDidMount', () => {
+    //     const props = generateProps('requirement');
+    //     updateHandlerMock.setup(u => u.onMount(props)).verifiable(Times.once());
+    //     const testObject = new ReflowAssessmentView(props);
 
-        testObject.componentDidMount();
+    //     testObject.componentDidMount();
 
-        updateHandlerMock.verifyAll();
-    });
+    //     updateHandlerMock.verifyAll();
+    // });
 
-    test('componentWillUnmount', () => {
-        const props = generateProps('requirement');
-        updateHandlerMock.setup(u => u.onUnmount(props)).verifiable(Times.once());
-        const testObject = new ReflowAssessmentView(props);
+    // test('componentWillUnmount', () => {
+    //     const props = generateProps('requirement');
+    //     updateHandlerMock.setup(u => u.onUnmount(props)).verifiable(Times.once());
+    //     const testObject = new ReflowAssessmentView(props);
 
-        testObject.componentWillUnmount();
+    //     testObject.componentWillUnmount();
 
-        updateHandlerMock.verifyAll();
-    });
+    //     updateHandlerMock.verifyAll();
+    // });
 
-    test('componentDidUpdate', () => {
-        const prevProps = generateProps('requirement1');
-        const props = generateProps('requirement2');
-        updateHandlerMock.setup(u => u.update(prevProps, props)).verifiable(Times.once());
-        const testObject = new ReflowAssessmentView(props);
+    // test('componentDidUpdate', () => {
+    //     const prevProps = generateProps('requirement1');
+    //     const props = generateProps('requirement2');
+    //     updateHandlerMock.setup(u => u.update(prevProps, props)).verifiable(Times.once());
+    //     const testObject = new ReflowAssessmentView(props);
 
-        testObject.componentDidUpdate(prevProps);
+    //     testObject.componentDidUpdate(prevProps);
 
-        updateHandlerMock.verifyAll();
-    });
+    //     updateHandlerMock.verifyAll();
+    // });
 
     function generateProps(subview: string): ReflowAssessmentViewProps {
         const assessmentDataMock = Mock.ofType<AssessmentData>();

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -14,12 +14,6 @@ import {
 } from '../../../../../DetailsView/components/reflow-assessment-view';
 
 describe('AssessmentViewTest', () => {
-    let updateHandlerMock: IMock<AssessmentViewUpdateHandler>;
-
-    beforeEach(() => {
-        updateHandlerMock = Mock.ofType(AssessmentViewUpdateHandler);
-    });
-
     test('render for requirement', () => {
         const props = generateProps('requirement');
         const rendered = shallow(<ReflowAssessmentView {...props} />);
@@ -32,37 +26,6 @@ describe('AssessmentViewTest', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    // test('componentDidMount', () => {
-    //     const props = generateProps('requirement');
-    //     updateHandlerMock.setup(u => u.onMount(props)).verifiable(Times.once());
-    //     const testObject = new ReflowAssessmentView(props);
-
-    //     testObject.componentDidMount();
-
-    //     updateHandlerMock.verifyAll();
-    // });
-
-    // test('componentWillUnmount', () => {
-    //     const props = generateProps('requirement');
-    //     updateHandlerMock.setup(u => u.onUnmount(props)).verifiable(Times.once());
-    //     const testObject = new ReflowAssessmentView(props);
-
-    //     testObject.componentWillUnmount();
-
-    //     updateHandlerMock.verifyAll();
-    // });
-
-    // test('componentDidUpdate', () => {
-    //     const prevProps = generateProps('requirement1');
-    //     const props = generateProps('requirement2');
-    //     updateHandlerMock.setup(u => u.update(prevProps, props)).verifiable(Times.once());
-    //     const testObject = new ReflowAssessmentView(props);
-
-    //     testObject.componentDidUpdate(prevProps);
-
-    //     updateHandlerMock.verifyAll();
-    // });
-
     function generateProps(subview: string): ReflowAssessmentViewProps {
         const assessmentDataMock = Mock.ofType<AssessmentData>();
 
@@ -73,9 +36,7 @@ describe('AssessmentViewTest', () => {
         } as AssessmentTestResult;
 
         const reflowProps = {
-            deps: {
-                assessmentViewUpdateHandler: updateHandlerMock.object,
-            } as ReflowAssessmentViewDeps,
+            deps: {} as ReflowAssessmentViewDeps,
             prevTarget: { id: 4 },
             currentTarget: { id: 5 },
             assessmentNavState: {

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -4,9 +4,8 @@ import { AssessmentTestResult } from 'common/assessment/assessment-test-result';
 import { AssessmentData } from 'common/types/store-data/assessment-result-data';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, Mock, Times } from 'typemoq';
+import { Mock } from 'typemoq';
 
-import { AssessmentViewUpdateHandler } from 'DetailsView/components/assessment-view-update-handler';
 import {
     ReflowAssessmentView,
     ReflowAssessmentViewDeps,

--- a/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
@@ -6,7 +6,10 @@ import { CollapsibleComponent } from 'common/components/collapsible-component';
 import { ManualTestStatus } from 'common/types/manual-test-status';
 import { VisualizationType } from 'common/types/visualization-type';
 import { AssessmentInstanceTable } from 'DetailsView/components/assessment-instance-table';
-import { AssessmentViewUpdateHandler } from 'DetailsView/components/assessment-view-update-handler';
+import {
+    AssessmentViewUpdateHandler,
+    AssessmentViewUpdateHandlerProps,
+} from 'DetailsView/components/assessment-view-update-handler';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
 import { ManualTestStepView } from 'DetailsView/components/manual-test-step-view';
 import {
@@ -150,7 +153,9 @@ describe('TestStepViewTest', () => {
             getVisualHelperToggleMock.object,
         ).build();
         prevProps.assessmentNavState.selectedTestSubview = 'prevTestStep';
-        updateHandlerMock.setup(u => u.update(prevProps, props)).verifiable(Times.once());
+        updateHandlerMock
+            .setup(u => u.update(getUpdateHandlerProps(prevProps), getUpdateHandlerProps(props)))
+            .verifiable(Times.once());
 
         const testObject = new TestStepView(props);
 
@@ -163,7 +168,9 @@ describe('TestStepViewTest', () => {
         const props = TestStepViewPropsBuilder.defaultProps(
             getVisualHelperToggleMock.object,
         ).build();
-        updateHandlerMock.setup(u => u.onMount(props)).verifiable(Times.once());
+        updateHandlerMock
+            .setup(u => u.onMount(getUpdateHandlerProps(props)))
+            .verifiable(Times.once());
 
         const testObject = new TestStepView(props);
 
@@ -176,7 +183,9 @@ describe('TestStepViewTest', () => {
         const props = TestStepViewPropsBuilder.defaultProps(
             getVisualHelperToggleMock.object,
         ).build();
-        updateHandlerMock.setup(u => u.onUnmount(props)).verifiable(Times.once());
+        updateHandlerMock
+            .setup(u => u.onUnmount(getUpdateHandlerProps(props)))
+            .verifiable(Times.once());
 
         const testObject = new TestStepView(props);
 
@@ -198,6 +207,17 @@ describe('TestStepViewTest', () => {
             view.prop('assessmentInstanceTableHandler'),
         );
         expect(props.assessmentsProvider).toEqual(view.prop('assessmentsProvider'));
+    }
+
+    function getUpdateHandlerProps(props: TestStepViewProps): AssessmentViewUpdateHandlerProps {
+        return {
+            deps: props.deps,
+            isRequirementEnabled: props.isStepEnabled,
+            assessmentNavState: props.assessmentNavState,
+            assessmentData: props.assessmentData,
+            prevTarget: props.prevTarget,
+            currentTarget: props.currentTarget,
+        };
     }
 });
 


### PR DESCRIPTION
#### Description of changes

Move UpdateHandler to TestStepView and remove it from AssessmentView and ReflowAssessmentView. This fixes errors that are currently thrown when trying to navigate the new reflow nav (the update handler attempts to enable or disable relevant visual helpers on the getting started view).

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1659964
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
