### PR TITLE
fix: Command button icon color in active state

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.scss
+++ b/src/DetailsView/components/details-view-command-bar.scss
@@ -32,3 +32,14 @@
         width: 50%;
     }
 }
+
+button.command-bar-button {
+    .command-bar-button-icon {
+        line-height: 16px;
+    }
+    &:active {
+        .command-bar-button-icon {
+            color: $primary-text;
+        }
+    }
+}

--- a/src/DetailsView/components/details-view-command-bar.scss
+++ b/src/DetailsView/components/details-view-command-bar.scss
@@ -32,14 +32,3 @@
         width: 50%;
     }
 }
-
-button.command-bar-button {
-    .command-bar-button-icon {
-        line-height: 16px;
-    }
-    &:active {
-        .command-bar-button-icon {
-            color: $primary-text;
-        }
-    }
-}

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { ReportExportFormat } from 'common/extension-telemetry-events';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
-import * as styles from 'DetailsView/components/details-view-command-bar.scss';
-import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 
@@ -76,13 +75,12 @@ export class ReportExportComponent extends React.Component<
         const { isOpen, exportName, exportDescription, exportData } = this.state;
         return (
             <>
-                <ActionButton
-                    iconProps={{ iconName: 'Export', className: styles.commandBarButtonIcon }}
+                <InsightsCommandButton
+                    iconProps={{ iconName: 'Export' }}
                     onClick={this.onExportButtonClick}
-                    className={styles.commandBarButton}
                 >
                     Export result
-                </ActionButton>
+                </InsightsCommandButton>
                 <ExportDialog
                     deps={deps}
                     isOpen={isOpen}

--- a/src/DetailsView/components/report-export-component.tsx
+++ b/src/DetailsView/components/report-export-component.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { ReportExportFormat } from 'common/extension-telemetry-events';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
+import * as styles from 'DetailsView/components/details-view-command-bar.scss';
 import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
@@ -75,7 +76,11 @@ export class ReportExportComponent extends React.Component<
         const { isOpen, exportName, exportDescription, exportData } = this.state;
         return (
             <>
-                <ActionButton iconProps={{ iconName: 'Export' }} onClick={this.onExportButtonClick}>
+                <ActionButton
+                    iconProps={{ iconName: 'Export', className: styles.commandBarButtonIcon }}
+                    onClick={this.onExportButtonClick}
+                    className={styles.commandBarButton}
+                >
                     Export result
                 </ActionButton>
                 <ExportDialog

--- a/src/DetailsView/components/start-over-dropdown.tsx
+++ b/src/DetailsView/components/start-over-dropdown.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { IPoint } from '@uifabric/utilities';
-import { ActionButton } from 'office-ui-fabric-react';
 import { ContextualMenu, IContextualMenuItem } from 'office-ui-fabric-react';
 import * as React from 'react';
 
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { VisualizationType } from '../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../actions/details-view-action-message-creator';
 import { DetailsRightPanelConfiguration } from './details-view-right-panel';
@@ -43,7 +43,7 @@ export class StartOverDropdown extends React.Component<StartOverProps, StartOver
     public render(): JSX.Element {
         return (
             <div>
-                <ActionButton
+                <InsightsCommandButton
                     iconProps={{
                         iconName: 'Refresh',
                     }}

--- a/src/common/components/controls/insights-command-button.scss
+++ b/src/common/components/controls/insights-command-button.scss
@@ -3,7 +3,16 @@
 @import '../../../common/styles/colors.scss';
 
 button.insights-command-button {
+    .command-bar-button-icon {
+        line-height: 16px;
+    }
+
     &:disabled {
         color: $disabled-text;
+    }
+    &:active {
+        .command-bar-button-icon {
+            color: $primary-text;
+        }
     }
 }

--- a/src/common/components/controls/insights-command-button.scss
+++ b/src/common/components/controls/insights-command-button.scss
@@ -9,6 +9,9 @@ button.insights-command-button {
 
     &:disabled {
         color: $disabled-text;
+        .command-bar-button-icon {
+            color: $disabled-text;
+        }
     }
     &:active {
         .command-bar-button-icon {

--- a/src/common/components/controls/insights-command-button.tsx
+++ b/src/common/components/controls/insights-command-button.tsx
@@ -15,6 +15,10 @@ export const InsightsCommandButton = NamedFC<InsightsCommandButtonProps>(
             <ActionButton
                 {...props}
                 className={css(styles.insightsCommandButton, props.className)}
+                iconProps={{
+                    ...props.iconProps,
+                    className: css(styles.commandBarButtonIcon, props.iconProps?.className),
+                }}
             />
         );
     },

--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -6,13 +6,30 @@
 button.settings-gear-button {
     color: $primary-text;
 
-    .button-icon {
+    .settings-gear-button-icon {
         color: $primary-text;
         line-height: 16px;
     }
 
+    &:active {
+        .settings-gear-button-icon {
+            color: $primary-text;
+        }
+    }
+
     &:focus::after {
         outline: $secondary-text solid 1px !important;
+    }
+}
+
+button.command-bar-button {
+    .command-bar-button-icon {
+        line-height: 16px;
+    }
+    &:active {
+        .command-bar-button-icon {
+            color: $primary-text;
+        }
     }
 }
 

--- a/src/electron/views/automated-checks/components/command-bar.scss
+++ b/src/electron/views/automated-checks/components/command-bar.scss
@@ -22,17 +22,6 @@ button.settings-gear-button {
     }
 }
 
-button.command-bar-button {
-    .command-bar-button-icon {
-        line-height: 16px;
-    }
-    &:active {
-        .command-bar-button-icon {
-            color: $primary-text;
-        }
-    }
-}
-
 .command-bar {
     border-bottom: 1px solid $neutral-alpha-8;
 

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -15,10 +15,10 @@ import { ScanActionCreator } from 'electron/flux/action-creator/scan-action-crea
 import { DeviceStoreData } from 'electron/flux/types/device-store-data';
 import { ScanStatus } from 'electron/flux/types/scan-status';
 import { ScanStoreData } from 'electron/flux/types/scan-store-data';
-import { CommandButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import * as styles from './command-bar.scss';
 
 export type CommandBarDeps = {
@@ -69,13 +69,12 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
     return (
         <section className={styles.commandBar} aria-label="command bar">
             <div className={styles.items}>
-                <CommandButton
+                <InsightsCommandButton
                     data-automation-id={commandButtonRefreshId}
                     text="Start over"
-                    iconProps={{ iconName: 'Refresh', className: styles.commandBarButtonIcon }}
+                    iconProps={{ iconName: 'Refresh' }}
                     onClick={() => deps.scanActionCreator.scan(deviceStoreData.port)}
                     disabled={props.scanStoreData.status === ScanStatus.Scanning}
-                    className={styles.commandBarButton}
                 />
             </div>
             <div className={styles.farItems}>
@@ -84,7 +83,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
                     featureFlagStoreData={featureFlagStoreData}
                     featureFlag={UnifiedFeatureFlags.exportReport}
                 />
-                <CommandButton
+                <InsightsCommandButton
                     data-automation-id={commandButtonSettingsId}
                     ariaLabel="settings"
                     iconProps={{ iconName: 'Gear', className: styles.settingsGearButtonIcon }}

--- a/src/electron/views/automated-checks/components/command-bar.tsx
+++ b/src/electron/views/automated-checks/components/command-bar.tsx
@@ -72,9 +72,10 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
                 <CommandButton
                     data-automation-id={commandButtonRefreshId}
                     text="Start over"
-                    iconProps={{ iconName: 'Refresh' }}
+                    iconProps={{ iconName: 'Refresh', className: styles.commandBarButtonIcon }}
                     onClick={() => deps.scanActionCreator.scan(deviceStoreData.port)}
                     disabled={props.scanStoreData.status === ScanStatus.Scanning}
+                    className={styles.commandBarButton}
                 />
             </div>
             <div className={styles.farItems}>
@@ -86,7 +87,7 @@ export const CommandBar = NamedFC<CommandBarProps>('CommandBar', props => {
                 <CommandButton
                     data-automation-id={commandButtonSettingsId}
                     ariaLabel="settings"
-                    iconProps={{ iconName: 'Gear', className: styles.buttonIcon }}
+                    iconProps={{ iconName: 'Gear', className: styles.settingsGearButtonIcon }}
                     onClick={event =>
                         deps.dropdownClickHandler.openSettingsPanelHandler(event as any)
                     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component-factory.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component-factory.test.tsx.snap
@@ -2,18 +2,18 @@
 
 exports[`ReportExportComponentPropsFactory getReportExportComponentForAssessment expected properties are set 1`] = `
 "<Fragment>
-  <CustomizedActionButton iconProps={{...}} onClick={[Function]}>
+  <InsightsCommandButton iconProps={{...}} onClick={[Function]}>
     Export result
-  </CustomizedActionButton>
+  </InsightsCommandButton>
   <ExportDialog deps={{...}} isOpen={false} fileName=\\"\\" description=\\"\\" html=\\"\\" onClose={[Function]} onDescriptionChange={[Function]} reportExportFormat=\\"Assessment\\" onExportClick={[Function]} featureFlagStoreData={{...}} />
 </Fragment>"
 `;
 
 exports[`ReportExportComponentPropsFactory getReportExportComponentForFastPass, scanResults is not null, test is Issues, properties are set 1`] = `
 "<Fragment>
-  <CustomizedActionButton iconProps={{...}} onClick={[Function]}>
+  <InsightsCommandButton iconProps={{...}} onClick={[Function]}>
     Export result
-  </CustomizedActionButton>
+  </InsightsCommandButton>
   <ExportDialog deps={{...}} isOpen={false} fileName=\\"\\" description=\\"\\" html=\\"\\" onClose={[Function]} onDescriptionChange={[Function]} reportExportFormat=\\"AutomatedChecks\\" onExportClick={[Function]} featureFlagStoreData={{...}} />
 </Fragment>"
 `;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
@@ -3,8 +3,10 @@
 exports[`ReportExportComponentTest render 1`] = `
 <React.Fragment>
   <CustomizedActionButton
+    className="commandBarButton"
     iconProps={
       Object {
+        "className": "commandBarButtonIcon",
         "iconName": "Export",
       }
     }
@@ -43,8 +45,10 @@ exports[`ReportExportComponentTest render 1`] = `
 exports[`ReportExportComponentTest user interactions click export button: dialog should show 1`] = `
 <React.Fragment>
   <CustomizedActionButton
+    className="commandBarButton"
     iconProps={
       Object {
+        "className": "commandBarButtonIcon",
         "iconName": "Export",
       }
     }
@@ -82,8 +86,10 @@ exports[`ReportExportComponentTest user interactions click export button: dialog
 exports[`ReportExportComponentTest user interactions dismiss dialog: dialog should be dismissed 1`] = `
 <React.Fragment>
   <CustomizedActionButton
+    className="commandBarButton"
     iconProps={
       Object {
+        "className": "commandBarButtonIcon",
         "iconName": "Export",
       }
     }
@@ -121,8 +127,10 @@ exports[`ReportExportComponentTest user interactions dismiss dialog: dialog shou
 exports[`ReportExportComponentTest user interactions edit text field: test content with special characters: <> $ " \` ' 1`] = `
 <React.Fragment>
   <CustomizedActionButton
+    className="commandBarButton"
     iconProps={
       Object {
+        "className": "commandBarButtonIcon",
         "iconName": "Export",
       }
     }

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/report-export-component.test.tsx.snap
@@ -2,18 +2,16 @@
 
 exports[`ReportExportComponentTest render 1`] = `
 <React.Fragment>
-  <CustomizedActionButton
-    className="commandBarButton"
+  <InsightsCommandButton
     iconProps={
       Object {
-        "className": "commandBarButtonIcon",
         "iconName": "Export",
       }
     }
     onClick={[Function]}
   >
     Export result
-  </CustomizedActionButton>
+  </InsightsCommandButton>
   <ExportDialog
     deps={
       Object {
@@ -44,18 +42,16 @@ exports[`ReportExportComponentTest render 1`] = `
 
 exports[`ReportExportComponentTest user interactions click export button: dialog should show 1`] = `
 <React.Fragment>
-  <CustomizedActionButton
-    className="commandBarButton"
+  <InsightsCommandButton
     iconProps={
       Object {
-        "className": "commandBarButtonIcon",
         "iconName": "Export",
       }
     }
     onClick={[Function]}
   >
     Export result
-  </CustomizedActionButton>
+  </InsightsCommandButton>
   <ExportDialog
     deps={
       Object {
@@ -85,18 +81,16 @@ exports[`ReportExportComponentTest user interactions click export button: dialog
 
 exports[`ReportExportComponentTest user interactions dismiss dialog: dialog should be dismissed 1`] = `
 <React.Fragment>
-  <CustomizedActionButton
-    className="commandBarButton"
+  <InsightsCommandButton
     iconProps={
       Object {
-        "className": "commandBarButtonIcon",
         "iconName": "Export",
       }
     }
     onClick={[Function]}
   >
     Export result
-  </CustomizedActionButton>
+  </InsightsCommandButton>
   <ExportDialog
     deps={
       Object {
@@ -126,18 +120,16 @@ exports[`ReportExportComponentTest user interactions dismiss dialog: dialog shou
 
 exports[`ReportExportComponentTest user interactions edit text field: test content with special characters: <> $ " \` ' 1`] = `
 <React.Fragment>
-  <CustomizedActionButton
-    className="commandBarButton"
+  <InsightsCommandButton
     iconProps={
       Object {
-        "className": "commandBarButtonIcon",
         "iconName": "Export",
       }
     }
     onClick={[Function]}
   >
     Export result
-  </CustomizedActionButton>
+  </InsightsCommandButton>
   <ExportDialog
     deps={
       Object {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/start-over-dropdown.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`StartOverDropdownTest render 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" ariaLabel=\\"start over menu\\" onClick={[Function]} menuIconProps={{...}} />
+  <InsightsCommandButton iconProps={{...}} text=\\"Start over\\" ariaLabel=\\"start over menu\\" onClick={[Function]} menuIconProps={{...}} />
 </div>"
 `;
 
 exports[`StartOverDropdownTest render ContextualMenu 1`] = `
 <div>
-  <CustomizedActionButton
+  <InsightsCommandButton
     ariaLabel="start over menu"
     iconProps={
       Object {
@@ -46,7 +46,7 @@ exports[`StartOverDropdownTest render ContextualMenu 1`] = `
 
 exports[`StartOverDropdownTest render ContextualMenu with only one option 1`] = `
 <div>
-  <CustomizedActionButton
+  <InsightsCommandButton
     ariaLabel="start over menu"
     iconProps={
       Object {
@@ -79,7 +79,7 @@ exports[`StartOverDropdownTest render ContextualMenu with only one option 1`] = 
 
 exports[`StartOverDropdownTest render GenericDialog for start over a test 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" ariaLabel=\\"start over menu\\" onClick={[Function]} menuIconProps={{...}} />
+  <InsightsCommandButton iconProps={{...}} text=\\"Start over\\" ariaLabel=\\"start over menu\\" onClick={[Function]} menuIconProps={{...}} />
   <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} />
   <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the test name test. Are you sure you want to start over?\\" onCancelButtonClick={[Function]} onPrimaryButtonClick={[Function]} primaryButtonText=\\"Start over\\" />
 </div>"
@@ -87,7 +87,7 @@ exports[`StartOverDropdownTest render GenericDialog for start over a test 1`] = 
 
 exports[`StartOverDropdownTest render GenericDialog for start over the whole assessment 1`] = `
 "<div>
-  <CustomizedActionButton iconProps={{...}} text=\\"Start over\\" ariaLabel=\\"start over menu\\" onClick={[Function]} menuIconProps={{...}} />
+  <InsightsCommandButton iconProps={{...}} text=\\"Start over\\" ariaLabel=\\"start over menu\\" onClick={[Function]} menuIconProps={{...}} />
   <StyledWithResponsiveMode onDismiss={[Function: onDismiss]} target=\\"test target\\" items={{...}} />
   <GenericDialog title=\\"Start over\\" messageText=\\"Starting over will clear all existing results from the Assessment. This will clear results and progress of all tests and requirements. Are you sure you want to start over?\\" onCancelButtonClick={[Function]} onPrimaryButtonClick={[Function]} primaryButtonText=\\"Start over\\" />
 </div>"

--- a/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/report-export-component.test.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { ActionButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { ReportGenerator } from 'reports/report-generator';
 import { IMock, It, Mock, Times } from 'typemoq';
 
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { ExportDialog } from '../../../../../DetailsView/components/export-dialog';
 import {
     ReportExportComponent,
@@ -67,7 +67,7 @@ describe('ReportExportComponentTest', () => {
             htmlGeneratorMock.setup(hgm => hgm(It.isAnyString())).verifiable(Times.never());
 
             const wrapper = shallow(<ReportExportComponent {...props} />);
-            const exportButton = wrapper.find(ActionButton);
+            const exportButton = wrapper.find(InsightsCommandButton);
 
             exportButton.simulate('click');
             const dialog = wrapper.find(ExportDialog);
@@ -97,7 +97,7 @@ describe('ReportExportComponentTest', () => {
 
             htmlGeneratorMock.setup(hgm => hgm(It.isAnyString())).verifiable(Times.never());
 
-            const exportButton = wrapper.find(ActionButton);
+            const exportButton = wrapper.find(InsightsCommandButton);
             exportButton.simulate('click');
             const dialog = wrapper.find(ExportDialog);
             dialog.props().onClose();

--- a/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/start-over-dropdown.test.tsx
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { shallow } from 'enzyme';
-import { ActionButton } from 'office-ui-fabric-react';
 import { ContextualMenu } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { IMock, Mock, Times } from 'typemoq';
 
+import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { VisualizationType } from '../../../../../common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from '../../../../../DetailsView/actions/details-view-action-message-creator';
 import { DetailsRightPanelConfiguration } from '../../../../../DetailsView/components/details-view-right-panel';
@@ -46,7 +46,7 @@ describe('StartOverDropdownTest', () => {
 
     it('render ContextualMenu', () => {
         const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
-        rendered.find(ActionButton).simulate('click', event);
+        rendered.find(InsightsCommandButton).simulate('click', event);
         expect(rendered.getElement()).toMatchSnapshot();
         expect(rendered.state().target).toBe(event.currentTarget);
     });
@@ -56,14 +56,14 @@ describe('StartOverDropdownTest', () => {
             GetStartOverContextualMenuItemKeys: () => ['assessment'],
         } as DetailsRightPanelConfiguration;
         const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
-        rendered.find(ActionButton).simulate('click', event);
+        rendered.find(InsightsCommandButton).simulate('click', event);
         expect(rendered.getElement()).toMatchSnapshot();
         expect(rendered.state().target).toBe(event.currentTarget);
     });
 
     it('render GenericDialog for start over a test', () => {
         const rendered = shallow(<StartOverDropdown {...defaultProps} />);
-        rendered.find(ActionButton).simulate('click', event);
+        rendered.find(InsightsCommandButton).simulate('click', event);
         rendered
             .find(ContextualMenu)
             .prop('items')
@@ -74,7 +74,7 @@ describe('StartOverDropdownTest', () => {
 
     it('render GenericDialog for start over the whole assessment', () => {
         const rendered = shallow(<StartOverDropdown {...defaultProps} />);
-        rendered.find(ActionButton).simulate('click', event);
+        rendered.find(InsightsCommandButton).simulate('click', event);
         rendered
             .find(ContextualMenu)
             .prop('items')
@@ -91,7 +91,7 @@ describe('StartOverDropdownTest', () => {
             .verifiable(Times.once());
 
         const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
-        rendered.find(ActionButton).simulate('click', event);
+        rendered.find(InsightsCommandButton).simulate('click', event);
         rendered
             .find(ContextualMenu)
             .prop('items')
@@ -109,7 +109,7 @@ describe('StartOverDropdownTest', () => {
             .verifiable(Times.once());
 
         const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
-        rendered.find(ActionButton).simulate('click', event);
+        rendered.find(InsightsCommandButton).simulate('click', event);
         rendered
             .find(ContextualMenu)
             .prop('items')
@@ -127,7 +127,7 @@ describe('StartOverDropdownTest', () => {
             .verifiable(Times.once());
 
         const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
-        rendered.find(ActionButton).simulate('click', event);
+        rendered.find(InsightsCommandButton).simulate('click', event);
         rendered
             .find(ContextualMenu)
             .prop('items')
@@ -145,7 +145,7 @@ describe('StartOverDropdownTest', () => {
             .verifiable(Times.once());
 
         const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
-        rendered.find(ActionButton).simulate('click', event);
+        rendered.find(InsightsCommandButton).simulate('click', event);
         rendered
             .find(ContextualMenu)
             .prop('items')
@@ -159,7 +159,7 @@ describe('StartOverDropdownTest', () => {
 
     it('should dismiss the contextMenu', () => {
         const rendered = shallow<StartOverDropdown>(<StartOverDropdown {...defaultProps} />);
-        rendered.find(ActionButton).simulate('click', event);
+        rendered.find(InsightsCommandButton).simulate('click', event);
         rendered.find(ContextualMenu).prop('onDismiss')();
 
         expect(rendered.state().isContextMenuVisible).toBe(false);

--- a/src/tests/unit/tests/common/components/controls/__snapshots__/insights-command-button.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/controls/__snapshots__/insights-command-button.test.tsx.snap
@@ -3,12 +3,45 @@
 exports[`InsightsCommandButton renders per snapshot with extra className combined with its own 1`] = `
 <CustomizedActionButton
   className="insightsCommandButton test-extra-class-name"
+  iconProps={
+    Object {
+      "className": "commandBarButtonIcon",
+    }
+  }
+/>
+`;
+
+exports[`InsightsCommandButton renders per snapshot with extra icon className combined with its own 1`] = `
+<CustomizedActionButton
+  className="insightsCommandButton"
+  iconProps={
+    Object {
+      "className": "commandBarButtonIcon icon-class-name",
+    }
+  }
+/>
+`;
+
+exports[`InsightsCommandButton renders per snapshot with iconProps passed through 1`] = `
+<CustomizedActionButton
+  className="insightsCommandButton"
+  iconProps={
+    Object {
+      "className": "commandBarButtonIcon",
+      "testProperty": "test-value",
+    }
+  }
 />
 `;
 
 exports[`InsightsCommandButton renders per snapshot with props passed through 1`] = `
 <CustomizedActionButton
   className="insightsCommandButton"
+  iconProps={
+    Object {
+      "className": "commandBarButtonIcon",
+    }
+  }
   text="test-text"
 />
 `;

--- a/src/tests/unit/tests/common/components/controls/insights-command-button.test.tsx
+++ b/src/tests/unit/tests/common/components/controls/insights-command-button.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { InsightsCommandButton } from 'common/components/controls/insights-command-button';
 import { shallow } from 'enzyme';
+import { IIconProps } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 describe('InsightsCommandButton', () => {
@@ -12,6 +13,20 @@ describe('InsightsCommandButton', () => {
 
     it('renders per snapshot with extra className combined with its own', () => {
         const testSubject = shallow(<InsightsCommandButton className={'test-extra-class-name'} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    it('renders per snapshot with iconProps passed through', () => {
+        const iconProps = { testProperty: 'test-value' } as IIconProps;
+        const testSubject = shallow(<InsightsCommandButton iconProps={iconProps} />);
+        expect(testSubject.getElement()).toMatchSnapshot();
+    });
+
+    it('renders per snapshot with extra icon className combined with its own', () => {
+        const iconProps = {
+            className: 'icon-class-name',
+        } as IIconProps;
+        const testSubject = shallow(<InsightsCommandButton iconProps={iconProps} />);
         expect(testSubject.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -8,13 +8,11 @@ exports[`CommandBar renders does not create report export when scan metadata is 
   <div
     className="items"
   >
-    <CustomizedActionButton
-      className="commandBarButton"
+    <InsightsCommandButton
       data-automation-id="command-button-refresh"
       disabled={true}
       iconProps={
         Object {
-          "className": "commandBarButtonIcon",
           "iconName": "Refresh",
         }
       }
@@ -34,7 +32,7 @@ exports[`CommandBar renders does not create report export when scan metadata is 
         }
       }
     />
-    <CustomizedActionButton
+    <InsightsCommandButton
       ariaLabel="settings"
       className="settingsGearButton"
       data-automation-id="command-button-settings"
@@ -58,13 +56,11 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
   <div
     className="items"
   >
-    <CustomizedActionButton
-      className="commandBarButton"
+    <InsightsCommandButton
       data-automation-id="command-button-refresh"
       disabled={false}
       iconProps={
         Object {
-          "className": "commandBarButtonIcon",
           "iconName": "Refresh",
         }
       }
@@ -110,7 +106,7 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
         }
       }
     />
-    <CustomizedActionButton
+    <InsightsCommandButton
       ariaLabel="settings"
       className="settingsGearButton"
       data-automation-id="command-button-settings"
@@ -134,13 +130,11 @@ exports[`CommandBar renders while status is <Default> 1`] = `
   <div
     className="items"
   >
-    <CustomizedActionButton
-      className="commandBarButton"
+    <InsightsCommandButton
       data-automation-id="command-button-refresh"
       disabled={false}
       iconProps={
         Object {
-          "className": "commandBarButtonIcon",
           "iconName": "Refresh",
         }
       }
@@ -186,7 +180,7 @@ exports[`CommandBar renders while status is <Default> 1`] = `
         }
       }
     />
-    <CustomizedActionButton
+    <InsightsCommandButton
       ariaLabel="settings"
       className="settingsGearButton"
       data-automation-id="command-button-settings"
@@ -210,13 +204,11 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
   <div
     className="items"
   >
-    <CustomizedActionButton
-      className="commandBarButton"
+    <InsightsCommandButton
       data-automation-id="command-button-refresh"
       disabled={false}
       iconProps={
         Object {
-          "className": "commandBarButtonIcon",
           "iconName": "Refresh",
         }
       }
@@ -262,7 +254,7 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
         }
       }
     />
-    <CustomizedActionButton
+    <InsightsCommandButton
       ariaLabel="settings"
       className="settingsGearButton"
       data-automation-id="command-button-settings"
@@ -286,13 +278,11 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
   <div
     className="items"
   >
-    <CustomizedActionButton
-      className="commandBarButton"
+    <InsightsCommandButton
       data-automation-id="command-button-refresh"
       disabled={true}
       iconProps={
         Object {
-          "className": "commandBarButtonIcon",
           "iconName": "Refresh",
         }
       }
@@ -338,7 +328,7 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
         }
       }
     />
-    <CustomizedActionButton
+    <InsightsCommandButton
       ariaLabel="settings"
       className="settingsGearButton"
       data-automation-id="command-button-settings"

--- a/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/automated-checks/components/__snapshots__/command-bar.test.tsx.snap
@@ -9,10 +9,12 @@ exports[`CommandBar renders does not create report export when scan metadata is 
     className="items"
   >
     <CustomizedActionButton
+      className="commandBarButton"
       data-automation-id="command-button-refresh"
       disabled={true}
       iconProps={
         Object {
+          "className": "commandBarButtonIcon",
           "iconName": "Refresh",
         }
       }
@@ -38,7 +40,7 @@ exports[`CommandBar renders does not create report export when scan metadata is 
       data-automation-id="command-button-settings"
       iconProps={
         Object {
-          "className": "buttonIcon",
+          "className": "settingsGearButtonIcon",
           "iconName": "Gear",
         }
       }
@@ -57,10 +59,12 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
     className="items"
   >
     <CustomizedActionButton
+      className="commandBarButton"
       data-automation-id="command-button-refresh"
       disabled={false}
       iconProps={
         Object {
+          "className": "commandBarButtonIcon",
           "iconName": "Refresh",
         }
       }
@@ -112,7 +116,7 @@ exports[`CommandBar renders while status is <Completed> 1`] = `
       data-automation-id="command-button-settings"
       iconProps={
         Object {
-          "className": "buttonIcon",
+          "className": "settingsGearButtonIcon",
           "iconName": "Gear",
         }
       }
@@ -131,10 +135,12 @@ exports[`CommandBar renders while status is <Default> 1`] = `
     className="items"
   >
     <CustomizedActionButton
+      className="commandBarButton"
       data-automation-id="command-button-refresh"
       disabled={false}
       iconProps={
         Object {
+          "className": "commandBarButtonIcon",
           "iconName": "Refresh",
         }
       }
@@ -186,7 +192,7 @@ exports[`CommandBar renders while status is <Default> 1`] = `
       data-automation-id="command-button-settings"
       iconProps={
         Object {
-          "className": "buttonIcon",
+          "className": "settingsGearButtonIcon",
           "iconName": "Gear",
         }
       }
@@ -205,10 +211,12 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
     className="items"
   >
     <CustomizedActionButton
+      className="commandBarButton"
       data-automation-id="command-button-refresh"
       disabled={false}
       iconProps={
         Object {
+          "className": "commandBarButtonIcon",
           "iconName": "Refresh",
         }
       }
@@ -260,7 +268,7 @@ exports[`CommandBar renders while status is <Failed> 1`] = `
       data-automation-id="command-button-settings"
       iconProps={
         Object {
-          "className": "buttonIcon",
+          "className": "settingsGearButtonIcon",
           "iconName": "Gear",
         }
       }
@@ -279,10 +287,12 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
     className="items"
   >
     <CustomizedActionButton
+      className="commandBarButton"
       data-automation-id="command-button-refresh"
       disabled={true}
       iconProps={
         Object {
+          "className": "commandBarButtonIcon",
           "iconName": "Refresh",
         }
       }
@@ -334,7 +344,7 @@ exports[`CommandBar renders while status is <Scanning> 1`] = `
       data-automation-id="command-button-settings"
       iconProps={
         Object {
-          "className": "buttonIcon",
+          "className": "settingsGearButtonIcon",
           "iconName": "Gear",
         }
       }


### PR DESCRIPTION
#### Description of changes

Currently, when a button in the command bar is in the active state, the button text is the primary text color, and the icon is very dark blue. Usually the text and icon colors are very close, but in high contrast mode, the icon color does not have sufficient contrast with the background:
<img width="76" alt="button active" src="https://user-images.githubusercontent.com/55459788/82715086-66872c80-9c46-11ea-84e1-2becb7598677.PNG">
<img width="80" alt="button active high contrast" src="https://user-images.githubusercontent.com/55459788/82714909-b1547480-9c45-11ea-944a-ff4900fb5307.PNG">

Changes in this pr:
- For InsightsCommandButton, change the icon style in active state to match text color (for all command bar buttons in web and electron)
- Consistently use InsightsCommandButton instead of Action Button in the command bar (this also adds the same high contrast mode styling to electron that we have in web for the start over button while the scan is in progress)

Active start over button with new styling:
<img width="80" alt="button active new" src="https://user-images.githubusercontent.com/55459788/82715263-22e0f280-9c47-11ea-877a-e634efe8990a.PNG">
<img width="80" alt="button active high contrast new" src="https://user-images.githubusercontent.com/55459788/82715267-27a5a680-9c47-11ea-91c9-59cd527a6b87.PNG">
This doesn't change the default or hover states.



#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: fixes #2736
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
