### PR TITLE
feat(android-setup): move android setup nav buttons into main landmark

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.scss
@@ -35,10 +35,6 @@
     }
 
     .prompt-more-info {
-        flex-grow: 0;
-        flex-shrink: 0;
-        flex-basis: auto;
-
         margin-top: 4px;
     }
 
@@ -54,10 +50,6 @@
     }
 
     .prompt-nav-button-footer {
-        flex-grow: 0;
-        flex-shrink: 0;
-        flex-basis: auto;
-
         width: 100%;
         margin-top: 24px;
         display: flex;

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.scss
@@ -1,9 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 @import '../../../../../common/styles/fonts.scss';
-@import '../../../../../common/styles/colors.scss';
 
-.prompt-layout {
+.prompt-main-layout {
     display: flex;
     flex-direction: column;
     flex-wrap: nowrap;
@@ -18,56 +17,43 @@
     padding-bottom: 32px;
     padding-top: 17px;
 
-    .prompt-main {
+    > {
+        // All flex growth is allocated to .prompt-content
+        flex-grow: 0;
+        flex-shrink: 0;
+        flex-basis: auto;
+    }
+
+    .prompt-header {
+        margin-top: 0;
+        margin-bottom: 0;
+
+        font-size: $fontSizeLML;
+        font-weight: $fontWeightNormal;
+        line-height: 25px;
+        letter-spacing: -0.02em;
+    }
+
+    .prompt-more-info {
+        flex-grow: 0;
+        flex-shrink: 0;
+        flex-basis: auto;
+
+        margin-top: 4px;
+    }
+
+    .prompt-content {
         flex-grow: 1;
         flex-shrink: 1;
         flex-basis: auto;
 
-        box-sizing: border-box;
         width: 100%;
-        height: 100%;
-
-        display: flex;
-        flex-direction: column;
-        flex-wrap: nowrap;
-        align-items: flex-start;
-        justify-items: stretch;
-
-        .prompt-header {
-            flex-grow: 0;
-            flex-shrink: 0;
-            flex-basis: auto;
-
-            margin-top: 0;
-            margin-bottom: 0;
-
-            font-size: $fontSizeLML;
-            font-weight: $fontWeightNormal;
-            line-height: 25px;
-            letter-spacing: -0.02em;
-        }
-
-        .prompt-more-info {
-            flex-grow: 0;
-            flex-shrink: 0;
-            flex-basis: auto;
-
-            margin-top: 4px;
-        }
-
-        .prompt-content {
-            flex-grow: 1;
-            flex-shrink: 1;
-            flex-basis: auto;
-
-            width: 100%;
-            margin-top: 24px;
-            font-size: $fontSizeM;
-            line-height: 16px;
-        }
+        margin-top: 24px;
+        font-size: $fontSizeM;
+        line-height: 16px;
     }
 
-    .prompt-footer {
+    .prompt-nav-button-footer {
         flex-grow: 0;
         flex-shrink: 0;
         flex-basis: auto;

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-prompt-layout.tsx
@@ -24,17 +24,15 @@ export const AndroidSetupPromptLayout = NamedFC<AndroidSetupPromptLayoutProps>(
         };
 
         return (
-            <div className={styles.promptLayout}>
-                <main className={styles.promptMain}>
-                    <h1 className={styles.promptHeader}>{props.headerText}</h1>
-                    {renderOptionalMoreInfoLink(props.moreInfoLink)}
-                    <div className={styles.promptContent}>{props.children}</div>
-                </main>
-                <footer className={styles.promptFooter}>
+            <main className={styles.promptMainLayout}>
+                <h1 className={styles.promptHeader}>{props.headerText}</h1>
+                {renderOptionalMoreInfoLink(props.moreInfoLink)}
+                <div className={styles.promptContent}>{props.children}</div>
+                <div className={styles.promptNavButtonFooter}>
                     <DefaultButton {...props.leftFooterButtonProps} />
                     <PrimaryButton {...props.rightFooterButtonProps} />
-                </footer>
-            </div>
+                </div>
+            </main>
         );
     },
 );

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-prompt-layout.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-prompt-layout.test.tsx.snap
@@ -1,36 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AndroidSetupPromptLayout renders per snapshot with a moreInfoLink 1`] = `
-<div
-  className="promptLayout"
+<main
+  className="promptMainLayout"
 >
-  <main
-    className="promptMain"
+  <h1
+    className="promptHeader"
   >
-    <h1
-      className="promptHeader"
+    Header text
+  </h1>
+  <div
+    className="promptMoreInfo"
+  >
+    <a
+      href="https://test"
     >
-      Header text
-    </h1>
-    <div
-      className="promptMoreInfo"
-    >
-      <a
-        href="https://test"
-      >
-        test link
-      </a>
-    </div>
-    <div
-      className="promptContent"
-    >
-      <p>
-        child content
-      </p>
-    </div>
-  </main>
-  <footer
-    className="promptFooter"
+      test link
+    </a>
+  </div>
+  <div
+    className="promptContent"
+  >
+    <p>
+      child content
+    </p>
+  </div>
+  <div
+    className="promptNavButtonFooter"
   >
     <CustomizedDefaultButton
       text="left footer button"
@@ -38,32 +34,28 @@ exports[`AndroidSetupPromptLayout renders per snapshot with a moreInfoLink 1`] =
     <CustomizedPrimaryButton
       text="right footer button"
     />
-  </footer>
-</div>
+  </div>
+</main>
 `;
 
 exports[`AndroidSetupPromptLayout renders per snapshot without a moreInfoLink 1`] = `
-<div
-  className="promptLayout"
+<main
+  className="promptMainLayout"
 >
-  <main
-    className="promptMain"
+  <h1
+    className="promptHeader"
   >
-    <h1
-      className="promptHeader"
-    >
-      Header text
-    </h1>
-    <div
-      className="promptContent"
-    >
-      <p>
-        child content
-      </p>
-    </div>
-  </main>
-  <footer
-    className="promptFooter"
+    Header text
+  </h1>
+  <div
+    className="promptContent"
+  >
+    <p>
+      child content
+    </p>
+  </div>
+  <div
+    className="promptNavButtonFooter"
   >
     <CustomizedDefaultButton
       text="left footer button"
@@ -71,6 +63,6 @@ exports[`AndroidSetupPromptLayout renders per snapshot without a moreInfoLink 1`
     <CustomizedPrimaryButton
       text="right footer button"
     />
-  </footer>
-</div>
+  </div>
+</main>
 `;


### PR DESCRIPTION
#### Description of changes

Per discussion in feature chat, we think the footer buttons don't actually belong in a footer landmark; this PR moves them out of their own separate landmark into the `<main>` element.

No visual change, verified reading in NVDA

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a, no visual change] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
