### PR TITLE
fix: make electron command bar button stylings match web

### DIFF
--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -12,28 +12,6 @@
     }
 }
 
-// specificity required to override fabric style
-button.menu-item-button {
-    color: $primary-text;
-
-    .button-icon {
-        color: $primary-text;
-        line-height: 16px;
-    }
-
-    &:hover {
-        @include buttonColors($neutral-alpha-4);
-    }
-
-    &:active {
-        @include buttonColors($neutral-alpha-8);
-    }
-
-    &:focus::after {
-        outline: $secondary-text solid 1px !important;
-    }
-}
-
 .command-bar {
     border-bottom: 1px solid $neutral-alpha-8;
 

--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -3,12 +3,16 @@
 @import '../../../../common/styles/colors.scss';
 @import '../../../../common/styles/fonts.scss';
 
-@mixin buttonColors($bckColor) {
+button.settings-gear-button {
     color: $primary-text;
-    background-color: $bckColor;
 
     .button-icon {
         color: $primary-text;
+        line-height: 16px;
+    }
+
+    &:focus::after {
+        outline: $secondary-text solid 1px !important;
     }
 }
 

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -72,8 +72,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
                 <CommandButton
                     data-automation-id={commandButtonRefreshId}
                     text="Start over"
-                    iconProps={{ iconName: 'Refresh', className: styles.buttonIcon }}
-                    className={styles.menuItemButton}
+                    iconProps={{ iconName: 'Refresh' }}
                     onClick={() => deps.scanActionCreator.scan(deviceStoreData.port)}
                     disabled={props.scanStoreData.status === ScanStatus.Scanning}
                 />
@@ -87,8 +86,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
                 <CommandButton
                     data-automation-id={commandButtonSettingsId}
                     ariaLabel="settings"
-                    iconProps={{ iconName: 'Gear', className: styles.buttonIcon }}
-                    className={styles.menuItemButton}
+                    iconProps={{ iconName: 'Gear' }}
                     onClick={event =>
                         deps.dropdownClickHandler.openSettingsPanelHandler(event as any)
                     }

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -86,10 +86,11 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
                 <CommandButton
                     data-automation-id={commandButtonSettingsId}
                     ariaLabel="settings"
-                    iconProps={{ iconName: 'Gear' }}
+                    iconProps={{ iconName: 'Gear', className: styles.buttonIcon }}
                     onClick={event =>
                         deps.dropdownClickHandler.openSettingsPanelHandler(event as any)
                     }
+                    className={styles.settingsGearButton}
                 />
             </div>
         </section>

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -9,12 +9,10 @@ exports[`CommandBar renders does not create report export when scan metadata is 
     className="items"
   >
     <CustomizedActionButton
-      className="menuItemButton"
       data-automation-id="command-button-refresh"
       disabled={true}
       iconProps={
         Object {
-          "className": "buttonIcon",
           "iconName": "Refresh",
         }
       }
@@ -36,11 +34,9 @@ exports[`CommandBar renders does not create report export when scan metadata is 
     />
     <CustomizedActionButton
       ariaLabel="settings"
-      className="menuItemButton"
       data-automation-id="command-button-settings"
       iconProps={
         Object {
-          "className": "buttonIcon",
           "iconName": "Gear",
         }
       }
@@ -59,12 +55,10 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
     className="items"
   >
     <CustomizedActionButton
-      className="menuItemButton"
       data-automation-id="command-button-refresh"
       disabled={false}
       iconProps={
         Object {
-          "className": "buttonIcon",
           "iconName": "Refresh",
         }
       }
@@ -112,11 +106,9 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
     />
     <CustomizedActionButton
       ariaLabel="settings"
-      className="menuItemButton"
       data-automation-id="command-button-settings"
       iconProps={
         Object {
-          "className": "buttonIcon",
           "iconName": "Gear",
         }
       }
@@ -135,12 +127,10 @@ exports[`CommandBar renders while status is <Default> 1`] = `
     className="items"
   >
     <CustomizedActionButton
-      className="menuItemButton"
       data-automation-id="command-button-refresh"
       disabled={false}
       iconProps={
         Object {
-          "className": "buttonIcon",
           "iconName": "Refresh",
         }
       }
@@ -188,11 +178,9 @@ exports[`CommandBar renders while status is <Default> 1`] = `
     />
     <CustomizedActionButton
       ariaLabel="settings"
-      className="menuItemButton"
       data-automation-id="command-button-settings"
       iconProps={
         Object {
-          "className": "buttonIcon",
           "iconName": "Gear",
         }
       }
@@ -211,12 +199,10 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
     className="items"
   >
     <CustomizedActionButton
-      className="menuItemButton"
       data-automation-id="command-button-refresh"
       disabled={false}
       iconProps={
         Object {
-          "className": "buttonIcon",
           "iconName": "Refresh",
         }
       }
@@ -264,11 +250,9 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
     />
     <CustomizedActionButton
       ariaLabel="settings"
-      className="menuItemButton"
       data-automation-id="command-button-settings"
       iconProps={
         Object {
-          "className": "buttonIcon",
           "iconName": "Gear",
         }
       }
@@ -287,12 +271,10 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
     className="items"
   >
     <CustomizedActionButton
-      className="menuItemButton"
       data-automation-id="command-button-refresh"
       disabled={true}
       iconProps={
         Object {
-          "className": "buttonIcon",
           "iconName": "Refresh",
         }
       }
@@ -340,11 +322,9 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
     />
     <CustomizedActionButton
       ariaLabel="settings"
-      className="menuItemButton"
       data-automation-id="command-button-settings"
       iconProps={
         Object {
-          "className": "buttonIcon",
           "iconName": "Gear",
         }
       }

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -34,9 +34,11 @@ exports[`CommandBar renders does not create report export when scan metadata is 
     />
     <CustomizedActionButton
       ariaLabel="settings"
+      className="settingsGearButton"
       data-automation-id="command-button-settings"
       iconProps={
         Object {
+          "className": "buttonIcon",
           "iconName": "Gear",
         }
       }
@@ -106,9 +108,11 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
     />
     <CustomizedActionButton
       ariaLabel="settings"
+      className="settingsGearButton"
       data-automation-id="command-button-settings"
       iconProps={
         Object {
+          "className": "buttonIcon",
           "iconName": "Gear",
         }
       }
@@ -178,9 +182,11 @@ exports[`CommandBar renders while status is <Default> 1`] = `
     />
     <CustomizedActionButton
       ariaLabel="settings"
+      className="settingsGearButton"
       data-automation-id="command-button-settings"
       iconProps={
         Object {
+          "className": "buttonIcon",
           "iconName": "Gear",
         }
       }
@@ -250,9 +256,11 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
     />
     <CustomizedActionButton
       ariaLabel="settings"
+      className="settingsGearButton"
       data-automation-id="command-button-settings"
       iconProps={
         Object {
+          "className": "buttonIcon",
           "iconName": "Gear",
         }
       }
@@ -322,9 +330,11 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
     />
     <CustomizedActionButton
       ariaLabel="settings"
+      className="settingsGearButton"
       data-automation-id="command-button-settings"
       iconProps={
         Object {
+          "className": "buttonIcon",
           "iconName": "Gear",
         }
       }


### PR DESCRIPTION
#### Description of changes

Currently, some of the button appearances in the command bar of the electron app are inconsistent:
<img width="299" alt="cmd bar old" src="https://user-images.githubusercontent.com/55459788/82504977-86391c00-9ab1-11ea-8a37-59f975dcfe82.PNG">
The icon for start over is black like the text, but the icon for export report is blue. In web, all button text is black and icons are blue in the default state. Per a conversation with Fer, these buttons should match the web stylings.

The different stylings also causes some issues in high contrast mode, as described in #2545. In addition to the text color not changing when hovering, buttons also appear whited out in the active state:
<img width="302" alt="cmd bar high contrast old active" src="https://user-images.githubusercontent.com/55459788/82505183-f182ee00-9ab1-11ea-8a12-47bb2dd11688.PNG">

To fix this, this pr will remove our custom styles from the command bar buttons and use the default office fabric styles like we currently do in web. As a result, all button icons will be blue:
<img width="299" alt="cmd bar" src="https://user-images.githubusercontent.com/55459788/82507238-999ab600-9ab6-11ea-812a-256706f5e112.PNG">
Hover and active states will appear the same (below shows the command bar with the start over button hovered):
<img width="299" alt="cmd bar hover" src="https://user-images.githubusercontent.com/55459788/82507248-a0292d80-9ab6-11ea-89a7-80489f27ee72.PNG">
High contrast mode will appear the same in default state:
<img width="300" alt="cmd bar high contrast" src="https://user-images.githubusercontent.com/55459788/82505503-c2b94780-9ab2-11ea-8854-14fe72efb820.PNG">
Button text will correctly change color when hovered:
<img width="299" alt="cmd bar high contrast hover" src="https://user-images.githubusercontent.com/55459788/82505541-d5cc1780-9ab2-11ea-8334-3b506dc9c90b.PNG">
And the active state is no longer whited out:
<img width="298" alt="cmd bar high contrast active" src="https://user-images.githubusercontent.com/55459788/82505876-365b5480-9ab3-11ea-98fa-8f2e39343178.PNG">
These changes are all consistent with what we currently have in the web extension.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #2545
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
