### PR TITLE
feat(detail-cmd-bar-style): minimize overlap with target page

### DIFF
--- a/src/DetailsView/components/details-view-command-bar.scss
+++ b/src/DetailsView/components/details-view-command-bar.scss
@@ -29,6 +29,6 @@
         overflow: hidden;
         text-overflow: ellipsis;
         color: $primary-text;
-        width: 50%;
+        flex: 1 1 auto;
     }
 }


### PR DESCRIPTION
#### Description of changes
These changes update the styling for the details view command bar to minimize overlap between the command buttons and the target page.

##### Before
![overlap](https://user-images.githubusercontent.com/8262156/83463935-a7442a00-a42c-11ea-9c80-d2b15d337d6f.png)

![overlap](https://user-images.githubusercontent.com/8262156/83463938-aa3f1a80-a42c-11ea-8c3b-ca7792bdc227.gif)

##### After
![no-overlap](https://user-images.githubusercontent.com/8262156/83463940-aca17480-a42c-11ea-9ba6-6ed286d81b30.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
