### PR TITLE
feat: Add feature flag for "needs review" feature

### DIFF
--- a/src/common/feature-flags.ts
+++ b/src/common/feature-flags.ts
@@ -15,6 +15,7 @@ export class FeatureFlags {
     public static readonly debugTools = 'debugTools';
     public static readonly reflowUI = 'reflowUI';
     public static readonly exportReportOptions = 'exportReportOptions';
+    public static readonly needsReview = 'needsReview';
 }
 
 export interface FeatureFlagDetail {
@@ -115,6 +116,15 @@ export function getAllFeatureFlagDetails(): FeatureFlagDetail[] {
             displayableName: 'Reflow UI',
             displayableDescription:
                 'Enables new UX to allow for better reflow of application content and UI elements.',
+            isPreviewFeature: false,
+            forceDefault: false,
+        },
+        {
+            id: FeatureFlags.needsReview,
+            defaultValue: false,
+            displayableName: 'Needs review',
+            displayableDescription:
+                'Enable a new test to show automated check rules that might have an accessibility issue and need to be reviewed.',
             isPreviewFeature: false,
             forceDefault: false,
         },

--- a/src/tests/unit/tests/background/feature-flags.test.ts
+++ b/src/tests/unit/tests/background/feature-flags.test.ts
@@ -27,6 +27,7 @@ describe('FeatureFlagsTest', () => {
             [FeatureFlags.debugTools]: false,
             [FeatureFlags.exportReportOptions]: false,
             [FeatureFlags.reflowUI]: false,
+            [FeatureFlags.needsReview]: false,
         };
 
         const featureFlagValueKeys = keys(featureFlagValues);
@@ -39,7 +40,7 @@ describe('FeatureFlagsTest', () => {
         });
     });
 
-    test('all feature flag have a corresponding feature flag value', () => {
+    test('all feature flags have a corresponding feature flag value', () => {
         const featureFlags = keys(FeatureFlags).sort();
         const featureFlagValueKeys = keys(featureFlagValues).sort();
 


### PR DESCRIPTION
#### Description of changes
Added a feature flag for the "needs review" feature.  The "Needs review" feature flag now appears in the (not publicly visible) list of feature flags. 

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS

![image](https://user-images.githubusercontent.com/33770444/83924400-92c8a000-a752-11ea-83e2-436235654125.png)
(Image of the "Preview Features" Pane, which now includes the "Needs review" feature flag at the bottom.)
