### PR TITLE
fix: improve compatibility of fastpass exported reports with IE

### DIFF
--- a/src/common/components/header.scss
+++ b/src/common/components/header.scss
@@ -18,6 +18,7 @@
     :global(.header-icon) {
         margin-left: 16px;
         height: 22px;
+        width: 22px;
         flex-shrink: 0;
     }
 

--- a/src/reports/components/new-tab-link-confirmation-dialog.tsx
+++ b/src/reports/components/new-tab-link-confirmation-dialog.tsx
@@ -27,12 +27,21 @@ export const NewTabLinkWithConfirmationDialog = NamedFC<ILinkProps>(
 
 export type ConfirmType = (message?: string) => boolean;
 
-// the following comment is to exclude the function from code coverage and prevent code cov from
-// injecting functions that interfere with eval in the unit tests
+// Note: the source of this function's body is stringified and injected into the report.
+//
+// The use of function() {} syntax over arrow functions is important for IE compat (see #1875).
+//
+// The "istanbul ignore next" excludes the function from code coverage to prevent code cov from
+// injecting functions that interfere with eval in the unit tests.
+//
 /* istanbul ignore next */
-const addConfirmOnClickHandler = (linkId: string, doc: Document, confirmCallback: ConfirmType) => {
+const addConfirmOnClickHandler = function (
+    linkId: string,
+    doc: Document,
+    confirmCallback: ConfirmType,
+): void {
     const targetPageLink = doc.getElementById(linkId);
-    targetPageLink.addEventListener('click', event => {
+    targetPageLink.addEventListener('click', function (event): void {
         const result = confirmCallback(
             'Are you sure you want to navigate away from the Accessibility Insights report?\n' +
                 'This link will open the target page in a new tab.\n\nPress OK to continue or ' +

--- a/src/reports/components/report-sections/collapsible-script-provider.tsx
+++ b/src/reports/components/report-sections/collapsible-script-provider.tsx
@@ -1,16 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// the following comment is to exclude the function from code coverage and prevent code cov from
-// injecting functions that affect snapshot tests
+// Note: the source of this function's body is stringified and injected into the report.
+//
+// The use of function() {} syntax over arrow functions is important for IE compat (see #1875).
+//
+// The "istanbul ignore next" excludes the function from code coverage to prevent code cov from
+// injecting functions that interfere with eval in the unit tests.
+//
 /* istanbul ignore next */
-export const addEventListenerForCollapsibleSection = (doc: Document) => {
+export const addEventListenerForCollapsibleSection = function (doc: Document): void {
     const collapsibles = doc.getElementsByClassName('collapsible-container');
 
     for (let index = 0; index < collapsibles.length; index++) {
         const container = collapsibles.item(index);
         const button = container.querySelector('.collapsible-control');
-        button.addEventListener('click', () => {
+        button.addEventListener('click', function (): void {
             const content = button.parentElement.nextElementSibling as HTMLElement;
             const wasExpandedBefore =
                 button.getAttribute('aria-expanded') === 'false' ? false : true;

--- a/src/reports/components/report-sections/header-section.scss
+++ b/src/reports/components/report-sections/header-section.scss
@@ -18,6 +18,7 @@
         flex-shrink: 0;
         margin-left: 16px;
         height: 22px;
+        width: 22px;
     }
 
     .header-text {

--- a/src/tests/unit/tests/reports/components/new-tab-link-confirmation-dialog.test.tsx
+++ b/src/tests/unit/tests/reports/components/new-tab-link-confirmation-dialog.test.tsx
@@ -69,7 +69,6 @@ describe('NewTabLinkWithConfirmationDialog', () => {
             const testSubject = shallow(<NewTabLinkWithConfirmationDialog />);
             const generatedScript = testSubject.find('script').render().html();
 
-            expect(generatedScript).toMatch(/function/);
             expect(generatedScript).not.toMatch(/=>/);
         });
 

--- a/src/tests/unit/tests/reports/components/new-tab-link-confirmation-dialog.test.tsx
+++ b/src/tests/unit/tests/reports/components/new-tab-link-confirmation-dialog.test.tsx
@@ -65,6 +65,14 @@ describe('NewTabLinkWithConfirmationDialog', () => {
             window.confirm = originalConfirm;
         });
 
+        it('does not use IE-incompatible arrow function syntax', () => {
+            const testSubject = shallow(<NewTabLinkWithConfirmationDialog />);
+            const generatedScript = testSubject.find('script').render().html();
+
+            expect(generatedScript).toMatch(/function/);
+            expect(generatedScript).not.toMatch(/=>/);
+        });
+
         it('is added to the link', () => {
             targetPageLinkMock
                 .setup(link => link.addEventListener('click', It.is(isFunction)))

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-script-provider.test.ts.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-script-provider.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CollapsibleScriptProvider getDefaultAddListenerForCollapsibleSection matches snapshot 1`] = `
+exports[`CollapsibleScriptProvider produces script source that matches snapshot 1`] = `
 "(function (doc) {
   const collapsibles = doc.getElementsByClassName('collapsible-container');
 
@@ -23,5 +23,3 @@ exports[`CollapsibleScriptProvider getDefaultAddListenerForCollapsibleSection ma
   }
 })(document)"
 `;
-
-exports[`CollapsibleScriptProvider match content 1`] = `"(this is test code)(document)"`;

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-script-provider.test.ts.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/collapsible-script-provider.test.ts.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CollapsibleScriptProvider getDefaultAddListenerForCollapsibleSection matches snapshot 1`] = `
-"(doc => {
+"(function (doc) {
   const collapsibles = doc.getElementsByClassName('collapsible-container');
 
   for (let index = 0; index < collapsibles.length; index++) {
     const container = collapsibles.item(index);
     const button = container.querySelector('.collapsible-control');
-    button.addEventListener('click', () => {
+    button.addEventListener('click', function () {
       const content = button.parentElement.nextElementSibling;
       const wasExpandedBefore = button.getAttribute('aria-expanded') === 'false' ? false : true;
       const isExpandedAfter = !wasExpandedBefore;

--- a/src/tests/unit/tests/reports/components/report-sections/collapsible-script-provider.test.ts
+++ b/src/tests/unit/tests/reports/components/report-sections/collapsible-script-provider.test.ts
@@ -5,91 +5,92 @@ import { It, Mock, MockBehavior, Times } from 'typemoq';
 
 import {
     addEventListenerForCollapsibleSection,
-    getAddListenerForCollapsibleSection,
     getDefaultAddListenerForCollapsibleSection,
 } from 'reports/components/report-sections/collapsible-script-provider';
 
 describe('CollapsibleScriptProvider', () => {
-    it('match content', () => {
-        const code = 'this is test code';
+    it('produces script source that matches snapshot', () => {
+        expect(getDefaultAddListenerForCollapsibleSection()).toMatchSnapshot();
+    });
 
-        const result = getAddListenerForCollapsibleSection(code);
-
-        expect(result).toMatchSnapshot();
+    it('produces script source that does not use IE-incompatible arrow functions', () => {
+        const result = getDefaultAddListenerForCollapsibleSection();
+        expect(result).not.toMatch(/=>/);
     });
 
     const isExpandedTestCases = [true, false];
 
-    it.each(isExpandedTestCases)('onClick, isExpanded %s', isExpanded => {
-        const isExpandedString = isExpanded ? 'true' : 'false';
-        const isHiddenString = isExpanded ? 'false' : 'true';
-        const classListMock = Mock.ofType<DOMTokenList>(null);
+    it.each(isExpandedTestCases)(
+        'registers onClick handlers which toggle expanded/hidden starting from expanded=%s',
+        isExpanded => {
+            const isExpandedString = isExpanded ? 'true' : 'false';
+            const isHiddenString = isExpanded ? 'false' : 'true';
+            const classListMock = Mock.ofType<DOMTokenList>(null);
 
-        const collapsibleNextSiblingMock = Mock.ofType<Element>();
+            const collapsibleNextSiblingMock = Mock.ofType<Element>();
 
-        const collapsibleParentMock = Mock.ofType<HTMLElement>();
-        collapsibleParentMock
-            .setup(parent => parent.nextElementSibling)
-            .returns(() => collapsibleNextSiblingMock.object);
+            const collapsibleParentMock = Mock.ofType<HTMLElement>();
+            collapsibleParentMock
+                .setup(parent => parent.nextElementSibling)
+                .returns(() => collapsibleNextSiblingMock.object);
 
-        const collapsibleContainerMock = Mock.ofType<Element>();
-        const collapsibleButtonMock = Mock.ofType<Element>();
+            const collapsibleContainerMock = Mock.ofType<Element>();
+            const collapsibleButtonMock = Mock.ofType<Element>();
 
-        let registeredButtonClickHandler: Function = null;
-        collapsibleButtonMock
-            .setup(ccm => ccm.addEventListener('click', It.is(isFunction)))
-            .callback((event, listener) => {
-                registeredButtonClickHandler = listener;
-            });
-        collapsibleButtonMock
-            .setup(collapsible => collapsible.parentElement)
-            .returns(() => collapsibleParentMock.object);
-        collapsibleButtonMock
-            .setup(collapsible => collapsible.getAttribute('aria-expanded'))
-            .returns(() => isExpandedString);
+            let registeredButtonClickHandler: Function = null;
+            collapsibleButtonMock
+                .setup(ccm => ccm.addEventListener('click', It.is(isFunction)))
+                .callback((event, listener) => {
+                    registeredButtonClickHandler = listener;
+                });
+            collapsibleButtonMock
+                .setup(collapsible => collapsible.parentElement)
+                .returns(() => collapsibleParentMock.object);
+            collapsibleButtonMock
+                .setup(collapsible => collapsible.getAttribute('aria-expanded'))
+                .returns(() => isExpandedString);
 
-        collapsibleContainerMock.setup(ccm => ccm.classList).returns(() => classListMock.object);
-        collapsibleContainerMock
-            .setup(ccm => ccm.querySelector('.collapsible-control'))
-            .returns(() => collapsibleButtonMock.object);
+            collapsibleContainerMock
+                .setup(ccm => ccm.classList)
+                .returns(() => classListMock.object);
+            collapsibleContainerMock
+                .setup(ccm => ccm.querySelector('.collapsible-control'))
+                .returns(() => collapsibleButtonMock.object);
 
-        const docMock = Mock.ofType<Document>(undefined, MockBehavior.Strict);
-        docMock
-            .setup(doc => doc.getElementsByClassName('collapsible-container'))
-            .returns(() => createHTMLCollectionOf([collapsibleContainerMock.object]));
+            const docMock = Mock.ofType<Document>(undefined, MockBehavior.Strict);
+            docMock
+                .setup(doc => doc.getElementsByClassName('collapsible-container'))
+                .returns(() => createHTMLCollectionOf([collapsibleContainerMock.object]));
 
-        addEventListenerForCollapsibleSection(docMock.object);
+            addEventListenerForCollapsibleSection(docMock.object);
 
-        collapsibleButtonMock.verify(
-            ccm => ccm.addEventListener('click', It.is(isFunction)),
-            Times.once(),
-        );
-        collapsibleContainerMock.verify(
-            ccm => ccm.addEventListener('click', It.is(isFunction)),
-            Times.never(),
-        );
+            collapsibleButtonMock.verify(
+                ccm => ccm.addEventListener('click', It.is(isFunction)),
+                Times.once(),
+            );
+            collapsibleContainerMock.verify(
+                ccm => ccm.addEventListener('click', It.is(isFunction)),
+                Times.never(),
+            );
 
-        registeredButtonClickHandler();
+            registeredButtonClickHandler();
 
-        collapsibleButtonMock.verify(
-            collapsible => collapsible.setAttribute('aria-expanded', isHiddenString),
-            Times.once(),
-        );
-        collapsibleNextSiblingMock.verify(
-            sibling => sibling.setAttribute('aria-hidden', isExpandedString),
-            Times.once(),
-        );
+            collapsibleButtonMock.verify(
+                collapsible => collapsible.setAttribute('aria-expanded', isHiddenString),
+                Times.once(),
+            );
+            collapsibleNextSiblingMock.verify(
+                sibling => sibling.setAttribute('aria-hidden', isExpandedString),
+                Times.once(),
+            );
 
-        if (isExpanded) {
-            classListMock.verify(clm => clm.add('collapsed'), Times.once());
-        } else {
-            classListMock.verify(clm => clm.remove('collapsed'), Times.once());
-        }
-    });
-
-    it('getDefaultAddListenerForCollapsibleSection matches snapshot', () => {
-        expect(getDefaultAddListenerForCollapsibleSection()).toMatchSnapshot();
-    });
+            if (isExpanded) {
+                classListMock.verify(clm => clm.add('collapsed'), Times.once());
+            } else {
+                classListMock.verify(clm => clm.remove('collapsed'), Times.once());
+            }
+        },
+    );
 
     const createHTMLCollectionOf = (elements: Element[]) => {
         return {

--- a/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
+++ b/src/tests/unit/tests/reports/package/__snapshots__/integration.test.ts.snap
@@ -235,9 +235,9 @@ exports[`report package integration with issues 1`] = `
           PAGE_TITLE
         </a>
         <script>
-          ((linkId, doc, confirmCallback) =&gt; {
+          (function (linkId, doc, confirmCallback) {
   const targetPageLink = doc.getElementById(linkId);
-  targetPageLink.addEventListener('click', event =&gt; {
+  targetPageLink.addEventListener('click', function (event) {
     const result = confirmCallback('Are you sure you want to navigate away from the Accessibility Insights report?\\n' + 'This link will open the target page in a new tab.\\n\\nPress OK to continue or ' + 'Cancel to stay on the current page.');
 
     if (result === false) {
@@ -435,9 +435,9 @@ exports[`report package integration with issues 1`] = `
                 https://markreay.github.io/AU/before.html
               </a>
               <script>
-                ((linkId, doc, confirmCallback) =&gt; {
+                (function (linkId, doc, confirmCallback) {
   const targetPageLink = doc.getElementById(linkId);
-  targetPageLink.addEventListener('click', event =&gt; {
+  targetPageLink.addEventListener('click', function (event) {
     const result = confirmCallback('Are you sure you want to navigate away from the Accessibility Insights report?\\n' + 'This link will open the target page in a new tab.\\n\\nPress OK to continue or ' + 'Cancel to stay on the current page.');
 
     if (result === false) {
@@ -7109,13 +7109,13 @@ exports[`report package integration with issues 1`] = `
         </div>
       </div>
       <script>
-        (doc =&gt; {
+        (function (doc) {
   const collapsibles = doc.getElementsByClassName('collapsible-container');
 
   for (let index = 0; index &lt; collapsibles.length; index++) {
     const container = collapsibles.item(index);
     const button = container.querySelector('.collapsible-control');
-    button.addEventListener('click', () =&gt; {
+    button.addEventListener('click', function () {
       const content = button.parentElement.nextElementSibling;
       const wasExpandedBefore = button.getAttribute('aria-expanded') === 'false' ? false : true;
       const isExpandedAfter = !wasExpandedBefore;
@@ -7390,9 +7390,9 @@ exports[`report package integration with no issues 1`] = `
           PAGE_TITLE
         </a>
         <script>
-          ((linkId, doc, confirmCallback) =&gt; {
+          (function (linkId, doc, confirmCallback) {
   const targetPageLink = doc.getElementById(linkId);
-  targetPageLink.addEventListener('click', event =&gt; {
+  targetPageLink.addEventListener('click', function (event) {
     const result = confirmCallback('Are you sure you want to navigate away from the Accessibility Insights report?\\n' + 'This link will open the target page in a new tab.\\n\\nPress OK to continue or ' + 'Cancel to stay on the current page.');
 
     if (result === false) {
@@ -7590,9 +7590,9 @@ exports[`report package integration with no issues 1`] = `
                 https://markreay.github.io/AU/after.html
               </a>
               <script>
-                ((linkId, doc, confirmCallback) =&gt; {
+                (function (linkId, doc, confirmCallback) {
   const targetPageLink = doc.getElementById(linkId);
-  targetPageLink.addEventListener('click', event =&gt; {
+  targetPageLink.addEventListener('click', function (event) {
     const result = confirmCallback('Are you sure you want to navigate away from the Accessibility Insights report?\\n' + 'This link will open the target page in a new tab.\\n\\nPress OK to continue or ' + 'Cancel to stay on the current page.');
 
     if (result === false) {
@@ -11086,13 +11086,13 @@ exports[`report package integration with no issues 1`] = `
         </div>
       </div>
       <script>
-        (doc =&gt; {
+        (function (doc) {
   const collapsibles = doc.getElementsByClassName('collapsible-container');
 
   for (let index = 0; index &lt; collapsibles.length; index++) {
     const container = collapsibles.item(index);
     const button = container.querySelector('.collapsible-control');
-    button.addEventListener('click', () =&gt; {
+    button.addEventListener('click', function () {
       const content = button.parentElement.nextElementSibling;
       const wasExpandedBefore = button.getAttribute('aria-expanded') === 'false' ? false : true;
       const isExpandedAfter = !wasExpandedBefore;


### PR DESCRIPTION
#### Description of changes

This is a partial fix for #1875. It fixes two issues:

* Our logo had an explicit `height` CSS property but only an implied `width` property, which IE misinterprets as "100%" instead of "scaled down by the same factor as the height". This caused the logo to take up the entire screen width and push the "Accessibility Insights for Web" text completely off-screen. We fix this by providing a `width` as well as a `height` (the logo image is a square, so we just use the same dimension as the height).
* The scripts we injected failed to run in IE because they were defined in terms of arrow-functions, which IE does not support. Updating the source of the injected functions to use `function() {}` style instead of `() => {}` style fixes the issue and makes expand/collapse behavior and our target page confirmation dialog work in IE.

This is not a complete fix for IE compat; there are still lots of issues with colors (due to IE not supporting CSS variables) and some other more minor formatting fixes. But it at least gets it to a point where the report is basically usable in IE.

Before (broken header bar, can't expand rules, no dialog on target page link):
![image](https://user-images.githubusercontent.com/376284/82511971-86daae00-9ac3-11ea-8a01-32ba0f795e44.png)

After (more normal header bar, can expand/collapse rules, confirmation dialog for target page link):
![image](https://user-images.githubusercontent.com/376284/82511940-788c9200-9ac3-11ea-804d-f67bbfa8ac24.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1875 (partially)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
