### PR TITLE
refactor(nav-bar-content): use const getting started string

### DIFF
--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import * as React from 'react';
-
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { Tab } from '../../common/itab';
 import {
     AssessmentData,
     AssessmentNavState,
+    gettingStartedSubview,
     PersistedTabInfo,
 } from '../../common/types/store-data/assessment-result-data';
 import { GettingStartedView } from './getting-started-view';
@@ -26,7 +26,7 @@ export type ReflowAssessmentViewProps = {
 export class ReflowAssessmentView extends React.Component<ReflowAssessmentViewProps> {
     public render(): JSX.Element {
         const { assessmentTestResult } = this.props;
-        if (this.props.assessmentNavState.selectedTestSubview === 'getting-started') {
+        if (this.props.assessmentNavState.selectedTestSubview === gettingStartedSubview) {
             return (
                 <div>
                     {this.renderTargetChangeDialog()}

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -3,6 +3,7 @@
 import * as TelemetryEvents from 'common/extension-telemetry-events';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
+import { gettingStartedSubview } from 'common/types/store-data/assessment-result-data';
 import {
     ScanBasePayload,
     ScanCompletedPayload,
@@ -236,7 +237,7 @@ export class AssessmentActionCreator {
 
     private onSelectGettingStarted = (payload: SelectGettingStartedPayload): void => {
         this.assessmentActions.selectTestSubview.invoke({
-            selectedTestSubview: 'getting-started',
+            selectedTestSubview: gettingStartedSubview,
             ...payload,
         });
         this.telemetryEventHandler.publishTelemetry(

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -1,11 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { AssessmentTestResult } from 'common/assessment/assessment-test-result';
-import { AssessmentData } from 'common/types/store-data/assessment-result-data';
+import {
+    AssessmentData,
+    GettingStarted,
+    gettingStartedSubview,
+    RequirementName,
+} from 'common/types/store-data/assessment-result-data';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock } from 'typemoq';
-
 import {
     ReflowAssessmentView,
     ReflowAssessmentViewDeps,
@@ -20,12 +24,12 @@ describe('AssessmentViewTest', () => {
     });
 
     test('render for gettting started', () => {
-        const props = generateProps('getting-started');
+        const props = generateProps(gettingStartedSubview);
         const rendered = shallow(<ReflowAssessmentView {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    function generateProps(subview: string): ReflowAssessmentViewProps {
+    function generateProps(subview: RequirementName | GettingStarted): ReflowAssessmentViewProps {
         const assessmentDataMock = Mock.ofType<AssessmentData>();
 
         const assessmentTestResultStub: AssessmentTestResult = {

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -23,6 +23,7 @@ import { Action } from 'common/flux/action';
 import { getStoreStateMessage, Messages } from 'common/messages';
 import { StoreNames } from 'common/stores/store-names';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { gettingStartedSubview } from 'common/types/store-data/assessment-result-data';
 import { VisualizationType } from 'common/types/visualization-type';
 import {
     ScanBasePayload,
@@ -559,7 +560,7 @@ describe('AssessmentActionCreatorTest', () => {
             ...telemetryOnlyPayload,
         } as SelectGettingStartedPayload;
         const actionPayload: SelectTestSubviewPayload = {
-            selectedTestSubview: 'getting-started',
+            selectedTestSubview: gettingStartedSubview,
             ...telemetryOnlyPayload,
         } as SelectTestSubviewPayload;
 


### PR DESCRIPTION
#### Description of changes

small refactor of using the same const for getting started subview instead of inline strings.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
