### PR TITLE
feat(android-bug-filing): Introduce OpenIssueLink to remove BrowserAdapter from createFileIssueHandler

### DIFF
--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -72,8 +72,8 @@ export class GlobalContextFactory {
         globalStoreHub.initialize();
 
         const issueFilingController = new IssueFilingControllerImpl(
+            browserAdapter.createActiveTab,
             issueFilingServiceProvider,
-            browserAdapter,
             toolData,
             globalStoreHub.userConfigurationStore,
         );

--- a/src/issue-filing/common/create-file-issue-handler.ts
+++ b/src/issue-filing/common/create-file-issue-handler.ts
@@ -1,18 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { CreateIssueDetailsTextData } from 'common/types/create-issue-details-text-data';
 import { IssueFilingServicePropertiesMap } from 'common/types/store-data/user-configuration-store';
 
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { IssueFilingUrlProvider } from '../types/issue-filing-service';
 
+export type OpenIssueLink = (url: string) => Promise<any>;
+
 export const createFileIssueHandler = <Settings>(
     getUrl: IssueFilingUrlProvider<Settings>,
     getSettings: (data: IssueFilingServicePropertiesMap) => Settings,
 ) => {
     return async (
-        browserAdapter: BrowserAdapter,
+        openIssueLink: OpenIssueLink,
         servicePropertiesMap: IssueFilingServicePropertiesMap,
         issueData: CreateIssueDetailsTextData,
         toolData: ToolData,
@@ -20,6 +21,6 @@ export const createFileIssueHandler = <Settings>(
         const serviceConfig = getSettings(servicePropertiesMap);
 
         const url = getUrl(serviceConfig, issueData, toolData);
-        await browserAdapter.createActiveTab(url);
+        await openIssueLink(url);
     };
 };

--- a/src/issue-filing/common/issue-filing-controller-impl.ts
+++ b/src/issue-filing/common/issue-filing-controller-impl.ts
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BaseStore } from 'common/base-store';
-import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { CreateIssueDetailsTextData } from 'common/types/create-issue-details-text-data';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 
 import { ToolData } from 'common/types/store-data/unified-data-interface';
+import { OpenIssueLink } from 'issue-filing/common/create-file-issue-handler';
 import { IssueFilingServiceProvider } from '../issue-filing-service-provider';
 
 export type IssueFilingController = {
@@ -14,8 +14,8 @@ export type IssueFilingController = {
 
 export class IssueFilingControllerImpl implements IssueFilingController {
     constructor(
+        private readonly openIssueLink: OpenIssueLink,
         private readonly provider: IssueFilingServiceProvider,
-        private readonly browserAdapter: BrowserAdapter,
         private readonly toolData: ToolData,
         private readonly userConfigurationStore: BaseStore<UserConfigurationStoreData>,
     ) {}
@@ -28,7 +28,7 @@ export class IssueFilingControllerImpl implements IssueFilingController {
         const userConfigurationStoreData = this.userConfigurationStore.getState();
 
         return service.fileIssue(
-            this.browserAdapter,
+            this.openIssueLink,
             userConfigurationStoreData.bugServicePropertiesMap,
             issueData,
             this.toolData,

--- a/src/issue-filing/types/issue-filing-service.ts
+++ b/src/issue-filing/types/issue-filing-service.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { ToolData } from 'common/types/store-data/unified-data-interface';
-import { BrowserAdapter } from '../../common/browser-adapters/browser-adapter';
+import { OpenIssueLink } from 'issue-filing/common/create-file-issue-handler';
 import { ReactFCWithDisplayName } from '../../common/react/named-fc';
 import { IssueFilingServicePropertiesMap } from '../../common/types/store-data/user-configuration-store';
 import { CreateIssueDetailsTextData } from './../../common/types/create-issue-details-text-data';
@@ -22,7 +22,7 @@ export interface IssueFilingService {
     isSettingsValid: (data: Object) => boolean;
     getSettingsFromStoreData: (data: IssueFilingServicePropertiesMap) => Object;
     fileIssue: (
-        browserAdapter: BrowserAdapter,
+        openIssueLink: OpenIssueLink,
         servicePropertiesMap: IssueFilingServicePropertiesMap,
         issueData: CreateIssueDetailsTextData,
         toolData: ToolData,

--- a/src/tests/unit/tests/issue-filing/common/create-file-issue-handler.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/create-file-issue-handler.test.ts
@@ -63,7 +63,7 @@ describe('createFileIssueHandler', () => {
         );
 
         await expect(
-            testSubject(browserAdapterMock.object, serviceMap, issueData, toolData),
+            testSubject(browserAdapterMock.object.createActiveTab, serviceMap, issueData, toolData),
         ).resolves.toBe(undefined);
 
         browserAdapterMock.verifyAll();
@@ -82,7 +82,7 @@ describe('createFileIssueHandler', () => {
         );
 
         await expect(
-            testSubject(browserAdapterMock.object, serviceMap, issueData, toolData),
+            testSubject(browserAdapterMock.object.createActiveTab, serviceMap, issueData, toolData),
         ).rejects.toEqual(errorMessage);
     });
 });

--- a/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { BaseStore } from 'common/base-store';
-import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 import { CreateIssueDetailsTextData } from 'common/types/create-issue-details-text-data';
 import { ToolData } from 'common/types/store-data/unified-data-interface';
 import {
     IssueFilingServicePropertiesMap,
     UserConfigurationStoreData,
 } from 'common/types/store-data/user-configuration-store';
+import { OpenIssueLink } from 'issue-filing/common/create-file-issue-handler';
 import { IssueFilingControllerImpl } from 'issue-filing/common/issue-filing-controller-impl';
 import { IssueFilingServiceProvider } from 'issue-filing/issue-filing-service-provider';
 import { IssueFilingService } from 'issue-filing/types/issue-filing-service';
@@ -38,12 +38,10 @@ describe('IssueFilingControllerImpl', () => {
         };
         const serviceConfig = { bugServicePropertiesMap: map } as UserConfigurationStoreData;
 
-        const browserAdapterMock = Mock.ofType<BrowserAdapter>();
+        const openIssueLinkMock = Mock.ofType<OpenIssueLink>();
         const issueFilingServiceMock = Mock.ofType<IssueFilingService>();
         issueFilingServiceMock
-            .setup(service =>
-                service.fileIssue(browserAdapterMock.object, map, issueData, toolData),
-            )
+            .setup(service => service.fileIssue(openIssueLinkMock.object, map, issueData, toolData))
             .returns(() => Promise.resolve());
 
         const providerMock = Mock.ofType<IssueFilingServiceProvider>();
@@ -55,14 +53,14 @@ describe('IssueFilingControllerImpl', () => {
         storeMock.setup(store => store.getState()).returns(() => serviceConfig);
 
         const testSubject = new IssueFilingControllerImpl(
+            openIssueLinkMock.object,
             providerMock.object,
-            browserAdapterMock.object,
             toolData,
             storeMock.object,
         );
 
         await expect(testSubject.fileIssue(serviceKey, issueData)).resolves.toBe(undefined);
 
-        browserAdapterMock.verifyAll();
+        openIssueLinkMock.verifyAll();
     });
 });


### PR DESCRIPTION
#### Description of changes
In preparation for issue filing in the unified client, we need to remove the issue filing dependence on the web-only `BrowserAdapter`. This PR accomplishes that by creating `OpenIssueLink` and using it in place of `BrowserAdapter.createActiveTab`. There should be no impact on functionality. A future PR will use this to enable issue filing on the unified side.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
