### PR TITLE
fix(firefox-compat): avoid relative paths from background windows.create()

### DIFF
--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -63,7 +63,7 @@ export class ExtensionDetailsViewController implements DetailsViewController {
     }
 
     private getDetailsUrlWithExtensionId(tabId: number): string {
-        return `${this.browserAdapter.getRunTimeId()}/${this.getDetailsUrl(tabId)}`;
+        return `${this.browserAdapter.getRunTimeId()}${this.getDetailsUrl(tabId)}`;
     }
 
     private getTargetTabIdForDetailsTabId(detailsTabId: number): number {

--- a/src/background/extension-details-view-controller.ts
+++ b/src/background/extension-details-view-controller.ts
@@ -59,7 +59,7 @@ export class ExtensionDetailsViewController implements DetailsViewController {
     }
 
     private getDetailsUrl(tabId: number): string {
-        return `DetailsView/detailsView.html?tabId=${tabId}`;
+        return `/DetailsView/detailsView.html?tabId=${tabId}`;
     }
 
     private getDetailsUrlWithExtensionId(tabId: number): string {

--- a/src/debug-tools/controllers/debug-tools-controller.ts
+++ b/src/debug-tools/controllers/debug-tools-controller.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { BrowserAdapter } from 'common/browser-adapters/browser-adapter';
 
-export const debugToolUrl = 'debug-tools/debug-tools.html';
+export const debugToolUrl = '/debug-tools/debug-tools.html';
 
 export class DebugToolsController {
     constructor(private readonly browserAdapter: BrowserAdapter) {}

--- a/src/tests/unit/tests/background/extension-details-view-controller.test.ts
+++ b/src/tests/unit/tests/background/extension-details-view-controller.test.ts
@@ -93,7 +93,7 @@ describe('ExtensionDetailsViewController', () => {
             browserAdapterMock
                 .setup(adapter =>
                     adapter.createTabInNewWindow(
-                        'DetailsView/detailsView.html?tabId=' + targetTabId,
+                        '/DetailsView/detailsView.html?tabId=' + targetTabId,
                     ),
                 )
                 .returns(() => Promise.reject(errorMessage))
@@ -372,7 +372,7 @@ describe('ExtensionDetailsViewController', () => {
     const setupCreateDetailsView = (targetTabId: number, resultingDetailsViewTabId: number) => {
         return browserAdapterMock
             .setup(adapter =>
-                adapter.createTabInNewWindow('DetailsView/detailsView.html?tabId=' + targetTabId),
+                adapter.createTabInNewWindow('/DetailsView/detailsView.html?tabId=' + targetTabId),
             )
             .returns(() => Promise.resolve({ id: resultingDetailsViewTabId } as Tabs.Tab));
     };


### PR DESCRIPTION
#### Description of changes

Firefox and Chromium have different behavior when the webextension `windows.create()` API is invoked with a relative URL; Chromium resolves the relative URL relative to the root of the webextension, where Firefox resolves it relative to the path containing the invoking page. In practice, this means that Firefox tries to open DetailsView/debug pages as `moz-extension://extensionid/background/debug-tools/debug-tools.html` (note the extra `/background/` in there).

This resolves the firefox issue without impacting the chromium behavior by updating the cases that use relative URLs to instead use document-root-relative URLs, which both engines resolve as relative to the extension origin.

The combination of this, #2744, and #2745, and using Firefox 77 (beta) is enough to get a details view to load and mostly render in Firefox. There are still further compatibility issues out of scope for this PR (the menus in the popup view don't work, there are a few minor rendering issues in the requirements list, and all interactions with the target page seem broken)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: progress on #445
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
