### PR TITLE
refactor: move some rendering logic out of details-view-container

### DIFF
--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { FeatureFlags } from 'common/feature-flags';
 import { NamedFC } from 'common/react/named-fc';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewOverlay } from 'DetailsView/components/details-view-overlay/details-view-overlay';
@@ -8,14 +7,11 @@ import { InteractiveHeader } from 'DetailsView/components/interactive-header';
 import { DetailsViewBody } from 'DetailsView/details-view-body';
 import { DetailsViewContainerProps } from 'DetailsView/details-view-container';
 import * as React from 'react';
-import ReactResizeDetector from 'react-resize-detector';
 
 export type DetailsViewContentProps = DetailsViewContainerProps;
 
 export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewContent', props => {
-    const [isSideNavOpen, setSideNavOpen] = React.useState(false);
-
-    const renderHeader = (isNarrowMode: boolean) => {
+    const renderHeader = () => {
         const storeState = props.storeState;
         const visualizationStoreData = storeState ? storeState.visualizationStoreData : null;
         return (
@@ -26,8 +22,6 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                 }
                 featureFlagStoreData={storeState.featureFlagStoreData}
                 tabClosed={props.storeState.tabStoreData.isClosed}
-                setSideNavOpen={setSideNavOpen}
-                isNarrowMode={isNarrowMode}
             />
         );
     };
@@ -48,7 +42,7 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
         );
     };
 
-    const renderDetailsView = (isNarrowMode: boolean) => {
+    const renderDetailsView = () => {
         const { deps, storeState } = props;
         const selectedDetailsRightPanelConfiguration = props.deps.getDetailsRightPanelConfiguration(
             {
@@ -116,27 +110,15 @@ export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewC
                     storeState.unifiedScanResultStoreData.scanIncompleteWarnings
                 }
                 scanMetadata={scanMetadata}
-                isSideNavOpen={isSideNavOpen}
-                setSideNavOpen={setSideNavOpen}
-                isNarrowMode={isNarrowMode}
             />
         );
     };
 
     return (
-        <ReactResizeDetector handleWidth querySelector="body">
-            {dimentions => {
-                const isNarrowMode =
-                    props.storeState.featureFlagStoreData[FeatureFlags.reflowUI] === true &&
-                    dimentions.width < 600;
-                return (
-                    <>
-                        {renderHeader(isNarrowMode)}
-                        {renderDetailsView(isNarrowMode)}
-                        {renderOverlay()}
-                    </>
-                );
-            }}
-        </ReactResizeDetector>
+        <>
+            {renderHeader()}
+            {renderDetailsView()}
+            {renderOverlay()}
+        </>
     );
 });

