### PR TITLE
feat(android-setup): Add core state machine logic

### DIFF
--- a/src/electron/platform/android/setup/state-machine/state-machine-action-callback.ts
+++ b/src/electron/platform/android/setup/state-machine/state-machine-action-callback.ts
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Action } from 'common/flux/action';
+
+// The following type requires a parameter
+// because if you pass a class type into StateMachineActionCallback
+// you will get a typescript error complaining about
+// how the indexer type on the class can't be infered.
+// https://github.com/microsoft/TypeScript/issues/15300
+export type ActionBag<ActionT> = {
+    [key in keyof ActionT]: Action<unknown>;
+};
+
+// This type represents a callback of form `(payload: PayloadT) => void`, where PayloadT matches
+// the type parameter of the Action corresponding to actionName.
+export type StateMachineActionCallback<
+    ActionT extends ActionBag<ActionT>,
+    actionName extends keyof ActionT
+> = Parameters<ActionT[actionName]['addListener']>[0];

--- a/src/electron/platform/android/setup/state-machine/state-machine-step.ts
+++ b/src/electron/platform/android/setup/state-machine/state-machine-step.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ActionBag, StateMachineActionCallback } from './state-machine-action-callback';
+
+export type StateMachineStep<ActionT extends ActionBag<ActionT>> = {
+    actions: {
+        // eg, 'adb-location-confirmed': (newAdbLocation) => { /* behavior */ }
+        [actionName in keyof ActionT]?: StateMachineActionCallback<ActionT, actionName>;
+    };
+    onEnter?: () => void;
+};

--- a/src/electron/platform/android/setup/state-machine/state-machine-steps-factory.ts
+++ b/src/electron/platform/android/setup/state-machine/state-machine-steps-factory.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ActionBag } from './state-machine-action-callback';
+import { StateMachineSteps } from './state-machine-steps';
+
+type StepTransitionCallback<StepIdT> = (nextStepId: StepIdT) => void;
+
+export type StateMachineStepsFactory<StepIdT extends string, ActionT extends ActionBag<ActionT>> = (
+    callback: StepTransitionCallback<StepIdT>,
+) => StateMachineSteps<StepIdT, ActionT>;

--- a/src/electron/platform/android/setup/state-machine/state-machine-steps.ts
+++ b/src/electron/platform/android/setup/state-machine/state-machine-steps.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { ActionBag } from './state-machine-action-callback';
+import { StateMachineStep } from './state-machine-step';
+
+export type StateMachineSteps<StepIdT extends string, ActionT extends ActionBag<ActionT>> = {
+    [stepId in StepIdT]: StateMachineStep<ActionT>;
+};

--- a/src/electron/platform/android/setup/state-machine/state-machine.ts
+++ b/src/electron/platform/android/setup/state-machine/state-machine.ts
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { EventHandlerList } from 'common/flux/event-handler-list';
 import { ActionBag } from './state-machine-action-callback';
 import { StateMachineSteps } from './state-machine-steps';
 import { StateMachineStepsFactory } from './state-machine-steps-factory';

--- a/src/electron/platform/android/setup/state-machine/state-machine.ts
+++ b/src/electron/platform/android/setup/state-machine/state-machine.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { EventHandlerList } from 'common/flux/event-handler-list';
+import { ActionBag } from './state-machine-action-callback';
+import { StateMachineSteps } from './state-machine-steps';
+import { StateMachineStepsFactory } from './state-machine-steps-factory';
+
+export class StateMachine<StepIdT extends string, ActionT extends ActionBag<ActionT>> {
+    private currentStep: StepIdT;
+    private readonly steps: StateMachineSteps<StepIdT, ActionT>;
+    private readonly stepTransitionCallback: (nextStep: StepIdT) => void;
+
+    constructor(
+        stepsFactory: StateMachineStepsFactory<StepIdT, ActionT>,
+        stepTransitionCallback: (nextStep: StepIdT) => void,
+        firstStep: StepIdT,
+    ) {
+        if (!stepsFactory) {
+            throw new Error('Expected stepsFactory to be defined and not null');
+        }
+        if (!stepTransitionCallback) {
+            throw new Error('Expected stepTransitionCallback to be defined and not null');
+        }
+
+        this.steps = stepsFactory(this.stepTransition);
+        if (!this.steps) {
+            throw new Error('Expected this.steps not to be null');
+        }
+
+        this.stepTransitionCallback = stepTransitionCallback;
+        this.stepTransition(firstStep);
+    }
+
+    public invokeAction(actionName: keyof ActionT, payload?: any): void {
+        const currentStep = this.steps[this.currentStep];
+        const actionCallback = currentStep.actions[actionName] as (payload: any) => void;
+
+        if (actionCallback != null) {
+            actionCallback(payload);
+        }
+    }
+
+    private stepTransition = (nextStep: StepIdT): void => {
+        // during development, all steps may not yet be implemented.
+        // Fail gracefully instead of throwing an exception
+        if (!this.steps[nextStep]) {
+            return;
+        }
+
+        this.currentStep = nextStep;
+
+        if (this.steps[nextStep].onEnter != null) {
+            this.steps[nextStep].onEnter();
+        }
+
+        this.stepTransitionCallback(nextStep);
+    };
+}

