### PR TITLE
refactor: move left-nav class to new css module

### DIFF
--- a/src/DetailsView/Styles/detailsview.scss
+++ b/src/DetailsView/Styles/detailsview.scss
@@ -237,26 +237,6 @@ div.insights-file-issue-details-dialog-container {
         min-height: 0;
         &.reflow-ui {
             grid-template-columns: $detailsViewReflowLeftNavWidth 1fr;
-
-            .left-nav,
-            .test-step-nav {
-                .ms-Nav-compositeLink {
-                    &.is-selected {
-                        a {
-                            background-color: $communication-tint-20;
-                        }
-                    }
-                    &.is-expanded,
-                    &.is-expanded + ul {
-                        background-color: $communication-tint-40;
-                        .index-circle {
-                            color: $neutral-0;
-                            background: $index-circle-background;
-                            border-color: $neutral-0;
-                        }
-                    }
-                }
-            }
         }
         .details-view-test-nav-area {
             box-sizing: border-box;
@@ -407,55 +387,12 @@ div.insights-file-issue-details-dialog-container {
             overflow: hidden;
             padding-left: calc(0.5vw + 13px); // 13px is Chevron width.
         }
-        .left-nav {
-            max-height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
-            height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
-            overflow-y: auto;
-            border-right: 1px solid $neutral-8;
-            .dark-gray {
-                color: $neutral-60;
-            }
-            .is-selected .button-flex-container {
-                color: $always-black;
-            }
-            .button-flex-container {
-                padding-left: 5%;
-                padding-right: 8%;
-                width: $detailsViewLeftNavWidth;
-                color: $primary-text;
-                .status-icon {
-                    font-size: 24px;
-                }
-            }
-            .ms-Nav-link {
-                height: fit-content;
-            }
-            .overview-label {
-                padding-left: 10%;
-                text-align: left;
-                margin-top: 6px;
-                margin-bottom: 6px;
-                display: flex;
-                flex-direction: column;
-            }
-            .overview-name {
-                line-height: 20px;
-            }
-            .overview-percent {
-                color: $neutral-55;
-                line-height: 16px;
-                font-size: 12px;
-            }
-        }
         .test-step-nav {
             .ms-Nav-compositeLink {
                 .button-flex-container {
                     width: 100%;
                 }
             }
-        }
-        .left-nav,
-        .test-step-nav {
             z-index: 100;
             background-color: $neutral-0;
             .index-circle {

--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+@import '../../../common/styles/colors.scss';
+@import '../../../common/styles/common.scss';
+
+:global(.reflow-ui) {
+    .left-nav {
+        :global {
+            .ms-Nav-compositeLink {
+                &.is-selected {
+                    a {
+                        background-color: $communication-tint-20 !important;
+                    }
+                }
+                &.is-expanded,
+                &.is-expanded + ul {
+                    background-color: $communication-tint-40;
+                    .index-circle {
+                        color: $neutral-0;
+                        background: $index-circle-background;
+                        border-color: $neutral-0;
+                    }
+                }
+            }
+        }
+    }
+}
+.left-nav {
+    max-height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
+    height: calc(100vh - (#{$detailsViewTotalHeaderHeight}));
+    overflow-y: auto;
+    border-right: 1px solid $neutral-8;
+    z-index: 100;
+    background-color: $neutral-0;
+    :global {
+        .dark-gray {
+            color: $neutral-60;
+        }
+        .is-selected .button-flex-container {
+            color: $always-black;
+        }
+        .button-flex-container {
+            padding-left: 5%;
+            padding-right: 8%;
+            width: $detailsViewLeftNavWidth;
+            color: $primary-text;
+            .status-icon {
+                font-size: 24px;
+            }
+        }
+        .ms-Nav-link {
+            height: fit-content;
+        }
+        .overview-label {
+            padding-left: 10%;
+            text-align: left;
+            margin-top: 6px;
+            margin-bottom: 6px;
+            display: flex;
+            flex-direction: column;
+        }
+        .overview-name {
+            line-height: 20px;
+        }
+        .overview-percent {
+            color: $neutral-55;
+            line-height: 16px;
+            font-size: 12px;
+        }
+        .index-circle {
+            border: 1px solid;
+            display: inline-block;
+            border-radius: 50%;
+            border: 1px solid;
+            width: 1.5em;
+            line-height: 1.5em;
+            padding: 0.07em;
+            margin-top: 0.23em;
+        }
+        .test-name {
+            padding-left: 10%;
+            display: inline-block;
+        }
+        .ms-Nav-navItems {
+            margin-top: 0px !important;
+        }
+        .ms-Nav-compositeLink {
+            .ms-Button-label {
+                color: $neutral-100;
+            }
+            .button-flex-container {
+                display: flex;
+                flex-wrap: nowrap;
+                justify-content: flex-start;
+                height: 100%;
+                align-items: center;
+            }
+            .index-circle {
+                color: $secondary-text;
+                background: $neutral-0;
+                border-color: $neutral-20;
+            }
+            &.is-selected {
+                a {
+                    background-color: $communication-tint-40;
+                }
+                a::after {
+                    border-left: 0px;
+                }
+                .ms-Button-label {
+                    color: $always-black;
+                }
+                .index-circle {
+                    color: $neutral-0;
+                    background: $index-circle-background;
+                    border-color: $neutral-0;
+                }
+            }
+        }
+        .ms-Pivot-text {
+            font-size: $fontSizeS;
+        }
+        .ms-Pivot-icon {
+            font-size: 9px;
+        }
+        button {
+            text-align: left;
+        }
+    }
+}

--- a/src/DetailsView/components/left-nav/details-view-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.tsx
@@ -16,6 +16,7 @@ import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-f
 import { VisualizationType } from '../../../common/types/visualization-type';
 import { DetailsRightPanelConfiguration } from '../details-view-right-panel';
 import { DetailsViewSwitcherNavConfiguration, LeftNavDeps } from '../details-view-switcher-nav';
+import * as styles from './details-view-left-nav.scss';
 
 export type DetailsViewLeftNavDeps = {
     assessmentsProvider: AssessmentsProvider;
@@ -71,7 +72,7 @@ export const DetailsViewLeftNav = NamedFC<DetailsViewLeftNavProps>('DetailsViewL
     );
 
     const leftNav: JSX.Element = (
-        <div className="left-nav main-nav">
+        <div className={`${styles.leftNav} main-nav`}>
             <FlaggedComponent
                 featureFlag={FeatureFlags[FeatureFlags.reflowUI]}
                 featureFlagStoreData={featureFlagStoreData}

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/details-view-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/details-view-left-nav.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`DetailsViewLeftNav should render from switcher nav 1`] = `
 <div
-  className="left-nav main-nav"
+  className="leftNav main-nav"
 >
   <FlaggedComponent
     enableJSXElement={


### PR DESCRIPTION
#### Description of changes

Move styling for left-nav from detailsview.scss into its own css module.

Left nav without reflow feature flag enabled (before refactoring on left, after on right):
<img width="139" alt="no-feat-flag-before" src="https://user-images.githubusercontent.com/55459788/83580629-5d714780-a4f1-11ea-8200-c2dc5061a939.PNG"> <img width="138" alt="no-feat-flag-after" src="https://user-images.githubusercontent.com/55459788/83580640-63672880-a4f1-11ea-9397-b5cc95a07737.PNG">

Left nav with reflow feature flag enabled (before refactoring on left, after on right):
<img width="176" alt="with-feat-flag-before" src="https://user-images.githubusercontent.com/55459788/83580684-8691d800-a4f1-11ea-9709-9eac633cc6c6.PNG"> <img width="176" alt="with-feat-flag-after" src="https://user-images.githubusercontent.com/55459788/83580688-898cc880-a4f1-11ea-8d1d-8ea197fedf0e.PNG">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
