### PR TITLE
feat(nav-bar-functionality): create side nav

### DIFF
--- a/src/DetailsView/components/left-nav/fluent-side-nav.scss
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.scss
@@ -5,11 +5,8 @@
 #side-nav-container {
     .left-nav-panel {
         margin-top: $detailsViewHeaderBarHeight;
-        .left-nav {
-            height: calc(100vh - $detailsViewHeaderBarHeight) !important;
+        :global(.ms-Panel-content) {
+            padding: 0px;
         }
-    }
-    :global(.ms-Panel-content) {
-        padding: 0px;
     }
 }

--- a/src/DetailsView/components/left-nav/fluent-side-nav.scss
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.scss
@@ -5,6 +5,9 @@
 #side-nav-container {
     .left-nav-panel {
         margin-top: $detailsViewHeaderBarHeight;
+        :global(.ms-Panel-main) {
+            width: $detailsViewReflowLeftNavWidth;
+        }
         :global(.ms-Panel-content) {
             padding: 0px;
         }

--- a/src/DetailsView/components/left-nav/fluent-side-nav.scss
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.scss
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../common/styles/common.scss';
+
+#side-nav-container {
+    .left-nav-panel {
+        margin-top: $detailsViewHeaderBarHeight;
+        .left-nav {
+            height: calc(100vh - $detailsViewHeaderBarHeight) !important;
+        }
+    }
+    :global(.ms-Panel-content) {
+        padding: 0px;
+    }
+}

--- a/src/DetailsView/components/left-nav/fluent-side-nav.tsx
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
+import { GenericPanel } from 'DetailsView/components/generic-panel';
+import {
+    DetailsViewLeftNav,
+    DetailsViewLeftNavDeps,
+    DetailsViewLeftNavProps,
+} from 'DetailsView/components/left-nav/details-view-left-nav';
+import * as styles from 'DetailsView/components/left-nav/fluent-side-nav.scss';
+import { PanelType } from 'office-ui-fabric-react';
+import * as React from 'react';
+
+export type FluentSideNavDeps = DetailsViewLeftNavDeps;
+export type FluentSideNavProps = DetailsViewLeftNavProps & {
+    tabStoreData: TabStoreData;
+    visualizationStoreData: VisualizationStoreData;
+};
+
+export class FluentSideNav extends React.Component<FluentSideNavProps> {
+    public render(): JSX.Element {
+        const tabClosed = this.props.tabStoreData.isClosed;
+
+        if (tabClosed) {
+            return null;
+        }
+        const nav = <DetailsViewLeftNav {...this.props} />;
+
+        const navPanel = (
+            <GenericPanel
+                className={styles.leftNavPanel}
+                isOpen={false}
+                isLightDismiss
+                hasCloseButton={false}
+                onRenderNavigationContent={() => null}
+                onRenderHeader={() => null}
+                onRenderNavigation={() => null}
+                isHiddenOnDismiss={true}
+                type={PanelType.customNear}
+                layerProps={{
+                    hostId: styles.sideNavContainer,
+                }}
+                customWidth={'240px'}
+            >
+                {nav}
+            </GenericPanel>
+        );
+
+        return (
+            <div id={styles.sideNavContainer}>
+                {nav}
+                {navPanel}
+            </div>
+        );
+    }
+}