--- a/src/tests/unit/tests/electron/platform/android/setup/state-machine/state-machine.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/state-machine/state-machine.test.ts
@@ -4,7 +4,6 @@
 import { Action } from 'common/flux/action';
 import { StateMachine } from 'electron/platform/android/setup/state-machine/state-machine';
 import { StateMachineSteps } from 'electron/platform/android/setup/state-machine/state-machine-steps';
-import { StateMachineStepsFactory } from 'electron/platform/android/setup/state-machine/state-machine-steps-factory';
 import { ExpectedCallType, It, Mock, MockBehavior, Times } from 'typemoq';
 
 type MartiniStepId = 'gin' | 'vermouth' | 'olives';
@@ -51,6 +50,7 @@ describe('Android setup state machine', () => {
             'gin',
         );
 
+        expect(sm).toBeTruthy();
         factoryMock.verifyAll();
         stepTransitionCallbackMock.verifyAll();
     });
@@ -61,15 +61,14 @@ describe('Android setup state machine', () => {
             .setup(m => m(It.is<MartiniStepId>(v => true)))
             .verifiable(Times.never());
 
-        const testFunc = () => {
-            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+        const construction = () =>
+            new StateMachine<MartiniStepId, MartiniActions>(
                 null,
                 stepTransitionCallbackMock.object,
                 'gin',
             );
-        };
 
-        expect(testFunc).toThrowError();
+        expect(construction).toThrowError();
 
         stepTransitionCallbackMock.verifyAll();
     });
@@ -81,15 +80,10 @@ describe('Android setup state machine', () => {
             .returns(factory)
             .verifiable(Times.never());
 
-        const testFunc = () => {
-            const sm = new StateMachine<MartiniStepId, MartiniActions>(
-                factoryMock.object,
-                null,
-                'gin',
-            );
-        };
+        const construction = () =>
+            new StateMachine<MartiniStepId, MartiniActions>(factoryMock.object, null, 'gin');
 
-        expect(testFunc).toThrowError();
+        expect(construction).toThrowError();
 
         factoryMock.verifyAll();
     });
