### PR TITLE
feat(nav-bar-content): add guidance icon to getting started view

### DIFF
--- a/src/DetailsView/components/getting-started-view.scss
+++ b/src/DetailsView/components/getting-started-view.scss
@@ -7,3 +7,19 @@
     padding-left: 6px;
     padding-top: 1vh;
 }
+
+.getting-started-header {
+    @include text-style-title-m;
+    padding-top: 8px;
+    i {
+        font-size: 16px;
+    }
+}
+
+.getting-started-header-title {
+    margin-right: 8px;
+}
+
+.getting-started-title {
+    @include text-style-title-s;
+}

--- a/src/DetailsView/components/getting-started-view.tsx
+++ b/src/DetailsView/components/getting-started-view.tsx
@@ -3,16 +3,25 @@
 import { NamedFC } from 'common/react/named-fc';
 import * as styles from 'DetailsView/components/getting-started-view.scss';
 import * as React from 'react';
+import { ContentLink, ContentLinkDeps } from 'views/content/content-link';
+import { ContentPageComponent } from 'views/content/content-page';
+
+export type GettingStartedViewDeps = ContentLinkDeps;
 
 export interface GettingStartedViewProps {
+    deps: GettingStartedViewDeps;
     gettingStartedContent: JSX.Element;
     title: string;
+    guidance: ContentPageComponent;
 }
 
 export const GettingStartedView = NamedFC<GettingStartedViewProps>('GettingStartedView', props => {
     return (
         <div className={styles.gettingStartedView}>
-            <h1>{props.title}</h1>
+            <h1>
+                {props.title}
+                <ContentLink deps={props.deps} reference={props.guidance} iconName="info" />
+            </h1>
             <h2>Getting Started</h2>
             {props.gettingStartedContent}
         </div>

--- a/src/DetailsView/components/getting-started-view.tsx
+++ b/src/DetailsView/components/getting-started-view.tsx
@@ -18,11 +18,11 @@ export interface GettingStartedViewProps {
 export const GettingStartedView = NamedFC<GettingStartedViewProps>('GettingStartedView', props => {
     return (
         <div className={styles.gettingStartedView}>
-            <h1>
-                {props.title}
+            <h1 className={styles.gettingStartedHeader}>
+                <span className={styles.gettingStartedHeaderTitle}>{props.title}</span>
                 <ContentLink deps={props.deps} reference={props.guidance} iconName="info" />
             </h1>
-            <h2>Getting Started</h2>
+            <h2 className={styles.gettingStartedTitle}>Getting Started</h2>
             {props.gettingStartedContent}
         </div>
     );

--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -8,6 +8,7 @@ import { PathSnippetStoreData } from 'common/types/store-data/path-snippet-store
 import { RequirementView, RequirementViewDeps } from 'DetailsView/components/requirement-view';
 import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
 import * as React from 'react';
+import { ContentLinkDeps } from 'views/content/content-link';
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { Tab } from '../../common/itab';
 import {
@@ -16,10 +17,12 @@ import {
     gettingStartedSubview,
     PersistedTabInfo,
 } from '../../common/types/store-data/assessment-result-data';
-import { GettingStartedView } from './getting-started-view';
+import { GettingStartedView, GettingStartedViewDeps } from './getting-started-view';
 import { TargetChangeDialog, TargetChangeDialogDeps } from './target-change-dialog';
 
-export type ReflowAssessmentViewDeps = TargetChangeDialogDeps & RequirementViewDeps;
+export type ReflowAssessmentViewDeps = TargetChangeDialogDeps &
+    GettingStartedViewDeps &
+    RequirementViewDeps;
 
 export type ReflowAssessmentViewProps = {
     deps: ReflowAssessmentViewDeps;
@@ -42,8 +45,10 @@ export const ReflowAssessmentView = NamedFC<ReflowAssessmentViewProps>(
         const renderGettingStartedView = () => {
             return (
                 <GettingStartedView
+                    deps={props.deps}
                     gettingStartedContent={props.assessmentTestResult.definition.gettingStarted}
                     title={props.assessmentTestResult.definition.title}
+                    guidance={props.assessmentTestResult.definition.guidance}
                 />
             );
         };

--- a/src/DetailsView/components/reflow-assessment-view.tsx
+++ b/src/DetailsView/components/reflow-assessment-view.tsx
@@ -8,7 +8,6 @@ import { PathSnippetStoreData } from 'common/types/store-data/path-snippet-store
 import { RequirementView, RequirementViewDeps } from 'DetailsView/components/requirement-view';
 import { AssessmentInstanceTableHandler } from 'DetailsView/handlers/assessment-instance-table-handler';
 import * as React from 'react';
-import { ContentLinkDeps } from 'views/content/content-link';
 import { AssessmentTestResult } from '../../common/assessment/assessment-test-result';
 import { Tab } from '../../common/itab';
 import {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/getting-started-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/getting-started-view.test.tsx.snap
@@ -6,6 +6,15 @@ exports[`GettingStartedViewTest renders with content from props 1`] = `
 >
   <h1>
     some title
+    <ContentLink
+      deps={Object {}}
+      iconName="info"
+      reference={
+        Object {
+          "pageTitle": "some page title",
+        }
+      }
+    />
   </h1>
   <h2>
     Getting Started

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/getting-started-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/getting-started-view.test.tsx.snap
@@ -4,8 +4,14 @@ exports[`GettingStartedViewTest renders with content from props 1`] = `
 <div
   className="gettingStartedView"
 >
-  <h1>
-    some title
+  <h1
+    className="gettingStartedHeader"
+  >
+    <span
+      className="gettingStartedHeaderTitle"
+    >
+      some title
+    </span>
     <ContentLink
       deps={Object {}}
       iconName="info"
@@ -16,7 +22,9 @@ exports[`GettingStartedViewTest renders with content from props 1`] = `
       }
     />
   </h1>
-  <h2>
+  <h2
+    className="gettingStartedTitle"
+  >
     Getting Started
   </h2>
   <div>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/reflow-assessment-view.test.tsx.snap
@@ -16,10 +16,16 @@ exports[`AssessmentViewTest render for gettting started 1`] = `
     }
   />
   <GettingStartedView
+    deps={Object {}}
     gettingStartedContent={
       <h1>
         Hello
       </h1>
+    }
+    guidance={
+      Object {
+        "pageTitle": "some page title",
+      }
     }
     title="some title"
   />

--- a/src/tests/unit/tests/DetailsView/components/getting-started-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/getting-started-view.test.tsx
@@ -2,16 +2,20 @@
 // Licensed under the MIT License.
 import {
     GettingStartedView,
+    GettingStartedViewDeps,
     GettingStartedViewProps,
 } from 'DetailsView/components/getting-started-view';
 import { shallow } from 'enzyme';
 import * as React from 'react';
+import { ContentPageComponent } from 'views/content/content-page';
 
 describe('GettingStartedViewTest', () => {
     it('renders with content from props', () => {
         const props: GettingStartedViewProps = {
+            deps: {} as GettingStartedViewDeps,
             gettingStartedContent: <div>test-getting-started-content</div>,
             title: 'some title',
+            guidance: { pageTitle: 'some page title' } as ContentPageComponent,
         };
 
         const rendered = shallow(<GettingStartedView {...props} />);

--- a/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/reflow-assessment-view.test.tsx
@@ -52,6 +52,7 @@ describe('AssessmentViewTest', () => {
             definition: {
                 gettingStarted: <h1>Hello</h1>,
                 title: 'some title',
+                guidance: { pageTitle: 'some page title' },
             },
             getRequirementResult: getRequirementResultStub,
         } as AssessmentTestResult;


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

- Added guidance icon to title in GettingStartedView
- Added GettingStartedView styles

Screenshot of Getting Started view for Headings test
![image](https://user-images.githubusercontent.com/48259897/82270867-100aad00-992b-11ea-8b05-6c01d6b9e73b.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Partially addresses an existing issue: # 1659964
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
