### PR TITLE
chore: fix error noise in yarn format from prettier + mp3 file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@
 **/*.gitignore
 **/*.icns
 **/*.ico
+**/*.mp3
 **/*.nsh
 **/*.png
 **/*.snap


### PR DESCRIPTION
#### Description of changes

The recently added unified codec test added an mp3 file to the repo, and `yarn fastpass` shows some noise when Prettier tries to analyze it:

```
[format:check   ] [error] No parser could be inferred for file: src\tests\miscellaneous\codecs\codecs-test.mp3
```

This update causes prettier to ignore the binary file.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
