### PR TITLE
feat(android-setup): adb setup experience flag

### DIFF
--- a/src/electron/common/unified-feature-flags.ts
+++ b/src/electron/common/unified-feature-flags.ts
@@ -6,6 +6,7 @@ export class UnifiedFeatureFlags {
     public static readonly logTelemetryToConsole = 'logTelemetryToConsole';
     public static readonly showAllFeatureFlags = 'showAllFeatureFlags';
     public static readonly exportReport = 'exportReport';
+    public static readonly adbSetupView = 'adbSetupView';
 }
 
 export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
@@ -34,6 +35,14 @@ export function getAllFeatureFlagDetailsUnified(): FeatureFlagDetail[] {
             displayableDescription: 'Show the export report button on the automated checks window',
             isPreviewFeature: false,
             forceDefault: true,
+        },
+        {
+            id: UnifiedFeatureFlags.adbSetupView,
+            defaultValue: false,
+            displayableName: 'Enable the new adb experience',
+            displayableDescription: 'Enable the new adb setup and installation experience',
+            isPreviewFeature: false,
+            forceDefault: false,
         },
     ];
 }

--- a/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
+++ b/src/tests/unit/tests/electron/common/unified-feature-flags.test.ts
@@ -23,6 +23,7 @@ describe('FeatureFlagsTest', () => {
             [UnifiedFeatureFlags.logTelemetryToConsole]: false,
             [UnifiedFeatureFlags.showAllFeatureFlags]: false,
             [UnifiedFeatureFlags.exportReport]: true,
+            [UnifiedFeatureFlags.adbSetupView]: false,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);


### PR DESCRIPTION
added a feature flag for the new setup/installation experience, set its default value to false and added a reference to the flag to the existing united-feature-flag.test file

#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [N/A] Addresses an existing issue: #0000
- [X] Ran `yarn fastpass`
- [X] Added/updated relevant unit test(s) (and ran `yarn test`)
- [X] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [X] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [N/A] (UI changes only) Added screenshots/GIFs to description above
- [N/A ] (UI changes only) Verified usability with NVDA/JAWS