@@ -106,15 +100,14 @@ describe('Android setup state machine', () => {
             .setup(m => m(It.is<MartiniStepId>(v => true)))
             .verifiable(Times.never());
 
-        const testFunc = () => {
-            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+        const construction = () =>
+            new StateMachine<MartiniStepId, MartiniActions>(
                 factoryMock.object,
                 stepTransitionCallbackMock.object,
                 'gin',
             );
-        };
 
-        expect(testFunc).toThrowError();
+        expect(construction).toThrowError();
 
         factoryMock.verifyAll();
         stepTransitionCallbackMock.verifyAll();
@@ -126,15 +119,14 @@ describe('Android setup state machine', () => {
             .setup(m => m(It.is<MartiniStepId>(v => true)))
             .verifiable(Times.never());
 
-        const testFunc = () => {
-            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+        const construction = () =>
+            new StateMachine<MartiniStepId, MartiniActions>(
                 factory,
                 stepTransitionCallbackMock.object,
                 'vermouth',
             );
-        };
 
-        expect(testFunc).not.toThrow();
+        expect(construction).not.toThrow();
         stepTransitionCallbackMock.verifyAll();
     });
 
@@ -202,6 +194,7 @@ describe('Android setup state machine', () => {
             'gin',
         );
 
+        expect(sm).toBeTruthy();
         onEnterMock.verifyAll();
         stepTransitionCallbackMock.verifyAll();
     });
@@ -220,15 +213,14 @@ describe('Android setup state machine', () => {
             .setup(m => m(It.is<MartiniStepId>(v => true)))
             .verifiable(Times.never());
 
-        const testFunc = () => {
-            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+        const construction = () =>
+            new StateMachine<MartiniStepId, MartiniActions>(
                 factoryMock.object,
                 stepTransitionCallbackMock.object,
                 'gin',
             );
-        };
 
-        expect(testFunc).toThrowError(error);
+        expect(construction).toThrowError(error);
         factoryMock.verifyAll();
         stepTransitionCallbackMock.verifyAll();
     });
@@ -248,15 +240,14 @@ describe('Android setup state machine', () => {
             .throws(error)
             .verifiable(Times.once());
 
-        const testFunc = () => {
-            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+        const construction = () =>
+            new StateMachine<MartiniStepId, MartiniActions>(
                 factoryMock.object,
                 stepTransitionCallbackMock.object,
                 'gin',
             );
-        };
 
-        expect(testFunc).toThrowError(error);
+        expect(construction).toThrowError(error);
         factoryMock.verifyAll();
         stepTransitionCallbackMock.verifyAll();
     });
@@ -286,15 +277,14 @@ describe('Android setup state machine', () => {
         const stepTransitionCallbackMock = Mock.ofInstance((_: MartiniStepId) => {});
         stepTransitionCallbackMock.setup(m => m('gin')).verifiable(Times.never());
 
-        const testFunc = () => {
-            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+        const construction = () =>
+            new StateMachine<MartiniStepId, MartiniActions>(
                 otherFactory,
                 stepTransitionCallbackMock.object,
                 'gin',
             );
-        };
 
-        expect(testFunc).toThrowError(error);
+        expect(construction).toThrowError(error);
         onEnterMock.verifyAll();
         stepTransitionCallbackMock.verifyAll();
     });

--- a/src/tests/unit/tests/electron/platform/android/setup/state-machine/state-machine.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/state-machine/state-machine.test.ts
@@ -1,0 +1,301 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { Action } from 'common/flux/action';
+import { StateMachine } from 'electron/platform/android/setup/state-machine/state-machine';
+import { StateMachineSteps } from 'electron/platform/android/setup/state-machine/state-machine-steps';
+import { StateMachineStepsFactory } from 'electron/platform/android/setup/state-machine/state-machine-steps-factory';
+import { ExpectedCallType, It, Mock, MockBehavior, Times } from 'typemoq';
+
+type MartiniStepId = 'gin' | 'vermouth' | 'olives';
+
+class MartiniActions {
+    public shake = new Action<void>();
+    public stir = new Action<void>();
+    public garnish = new Action<string>();
+}
+
+type MartiniSteps = StateMachineSteps<MartiniStepId, MartiniActions>;
+type MartiniStepTransition = (stepId: MartiniStepId) => void;
+
+describe('Android setup state machine', () => {
+    const factory = (onStepTransition: MartiniStepTransition): MartiniSteps => {
+        return {
+            gin: {
+                actions: {
+                    shake: () => onStepTransition('olives'),
+                },
+            },
+            vermouth: null,
+            olives: {
+                actions: {
+                    garnish: (name: string) => onStepTransition('vermouth'),
+                },
+            },
+        };
+    };
+
+    it('constructor calls factory and step transition callback', () => {
+        const factoryMock = Mock.ofInstance(factory, MockBehavior.Strict, true);
+        factoryMock
+            .setup(m => m(It.isAny()))
+            .returns(factory)
+            .verifiable(Times.once());
+
+        const stepTransitionCallbackMock = Mock.ofInstance((_: MartiniStepId) => {});
+        stepTransitionCallbackMock.setup(m => m('gin')).verifiable(Times.once());
+
+        const sm = new StateMachine<MartiniStepId, MartiniActions>(
+            factoryMock.object,
+            stepTransitionCallbackMock.object,
+            'gin',
+        );
+
+        factoryMock.verifyAll();
+        stepTransitionCallbackMock.verifyAll();
+    });
+
+    it('constructor throws exception on null factory', () => {
+        const stepTransitionCallbackMock = Mock.ofInstance((_: MartiniStepId) => {});
+        stepTransitionCallbackMock
+            .setup(m => m(It.is<MartiniStepId>(v => true)))
+            .verifiable(Times.never());
+
+        const testFunc = () => {
+            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+                null,
+                stepTransitionCallbackMock.object,
+                'gin',
+            );
+        };
+
+        expect(testFunc).toThrowError();
+
+        stepTransitionCallbackMock.verifyAll();
+    });
+
+    it('constructor throws exception on null step transition callback', () => {
+        const factoryMock = Mock.ofInstance(factory, MockBehavior.Strict, true);
+        factoryMock
+            .setup(m => m(It.isAny()))
+            .returns(factory)
+            .verifiable(Times.never());
+
+        const testFunc = () => {
+            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+                factoryMock.object,
+                null,
+                'gin',
+            );
+        };
+
+        expect(testFunc).toThrowError();
+
+        factoryMock.verifyAll();
+    });
+
+    it('constructor throws exception if factory returns invalid object', () => {
+        const factoryMock = Mock.ofInstance(factory, MockBehavior.Strict, true);
+        factoryMock
+            .setup(m => m(It.isAny()))
+            .returns(null)
+            .verifiable(Times.once());
+
+        const stepTransitionCallbackMock = Mock.ofInstance((_: MartiniStepId) => {});
+        stepTransitionCallbackMock
+            .setup(m => m(It.is<MartiniStepId>(v => true)))
+            .verifiable(Times.never());
+
+        const testFunc = () => {
+            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+                factoryMock.object,
+                stepTransitionCallbackMock.object,
+                'gin',
+            );
+        };
+
+        expect(testFunc).toThrowError();
+
+        factoryMock.verifyAll();
+        stepTransitionCallbackMock.verifyAll();
+    });
+
+    it('Fails gracefully when a step is null', () => {
+        const stepTransitionCallbackMock = Mock.ofInstance((_: MartiniStepId) => {});
+        stepTransitionCallbackMock
+            .setup(m => m(It.is<MartiniStepId>(v => true)))
+            .verifiable(Times.never());
+
+        const testFunc = () => {
+            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+                factory,
+                stepTransitionCallbackMock.object,
+                'vermouth',
+            );
+        };
+
+        expect(testFunc).not.toThrow();
+        stepTransitionCallbackMock.verifyAll();
+    });
+
+    it('step transition listener works', () => {
+        const stepTransitionCallbackMock = Mock.ofInstance((_: MartiniStepId) => {});
+        stepTransitionCallbackMock
+            .setup(m => m('gin'))
+            .verifiable(Times.once(), ExpectedCallType.InSequence);
+        stepTransitionCallbackMock
+            .setup(m => m('olives'))
+            .verifiable(Times.once(), ExpectedCallType.InSequence);
+
+        const sm = new StateMachine<MartiniStepId, MartiniActions>(
+            factory,
+            stepTransitionCallbackMock.object,
+            'gin',
+        );
+
+        sm.invokeAction('shake');
+
+        stepTransitionCallbackMock.verifyAll();
+    });
+
+    it('invoke action fails gracefully when no action is found', () => {
+        const stepTransitionCallbackMock = Mock.ofInstance((_: MartiniStepId) => {});
+        stepTransitionCallbackMock.setup(m => m('gin')).verifiable(Times.once());
+
+        const sm = new StateMachine<MartiniStepId, MartiniActions>(
+            factory,
+            stepTransitionCallbackMock.object,
+            'gin',
+        );
+
+        const testFunc = () => {
+            sm.invokeAction('stir');
+        };
+
+        expect(testFunc).not.toThrow();
+        stepTransitionCallbackMock.verifyAll();
+    });
+
+    it('onEnter is invoked when transition happens', () => {
+        const onEnterMock = Mock.ofInstance(() => {});
+        onEnterMock.setup(m => m()).verifiable(Times.once());
+
+        const otherFactory = (
+            onStepTransition: MartiniStepTransition,
+        ): StateMachineSteps<MartiniStepId, MartiniActions> => {
+            return {
+                gin: {
+                    actions: {},
+                    onEnter: onEnterMock.object,
+                },
+                vermouth: null,
+                olives: null,
+            };
+        };
+
+        const stepTransitionCallbackMock = Mock.ofInstance((_: MartiniStepId) => {});
+        stepTransitionCallbackMock.setup(m => m('gin')).verifiable(Times.once());
+
+        const sm = new StateMachine<MartiniStepId, MartiniActions>(
+            otherFactory,
+            stepTransitionCallbackMock.object,
+            'gin',
+        );
+
+        onEnterMock.verifyAll();
+        stepTransitionCallbackMock.verifyAll();
+    });
+
+    it('does not catch exceptions when calling factory', () => {
+        const error = new Error('my error');
+
+        const factoryMock = Mock.ofInstance(factory, MockBehavior.Strict, true);
+        factoryMock
+            .setup(m => m(It.isAny()))
+            .throws(error)
+            .verifiable(Times.once());
+
+        const stepTransitionCallbackMock = Mock.ofInstance((_: MartiniStepId) => {});
+        stepTransitionCallbackMock
+            .setup(m => m(It.is<MartiniStepId>(v => true)))
+            .verifiable(Times.never());
+
+        const testFunc = () => {
+            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+                factoryMock.object,
+                stepTransitionCallbackMock.object,
+                'gin',
+            );
+        };
+
+        expect(testFunc).toThrowError(error);
+        factoryMock.verifyAll();
+        stepTransitionCallbackMock.verifyAll();
+    });
+
+    it('does not catch exceptions when calling step transition callback', () => {
+        const factoryMock = Mock.ofInstance(factory, MockBehavior.Strict, true);
+        factoryMock
+            .setup(m => m(It.isAny()))
+            .returns(factory)
+            .verifiable(Times.once());
+
+        const error = new Error('my error');
+
+        const stepTransitionCallbackMock = Mock.ofInstance((_: MartiniStepId) => {});
+        stepTransitionCallbackMock
+            .setup(m => m(It.is<MartiniStepId>(v => true)))
+            .throws(error)
+            .verifiable(Times.once());
+
+        const testFunc = () => {
+            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+                factoryMock.object,
+                stepTransitionCallbackMock.object,
+                'gin',
+            );
+        };
+
+        expect(testFunc).toThrowError(error);
+        factoryMock.verifyAll();
+        stepTransitionCallbackMock.verifyAll();
+    });
+
+    it('does not catch exceptions when calling onEnter', () => {
+        const error = new Error('my error');
+
+        const onEnterMock = Mock.ofInstance(() => {});
+        onEnterMock
+            .setup(m => m())
+            .throws(error)
+            .verifiable(Times.once());
+
+        const otherFactory = (
+            onStepTransition: MartiniStepTransition,
+        ): StateMachineSteps<MartiniStepId, MartiniActions> => {
+            return {
+                gin: {
+                    actions: {},
+                    onEnter: onEnterMock.object,
+                },
+                vermouth: null,
+                olives: null,
+            };
+        };
+
+        const stepTransitionCallbackMock = Mock.ofInstance((_: MartiniStepId) => {});
+        stepTransitionCallbackMock.setup(m => m('gin')).verifiable(Times.never());
+
+        const testFunc = () => {
+            const sm = new StateMachine<MartiniStepId, MartiniActions>(
+                otherFactory,
+                stepTransitionCallbackMock.object,
+                'gin',
+            );
+        };
+
+        expect(testFunc).toThrowError(error);
+        onEnterMock.verifyAll();
+        stepTransitionCallbackMock.verifyAll();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Given a set of steps (states), the job of the state machine is to link a step to a set of actions. When an action is invoked on the state machine, the action is invoked for the current step. The step itself may fire a callback to transition to another step and the process repeats.

This implementation is designed to link specific Action<> invocations to the actions contained in the steps. In this way, a store which uses the state machine can forward action calls, and consistency with the standard actions mechanism can be maintained.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
