### PR TITLE
feat(nav-bar-functionality): change hover colors for reflow ui

### DIFF
--- a/src/DetailsView/components/left-nav/details-view-left-nav.scss
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.scss
@@ -9,6 +9,7 @@
         :global {
             .ms-Nav-compositeLink {
                 &.is-selected {
+                    background-color: $communication-tint-20;
                     a {
                         background-color: $communication-tint-20 !important;
                     }
@@ -20,6 +21,11 @@
                         color: $neutral-0;
                         background: $index-circle-background;
                         border-color: $neutral-0;
+                    }
+                }
+                &:hover {
+                    a {
+                        background-color: $nav-link-hover !important;
                     }
                 }
             }

--- a/src/common/styles/colors.scss
+++ b/src/common/styles/colors.scss
@@ -86,6 +86,7 @@ $pill-background: var(--pill-background);
 $pill: var(--pill);
 $screenshot-image-outline: var(--screenshot-image-outline);
 $spinner-text: var(--spinner-text);
+$nav-link-hover: var(--nav-link-hover);
 
 // Consistent colors that don't vary with high contrast mode. Use sparingly.
 $always-white: var(--white);

--- a/src/common/styles/root-level-only/color-definitions.scss
+++ b/src/common/styles/root-level-only/color-definitions.scss
@@ -85,6 +85,7 @@
     --pill-background: var(--neutral-alpha-8);
     --pill: var(--primary-text);
     --spinner-text: var(--communication-primary);
+    --nav-link-hover: var(--neutral-alpha-8);
 
     // Landmark colors
     --landmark-contentinfo: #00a88c;
@@ -151,5 +152,6 @@
         --pill: var(--black);
         --screenshot-image-outline: var(--white);
         --spinner-text: var(--communication-tint-40);
+        --nav-link-hover: #2a2a2a;
     }
 }


### PR DESCRIPTION
#### Description of changes

Change the hover color for the reflow UI to a transparent gray so we have sufficient contrast with both the default white background and the blue blackground for the expanded links:
<img width="176" alt="hover collapsed link" src="https://user-images.githubusercontent.com/55459788/83814691-9e916500-a673-11ea-95f3-158947b35356.PNG"> <img width="175" alt="hover expanded link" src="https://user-images.githubusercontent.com/55459788/83814693-9f29fb80-a673-11ea-9dc6-16a26cc834c4.PNG"> <img width="173" alt="hover selected link" src="https://user-images.githubusercontent.com/55459788/83814695-9fc29200-a673-11ea-80eb-6e21b13230e0.PNG">

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #1724870
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
