### PR TITLE
feat(nav-bar-functionality): Add header in side nav panel

### DIFF
--- a/src/DetailsView/components/interactive-header.tsx
+++ b/src/DetailsView/components/interactive-header.tsx
@@ -22,6 +22,7 @@ export interface InteractiveHeaderProps {
     navMenu: ReactFCWithDisplayName<ExpandCollpaseLeftNavButtonProps>;
     isSideNavOpen: boolean;
     setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
+    showFarItems?: boolean;
 }
 
 export const InteractiveHeader = NamedFC<InteractiveHeaderProps>('InteractiveHeader', props => {
@@ -62,9 +63,12 @@ export const InteractiveHeader = NamedFC<InteractiveHeaderProps>('InteractiveHea
         );
     };
 
-    const getFarItems = () => (
-        <GearMenuButton deps={props.deps} featureFlagData={props.featureFlagStoreData} />
-    );
+    const getFarItems = () => {
+        if (props.showFarItems === false) {
+            return null;
+        }
+        return <GearMenuButton deps={props.deps} featureFlagData={props.featureFlagStoreData} />;
+    };
 
     return (
         <Header

--- a/src/DetailsView/components/left-nav/fluent-side-nav.scss
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.scss
@@ -4,9 +4,8 @@
 
 #side-nav-container {
     .left-nav-panel {
-        margin-top: $detailsViewHeaderBarHeight;
         :global(.ms-Panel-main) {
-            width: $detailsViewReflowLeftNavWidth;
+            width: $minPanelWidth;
         }
         :global(.ms-Panel-content) {
             padding: 0px;

--- a/src/DetailsView/components/left-nav/fluent-side-nav.tsx
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.tsx
@@ -3,17 +3,21 @@
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { GenericPanel } from 'DetailsView/components/generic-panel';
 import {
+    InteractiveHeader,
+    InteractiveHeaderDeps,
+} from 'DetailsView/components/interactive-header';
+import {
     DetailsViewLeftNav,
     DetailsViewLeftNavDeps,
     DetailsViewLeftNavProps,
 } from 'DetailsView/components/left-nav/details-view-left-nav';
 import * as styles from 'DetailsView/components/left-nav/fluent-side-nav.scss';
-import { isNil } from 'lodash';
 import { PanelType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
-export type FluentSideNavDeps = DetailsViewLeftNavDeps;
+export type FluentSideNavDeps = DetailsViewLeftNavDeps & InteractiveHeaderDeps;
 export type FluentSideNavProps = DetailsViewLeftNavProps & {
+    deps: FluentSideNavDeps;
     tabStoreData: TabStoreData;
     isSideNavOpen: boolean;
     setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -29,10 +33,22 @@ export class FluentSideNav extends React.Component<FluentSideNavProps> {
         const nav = <DetailsViewLeftNav {...this.props} />;
 
         const dismissPanel = (ev: React.SyntheticEvent<HTMLElement, Event>) => {
-            if (isNil(ev)) {
-                return;
-            }
             this.props.setSideNavOpen(false);
+        };
+
+        const renderHeader = () => {
+            return (
+                <InteractiveHeader
+                    deps={this.props.deps}
+                    tabClosed={false}
+                    selectedPivot={this.props.selectedPivot}
+                    featureFlagStoreData={this.props.featureFlagStoreData}
+                    navMenu={this.props.switcherNavConfiguration.leftNavHamburgerButton}
+                    isSideNavOpen={this.props.isSideNavOpen}
+                    setSideNavOpen={this.props.setSideNavOpen}
+                    showFarItems={false}
+                />
+            );
         };
 
         const navPanel = (
@@ -42,7 +58,7 @@ export class FluentSideNav extends React.Component<FluentSideNavProps> {
                 isLightDismiss
                 hasCloseButton={false}
                 onRenderNavigationContent={() => null}
-                onRenderHeader={() => null}
+                onRenderHeader={renderHeader}
                 onRenderNavigation={() => null}
                 onDismiss={dismissPanel}
                 type={PanelType.customNear}

--- a/src/DetailsView/details-view-body.tsx
+++ b/src/DetailsView/details-view-body.tsx
@@ -7,7 +7,7 @@ import { ScanIncompleteWarningId } from 'common/types/scan-incomplete-warnings';
 import { CardsViewModel } from 'common/types/store-data/card-view-model';
 import { ScanMetadata } from 'common/types/store-data/unified-data-interface';
 import { DetailsViewCommandBarProps } from 'DetailsView/components/details-view-command-bar';
-import { FluentSideNav } from 'DetailsView/components/left-nav/fluent-side-nav';
+import { FluentSideNav, FluentSideNavDeps } from 'DetailsView/components/left-nav/fluent-side-nav';
 import { ISelection } from 'office-ui-fabric-react';
 import * as React from 'react';
 
@@ -36,7 +36,8 @@ import { DetailsViewToggleClickHandlerFactory } from './handlers/details-view-to
 
 export type DetailsViewBodyDeps = DetailsViewContentDeps &
     DetailsViewLeftNavDeps &
-    DetailsViewCommandBarDeps;
+    DetailsViewCommandBarDeps &
+    FluentSideNavDeps;
 
 export interface DetailsViewBodyProps {
     deps: DetailsViewBodyDeps;

--- a/src/common/styles/common.scss
+++ b/src/common/styles/common.scss
@@ -35,6 +35,7 @@ $detailsViewTotalHeaderHeight: (
 $fastPassRightPanelMarginRight: 24px !default;
 $fastPassRightPanelMarginLeft: 24px !default;
 $fastPassRightPanelMarginTop: 24px !default;
+$minPanelWidth: 340px !default;
 
 @mixin ellipsedText {
     white-space: nowrap;


### PR DESCRIPTION
#### Description of changes
Added product header in the nav panel as suggested by Fer.

According to [Microsoft Fluent UI - Panel](https://developer.microsoft.com/en-us/fluentui#/controls/web/panel): **Make sure to have a minimum width of 340px for the Panel component**, I made the width of the panel as 340px this also avoids the problem where the product name overflows when panel width is set to 250px. 

Will check with designer to figure out if this is ideal.

![image](https://user-images.githubusercontent.com/15974344/83964831-600ecc80-a864-11ea-8f61-526385552f80.png)

 

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
