### PR TITLE
feat(android-bug-filing): Get ToolData at moment issue is filed rather than initialization

### DIFF
--- a/src/DetailsView/components/issue-filing-dialog.tsx
+++ b/src/DetailsView/components/issue-filing-dialog.tsx
@@ -118,6 +118,7 @@ export class IssueFilingDialog extends React.Component<
             ev,
             service,
             this.props.selectedIssueData,
+            this.props.deps.toolData,
         );
         this.props.onClose(ev);
     };

--- a/src/DetailsView/details-view-initializer.ts
+++ b/src/DetailsView/details-view-initializer.ts
@@ -346,7 +346,6 @@ if (isNaN(tabId) === false) {
 
             const issueDetailsTextGenerator = new IssueDetailsTextGenerator(
                 IssueFilingUrlStringUtils,
-                toolData,
                 createIssueDetailsBuilder(PlainTextFormatter),
             );
 

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -163,6 +163,7 @@ export interface SetIssueFilingServicePropertyPayload extends BaseActionPayload 
 export interface FileIssuePayload extends BaseActionPayload {
     issueData: CreateIssueDetailsTextData;
     service: string;
+    toolData: ToolData;
 }
 
 export interface UnifiedScanCompletedPayload extends BaseActionPayload {

--- a/src/background/global-action-creators/issue-filing-action-creator.ts
+++ b/src/background/global-action-creators/issue-filing-action-creator.ts
@@ -23,6 +23,6 @@ export class IssueFilingActionCreator {
 
     private onFileIssue = (payload: FileIssuePayload) => {
         this.telemetryEventHandler.publishTelemetry(FILE_ISSUE_CLICK, payload);
-        this.issueFilingController.fileIssue(payload.service, payload.issueData);
+        this.issueFilingController.fileIssue(payload.service, payload.issueData, payload.toolData);
     };
 }

--- a/src/background/global-context-factory.ts
+++ b/src/background/global-context-factory.ts
@@ -74,7 +74,6 @@ export class GlobalContextFactory {
         const issueFilingController = new IssueFilingControllerImpl(
             browserAdapter.createActiveTab,
             issueFilingServiceProvider,
-            toolData,
             globalStoreHub.userConfigurationStore,
         );
 

--- a/src/background/issue-details-text-generator.ts
+++ b/src/background/issue-details-text-generator.ts
@@ -8,18 +8,17 @@ import { IssueUrlCreationUtils } from '../issue-filing/common/issue-filing-url-s
 export class IssueDetailsTextGenerator {
     constructor(
         private issueFilingUrlStringUtils: IssueUrlCreationUtils,
-        private toolData: ToolData,
         private issueDetailsBuilder: IssueDetailsBuilder,
     ) {}
 
-    public buildText(data: CreateIssueDetailsTextData): string {
+    public buildText(data: CreateIssueDetailsTextData, toolData: ToolData): string {
         const standardTags = this.issueFilingUrlStringUtils.standardizeTags(data);
 
         const text = [
             `Title: ${this.issueFilingUrlStringUtils.getTitle(data)}`,
             `Tags: ${this.buildTags(data, standardTags)}`,
             ``,
-            this.issueDetailsBuilder(this.toolData, data),
+            this.issueDetailsBuilder(toolData, data),
         ].join('\n');
 
         return text;

--- a/src/common/components/cards/card-kebab-menu-button.tsx
+++ b/src/common/components/cards/card-kebab-menu-button.tsx
@@ -129,7 +129,7 @@ export class CardKebabMenuButton extends React.Component<
 
     private fileIssue = (event: React.MouseEvent<any>): void => {
         const { issueDetailsData, userConfigurationStoreData, deps } = this.props;
-        const { issueFilingServiceProvider, issueFilingActionMessageCreator } = deps;
+        const { issueFilingServiceProvider, issueFilingActionMessageCreator, toolData } = deps;
 
         const selectedBugFilingService = issueFilingServiceProvider.forKey(
             userConfigurationStoreData.bugService,
@@ -146,6 +146,7 @@ export class CardKebabMenuButton extends React.Component<
                 event,
                 userConfigurationStoreData.bugService,
                 issueDetailsData,
+                toolData,
             );
             this.closeNeedsSettingsContent();
         } else {
@@ -156,6 +157,7 @@ export class CardKebabMenuButton extends React.Component<
     private copyFailureDetails = async (event: React.MouseEvent<any>): Promise<void> => {
         const text = this.props.deps.issueDetailsTextGenerator.buildText(
             this.props.issueDetailsData,
+            this.props.deps.toolData,
         );
         this.props.deps.detailsViewActionMessageCreator.copyIssueDetailsClicked(event);
 

--- a/src/common/components/copy-issue-details-button.tsx
+++ b/src/common/components/copy-issue-details-button.tsx
@@ -5,6 +5,7 @@ import { NavigatorUtils } from 'common/navigator-utils';
 import { DefaultButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { CopyIcon } from '../../common/icons/copy-icon';
 import { CreateIssueDetailsTextData } from '../types/create-issue-details-text-data';
 import { Toast, ToastDeps } from './toast';
@@ -12,6 +13,7 @@ import { Toast, ToastDeps } from './toast';
 export type CopyIssueDetailsButtonDeps = ToastDeps & {
     navigatorUtils: NavigatorUtils;
     issueDetailsTextGenerator: IssueDetailsTextGenerator;
+    toolData: ToolData;
 };
 
 export type CopyIssueDetailsButtonProps = {
@@ -28,7 +30,10 @@ export class CopyIssueDetailsButton extends React.Component<CopyIssueDetailsButt
     }
 
     private getIssueDetailsText(issueData: CreateIssueDetailsTextData): string {
-        return this.props.deps.issueDetailsTextGenerator.buildText(issueData);
+        return this.props.deps.issueDetailsTextGenerator.buildText(
+            issueData,
+            this.props.deps.toolData,
+        );
     }
 
     private copyButtonClicked = async (event: React.MouseEvent<any>): Promise<void> => {

--- a/src/common/components/issue-filing-button.tsx
+++ b/src/common/components/issue-filing-button.tsx
@@ -92,7 +92,7 @@ export class IssueFilingButton extends React.Component<
 
     private onClickFileIssueButton = (event: React.MouseEvent<any>): void => {
         const { issueDetailsData, userConfigurationStoreData, deps } = this.props;
-        const { issueFilingServiceProvider, issueFilingActionMessageCreator } = deps;
+        const { issueFilingServiceProvider, issueFilingActionMessageCreator, toolData } = deps;
 
         const selectedBugFilingService = issueFilingServiceProvider.forKey(
             userConfigurationStoreData.bugService,
@@ -109,6 +109,7 @@ export class IssueFilingButton extends React.Component<
                 event,
                 userConfigurationStoreData.bugService,
                 issueDetailsData,
+                toolData,
             );
             this.closeNeedsSettingsContent();
         } else {

--- a/src/common/message-creators/issue-filing-action-message-creator.ts
+++ b/src/common/message-creators/issue-filing-action-message-creator.ts
@@ -3,6 +3,7 @@
 import { BaseActionPayload, FileIssuePayload } from 'background/actions/action-payloads';
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { FILE_ISSUE_CLICK, TelemetryEventSource } from '../extension-telemetry-events';
 import { Message } from '../message';
 import { Messages } from '../messages';
@@ -43,6 +44,7 @@ export class IssueFilingActionMessageCreator {
         event: SupportedMouseEvent,
         serviceKey: string,
         issueData: CreateIssueDetailsTextData,
+        toolData: ToolData,
     ): void {
         const messageType = Messages.IssueFiling.FileIssue;
         const telemetry = this.telemetryFactory.forFileIssueClick(event, this.source, serviceKey);
@@ -50,6 +52,7 @@ export class IssueFilingActionMessageCreator {
             telemetry,
             issueData,
             service: serviceKey,
+            toolData,
         };
         const message: Message = {
             messageType,

--- a/src/electron/views/automated-checks/automated-checks-view.tsx
+++ b/src/electron/views/automated-checks/automated-checks-view.tsx
@@ -71,13 +71,14 @@ export class AutomatedChecksView extends React.Component<AutomatedChecksViewProp
             return this.renderLayout(null, null, this.renderDeviceDisconnected());
         } else if (status === ScanStatus.Completed) {
             const { unifiedScanResultStoreData, cardSelectionStoreData, deps } = this.props;
-            const { rules, results } = unifiedScanResultStoreData;
+            const { rules, results, toolInfo } = unifiedScanResultStoreData;
             const cardSelectionViewData = deps.getCardSelectionViewData(
                 cardSelectionStoreData,
                 unifiedScanResultStoreData,
                 deps.isResultHighlightUnavailable,
             );
             const cardsViewData = deps.getCardsViewData(rules, results, cardSelectionViewData);
+            deps.toolData = toolInfo;
             const highlightedResultUids = Object.keys(
                 cardSelectionViewData.resultsHighlightStatus,
             ).filter(uid => cardSelectionViewData.resultsHighlightStatus[uid] === 'visible');

--- a/src/injected/dialog-renderer.tsx
+++ b/src/injected/dialog-renderer.tsx
@@ -83,7 +83,6 @@ export class DialogRenderer {
 
             const issueDetailsTextGenerator = new IssueDetailsTextGenerator(
                 IssueFilingUrlStringUtils,
-                mainWindowContext.getToolData(),
                 createIssueDetailsBuilder(PlainTextFormatter),
             );
 

--- a/src/issue-filing/common/issue-filing-controller-impl.ts
+++ b/src/issue-filing/common/issue-filing-controller-impl.ts
@@ -9,20 +9,24 @@ import { OpenIssueLink } from 'issue-filing/common/create-file-issue-handler';
 import { IssueFilingServiceProvider } from '../issue-filing-service-provider';
 
 export type IssueFilingController = {
-    fileIssue: (serviceKey: string, issueData: CreateIssueDetailsTextData) => void;
+    fileIssue: (
+        serviceKey: string,
+        issueData: CreateIssueDetailsTextData,
+        toolData: ToolData,
+    ) => void;
 };
 
 export class IssueFilingControllerImpl implements IssueFilingController {
     constructor(
         private readonly openIssueLink: OpenIssueLink,
         private readonly provider: IssueFilingServiceProvider,
-        private readonly toolData: ToolData,
         private readonly userConfigurationStore: BaseStore<UserConfigurationStoreData>,
     ) {}
 
     public fileIssue = (
         serviceKey: string,
         issueData: CreateIssueDetailsTextData,
+        toolData: ToolData,
     ): Promise<void> => {
         const service = this.provider.forKey(serviceKey);
         const userConfigurationStoreData = this.userConfigurationStore.getState();
@@ -31,7 +35,7 @@ export class IssueFilingControllerImpl implements IssueFilingController {
             this.openIssueLink,
             userConfigurationStoreData.bugServicePropertiesMap,
             issueData,
-            this.toolData,
+            toolData,
         );
     };
 }

--- a/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/issue-filing-dialog.test.tsx
@@ -135,6 +135,7 @@ describe('IssueFilingDialog', () => {
                     eventStub as any,
                     serviceKey,
                     It.isValue(props.selectedIssueData),
+                    toolData,
                 ),
             )
             .verifiable(Times.once());

--- a/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
+++ b/src/tests/unit/tests/background/global-action-creators/issue-filing-action-creator.test.ts
@@ -6,6 +6,7 @@ import { FileIssuePayload } from 'background/actions/action-payloads';
 import { IssueFilingActionCreator } from 'background/global-action-creators/issue-filing-action-creator';
 import { Interpreter } from 'background/interpreter';
 import { TelemetryEventHandler } from 'background/telemetry/telemetry-event-handler';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import {
     FILE_ISSUE_CLICK,
     TelemetryEventSource,
@@ -25,6 +26,7 @@ describe('IssueFilingActionCreator', () => {
                 triggeredBy: 'test' as TriggeredBy,
                 source: -1 as TelemetryEventSource,
             },
+            toolData: {} as ToolData,
         };
 
         const interpreterMock = Mock.ofType<Interpreter>();
@@ -42,7 +44,9 @@ describe('IssueFilingActionCreator', () => {
             MockBehavior.Strict,
         );
         issueFilingControllerMock
-            .setup(controller => controller.fileIssue(payload.service, payload.issueData))
+            .setup(controller =>
+                controller.fileIssue(payload.service, payload.issueData, payload.toolData),
+            )
             .verifiable(Times.once());
 
         const testSubject = new IssueFilingActionCreator(

--- a/src/tests/unit/tests/background/issue-details-text-generator.test.ts
+++ b/src/tests/unit/tests/background/issue-details-text-generator.test.ts
@@ -70,13 +70,12 @@ describe('Issue details text builder', () => {
 
         testSubject = new IssueDetailsTextGenerator(
             issueUrlCreationUtilsMock.object,
-            toolData,
             issueDetailsBuilderMock.object,
         );
     });
 
     test('buildText', () => {
-        const actual = testSubject.buildText(sampleIssueDetailsData);
+        const actual = testSubject.buildText(sampleIssueDetailsData, toolData);
         const expected = [
             `Title: ${title}`,
             `Tags: Accessibility, ${wcagTags.join(', ')}, RR-rule-id`,

--- a/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
+++ b/src/tests/unit/tests/common/components/cards/card-kebab-menu-button.test.tsx
@@ -16,6 +16,7 @@ import { IssueFilingActionMessageCreator } from 'common/message-creators/issue-f
 import { NavigatorUtils } from 'common/navigator-utils';
 import { NamedFC } from 'common/react/named-fc';
 import { CreateIssueDetailsTextData } from 'common/types/create-issue-details-text-data';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { WindowUtils } from 'common/window-utils';
 import { guidanceTags } from 'content/guidance-tags';
@@ -46,6 +47,18 @@ describe('CardKebabMenuButtonTest', () => {
     } as React.MouseEvent<any>;
 
     const issueDetailsText = 'placeholder text';
+
+    const toolData: ToolData = {
+        scanEngineProperties: {
+            name: 'engine-name',
+            version: 'engine-version',
+        },
+        applicationProperties: {
+            name: 'app-name',
+            version: 'app-version',
+            environmentName: 'environmentName',
+        },
+    };
 
     beforeEach(() => {
         testIssueFilingServiceStub = {
@@ -107,7 +120,7 @@ describe('CardKebabMenuButtonTest', () => {
             .verifiable(Times.exactly(3));
 
         textGeneratorMock
-            .setup(tg => tg.buildText(issueDetailsData))
+            .setup(tg => tg.buildText(issueDetailsData, toolData))
             .returns(() => issueDetailsText)
             .verifiable();
 
@@ -119,6 +132,7 @@ describe('CardKebabMenuButtonTest', () => {
             issueFilingActionMessageCreator: issueFilingActionMessageCreatorMock.object,
             issueDetailsTextGenerator: textGeneratorMock.object,
             cardInteractionSupport: allCardInteractionsSupported,
+            toolData,
         } as CardKebabMenuButtonDeps;
 
         defaultProps = {
@@ -256,7 +270,9 @@ describe('CardKebabMenuButtonTest', () => {
 
     it('should file issue, valid settings', async () => {
         issueFilingActionMessageCreatorMock
-            .setup(creator => creator.fileIssue(event, testKey, defaultProps.issueDetailsData))
+            .setup(creator =>
+                creator.fileIssue(event, testKey, defaultProps.issueDetailsData, toolData),
+            )
             .verifiable(Times.once());
 
         const rendered = shallow<CardKebabMenuButton>(<CardKebabMenuButton {...defaultProps} />);
@@ -275,7 +291,9 @@ describe('CardKebabMenuButtonTest', () => {
     it('should click file issue, invalid settings', () => {
         testIssueFilingServiceStub.isSettingsValid = () => false;
         issueFilingActionMessageCreatorMock
-            .setup(creator => creator.fileIssue(event, testKey, defaultProps.issueDetailsData))
+            .setup(creator =>
+                creator.fileIssue(event, testKey, defaultProps.issueDetailsData, toolData),
+            )
             .verifiable(Times.never());
 
         const rendered = shallow<CardKebabMenuButton>(<CardKebabMenuButton {...defaultProps} />);

--- a/src/tests/unit/tests/common/components/copy-issue-details-button.test.tsx
+++ b/src/tests/unit/tests/common/components/copy-issue-details-button.test.tsx
@@ -8,6 +8,7 @@ import { IMock, It, Mock, Times } from 'typemoq';
 import { IssueDetailsTextGenerator } from 'background/issue-details-text-generator';
 import { Toast } from 'common/components/toast';
 import { NavigatorUtils } from 'common/navigator-utils';
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import { WindowUtils } from 'common/window-utils';
 import {
     CopyIssueDetailsButton,
@@ -21,6 +22,18 @@ describe('CopyIssueDetailsButtonTest', () => {
     let windowUtilsMock: IMock<WindowUtils>;
     let navigatorUtilsMock: IMock<NavigatorUtils>;
     const issueDetailsText = 'placeholder text';
+    const toolData: ToolData = {
+        scanEngineProperties: {
+            name: 'engine-name',
+            version: 'engine-version',
+        },
+        applicationProperties: {
+            name: 'app-name',
+            version: 'app-version',
+            environmentName: 'environmentName',
+        },
+    };
+
     beforeEach(() => {
         onClickMock = Mock.ofInstance(e => {});
         windowUtilsMock = Mock.ofType<WindowUtils>();
@@ -30,8 +43,9 @@ describe('CopyIssueDetailsButtonTest', () => {
                 windowUtils: windowUtilsMock.object,
                 navigatorUtils: navigatorUtilsMock.object,
                 issueDetailsTextGenerator: {
-                    buildText: _ => issueDetailsText,
+                    buildText: (_, __) => issueDetailsText,
                 } as IssueDetailsTextGenerator,
+                toolData,
             },
             issueDetailsData: {} as CreateIssueDetailsTextData,
             onClick: onClickMock.object,

--- a/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
+++ b/src/tests/unit/tests/common/components/issue-filing-button.test.tsx
@@ -98,7 +98,9 @@ describe('IssueFilingButtonTest', () => {
             needsSettingsContentRenderer,
         };
         issueFilingActionMessageCreatorMock
-            .setup(creator => creator.fileIssue(eventStub, testKey, props.issueDetailsData))
+            .setup(creator =>
+                creator.fileIssue(eventStub, testKey, props.issueDetailsData, toolData),
+            )
             .verifiable(Times.once());
         const wrapper = shallow<IssueFilingButton>(<IssueFilingButton {...props} />);
 

--- a/src/tests/unit/tests/common/message-creators/issue-filing-action-message-creator.test.ts
+++ b/src/tests/unit/tests/common/message-creators/issue-filing-action-message-creator.test.ts
@@ -3,6 +3,7 @@
 import { ActionMessageDispatcher } from 'common/message-creators/types/dispatcher';
 import { IMock, It, Mock, Times } from 'typemoq';
 
+import { ToolData } from 'common/types/store-data/unified-data-interface';
 import {
     BaseTelemetryData,
     FILE_ISSUE_CLICK,
@@ -22,6 +23,18 @@ describe('IssueFilingActionMessageCreator', () => {
     const telemetryStub: BaseTelemetryData = {
         triggeredBy: 'test' as TriggeredBy,
         source,
+    };
+
+    const toolData: ToolData = {
+        scanEngineProperties: {
+            name: 'engine-name',
+            version: 'engine-version',
+        },
+        applicationProperties: {
+            name: 'app-name',
+            version: 'app-version',
+            environmentName: 'environmentName',
+        },
     };
 
     let telemetryFactoryMock: IMock<TelemetryDataFactory>;
@@ -90,7 +103,7 @@ describe('IssueFilingActionMessageCreator', () => {
             .returns(() => telemetry);
         const issueDetailsData: CreateIssueDetailsTextData = {} as any;
 
-        testSubject.fileIssue(eventStub, testService, issueDetailsData);
+        testSubject.fileIssue(eventStub, testService, issueDetailsData, toolData);
 
         dispatcherMock.verify(
             dispatcher =>
@@ -101,6 +114,7 @@ describe('IssueFilingActionMessageCreator', () => {
                             service: testService,
                             issueData: issueDetailsData,
                             telemetry,
+                            toolData,
                         },
                     }),
                 ),

--- a/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/__snapshots__/automated-checks-view.test.tsx.snap
@@ -17,6 +17,11 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
           "scanActions": undefined,
         },
         "screenshotViewModelProvider": [Function],
+        "toolData": Object {
+          "applicationProperties": Object {
+            "name": "some app",
+          },
+        },
       }
     }
     pageTitle="Automated checks"
@@ -50,6 +55,11 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
               "scanActions": undefined,
             },
             "screenshotViewModelProvider": [Function],
+            "toolData": Object {
+              "applicationProperties": Object {
+                "name": "some app",
+              },
+            },
           }
         }
         deviceStoreData={Object {}}
@@ -98,6 +108,11 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
                 "scanActions": undefined,
               },
               "screenshotViewModelProvider": [Function],
+              "toolData": Object {
+                "applicationProperties": Object {
+                  "name": "some app",
+                },
+              },
             }
           }
           scanMetadata={
@@ -144,6 +159,11 @@ exports[`AutomatedChecksView renders when status scan <Completed> 1`] = `
           "scanActions": undefined,
         },
         "screenshotViewModelProvider": [Function],
+        "toolData": Object {
+          "applicationProperties": Object {
+            "name": "some app",
+          },
+        },
       }
     }
     featureFlagData={Object {}}

--- a/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
+++ b/src/tests/unit/tests/issue-filing/common/issue-filing-controller-impl.test.ts
@@ -55,11 +55,12 @@ describe('IssueFilingControllerImpl', () => {
         const testSubject = new IssueFilingControllerImpl(
             openIssueLinkMock.object,
             providerMock.object,
-            toolData,
             storeMock.object,
         );
 
-        await expect(testSubject.fileIssue(serviceKey, issueData)).resolves.toBe(undefined);
+        await expect(testSubject.fileIssue(serviceKey, issueData, toolData)).resolves.toBe(
+            undefined,
+        );
 
         openIssueLinkMock.verifyAll();
     });


### PR DESCRIPTION
#### Description of changes
Currently, issue filing `ToolData` is set during initialization. This works for the web product, but the unified product's `ToolData` is not fully generated until a scan has been run (because it needs info from the android device). This PR refactors issue filing to get `ToolData` passed in along with other issue data at the moment an issue is filed. It should have no impact on functionality. A future PR will put it to use in the unified product. 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
