### PR TITLE
feat(android-setup): add close app functionality to android setup steps

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-types.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-types.ts
@@ -4,6 +4,7 @@ import { LinkComponentType } from 'common/types/link-component-type';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { AndroidSetupStoreData } from 'electron/flux/types/android-setup-store-data';
+import { IpcRendererShim } from 'electron/ipc/ipc-renderer-shim';
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import * as React from 'react';
 
@@ -19,6 +20,7 @@ export type AndroidSetupPageDeps = {
     androidSetupActionCreator: AndroidSetupActionCreator;
     androidSetupStepComponentProvider: AndroidSetupStepComponentProvider;
     LinkComponent: LinkComponentType;
+    closeApp: () => void;
 };
 
 // 'Partial' is used to allow missing step IDs as they get implemented.

--- a/src/electron/views/device-connect-view/components/android-setup/android-setup-types.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/android-setup-types.ts
@@ -4,7 +4,6 @@ import { LinkComponentType } from 'common/types/link-component-type';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { AndroidSetupStoreData } from 'electron/flux/types/android-setup-store-data';
-import { IpcRendererShim } from 'electron/ipc/ipc-renderer-shim';
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import * as React from 'react';
 

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -16,11 +16,6 @@ import * as styles from './prompt-choose-device-step.scss';
 export const PromptChooseDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptChooseDeviceStep',
     (props: CommonAndroidSetupStepProps) => {
-        const onCloseButton = () => {
-            // To be implemented in future feature work
-            console.log(`ipc call to close`);
-        };
-
         const onNextButton = () => {
             // To be implemented in future feature work
             console.log(`androidSetupActionCreator.next()`);
@@ -73,7 +68,7 @@ export const PromptChooseDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
             ),
             leftFooterButtonProps: {
                 text: 'Close',
-                onClick: onCloseButton,
+                onClick: props.deps.closeApp,
             },
             rightFooterButtonProps: {
                 text: 'Next',

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.tsx
@@ -11,11 +11,6 @@ export const PromptConnectToDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
     (props: CommonAndroidSetupStepProps) => {
         const { LinkComponent } = props.deps;
 
-        const onCloseButton = () => {
-            // To be implemented in future feature work
-            console.log(`androidSetupActionCreator.close()`);
-        };
-
         const onDetectButton = () => {
             // To be implemented in future feature work
             console.log(`androidSetupActionCreator.detectDevices()`);
@@ -30,7 +25,7 @@ export const PromptConnectToDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
             ),
             leftFooterButtonProps: {
                 text: 'Close',
-                onClick: onCloseButton,
+                onClick: props.deps.closeApp,
             },
             rightFooterButtonProps: {
                 text: 'Next',

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
@@ -15,11 +15,6 @@ export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
 
         const { LinkComponent } = props.deps;
 
-        const onCloseButton = () => {
-            // To be implemented in future feature work
-            console.log(`androidSetupActionCreator.close()`);
-        };
-
         const onNextButton = () => {
             // To be implemented in future feature work
             console.log(`androidSetupActionCreator.confirmAdbLocation(${adbLocation})`);
@@ -38,7 +33,7 @@ export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
             ),
             leftFooterButtonProps: {
                 text: 'Close',
-                onClick: onCloseButton,
+                onClick: props.deps.closeApp,
             },
             rightFooterButtonProps: {
                 text: 'Next',

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -468,6 +468,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
             getDateFromTimestamp: DateProvider.getDateFromTimestamp,
             reportExportServiceProvider: ReportExportServiceProviderImpl,
             androidSetupStepComponentProvider: defaultAndroidSetupComponents,
+            closeApp: ipcRendererShim.closeWindow,
         };
 
         window.insightsUserConfiguration = new UserConfigurationController(interpreter);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-step-container.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/android-setup-step-container.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`AndroidSetupStepContainer passes common props and deps through 1`] = `
         "detect-adb": [Function],
         "prompt-locate-adb": [Function],
       },
+      "closeApp": null,
     }
   }
   userConfigurationStoreData={null}

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`PromptChooseDeviceStep renders per snapshot 1`] = `
   headerText="Choose which device to use"
   leftFooterButtonProps={
     Object {
-      "onClick": [Function],
+      "onClick": null,
       "text": "Close",
     }
   }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connect-to-device-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-connect-to-device-step.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`PromptConnectToDeviceStep renders per snapshot 1`] = `
   headerText="Connect to your Android device"
   leftFooterButtonProps={
     Object {
-      "onClick": [Function],
+      "onClick": null,
       "text": "Close",
     }
   }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-locate-adb-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-locate-adb-step.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`PromptLocateAdbStep renders per snapshot with adbLocation not set 1`] =
   headerText="Locate Android Debug Bridge (adb)"
   leftFooterButtonProps={
     Object {
-      "onClick": [Function],
+      "onClick": null,
       "text": "Close",
     }
   }
@@ -37,7 +37,7 @@ exports[`PromptLocateAdbStep renders per snapshot with adbLocation set 1`] = `
   headerText="Locate Android Debug Bridge (adb)"
   leftFooterButtonProps={
     Object {
-      "onClick": [Function],
+      "onClick": null,
       "text": "Close",
     }
   }

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/android-setup-step-container.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/android-setup-step-container.test.tsx
@@ -23,6 +23,7 @@ describe('AndroidSetupStepContainer', () => {
                 )),
             },
             LinkComponent: null,
+            closeApp: null,
         },
     };
 

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/detect-adb-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/detect-adb-step.test.tsx
@@ -14,6 +14,7 @@ describe('DetectAdbStep', () => {
             androidSetupActionCreator: null,
             androidSetupStepComponentProvider: null,
             LinkComponent: null,
+            closeApp: null,
         },
     };
 

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
@@ -8,7 +8,6 @@ import * as React from 'react';
 
 describe('PromptChooseDeviceStep', () => {
     let props: CommonAndroidSetupStepProps;
-
     beforeEach(() => {
         props = {
             userConfigurationStoreData: {} as UserConfigurationStoreData,
@@ -19,6 +18,7 @@ describe('PromptChooseDeviceStep', () => {
                 androidSetupActionCreator: null,
                 androidSetupStepComponentProvider: null,
                 LinkComponent: linkProps => <a {...linkProps} />,
+                closeApp: null,
             },
         };
     });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
@@ -8,6 +8,7 @@ import * as React from 'react';
 
 describe('PromptChooseDeviceStep', () => {
     let props: CommonAndroidSetupStepProps;
+
     beforeEach(() => {
         props = {
             userConfigurationStoreData: {} as UserConfigurationStoreData,

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step.test.tsx
@@ -19,6 +19,7 @@ describe('PromptConnectToDeviceStep', () => {
                 androidSetupActionCreator: null,
                 androidSetupStepComponentProvider: null,
                 LinkComponent: linkProps => <a {...linkProps} />,
+                closeApp: null,
             },
         };
     });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.test.tsx
@@ -19,6 +19,7 @@ describe('PromptLocateAdbStep', () => {
                 androidSetupActionCreator: null,
                 androidSetupStepComponentProvider: null,
                 LinkComponent: linkProps => <a {...linkProps} />,
+                closeApp: null,
             },
         };
     });


### PR DESCRIPTION
#### Description of changes

This PR plumbs through the ipc shim so that clicking the 'close' buttons on our android setup steps will close the app. I tested this by opening each of the setup screens and selecting close.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
