### PR TITLE
feat(android-setup): Add "detect my device" dialog

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
@@ -2,9 +2,11 @@
 // Licensed under the MIT License.
 import { AndroidSetupStepComponentProvider } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { DetectAdbStep } from 'electron/views/device-connect-view/components/android-setup/detect-adb-step';
+import { PromptConnectToDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step';
 import { PromptLocateAdbStep } from 'electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step';
 
 export const defaultAndroidSetupComponents: AndroidSetupStepComponentProvider = {
     'detect-adb': DetectAdbStep,
     'prompt-locate-adb': PromptLocateAdbStep,
+    'prompt-connect-to-device': PromptConnectToDeviceStep,
 };

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
@@ -1,0 +1,51 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import { PrimaryButton } from 'office-ui-fabric-react';
+import * as React from 'react';
+import {
+    AndroidSetupPromptLayout,
+    AndroidSetupPromptLayoutProps,
+} from './android-setup-prompt-layout';
+import { CommonAndroidSetupStepProps } from './android-setup-types';
+
+export const PromptConnectToDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
+    'PromptConnectToDeviceStep',
+    (props: CommonAndroidSetupStepProps) => {
+        const { LinkComponent } = props.deps;
+
+        const onCloseButton = () => {
+            // To be implemented in future feature work
+            console.log(`androidSetupActionCreator.close()`);
+        };
+
+        const onDetectButton = () => {
+            // To be implemented in future feature work
+            console.log(`androidSetupActionCreator.detectDevices()`);
+        };
+
+        const layoutProps: AndroidSetupPromptLayoutProps = {
+            headerText: 'Connect to your Android device',
+            moreInfoLink: (
+                <LinkComponent href="https://aka.ms/accessibility-insights-for-android/connectDevice">
+                    How do I connect to my device?
+                </LinkComponent>
+            ),
+            leftFooterButtonProps: {
+                text: 'Close',
+                onClick: onCloseButton,
+            },
+            rightFooterButtonProps: {
+                text: 'Next',
+                disabled: true,
+                onClick: null,
+            },
+        };
+
+        return (
+            <AndroidSetupPromptLayout {...layoutProps}>
+                <PrimaryButton text="Detect my device" onClick={onDetectButton} />
+            </AndroidSetupPromptLayout>
+        );
+    },
+);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connect-to-device-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connect-to-device-step.test.tsx.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PromptConnectToDeviceStep renders per snapshot 1`] = `
+<AndroidSetupPromptLayout
+  headerText="Connect to your Android device"
+  leftFooterButtonProps={
+    Object {
+      "onClick": [Function],
+      "text": "Close",
+    }
+  }
+  moreInfoLink={
+    <LinkComponent
+      href="https://aka.ms/accessibility-insights-for-android/connectDevice"
+    >
+      How do I connect to my device?
+    </LinkComponent>
+  }
+  rightFooterButtonProps={
+    Object {
+      "disabled": true,
+      "onClick": null,
+      "text": "Next",
+    }
+  }
+>
+  <CustomizedPrimaryButton
+    onClick={[Function]}
+    text="Detect my device"
+  />
+</AndroidSetupPromptLayout>
+`;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.test.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
+import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
+import { PromptConnectToDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+
+describe('PromptConnectToDeviceStep', () => {
+    let props: CommonAndroidSetupStepProps;
+
+    beforeEach(() => {
+        props = {
+            userConfigurationStoreData: {} as UserConfigurationStoreData,
+            androidSetupStoreData: {
+                currentStepId: 'prompt-connect-to-device',
+            },
+            deps: {
+                androidSetupActionCreator: null,
+                androidSetupStepComponentProvider: null,
+                LinkComponent: linkProps => <a {...linkProps} />,
+            },
+        };
+    });
+
+    it('renders per snapshot', () => {
+        const rendered = shallow(<PromptConnectToDeviceStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Add the "detect my device" dialog as called out in story 1724337. This is a very simple dialog that does nothing until the user presses a button or the link.

Screenshot (grey border is just background, not part of the dialog):
![image](https://user-images.githubusercontent.com/45672944/84087389-dadc0280-a99e-11ea-81c5-538eeba806ea.png)


<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1724337](https://mseng.visualstudio.com/1ES/_workitems/edit/1724337)

- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
