### PR TITLE
feat(android-setup): Modify AndroidSetupStore to use the state machine as it's engine

### DIFF
--- a/src/electron/flux/action/android-setup-actions.ts
+++ b/src/electron/flux/action/android-setup-actions.ts
@@ -2,6 +2,13 @@
 // Licensed under the MIT License.
 import { Action } from 'common/flux/action';
 
+// This class needs only to represent possible simultaneously invokable actions
+// So, for example, the 'next' action may represent 'continue', 'str again', or 'start scanning'
 export class AndroidSetupActions {
     public readonly cancel = new Action<void>();
+    public readonly close = new Action<void>();
+    public readonly next = new Action<void>();
+    public readonly rescan = new Action<void>();
+    public readonly saveAdbPath = new Action<string>();
+    public readonly setSelectedDevice = new Action<string>();
 }

--- a/src/electron/flux/store/android-setup-store.ts
+++ b/src/electron/flux/store/android-setup-store.ts
@@ -16,7 +16,7 @@ export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
 
     constructor(
         private readonly androidSetupActions: AndroidSetupActions,
-        private createAndroidSetupStateMachine: AndroidSetupStateMachineFactory,
+        private readonly createAndroidSetupStateMachine: AndroidSetupStateMachineFactory,
     ) {
         super(StoreNames.AndroidSetupStore);
     }
@@ -29,7 +29,7 @@ export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
     public getDefaultState(): AndroidSetupStoreData {
         // the value of currentStepId below is not especially meaningful
         // because the state will be overridden on the call to initialize
-        // when the state machine factory is run.
+        // when the state machine factory is created.
         return { currentStepId: 'detect-adb' };
     }
 
