### PR TITLE
feat(nav-bar-functionality): Store expanded nav state in AssessmentStore and toggle nav link expansion state

### DIFF
--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -10,6 +10,7 @@ import {
     ChangeInstanceStatusPayload,
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
+    ExpandOrCollapseTestNavPayload,
     OnDetailsViewOpenPayload,
     OnDetailsViewPivotSelected,
     RemoveFailureInstancePayload,
@@ -199,7 +200,14 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         event: React.MouseEvent<HTMLElement>,
         visualizationType: VisualizationType,
     ): void {
-        // TODO: write this
+        const payload: ExpandOrCollapseTestNavPayload = {
+            selectedTest: visualizationType,
+        };
+
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.ExpandOrCollapseTestNav,
+            payload: payload,
+        });
     }
 
     public sendPivotItemClicked(pivotKey: string, ev?: React.MouseEvent<HTMLElement>): void {

--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -10,7 +10,7 @@ import {
     ChangeInstanceStatusPayload,
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
-    ExpandOrCollapseTestNavPayload,
+    ExpandTestNavPayload,
     OnDetailsViewOpenPayload,
     OnDetailsViewPivotSelected,
     RemoveFailureInstancePayload,
@@ -196,16 +196,16 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
-    public expandOrCollapseTestNav(
+    public expandTestNav(
         event: React.MouseEvent<HTMLElement>,
         visualizationType: VisualizationType,
     ): void {
-        const payload: ExpandOrCollapseTestNavPayload = {
+        const payload: ExpandTestNavPayload = {
             selectedTest: visualizationType,
         };
 
         this.dispatcher.dispatchMessage({
-            messageType: Messages.Assessment.ExpandOrCollapseTestNav,
+            messageType: Messages.Assessment.ExpandTestNav,
             payload: payload,
         });
     }

--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -196,10 +196,7 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
-    public expandTestNav(
-        event: React.MouseEvent<HTMLElement>,
-        visualizationType: VisualizationType,
-    ): void {
+    public expandTestNav(visualizationType: VisualizationType): void {
         const payload: ExpandTestNavPayload = {
             selectedTest: visualizationType,
         };
@@ -207,6 +204,12 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         this.dispatcher.dispatchMessage({
             messageType: Messages.Assessment.ExpandTestNav,
             payload: payload,
+        });
+    }
+
+    public collapseTestNav(): void {
+        this.dispatcher.dispatchMessage({
+            messageType: Messages.Assessment.CollapseTestNav,
         });
     }
 

--- a/src/DetailsView/actions/details-view-action-message-creator.ts
+++ b/src/DetailsView/actions/details-view-action-message-creator.ts
@@ -195,6 +195,13 @@ export class DetailsViewActionMessageCreator extends DevToolActionMessageCreator
         });
     }
 
+    public expandOrCollapseTestNav(
+        event: React.MouseEvent<HTMLElement>,
+        visualizationType: VisualizationType,
+    ): void {
+        // TODO: write this
+    }
+
     public sendPivotItemClicked(pivotKey: string, ev?: React.MouseEvent<HTMLElement>): void {
         const telemetry = this.telemetryFactory.forDetailsViewNavPivotActivated(ev, pivotKey);
 

--- a/src/DetailsView/components/left-nav/assessment-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/assessment-left-nav.tsx
@@ -34,6 +34,11 @@ export type AssessmentLeftNavLink = {
     status: ManualTestStatus;
 } & BaseLeftNavLink;
 
+export type ReflowAssessmentLeftNavLink = {
+    testType: VisualizationType;
+    status: ManualTestStatus;
+} & BaseLeftNavLink;
+
 export type TestGettingStartedNavLink = {
     testType: VisualizationType;
 } & BaseLeftNavLink;

--- a/src/DetailsView/components/left-nav/assessment-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/assessment-left-nav.tsx
@@ -28,6 +28,7 @@ export type AssessmentLeftNavProps = {
     assessmentsProvider: AssessmentsProvider;
     assessmentsData: DictionaryStringTo<ManualTestStatusData>;
     featureFlagStoreData: FeatureFlagStoreData;
+    expandedTest: VisualizationType | undefined;
 };
 
 export type AssessmentLeftNavLink = {
@@ -60,7 +61,14 @@ export type onTestGettingStartedClick = (
 ) => void;
 
 export const AssessmentLeftNav = NamedFC<AssessmentLeftNavProps>('AssessmentLeftNav', props => {
-    const { deps, selectedKey, assessmentsProvider, assessmentsData, featureFlagStoreData } = props;
+    const {
+        deps,
+        selectedKey,
+        assessmentsProvider,
+        assessmentsData,
+        featureFlagStoreData,
+        expandedTest,
+    } = props;
 
     const { navLinkHandler, leftNavLinkBuilder } = deps;
 
@@ -82,6 +90,7 @@ export const AssessmentLeftNav = NamedFC<AssessmentLeftNavProps>('AssessmentLeft
                 assessmentsProvider,
                 assessmentsData,
                 1,
+                expandedTest,
             ),
         );
     } else {

--- a/src/DetailsView/components/left-nav/details-view-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.tsx
@@ -86,6 +86,7 @@ export const DetailsViewLeftNav = NamedFC<DetailsViewLeftNavProps>('DetailsViewL
                     data => data.testStepStatus,
                 )}
                 featureFlagStoreData={featureFlagStoreData}
+                expandedTest={assessmentStoreData.assessmentNavState.expandedTestType}
             />
         </div>
     );

--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -7,6 +7,7 @@ import { gettingStartedSubview } from 'common/types/store-data/assessment-result
 import {
     onTestGettingStartedClick,
     onTestRequirementClick,
+    ReflowAssessmentLeftNavLink,
     TestGettingStartedNavLink,
     TestRequirementLeftNavLink,
 } from 'DetailsView/components/left-nav/assessment-left-nav';
@@ -155,7 +156,7 @@ export class LeftNavLinkBuilder {
         assessment: Assessment,
         index: number,
         assessmentsData: DictionaryStringTo<ManualTestStatusData>,
-    ) => {
+    ): ReflowAssessmentLeftNavLink => {
         const {
             getStatusForTest,
             outcomeTypeSemanticsFromTestStatus,
@@ -175,7 +176,7 @@ export class LeftNavLinkBuilder {
             VisualizationType[assessment.visualizationType],
             index,
             navLinkRenderer.renderAssessmentTestLink,
-            () => {},
+            navLinkHandler.onTestHeadingClick,
         );
 
         const gettingStartedLink = this.buildGettingStartedLink(
@@ -203,6 +204,7 @@ export class LeftNavLinkBuilder {
             title: `${index}: ${name} (${narratorTestStatus})`,
             links: [gettingStartedLink, ...requirementLinks],
             isExpanded: true,
+            testType: assessment.visualizationType,
         };
 
         return testLink;

--- a/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
+++ b/src/DetailsView/components/left-nav/left-nav-link-builder.tsx
@@ -138,12 +138,20 @@ export class LeftNavLinkBuilder {
         assessmentsProvider: AssessmentsProvider,
         assessmentsData: DictionaryStringTo<ManualTestStatusData>,
         startingIndex: number,
+        expandedTest: VisualizationType | undefined,
     ): BaseLeftNavLink[] {
         const assessments = assessmentsProvider.all();
         let index = startingIndex;
 
         const allTestLinks = map(assessments, assessment => {
-            const test = this.buildAssessmentLink(deps, assessment, index, assessmentsData);
+            const isExpanded = assessment.visualizationType === expandedTest;
+            const test = this.buildAssessmentLink(
+                deps,
+                assessment,
+                index,
+                assessmentsData,
+                isExpanded,
+            );
             index++;
             return test;
         });
@@ -156,6 +164,7 @@ export class LeftNavLinkBuilder {
         assessment: Assessment,
         index: number,
         assessmentsData: DictionaryStringTo<ManualTestStatusData>,
+        isExpanded: boolean,
     ): ReflowAssessmentLeftNavLink => {
         const {
             getStatusForTest,
@@ -203,7 +212,7 @@ export class LeftNavLinkBuilder {
             status,
             title: `${index}: ${name} (${narratorTestStatus})`,
             links: [gettingStartedLink, ...requirementLinks],
-            isExpanded: true,
+            isExpanded: isExpanded,
             testType: assessment.visualizationType,
         };
 

--- a/src/DetailsView/components/left-nav/nav-link-handler.ts
+++ b/src/DetailsView/components/left-nav/nav-link-handler.ts
@@ -62,6 +62,6 @@ export class NavLinkHandler {
         event: React.MouseEvent<HTMLElement>,
         item: ReflowAssessmentLeftNavLink,
     ) => {
-        this.detailsViewActionMessageCreator.expandOrCollapseTestNav(event, item.testType);
+        this.detailsViewActionMessageCreator.expandTestNav(event, item.testType);
     };
 }

--- a/src/DetailsView/components/left-nav/nav-link-handler.ts
+++ b/src/DetailsView/components/left-nav/nav-link-handler.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import {
+    ReflowAssessmentLeftNavLink,
     TestGettingStartedNavLink,
     TestRequirementLeftNavLink,
 } from 'DetailsView/components/left-nav/assessment-left-nav';
@@ -55,5 +56,12 @@ export class NavLinkHandler {
     ) => {
         this.detailsViewActionMessageCreator.selectGettingStarted(event, item.testType);
         this.detailsViewActionMessageCreator.changeRightContentPanel('TestView');
+    };
+
+    public onTestHeadingClick = (
+        event: React.MouseEvent<HTMLElement>,
+        item: ReflowAssessmentLeftNavLink,
+    ) => {
+        this.detailsViewActionMessageCreator.expandOrCollapseTestNav(event, item.testType);
     };
 }

--- a/src/DetailsView/components/left-nav/nav-link-handler.ts
+++ b/src/DetailsView/components/left-nav/nav-link-handler.ts
@@ -62,6 +62,10 @@ export class NavLinkHandler {
         event: React.MouseEvent<HTMLElement>,
         item: ReflowAssessmentLeftNavLink,
     ) => {
-        this.detailsViewActionMessageCreator.expandTestNav(event, item.testType);
+        if (item.isExpanded) {
+            this.detailsViewActionMessageCreator.collapseTestNav();
+        } else {
+            this.detailsViewActionMessageCreator.expandTestNav(item.testType);
+        }
     };
 }

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -38,7 +38,7 @@ export interface SelectGettingStartedPayload extends BaseActionPayload {
     selectedTest: VisualizationType;
 }
 
-export interface ExpandOrCollapseTestNavPayload extends BaseActionPayload {
+export interface ExpandTestNavPayload extends BaseActionPayload {
     selectedTest: VisualizationType;
 }
 

--- a/src/background/actions/action-payloads.ts
+++ b/src/background/actions/action-payloads.ts
@@ -38,6 +38,10 @@ export interface SelectGettingStartedPayload extends BaseActionPayload {
     selectedTest: VisualizationType;
 }
 
+export interface ExpandOrCollapseTestNavPayload extends BaseActionPayload {
+    selectedTest: VisualizationType;
+}
+
 export interface AssessmentToggleActionPayload extends ToggleActionPayload {
     requirement: string;
 }

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -21,7 +21,7 @@ import {
     ChangeInstanceStatusPayload,
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
-    ExpandOrCollapseTestNavPayload,
+    ExpandTestNavPayload,
     OnDetailsViewOpenPayload,
     RemoveFailureInstancePayload,
     SelectGettingStartedPayload,
@@ -49,8 +49,8 @@ export class AssessmentActionCreator {
             this.onSelectGettingStarted,
         );
         this.interpreter.registerTypeToPayloadCallback(
-            AssessmentMessages.ExpandOrCollapseTestNav,
-            this.onExpandOrCollapseTestNav,
+            AssessmentMessages.ExpandTestNav,
+            this.onExpandTestNav,
         );
         this.interpreter.registerTypeToPayloadCallback(
             getStoreStateMessage(StoreNames.AssessmentStore),
@@ -251,8 +251,8 @@ export class AssessmentActionCreator {
         );
     };
 
-    private onExpandOrCollapseTestNav = (payload: ExpandOrCollapseTestNavPayload): void => {
-        this.assessmentActions.expandOrCollapseTestNav.invoke(payload);
+    private onExpandTestNav = (payload: ExpandTestNavPayload): void => {
+        this.assessmentActions.expandTestNav.invoke(payload);
     };
 
     private onScanUpdate = (payload: ScanUpdatePayload): void => {

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -53,6 +53,10 @@ export class AssessmentActionCreator {
             this.onExpandTestNav,
         );
         this.interpreter.registerTypeToPayloadCallback(
+            AssessmentMessages.CollapseTestNav,
+            this.onCollapseTestNav,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
             getStoreStateMessage(StoreNames.AssessmentStore),
             this.onGetAssessmentCurrentState,
         );
@@ -252,7 +256,11 @@ export class AssessmentActionCreator {
     };
 
     private onExpandTestNav = (payload: ExpandTestNavPayload): void => {
-        this.assessmentActions.expandTestNav.invoke(payload);
+        this.assessmentActions.setExpandedTestNav.invoke(payload);
+    };
+
+    private onCollapseTestNav = (): void => {
+        this.assessmentActions.setExpandedTestNav.invoke({ selectedTest: null });
     };
 
     private onScanUpdate = (payload: ScanUpdatePayload): void => {

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -21,6 +21,7 @@ import {
     ChangeInstanceStatusPayload,
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
+    ExpandOrCollapseTestNavPayload,
     OnDetailsViewOpenPayload,
     RemoveFailureInstancePayload,
     SelectGettingStartedPayload,
@@ -46,6 +47,10 @@ export class AssessmentActionCreator {
         this.interpreter.registerTypeToPayloadCallback(
             AssessmentMessages.SelectGettingStarted,
             this.onSelectGettingStarted,
+        );
+        this.interpreter.registerTypeToPayloadCallback(
+            AssessmentMessages.ExpandOrCollapseTestNav,
+            this.onExpandOrCollapseTestNav,
         );
         this.interpreter.registerTypeToPayloadCallback(
             getStoreStateMessage(StoreNames.AssessmentStore),
@@ -244,6 +249,10 @@ export class AssessmentActionCreator {
             TelemetryEvents.SELECT_GETTING_STARTED,
             payload,
         );
+    };
+
+    private onExpandOrCollapseTestNav = (payload: ExpandOrCollapseTestNavPayload): void => {
+        this.assessmentActions.expandOrCollapseTestNav.invoke(payload);
     };
 
     private onScanUpdate = (payload: ScanUpdatePayload): void => {

--- a/src/background/actions/assessment-action-creator.ts
+++ b/src/background/actions/assessment-action-creator.ts
@@ -256,11 +256,11 @@ export class AssessmentActionCreator {
     };
 
     private onExpandTestNav = (payload: ExpandTestNavPayload): void => {
-        this.assessmentActions.setExpandedTestNav.invoke(payload);
+        this.assessmentActions.expandTestNav.invoke(payload);
     };
 
     private onCollapseTestNav = (): void => {
-        this.assessmentActions.setExpandedTestNav.invoke({ selectedTest: null });
+        this.assessmentActions.collapseTestNav.invoke(null);
     };
 
     private onScanUpdate = (payload: ScanUpdatePayload): void => {

--- a/src/background/actions/assessment-actions.ts
+++ b/src/background/actions/assessment-actions.ts
@@ -14,7 +14,7 @@ import {
     ChangeInstanceStatusPayload,
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
-    ExpandOrCollapseTestNavPayload,
+    ExpandTestNavPayload,
     RemoveFailureInstancePayload,
     SelectTestSubviewPayload,
     ToggleActionPayload,
@@ -23,7 +23,7 @@ import {
 
 export class AssessmentActions {
     public readonly selectTestSubview = new Action<SelectTestSubviewPayload>();
-    public readonly expandOrCollapseTestNav = new Action<ExpandOrCollapseTestNavPayload>();
+    public readonly expandTestNav = new Action<ExpandTestNavPayload>();
     public readonly changeInstanceStatus = new Action<ChangeInstanceStatusPayload>();
     public readonly changeRequirementStatus = new Action<ChangeRequirementStatusPayload>();
     public readonly addFailureInstance = new Action<AddFailureInstancePayload>();

--- a/src/background/actions/assessment-actions.ts
+++ b/src/background/actions/assessment-actions.ts
@@ -23,7 +23,8 @@ import {
 
 export class AssessmentActions {
     public readonly selectTestSubview = new Action<SelectTestSubviewPayload>();
-    public readonly setExpandedTestNav = new Action<ExpandTestNavPayload>();
+    public readonly expandTestNav = new Action<ExpandTestNavPayload>();
+    public readonly collapseTestNav = new Action<null>();
     public readonly changeInstanceStatus = new Action<ChangeInstanceStatusPayload>();
     public readonly changeRequirementStatus = new Action<ChangeRequirementStatusPayload>();
     public readonly addFailureInstance = new Action<AddFailureInstancePayload>();

--- a/src/background/actions/assessment-actions.ts
+++ b/src/background/actions/assessment-actions.ts
@@ -14,6 +14,7 @@ import {
     ChangeInstanceStatusPayload,
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
+    ExpandOrCollapseTestNavPayload,
     RemoveFailureInstancePayload,
     SelectTestSubviewPayload,
     ToggleActionPayload,
@@ -22,6 +23,7 @@ import {
 
 export class AssessmentActions {
     public readonly selectTestSubview = new Action<SelectTestSubviewPayload>();
+    public readonly expandOrCollapseTestNav = new Action<ExpandOrCollapseTestNavPayload>();
     public readonly changeInstanceStatus = new Action<ChangeInstanceStatusPayload>();
     public readonly changeRequirementStatus = new Action<ChangeRequirementStatusPayload>();
     public readonly addFailureInstance = new Action<AddFailureInstancePayload>();

--- a/src/background/actions/assessment-actions.ts
+++ b/src/background/actions/assessment-actions.ts
@@ -23,7 +23,7 @@ import {
 
 export class AssessmentActions {
     public readonly selectTestSubview = new Action<SelectTestSubviewPayload>();
-    public readonly expandTestNav = new Action<ExpandTestNavPayload>();
+    public readonly setExpandedTestNav = new Action<ExpandTestNavPayload>();
     public readonly changeInstanceStatus = new Action<ChangeInstanceStatusPayload>();
     public readonly changeRequirementStatus = new Action<ChangeRequirementStatusPayload>();
     public readonly addFailureInstance = new Action<AddFailureInstancePayload>();

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -25,7 +25,7 @@ import { forEach, isEmpty, pickBy } from 'lodash';
 import { DictionaryStringTo } from 'types/common-types';
 import {
     AddResultDescriptionPayload,
-    ExpandOrCollapseTestNavPayload,
+    ExpandTestNavPayload,
     SelectTestSubviewPayload,
 } from '../actions/action-payloads';
 import { AssessmentDataConverter } from '../assessment-data-converter';
@@ -112,7 +112,7 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.assessmentActions.resetData.addListener(this.onResetData);
         this.assessmentActions.resetAllAssessmentsData.addListener(this.onResetAllAssessmentsData);
         this.assessmentActions.selectTestSubview.addListener(this.onSelectTestSubview);
-        this.assessmentActions.expandOrCollapseTestNav.addListener(this.onExpandOrCollapseTestNav);
+        this.assessmentActions.expandTestNav.addListener(this.onExpandTestNav);
         this.assessmentActions.changeInstanceStatus.addListener(this.onChangeInstanceStatus);
         this.assessmentActions.changeRequirementStatus.addListener(this.onChangeStepStatus);
         this.assessmentActions.undoRequirementStatusChange.addListener(this.onUndoStepStatusChange);
@@ -375,12 +375,8 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onExpandOrCollapseTestNav = (payload: ExpandOrCollapseTestNavPayload): void => {
-        const expandedTest = payload.selectedTest;
-        this.state.assessmentNavState.expandedTestType =
-            expandedTest === this.state.assessmentNavState.expandedTestType
-                ? undefined
-                : expandedTest;
+    private onExpandTestNav = (payload: ExpandTestNavPayload): void => {
+        this.state.assessmentNavState.expandedTestType = payload.selectedTest;
         this.emitChanged();
     };
 

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -112,7 +112,8 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.assessmentActions.resetData.addListener(this.onResetData);
         this.assessmentActions.resetAllAssessmentsData.addListener(this.onResetAllAssessmentsData);
         this.assessmentActions.selectTestSubview.addListener(this.onSelectTestSubview);
-        this.assessmentActions.setExpandedTestNav.addListener(this.onSetExpandedTestNav);
+        this.assessmentActions.expandTestNav.addListener(this.onExpandTestNav);
+        this.assessmentActions.collapseTestNav.addListener(this.onCollapseTestNav);
         this.assessmentActions.changeInstanceStatus.addListener(this.onChangeInstanceStatus);
         this.assessmentActions.changeRequirementStatus.addListener(this.onChangeStepStatus);
         this.assessmentActions.undoRequirementStatusChange.addListener(this.onUndoStepStatusChange);
@@ -375,8 +376,13 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onSetExpandedTestNav = (payload: ExpandTestNavPayload): void => {
+    private onExpandTestNav = (payload: ExpandTestNavPayload): void => {
         this.state.assessmentNavState.expandedTestType = payload.selectedTest;
+        this.emitChanged();
+    };
+
+    private onCollapseTestNav = (): void => {
+        this.state.assessmentNavState.expandedTestType = null;
         this.emitChanged();
     };
 

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -112,7 +112,7 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.assessmentActions.resetData.addListener(this.onResetData);
         this.assessmentActions.resetAllAssessmentsData.addListener(this.onResetAllAssessmentsData);
         this.assessmentActions.selectTestSubview.addListener(this.onSelectTestSubview);
-        this.assessmentActions.expandTestNav.addListener(this.onExpandTestNav);
+        this.assessmentActions.setExpandedTestNav.addListener(this.onSetExpandedTestNav);
         this.assessmentActions.changeInstanceStatus.addListener(this.onChangeInstanceStatus);
         this.assessmentActions.changeRequirementStatus.addListener(this.onChangeStepStatus);
         this.assessmentActions.undoRequirementStatusChange.addListener(this.onUndoStepStatusChange);
@@ -375,7 +375,7 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.emitChanged();
     };
 
-    private onExpandTestNav = (payload: ExpandTestNavPayload): void => {
+    private onSetExpandedTestNav = (payload: ExpandTestNavPayload): void => {
         this.state.assessmentNavState.expandedTestType = payload.selectedTest;
         this.emitChanged();
     };

--- a/src/background/stores/assessment-store.ts
+++ b/src/background/stores/assessment-store.ts
@@ -23,7 +23,11 @@ import {
 } from 'injected/analyzers/analyzer';
 import { forEach, isEmpty, pickBy } from 'lodash';
 import { DictionaryStringTo } from 'types/common-types';
-import { AddResultDescriptionPayload, SelectTestSubviewPayload } from '../actions/action-payloads';
+import {
+    AddResultDescriptionPayload,
+    ExpandOrCollapseTestNavPayload,
+    SelectTestSubviewPayload,
+} from '../actions/action-payloads';
 import { AssessmentDataConverter } from '../assessment-data-converter';
 import { InitialAssessmentStoreDataGenerator } from '../initial-assessment-store-data-generator';
 import {
@@ -108,6 +112,7 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
         this.assessmentActions.resetData.addListener(this.onResetData);
         this.assessmentActions.resetAllAssessmentsData.addListener(this.onResetAllAssessmentsData);
         this.assessmentActions.selectTestSubview.addListener(this.onSelectTestSubview);
+        this.assessmentActions.expandOrCollapseTestNav.addListener(this.onExpandOrCollapseTestNav);
         this.assessmentActions.changeInstanceStatus.addListener(this.onChangeInstanceStatus);
         this.assessmentActions.changeRequirementStatus.addListener(this.onChangeStepStatus);
         this.assessmentActions.undoRequirementStatusChange.addListener(this.onUndoStepStatusChange);
@@ -367,6 +372,15 @@ export class AssessmentStore extends BaseStoreImpl<AssessmentStoreData> {
     private onSelectTestSubview = (payload: SelectTestSubviewPayload): void => {
         this.state.assessmentNavState.selectedTestType = payload.selectedTest;
         this.state.assessmentNavState.selectedTestSubview = payload.selectedTestSubview;
+        this.emitChanged();
+    };
+
+    private onExpandOrCollapseTestNav = (payload: ExpandOrCollapseTestNavPayload): void => {
+        const expandedTest = payload.selectedTest;
+        this.state.assessmentNavState.expandedTestType =
+            expandedTest === this.state.assessmentNavState.expandedTestType
+                ? undefined
+                : expandedTest;
         this.emitChanged();
     };
 

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -117,6 +117,7 @@ export class Messages {
         SelectTestRequirement: `${messagePrefix}/details-view/requirement/select`,
         SelectGettingStarted: `${messagePrefix}/details-view/select-getting-started`,
         ExpandTestNav: `${messagePrefix}/details-view/expand-test-nav`,
+        CollapseTestNav: `${messagePrefix}/details-view/collapse-test-nav`,
         AssessmentScanCompleted: `${messagePrefix}/assessment/scanComplete`,
         TabbedElementAdded: `${messagePrefix}/assessment/tab-stops/element-added`,
         TrackingCompleted: `${messagePrefix}/assessment/tab-stops/recording-completed`,

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -116,6 +116,7 @@ export class Messages {
     public static readonly Assessment = {
         SelectTestRequirement: `${messagePrefix}/details-view/requirement/select`,
         SelectGettingStarted: `${messagePrefix}/details-view/select-getting-started`,
+        ExpandOrCollapseTestNav: `${messagePrefix}/details-view/expand-or-collapse-test-nav`,
         AssessmentScanCompleted: `${messagePrefix}/assessment/scanComplete`,
         TabbedElementAdded: `${messagePrefix}/assessment/tab-stops/element-added`,
         TrackingCompleted: `${messagePrefix}/assessment/tab-stops/recording-completed`,

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -116,7 +116,7 @@ export class Messages {
     public static readonly Assessment = {
         SelectTestRequirement: `${messagePrefix}/details-view/requirement/select`,
         SelectGettingStarted: `${messagePrefix}/details-view/select-getting-started`,
-        ExpandOrCollapseTestNav: `${messagePrefix}/details-view/expand-or-collapse-test-nav`,
+        ExpandTestNav: `${messagePrefix}/details-view/expand-test-nav`,
         AssessmentScanCompleted: `${messagePrefix}/assessment/scanComplete`,
         TabbedElementAdded: `${messagePrefix}/assessment/tab-stops/element-added`,
         TrackingCompleted: `${messagePrefix}/assessment/tab-stops/recording-completed`,

--- a/src/common/types/store-data/assessment-result-data.ts
+++ b/src/common/types/store-data/assessment-result-data.ts
@@ -70,6 +70,7 @@ export interface TestStepResult {
 export interface AssessmentNavState {
     selectedTestSubview: RequirementName | GettingStarted;
     selectedTestType: VisualizationType;
+    expandedTestType?: VisualizationType;
 }
 
 export interface HeadingsAssessmentProperties {

--- a/src/tests/unit/common/assessment-store-data-builder.ts
+++ b/src/tests/unit/common/assessment-store-data-builder.ts
@@ -71,6 +71,11 @@ export class AssessmentsStoreDataBuilder extends BaseDataBuilder<AssessmentStore
         return this;
     }
 
+    public withExpandedTest(visualizationType: VisualizationType): AssessmentsStoreDataBuilder {
+        this.data.assessmentNavState.expandedTestType = visualizationType;
+        return this;
+    }
+
     public withTargetTab(
         id: number,
         url: string,

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -217,8 +217,6 @@ describe('DetailsViewActionMessageCreatorTest', () => {
     });
 
     test('collapseTestNav', () => {
-        const event = eventStubFactory.createKeypressEvent() as any;
-
         const expectedMessage = {
             messageType: Messages.Assessment.CollapseTestNav,
         };

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -198,6 +198,25 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         );
     });
 
+    test('expandOrCollapseTestNav', () => {
+        const view = VisualizationType.Headings;
+        const event = eventStubFactory.createKeypressEvent() as any;
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.ExpandOrCollapseTestNav,
+            payload: {
+                selectedTest: view,
+            },
+        };
+
+        testSubject.expandOrCollapseTestNav(event, view);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
     test('setFeatureFlag', () => {
         const event = eventStubFactory.createKeypressEvent() as any;
         const telemetry: FeatureFlagToggleTelemetryData = {

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -198,18 +198,18 @@ describe('DetailsViewActionMessageCreatorTest', () => {
         );
     });
 
-    test('expandOrCollapseTestNav', () => {
+    test('expandTestNav', () => {
         const view = VisualizationType.Headings;
         const event = eventStubFactory.createKeypressEvent() as any;
 
         const expectedMessage = {
-            messageType: Messages.Assessment.ExpandOrCollapseTestNav,
+            messageType: Messages.Assessment.ExpandTestNav,
             payload: {
                 selectedTest: view,
             },
         };
 
-        testSubject.expandOrCollapseTestNav(event, view);
+        testSubject.expandTestNav(event, view);
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),

--- a/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
+++ b/src/tests/unit/tests/DetailsView/actions/details-view-action-message-creator.test.ts
@@ -200,7 +200,6 @@ describe('DetailsViewActionMessageCreatorTest', () => {
 
     test('expandTestNav', () => {
         const view = VisualizationType.Headings;
-        const event = eventStubFactory.createKeypressEvent() as any;
 
         const expectedMessage = {
             messageType: Messages.Assessment.ExpandTestNav,
@@ -209,7 +208,22 @@ describe('DetailsViewActionMessageCreatorTest', () => {
             },
         };
 
-        testSubject.expandTestNav(event, view);
+        testSubject.expandTestNav(view);
+
+        dispatcherMock.verify(
+            dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),
+            Times.once(),
+        );
+    });
+
+    test('collapseTestNav', () => {
+        const event = eventStubFactory.createKeypressEvent() as any;
+
+        const expectedMessage = {
+            messageType: Messages.Assessment.CollapseTestNav,
+        };
+
+        testSubject.collapseTestNav();
 
         dispatcherMock.verify(
             dispatcher => dispatcher.dispatchMessage(It.isValue(expectedMessage)),

--- a/src/tests/unit/tests/DetailsView/components/left-nav/assessment-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/assessment-left-nav.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { FeatureFlags } from 'common/feature-flags';
+import { VisualizationType } from 'common/types/visualization-type';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { IMock, Mock, MockBehavior } from 'typemoq';
@@ -27,6 +28,7 @@ describe('AssessmentLeftNav', () => {
     let navLinkHandlerMock: NavLinkHandler;
     let assessmentsProviderStub: AssessmentsProvider;
     let assessmentsDataStub: DictionaryStringTo<ManualTestStatusData>;
+    const expandedTest: VisualizationType = 1;
 
     beforeEach(() => {
         assessmentsDataStub = {};
@@ -50,6 +52,7 @@ describe('AssessmentLeftNav', () => {
             assessmentsProvider: assessmentsProviderStub,
             assessmentsData: assessmentsDataStub,
             featureFlagStoreData: {},
+            expandedTest,
         };
 
         leftNavLinkBuilderMock
@@ -75,6 +78,7 @@ describe('AssessmentLeftNav', () => {
                     assessmentsProviderStub,
                     assessmentsDataStub,
                     1,
+                    expandedTest,
                 ),
             )
             .returns(() => [linkStub]);

--- a/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
@@ -281,6 +281,7 @@ describe('LeftNavBuilder', () => {
                         narratorStatusStub.pastTense
                     })`,
                     onRenderNavLink: navLinkRendererMock.object.renderAssessmentTestLink,
+                    testType: visualizationType,
                 };
                 const expectedGettingStartedLink = {
                     name: 'Getting Started',

--- a/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/left-nav-link-builder.test.tsx
@@ -221,13 +221,19 @@ describe('LeftNavBuilder', () => {
                 name: 'requirement-name-2',
                 key: 'requirement-key-2',
             } as Requirement;
-            const assessmentStub = {
+            const assessmentStub1 = {
                 key: 'some key',
                 title: 'some title',
                 visualizationType: 1,
                 requirements: [requirementStubA, requirementStubB],
             } as Assessment;
-            const assessmentsStub = [assessmentStub, assessmentStub];
+            const assessmentStub2 = {
+                key: 'another key',
+                title: 'another title',
+                visualizationType: 2,
+                requirements: [requirementStubA, requirementStubB],
+            } as Assessment;
+            const assessmentsStub = [assessmentStub1, assessmentStub2];
             const outcomeStatsStub = {} as RequirementOutcomeStats;
             const testStatusStub = -2 as ManualTestStatus;
             const narratorStatusStub = { pastTense: 'passed' } as OutcomeTypeSemantic;
@@ -239,9 +245,11 @@ describe('LeftNavBuilder', () => {
                     stepFinalResult: testStatusStub,
                 },
             } as ManualTestStatusData;
+            const expandedTest = assessmentStub1.visualizationType;
 
             assessmentsDataStub = {
-                [assessmentStub.key]: stepStatusStub,
+                [assessmentStub1.key]: stepStatusStub,
+                [assessmentStub2.key]: stepStatusStub,
             };
 
             assessmentProviderMock.setup(apm => apm.all()).returns(() => assessmentsStub);
@@ -263,9 +271,11 @@ describe('LeftNavBuilder', () => {
                 assessmentProviderMock.object,
                 assessmentsDataStub,
                 startingIndexStub,
+                expandedTest,
             );
 
             links.forEach((testLink, linkIndex) => {
+                const assessmentStub = assessmentsStub[linkIndex];
                 const visualizationType = assessmentStub.visualizationType;
                 const expectedTestLink = {
                     name: assessmentStub.title,
@@ -281,6 +291,7 @@ describe('LeftNavBuilder', () => {
                         narratorStatusStub.pastTense
                     })`,
                     onRenderNavLink: navLinkRendererMock.object.renderAssessmentTestLink,
+                    isExpanded: assessmentStub.visualizationType === expandedTest,
                     testType: visualizationType,
                 };
                 const expectedGettingStartedLink = {

--- a/src/tests/unit/tests/DetailsView/handlers/nav-link-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/handlers/nav-link-handler.test.ts
@@ -123,12 +123,12 @@ describe('NavLinkHandler', () => {
     });
 
     describe('onTestHeadingClick', () => {
-        it('should call expandOrCollapseTestNav with appropriate params', () => {
+        it('should call expandTestNav with appropriate params', () => {
             const testHeadingLink = {
                 testType: -1,
             } as ReflowAssessmentLeftNavLink;
             detailsViewActionMessageCreatorMock
-                .setup(amc => amc.expandOrCollapseTestNav(eventStub, testHeadingLink.testType))
+                .setup(amc => amc.expandTestNav(eventStub, testHeadingLink.testType))
                 .verifiable();
 
             testSubject.onTestHeadingClick(eventStub, testHeadingLink);

--- a/src/tests/unit/tests/DetailsView/handlers/nav-link-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/handlers/nav-link-handler.test.ts
@@ -122,14 +122,28 @@ describe('NavLinkHandler', () => {
         });
     });
 
-    describe('onTestHeadingClick', () => {
+    describe('onTestHeadingClick with unexpanded link', () => {
         it('should call expandTestNav with appropriate params', () => {
             const testHeadingLink = {
                 testType: -1,
+                isExpanded: false,
             } as ReflowAssessmentLeftNavLink;
             detailsViewActionMessageCreatorMock
-                .setup(amc => amc.expandTestNav(eventStub, testHeadingLink.testType))
+                .setup(amc => amc.expandTestNav(testHeadingLink.testType))
                 .verifiable();
+
+            testSubject.onTestHeadingClick(eventStub, testHeadingLink);
+            detailsViewActionMessageCreatorMock.verifyAll();
+        });
+    });
+
+    describe('onTestHeadingClick with already expanded link', () => {
+        it('should call expandTestNav with appropriate params', () => {
+            const testHeadingLink = {
+                testType: -1,
+                isExpanded: true,
+            } as ReflowAssessmentLeftNavLink;
+            detailsViewActionMessageCreatorMock.setup(amc => amc.collapseTestNav()).verifiable();
 
             testSubject.onTestHeadingClick(eventStub, testHeadingLink);
             detailsViewActionMessageCreatorMock.verifyAll();

--- a/src/tests/unit/tests/DetailsView/handlers/nav-link-handler.test.ts
+++ b/src/tests/unit/tests/DetailsView/handlers/nav-link-handler.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.`
 import {
+    ReflowAssessmentLeftNavLink,
     TestGettingStartedNavLink,
     TestRequirementLeftNavLink,
 } from 'DetailsView/components/left-nav/assessment-left-nav';
@@ -117,6 +118,20 @@ describe('NavLinkHandler', () => {
                 .verifiable();
 
             testSubject.onGettingStartedClick(eventStub, gettingStartedLink);
+            detailsViewActionMessageCreatorMock.verifyAll();
+        });
+    });
+
+    describe('onTestHeadingClick', () => {
+        it('should call expandOrCollapseTestNav with appropriate params', () => {
+            const testHeadingLink = {
+                testType: -1,
+            } as ReflowAssessmentLeftNavLink;
+            detailsViewActionMessageCreatorMock
+                .setup(amc => amc.expandOrCollapseTestNav(eventStub, testHeadingLink.testType))
+                .verifiable();
+
+            testSubject.onTestHeadingClick(eventStub, testHeadingLink);
             detailsViewActionMessageCreatorMock.verifyAll();
         });
     });

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -8,6 +8,7 @@ import {
     ChangeInstanceSelectionPayload,
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
+    ExpandOrCollapseTestNavPayload,
     OnDetailsViewOpenPayload,
     RemoveFailureInstancePayload,
     SelectGettingStartedPayload,
@@ -584,6 +585,32 @@ describe('AssessmentActionCreatorTest', () => {
             tp => tp.publishTelemetry(TelemetryEvents.SELECT_GETTING_STARTED, payload),
             Times.once(),
         );
+    });
+
+    it('handles ExpandOrCollapseTestNav message', () => {
+        const payload: ExpandOrCollapseTestNavPayload = {
+            selectedTest: 1,
+        } as ExpandOrCollapseTestNavPayload;
+
+        const expandOrCollapseTestNavMock = createActionMock(payload);
+        const actionsMock = createActionsMock(
+            'expandOrCollapseTestNav',
+            expandOrCollapseTestNavMock.object,
+        );
+        const interpreterMock = createInterpreterMock(
+            AssessmentMessages.ExpandOrCollapseTestNav,
+            payload,
+        );
+
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        expandOrCollapseTestNavMock.verifyAll();
     });
 
     it('handles ScanUpdate message', () => {

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -592,8 +592,8 @@ describe('AssessmentActionCreatorTest', () => {
             selectedTest: 1,
         } as ExpandTestNavPayload;
 
-        const expandTestNavMock = createActionMock(payload);
-        const actionsMock = createActionsMock('expandTestNav', expandTestNavMock.object);
+        const setExpandedTestNavMock = createActionMock(payload);
+        const actionsMock = createActionsMock('setExpandedTestNav', setExpandedTestNavMock.object);
         const interpreterMock = createInterpreterMock(AssessmentMessages.ExpandTestNav, payload);
 
         const testSubject = new AssessmentActionCreator(
@@ -604,7 +604,27 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
-        expandTestNavMock.verifyAll();
+        setExpandedTestNavMock.verifyAll();
+    });
+
+    it('handles CollapseTestNav message', () => {
+        const payload: ExpandTestNavPayload = {
+            selectedTest: null,
+        } as ExpandTestNavPayload;
+
+        const setExpandedTestNavMock = createActionMock(payload);
+        const actionsMock = createActionsMock('setExpandedTestNav', setExpandedTestNavMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.CollapseTestNav, null);
+
+        const testSubject = new AssessmentActionCreator(
+            interpreterMock.object,
+            actionsMock.object,
+            telemetryEventHandlerMock.object,
+        );
+
+        testSubject.registerCallbacks();
+
+        setExpandedTestNavMock.verifyAll();
     });
 
     it('handles ScanUpdate message', () => {

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -8,7 +8,7 @@ import {
     ChangeInstanceSelectionPayload,
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
-    ExpandOrCollapseTestNavPayload,
+    ExpandTestNavPayload,
     OnDetailsViewOpenPayload,
     RemoveFailureInstancePayload,
     SelectGettingStartedPayload,
@@ -587,20 +587,14 @@ describe('AssessmentActionCreatorTest', () => {
         );
     });
 
-    it('handles ExpandOrCollapseTestNav message', () => {
-        const payload: ExpandOrCollapseTestNavPayload = {
+    it('handles ExpandTestNav message', () => {
+        const payload: ExpandTestNavPayload = {
             selectedTest: 1,
-        } as ExpandOrCollapseTestNavPayload;
+        } as ExpandTestNavPayload;
 
-        const expandOrCollapseTestNavMock = createActionMock(payload);
-        const actionsMock = createActionsMock(
-            'expandOrCollapseTestNav',
-            expandOrCollapseTestNavMock.object,
-        );
-        const interpreterMock = createInterpreterMock(
-            AssessmentMessages.ExpandOrCollapseTestNav,
-            payload,
-        );
+        const expandTestNavMock = createActionMock(payload);
+        const actionsMock = createActionsMock('expandTestNav', expandTestNavMock.object);
+        const interpreterMock = createInterpreterMock(AssessmentMessages.ExpandTestNav, payload);
 
         const testSubject = new AssessmentActionCreator(
             interpreterMock.object,
@@ -610,7 +604,7 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
-        expandOrCollapseTestNavMock.verifyAll();
+        expandTestNavMock.verifyAll();
     });
 
     it('handles ScanUpdate message', () => {

--- a/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
+++ b/src/tests/unit/tests/background/actions/assessment-action-creator.test.ts
@@ -592,8 +592,8 @@ describe('AssessmentActionCreatorTest', () => {
             selectedTest: 1,
         } as ExpandTestNavPayload;
 
-        const setExpandedTestNavMock = createActionMock(payload);
-        const actionsMock = createActionsMock('setExpandedTestNav', setExpandedTestNavMock.object);
+        const expandTestNavMock = createActionMock(payload);
+        const actionsMock = createActionsMock('expandTestNav', expandTestNavMock.object);
         const interpreterMock = createInterpreterMock(AssessmentMessages.ExpandTestNav, payload);
 
         const testSubject = new AssessmentActionCreator(
@@ -604,16 +604,12 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
-        setExpandedTestNavMock.verifyAll();
+        expandTestNavMock.verifyAll();
     });
 
     it('handles CollapseTestNav message', () => {
-        const payload: ExpandTestNavPayload = {
-            selectedTest: null,
-        } as ExpandTestNavPayload;
-
-        const setExpandedTestNavMock = createActionMock(payload);
-        const actionsMock = createActionsMock('setExpandedTestNav', setExpandedTestNavMock.object);
+        const collapseTestNavMock = createActionMock(null);
+        const actionsMock = createActionsMock('collapseTestNav', collapseTestNavMock.object);
         const interpreterMock = createInterpreterMock(AssessmentMessages.CollapseTestNav, null);
 
         const testSubject = new AssessmentActionCreator(
@@ -624,7 +620,7 @@ describe('AssessmentActionCreatorTest', () => {
 
         testSubject.registerCallbacks();
 
-        setExpandedTestNavMock.verifyAll();
+        collapseTestNavMock.verifyAll();
     });
 
     it('handles ScanUpdate message', () => {

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -914,7 +914,7 @@ describe('AssessmentStore', () => {
             .testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on setExpandedTestNav', () => {
+    test('on expandTestNav', () => {
         const visualizationType = 1 as VisualizationType;
         const initialState = new AssessmentsStoreDataBuilder(
             assessmentsProvider,
@@ -933,9 +933,29 @@ describe('AssessmentStore', () => {
 
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
 
-        createStoreTesterForAssessmentActions('setExpandedTestNav')
+        createStoreTesterForAssessmentActions('expandTestNav')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, finalState);
+    });
+
+    test('on collapseTestNav', () => {
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        ).build();
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
+            .withExpandedTest(null)
+            .build();
+
+        assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
+
+        createStoreTesterForAssessmentActions('collapseTestNav').testListenerToBeCalledOnce(
+            initialState,
+            finalState,
+        );
     });
 
     test('onUpdateTargetTabId', () => {

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -10,6 +10,7 @@ import {
     ChangeInstanceStatusPayload,
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
+    ExpandOrCollapseTestNavPayload,
     RemoveFailureInstancePayload,
     SelectTestSubviewPayload,
     ToggleActionPayload,
@@ -909,6 +910,56 @@ describe('AssessmentStore', () => {
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
 
         createStoreTesterForAssessmentActions('selectTestSubview')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, finalState);
+    });
+
+    test('on expandOrCollapseTestNav when clicked test is not selected', () => {
+        const visualizationType = 1 as VisualizationType;
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        ).build();
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
+            .withExpandedTest(visualizationType)
+            .build();
+
+        const payload: ExpandOrCollapseTestNavPayload = {
+            selectedTest: visualizationType,
+        };
+
+        assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
+
+        createStoreTesterForAssessmentActions('expandOrCollapseTestNav')
+            .withActionParam(payload)
+            .testListenerToBeCalledOnce(initialState, finalState);
+    });
+
+    test('on expandOrCollapseTestNav when clicked test is already selected', () => {
+        const visualizationType = 1 as VisualizationType;
+        const initialState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
+            .withExpandedTest(visualizationType)
+            .build();
+        const finalState = new AssessmentsStoreDataBuilder(
+            assessmentsProvider,
+            assessmentDataConverterMock.object,
+        )
+            .withExpandedTest(undefined)
+            .build();
+
+        const payload: ExpandOrCollapseTestNavPayload = {
+            selectedTest: visualizationType,
+        };
+
+        assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
+
+        createStoreTesterForAssessmentActions('expandOrCollapseTestNav')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, finalState);
     });

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -914,7 +914,7 @@ describe('AssessmentStore', () => {
             .testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on expandTestNav when clicked test is not selected', () => {
+    test('on setExpandedTestNav', () => {
         const visualizationType = 1 as VisualizationType;
         const initialState = new AssessmentsStoreDataBuilder(
             assessmentsProvider,
@@ -933,33 +933,7 @@ describe('AssessmentStore', () => {
 
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
 
-        createStoreTesterForAssessmentActions('expandTestNav')
-            .withActionParam(payload)
-            .testListenerToBeCalledOnce(initialState, finalState);
-    });
-
-    test('on expandTestNav when clicked test is already selected', () => {
-        const visualizationType = 1 as VisualizationType;
-        const initialState = new AssessmentsStoreDataBuilder(
-            assessmentsProvider,
-            assessmentDataConverterMock.object,
-        )
-            .withExpandedTest(visualizationType)
-            .build();
-        const finalState = new AssessmentsStoreDataBuilder(
-            assessmentsProvider,
-            assessmentDataConverterMock.object,
-        )
-            .withExpandedTest(undefined)
-            .build();
-
-        const payload: ExpandTestNavPayload = {
-            selectedTest: visualizationType,
-        };
-
-        assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
-
-        createStoreTesterForAssessmentActions('expandTestNav')
+        createStoreTesterForAssessmentActions('setExpandedTestNav')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, finalState);
     });

--- a/src/tests/unit/tests/background/stores/assessment-store.test.ts
+++ b/src/tests/unit/tests/background/stores/assessment-store.test.ts
@@ -10,7 +10,7 @@ import {
     ChangeInstanceStatusPayload,
     ChangeRequirementStatusPayload,
     EditFailureInstancePayload,
-    ExpandOrCollapseTestNavPayload,
+    ExpandTestNavPayload,
     RemoveFailureInstancePayload,
     SelectTestSubviewPayload,
     ToggleActionPayload,
@@ -914,7 +914,7 @@ describe('AssessmentStore', () => {
             .testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on expandOrCollapseTestNav when clicked test is not selected', () => {
+    test('on expandTestNav when clicked test is not selected', () => {
         const visualizationType = 1 as VisualizationType;
         const initialState = new AssessmentsStoreDataBuilder(
             assessmentsProvider,
@@ -927,18 +927,18 @@ describe('AssessmentStore', () => {
             .withExpandedTest(visualizationType)
             .build();
 
-        const payload: ExpandOrCollapseTestNavPayload = {
+        const payload: ExpandTestNavPayload = {
             selectedTest: visualizationType,
         };
 
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
 
-        createStoreTesterForAssessmentActions('expandOrCollapseTestNav')
+        createStoreTesterForAssessmentActions('expandTestNav')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, finalState);
     });
 
-    test('on expandOrCollapseTestNav when clicked test is already selected', () => {
+    test('on expandTestNav when clicked test is already selected', () => {
         const visualizationType = 1 as VisualizationType;
         const initialState = new AssessmentsStoreDataBuilder(
             assessmentsProvider,
@@ -953,13 +953,13 @@ describe('AssessmentStore', () => {
             .withExpandedTest(undefined)
             .build();
 
-        const payload: ExpandOrCollapseTestNavPayload = {
+        const payload: ExpandTestNavPayload = {
             selectedTest: visualizationType,
         };
 
         assessmentsProviderMock.setup(apm => apm.all()).returns(() => assessmentsProvider.all());
 
-        createStoreTesterForAssessmentActions('expandOrCollapseTestNav')
+        createStoreTesterForAssessmentActions('expandTestNav')
             .withActionParam(payload)
             .testListenerToBeCalledOnce(initialState, finalState);
     });


### PR DESCRIPTION
#### Description of changes

When the test's heading nav link is clicked, store that test as the currently expanded test in AssessmentStore and toggle the expanded state of the nav link. All links will start as collapsed by default.

<img width="175" alt="expanded nav" src="https://user-images.githubusercontent.com/55459788/83205067-684b6700-a102-11ea-824f-01435c492205.PNG">

Styling to highlight the expanded portion of the nav will be added in a later PR.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1724866
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
