### PR TITLE
feat (nav-bar-content): getting-started-nav-link padding update

### DIFF
--- a/src/DetailsView/components/left-nav/getting-started-nav-link.scss
+++ b/src/DetailsView/components/left-nav/getting-started-nav-link.scss
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../common/styles/common.scss';
+.getting-started {
+    padding-left: 5%;
+}

--- a/src/DetailsView/components/left-nav/getting-started-nav-link.scss
+++ b/src/DetailsView/components/left-nav/getting-started-nav-link.scss
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-@import '../../../common/styles/common.scss';
 .getting-started {
     padding-left: 5%;
 }

--- a/src/DetailsView/components/left-nav/getting-started-nav-link.tsx
+++ b/src/DetailsView/components/left-nav/getting-started-nav-link.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-
 import { NamedFC } from 'common/react/named-fc';
+import * as styles from 'DetailsView/components/left-nav/getting-started-nav-link.scss';
 import * as React from 'react';
 
 export type GettingStartedNavLinkProps = {};
@@ -9,6 +9,6 @@ export type GettingStartedNavLinkProps = {};
 export const GettingStartedNavLink = NamedFC<GettingStartedNavLinkProps>(
     'GettingStartedNavLink',
     _ => {
-        return <span className="getting-started">Getting Started</span>;
+        return <span className={styles.gettingStarted}>Getting Started</span>;
     },
 );

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/getting-started-nav-link.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/getting-started-nav-link.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`GettingStartedNavLink renders 1`] = `
 <span
-  className="getting-started"
+  className="gettingStarted"
 >
   Getting Started
 </span>


### PR DESCRIPTION
added an scss file for the getting-started-nav-link so that the "Getting Started" navigation link shares the same padding as the requirements.

Image of the change: 

![image](https://user-images.githubusercontent.com/19158512/81959901-026cc480-95c5-11ea-858e-164f7f08ebfe.png)


#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [X] Ran `yarn fastpass`
- [X] Added/updated relevant unit test(s) (and ran `yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [X] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
