### PR TITLE
feat(nav-bar-content): remove update-handler from ReflowAssessmentView

### DIFF
--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -2,11 +2,6 @@
 // Licensed under the MIT License.
 import * as React from 'react';
 
-import {
-    AssessmentViewUpdateHandler,
-    AssessmentViewUpdateHandlerDeps,
-    AssessmentViewUpdateHandlerProps,
-} from 'DetailsView/components/assessment-view-update-handler';
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { Tab } from '../../common/itab';
 import {
@@ -17,10 +12,7 @@ import {
 import { GettingStartedView } from './getting-started-view';
 import { TargetChangeDialog, TargetChangeDialogDeps } from './target-change-dialog';
 
-export type ReflowAssessmentViewDeps = {
-    assessmentViewUpdateHandler: AssessmentViewUpdateHandler;
-} & AssessmentViewUpdateHandlerDeps &
-    TargetChangeDialogDeps;
+export type ReflowAssessmentViewDeps = TargetChangeDialogDeps;
 
 export type ReflowAssessmentViewProps = {
     deps: ReflowAssessmentViewDeps;
@@ -29,7 +21,7 @@ export type ReflowAssessmentViewProps = {
     currentTarget: Tab;
     prevTarget: PersistedTabInfo;
     assessmentTestResult: AssessmentTestResult;
-} & AssessmentViewUpdateHandlerProps;
+};
 
 export class ReflowAssessmentView extends React.Component<ReflowAssessmentViewProps> {
     public render(): JSX.Element {
@@ -45,18 +37,6 @@ export class ReflowAssessmentView extends React.Component<ReflowAssessmentViewPr
             );
         }
         return null;
-    }
-
-    public componentDidMount(): void {
-        this.props.deps.assessmentViewUpdateHandler.onMount(this.props);
-    }
-
-    public componentDidUpdate(prevProps: ReflowAssessmentViewProps): void {
-        this.props.deps.assessmentViewUpdateHandler.update(prevProps, this.props);
-    }
-
-    public componentWillUnmount(): void {
-        this.props.deps.assessmentViewUpdateHandler.onUnmount(this.props);
     }
 
     private renderTargetChangeDialog(): JSX.Element {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
@@ -3,13 +3,7 @@
 exports[`AssessmentViewTest render for gettting started 1`] = `
 <div>
   <TargetChangeDialog
-    deps={
-      Object {
-        "assessmentViewUpdateHandler": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-        },
-      }
-    }
+    deps={Object {}}
     newTab={
       Object {
         "id": 5,

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -4,9 +4,8 @@ import { AssessmentTestResult } from 'common/assessment/assessment-test-result';
 import { AssessmentData } from 'common/types/store-data/assessment-result-data';
 import { shallow } from 'enzyme';
 import * as React from 'react';
-import { IMock, Mock, Times } from 'typemoq';
+import { Mock } from 'typemoq';
 
-import { AssessmentViewUpdateHandler } from 'DetailsView/components/assessment-view-update-handler';
 import {
     ReflowAssessmentView,
     ReflowAssessmentViewDeps,
@@ -14,12 +13,6 @@ import {
 } from '../../../../../DetailsView/components/reflow-assessment-view';
 
 describe('AssessmentViewTest', () => {
-    let updateHandlerMock: IMock<AssessmentViewUpdateHandler>;
-
-    beforeEach(() => {
-        updateHandlerMock = Mock.ofType(AssessmentViewUpdateHandler);
-    });
-
     test('render for requirement', () => {
         const props = generateProps('requirement');
         const rendered = shallow(<ReflowAssessmentView {...props} />);
@@ -32,37 +25,6 @@ describe('AssessmentViewTest', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    test('componentDidMount', () => {
-        const props = generateProps('requirement');
-        updateHandlerMock.setup(u => u.onMount(props)).verifiable(Times.once());
-        const testObject = new ReflowAssessmentView(props);
-
-        testObject.componentDidMount();
-
-        updateHandlerMock.verifyAll();
-    });
-
-    test('componentWillUnmount', () => {
-        const props = generateProps('requirement');
-        updateHandlerMock.setup(u => u.onUnmount(props)).verifiable(Times.once());
-        const testObject = new ReflowAssessmentView(props);
-
-        testObject.componentWillUnmount();
-
-        updateHandlerMock.verifyAll();
-    });
-
-    test('componentDidUpdate', () => {
-        const prevProps = generateProps('requirement1');
-        const props = generateProps('requirement2');
-        updateHandlerMock.setup(u => u.update(prevProps, props)).verifiable(Times.once());
-        const testObject = new ReflowAssessmentView(props);
-
-        testObject.componentDidUpdate(prevProps);
-
-        updateHandlerMock.verifyAll();
-    });
-
     function generateProps(subview: string): ReflowAssessmentViewProps {
         const assessmentDataMock = Mock.ofType<AssessmentData>();
 
@@ -73,9 +35,7 @@ describe('AssessmentViewTest', () => {
         } as AssessmentTestResult;
 
         const reflowProps = {
-            deps: {
-                assessmentViewUpdateHandler: updateHandlerMock.object,
-            } as ReflowAssessmentViewDeps,
+            deps: {} as ReflowAssessmentViewDeps,
             prevTarget: { id: 4 },
             currentTarget: { id: 5 },
             assessmentNavState: {


### PR DESCRIPTION
#### Description of changes

Remove update-handler from ReflowAssessmentView (to be added back later in RequirementView). This will fix the errors on Getting Started that were reintroduced by the revert in #2698.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1659964
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
