### PR TITLE
fix: avoid over-escaping special characters in Export Results dialog

### DIFF
--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -51,8 +51,7 @@ export class ReportExportComponent extends React.Component<
 
     private onExportDescriptionChange = (value: string) => {
         this.props.updatePersistedDescription(value);
-        const escapedExportDescription = escape(value);
-        this.setState({ exportDescription: escapedExportDescription });
+        this.setState({ exportDescription: value });
     };
 
     private generateHtml = () => {

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 import { ReportExportFormat } from 'common/extension-telemetry-events';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import { escape } from 'lodash';
 import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
@@ -118,7 +118,7 @@ exports[`ReportExportComponentTest user interactions dismiss dialog: dialog shou
 </React.Fragment>
 `;
 
-exports[`ReportExportComponentTest user interactions edit text field: user input new description 1`] = `
+exports[`ReportExportComponentTest user interactions edit text field: test content with special characters: <> $ " \` ' 1`] = `
 <React.Fragment>
   <CustomizedActionButton
     iconProps={
@@ -141,7 +141,7 @@ exports[`ReportExportComponentTest user interactions edit text field: user input
         },
       }
     }
-    description="new description"
+    description="test content with special characters: <> $ \\" \` '"
     featureFlagStoreData={
       Object {
         "test-feature-flag": true,

--- a/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
@@ -108,27 +108,33 @@ describe('ReportExportComponentTest', () => {
             htmlGeneratorMock.verifyAll();
         });
 
+        // We expect fabric's TextView.value and our htmlGenerator to take responsibility for
+        // escaping special characters, so we test that the export component passes specials down to
+        // the underlying dialog and the htmlGenerator as-is without escaping
+        const testContentWithSpecials = 'test content with special characters: <> $ " ` \'';
+
         test('edit text field', () => {
             updateDescriptionMock
-                .setup(udm => udm(It.isValue('new description')))
+                .setup(udm => udm(It.isValue(testContentWithSpecials)))
                 .returns(() => null)
                 .verifiable(Times.once());
 
             const wrapper = shallow(<ReportExportComponent {...props} />);
 
             const dialog = wrapper.find(ExportDialog);
-            dialog.props().onDescriptionChange('new description');
+            dialog.props().onDescriptionChange(testContentWithSpecials);
 
-            expect(wrapper.getElement()).toMatchSnapshot('user input new description');
+            expect(wrapper.getElement()).toMatchSnapshot(testContentWithSpecials);
 
             updateDescriptionMock.verifyAll();
         });
 
-        test('clicking export on the dialog should trigger the generateHtml', () => {
+        test('clicking export on the dialog should trigger generateHtml with the current exportDescription', () => {
             const wrapper = shallow(<ReportExportComponent {...props} />);
+            wrapper.setState({ exportDescription: testContentWithSpecials });
 
             htmlGeneratorMock
-                .setup(hgm => hgm(wrapper.state('exportDescription')))
+                .setup(hgm => hgm(testContentWithSpecials))
                 .returns(() => 'test html')
                 .verifiable(Times.once());
 


### PR DESCRIPTION
#### Description of changes

This PR fixes an issue where special characters were being double-escaped in our export results dialog's description text field; before, entering a &, <, > character would cause it to re-escape the & as an HTML entity with every new keystroke.

The escaping here is unnecessary; both the fabric `TextField` that's rendering the dialog's text and also the `htmlGenerator` we pass the description to already handle unescaped special characters correctly (via passing them to React to render). This PR removed it and updates unit tests to pin the new behavior.

**Before**:

![animation showing export dialog over-escaping with every keystroke after typing &, <, > characters](https://user-images.githubusercontent.com/376284/82382156-5a019a80-99e0-11ea-81b6-c916d6095602.gif)

**After**:

![screenshot of successfully typing special characters into the export dialog](https://user-images.githubusercontent.com/376284/82382009-1018b480-99e0-11ea-83b7-0e35ef739db5.png)

![screenshot of specials showing up correctly as-typed (not interpreted as HTML) in the generated report](https://user-images.githubusercontent.com/376284/82381955-fc6d4e00-99df-11ea-86a9-c39dfd87d9ea.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2563
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