--- a/src/DetailsView/components/left-nav/fluent-side-nav.tsx
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
-import { VisualizationStoreData } from 'common/types/store-data/visualization-store-data';
 import { GenericPanel } from 'DetailsView/components/generic-panel';
 import {
     DetailsViewLeftNav,
@@ -29,7 +28,7 @@ export class FluentSideNav extends React.Component<FluentSideNavProps> {
         const navPanel = (
             <GenericPanel
                 className={styles.leftNavPanel}
-                isOpen={false}
+                isOpen={true}
                 isLightDismiss
                 hasCloseButton={false}
                 onRenderNavigationContent={() => null}

--- a/src/DetailsView/components/left-nav/fluent-side-nav.tsx
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.tsx
@@ -15,7 +15,6 @@ import * as React from 'react';
 export type FluentSideNavDeps = DetailsViewLeftNavDeps;
 export type FluentSideNavProps = DetailsViewLeftNavProps & {
     tabStoreData: TabStoreData;
-    visualizationStoreData: VisualizationStoreData;
 };
 
 export class FluentSideNav extends React.Component<FluentSideNavProps> {

--- a/src/DetailsView/components/left-nav/fluent-side-nav.tsx
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.tsx
@@ -34,7 +34,6 @@ export class FluentSideNav extends React.Component<FluentSideNavProps> {
                 onRenderNavigationContent={() => null}
                 onRenderHeader={() => null}
                 onRenderNavigation={() => null}
-                isHiddenOnDismiss={true}
                 type={PanelType.customNear}
                 layerProps={{
                     hostId: styles.sideNavContainer,

--- a/src/DetailsView/components/left-nav/fluent-side-nav.tsx
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.tsx
@@ -28,7 +28,7 @@ export class FluentSideNav extends React.Component<FluentSideNavProps> {
         const navPanel = (
             <GenericPanel
                 className={styles.leftNavPanel}
-                isOpen={true}
+                isOpen={false}
                 isLightDismiss
                 hasCloseButton={false}
                 onRenderNavigationContent={() => null}
@@ -39,7 +39,6 @@ export class FluentSideNav extends React.Component<FluentSideNavProps> {
                 layerProps={{
                     hostId: styles.sideNavContainer,
                 }}
-                customWidth={'240px'}
             >
                 {nav}
             </GenericPanel>

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -74,7 +74,7 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
         return (
             <div className="details-view-body">
                 {this.renderCommandBar()}
-                <div className={bodyLayoutClassname} id="details-view-body-nav-content-layout">
+                <div className={bodyLayoutClassname}>
                     {this.renderNavBar()}
                     <div className="details-view-body-content-pane">
                         {this.getTargetPageHiddenBar()}

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -7,6 +7,7 @@ import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
+import { FluentSideNav } from 'DetailsView/components/left-nav/fluent-side-nav';
 import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';
 
@@ -28,10 +29,7 @@ import {
 } from './components/details-view-right-panel';
 import { DetailsViewSwitcherNavConfiguration } from './components/details-view-switcher-nav';
 import { IssuesTableHandler } from './components/issues-table-handler';
-import {
-    DetailsViewLeftNav,
-    DetailsViewLeftNavDeps,
-} from './components/left-nav/details-view-left-nav';
+import { DetailsViewLeftNavDeps } from './components/left-nav/details-view-left-nav';
 import { TargetPageHiddenBar } from './components/target-page-hidden-bar';
 import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-table-handler';
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
@@ -76,7 +74,7 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
         return (
             <div className="details-view-body">
                 {this.renderCommandBar()}
-                <div className={bodyLayoutClassname}>
+                <div className={bodyLayoutClassname} id="details-view-body-nav-content-layout">
                     {this.renderNavBar()}
                     <div className="details-view-body-content-pane">
                         {this.getTargetPageHiddenBar()}
@@ -100,14 +98,8 @@ export class DetailsViewBody extends React.Component<DetailsViewBodyProps> {
     }
 
     private renderNavBar(): JSX.Element {
-        const tabClosed = this.props.tabStoreData.isClosed;
-
-        if (tabClosed) {
-            return null;
-        }
-
         return (
-            <DetailsViewLeftNav
+            <FluentSideNav
                 selectedPivot={this.props.visualizationStoreData?.selectedDetailsViewPivot}
                 {...this.props}
             />

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/fluent-side-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/fluent-side-nav.test.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FluentSideNav render null if tab is closed 1`] = `null`;
+
+exports[`FluentSideNav render side nav 1`] = `
+<div
+  id="sideNavContainer"
+>
+  <DetailsViewLeftNav
+    selectedPivot={0}
+    tabStoreData={
+      Object {
+        "isClosed": false,
+      }
+    }
+  />
+  <GenericPanel
+    className="leftNavPanel"
+    customWidth="240px"
+    hasCloseButton={false}
+    isHiddenOnDismiss={true}
+    isLightDismiss={true}
+    isOpen={false}
+    layerProps={
+      Object {
+        "hostId": "sideNavContainer",
+      }
+    }
+    onRenderHeader={[Function]}
+    onRenderNavigation={[Function]}
+    onRenderNavigationContent={[Function]}
+    type={8}
+  >
+    <DetailsViewLeftNav
+      selectedPivot={0}
+      tabStoreData={
+        Object {
+          "isClosed": false,
+        }
+      }
+    />
+  </GenericPanel>
+</div>
+`;

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/fluent-side-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/fluent-side-nav.test.tsx.snap
@@ -16,7 +16,6 @@ exports[`FluentSideNav render side nav 1`] = `
   />
   <GenericPanel
     className="leftNavPanel"
-    customWidth="240px"
     hasCloseButton={false}
     isHiddenOnDismiss={true}
     isLightDismiss={true}

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/fluent-side-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/fluent-side-nav.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`FluentSideNav render side nav 1`] = `
   <GenericPanel
     className="leftNavPanel"
     hasCloseButton={false}
-    isHiddenOnDismiss={true}
     isLightDismiss={true}
     isOpen={false}
     layerProps={

--- a/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { TabStoreData } from 'common/types/store-data/tab-store-data';
+import { FluentSideNav, FluentSideNavProps } from 'DetailsView/components/left-nav/fluent-side-nav';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe(FluentSideNav, () => {
+    let tabStoreData: TabStoreData;
+
+    beforeEach(() => {});
+
+    test('render null if tab is closed', () => {
+        tabStoreData = {
+            isClosed: true,
+        } as TabStoreData;
+
+        const props: FluentSideNavProps = {
+            tabStoreData,
+        } as FluentSideNavProps;
+
+        const wrapper = shallow(
+            <FluentSideNav selectedPivot={DetailsViewPivotType.fastPass} {...props} />,
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+
+    test('render side nav', () => {
+        tabStoreData = {
+            isClosed: false,
+        } as TabStoreData;
+
+        const props: FluentSideNavProps = {
+            tabStoreData,
+        } as FluentSideNavProps;
+
+        const wrapper = shallow(
+            <FluentSideNav selectedPivot={DetailsViewPivotType.fastPass} {...props} />,
+        );
+
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
@@ -9,8 +9,6 @@ import * as React from 'react';
 describe(FluentSideNav, () => {
     let tabStoreData: TabStoreData;
 
-    beforeEach(() => {});
-
     test('render null if tab is closed', () => {
         tabStoreData = {
             isClosed: true,

--- a/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-body.test.tsx
@@ -1,14 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import * as React from 'react';
-import { IMock, Mock, MockBehavior } from 'typemoq';
-
 import { getDefaultFeatureFlagsWeb } from 'common/feature-flags';
 import { ScanMetadata, TargetAppData } from 'common/types/store-data/unified-data-interface';
 import {
     DetailsViewCommandBarDeps,
     DetailsViewCommandBarProps,
 } from 'DetailsView/components/details-view-command-bar';
+import { FluentSideNav } from 'DetailsView/components/left-nav/fluent-side-nav';
+import * as React from 'react';
+import { IMock, Mock, MockBehavior } from 'typemoq';
+
 import { VisualizationConfiguration } from '../../../../common/configs/visualization-configuration';
 import { VisualizationConfigurationFactory } from '../../../../common/configs/visualization-configuration-factory';
 import { NamedFC, ReactFCWithDisplayName } from '../../../../common/react/named-fc';
@@ -33,7 +34,6 @@ import {
     DetailsViewSwitcherNavConfiguration,
     LeftNavProps,
 } from '../../../../DetailsView/components/details-view-switcher-nav';
-import { DetailsViewLeftNav } from '../../../../DetailsView/components/left-nav/details-view-left-nav';
 import { TargetPageHiddenBar } from '../../../../DetailsView/components/target-page-hidden-bar';
 import { DetailsViewBody, DetailsViewBodyProps } from '../../../../DetailsView/details-view-body';
 import { DetailsViewToggleClickHandlerFactory } from '../../../../DetailsView/handlers/details-view-toggle-click-handler-factory';
@@ -212,7 +212,7 @@ describe('DetailsViewBody', () => {
 
     function buildLeftNav(givenProps: DetailsViewBodyProps): JSX.Element {
         return (
-            <DetailsViewLeftNav
+            <FluentSideNav
                 selectedPivot={givenProps.visualizationStoreData.selectedDetailsViewPivot}
                 {...givenProps}
             />


### PR DESCRIPTION
#### Description of changes
Adding the left panel that contains the nav component. (It is not wired up yet).
The same nav component will have two instances in the dom, and the media query will control which one to show.
Screenshot: 
![image](https://user-images.githubusercontent.com/15974344/83205717-320ee700-a104-11ea-8ace-edaeeff4d1f3.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
