### PR TITLE
fix(firefox-compat): avoid RegExp named captures

### DIFF
--- a/src/common/components/fix-instruction-processor.tsx
+++ b/src/common/components/fix-instruction-processor.tsx
@@ -9,8 +9,7 @@ type ColorMatch = {
 };
 
 export class FixInstructionProcessor {
-    private readonly colorGroupName = 'color';
-    private readonly colorValueMatcher = `(?<${this.colorGroupName}>#[0-9a-f]{6})`;
+    private readonly colorValueMatcher = `(#[0-9a-f]{6})`;
     private readonly foregroundColorText = 'foreground color: ';
     private readonly foregroundRegExp = new RegExp(
         `${this.foregroundColorText}${this.colorValueMatcher}`,
@@ -37,9 +36,7 @@ export class FixInstructionProcessor {
         }
 
         const match = colorRegex.exec(fixInstruction);
-
-        const groups = match['groups'];
-        const colorHexValue = groups[this.colorGroupName];
+        const colorHexValue = match[1];
 
         return {
             splitIndex: match.index + this.foregroundColorText.length + colorHexValue.length,

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-fix-card-row.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/how-to-fix-card-row.test.tsx.snap
@@ -23,11 +23,10 @@ exports[`HowToFixWebCardRow renders 1`] = `
             "fixInstructionProcessor": proxy {
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
               "backgroundColorText": "background color: ",
-              "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-              "colorGroupName": "color",
-              "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+              "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
+              "colorValueMatcher": "(#[0-9a-f]{6})",
               "foregroundColorText": "foreground color: ",
-              "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+              "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
             },
           }
         }
@@ -47,11 +46,10 @@ exports[`HowToFixWebCardRow renders 1`] = `
             "fixInstructionProcessor": proxy {
               "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
               "backgroundColorText": "background color: ",
-              "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-              "colorGroupName": "color",
-              "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+              "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
+              "colorValueMatcher": "(#[0-9a-f]{6})",
               "foregroundColorText": "foreground color: ",
-              "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+              "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
             },
           }
         }

--- a/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/cards/__snapshots__/rules-with-instances.test.tsx.snap
@@ -20,11 +20,10 @@ exports[`RulesWithInstances renders 1`] = `
           proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "backgroundColorText": "background color: ",
-            "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "colorGroupName": "color",
-            "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+            "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "colorValueMatcher": "(#[0-9a-f]{6})",
             "foregroundColorText": "foreground color: ",
-            "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           }
         }
         rule={

--- a/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
+++ b/src/tests/unit/tests/reports/components/report-sections/__snapshots__/report-body.test.tsx.snap
@@ -60,11 +60,10 @@ exports[`ReportBody renders 1`] = `
       proxy {
         "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
         "backgroundColorText": "background color: ",
-        "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-        "colorGroupName": "color",
-        "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+        "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
+        "colorValueMatcher": "(#[0-9a-f]{6})",
         "foregroundColorText": "foreground color: ",
-        "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+        "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
       }
     }
     getCollapsibleScript={[Function]}
@@ -184,11 +183,10 @@ exports[`ReportBody renders 1`] = `
         proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "backgroundColorText": "background color: ",
-          "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "colorGroupName": "color",
-          "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+          "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "colorValueMatcher": "(#[0-9a-f]{6})",
           "foregroundColorText": "foreground color: ",
-          "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
         }
       }
       getCollapsibleScript={[Function]}
@@ -306,11 +304,10 @@ exports[`ReportBody renders 1`] = `
         proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "backgroundColorText": "background color: ",
-          "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "colorGroupName": "color",
-          "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+          "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "colorValueMatcher": "(#[0-9a-f]{6})",
           "foregroundColorText": "foreground color: ",
-          "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
         }
       }
       getCollapsibleScript={[Function]}
@@ -428,11 +425,10 @@ exports[`ReportBody renders 1`] = `
         proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "backgroundColorText": "background color: ",
-          "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "colorGroupName": "color",
-          "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+          "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "colorValueMatcher": "(#[0-9a-f]{6})",
           "foregroundColorText": "foreground color: ",
-          "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
         }
       }
       getCollapsibleScript={[Function]}
@@ -550,11 +546,10 @@ exports[`ReportBody renders 1`] = `
           proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "backgroundColorText": "background color: ",
-            "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "colorGroupName": "color",
-            "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+            "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "colorValueMatcher": "(#[0-9a-f]{6})",
             "foregroundColorText": "foreground color: ",
-            "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           }
         }
         getCollapsibleScript={[Function]}
@@ -672,11 +667,10 @@ exports[`ReportBody renders 1`] = `
           proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "backgroundColorText": "background color: ",
-            "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "colorGroupName": "color",
-            "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+            "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "colorValueMatcher": "(#[0-9a-f]{6})",
             "foregroundColorText": "foreground color: ",
-            "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           }
         }
         getCollapsibleScript={[Function]}
@@ -794,11 +788,10 @@ exports[`ReportBody renders 1`] = `
           proxy {
             "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
             "backgroundColorText": "background color: ",
-            "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-            "colorGroupName": "color",
-            "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+            "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "colorValueMatcher": "(#[0-9a-f]{6})",
             "foregroundColorText": "foreground color: ",
-            "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+            "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
           }
         }
         getCollapsibleScript={[Function]}
@@ -919,11 +912,10 @@ exports[`ReportBody renders 1`] = `
         proxy {
           "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
           "backgroundColorText": "background color: ",
-          "backgroundRegExp": /background color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
-          "colorGroupName": "color",
-          "colorValueMatcher": "(?<color>#[0-9a-f]{6})",
+          "backgroundRegExp": /background color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "colorValueMatcher": "(#[0-9a-f]{6})",
           "foregroundColorText": "foreground color: ",
-          "foregroundRegExp": /foreground color: \\(\\?<color>#\\[0-9a-f\\]\\{6\\}\\)/i,
+          "foregroundRegExp": /foreground color: \\(#\\[0-9a-f\\]\\{6\\}\\)/i,
         }
       }
       getCollapsibleScript={[Function]}


### PR DESCRIPTION
#### Description of changes

Firefox's `RegExp` implementation doesn't support named capture groups ([bugzilla 1362154](https://bugzilla.mozilla.org/show_bug.cgi?id=1362154)). This updates the one place we currently use them to use an index-based capture group instead. No impact on Chromium.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: part of #445
- [x] Ran `yarn fastpass`
- [n/a (existing test already covers implementation)] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
