### PR TITLE
fix: use throttle instead of timeout for scroll/resize re-drawing

### DIFF
--- a/src/injected/visualization/svg-drawer.ts
+++ b/src/injected/visualization/svg-drawer.ts
@@ -152,10 +152,10 @@ export class SVGDrawer extends BaseDrawer {
         return svg;
     }
 
-    protected handlePositionChange(): void {
+    protected handlePositionChange = () => {
         super.handlePositionChange();
         this.setSVGSize();
-    }
+    };
 
     private setSVGSize(): void {
         const doc = this.drawerUtils.getDocumentElement();


### PR DESCRIPTION
#### Description of changes

A couple changes I looked into here:
1. Re-drawing more frequently on scroll/re-size (60fps).
2. Using throttle instead of manually creating/managing timeouts. Throttle effectively can handle that for us making this simpler and ensuring that we're not calling this method too frequently.

Notes: I'm very interested to see how this performs on other people's machines and hence added the second review required label. I think we can safely make the 2nd change but I'm open to increasing the throttle time for a less perf heavy task. In my experience, resizing manually did yield some noticeable lag however scrolling was indistinguishable. I also noticed some lag in resizing regardless of the visualization or not so ... 🤷 

Here's the difference:

Before:
![bingheadingtimeoutredraw](https://user-images.githubusercontent.com/32555133/83208522-c8460b80-a10a-11ea-9129-b1277027ff39.gif)

After:
![bingheadingthrottleredraw](https://user-images.githubusercontent.com/32555133/83208536-cf6d1980-a10a-11ea-972c-718e56c8d144.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [.] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [.] (UI changes only) Verified usability with NVDA/JAWS
