### PR TITLE
fix: missing AT announcement for error when using Inspect HTML without dev tools open

### DIFF
--- a/src/injected/components/command-bar.tsx
+++ b/src/injected/components/command-bar.tsx
@@ -91,7 +91,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
     const renderInspectMessage = (): JSX.Element => {
         if (props.shouldShowInspectButtonMessage()) {
             return (
-                <div className="insights-dialog-inspect-disabled">
+                <div role="alert" className="insights-dialog-inspect-disabled">
                     {`To use the Inspect HTML button, first open the developer tools (${props.devToolsShortcut}).`}
                 </div>
             );

--- a/src/tests/unit/tests/injected/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/injected/components/__snapshots__/command-bar.test.tsx.snap
@@ -95,6 +95,7 @@ exports[`CommandBar renders renders, shows inspect button message: true 1`] = `
   </React.Fragment>
   <div
     className="insights-dialog-inspect-disabled"
+    role="alert"
   >
     To use the Inspect HTML button, first open the developer tools (dev-tools-shortcut).
   </div>


### PR DESCRIPTION
#### Description of changes

Addresses accessibility issue 1720062, noting that NVDA/Narrator don't announce the error message we show when you try to use the target page dialog's Inspect HTML button without dev tools open ("To use the Inspect HTML button, first open the developer tools (F12).").

Just adds `role="alert"` to the container for the message.

No visual change. Verified that it didn't read it before and does read it after in both NVDA and Narrator.

![screenshot of the inspect HTML error message at issue](https://user-images.githubusercontent.com/376284/82378968-f3c64900-99da-11ea-8abd-914187902458.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: 1720062
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
