### PR TITLE
fix: updated Tab Stops toggle aria-label to match the visually displayed label

### DIFF
--- a/src/common/components/visualization-toggle.tsx
+++ b/src/common/components/visualization-toggle.tsx
@@ -26,7 +26,7 @@ export class VisualizationToggle extends React.Component<VisualizationToggleProp
             className: this.props.className,
             onText: 'On',
             offText: 'Off',
-            ariaLabel: this.props.visualizationName,
+            ariaLabel: this.props.label ? this.props.label : this.props.visualizationName,
             componentRef: this.props.componentRef,
             onBlur: this.props.onBlur,
             onFocus: this.props.onFocus,

--- a/src/common/components/visualization-toggle.tsx
+++ b/src/common/components/visualization-toggle.tsx
@@ -26,7 +26,7 @@ export class VisualizationToggle extends React.Component<VisualizationToggleProp
             className: this.props.className,
             onText: 'On',
             offText: 'Off',
-            ariaLabel: this.props.label ? this.props.label : this.props.visualizationName,
+            ariaLabel: this.props.label ?? this.props.visualizationName,
             componentRef: this.props.componentRef,
             onBlur: this.props.onBlur,
             onFocus: this.props.onFocus,

--- a/src/tests/unit/tests/common/components/__snapshots__/visualization-toggle.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/visualization-toggle.test.tsx.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`VisualizationToggleTest render with a specified label 1`] = `
+<StyledToggleBase
+  ariaLabel="test-label"
+  checked={false}
+  className="my test class"
+  componentRef={Object {}}
+  data-automation-id="test-automation-id"
+  disabled={true}
+  label="test-label"
+  offText="Off"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onText="On"
+/>
+`;
+
+exports[`VisualizationToggleTest render with no label 1`] = `
+<StyledToggleBase
+  ariaLabel="visualizationName"
+  checked={false}
+  className="my test class"
+  componentRef={Object {}}
+  data-automation-id="test-automation-id"
+  disabled={true}
+  offText="Off"
+  onBlur={[Function]}
+  onClick={[Function]}
+  onFocus={[Function]}
+  onText="On"
+/>
+`;