--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -13,13 +13,11 @@ export type DetailsViewContentProps = DetailsViewContainerProps;
 export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewContent', props => {
     const renderHeader = () => {
         const storeState = props.storeState;
-        const visualizationStoreData = storeState ? storeState.visualizationStoreData : null;
+        const visualizationStoreData = storeState.visualizationStoreData;
         return (
             <InteractiveHeader
                 deps={props.deps}
-                selectedPivot={
-                    visualizationStoreData ? visualizationStoreData.selectedDetailsViewPivot : null
-                }
+                selectedPivot={visualizationStoreData.selectedDetailsViewPivot}
                 featureFlagStoreData={storeState.featureFlagStoreData}
                 tabClosed={props.storeState.tabStoreData.isClosed}
             />

--- a/src/DetailsView/components/details-view-content.tsx
+++ b/src/DetailsView/components/details-view-content.tsx
@@ -1,0 +1,142 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { FeatureFlags } from 'common/feature-flags';
+import { NamedFC } from 'common/react/named-fc';
+import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
+import { DetailsViewOverlay } from 'DetailsView/components/details-view-overlay/details-view-overlay';
+import { InteractiveHeader } from 'DetailsView/components/interactive-header';
+import { DetailsViewBody } from 'DetailsView/details-view-body';
+import { DetailsViewContainerProps } from 'DetailsView/details-view-container';
+import * as React from 'react';
+import ReactResizeDetector from 'react-resize-detector';
+
+export type DetailsViewContentProps = DetailsViewContainerProps;
+
+export const DetailsViewContent = NamedFC<DetailsViewContentProps>('DetailsViewContent', props => {
+    const [isSideNavOpen, setSideNavOpen] = React.useState(false);
+
+    const renderHeader = (isNarrowMode: boolean) => {
+        const storeState = props.storeState;
+        const visualizationStoreData = storeState ? storeState.visualizationStoreData : null;
+        return (
+            <InteractiveHeader
+                deps={props.deps}
+                selectedPivot={
+                    visualizationStoreData ? visualizationStoreData.selectedDetailsViewPivot : null
+                }
+                featureFlagStoreData={storeState.featureFlagStoreData}
+                tabClosed={props.storeState.tabStoreData.isClosed}
+                setSideNavOpen={setSideNavOpen}
+                isNarrowMode={isNarrowMode}
+            />
+        );
+    };
+
+    const renderOverlay = () => {
+        const { deps, storeState } = props;
+        return (
+            <DetailsViewOverlay
+                deps={deps}
+                previewFeatureFlagsHandler={props.deps.previewFeatureFlagsHandler}
+                scopingActionMessageCreator={props.deps.scopingActionMessageCreator}
+                inspectActionMessageCreator={props.deps.inspectActionMessageCreator}
+                detailsViewStoreData={storeState.detailsViewStoreData}
+                scopingStoreData={storeState.scopingPanelStateStoreData}
+                featureFlagStoreData={storeState.featureFlagStoreData}
+                userConfigurationStoreData={storeState.userConfigurationStoreData}
+            />
+        );
+    };
+
+    const renderDetailsView = (isNarrowMode: boolean) => {
+        const { deps, storeState } = props;
+        const selectedDetailsRightPanelConfiguration = props.deps.getDetailsRightPanelConfiguration(
+            {
+                selectedDetailsViewPivot:
+                    storeState.visualizationStoreData.selectedDetailsViewPivot,
+                detailsViewRightContentPanel:
+                    storeState.detailsViewStoreData.detailsViewRightContentPanel,
+            },
+        );
+        const selectedDetailsViewSwitcherNavConfiguration = props.deps.getDetailsSwitcherNavConfiguration(
+            {
+                selectedDetailsViewPivot:
+                    storeState.visualizationStoreData.selectedDetailsViewPivot,
+            },
+        );
+        const selectedTest = selectedDetailsViewSwitcherNavConfiguration.getSelectedDetailsView(
+            storeState,
+        );
+
+        const cardsViewData = props.deps.getCardViewData(
+            props.storeState.unifiedScanResultStoreData.rules,
+            props.storeState.unifiedScanResultStoreData.results,
+            props.deps.getCardSelectionViewData(
+                props.storeState.cardSelectionStoreData,
+                props.storeState.unifiedScanResultStoreData,
+                props.deps.isResultHighlightUnavailable,
+            ),
+        );
+
+        const targetAppInfo = {
+            name: props.storeState.tabStoreData.title,
+            url: props.storeState.tabStoreData.url,
+        };
+
+        const scanMetadata: ScanMetadata = {
+            timestamp: props.storeState.unifiedScanResultStoreData.timestamp,
+            targetAppInfo: targetAppInfo,
+            toolData: props.storeState.unifiedScanResultStoreData.toolInfo,
+        };
+
+        return (
+            <DetailsViewBody
+                deps={deps}
+                tabStoreData={storeState.tabStoreData}
+                assessmentStoreData={storeState.assessmentStoreData}
+                pathSnippetStoreData={storeState.pathSnippetStoreData}
+                featureFlagStoreData={storeState.featureFlagStoreData}
+                selectedTest={selectedTest}
+                detailsViewStoreData={storeState.detailsViewStoreData}
+                visualizationStoreData={storeState.visualizationStoreData}
+                visualizationScanResultData={storeState.visualizationScanResultStoreData}
+                visualizationConfigurationFactory={props.deps.visualizationConfigurationFactory}
+                assessmentsProvider={props.deps.assessmentsProvider}
+                dropdownClickHandler={props.deps.dropdownClickHandler}
+                clickHandlerFactory={props.deps.clickHandlerFactory}
+                assessmentInstanceTableHandler={props.deps.assessmentInstanceTableHandler}
+                issuesSelection={props.deps.issuesSelection}
+                issuesTableHandler={props.deps.issuesTableHandler}
+                rightPanelConfiguration={selectedDetailsRightPanelConfiguration}
+                switcherNavConfiguration={selectedDetailsViewSwitcherNavConfiguration}
+                userConfigurationStoreData={storeState.userConfigurationStoreData}
+                cardsViewData={cardsViewData}
+                cardSelectionStoreData={storeState.cardSelectionStoreData}
+                scanIncompleteWarnings={
+                    storeState.unifiedScanResultStoreData.scanIncompleteWarnings
+                }
+                scanMetadata={scanMetadata}
+                isSideNavOpen={isSideNavOpen}
+                setSideNavOpen={setSideNavOpen}
+                isNarrowMode={isNarrowMode}
+            />
+        );
+    };
+
+    return (
+        <ReactResizeDetector handleWidth querySelector="body">
+            {dimentions => {
+                const isNarrowMode =
+                    props.storeState.featureFlagStoreData[FeatureFlags.reflowUI] === true &&
+                    dimentions.width < 600;
+                return (
+                    <>
+                        {renderHeader(isNarrowMode)}
+                        {renderDetailsView(isNarrowMode)}
+                        {renderOverlay()}
+                    </>
+                );
+            }}
+        </ReactResizeDetector>
+    );
+});

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -1,8 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { Header } from 'common/components/header';
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { DetailsViewContent } from 'DetailsView/components/details-view-content';
 import { ISelection, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 
@@ -21,29 +23,23 @@ import { FeatureFlagStoreData } from '../common/types/store-data/feature-flag-st
 import { PathSnippetStoreData } from '../common/types/store-data/path-snippet-store-data';
 import { ScopingStoreData } from '../common/types/store-data/scoping-store-data';
 import { TabStoreData } from '../common/types/store-data/tab-store-data';
-import {
-    ScanMetadata,
-    UnifiedScanResultStoreData,
-} from '../common/types/store-data/unified-data-interface';
+import { UnifiedScanResultStoreData } from '../common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from '../common/types/store-data/user-configuration-store';
 import { VisualizationScanResultData } from '../common/types/store-data/visualization-scan-result-data';
 import { VisualizationStoreData } from '../common/types/store-data/visualization-store-data';
 import { VisualizationType } from '../common/types/visualization-type';
 import { DetailsViewCommandBarDeps } from './components/details-view-command-bar';
-import {
-    DetailsViewOverlay,
-    DetailsViewOverlayDeps,
-} from './components/details-view-overlay/details-view-overlay';
+import { DetailsViewOverlayDeps } from './components/details-view-overlay/details-view-overlay';
 import {
     DetailsRightPanelConfiguration,
     GetDetailsRightPanelConfiguration,
 } from './components/details-view-right-panel';
 import { GetDetailsSwitcherNavConfiguration } from './components/details-view-switcher-nav';
-import { InteractiveHeader, InteractiveHeaderDeps } from './components/interactive-header';
+import { InteractiveHeaderDeps } from './components/interactive-header';
 import { IssuesTableHandler } from './components/issues-table-handler';
 import { NoContentAvailable } from './components/no-content-available/no-content-available';
 import { TargetChangeDialogDeps } from './components/target-change-dialog';
-import { DetailsViewBody, DetailsViewBodyDeps } from './details-view-body';
+import { DetailsViewBodyDeps } from './details-view-body';
 import { AssessmentInstanceTableHandler } from './handlers/assessment-instance-table-handler';
 import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-toggle-click-handler-factory';
 import { PreviewFeatureFlagsHandler } from './handlers/preview-feature-flags-handler';
@@ -98,7 +94,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
         if (this.isTargetPageClosed()) {
             return (
                 <>
-                    {this.renderHeader()}
+                    <Header deps={this.props.deps} />
                     <NoContentAvailable />
                 </>
             );
@@ -133,118 +129,7 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
     }
 
     private renderContent(): JSX.Element {
-        return (
-            <>
-                {this.renderHeader()}
-                {this.renderDetailsView()}
-                {this.renderOverlay()}
-            </>
-        );
-    }
-
-    private renderHeader(): JSX.Element {
-        const storeState = this.props.storeState;
-        const visualizationStoreData = storeState ? storeState.visualizationStoreData : null;
-        return (
-            <InteractiveHeader
-                deps={this.props.deps}
-                selectedPivot={
-                    visualizationStoreData ? visualizationStoreData.selectedDetailsViewPivot : null
-                }
-                featureFlagStoreData={this.hasStores() ? storeState.featureFlagStoreData : null}
-                tabClosed={this.hasStores() ? this.props.storeState.tabStoreData.isClosed : true}
-            />
-        );
-    }
-
-    private renderOverlay(): JSX.Element {
-        const { deps, storeState } = this.props;
-        return (
-            <DetailsViewOverlay
-                deps={deps}
-                previewFeatureFlagsHandler={this.props.deps.previewFeatureFlagsHandler}
-                scopingActionMessageCreator={this.props.deps.scopingActionMessageCreator}
-                inspectActionMessageCreator={this.props.deps.inspectActionMessageCreator}
-                detailsViewStoreData={storeState.detailsViewStoreData}
-                scopingStoreData={storeState.scopingPanelStateStoreData}
-                featureFlagStoreData={storeState.featureFlagStoreData}
-                userConfigurationStoreData={storeState.userConfigurationStoreData}
-            />
-        );
-    }
-
-    private renderDetailsView(): JSX.Element {
-        const { deps, storeState } = this.props;
-        const selectedDetailsRightPanelConfiguration = this.props.deps.getDetailsRightPanelConfiguration(
-            {
-                selectedDetailsViewPivot:
-                    storeState.visualizationStoreData.selectedDetailsViewPivot,
-                detailsViewRightContentPanel:
-                    storeState.detailsViewStoreData.detailsViewRightContentPanel,
-            },
-        );
-        const selectedDetailsViewSwitcherNavConfiguration = this.props.deps.getDetailsSwitcherNavConfiguration(
-            {
-                selectedDetailsViewPivot:
-                    storeState.visualizationStoreData.selectedDetailsViewPivot,
-            },
-        );
-        const selectedTest = selectedDetailsViewSwitcherNavConfiguration.getSelectedDetailsView(
-            storeState,
-        );
-
-        const cardsViewData = this.props.deps.getCardViewData(
-            this.props.storeState.unifiedScanResultStoreData.rules,
-            this.props.storeState.unifiedScanResultStoreData.results,
-            this.props.deps.getCardSelectionViewData(
-                this.props.storeState.cardSelectionStoreData,
-                this.props.storeState.unifiedScanResultStoreData,
-                this.props.deps.isResultHighlightUnavailable,
-            ),
-        );
-
-        const targetAppInfo = {
-            name: this.props.storeState.tabStoreData.title,
-            url: this.props.storeState.tabStoreData.url,
-        };
-
-        const scanMetadata: ScanMetadata = {
-            timestamp: this.props.storeState.unifiedScanResultStoreData.timestamp,
-            targetAppInfo: targetAppInfo,
-            toolData: this.props.storeState.unifiedScanResultStoreData.toolInfo,
-        };
-
-        return (
-            <DetailsViewBody
-                deps={deps}
-                tabStoreData={storeState.tabStoreData}
-                assessmentStoreData={storeState.assessmentStoreData}
-                pathSnippetStoreData={storeState.pathSnippetStoreData}
-                featureFlagStoreData={storeState.featureFlagStoreData}
-                selectedTest={selectedTest}
-                detailsViewStoreData={storeState.detailsViewStoreData}
-                visualizationStoreData={storeState.visualizationStoreData}
-                visualizationScanResultData={storeState.visualizationScanResultStoreData}
-                visualizationConfigurationFactory={
-                    this.props.deps.visualizationConfigurationFactory
-                }
-                assessmentsProvider={this.props.deps.assessmentsProvider}
-                dropdownClickHandler={this.props.deps.dropdownClickHandler}
-                clickHandlerFactory={this.props.deps.clickHandlerFactory}
-                assessmentInstanceTableHandler={this.props.deps.assessmentInstanceTableHandler}
-                issuesSelection={this.props.deps.issuesSelection}
-                issuesTableHandler={this.props.deps.issuesTableHandler}
-                rightPanelConfiguration={selectedDetailsRightPanelConfiguration}
-                switcherNavConfiguration={selectedDetailsViewSwitcherNavConfiguration}
-                userConfigurationStoreData={storeState.userConfigurationStoreData}
-                cardsViewData={cardsViewData}
-                cardSelectionStoreData={storeState.cardSelectionStoreData}
-                scanIncompleteWarnings={
-                    storeState.unifiedScanResultStoreData.scanIncompleteWarnings
-                }
-                scanMetadata={scanMetadata}
-            />
-        );
+        return <DetailsViewContent {...this.props} />;
     }
 
     private hasStores(): boolean {

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
@@ -10,14 +10,16 @@ exports[`DetailsViewContainer render renders spinner when stores not ready 1`] =
 
 exports[`DetailsViewContainer renderContent renders TargetPageClosedView when target page closed 1`] = `
 "<Fragment>
-  <InteractiveHeader deps={{...}} selectedPivot={{...}} featureFlagStoreData={{...}} tabClosed={true} />
+  <Header deps={{...}} />
   <NoContentAvailable />
 </Fragment>"
 `;
 
+exports[`DetailsViewContainer renderContent renders normally 1`] = `"<DetailsViewContent deps={{...}} storeState={{...}} />"`;
+
 exports[`DetailsViewContainer renderContent shows target tab was closed when stores are not loaded 1`] = `
 "<Fragment>
-  <InteractiveHeader deps={{...}} selectedPivot={0} featureFlagStoreData={{...}} tabClosed={true} />
+  <Header deps={{...}} />
   <NoContentAvailable />
 </Fragment>"
 `;

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` render renders normally 1`] = `
+"<Fragment>
+  <InteractiveHeader deps={{...}} selectedPivot={0} featureFlagStoreData={{...}} tabClosed={false} />
+  <DetailsViewBody deps={{...}} tabStoreData={{...}} assessmentStoreData={{...}} pathSnippetStoreData={{...}} featureFlagStoreData={{...}} selectedTest={-1} detailsViewStoreData={{...}} visualizationStoreData={{...}} visualizationScanResultData={{...}} visualizationConfigurationFactory={[undefined]} assessmentsProvider={[undefined]} dropdownClickHandler={{...}} clickHandlerFactory={[undefined]} assessmentInstanceTableHandler={[undefined]} issuesSelection={[undefined]} issuesTableHandler={[undefined]} rightPanelConfiguration={{...}} switcherNavConfiguration={{...}} userConfigurationStoreData={{...}} cardsViewData={{...}} cardSelectionStoreData={{...}} scanIncompleteWarnings={[undefined]} scanMetadata={{...}} />
+  <DetailsViewOverlay deps={{...}} previewFeatureFlagsHandler={[undefined]} scopingActionMessageCreator={[undefined]} inspectActionMessageCreator={[undefined]} detailsViewStoreData={{...}} scopingStoreData={{...}} featureFlagStoreData={{...}} userConfigurationStoreData={{...}} />
+</Fragment>"
+`;

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-content.test.tsx.snap
@@ -1,9 +1,468 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[` render renders normally 1`] = `
-"<Fragment>
-  <InteractiveHeader deps={{...}} selectedPivot={0} featureFlagStoreData={{...}} tabClosed={false} />
-  <DetailsViewBody deps={{...}} tabStoreData={{...}} assessmentStoreData={{...}} pathSnippetStoreData={{...}} featureFlagStoreData={{...}} selectedTest={-1} detailsViewStoreData={{...}} visualizationStoreData={{...}} visualizationScanResultData={{...}} visualizationConfigurationFactory={[undefined]} assessmentsProvider={[undefined]} dropdownClickHandler={{...}} clickHandlerFactory={[undefined]} assessmentInstanceTableHandler={[undefined]} issuesSelection={[undefined]} issuesTableHandler={[undefined]} rightPanelConfiguration={{...}} switcherNavConfiguration={{...}} userConfigurationStoreData={{...}} cardsViewData={{...}} cardSelectionStoreData={{...}} scanIncompleteWarnings={[undefined]} scanMetadata={{...}} />
-  <DetailsViewOverlay deps={{...}} previewFeatureFlagsHandler={[undefined]} scopingActionMessageCreator={[undefined]} inspectActionMessageCreator={[undefined]} detailsViewStoreData={{...}} scopingStoreData={{...}} featureFlagStoreData={{...}} userConfigurationStoreData={{...}} />
-</Fragment>"
+<React.Fragment>
+  <InteractiveHeader
+    deps={
+      Object {
+        "detailsViewActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "addPathForValidation": [Function],
+          "cancelStartOver": [Function],
+          "cancelStartOverAllAssessments": [Function],
+          "changeAssessmentVisualizationState": [Function],
+          "changeManualRequirementStatus": [Function],
+          "changeManualTestStatus": [Function],
+          "clearPathSnippetData": [Function],
+          "closePreviewFeaturesPanel": [Function],
+          "closeScopingPanel": [Function],
+          "closeSettingsPanel": [Function],
+          "continuePreviousAssessment": [Function],
+          "copyIssueDetailsClicked": [Function],
+          "dispatcher": undefined,
+          "editFailureInstance": [Function],
+          "removeFailureInstance": [Function],
+          "rescanVisualization": [Function],
+          "setAllUrlsPermissionState": [Function],
+          "setFeatureFlag": [Function],
+          "startOverAllAssessments": [Function],
+          "switchToTargetTab": [Function],
+          "telemetryFactory": undefined,
+          "undoManualRequirementStatusChange": [Function],
+          "undoManualTestStatusChange": [Function],
+        },
+        "dropdownClickHandler": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dropdownActionMessageCreator": undefined,
+          "openDebugTools": [Function],
+          "openPreviewFeaturesPanelHandler": [Function],
+          "openScopingPanelHandler": [Function],
+          "openSettingsPanelHandler": [Function],
+          "source": undefined,
+        },
+        "getCardSelectionViewData": [Function],
+        "getCardViewData": [Function],
+        "getDetailsRightPanelConfiguration": [Function],
+        "getDetailsSwitcherNavConfiguration": [Function],
+        "isResultHighlightUnavailable": [Function],
+        "storeActionMessageCreator": undefined,
+        "storesHub": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "stores": undefined,
+        },
+      }
+    }
+    featureFlagStoreData={
+      Object {
+        "logTelemetryToConsole": false,
+      }
+    }
+    selectedPivot={0}
+    tabClosed={false}
+  />
+  <DetailsViewBody
+    assessmentStoreData={
+      Object {
+        "assessmentNavState": Object {
+          "selectedTestSubview": null,
+          "selectedTestType": null,
+        },
+        "assessments": Object {},
+        "persistedTabInfo": null,
+        "resultDescription": "",
+      }
+    }
+    cardSelectionStoreData={
+      Object {
+        "focusedResultUid": null,
+        "rules": Object {},
+        "visualHelperEnabled": false,
+      }
+    }
+    cardsViewData={Object {}}
+    deps={
+      Object {
+        "detailsViewActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "addPathForValidation": [Function],
+          "cancelStartOver": [Function],
+          "cancelStartOverAllAssessments": [Function],
+          "changeAssessmentVisualizationState": [Function],
+          "changeManualRequirementStatus": [Function],
+          "changeManualTestStatus": [Function],
+          "clearPathSnippetData": [Function],
+          "closePreviewFeaturesPanel": [Function],
+          "closeScopingPanel": [Function],
+          "closeSettingsPanel": [Function],
+          "continuePreviousAssessment": [Function],
+          "copyIssueDetailsClicked": [Function],
+          "dispatcher": undefined,
+          "editFailureInstance": [Function],
+          "removeFailureInstance": [Function],
+          "rescanVisualization": [Function],
+          "setAllUrlsPermissionState": [Function],
+          "setFeatureFlag": [Function],
+          "startOverAllAssessments": [Function],
+          "switchToTargetTab": [Function],
+          "telemetryFactory": undefined,
+          "undoManualRequirementStatusChange": [Function],
+          "undoManualTestStatusChange": [Function],
+        },
+        "dropdownClickHandler": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dropdownActionMessageCreator": undefined,
+          "openDebugTools": [Function],
+          "openPreviewFeaturesPanelHandler": [Function],
+          "openScopingPanelHandler": [Function],
+          "openSettingsPanelHandler": [Function],
+          "source": undefined,
+        },
+        "getCardSelectionViewData": [Function],
+        "getCardViewData": [Function],
+        "getDetailsRightPanelConfiguration": [Function],
+        "getDetailsSwitcherNavConfiguration": [Function],
+        "isResultHighlightUnavailable": [Function],
+        "storeActionMessageCreator": undefined,
+        "storesHub": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "stores": undefined,
+        },
+      }
+    }
+    detailsViewStoreData={
+      Object {
+        "contentPath": "",
+        "contentTitle": "",
+        "currentPanel": Object {
+          "isContentOpen": false,
+          "isPreviewFeaturesOpen": false,
+          "isScopingOpen": false,
+          "isSettingsOpen": false,
+        },
+        "detailsViewRightContentPanel": "TestView",
+      }
+    }
+    dropdownClickHandler={
+      proxy {
+        "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+        "dropdownActionMessageCreator": undefined,
+        "openDebugTools": [Function],
+        "openPreviewFeaturesPanelHandler": [Function],
+        "openScopingPanelHandler": [Function],
+        "openSettingsPanelHandler": [Function],
+        "source": undefined,
+      }
+    }
+    featureFlagStoreData={
+      Object {
+        "logTelemetryToConsole": false,
+      }
+    }
+    pathSnippetStoreData={
+      Object {
+        "path": null,
+        "snippet": null,
+      }
+    }
+    rightPanelConfiguration={Object {}}
+    scanMetadata={
+      Object {
+        "targetAppInfo": Object {
+          "name": "DetailsViewContainerTest title",
+          "url": "http://detailsViewContainerTest/url/",
+        },
+        "timestamp": "timestamp",
+        "toolData": Object {
+          "applicationProperties": Object {
+            "name": "some app",
+          },
+        },
+      }
+    }
+    selectedTest={-1}
+    switcherNavConfiguration={
+      Object {
+        "getSelectedDetailsView": [Function],
+      }
+    }
+    tabStoreData={
+      Object {
+        "id": 1,
+        "isChanged": false,
+        "isClosed": false,
+        "isPageHidden": false,
+        "title": "DetailsViewContainerTest title",
+        "url": "http://detailsViewContainerTest/url/",
+      }
+    }
+    userConfigurationStoreData={
+      Object {
+        "bugService": "gitHub",
+        "bugServicePropertiesMap": Object {
+          "gitHub": Object {
+            "repository": "gitHub-repository",
+          },
+        },
+        "enableHighContrast": false,
+        "enableTelemetry": true,
+        "isFirstTime": false,
+        "lastSelectedHighContrast": false,
+      }
+    }
+    visualizationScanResultData={
+      Object {
+        "color": Object {
+          "fullAxeResultsMap": null,
+          "fullIdToRuleResultMap": null,
+          "scanResult": null,
+          "selectedAxeResultsMap": null,
+          "selectedIdToRuleResultMap": null,
+        },
+        "headings": Object {
+          "fullAxeResultsMap": null,
+          "fullIdToRuleResultMap": null,
+          "scanResult": null,
+          "selectedAxeResultsMap": null,
+          "selectedIdToRuleResultMap": null,
+        },
+        "issues": Object {
+          "fullAxeResultsMap": null,
+          "fullIdToRuleResultMap": null,
+          "scanResult": null,
+          "selectedAxeResultsMap": null,
+          "selectedIdToRuleResultMap": null,
+        },
+        "landmarks": Object {
+          "fullAxeResultsMap": null,
+          "fullIdToRuleResultMap": null,
+          "scanResult": null,
+          "selectedAxeResultsMap": null,
+          "selectedIdToRuleResultMap": null,
+        },
+        "tabStops": Object {
+          "tabbedElements": null,
+        },
+      }
+    }
+    visualizationStoreData={
+      Object {
+        "focusedTarget": null,
+        "injectingInProgress": null,
+        "injectingStarted": false,
+        "scanning": null,
+        "selectedAdhocDetailsView": -1,
+        "selectedDetailsViewPivot": 0,
+        "selectedFastPassDetailsView": 1,
+        "tests": Object {
+          "adhoc": Object {
+            "color": Object {
+              "enabled": false,
+            },
+            "headings": Object {
+              "enabled": false,
+            },
+            "issues": Object {
+              "enabled": false,
+            },
+            "landmarks": Object {
+              "enabled": false,
+            },
+            "tabStops": Object {
+              "enabled": false,
+            },
+          },
+          "assessments": Object {
+            "audioVideoOnlyAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "automatedChecks": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "colorSensoryAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "contrastAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "customWidgetsAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "errorsAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "headingsAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "imageAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "keyboardInteractionAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "landmarksAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "languageAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "linksAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "liveMultimediaAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "nativeWidgetsAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "pageAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "parsingAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "pointerMotionAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "prerecordedMultimediaAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "repetitiveContentAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "semanticsAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "sequenceAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "textLegibilityAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "timedEventsAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+            "visibleFocusOrderAssessment": Object {
+              "enabled": false,
+              "stepStatus": Object {},
+            },
+          },
+        },
+      }
+    }
+  />
+  <DetailsViewOverlay
+    deps={
+      Object {
+        "detailsViewActionMessageCreator": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "addPathForValidation": [Function],
+          "cancelStartOver": [Function],
+          "cancelStartOverAllAssessments": [Function],
+          "changeAssessmentVisualizationState": [Function],
+          "changeManualRequirementStatus": [Function],
+          "changeManualTestStatus": [Function],
+          "clearPathSnippetData": [Function],
+          "closePreviewFeaturesPanel": [Function],
+          "closeScopingPanel": [Function],
+          "closeSettingsPanel": [Function],
+          "continuePreviousAssessment": [Function],
+          "copyIssueDetailsClicked": [Function],
+          "dispatcher": undefined,
+          "editFailureInstance": [Function],
+          "removeFailureInstance": [Function],
+          "rescanVisualization": [Function],
+          "setAllUrlsPermissionState": [Function],
+          "setFeatureFlag": [Function],
+          "startOverAllAssessments": [Function],
+          "switchToTargetTab": [Function],
+          "telemetryFactory": undefined,
+          "undoManualRequirementStatusChange": [Function],
+          "undoManualTestStatusChange": [Function],
+        },
+        "dropdownClickHandler": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "dropdownActionMessageCreator": undefined,
+          "openDebugTools": [Function],
+          "openPreviewFeaturesPanelHandler": [Function],
+          "openScopingPanelHandler": [Function],
+          "openSettingsPanelHandler": [Function],
+          "source": undefined,
+        },
+        "getCardSelectionViewData": [Function],
+        "getCardViewData": [Function],
+        "getDetailsRightPanelConfiguration": [Function],
+        "getDetailsSwitcherNavConfiguration": [Function],
+        "isResultHighlightUnavailable": [Function],
+        "storeActionMessageCreator": undefined,
+        "storesHub": proxy {
+          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+          "stores": undefined,
+        },
+      }
+    }
+    detailsViewStoreData={
+      Object {
+        "contentPath": "",
+        "contentTitle": "",
+        "currentPanel": Object {
+          "isContentOpen": false,
+          "isPreviewFeaturesOpen": false,
+          "isScopingOpen": false,
+          "isSettingsOpen": false,
+        },
+        "detailsViewRightContentPanel": "TestView",
+      }
+    }
+    featureFlagStoreData={
+      Object {
+        "logTelemetryToConsole": false,
+      }
+    }
+    scopingStoreData={
+      Object {
+        "selectors": Object {
+          "exclude": Array [],
+          "include": Array [],
+        },
+      }
+    }
+    userConfigurationStoreData={
+      Object {
+        "bugService": "gitHub",
+        "bugServicePropertiesMap": Object {
+          "gitHub": Object {
+            "repository": "gitHub-repository",
+          },
+        },
+        "enableHighContrast": false,
+        "enableTelemetry": true,
+        "isFirstTime": false,
+        "lastSelectedHighContrast": false,
+      }
+    }
+  />
+</React.Fragment>
 `;

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -1,48 +1,25 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { DropdownClickHandler } from 'common/dropdown-click-handler';
-import {
-    CardSelectionViewData,
-    GetCardSelectionViewData,
-} from 'common/get-card-selection-view-data';
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { StoreActionMessageCreator } from 'common/message-creators/store-action-message-creator';
 import { StoreActionMessageCreatorImpl } from 'common/message-creators/store-action-message-creator-impl';
-import { GetCardViewData } from 'common/rule-based-view-model-provider';
 import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
-import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
-import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import {
     TargetAppData,
     ToolData,
-    UnifiedResult,
-    UnifiedRule,
     UnifiedScanResultStoreData,
 } from 'common/types/store-data/unified-data-interface';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { VisualizationType } from 'common/types/visualization-type';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
-import { DetailsViewOverlay } from 'DetailsView/components/details-view-overlay/details-view-overlay';
-import {
-    DetailsRightPanelConfiguration,
-    GetDetailsRightPanelConfiguration,
-    GetDetailsRightPanelConfigurationProps,
-} from 'DetailsView/components/details-view-right-panel';
-import {
-    DetailsViewSwitcherNavConfiguration,
-    GetDetailsSwitcherNavConfiguration,
-    GetDetailsSwitcherNavConfigurationProps,
-} from 'DetailsView/components/details-view-switcher-nav';
-import { InteractiveHeader } from 'DetailsView/components/interactive-header';
-import { DetailsViewRightContentPanelType } from 'DetailsView/components/left-nav/details-view-right-content-panel-type';
+import { DetailsRightPanelConfiguration } from 'DetailsView/components/details-view-right-panel';
 import { GetSelectedDetailsViewProps } from 'DetailsView/components/left-nav/get-selected-details-view';
-import { DetailsViewBody } from 'DetailsView/details-view-body';
 import {
     DetailsViewContainer,
     DetailsViewContainerDeps,
-    DetailsViewContainerProps,
     DetailsViewContainerState,
 } from 'DetailsView/details-view-container';
 import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
@@ -61,10 +38,6 @@ describe('DetailsViewContainer', () => {
     const pageUrl = 'http://detailsViewContainerTest/url/';
     let detailsViewActionMessageCreator: IMock<DetailsViewActionMessageCreator>;
     let deps: DetailsViewContainerDeps;
-    let getDetailsRightPanelConfiguration: IMock<GetDetailsRightPanelConfiguration>;
-    let getDetailsSwitcherNavConfiguration: IMock<GetDetailsSwitcherNavConfiguration>;
-    let getCardViewDataMock: IMock<GetCardViewData>;
-    let getCardSelectionViewDataMock: IMock<GetCardSelectionViewData>;
     let targetAppInfo: TargetAppData;
     let isResultHighlightUnavailableStub: IsResultHighlightUnavailable;
     let timestamp: string;
@@ -72,26 +45,6 @@ describe('DetailsViewContainer', () => {
 
     beforeEach(() => {
         detailsViewActionMessageCreator = Mock.ofType<DetailsViewActionMessageCreator>();
-        getDetailsRightPanelConfiguration = Mock.ofInstance(
-            (props: GetDetailsRightPanelConfigurationProps) => null,
-            MockBehavior.Strict,
-        );
-        getDetailsSwitcherNavConfiguration = Mock.ofInstance(
-            (props: GetDetailsSwitcherNavConfigurationProps) => null,
-            MockBehavior.Strict,
-        );
-        getCardViewDataMock = Mock.ofInstance(
-            (
-                rules: UnifiedRule[],
-                results: UnifiedResult[],
-                cardSelectionViewData: CardSelectionViewData,
-            ) => null,
-            MockBehavior.Strict,
-        );
-        getCardSelectionViewDataMock = Mock.ofInstance(
-            (storeData: CardSelectionStoreData) => null,
-            MockBehavior.Strict,
-        );
         isResultHighlightUnavailableStub = () => null;
         timestamp = 'timestamp';
         targetAppInfo = {
@@ -103,10 +56,6 @@ describe('DetailsViewContainer', () => {
         } as ToolData;
         deps = {
             detailsViewActionMessageCreator: detailsViewActionMessageCreator.object,
-            getDetailsRightPanelConfiguration: getDetailsRightPanelConfiguration.object,
-            getDetailsSwitcherNavConfiguration: getDetailsSwitcherNavConfiguration.object,
-            getCardViewData: getCardViewDataMock.object,
-            getCardSelectionViewData: getCardSelectionViewDataMock.object,
             isResultHighlightUnavailable: isResultHighlightUnavailableStub,
         } as DetailsViewContainerDeps;
     });
@@ -199,7 +148,7 @@ describe('DetailsViewContainer', () => {
             expect(rendered.debug()).toMatchSnapshot();
         });
 
-        it('render twice; should not call details view opened on 2nd render', () => {
+        it('render twice; should not call details view opened on second render', () => {
             const storeActionCreator = Mock.ofType(
                 StoreActionMessageCreatorImpl,
                 MockBehavior.Strict,
@@ -210,25 +159,11 @@ describe('DetailsViewContainer', () => {
             );
             const rightContentPanelType = 'TestView';
             const viewType = VisualizationType.Headings;
-            const switcherNavConfig = {
-                getSelectedDetailsView: getSelectedDetailsViewMock.object,
-            } as DetailsViewSwitcherNavConfiguration;
-
             const visualizationStoreData = new VisualizationStoreDataBuilder().build();
             const detailsViewState = new DetailsViewStoreDataBuilder()
                 .withDetailsViewRightContentPanel(rightContentPanelType)
                 .build();
             const tabStoreData = new TabStoreDataBuilder().with('isClosed', false).build();
-
-            setupGetDetailsRightPanelConfiguration(
-                rightContentPanelType,
-                visualizationStoreData.selectedDetailsViewPivot,
-                null,
-            );
-            setupGetSwitcherNavConfiguration(
-                visualizationStoreData.selectedDetailsViewPivot,
-                switcherNavConfig,
-            );
             setupActionMessageCreatorMock(
                 detailsViewActionMessageCreator,
                 visualizationStoreData.selectedDetailsViewPivot,
@@ -267,32 +202,6 @@ describe('DetailsViewContainer', () => {
                     ),
                 )
                 .returns(() => viewType);
-
-            const cardViewData: CardsViewModel = {
-                cards: {},
-                visualHelperEnabled: true,
-                allCardsCollapsed: true,
-            } as CardsViewModel;
-            const cardSelectionViewData: CardSelectionViewData = {} as CardSelectionViewData;
-            getCardSelectionViewDataMock
-                .setup(g =>
-                    g(
-                        state.cardSelectionStoreData,
-                        state.unifiedScanResultStoreData,
-                        isResultHighlightUnavailableStub,
-                    ),
-                )
-                .returns(() => cardSelectionViewData);
-            getCardViewDataMock
-                .setup(m =>
-                    m(
-                        state.unifiedScanResultStoreData.rules,
-                        state.unifiedScanResultStoreData.results,
-                        cardSelectionViewData,
-                    ),
-                )
-                .returns(() => cardViewData);
-
             testObject.render();
 
             detailsViewActionMessageCreator.verifyAll();
@@ -376,92 +285,6 @@ describe('DetailsViewContainer', () => {
         return storesHubMock;
     }
 
-    function buildDetailsViewBody(
-        storeMocks: StoreMocks,
-        props: DetailsViewContainerProps,
-        selectedDetailsView: VisualizationType,
-        rightPanelConfiguration: DetailsRightPanelConfiguration,
-        switcherNavConfiguration: DetailsViewSwitcherNavConfiguration,
-        cardsViewData: CardsViewModel,
-        targetApp: TargetAppData,
-    ): JSX.Element {
-        const scanMetadata = {
-            timestamp: timestamp,
-            toolData: toolData,
-            targetAppInfo: targetApp,
-        };
-        return (
-            <DetailsViewBody
-                deps={deps}
-                tabStoreData={storeMocks.tabStoreData}
-                assessmentStoreData={storeMocks.assessmentStoreData}
-                pathSnippetStoreData={storeMocks.pathSnippetStoreData}
-                featureFlagStoreData={storeMocks.featureFlagStoreData}
-                selectedTest={selectedDetailsView}
-                detailsViewStoreData={storeMocks.detailsViewStoreData}
-                visualizationStoreData={storeMocks.visualizationStoreData}
-                visualizationScanResultData={storeMocks.visualizationScanResultsStoreData}
-                visualizationConfigurationFactory={props.deps.visualizationConfigurationFactory}
-                assessmentsProvider={props.deps.assessmentsProvider}
-                dropdownClickHandler={props.deps.dropdownClickHandler}
-                clickHandlerFactory={props.deps.clickHandlerFactory}
-                assessmentInstanceTableHandler={props.deps.assessmentInstanceTableHandler}
-                issuesSelection={props.deps.issuesSelection}
-                issuesTableHandler={props.deps.issuesTableHandler}
-                rightPanelConfiguration={rightPanelConfiguration}
-                switcherNavConfiguration={switcherNavConfiguration}
-                userConfigurationStoreData={storeMocks.userConfigurationStoreData}
-                cardsViewData={cardsViewData}
-                cardSelectionStoreData={storeMocks.cardSelectionStoreData}
-                scanIncompleteWarnings={
-                    storeMocks.unifiedScanResultStoreData.scanIncompleteWarnings
-                }
-                scanMetadata={scanMetadata}
-            />
-        );
-    }
-
-    function setupGetDetailsRightPanelConfiguration(
-        contentPanelType: DetailsViewRightContentPanelType,
-        selectedPivot: DetailsViewPivotType,
-        returnConfiguration: DetailsRightPanelConfiguration,
-    ): void {
-        const expected: GetDetailsRightPanelConfigurationProps = {
-            selectedDetailsViewPivot: selectedPivot,
-            detailsViewRightContentPanel: contentPanelType,
-        };
-        getDetailsRightPanelConfiguration
-            .setup(gtrpc => gtrpc(It.isValue(expected)))
-            .returns(() => returnConfiguration);
-    }
-
-    function setupGetSwitcherNavConfiguration(
-        selectedPivot: DetailsViewPivotType,
-        returnConfiguration: DetailsViewSwitcherNavConfiguration,
-    ): void {
-        const expected: GetDetailsSwitcherNavConfigurationProps = {
-            selectedDetailsViewPivot: selectedPivot,
-        };
-        getDetailsSwitcherNavConfiguration
-            .setup(gtrpc => gtrpc(It.isValue(expected)))
-            .returns(() => returnConfiguration);
-    }
-
-    function buildOverlay(storeMocks: StoreMocks, props: DetailsViewContainerProps): JSX.Element {
-        return (
-            <DetailsViewOverlay
-                deps={props.deps}
-                previewFeatureFlagsHandler={props.deps.previewFeatureFlagsHandler}
-                scopingActionMessageCreator={props.deps.scopingActionMessageCreator}
-                inspectActionMessageCreator={props.deps.inspectActionMessageCreator}
-                detailsViewStoreData={storeMocks.detailsViewStoreData}
-                scopingStoreData={storeMocks.scopingStoreData}
-                featureFlagStoreData={storeMocks.featureFlagStoreData}
-                userConfigurationStoreData={storeMocks.userConfigurationStoreData}
-            />
-        );
-    }
-
     function setupActionMessageCreatorMock(
         mock: IMock<DetailsViewActionMessageCreator>,
         pivot: DetailsViewPivotType,
@@ -496,18 +319,9 @@ describe('DetailsViewContainer', () => {
         viewType: VisualizationType,
         isPreviewFeaturesOpen: boolean,
     ): void {
-        const clickHandlerFactoryMock = Mock.ofType(DetailsViewToggleClickHandlerFactory);
         const dropdownClickHandler = Mock.ofType(DropdownClickHandler);
-        const getSelectedDetailsViewMock = Mock.ofInstance(
-            (theProps: GetSelectedDetailsViewProps) => null,
-            MockBehavior.Strict,
-        );
         const rightContentPanelType = 'TestView';
         const rightContentPanelConfig = {} as DetailsRightPanelConfiguration;
-        const switcherNavConfig = {
-            getSelectedDetailsView: getSelectedDetailsViewMock.object,
-        } as DetailsViewSwitcherNavConfiguration;
-
         const visualizationStoreData = new VisualizationStoreDataBuilder()
             .withSelectedDetailsViewPivot(DetailsViewPivotType.fastPass)
             .with('selectedAdhocDetailsView', viewType)
@@ -517,17 +331,6 @@ describe('DetailsViewContainer', () => {
             detailsViewActionMessageCreator,
             visualizationStoreData.selectedDetailsViewPivot,
             1,
-        );
-
-        setupGetDetailsRightPanelConfiguration(
-            rightContentPanelType,
-            visualizationStoreData.selectedDetailsViewPivot,
-            rightContentPanelConfig,
-        );
-
-        setupGetSwitcherNavConfiguration(
-            visualizationStoreData.selectedDetailsViewPivot,
-            switcherNavConfig,
         );
 
         const detailsViewState = new DetailsViewStoreDataBuilder()
@@ -571,65 +374,7 @@ describe('DetailsViewContainer', () => {
         const state = getState(storeMocks, viewType, rightContentPanelConfig);
         testObject.state = state;
 
-        getSelectedDetailsViewMock
-            .setup(gsdvm =>
-                gsdvm(
-                    It.isObjectWith({
-                        assessmentStoreData: state.assessmentStoreData,
-                        visualizationStoreData: state.visualizationStoreData,
-                        pathSnippetStoreData: state.pathSnippetStoreData,
-                    }),
-                ),
-            )
-            .returns(() => viewType);
-
-        const cardSelectionViewData: CardSelectionViewData = {} as CardSelectionViewData;
-        getCardSelectionViewDataMock
-            .setup(g =>
-                g(
-                    state.cardSelectionStoreData,
-                    state.unifiedScanResultStoreData,
-                    isResultHighlightUnavailableStub,
-                ),
-            )
-            .returns(() => cardSelectionViewData)
-            .verifiable(Times.once());
-
-        const cardsViewData: CardsViewModel = {} as any;
-        getCardViewDataMock
-            .setup(m =>
-                m(
-                    state.unifiedScanResultStoreData.rules,
-                    state.unifiedScanResultStoreData.results,
-                    cardSelectionViewData,
-                ),
-            )
-            .returns(() => cardsViewData);
-
-        const expected: JSX.Element = (
-            <>
-                <InteractiveHeader
-                    deps={props.deps}
-                    selectedPivot={DetailsViewPivotType.fastPass}
-                    featureFlagStoreData={storeMocks.featureFlagStoreData}
-                    tabClosed={storeMocks.tabStoreData.isClosed}
-                />
-                {buildDetailsViewBody(
-                    storeMocks,
-                    props,
-                    viewType,
-                    rightContentPanelConfig,
-                    switcherNavConfig,
-                    cardsViewData,
-                    targetAppInfo,
-                )}
-                {buildOverlay(storeMocks, props)}
-            </>
-        );
-
-        expect(testObject.render()).toEqual(expected);
-
-        clickHandlerFactoryMock.verifyAll();
-        getCardSelectionViewDataMock.verifyAll();
+        const rendered = shallow(<DetailsViewContainer {...props} />);
+        expect(rendered.debug()).toMatchSnapshot();
     }
 });

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -63,7 +63,7 @@ describe(DetailsViewContent, () => {
     let toolData: ToolData;
 
     beforeEach(() => {
-        detailsViewActionMessageCreator = Mock.ofType<DetailsViewActionMessageCreator>();
+        detailsViewActionMessageCreator = Mock.ofType(DetailsViewActionMessageCreator);
         getDetailsRightPanelConfiguration = Mock.ofInstance(
             (props: GetDetailsRightPanelConfigurationProps) => null,
             MockBehavior.Strict,
@@ -179,7 +179,6 @@ describe(DetailsViewContent, () => {
                 .build();
 
             const state = getState(storeMocks, viewType, rightContentPanelConfig);
-            // testObject.state = state;
 
             getSelectedDetailsViewMock
                 .setup(gsdvm =>
@@ -217,7 +216,7 @@ describe(DetailsViewContent, () => {
                 .returns(() => cardsViewData);
 
             const rendered = shallow(<DetailsViewContent {...props} />);
-            expect(rendered.debug()).toMatchSnapshot();
+            expect(rendered.getElement()).toMatchSnapshot();
 
             clickHandlerFactoryMock.verifyAll();
             getCardSelectionViewDataMock.verifyAll();

--- a/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-content.test.tsx
@@ -1,0 +1,316 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DropdownClickHandler } from 'common/dropdown-click-handler';
+import {
+    CardSelectionViewData,
+    GetCardSelectionViewData,
+} from 'common/get-card-selection-view-data';
+import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
+import { GetCardViewData } from 'common/rule-based-view-model-provider';
+import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
+import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
+import { CardsViewModel } from 'common/types/store-data/card-view-model';
+import {
+    TargetAppData,
+    ToolData,
+    UnifiedResult,
+    UnifiedRule,
+    UnifiedScanResultStoreData,
+} from 'common/types/store-data/unified-data-interface';
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { VisualizationType } from 'common/types/visualization-type';
+import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
+import { DetailsViewContent } from 'DetailsView/components/details-view-content';
+import {
+    DetailsRightPanelConfiguration,
+    GetDetailsRightPanelConfiguration,
+    GetDetailsRightPanelConfigurationProps,
+} from 'DetailsView/components/details-view-right-panel';
+import {
+    DetailsViewSwitcherNavConfiguration,
+    GetDetailsSwitcherNavConfiguration,
+    GetDetailsSwitcherNavConfigurationProps,
+} from 'DetailsView/components/details-view-switcher-nav';
+import { DetailsViewRightContentPanelType } from 'DetailsView/components/left-nav/details-view-right-content-panel-type';
+import { GetSelectedDetailsViewProps } from 'DetailsView/components/left-nav/get-selected-details-view';
+import {
+    DetailsViewContainerDeps,
+    DetailsViewContainerState,
+} from 'DetailsView/details-view-container';
+import { DetailsViewToggleClickHandlerFactory } from 'DetailsView/handlers/details-view-toggle-click-handler-factory';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { IMock, It, Mock, MockBehavior, Times } from 'typemoq';
+
+import { DetailsViewStoreDataBuilder } from '../../common/details-view-store-data-builder';
+import { VisualizationStoreDataBuilder } from '../../common/visualization-store-data-builder';
+import { DetailsViewContainerPropsBuilder } from './details-view-container-props-builder';
+import { StoreMocks } from './store-mocks';
+
+describe(DetailsViewContent, () => {
+    const pageTitle = 'DetailsViewContainerTest title';
+    const pageUrl = 'http://detailsViewContainerTest/url/';
+    let detailsViewActionMessageCreator: IMock<DetailsViewActionMessageCreator>;
+    let deps: DetailsViewContainerDeps;
+    let getDetailsRightPanelConfiguration: IMock<GetDetailsRightPanelConfiguration>;
+    let getDetailsSwitcherNavConfiguration: IMock<GetDetailsSwitcherNavConfiguration>;
+    let getCardViewDataMock: IMock<GetCardViewData>;
+    let getCardSelectionViewDataMock: IMock<GetCardSelectionViewData>;
+    let targetAppInfo: TargetAppData;
+    let isResultHighlightUnavailableStub: IsResultHighlightUnavailable;
+    let timestamp: string;
+    let toolData: ToolData;
+
+    beforeEach(() => {
+        detailsViewActionMessageCreator = Mock.ofType<DetailsViewActionMessageCreator>();
+        getDetailsRightPanelConfiguration = Mock.ofInstance(
+            (props: GetDetailsRightPanelConfigurationProps) => null,
+            MockBehavior.Strict,
+        );
+        getDetailsSwitcherNavConfiguration = Mock.ofInstance(
+            (props: GetDetailsSwitcherNavConfigurationProps) => null,
+            MockBehavior.Strict,
+        );
+        getCardViewDataMock = Mock.ofInstance(
+            (
+                rules: UnifiedRule[],
+                results: UnifiedResult[],
+                cardSelectionViewData: CardSelectionViewData,
+            ) => null,
+            MockBehavior.Strict,
+        );
+        getCardSelectionViewDataMock = Mock.ofInstance(
+            (storeData: CardSelectionStoreData) => null,
+            MockBehavior.Strict,
+        );
+        isResultHighlightUnavailableStub = () => null;
+        timestamp = 'timestamp';
+        targetAppInfo = {
+            name: pageTitle,
+            url: pageUrl,
+        };
+        toolData = {
+            applicationProperties: { name: 'some app' },
+        } as ToolData;
+        deps = {
+            detailsViewActionMessageCreator: detailsViewActionMessageCreator.object,
+            getDetailsRightPanelConfiguration: getDetailsRightPanelConfiguration.object,
+            getDetailsSwitcherNavConfiguration: getDetailsSwitcherNavConfiguration.object,
+            getCardViewData: getCardViewDataMock.object,
+            getCardSelectionViewData: getCardSelectionViewDataMock.object,
+            isResultHighlightUnavailable: isResultHighlightUnavailableStub,
+        } as DetailsViewContainerDeps;
+    });
+
+    describe('render', () => {
+        it('renders normally', () => {
+            const viewType = -1;
+            const isPreviewFeaturesOpen = false;
+            const clickHandlerFactoryMock = Mock.ofType(DetailsViewToggleClickHandlerFactory);
+            const dropdownClickHandler = Mock.ofType(DropdownClickHandler);
+            const getSelectedDetailsViewMock = Mock.ofInstance(
+                (theProps: GetSelectedDetailsViewProps) => null,
+                MockBehavior.Strict,
+            );
+            const rightContentPanelType = 'TestView';
+            const rightContentPanelConfig = {} as DetailsRightPanelConfiguration;
+            const switcherNavConfig = {
+                getSelectedDetailsView: getSelectedDetailsViewMock.object,
+            } as DetailsViewSwitcherNavConfiguration;
+
+            const visualizationStoreData = new VisualizationStoreDataBuilder()
+                .withSelectedDetailsViewPivot(DetailsViewPivotType.fastPass)
+                .with('selectedAdhocDetailsView', viewType)
+                .build();
+
+            setupActionMessageCreatorMock(
+                detailsViewActionMessageCreator,
+                visualizationStoreData.selectedDetailsViewPivot,
+                1,
+            );
+
+            setupGetDetailsRightPanelConfiguration(
+                rightContentPanelType,
+                visualizationStoreData.selectedDetailsViewPivot,
+                rightContentPanelConfig,
+            );
+
+            setupGetSwitcherNavConfiguration(
+                visualizationStoreData.selectedDetailsViewPivot,
+                switcherNavConfig,
+            );
+
+            const detailsViewState = new DetailsViewStoreDataBuilder()
+                .withPreviewFeaturesOpen(isPreviewFeaturesOpen)
+                .withDetailsViewRightContentPanel(rightContentPanelType)
+                .build();
+
+            const userConfigurationStoreData: UserConfigurationStoreData = {
+                isFirstTime: false,
+                enableTelemetry: true,
+                enableHighContrast: false,
+                lastSelectedHighContrast: false,
+                bugService: 'gitHub',
+                bugServicePropertiesMap: { gitHub: { repository: 'gitHub-repository' } },
+            };
+
+            const unifiedScanResultStoreData: UnifiedScanResultStoreData = {
+                results: [],
+                rules: [],
+                targetAppInfo: targetAppInfo,
+                timestamp: timestamp,
+                toolInfo: toolData,
+            };
+
+            const storeMocks = new StoreMocks()
+                .setVisualizationStoreData(visualizationStoreData)
+                .setDetailsViewStoreData(detailsViewState)
+                .setUserConfigurationStoreData(userConfigurationStoreData)
+                .setUnifiedScanResultStoreData(unifiedScanResultStoreData);
+
+            const storesHubMock = createStoresHubMock(storeMocks);
+
+            deps.dropdownClickHandler = dropdownClickHandler.object;
+
+            const props = new DetailsViewContainerPropsBuilder(deps)
+                .setStoreMocks(storeMocks)
+                .setStoresHubMock(storesHubMock.object)
+                .build();
+
+            const state = getState(storeMocks, viewType, rightContentPanelConfig);
+            // testObject.state = state;
+
+            getSelectedDetailsViewMock
+                .setup(gsdvm =>
+                    gsdvm(
+                        It.isObjectWith({
+                            assessmentStoreData: state.assessmentStoreData,
+                            visualizationStoreData: state.visualizationStoreData,
+                            pathSnippetStoreData: state.pathSnippetStoreData,
+                        }),
+                    ),
+                )
+                .returns(() => viewType);
+
+            const cardSelectionViewData: CardSelectionViewData = {} as CardSelectionViewData;
+            getCardSelectionViewDataMock
+                .setup(g =>
+                    g(
+                        state.cardSelectionStoreData,
+                        state.unifiedScanResultStoreData,
+                        isResultHighlightUnavailableStub,
+                    ),
+                )
+                .returns(() => cardSelectionViewData)
+                .verifiable(Times.once());
+
+            const cardsViewData: CardsViewModel = {} as any;
+            getCardViewDataMock
+                .setup(m =>
+                    m(
+                        state.unifiedScanResultStoreData.rules,
+                        state.unifiedScanResultStoreData.results,
+                        cardSelectionViewData,
+                    ),
+                )
+                .returns(() => cardsViewData);
+
+            const rendered = shallow(<DetailsViewContent {...props} />);
+            expect(rendered.debug()).toMatchSnapshot();
+
+            clickHandlerFactoryMock.verifyAll();
+            getCardSelectionViewDataMock.verifyAll();
+        });
+    });
+
+    function createStoresHubMock(
+        storeMocks: StoreMocks,
+        hasStores = true,
+        hasStoreData = true,
+    ): IMock<BaseClientStoresHub<any>> {
+        const storesHubMock = Mock.ofType(BaseClientStoresHub);
+        storesHubMock.setup(s => s.hasStores()).returns(() => hasStores);
+        storesHubMock.setup(s => s.hasStoreData()).returns(() => hasStoreData);
+        storesHubMock.setup(s => s.addChangedListenerToAllStores(It.isAny())).verifiable();
+        storesHubMock.setup(s => s.removeChangedListenerFromAllStores(It.isAny())).verifiable();
+
+        storesHubMock
+            .setup(s => s.getAllStoreData())
+            .returns(() => {
+                return (
+                    storeMocks && {
+                        visualizationStoreData: storeMocks.visualizationStoreData,
+                        tabStoreData: storeMocks.tabStoreData,
+                        visualizationScanResultStoreData:
+                            storeMocks.visualizationScanResultsStoreData,
+                        featureFlagStoreData: storeMocks.featureFlagStoreData,
+                        detailsViewStoreData: storeMocks.detailsViewStoreData,
+                        assessmentStoreData: storeMocks.assessmentStoreData,
+                        pathSnippetStoreData: storeMocks.pathSnippetStoreData,
+                        scopingPanelStateStoreData: storeMocks.scopingStoreData,
+                        userConfigurationStoreData: storeMocks.userConfigurationStoreData,
+                        unifiedScanResultStoreData: storeMocks.unifiedScanResultStoreData,
+                        cardSelectionStoreData: storeMocks.cardSelectionStoreData,
+                    }
+                );
+            });
+        return storesHubMock;
+    }
+
+    function setupGetDetailsRightPanelConfiguration(
+        contentPanelType: DetailsViewRightContentPanelType,
+        selectedPivot: DetailsViewPivotType,
+        returnConfiguration: DetailsRightPanelConfiguration,
+    ): void {
+        const expected: GetDetailsRightPanelConfigurationProps = {
+            selectedDetailsViewPivot: selectedPivot,
+            detailsViewRightContentPanel: contentPanelType,
+        };
+        getDetailsRightPanelConfiguration
+            .setup(gtrpc => gtrpc(It.isValue(expected)))
+            .returns(() => returnConfiguration);
+    }
+
+    function setupGetSwitcherNavConfiguration(
+        selectedPivot: DetailsViewPivotType,
+        returnConfiguration: DetailsViewSwitcherNavConfiguration,
+    ): void {
+        const expected: GetDetailsSwitcherNavConfigurationProps = {
+            selectedDetailsViewPivot: selectedPivot,
+        };
+        getDetailsSwitcherNavConfiguration
+            .setup(gtrpc => gtrpc(It.isValue(expected)))
+            .returns(() => returnConfiguration);
+    }
+
+    function setupActionMessageCreatorMock(
+        mock: IMock<DetailsViewActionMessageCreator>,
+        pivot: DetailsViewPivotType,
+        timesCalled: number,
+    ): void {
+        mock.setup(acm => acm.detailsViewOpened(pivot)).verifiable(Times.exactly(timesCalled));
+    }
+
+    function getState(
+        storeMocks: StoreMocks,
+        viewType: VisualizationType,
+        rightPanel: DetailsRightPanelConfiguration,
+    ): DetailsViewContainerState {
+        return {
+            visualizationStoreData: storeMocks.visualizationStoreData,
+            tabStoreData: storeMocks.tabStoreData,
+            featureFlagStoreData: storeMocks.featureFlagStoreData,
+            detailsViewStoreData: storeMocks.detailsViewStoreData,
+            assessmentStoreData: storeMocks.assessmentStoreData,
+            pathSnippetStoreData: storeMocks.pathSnippetStoreData,
+            userConfigurationStoreData: storeMocks.userConfigurationStoreData,
+            visualizationScanResultStoreData: storeMocks.visualizationScanResultsStoreData,
+            scopingPanelStateStoreData: storeMocks.scopingSelectorsData,
+            unifiedScanResultStoreData: storeMocks.unifiedScanResultStoreData,
+            selectedDetailsView: viewType,
+            selectedDetailsRightPanelConfiguration: rightPanel,
+            cardSelectionStoreData: storeMocks.cardSelectionStoreData,
+        };
+    }
+});


### PR DESCRIPTION
#### Description of changes
To unblock the nav feature I need to do some refactoring to avoid putting any more logic into details view container.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
