### PR TITLE
feat(android-setup): create UI layout for prompt-locate-adb step

### DIFF
--- a/src/common/fabric-icons.ts
+++ b/src/common/fabric-icons.ts
@@ -37,6 +37,7 @@ export function initializeFabricIcons(): void {
             diagnostic: '\uE9D9',
             edit: '\uE70F',
             export: '\uEDE1',
+            FabricFolder: '\uF0A9',
             feedback: '\uED15',
             fileHTML: '\uF2ED',
             gear: '\uE713',

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.scss
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../../../common/styles/fonts.scss';
+
+.prompt-layout {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: nowrap;
+    align-items: flex-start;
+    justify-items: stretch;
+
+    margin-left: 32px;
+    margin-right: 32px;
+    margin-bottom: 32px;
+    margin-top: 17px;
+
+    > {
+        // All flex growth goes to .prompt-content
+        flex-grow: 0;
+        flex-shrink: 0;
+        flex-basis: auto;
+    }
+
+    .prompt-header {
+        margin-top: 0;
+        margin-bottom: 0;
+
+        font-size: $fontSizeLML;
+        font-weight: $fontWeightNormal;
+        line-height: 25px;
+        letter-spacing: -0.02em;
+    }
+    .prompt-more-info {
+        margin-top: 4px;
+        font-size: $fontSize;
+        line-height: 14px;
+    }
+    .prompt-content {
+        flex-grow: 1;
+        flex-shrink: 1;
+        flex-basis: auto;
+
+        margin-top: 24px;
+        font-size: $fontSizeM;
+        line-height: 16px;
+    }
+    .prompt-footer {
+        margin-top: 24px;
+        display: flex;
+        flex-direction: row;
+        justify-items: space-between;
+    }
+}

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.scss
@@ -18,39 +18,60 @@
     padding-bottom: 32px;
     padding-top: 17px;
 
-    > {
-        // All flex growth goes to .prompt-content
-        flex-grow: 0;
-        flex-shrink: 0;
-        flex-basis: auto;
-    }
-
-    .prompt-header {
-        margin-top: 0;
-        margin-bottom: 0;
-
-        font-size: $fontSizeLML;
-        font-weight: $fontWeightNormal;
-        line-height: 25px;
-        letter-spacing: -0.02em;
-    }
-
-    .prompt-more-info {
-        margin-top: 4px;
-    }
-
-    .prompt-content {
-        width: 100%;
+    .prompt-main {
         flex-grow: 1;
         flex-shrink: 1;
         flex-basis: auto;
 
-        margin-top: 24px;
-        font-size: $fontSizeM;
-        line-height: 16px;
+        box-sizing: border-box;
+        width: 100%;
+        height: 100%;
+
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        align-items: flex-start;
+        justify-items: stretch;
+
+        .prompt-header {
+            flex-grow: 0;
+            flex-shrink: 0;
+            flex-basis: auto;
+
+            margin-top: 0;
+            margin-bottom: 0;
+
+            font-size: $fontSizeLML;
+            font-weight: $fontWeightNormal;
+            line-height: 25px;
+            letter-spacing: -0.02em;
+        }
+
+        .prompt-more-info {
+            flex-grow: 0;
+            flex-shrink: 0;
+            flex-basis: auto;
+
+            margin-top: 4px;
+        }
+
+        .prompt-content {
+            flex-grow: 1;
+            flex-shrink: 1;
+            flex-basis: auto;
+
+            width: 100%;
+            margin-top: 24px;
+            font-size: $fontSizeM;
+            line-height: 16px;
+        }
     }
 
     .prompt-footer {
+        flex-grow: 0;
+        flex-shrink: 0;
+        flex-basis: auto;
+
         width: 100%;
         margin-top: 24px;
         display: flex;

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.scss
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../../../../common/styles/fonts.scss';
+@import '../../../../../common/styles/colors.scss';
 
 .prompt-layout {
     display: flex;
@@ -9,10 +10,13 @@
     align-items: flex-start;
     justify-items: stretch;
 
-    margin-left: 32px;
-    margin-right: 32px;
-    margin-bottom: 32px;
-    margin-top: 17px;
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    padding-left: 32px;
+    padding-right: 32px;
+    padding-bottom: 32px;
+    padding-top: 17px;
 
     > {
         // All flex growth goes to .prompt-content
@@ -30,12 +34,13 @@
         line-height: 25px;
         letter-spacing: -0.02em;
     }
+
     .prompt-more-info {
         margin-top: 4px;
-        font-size: $fontSize;
-        line-height: 14px;
     }
+
     .prompt-content {
+        width: 100%;
         flex-grow: 1;
         flex-shrink: 1;
         flex-basis: auto;
@@ -44,10 +49,16 @@
         font-size: $fontSizeM;
         line-height: 16px;
     }
+
     .prompt-footer {
+        width: 100%;
         margin-top: 24px;
         display: flex;
         flex-direction: row;
-        justify-items: space-between;
+        justify-content: space-between;
+
+        > {
+            margin-left: 8px;
+        }
     }
 }

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.tsx
@@ -25,9 +25,11 @@ export const AndroidSetupPromptLayout = NamedFC<AndroidSetupPromptLayoutProps>(
 
         return (
             <div className={styles.promptLayout}>
-                <h1 className={styles.promptHeader}>{props.headerText}</h1>
-                {renderOptionalMoreInfoLink(props.moreInfoLink)}
-                <div className={styles.promptContent}>{props.children}</div>
+                <main className={styles.promptMain}>
+                    <h1 className={styles.promptHeader}>{props.headerText}</h1>
+                    {renderOptionalMoreInfoLink(props.moreInfoLink)}
+                    <div className={styles.promptContent}>{props.children}</div>
+                </main>
                 <footer className={styles.promptFooter}>
                     <DefaultButton {...props.leftFooterButtonProps} />
                     <PrimaryButton {...props.rightFooterButtonProps} />

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { Button, IButtonProps, PrimaryButton } from 'office-ui-fabric-react';
+import { DefaultButton, IButtonProps, PrimaryButton } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './android-setup-prompt-layout.scss';
 
@@ -29,7 +29,7 @@ export const AndroidSetupPromptLayout = NamedFC<AndroidSetupPromptLayoutProps>(
                 {renderOptionalMoreInfoLink(props.moreInfoLink)}
                 <div className={styles.promptContent}>{props.children}</div>
                 <footer className={styles.promptFooter}>
-                    <Button {...props.leftFooterButtonProps} />
+                    <DefaultButton {...props.leftFooterButtonProps} />
                     <PrimaryButton {...props.rightFooterButtonProps} />
                 </footer>
             </div>

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { Button, IButtonProps, PrimaryButton } from 'office-ui-fabric-react';
+import * as React from 'react';
+import * as styles from './android-setup-prompt-layout.scss';
+
+export type AndroidSetupPromptFooterButtonProps = IButtonProps;
+export type AndroidSetupPromptLayoutProps = {
+    headerText: string;
+    moreInfoLink?: JSX.Element;
+    children?: JSX.Element | JSX.Element[];
+    leftFooterButtonProps: AndroidSetupPromptFooterButtonProps;
+    rightFooterButtonProps: AndroidSetupPromptFooterButtonProps;
+};
+
+export const AndroidSetupPromptLayout = NamedFC<AndroidSetupPromptLayoutProps>(
+    'AndroidSetupPromptLayout',
+    props => {
+        const renderOptionalMoreInfoLink = (renderedLink?: JSX.Element) => {
+            return renderedLink == null ? null : (
+                <div className={styles.promptMoreInfo}>{renderedLink}</div>
+            );
+        };
+
+        return (
+            <div className={styles.promptLayout}>
+                <h1 className={styles.promptHeader}>{props.headerText}</h1>
+                {renderOptionalMoreInfoLink(props.moreInfoLink)}
+                <div className={styles.promptContent}>{props.children}</div>
+                <footer className={styles.promptFooter}>
+                    <Button {...props.leftFooterButtonProps} />
+                    <PrimaryButton {...props.rightFooterButtonProps} />
+                </footer>
+            </div>
+        );
+    },
+);

--- a/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 import { AndroidSetupStepComponentProvider } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { DetectAdbStep } from 'electron/views/device-connect-view/components/android-setup/detect-adb-step';
+import { PromptLocateAdbStep } from 'electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step';
 
 export const defaultAndroidSetupComponents: AndroidSetupStepComponentProvider = {
     'detect-adb': DetectAdbStep,
+    'prompt-locate-adb': PromptLocateAdbStep,
 };

--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.scss
@@ -1,21 +1,33 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-.folder-picker {
-    display: flex;
-    flex-direction: row;
+@import '../../../../../common/styles/fonts.scss';
 
-    .text-field {
-        flex-grow: 1;
-        flex-shrink: 1;
-        flex-basis: auto;
-        min-width: 160px;
+.folder-picker {
+    .label {
+        margin-top: 0px;
+        @include text-style-body-m;
     }
 
-    .browse-button {
-        margin-left: 8px;
+    .picker-control {
+        margin-top: 24px;
 
-        flex-grow: 0;
-        flex-shrink: 0;
-        flex-basis: auto;
+        display: flex;
+        flex-direction: row;
+
+        .text-field {
+            flex-grow: 1;
+            flex-shrink: 1;
+            flex-basis: auto;
+
+            min-width: 100px;
+        }
+
+        .browse-button {
+            margin-left: 8px;
+
+            flex-grow: 0;
+            flex-shrink: 0;
+            flex-basis: auto;
+        }
     }
 }

--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.scss
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+.folder-picker {
+    display: flex;
+    flex-direction: row;
+
+    .text-field {
+        flex-grow: 1;
+        flex-shrink: 1;
+        flex-basis: auto;
+        min-width: 160px;
+    }
+
+    .browse-button {
+        margin-left: 8px;
+
+        flex-grow: 0;
+        flex-shrink: 0;
+        flex-basis: auto;
+    }
+}

--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.scss
@@ -3,7 +3,7 @@
 @import '../../../../../common/styles/fonts.scss';
 
 .folder-picker {
-    .label {
+    .instructions {
         margin-top: 0px;
         @include text-style-body-m;
     }

--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import * as styles from './folder-picker.scss';
 
 export type FolderPickerProps = {
-    labelText: string;
+    instructionsText: string;
     value: string;
     onChange: (newValue?: string) => void;
 };
@@ -22,19 +22,20 @@ export const FolderPicker = NamedFC<FolderPickerProps>(
             // To be implemented in terms of Electron.dialog.showOpenDialog in later feature work
         };
 
-        const textFieldId = getId('folder-picker-text-field__');
+        const instructionsId = getId('folder-picker-instructions__');
 
         return (
             <div className={styles.folderPicker}>
-                <label htmlFor={textFieldId} className={styles.label}>
-                    {props.labelText}
-                </label>
+                <p id={instructionsId} className={styles.instructions}>
+                    {props.instructionsText}
+                </p>
                 <div className={styles.pickerControl}>
                     <TextField
-                        id={textFieldId}
+                        placeholder="Enter a path..."
+                        aria-label="Enter a path"
+                        aria-describedby={instructionsId}
                         className={styles.textField}
                         iconProps={{ iconName: 'FabricFolder' }}
-                        placeholder="Type a path..."
                         value={props.value}
                         onChange={onTextFieldChange}
                     />

--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { PrimaryButton, TextField } from 'office-ui-fabric-react';
+import * as React from 'react';
+import * as styles from './folder-picker-text-field.scss';
+
+export type FolderPickerProps = {
+    value: string;
+    onChange: (newValue?: string) => void;
+};
+
+export const FolderPicker = NamedFC<FolderPickerProps>(
+    'FolderPicker',
+    (props: FolderPickerProps) => {
+        const onTextFieldChange = (_, newValue) => {
+            props.onChange(newValue);
+        };
+
+        const onBrowseButtonClick = () => {
+            // To be implemented in terms of Electron.dialog.showOpenDialog in later feature work
+        };
+
+        return (
+            <div className={styles.folderPicker}>
+                <TextField
+                    className={styles.textField}
+                    iconProps={{ iconName: 'FabricFolder' }}
+                    placeholder="Type a path..."
+                    value={props.value}
+                    onChange={onTextFieldChange}
+                />
+                <PrimaryButton
+                    className={styles.browseButton}
+                    text="Browse"
+                    onClick={onBrowseButtonClick}
+                />
+            </div>
+        );
+    },
+);

--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { PrimaryButton, TextField } from 'office-ui-fabric-react';
+import { PrimaryButton, TextField, getId } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './folder-picker.scss';
 
 export type FolderPickerProps = {
+    labelText: string;
     value: string;
     onChange: (newValue?: string) => void;
 };
@@ -21,20 +22,28 @@ export const FolderPicker = NamedFC<FolderPickerProps>(
             // To be implemented in terms of Electron.dialog.showOpenDialog in later feature work
         };
 
+        const textFieldId = getId('folder-picker-text-field__');
+
         return (
             <div className={styles.folderPicker}>
-                <TextField
-                    className={styles.textField}
-                    iconProps={{ iconName: 'FabricFolder' }}
-                    placeholder="Type a path..."
-                    value={props.value}
-                    onChange={onTextFieldChange}
-                />
-                <PrimaryButton
-                    className={styles.browseButton}
-                    text="Browse"
-                    onClick={onBrowseButtonClick}
-                />
+                <label htmlFor={textFieldId} className={styles.label}>
+                    {props.labelText}
+                </label>
+                <div className={styles.pickerControl}>
+                    <TextField
+                        id={textFieldId}
+                        className={styles.textField}
+                        iconProps={{ iconName: 'FabricFolder' }}
+                        placeholder="Type a path..."
+                        value={props.value}
+                        onChange={onTextFieldChange}
+                    />
+                    <PrimaryButton
+                        className={styles.browseButton}
+                        text="Browse"
+                        onClick={onBrowseButtonClick}
+                    />
+                </div>
             </div>
         );
     },

--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
@@ -3,18 +3,9 @@
 import { NamedFC } from 'common/react/named-fc';
 import { PrimaryButton, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
-import * as styles from './folder-picker-text-field.scss';
-
-export type ShowOpenDialog = (
-    opts: Electron.OpenDialogOptions,
-) => Promise<Electron.OpenDialogReturnValue>;
-
-export type FolderPickerDeps = {
-    showOpenDialog: ShowOpenDialog;
-};
+import * as styles from './folder-picker.scss';
 
 export type FolderPickerProps = {
-    deps: FolderPickerDeps;
     value: string;
     onChange: (newValue?: string) => void;
 };
@@ -26,20 +17,8 @@ export const FolderPicker = NamedFC<FolderPickerProps>(
             props.onChange(newValue);
         };
 
-        const onBrowseDialogComplete = (result: Electron.OpenDialogReturnValue) => {
-            if (result.filePaths.length >= 1) {
-                props.onChange(result.filePaths[0]);
-            }
-        };
-
         const onBrowseButtonClick = () => {
-            // To be implemented in later feature work
-            props.deps
-                .showOpenDialog({
-                    properties: ['openDirectory'],
-                })
-                .then(onBrowseDialogComplete)
-                .catch(console.error);
+            // To be implemented in terms of Electron.dialog.showOpenDialog in later feature work
         };
 
         return (

--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { PrimaryButton, TextField, getId } from 'office-ui-fabric-react';
+import { getId, PrimaryButton, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './folder-picker.scss';
 

--- a/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/folder-picker.tsx
@@ -5,7 +5,16 @@ import { PrimaryButton, TextField } from 'office-ui-fabric-react';
 import * as React from 'react';
 import * as styles from './folder-picker-text-field.scss';
 
+export type ShowOpenDialog = (
+    opts: Electron.OpenDialogOptions,
+) => Promise<Electron.OpenDialogReturnValue>;
+
+export type FolderPickerDeps = {
+    showOpenDialog: ShowOpenDialog;
+};
+
 export type FolderPickerProps = {
+    deps: FolderPickerDeps;
     value: string;
     onChange: (newValue?: string) => void;
 };
@@ -17,8 +26,20 @@ export const FolderPicker = NamedFC<FolderPickerProps>(
             props.onChange(newValue);
         };
 
+        const onBrowseDialogComplete = (result: Electron.OpenDialogReturnValue) => {
+            if (result.filePaths.length >= 1) {
+                props.onChange(result.filePaths[0]);
+            }
+        };
+
         const onBrowseButtonClick = () => {
-            // To be implemented in terms of Electron.dialog.showOpenDialog in later feature work
+            // To be implemented in later feature work
+            props.deps
+                .showOpenDialog({
+                    properties: ['openDirectory'],
+                })
+                .then(onBrowseDialogComplete)
+                .catch(console.error);
         };
 
         return (

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
@@ -1,12 +1,59 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
-import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import * as React from 'react';
+import {
+    AndroidSetupPromptLayout,
+    AndroidSetupPromptLayoutProps,
+} from './android-setup-prompt-layout';
+import { CommonAndroidSetupStepProps } from './android-setup-types';
+import { FolderPickerTextField } from './folder-picker-text-field';
 
 export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptLocateAdbStep',
     (props: CommonAndroidSetupStepProps) => {
-        return <div>prompt-locate-adb</div>;
+        const [adbLocation, setAdbLocation] = React.useState(
+            props.userConfigurationStoreData.adbLocation ?? '',
+        );
+
+        const { LinkComponent } = props.deps;
+
+        const onCloseButton = () => {
+            console.log(`androidSetupActionCreator.close()`);
+            // props.deps.androidSetupActionCreator.close();
+        };
+
+        const onNextButton = () => {
+            console.log(`androidSetupActionCreator.commitAdbLocation(${adbLocation})`);
+            // props.deps.androidSetupActionCreator.commitAdbLocation(adbLocation);
+        };
+
+        const onFolderPickerChange = (newValue?: string) => {
+            setAdbLocation(newValue ?? '');
+        };
+
+        const layoutProps: AndroidSetupPromptLayoutProps = {
+            headerText: 'Locate Android Debug Bridge (adb)',
+            moreInfoLink: <LinkComponent href="https://TODO">How do I locate adb?</LinkComponent>,
+            leftFooterButtonProps: {
+                text: 'Close',
+                onClick: onCloseButton,
+            },
+            rightFooterButtonProps: {
+                text: 'Next',
+                disabled: adbLocation === '',
+                onClick: onNextButton,
+            },
+        };
+
+        return (
+            <AndroidSetupPromptLayout {...layoutProps}>
+                <FolderPickerTextField
+                    deps={props.deps}
+                    value={adbLocation}
+                    onChange={onFolderPickerChange}
+                />
+            </AndroidSetupPromptLayout>
+        );
     },
 );

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
@@ -7,7 +7,7 @@ import {
     AndroidSetupPromptLayoutProps,
 } from './android-setup-prompt-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
-import { FolderPickerTextField } from './folder-picker-text-field';
+import { FolderPicker } from './folder-picker';
 
 export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptLocateAdbStep',
@@ -48,11 +48,7 @@ export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
 
         return (
             <AndroidSetupPromptLayout {...layoutProps}>
-                <FolderPickerTextField
-                    deps={props.deps}
-                    value={adbLocation}
-                    onChange={onFolderPickerChange}
-                />
+                <FolderPicker value={adbLocation} onChange={onFolderPickerChange} />
             </AndroidSetupPromptLayout>
         );
     },

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
@@ -53,7 +53,7 @@ export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
         return (
             <AndroidSetupPromptLayout {...layoutProps}>
                 <FolderPicker
-                    labelText="Select the folder containing adb. We'll use it to connect to your device."
+                    instructionsText="Select the folder containing adb. We'll use it to connect to your device."
                     value={adbLocation}
                     onChange={onFolderPickerChange}
                 />

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
@@ -19,13 +19,13 @@ export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
         const { LinkComponent } = props.deps;
 
         const onCloseButton = () => {
+            // To be implemented in future feature work
             console.log(`androidSetupActionCreator.close()`);
-            // props.deps.androidSetupActionCreator.close();
         };
 
         const onNextButton = () => {
-            console.log(`androidSetupActionCreator.commitAdbLocation(${adbLocation})`);
-            // props.deps.androidSetupActionCreator.commitAdbLocation(adbLocation);
+            // To be implemented in future feature work
+            console.log(`androidSetupActionCreator.confirmAdbLocation(${adbLocation})`);
         };
 
         const onFolderPickerChange = (newValue?: string) => {
@@ -34,7 +34,11 @@ export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
 
         const layoutProps: AndroidSetupPromptLayoutProps = {
             headerText: 'Locate Android Debug Bridge (adb)',
-            moreInfoLink: <LinkComponent href="https://TODO">How do I locate adb?</LinkComponent>,
+            moreInfoLink: (
+                <LinkComponent href="https://aka.ms/accessibility-insights-for-android/locateadb">
+                    How do I locate adb?
+                </LinkComponent>
+            ),
             leftFooterButtonProps: {
                 text: 'Close',
                 onClick: onCloseButton,
@@ -48,7 +52,11 @@ export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
 
         return (
             <AndroidSetupPromptLayout {...layoutProps}>
-                <FolderPicker value={adbLocation} onChange={onFolderPickerChange} />
+                <FolderPicker
+                    labelText="Select the folder containing adb. We'll use it to connect to your device."
+                    value={adbLocation}
+                    onChange={onFolderPickerChange}
+                />
             </AndroidSetupPromptLayout>
         );
     },

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
+import * as React from 'react';
+
+export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
+    'PromptLocateAdbStep',
+    (props: CommonAndroidSetupStepProps) => {
+        return <div>prompt-locate-adb</div>;
+    },
+);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-prompt-layout.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-prompt-layout.test.tsx.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AndroidSetupPromptLayout renders per snapshot with a moreInfoLink 1`] = `
+<div
+  className="promptLayout"
+>
+  <main
+    className="promptMain"
+  >
+    <h1
+      className="promptHeader"
+    >
+      Header text
+    </h1>
+    <div
+      className="promptMoreInfo"
+    >
+      <a
+        href="https://test"
+      >
+        test link
+      </a>
+    </div>
+    <div
+      className="promptContent"
+    >
+      <p>
+        child content
+      </p>
+    </div>
+  </main>
+  <footer
+    className="promptFooter"
+  >
+    <CustomizedDefaultButton
+      text="left footer button"
+    />
+    <CustomizedPrimaryButton
+      text="right footer button"
+    />
+  </footer>
+</div>
+`;
+
+exports[`AndroidSetupPromptLayout renders per snapshot without a moreInfoLink 1`] = `
+<div
+  className="promptLayout"
+>
+  <main
+    className="promptMain"
+  >
+    <h1
+      className="promptHeader"
+    >
+      Header text
+    </h1>
+    <div
+      className="promptContent"
+    >
+      <p>
+        child content
+      </p>
+    </div>
+  </main>
+  <footer
+    className="promptFooter"
+  >
+    <CustomizedDefaultButton
+      text="left footer button"
+    />
+    <CustomizedPrimaryButton
+      text="right footer button"
+    />
+  </footer>
+</div>
+`;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/folder-picker.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/folder-picker.test.tsx.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FolderPicker renders per snapshot 1`] = `
+<div
+  className="folderPicker"
+>
+  <label
+    className="label"
+    htmlFor="folder-picker-text-field__1"
+  >
+    Test label
+  </label>
+  <div
+    className="pickerControl"
+  >
+    <StyledTextFieldBase
+      className="textField"
+      iconProps={
+        Object {
+          "iconName": "FabricFolder",
+        }
+      }
+      id="folder-picker-text-field__1"
+      onChange={[Function]}
+      placeholder="Type a path..."
+      value="/path/to/folder"
+    />
+    <CustomizedPrimaryButton
+      className="browseButton"
+      onClick={[Function]}
+      text="Browse"
+    />
+  </div>
+</div>
+`;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/folder-picker.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/folder-picker.test.tsx.snap
@@ -4,25 +4,26 @@ exports[`FolderPicker renders per snapshot 1`] = `
 <div
   className="folderPicker"
 >
-  <label
-    className="label"
-    htmlFor="folder-picker-text-field__1"
+  <p
+    className="instructions"
+    id="folder-picker-instructions__1"
   >
-    Test label
-  </label>
+    some instructions
+  </p>
   <div
     className="pickerControl"
   >
     <StyledTextFieldBase
+      aria-describedby="folder-picker-instructions__1"
+      aria-label="Enter a path"
       className="textField"
       iconProps={
         Object {
           "iconName": "FabricFolder",
         }
       }
-      id="folder-picker-text-field__1"
       onChange={[Function]}
-      placeholder="Type a path..."
+      placeholder="Enter a path..."
       value="/path/to/folder"
     />
     <CustomizedPrimaryButton

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-locate-adb-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-locate-adb-step.test.tsx.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PromptLocateAdbStep renders per snapshot with adbLocation not set 1`] = `
+<AndroidSetupPromptLayout
+  headerText="Locate Android Debug Bridge (adb)"
+  leftFooterButtonProps={
+    Object {
+      "onClick": [Function],
+      "text": "Close",
+    }
+  }
+  moreInfoLink={
+    <LinkComponent
+      href="https://aka.ms/accessibility-insights-for-android/locateadb"
+    >
+      How do I locate adb?
+    </LinkComponent>
+  }
+  rightFooterButtonProps={
+    Object {
+      "disabled": true,
+      "onClick": [Function],
+      "text": "Next",
+    }
+  }
+>
+  <FolderPicker
+    labelText="Select the folder containing adb. We'll use it to connect to your device."
+    onChange={[Function]}
+    value=""
+  />
+</AndroidSetupPromptLayout>
+`;
+
+exports[`PromptLocateAdbStep renders per snapshot with adbLocation set 1`] = `
+<AndroidSetupPromptLayout
+  headerText="Locate Android Debug Bridge (adb)"
+  leftFooterButtonProps={
+    Object {
+      "onClick": [Function],
+      "text": "Close",
+    }
+  }
+  moreInfoLink={
+    <LinkComponent
+      href="https://aka.ms/accessibility-insights-for-android/locateadb"
+    >
+      How do I locate adb?
+    </LinkComponent>
+  }
+  rightFooterButtonProps={
+    Object {
+      "disabled": false,
+      "onClick": [Function],
+      "text": "Next",
+    }
+  }
+>
+  <FolderPicker
+    labelText="Select the folder containing adb. We'll use it to connect to your device."
+    onChange={[Function]}
+    value="/some/path/to/android/home"
+  />
+</AndroidSetupPromptLayout>
+`;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-locate-adb-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-locate-adb-step.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`PromptLocateAdbStep renders per snapshot with adbLocation not set 1`] =
   }
 >
   <FolderPicker
-    labelText="Select the folder containing adb. We'll use it to connect to your device."
+    instructionsText="Select the folder containing adb. We'll use it to connect to your device."
     onChange={[Function]}
     value=""
   />
@@ -57,7 +57,7 @@ exports[`PromptLocateAdbStep renders per snapshot with adbLocation set 1`] = `
   }
 >
   <FolderPicker
-    labelText="Select the folder containing adb. We'll use it to connect to your device."
+    instructionsText="Select the folder containing adb. We'll use it to connect to your device."
     onChange={[Function]}
     value="/some/path/to/android/home"
   />

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.test.tsx
@@ -1,37 +1,36 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
-import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
-import { PromptLocateAdbStep } from 'electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step';
+import {
+    AndroidSetupPromptLayout,
+    AndroidSetupPromptLayoutProps,
+} from 'electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 
-describe('PromptLocateAdbStep', () => {
-    let props: CommonAndroidSetupStepProps;
-
+describe('AndroidSetupPromptLayout', () => {
+    let props: AndroidSetupPromptLayoutProps;
+    const stubChildContent = <p>child content</p>;
     beforeEach(() => {
         props = {
-            userConfigurationStoreData: {} as UserConfigurationStoreData,
-            androidSetupStoreData: {
-                currentStepId: 'prompt-locate-adb',
-            },
-            deps: {
-                androidSetupActionCreator: null,
-                androidSetupStepComponentProvider: null,
-                LinkComponent: null,
-            },
+            headerText: 'Header text',
+            leftFooterButtonProps: { text: 'left footer button' },
+            rightFooterButtonProps: { text: 'right footer button' },
         };
     });
 
-    it('renders per snapshot with adbLocation not set', () => {
-        props.userConfigurationStoreData.adbLocation = null;
-        const rendered = shallow(<PromptLocateAdbStep {...props} />);
+    it('renders per snapshot without a moreInfoLink', () => {
+        props.moreInfoLink = undefined;
+        const rendered = shallow(
+            <AndroidSetupPromptLayout {...props}>{stubChildContent}</AndroidSetupPromptLayout>,
+        );
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    it('renders per snapshot with adbLocation set', () => {
-        props.userConfigurationStoreData.adbLocation = '/some/path/to/android/home';
-        const rendered = shallow(<PromptLocateAdbStep {...props} />);
+    it('renders per snapshot with a moreInfoLink', () => {
+        props.moreInfoLink = <a href="https://test">test link</a>;
+        const rendered = shallow(
+            <AndroidSetupPromptLayout {...props}>{stubChildContent}</AndroidSetupPromptLayout>,
+        );
         expect(rendered.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.test.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
+import { PromptLocateAdbStep } from 'electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('PromptLocateAdbStep', () => {
+    let props: CommonAndroidSetupStepProps;
+
+    beforeEach(() => {
+        props = {
+            userConfigurationStoreData: {} as UserConfigurationStoreData,
+            androidSetupStoreData: {
+                currentStepId: 'prompt-locate-adb',
+            },
+            deps: {
+                androidSetupActionCreator: null,
+                androidSetupStepComponentProvider: null,
+                LinkComponent: null,
+            },
+        };
+    });
+
+    it('renders per snapshot with adbLocation not set', () => {
+        props.userConfigurationStoreData.adbLocation = null;
+        const rendered = shallow(<PromptLocateAdbStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('renders per snapshot with adbLocation set', () => {
+        props.userConfigurationStoreData.adbLocation = '/some/path/to/android/home';
+        const rendered = shallow(<PromptLocateAdbStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+});

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/folder-picker.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/folder-picker.test.tsx
@@ -14,7 +14,7 @@ describe('FolderPicker', () => {
 
     beforeEach(() => {
         props = {
-            labelText: 'Test label',
+            instructionsText: 'some instructions',
             value: '/path/to/folder',
             onChange: null,
         };
@@ -25,9 +25,11 @@ describe('FolderPicker', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    it("coordinates the label's for attribute with the TextField's id", () => {
+    it("coordinates the instructions' id with the TextField's aria-describedby", () => {
         const rendered = shallow(<FolderPicker {...props} />);
-        expect(rendered.find('label').prop('htmlFor')).toBe(rendered.find(TextField).prop('id'));
+        expect(rendered.find('.instructions').prop('id')).toBe(
+            rendered.find(TextField).prop('aria-describedby'),
+        );
     });
 
     it('invokes onChange when the TextField is changed', () => {

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/folder-picker.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/folder-picker.test.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import {
+    FolderPicker,
+    FolderPickerProps,
+} from 'electron/views/device-connect-view/components/android-setup/folder-picker';
+import { shallow } from 'enzyme';
+import { TextField } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { Mock, Times } from 'typemoq';
+
+describe('FolderPicker', () => {
+    let props: FolderPickerProps;
+
+    beforeEach(() => {
+        props = {
+            labelText: 'Test label',
+            value: '/path/to/folder',
+            onChange: null,
+        };
+    });
+
+    it('renders per snapshot', () => {
+        const rendered = shallow(<FolderPicker {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it("coordinates the label's for attribute with the TextField's id", () => {
+        const rendered = shallow(<FolderPicker {...props} />);
+        expect(rendered.find('label').prop('htmlFor')).toBe(rendered.find(TextField).prop('id'));
+    });
+
+    it('invokes onChange when the TextField is changed', () => {
+        const onChangeMock = Mock.ofType<typeof props.onChange>();
+        props.onChange = onChangeMock.object;
+
+        const eventStub = {} as React.FormEvent<any>;
+        const rendered = shallow(<FolderPicker {...props} />);
+        rendered.find(TextField).prop('onChange')(eventStub, 'new text');
+
+        onChangeMock.verify(m => m('new text'), Times.once());
+    });
+});

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.test.tsx
@@ -18,7 +18,7 @@ describe('PromptLocateAdbStep', () => {
             deps: {
                 androidSetupActionCreator: null,
                 androidSetupStepComponentProvider: null,
-                LinkComponent: null,
+                LinkComponent: linkProps => <a {...linkProps} />,
             },
         };
     });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.test.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
+import { PromptLocateAdbStep } from 'electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('PromptLocateAdbStep', () => {
+    let props: CommonAndroidSetupStepProps;
+
+    beforeEach(() => {
+        props = {
+            userConfigurationStoreData: {} as UserConfigurationStoreData,
+            androidSetupStoreData: {
+                currentStepId: 'prompt-locate-adb',
+            },
+            deps: {
+                androidSetupActionCreator: null,
+                androidSetupStepComponentProvider: null,
+                LinkComponent: null,
+            },
+        };
+    });
+
+    it('renders per snapshot with adbLocation not set', () => {
+        props.userConfigurationStoreData.adbLocation = null;
+        const rendered = shallow(<PromptLocateAdbStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('renders per snapshot with adbLocation set', () => {
+        props.userConfigurationStoreData.adbLocation = '/some/path/to/android/home';
+        const rendered = shallow(<PromptLocateAdbStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

This PR adds in the UI layout for the `prompt-locate-adb`. It's focused on getting the UI to look right per the mock.

Out of scope until later PRs:
* Hooking up the "Browse" button to the OS file browser via `Electron.dialog"
* Hooking up buttons to their corresponding actions (deferring until #2806 merges with the action definitions)

To visually test the new UI, I temporarily updated `android-setup-step-container.tsx` L13 to `'prompt-locate-adb'`.

Known visual differences:
* Padding between logo and window title differs in mock; out of scope for this PR
* Link style uses our standard styling rather than the nonstandard styling suggested by the mock, per discussion with Fer
* With OK from Fer, folder icon in text field is on right instead of left, since that's what fluent's TextField supports
* Some font weights appear different due to figma vs windows text rendering; weights match the values in the figma, except...
* minor variations between mock and button formatting; I've used our standard fluent UI button controls here, the weights/padding/etc they use is consistent with the rest of the app
* intentionally changed wording of "the adb" to just "adb" per discussion during feature estimation
* intentionally changed wording of placeholder text from "Type a path..." to "Enter a path..." per discussion with Fer

Screenshot of mock:
![Screenshot of mock](https://user-images.githubusercontent.com/376284/83933846-18534c80-a761-11ea-9f96-b89d495d3e89.png)

Screenshot of UI as-implemented here (note: screenshots still show "Type a path..." text from earlier PR revision, actual UI now uses "Enter a path..."):
![screenshot of implemented UI](https://user-images.githubusercontent.com/376284/83933834-f659ca00-a760-11ea-86d9-bee0a8261b9a.png)

High contrast mode:
![image](https://user-images.githubusercontent.com/376284/83933941-c19a4280-a761-11ea-9733-69ee0a412277.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: Part 1 of 1724336
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