--- a/src/tests/unit/tests/common/components/visualization-toggle.test.tsx
+++ b/src/tests/unit/tests/common/components/visualization-toggle.test.tsx
@@ -1,49 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as Enzyme from 'enzyme';
-import { IToggleProps, Toggle } from 'office-ui-fabric-react';
+import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
+
 import {
     VisualizationToggle,
     VisualizationToggleProps,
 } from '../../../../../common/components/visualization-toggle';
 
 describe('VisualizationToggleTest', () => {
-    test('constructor', () => {
-        const testObject = new VisualizationToggle({} as VisualizationToggleProps);
-        expect(testObject).toBeInstanceOf(React.Component);
+    test('render with no label', () => {
+        const generatedProps = generateVisualizationToggleProps();
+        const renderedToggle = shallow(<VisualizationToggle {...generatedProps} />);
+        expect(renderedToggle.getElement()).toMatchSnapshot();
     });
 
-    test('render no optional props', () => {
-        const props: VisualizationToggleProps = new VisualizationTogglePropsBuilder().build();
-
-        const wrapper = Enzyme.shallow(<VisualizationToggle {...props} />);
-
-        const toggle = wrapper.find(Toggle);
-
-        expect(toggle).toBeDefined();
-
-        const expectedProps = visualizationTogglePropsToToggleProps(props);
-        expect(toggle.props()).toEqual(expectedProps);
-    });
-
-    test('render all props', () => {
-        const props: VisualizationToggleProps = new VisualizationTogglePropsBuilder()
-            .setLabel('my test label')
-            .setClassName('my test class')
-            .setDisabled(true)
-            .setDataAutomationId('test-automation-id')
-            .build();
-
-        const wrapper = Enzyme.shallow(<VisualizationToggle {...props} />);
-
-        const toggle = wrapper.find(Toggle);
-
-        expect(toggle).toBeDefined();
-
-        const expectedProps = visualizationTogglePropsToToggleProps(props);
-        expect(toggle.props()).toEqual(expectedProps);
+    test('render with a specified label', () => {
+        const generatedProps = generateVisualizationToggleProps('test-label');
+        const renderedToggle = shallow(<VisualizationToggle {...generatedProps} />);
+        expect(renderedToggle.getElement()).toMatchSnapshot();
     });
 
     test('verify onClick being called when toggle clicked', () => {
@@ -51,105 +27,41 @@ describe('VisualizationToggleTest', () => {
         const clickEventStub = {};
         onClickMock.setup(onClick => onClick(clickEventStub)).verifiable(Times.once());
 
-        const props: VisualizationToggleProps = new VisualizationTogglePropsBuilder()
-            .setLabel('my test label')
-            .setClassName('my test class')
-            .setDisabled(true)
-            .setOnClickMock(onClickMock)
-            .build();
+        const generatedProps = generateVisualizationToggleProps('test-label', onClickMock);
+        const renderedToggle = shallow(<VisualizationToggle {...generatedProps} />);
 
-        const wrapper = Enzyme.shallow(<VisualizationToggle {...props} />);
-
-        wrapper.find(Toggle).simulate('click', clickEventStub);
+        renderedToggle.simulate('click', clickEventStub);
 
         onClickMock.verifyAll();
     });
 
-    function visualizationTogglePropsToToggleProps(props: VisualizationToggleProps): IToggleProps {
-        const result: IToggleProps = {
-            checked: props.checked,
-            onClick: props.onClick,
-            disabled: props.disabled,
-            label: props.label,
-            className: props.className,
+    function generateVisualizationToggleProps(
+        labelValue?: string,
+        passedOnClickMock?: IMock<(event) => void>,
+    ): VisualizationToggleProps {
+        const onClickMock: IMock<(event) => void> =
+            passedOnClickMock ?? Mock.ofInstance(event => {});
+        const componentRefStub: React.RefObject<any> = {} as React.RefObject<any>;
+        const onBlurMock: IMock<(event) => void> = Mock.ofInstance(event => {});
+        const onFocusMock: IMock<(event) => void> = Mock.ofInstance(event => {});
+        const result = {
+            checked: false,
+            onClick: onClickMock.object,
+            disabled: true,
+            className: 'my test class',
+            visualizationName: 'visualizationName',
             onText: 'On',
             offText: 'Off',
-            ariaLabel: props.label ? props.label : props.visualizationName,
-            componentRef: props.componentRef,
-            onFocus: props.onFocus,
-            onBlur: props.onBlur,
-            'data-automation-id': props['data-automation-id'],
-        };
+            componentRef: componentRefStub,
+            onFocus: onFocusMock.object,
+            onBlur: onBlurMock.object,
+            'data-automation-id': 'test-automation-id',
+        } as VisualizationToggleProps;
+
+        if (labelValue) {
+            result.label = labelValue;
+        }
 
         return result;
     }
 });
-
-class VisualizationTogglePropsBuilder {
-    private checked: boolean = false;
-    private onClickMock: IMock<(event) => void> = Mock.ofInstance(event => {});
-    private disabled: boolean;
-    private label: string;
-    private className: string;
-    private dataAutomationId: string;
-    private visualizationName: string = 'visualizationName';
-    private componentRefStub: React.RefObject<any> = {} as React.RefObject<any>;
-    private onBlurMock: IMock<(event) => void> = Mock.ofInstance(event => {});
-    private onFocusMock: IMock<(event) => void> = Mock.ofInstance(event => {});
-
-    public setClassName(className: string): VisualizationTogglePropsBuilder {
-        this.className = className;
-        return this;
-    }
-
-    public setDataAutomationId(dataAutomationId: string): VisualizationTogglePropsBuilder {
-        this.dataAutomationId = dataAutomationId;
-        return this;
-    }
-
-    public setLabel(label: string): VisualizationTogglePropsBuilder {
-        this.label = label;
-        return this;
-    }
-
-    public setDisabled(isDisabled: boolean): VisualizationTogglePropsBuilder {
-        this.disabled = isDisabled;
-        return this;
-    }
-
-    public setOnClickMock(onClickMock: IMock<(event) => void>): VisualizationTogglePropsBuilder {
-        this.onClickMock = onClickMock;
-        return this;
-    }
-
-    public build(): VisualizationToggleProps {
-        const props: VisualizationToggleProps = {
-            onText: 'On',
-            offText: 'Off',
-            checked: this.checked,
-            onClick: this.onClickMock.object,
-            visualizationName: this.visualizationName,
-            componentRef: this.componentRefStub,
-            onFocus: this.onFocusMock.object,
-            onBlur: this.onBlurMock.object,
-        };
-
-        if (this.disabled != null) {
-            props.disabled = this.disabled;
-        }
-
-        if (this.label != null) {
-            props.label = this.label;
-        }
-
-        if (this.className != null) {
-            props.className = this.className;
-        }
-
-        if (this.dataAutomationId != null) {
-            props['data-automation-id'] = this.dataAutomationId;
-        }
-
-        return props;
-    }
-}

--- a/src/tests/unit/tests/common/components/visualization-toggle.test.tsx
+++ b/src/tests/unit/tests/common/components/visualization-toggle.test.tsx
@@ -74,7 +74,7 @@ describe('VisualizationToggleTest', () => {
             className: props.className,
             onText: 'On',
             offText: 'Off',
-            ariaLabel: props.visualizationName,
+            ariaLabel: props.label ? props.label : props.visualizationName,
             componentRef: props.componentRef,
             onFocus: props.onFocus,
             onBlur: props.onBlur,


### PR DESCRIPTION
Added logic to visualization-toggle to set the ariaLabel to have the same value as the label displayed on the visualization toggle. Previously, we always set the aria-label value to the visualization name; having parity between the visually rendered label and ariaLabel makes the most sense. If no label is present in the toggle props, the aria-label value will default to the visualization name.

Tested the changes using the repro steps in the Trusted Tester bug; used NVDA and Narrator in Edge Insider

#### Description of changes
Before changes in this PR:
- displayed label: "Show tab stops"
- aria-label: "Tab stops" (since that's the visualization name)

After this PR:
- displayed label: "Show tab stops"
- aria-label: "Show tab stops" 

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [X] Addresses an existing issue: Bug 1720359: A11y_Accessibility Insights for Web_Tab stops_Label in name: Narrator/NVDA is reading Label "Show tab stops" as "tab stops"
- [X] Ran `yarn fastpass`
- [X] Added/updated relevant unit test(s) (and ran `yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [X] (UI changes only) Verified usability with NVDA/JAWS
