### PR TITLE
feat(nav-bar-content): nav link handler uses requirement key explicitly

### DIFF
--- a/src/DetailsView/components/left-nav/assessment-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/assessment-left-nav.tsx
@@ -41,6 +41,7 @@ export type TestGettingStartedNavLink = {
 export type TestRequirementLeftNavLink = {
     displayedIndex: string;
     testType: VisualizationType;
+    requirementKey: string;
 } & AssessmentLeftNavLink;
 
 export type onTestRequirementClick = (

--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -226,6 +226,7 @@ export class LeftNavLinkBuilder {
             title: `${displayedIndex}: ${name} (${narratorRequirementStatus})`,
             displayedIndex,
             testType: test,
+            requirementKey: requirement.key,
         };
     }
 

--- a/src/DetailsView/components/left-nav/nav-link-handler.ts
+++ b/src/DetailsView/components/left-nav/nav-link-handler.ts
@@ -41,7 +41,11 @@ export class NavLinkHandler {
         event: React.MouseEvent<HTMLElement>,
         item: TestRequirementLeftNavLink,
     ) => {
-        this.detailsViewActionMessageCreator.selectRequirement(event, item.key, item.testType);
+        this.detailsViewActionMessageCreator.selectRequirement(
+            event,
+            item.requirementKey,
+            item.testType,
+        );
         this.detailsViewActionMessageCreator.changeRightContentPanel('TestView');
     };
 

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-link-builder.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/left-nav-link-builder.test.tsx.snap
@@ -86,6 +86,27 @@ exports[`LeftNavBuilder buildAssessmentTestLinks should build links for assessme
 />
 `;
 
+exports[`LeftNavBuilder buildOverviewLink should build overview link 1`] = `
+<OverviewLeftNavLink
+  link={
+    Object {
+      "forceAnchor": true,
+      "iconProps": Object {
+        "className": "hidden",
+      },
+      "index": -1,
+      "key": "Overview",
+      "name": "Overview",
+      "onClickNavLink": [Function],
+      "onRenderNavLink": [Function],
+      "percentComplete": 75,
+      "title": "Overview 75% Completed",
+      "url": "",
+    }
+  }
+/>
+`;
+
 exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: getting started nav link render 1`] = `<GettingStartedNavLink />`;
 
 exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for assessments: getting started nav link render 2`] = `<GettingStartedNavLink />`;
@@ -104,6 +125,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
       "name": "requirement-name-1",
       "onClickNavLink": [Function],
       "onRenderNavLink": [Function],
+      "requirementKey": "requirement-key-1",
       "status": -2,
       "testType": 1,
       "title": "-1.1: requirement-name-1 (passed)",
@@ -128,6 +150,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
       "name": "requirement-name-1",
       "onClickNavLink": [Function],
       "onRenderNavLink": [Function],
+      "requirementKey": "requirement-key-1",
       "status": -2,
       "testType": 1,
       "title": "0.1: requirement-name-1 (passed)",
@@ -154,6 +177,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
           "name": "requirement-name-1",
           "onClickNavLink": [Function],
           "onRenderNavLink": [Function],
+          "requirementKey": "requirement-key-1",
           "status": -2,
           "testType": 1,
           "title": "-1.1: requirement-name-1 (passed)",
@@ -182,6 +206,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
           "name": "requirement-name-1",
           "onClickNavLink": [Function],
           "onRenderNavLink": [Function],
+          "requirementKey": "requirement-key-1",
           "status": -2,
           "testType": 1,
           "title": "0.1: requirement-name-1 (passed)",
@@ -230,6 +255,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
           "name": "requirement-name-1",
           "onClickNavLink": [Function],
           "onRenderNavLink": [Function],
+          "requirementKey": "requirement-key-1",
           "status": -2,
           "testType": 1,
           "title": "-1.1: requirement-name-1 (passed)",
@@ -246,6 +272,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
           "name": "requirement-name-2",
           "onClickNavLink": [Function],
           "onRenderNavLink": [Function],
+          "requirementKey": "requirement-key-2",
           "status": -2,
           "testType": 1,
           "title": "-1.2: requirement-name-2 (passed)",
@@ -300,6 +327,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
           "name": "requirement-name-1",
           "onClickNavLink": [Function],
           "onRenderNavLink": [Function],
+          "requirementKey": "requirement-key-1",
           "status": -2,
           "testType": 1,
           "title": "0.1: requirement-name-1 (passed)",
@@ -316,6 +344,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
           "name": "requirement-name-2",
           "onClickNavLink": [Function],
           "onRenderNavLink": [Function],
+          "requirementKey": "requirement-key-2",
           "status": -2,
           "testType": 1,
           "title": "0.2: requirement-name-2 (passed)",
@@ -370,6 +399,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
           "name": "requirement-name-1",
           "onClickNavLink": [Function],
           "onRenderNavLink": [Function],
+          "requirementKey": "requirement-key-1",
           "status": -2,
           "testType": 1,
           "title": "-1.1: requirement-name-1 (passed)",
@@ -386,6 +416,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
           "name": "requirement-name-2",
           "onClickNavLink": [Function],
           "onRenderNavLink": [Function],
+          "requirementKey": "requirement-key-2",
           "status": -2,
           "testType": 1,
           "title": "-1.2: requirement-name-2 (passed)",
@@ -439,6 +470,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
           "name": "requirement-name-1",
           "onClickNavLink": [Function],
           "onRenderNavLink": [Function],
+          "requirementKey": "requirement-key-1",
           "status": -2,
           "testType": 1,
           "title": "0.1: requirement-name-1 (passed)",
@@ -455,6 +487,7 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
           "name": "requirement-name-2",
           "onClickNavLink": [Function],
           "onRenderNavLink": [Function],
+          "requirementKey": "requirement-key-2",
           "status": -2,
           "testType": 1,
           "title": "0.2: requirement-name-2 (passed)",
@@ -466,27 +499,6 @@ exports[`LeftNavBuilder buildReflowAssessmentTestLinks should build links for as
       "onRenderNavLink": [Function],
       "status": -2,
       "title": "0: some title (passed)",
-      "url": "",
-    }
-  }
-/>
-`;
-
-exports[`LeftNavBuilder buildOverviewLink should build overview link 1`] = `
-<OverviewLeftNavLink
-  link={
-    Object {
-      "forceAnchor": true,
-      "iconProps": Object {
-        "className": "hidden",
-      },
-      "index": -1,
-      "key": "Overview",
-      "name": "Overview",
-      "onClickNavLink": [Function],
-      "onRenderNavLink": [Function],
-      "percentComplete": 75,
-      "title": "Overview 75% Completed",
       "url": "",
     }
   }

--- a/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
@@ -327,7 +327,6 @@ describe('LeftNavBuilder', () => {
     ): TestRequirementLeftNavLink {
         return {
             name: requirement.name,
-            key: requirement.key,
             forceAnchor: true,
             url: '',
             iconProps: {
@@ -335,6 +334,7 @@ describe('LeftNavBuilder', () => {
             },
             testType: test,
             status,
+            requirementKey: requirement.key,
         } as TestRequirementLeftNavLink;
     }
 });

--- a/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
@@ -327,6 +327,7 @@ describe('LeftNavBuilder', () => {
     ): TestRequirementLeftNavLink {
         return {
             name: requirement.name,
+            key: requirement.key,
             forceAnchor: true,
             url: '',
             iconProps: {

--- a/src/tests/unit/tests/DetailsView/handlers/nav-link-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/handlers/nav-link-handler.test.ts
@@ -81,12 +81,16 @@ describe('NavLinkHandler', () => {
     describe('onRequirementClick', () => {
         it('should call selectRequirement and changeRightContentPanel with appropriate params', () => {
             const requirementLink = {
-                key: 'some requirement',
+                requirementKey: 'some requirement',
                 testType: -1,
             } as TestRequirementLeftNavLink;
             detailsViewActionMessageCreatorMock
                 .setup(amc =>
-                    amc.selectRequirement(eventStub, requirementLink.key, requirementLink.testType),
+                    amc.selectRequirement(
+                        eventStub,
+                        requirementLink.requirementKey,
+                        requirementLink.testType,
+                    ),
                 )
                 .verifiable();
 


### PR DESCRIPTION
#### Description of changes

This enables us to generate keys for the purpose of left nav selection orthogonally from selecting a requirement/getting-started.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [.] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [.] (UI changes only) Added screenshots/GIFs to description above
- [.] (UI changes only) Verified usability with NVDA/JAWS