@@ -37,6 +37,11 @@ export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
         const actionNames = Object.keys(this.androidSetupActions) as (keyof AndroidSetupActions)[];
 
         for (const actionName of actionNames) {
+            // this.androidSetupActions will not be a type of exactly AndroidSetupActions at runtime during unit tests
+            if (!this.androidSetupActions[actionName].addListener) {
+                continue;
+            }
+
             this.androidSetupActions[actionName].addListener(payload =>
                 this.stateMachine.invokeAction(actionName, payload),
             );

--- a/src/electron/flux/store/android-setup-store.ts
+++ b/src/electron/flux/store/android-setup-store.ts
@@ -2,23 +2,49 @@
 // Licensed under the MIT License.
 import { BaseStoreImpl } from 'background/stores/base-store-impl';
 import { StoreNames } from 'common/stores/store-names';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { AndroidSetupActions } from '../action/android-setup-actions';
 import { AndroidSetupStoreData } from '../types/android-setup-store-data';
 
+import {
+    AndroidSetupStateMachine,
+    AndroidSetupStateMachineFactory,
+} from '../types/android-setup-state-machine-types';
+
 export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
-    constructor(private readonly androidSetupActions: AndroidSetupActions) {
+    private stateMachine: AndroidSetupStateMachine;
+
+    constructor(
+        private readonly androidSetupActions: AndroidSetupActions,
+        private createAndroidSetupStateMachine: AndroidSetupStateMachineFactory,
+    ) {
         super(StoreNames.AndroidSetupStore);
     }
 
+    public initialize(initialState?: AndroidSetupStoreData): void {
+        super.initialize(initialState);
+        this.stateMachine = this.createAndroidSetupStateMachine(this.stepTransition);
+    }
+
     public getDefaultState(): AndroidSetupStoreData {
+        // the value of currentStepId below is not especially meaningful
+        // because the state will be overridden on the call to initialize
+        // when the state machine factory is run.
         return { currentStepId: 'detect-adb' };
     }
 
-    private onCancel = () => {
+    protected addActionListeners(): void {
+        const actionNames = Object.keys(this.androidSetupActions) as (keyof AndroidSetupActions)[];
+
+        for (const actionName of actionNames) {
+            this.androidSetupActions[actionName].addListener(payload =>
+                this.stateMachine.invokeAction(actionName, payload),
+            );
+        }
+    }
+
+    private stepTransition = (nextStep: AndroidSetupStepId): void => {
+        this.state.currentStepId = nextStep;
         this.emitChanged();
     };
-
-    protected addActionListeners(): void {
-        this.androidSetupActions.cancel.addListener(this.onCancel);
-    }
 }

--- a/src/electron/flux/types/android-setup-state-machine-types.ts
+++ b/src/electron/flux/types/android-setup-state-machine-types.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
+import { StateMachine } from 'electron/platform/android/setup/state-machine/state-machine';
+import { AndroidSetupActions } from '../action/android-setup-actions';
+
+export type AndroidSetupStateMachine = StateMachine<AndroidSetupStepId, AndroidSetupActions>;
+export type AndroidSetupStepTransitionCallback = (nextStep: AndroidSetupStepId) => void;
+export type AndroidSetupStateMachineFactory = (
+    stepTransitionCallback: AndroidSetupStepTransitionCallback,
+) => AndroidSetupStateMachine;

--- a/src/electron/flux/types/android-setup-state-machine-types.ts
+++ b/src/electron/flux/types/android-setup-state-machine-types.ts
@@ -6,7 +6,9 @@ import { StateMachine } from 'electron/platform/android/setup/state-machine/stat
 import { AndroidSetupActions } from '../action/android-setup-actions';
 
 export type AndroidSetupStateMachine = StateMachine<AndroidSetupStepId, AndroidSetupActions>;
+
 export type AndroidSetupStepTransitionCallback = (nextStep: AndroidSetupStepId) => void;
+
 export type AndroidSetupStateMachineFactory = (
     stepTransitionCallback: AndroidSetupStepTransitionCallback,
 ) => AndroidSetupStateMachine;

--- a/src/electron/platform/android/setup/android-setup-state-machine-factory.ts
+++ b/src/electron/platform/android/setup/android-setup-state-machine-factory.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions';
+import {
+    AndroidSetupStateMachineFactory,
+    AndroidSetupStepTransitionCallback,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
+import { createAndroidSetupSteps } from 'electron/platform/android/setup/android-setup-steps-factory';
+import { StateMachine } from 'electron/platform/android/setup/state-machine/state-machine';
+import { AndroidSetupStepDeps } from './android-setup-step-deps';
+import { StateMachineSteps } from './state-machine/state-machine-steps';
+
+type AndroidSetupStepsFactory = (
+    stepTransition: AndroidSetupStepTransitionCallback,
+) => StateMachineSteps<AndroidSetupStepId, AndroidSetupActions>;
+
+const stepsFactory = (
+    deps: Omit<AndroidSetupStepDeps, 'stepTransition'>,
+): AndroidSetupStepsFactory => {
+    return (stateMachineStepTransition: AndroidSetupStepTransitionCallback) => {
+        const allDeps = {
+            ...deps,
+            stepTransition: stateMachineStepTransition,
+        };
+
+        return createAndroidSetupSteps(allDeps);
+    };
+};
+
+export const createAndroidSetupStateMachineFactory = (
+    deps: Omit<AndroidSetupStepDeps, 'stepTransition'>,
+): AndroidSetupStateMachineFactory => {
+    return storeStepTransition => {
+        return new StateMachine<AndroidSetupStepId, AndroidSetupActions>(
+            stepsFactory(deps),
+            storeStepTransition,
+            'detect-adb',
+        );
+    };
+};

--- a/src/electron/platform/android/setup/android-setup-step-deps.ts
+++ b/src/electron/platform/android/setup/android-setup-step-deps.ts
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
+
+export type AndroidSetupStepDeps = {
+    stepTransition: (nextStep: AndroidSetupStepId) => void;
+};

--- a/src/electron/platform/android/setup/android-setup-step-deps.ts
+++ b/src/electron/platform/android/setup/android-setup-step-deps.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
+import { AndroidSetupStepId } from './android-setup-step-id';
 
 export type AndroidSetupStepDeps = {
     stepTransition: (nextStep: AndroidSetupStepId) => void;

--- a/src/electron/platform/android/setup/android-setup-steps-factory.ts
+++ b/src/electron/platform/android/setup/android-setup-steps-factory.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions';
+import { AndroidSetupStepDeps } from 'electron/platform/android/setup/android-setup-step-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
+import { StateMachineStep } from 'electron/platform/android/setup/state-machine/state-machine-step';
+import { StateMachineSteps } from 'electron/platform/android/setup/state-machine/state-machine-steps';
+import { mapValues } from 'lodash';
+
+type AndroidSetupStepConfig = (deps: AndroidSetupStepDeps) => StateMachineStep<AndroidSetupActions>;
+
+type AndroidSetupStepConfigs = {
+    [stepId in AndroidSetupStepId]: AndroidSetupStepConfig;
+};
+
+const allAndroidSetupStepConfigs: AndroidSetupStepConfigs = {
+    'detect-adb': null,
+    'prompt-locate-adb': null,
+    'prompt-connect-to-device': null,
+    'detect-devices': null,
+    'prompt-choose-device': null,
+    'detect-service': null,
+    'prompt-install-service': null,
+    'installing-service': null,
+    'prompt-install-failed': null,
+    'detect-permissions': null,
+    'prompt-grant-permissions': null,
+    'prompt-connected-start-testing': null,
+};
+
+export const createAndroidSetupSteps = (
+    deps: AndroidSetupStepDeps,
+): StateMachineSteps<AndroidSetupStepId, AndroidSetupActions> => {
+    return mapValues(allAndroidSetupStepConfigs, config => config && config(deps));
+};

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -73,6 +73,7 @@ import { IpcRendererShim } from 'electron/ipc/ipc-renderer-shim';
 import { createDeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
 import { createScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
 import { ScanController } from 'electron/platform/android/scan-controller';
+import { createAndroidSetupStateMachineFactory } from 'electron/platform/android/setup/android-setup-state-machine-factory';
 import { createDefaultBuilder } from 'electron/platform/android/unified-result-builder';
 import { UnifiedSettingsProvider } from 'electron/settings/unified-settings-provider';
 import { defaultAndroidSetupComponents } from 'electron/views/device-connect-view/components/android-setup/default-android-setup-components';
@@ -185,7 +186,10 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
         const deviceStore = new DeviceStore(deviceActions);
         deviceStore.initialize();
 
-        const androidSetupStore = new AndroidSetupStore(androidSetupActions);
+        const androidSetupStore = new AndroidSetupStore(
+            androidSetupActions,
+            createAndroidSetupStateMachineFactory({}),
+        );
         androidSetupStore.initialize();
 
         const windowStateStore = new WindowStateStore(windowStateActions);

--- a/src/tests/unit/tests/electron/flux/store/android-setup-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/android-setup-store.test.ts
@@ -2,16 +2,21 @@
 // Licensed under the MIT License.
 import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions';
 import { AndroidSetupStore } from 'electron/flux/store/android-setup-store';
-import { AndroidSetupStoreData } from 'electron/flux/types/android-setup-store-data';
-import { createStoreWithNullParams, StoreTester } from '../../../../common/store-tester';
+import {
+    AndroidSetupStateMachine,
+    AndroidSetupStepTransitionCallback,
+} from 'electron/flux/types/android-setup-state-machine-types';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
+import { createStoreWithNullParams } from 'tests/unit/common/store-tester';
+import { It, Mock, Times } from 'typemoq';
+
+const mockableStateMachineFactory = (
+    stepTransition: AndroidSetupStepTransitionCallback,
+): AndroidSetupStateMachine => {
+    return null;
+};
 
 describe('AndroidSetupStore', () => {
-    let initialState: AndroidSetupStoreData;
-
-    beforeEach(() => {
-        initialState = createStoreWithNullParams(AndroidSetupStore).getDefaultState();
-    });
-
     describe('constructor', () => {
         it('has no side effects', () => {
             const testObject = createStoreWithNullParams(AndroidSetupStore);
@@ -19,17 +24,80 @@ describe('AndroidSetupStore', () => {
         });
     });
 
-    it('cancel action calls listener', () => {
-        createStoreTesterForAndroidSetupActions('cancel').testListenerToBeCalledOnce(
-            initialState,
-            initialState,
-        );
+    it('invoked actions result in state machine invoke calls', () => {
+        const actionNames = Object.keys(new AndroidSetupActions()) as (keyof AndroidSetupActions)[];
+
+        const stateMachineMock = Mock.ofType<AndroidSetupStateMachine>();
+
+        for (const actionName of actionNames) {
+            stateMachineMock
+                .setup(m => m.invokeAction(actionName, It.isAny()))
+                .verifiable(Times.once());
+        }
+
+        const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
+        stateMachineFactoryMock
+            .setup(m => m(It.isAny()))
+            .returns(_ => stateMachineMock.object)
+            .verifiable(Times.once());
+
+        const setupActions = new AndroidSetupActions();
+
+        const store = new AndroidSetupStore(setupActions, stateMachineFactoryMock.object);
+        store.initialize();
+
+        setupActions.cancel.invoke();
+        setupActions.close.invoke();
+        setupActions.next.invoke();
+        setupActions.rescan.invoke();
+        setupActions.saveAdbPath.invoke('');
+        setupActions.setSelectedDevice.invoke('');
+
+        stateMachineFactoryMock.verifyAll();
+        stateMachineMock.verifyAll();
     });
 
-    function createStoreTesterForAndroidSetupActions(
-        actionName: keyof AndroidSetupActions,
-    ): StoreTester<AndroidSetupStoreData, AndroidSetupActions> {
-        const factory = (actions: AndroidSetupActions) => new AndroidSetupStore(actions);
-        return new StoreTester(AndroidSetupActions, actionName, factory);
-    }
+    it('action parameters are passed through as expected', () => {
+        const testString = 'may the force be with you';
+
+        const stateMachineMock = Mock.ofType<AndroidSetupStateMachine>();
+        stateMachineMock
+            .setup(m => m.invokeAction('saveAdbPath', testString))
+            .verifiable(Times.once());
+
+        const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
+        stateMachineFactoryMock
+            .setup(m => m(It.isAny()))
+            .returns(_ => stateMachineMock.object)
+            .verifiable(Times.once());
+
+        const setupActions = new AndroidSetupActions();
+
+        const store = new AndroidSetupStore(setupActions, stateMachineFactoryMock.object);
+        store.initialize();
+
+        setupActions.saveAdbPath.invoke(testString);
+
+        stateMachineFactoryMock.verifyAll();
+        stateMachineMock.verifyAll();
+    });
+
+    it('ensure step transition function results in store update', () => {
+        const expectedStepId: AndroidSetupStepId = 'prompt-choose-device';
+
+        const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
+        stateMachineFactoryMock
+            .setup(m => m(It.isAny()))
+            .callback(stepTransition => stepTransition(expectedStepId))
+            .returns(_ => null)
+            .verifiable(Times.once());
+
+        const setupActions = new AndroidSetupActions();
+
+        const store = new AndroidSetupStore(setupActions, stateMachineFactoryMock.object);
+        store.initialize();
+
+        expect(store.getState().currentStepId).toBe(expectedStepId);
+        stateMachineFactoryMock.verifyAll();
+    });
 });

--- a/src/tests/unit/tests/electron/platform/android/setup/android-setup-steps-factory.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/android-setup-steps-factory.test.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions';
+import { AndroidSetupStepDeps } from 'electron/platform/android/setup/android-setup-step-deps';
+import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
+import { createAndroidSetupSteps } from 'electron/platform/android/setup/android-setup-steps-factory';
+import { StateMachineStep } from 'electron/platform/android/setup/state-machine/state-machine-step';
+import { StateMachineSteps } from 'electron/platform/android/setup/state-machine/state-machine-steps';
+import { mapValues } from 'lodash';
+import { IMock, It, Mock, Times } from 'typemoq';
+
+describe('android setup steps factory', () => {
+    it('returns expected steps', () => {
+        const stepTransitionMock = Mock.ofInstance((_: AndroidSetupStepId) => {});
+        stepTransitionMock.setup(m => m(It.isAny())).verifiable(Times.never());
+
+        const deps: AndroidSetupStepDeps = {
+            stepTransition: stepTransitionMock.object,
+        };
+
+        // The following object should be filled out with the results of individual step factories
+        // called with the deps object created above.
+        // Values are allowed to be null while steps are under construction
+        const allAndroidSetupSteps: StateMachineSteps<AndroidSetupStepId, AndroidSetupActions> = {
+            'detect-adb': null,
+            'prompt-locate-adb': null,
+            'prompt-connect-to-device': null,
+            'detect-devices': null,
+            'prompt-choose-device': null,
+            'detect-service': null,
+            'prompt-install-service': null,
+            'installing-service': null,
+            'prompt-install-failed': null,
+            'detect-permissions': null,
+            'prompt-grant-permissions': null,
+            'prompt-connected-start-testing': null,
+        };
+
+        const steps = createAndroidSetupSteps(deps);
+        expect(steps).toStrictEqual(allAndroidSetupSteps);
+
+        stepTransitionMock.verifyAll();
+    });
+});

--- a/src/tests/unit/tests/electron/platform/android/setup/android-setup-steps-factory.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/android-setup-steps-factory.test.ts
@@ -5,10 +5,8 @@ import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions'
 import { AndroidSetupStepDeps } from 'electron/platform/android/setup/android-setup-step-deps';
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { createAndroidSetupSteps } from 'electron/platform/android/setup/android-setup-steps-factory';
-import { StateMachineStep } from 'electron/platform/android/setup/state-machine/state-machine-step';
 import { StateMachineSteps } from 'electron/platform/android/setup/state-machine/state-machine-steps';
-import { mapValues } from 'lodash';
-import { IMock, It, Mock, Times } from 'typemoq';
+import { It, Mock, Times } from 'typemoq';
 
 describe('android setup steps factory', () => {
     it('returns expected steps', () => {


### PR DESCRIPTION
#### Description of changes

The store now takes a factory which will build the state machine and call a provided callback (AndroidSetupStore.stepTransition) which updates the store data.

There is a factory function (createAndroidSetupSteps) which generates steps using dependencies.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
