### PR TITLE
feat(nav-bar-functionality): Highlight expanded part of nav

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -237,6 +237,26 @@ div.insights-file-issue-details-dialog-container {
         min-height: 0;
         &.reflow-ui {
             grid-template-columns: $detailsViewReflowLeftNavWidth 1fr;
+
+            .left-nav,
+            .test-step-nav {
+                .ms-Nav-compositeLink {
+                    &.is-selected {
+                        a {
+                            background-color: $communication-tint-20;
+                        }
+                    }
+                    &.is-expanded,
+                    &.is-expanded + ul {
+                        background-color: $communication-tint-40;
+                        .index-circle {
+                            color: $neutral-0;
+                            background: $index-circle-background;
+                            border-color: $neutral-0;
+                        }
+                    }
+                }
+            }
         }
         .details-view-test-nav-area {
             box-sizing: border-box;


### PR DESCRIPTION
#### Description of changes

Add styling to highlight the expanded part of the nav to match the figma:

<img width="176" alt="expanded nav highlighting" src="https://user-images.githubusercontent.com/55459788/83460170-9ee2f380-a41a-11ea-922d-c7a65af48605.PNG"> <img width="176" alt="expanded nav highlighting high contrast" src="https://user-images.githubusercontent.com/55459788/83460177-a1454d80-a41a-11ea-9ee1-475a34e78e26.PNG">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1724870
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
