### PR TITLE
fix: revert 63145e4 to fix stuck assessment > automated checks scanning

### DIFF
--- a/src/DetailsView/components/assessment-test-view.tsx
+++ b/src/DetailsView/components/assessment-test-view.tsx
@@ -73,6 +73,7 @@ export const AssessmentTestView = NamedFC<AssessmentTestViewProps>(
                     currentTarget={currentTarget}
                     prevTarget={prevTarget}
                     assessmentTestResult={assessmentTestResult}
+                    selectedRequirementIsEnabled={selectedRequirementIsEnabled}
                 />
             );
         };

--- a/src/DetailsView/components/assessment-view-update-handler.ts
+++ b/src/DetailsView/components/assessment-view-update-handler.ts
@@ -26,7 +26,7 @@ export interface AssessmentViewUpdateHandlerProps {
     deps: AssessmentViewUpdateHandlerDeps;
     assessmentNavState: AssessmentNavState;
     assessmentData: AssessmentData;
-    isRequirementEnabled: boolean;
+    selectedRequirementIsEnabled: boolean;
     currentTarget: Tab;
     prevTarget: PersistedTabInfo;
 }
@@ -65,12 +65,12 @@ export class AssessmentViewUpdateHandler {
             return;
         }
 
-        const isRequirementNotScanned = !props.assessmentData.testStepStatus[step].isStepScanned;
-        if (props.isRequirementEnabled === false || isRequirementNotScanned) {
+        const isStepNotScanned = !props.assessmentData.testStepStatus[step].isStepScanned;
+        if (props.selectedRequirementIsEnabled === false || isStepNotScanned) {
             props.deps.detailsViewActionMessageCreator.enableVisualHelper(
                 test,
                 step,
-                isRequirementNotScanned,
+                isStepNotScanned,
                 sendTelemetry,
             );
         }

--- a/src/DetailsView/components/assessment-view.tsx
+++ b/src/DetailsView/components/assessment-view.tsx
@@ -92,11 +92,21 @@ export class AssessmentView extends React.Component<AssessmentViewProps> {
         );
     }
 
+    public componentDidMount(): void {
+        this.deps.assessmentViewUpdateHandler.onMount(this.props);
+    }
+
     public componentDidUpdate(prevProps: AssessmentViewProps): void {
+        this.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
+
         const { assessmentTestResult } = this.props;
         this.deps.detailsViewExtensionPoint
             .apply(assessmentTestResult.definition.extensions)
             .onAssessmentViewUpdate(prevProps, this.props);
+    }
+
+    public componentWillUnmount(): void {
+        this.deps.assessmentViewUpdateHandler.onUnmount(this.props);
     }
 
     private renderTargetChangeDialog(): JSX.Element {
@@ -174,9 +184,6 @@ export class AssessmentView extends React.Component<AssessmentViewProps> {
                         }
                         featureFlagStoreData={this.props.featureFlagStoreData}
                         pathSnippetStoreData={this.props.pathSnippetStoreData}
-                        assessmentData={this.props.assessmentData}
-                        currentTarget={this.props.currentTarget}
-                        prevTarget={this.props.prevTarget}
                     />
                 </div>
             </div>

--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 import {
     AssessmentViewUpdateHandler,
     AssessmentViewUpdateHandlerDeps,
+    AssessmentViewUpdateHandlerProps,
 } from 'DetailsView/components/assessment-view-update-handler';
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { Tab } from '../../common/itab';
@@ -28,7 +29,7 @@ export type ReflowAssessmentViewProps = {
     currentTarget: Tab;
     prevTarget: PersistedTabInfo;
     assessmentTestResult: AssessmentTestResult;
-};
+} & AssessmentViewUpdateHandlerProps;
 
 export class ReflowAssessmentView extends React.Component<ReflowAssessmentViewProps> {
     public render(): JSX.Element {
@@ -44,6 +45,18 @@ export class ReflowAssessmentView extends React.Component<ReflowAssessmentViewPr
             );
         }
         return null;
+    }
+
+    public componentDidMount(): void {
+        this.props.deps.assessmentViewUpdateHandler.onMount(this.props);
+    }
+
+    public componentDidUpdate(prevProps: ReflowAssessmentViewProps): void {
+        this.props.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
+    }
+
+    public componentWillUnmount(): void {
+        this.props.deps.assessmentViewUpdateHandler.onUnmount(this.props);
     }
 
     private renderTargetChangeDialog(): JSX.Element {

--- a/src/DetailsView/components/test-step-view.tsx
+++ b/src/DetailsView/components/test-step-view.tsx
@@ -6,11 +6,9 @@ import { Requirement, VisualHelperToggleConfig } from 'assessments/types/require
 import { CollapsibleComponent } from 'common/components/collapsible-component';
 import { GuidanceTags, GuidanceTagsDeps } from 'common/components/guidance-tags';
 import {
-    AssessmentData,
     AssessmentNavState,
     GeneratedAssessmentInstance,
     ManualTestStepResult,
-    PersistedTabInfo,
 } from 'common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { PathSnippetStoreData } from 'common/types/store-data/path-snippet-store-data';
@@ -19,12 +17,6 @@ import * as React from 'react';
 import { DictionaryStringTo } from 'types/common-types';
 import { ContentPanelButton, ContentPanelButtonDeps } from 'views/content/content-panel-button';
 
-import { Tab } from 'common/itab';
-import {
-    AssessmentViewUpdateHandler,
-    AssessmentViewUpdateHandlerDeps,
-    AssessmentViewUpdateHandlerProps,
-} from 'DetailsView/components/assessment-view-update-handler';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { AssessmentInstanceTableHandler } from '../handlers/assessment-instance-table-handler';
 import { AssessmentInstanceTable } from './assessment-instance-table';
@@ -33,12 +25,10 @@ import * as styles from './test-step-view.scss';
 
 export type TestStepViewDeps = {
     detailsViewActionMessageCreator: DetailsViewActionMessageCreator;
-    assessmentViewUpdateHandler: AssessmentViewUpdateHandler;
 } & ContentPanelButtonDeps &
-    GuidanceTagsDeps &
-    AssessmentViewUpdateHandlerDeps;
+    GuidanceTagsDeps;
 
-export type TestStepViewProps = {
+export interface TestStepViewProps {
     deps: TestStepViewDeps;
     isStepEnabled: boolean;
     isStepScanned: boolean;
@@ -53,10 +43,7 @@ export type TestStepViewProps = {
     assessmentDefaultMessageGenerator: AssessmentDefaultMessageGenerator;
     featureFlagStoreData: FeatureFlagStoreData;
     pathSnippetStoreData: PathSnippetStoreData;
-    assessmentData: AssessmentData;
-    currentTarget: Tab;
-    prevTarget: PersistedTabInfo;
-};
+}
 
 export class TestStepView extends React.Component<TestStepViewProps> {
     public render(): JSX.Element {
@@ -88,34 +75,6 @@ export class TestStepView extends React.Component<TestStepViewProps> {
                 {this.renderTable()}
             </div>
         );
-    }
-
-    public componentDidMount(): void {
-        this.props.deps.assessmentViewUpdateHandler.onMount(this.getUpdateHandlerProps(this.props));
-    }
-
-    public componentDidUpdate(prevProps: TestStepViewProps): void {
-        this.props.deps.assessmentViewUpdateHandler.update(
-            this.getUpdateHandlerProps(prevProps),
-            this.getUpdateHandlerProps(this.props),
-        );
-    }
-
-    public componentWillUnmount(): void {
-        this.props.deps.assessmentViewUpdateHandler.onUnmount(
-            this.getUpdateHandlerProps(this.props),
-        );
-    }
-
-    private getUpdateHandlerProps(props: TestStepViewProps): AssessmentViewUpdateHandlerProps {
-        return {
-            deps: props.deps,
-            isRequirementEnabled: props.isStepEnabled,
-            assessmentNavState: props.assessmentNavState,
-            assessmentData: props.assessmentData,
-            prevTarget: props.prevTarget,
-            currentTarget: props.currentTarget,
-        };
     }
 
     private renderTable(): JSX.Element {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-test-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-test-view.test.tsx.snap
@@ -88,6 +88,7 @@ exports[`AssessmentTestView assessment view, isScanning is false 1`] = `
             "detailsViewActionMessageCreator": Object {},
           }
         }
+        selectedRequirementIsEnabled={false}
       />
     }
     featureFlag="reflowUI"
@@ -184,6 +185,7 @@ exports[`AssessmentTestView assessment view, isScanning is true 1`] = `
             "detailsViewActionMessageCreator": Object {},
           }
         }
+        selectedRequirementIsEnabled={false}
       />
     }
     featureFlag="reflowUI"

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/assessment-view.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`AssessmentViewTest render 1`] = `
         <TestStepsNav deps={{...}} ariaLabel=\\"Requirements\\" selectedTest={-1} selectedTestStep=\\"assessment-1-step-1\\" stepStatus={{...}} />
       </div>
       <div className=\\"testStepViewContainer\\">
-        <TestStepView deps={{...}} isScanning={false} testStep={{...}} renderStaticContent={[undefined]} instancesMap={{...}} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} manualTestStepResultMap={{...}} assessmentsProvider={{...}} isStepEnabled={false} isStepScanned={false} assessmentDefaultMessageGenerator={{...}} featureFlagStoreData={{...}} pathSnippetStoreData={{...}} assessmentData={{...}} currentTarget={{...}} prevTarget={{...}} />
+        <TestStepView deps={{...}} isScanning={false} testStep={{...}} renderStaticContent={[undefined]} instancesMap={{...}} assessmentNavState={{...}} assessmentInstanceTableHandler={{...}} manualTestStepResultMap={{...}} assessmentsProvider={{...}} isStepEnabled={false} isStepScanned={false} assessmentDefaultMessageGenerator={{...}} featureFlagStoreData={{...}} pathSnippetStoreData={{...}} />
       </div>
     </div>
   </AssessmentViewMainContentExtensionPoint>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
@@ -3,7 +3,13 @@
 exports[`AssessmentViewTest render for gettting started 1`] = `
 <div>
   <TargetChangeDialog
-    deps={Object {}}
+    deps={
+      Object {
+        "assessmentViewUpdateHandler": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        },
+      }
+    }
     newTab={
       Object {
         "id": 5,

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/test-step-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/test-step-view.test.tsx.snap
@@ -5,9 +5,9 @@ exports[`TestStepViewTest render snapshot matches with manual false and scanning
   <div className=\\"test-step-title-container\\">
     <h3 className=\\"test-step-view-title\\">
       Test Step Test Name
-      <GuidanceTags deps={{...}} links={{...}} />
+      <GuidanceTags deps={[undefined]} links={{...}} />
     </h3>
-    <ContentPanelButton deps={{...}} reference={[undefined]} iconName=\\"info\\" contentTitle=\\"Test Step Test Name\\">
+    <ContentPanelButton deps={[undefined]} reference={[undefined]} iconName=\\"info\\" contentTitle=\\"Test Step Test Name\\">
       Info &amp; examples
     </ContentPanelButton>
   </div>
@@ -25,9 +25,9 @@ exports[`TestStepViewTest render, variable part for assisted test 1`] = `
   <div className=\\"test-step-title-container\\">
     <h3 className=\\"test-step-view-title\\">
       Test Step Test Name
-      <GuidanceTags deps={{...}} links={{...}} />
+      <GuidanceTags deps={[undefined]} links={{...}} />
     </h3>
-    <ContentPanelButton deps={{...}} reference={[undefined]} iconName=\\"info\\" contentTitle=\\"Test Step Test Name\\">
+    <ContentPanelButton deps={[undefined]} reference={[undefined]} iconName=\\"info\\" contentTitle=\\"Test Step Test Name\\">
       Info &amp; examples
     </ContentPanelButton>
   </div>

--- a/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view-update-handler.test.ts
@@ -18,12 +18,12 @@ describe('AssessmentViewTest', () => {
     const firstAssessment = assessmentsProvider.all()[0];
     const stepName = firstAssessment.requirements[0].key;
     let detailsViewActionMessageCreatorMock: IMock<DetailsViewActionMessageCreator>;
-    let isRequirementEnabled: boolean;
+    let selectedRequirementIsEnabled: boolean;
 
     let testObject: AssessmentViewUpdateHandler;
 
     beforeEach(() => {
-        isRequirementEnabled = false;
+        selectedRequirementIsEnabled = false;
         detailsViewActionMessageCreatorMock = Mock.ofType<DetailsViewActionMessageCreator>();
         testObject = new AssessmentViewUpdateHandler();
     });
@@ -71,7 +71,7 @@ describe('AssessmentViewTest', () => {
                     a.enableVisualHelper(firstAssessment.visualizationType, stepName, false),
                 )
                 .verifiable(Times.never());
-            isRequirementEnabled = true;
+            selectedRequirementIsEnabled = true;
             const props = buildProps({ selector: {} });
 
             testObject.onMount(props);
@@ -218,7 +218,7 @@ describe('AssessmentViewTest', () => {
             deps,
             prevTarget,
             currentTarget: isTargetChanged ? anotherTarget : prevTarget,
-            isRequirementEnabled: isRequirementEnabled,
+            selectedRequirementIsEnabled: selectedRequirementIsEnabled,
             assessmentNavState,
             assessmentData,
         };

--- a/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/assessment-view.test.tsx
@@ -37,6 +37,16 @@ describe('AssessmentViewTest', () => {
         expect(rendered.debug()).toMatchSnapshot();
     });
 
+    test('componentDidMount', () => {
+        const props = builder.buildProps();
+        builder.updateHandlerMock.setup(u => u.onMount(props)).verifiable(Times.once());
+
+        const testObject = new AssessmentView(props);
+
+        testObject.componentDidMount();
+        builder.verifyAll();
+    });
+
     test('componentDidUpdate', () => {
         const prevProps = buildPrevProps();
         const props = builder.buildProps();
@@ -44,6 +54,7 @@ describe('AssessmentViewTest', () => {
             (previousProps: AssessmentViewProps, currentProps: AssessmentViewProps) => {},
         );
 
+        builder.updateHandlerMock.setup(u => u.update(prevProps, props)).verifiable(Times.once());
         builder.detailsViewExtensionPointMock
             .setup(d => d.apply(props.assessmentTestResult.definition.extensions))
             .returns(() => {
@@ -58,6 +69,16 @@ describe('AssessmentViewTest', () => {
 
         builder.verifyAll();
         onAssessmentViewUpdateMock.verifyAll();
+    });
+
+    test('componentWillUnmount', () => {
+        const props = builder.buildProps();
+        builder.updateHandlerMock.setup(u => u.onUnmount(props)).verifiable(Times.once());
+
+        const testObject = new AssessmentView(props);
+
+        testObject.componentWillUnmount();
+        builder.verifyAll();
     });
 
     function buildPrevProps(): AssessmentViewProps {

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -4,8 +4,9 @@ import { AssessmentTestResult } from 'common/assessment/assessment-test-result';
 import { AssessmentData } from 'common/types/store-data/assessment-result-data';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { Mock } from 'typemoq';
+import { IMock, Mock, Times } from 'typemoq';
 
+import { AssessmentViewUpdateHandler } from 'DetailsView/components/assessment-view-update-handler';
 import {
     ReflowAssessmentView,
     ReflowAssessmentViewDeps,
@@ -13,6 +14,12 @@ import {
 } from '../../../../../DetailsView/components/reflow-assessment-view';
 
 describe('AssessmentViewTest', () => {
+    let updateHandlerMock: IMock<AssessmentViewUpdateHandler>;
+
+    beforeEach(() => {
+        updateHandlerMock = Mock.ofType(AssessmentViewUpdateHandler);
+    });
+
     test('render for requirement', () => {
         const props = generateProps('requirement');
         const rendered = shallow(<ReflowAssessmentView {...props} />);
@@ -25,6 +32,37 @@ describe('AssessmentViewTest', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
+    test('componentDidMount', () => {
+        const props = generateProps('requirement');
+        updateHandlerMock.setup(u => u.onMount(props)).verifiable(Times.once());
+        const testObject = new ReflowAssessmentView(props);
+
+        testObject.componentDidMount();
+
+        updateHandlerMock.verifyAll();
+    });
+
+    test('componentWillUnmount', () => {
+        const props = generateProps('requirement');
+        updateHandlerMock.setup(u => u.onUnmount(props)).verifiable(Times.once());
+        const testObject = new ReflowAssessmentView(props);
+
+        testObject.componentWillUnmount();
+
+        updateHandlerMock.verifyAll();
+    });
+
+    test('componentDidUpdate', () => {
+        const prevProps = generateProps('requirement1');
+        const props = generateProps('requirement2');
+        updateHandlerMock.setup(u => u.update(prevProps, props)).verifiable(Times.once());
+        const testObject = new ReflowAssessmentView(props);
+
+        testObject.componentDidUpdate(prevProps);
+
+        updateHandlerMock.verifyAll();
+    });
+
     function generateProps(subview: string): ReflowAssessmentViewProps {
         const assessmentDataMock = Mock.ofType<AssessmentData>();
 
@@ -35,7 +73,9 @@ describe('AssessmentViewTest', () => {
         } as AssessmentTestResult;
 
         const reflowProps = {
-            deps: {} as ReflowAssessmentViewDeps,
+            deps: {
+                assessmentViewUpdateHandler: updateHandlerMock.object,
+            } as ReflowAssessmentViewDeps,
             prevTarget: { id: 4 },
             currentTarget: { id: 5 },
             assessmentNavState: {

--- a/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/test-step-view.test.tsx
@@ -6,17 +6,9 @@ import { CollapsibleComponent } from 'common/components/collapsible-component';
 import { ManualTestStatus } from 'common/types/manual-test-status';
 import { VisualizationType } from 'common/types/visualization-type';
 import { AssessmentInstanceTable } from 'DetailsView/components/assessment-instance-table';
-import {
-    AssessmentViewUpdateHandler,
-    AssessmentViewUpdateHandlerProps,
-} from 'DetailsView/components/assessment-view-update-handler';
 import { AssessmentVisualizationEnabledToggle } from 'DetailsView/components/assessment-visualization-enabled-toggle';
 import { ManualTestStepView } from 'DetailsView/components/manual-test-step-view';
-import {
-    TestStepView,
-    TestStepViewDeps,
-    TestStepViewProps,
-} from 'DetailsView/components/test-step-view';
+import { TestStepView, TestStepViewProps } from 'DetailsView/components/test-step-view';
 import * as styles from 'DetailsView/components/test-step-view.scss';
 import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
 import * as Enzyme from 'enzyme';
@@ -25,14 +17,12 @@ import { BaseDataBuilder } from 'tests/unit/common/base-data-builder';
 import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
 
 let getVisualHelperToggleMock: IMock<(provider, props) => {}>;
-let updateHandlerMock: IMock<AssessmentViewUpdateHandler>;
 
 describe('TestStepViewTest', () => {
     beforeEach(() => {
         getVisualHelperToggleMock = Mock.ofInstance((provider, props) => {
             return null;
         });
-        updateHandlerMock = Mock.ofType<AssessmentViewUpdateHandler>();
     });
 
     test('constructor, no side effects', () => {
@@ -145,55 +135,6 @@ describe('TestStepViewTest', () => {
         expect(wrapper.debug()).toMatchSnapshot();
     });
 
-    test('componentDidUpdate', () => {
-        const props = TestStepViewPropsBuilder.defaultProps(
-            getVisualHelperToggleMock.object,
-        ).build();
-        const prevProps = TestStepViewPropsBuilder.defaultProps(
-            getVisualHelperToggleMock.object,
-        ).build();
-        prevProps.assessmentNavState.selectedTestSubview = 'prevTestStep';
-        updateHandlerMock
-            .setup(u => u.update(getUpdateHandlerProps(prevProps), getUpdateHandlerProps(props)))
-            .verifiable(Times.once());
-
-        const testObject = new TestStepView(props);
-
-        testObject.componentDidUpdate(prevProps);
-
-        updateHandlerMock.verifyAll();
-    });
-
-    test('componentDidMount', () => {
-        const props = TestStepViewPropsBuilder.defaultProps(
-            getVisualHelperToggleMock.object,
-        ).build();
-        updateHandlerMock
-            .setup(u => u.onMount(getUpdateHandlerProps(props)))
-            .verifiable(Times.once());
-
-        const testObject = new TestStepView(props);
-
-        testObject.componentDidMount();
-
-        updateHandlerMock.verifyAll();
-    });
-
-    test('componentWillUnmount', () => {
-        const props = TestStepViewPropsBuilder.defaultProps(
-            getVisualHelperToggleMock.object,
-        ).build();
-        updateHandlerMock
-            .setup(u => u.onUnmount(getUpdateHandlerProps(props)))
-            .verifiable(Times.once());
-
-        const testObject = new TestStepView(props);
-
-        testObject.componentWillUnmount();
-
-        updateHandlerMock.verifyAll();
-    });
-
     function validateManualTestStepView(
         wrapper: Enzyme.ShallowWrapper,
         props: TestStepViewProps,
@@ -207,17 +148,6 @@ describe('TestStepViewTest', () => {
             view.prop('assessmentInstanceTableHandler'),
         );
         expect(props.assessmentsProvider).toEqual(view.prop('assessmentsProvider'));
-    }
-
-    function getUpdateHandlerProps(props: TestStepViewProps): AssessmentViewUpdateHandlerProps {
-        return {
-            deps: props.deps,
-            isRequirementEnabled: props.isStepEnabled,
-            assessmentNavState: props.assessmentNavState,
-            assessmentData: props.assessmentData,
-            prevTarget: props.prevTarget,
-            currentTarget: props.currentTarget,
-        };
     }
 });
 
@@ -289,10 +219,7 @@ class TestStepViewPropsBuilder extends BaseDataBuilder<TestStepViewProps> {
                 howToTest: <p>Instructions</p>,
                 isManual: false,
                 guidanceLinks: [],
-            })
-            .with('deps', {
-                assessmentViewUpdateHandler: updateHandlerMock.object,
-            } as TestStepViewDeps);
+            });
     }
 
     public withNoGetToggleConfig(): TestStepViewPropsBuilder {


### PR DESCRIPTION
This reverts 63145e4, which introduced #2695. Details from Dan: 

> automated checks only indirectly renders the TestStepView via src\DetailsView\extensions\wait-for-all-requirements-to-complete.tsx; the test step view doesn't get mounted until after all the requirements complete, but the logic to start the visualizer was moved to the mount phase of the TestStepView"

This impacts the under-feature-flag reflow work, but is not intended to have other side effects

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
