### PR TITLE
feat(nav-bar-functionality): set focus back to the first focusable element in nav bar

### DIFF
--- a/src/DetailsView/components/base-left-nav.tsx
+++ b/src/DetailsView/components/base-left-nav.tsx
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { INavLink, Nav } from 'office-ui-fabric-react';
+import { INav, INavLink, Nav } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export type onBaseLeftNavItemClick = (
@@ -12,6 +12,7 @@ export type onBaseLeftNavItemRender = (link: BaseLeftNavLink) => JSX.Element;
 export type BaseLeftNavProps = {
     selectedKey: string;
     links: BaseLeftNavLink[];
+    setNavComponentRef: (nav: INav) => void;
 };
 
 export interface BaseLeftNavLink extends INavLink {
@@ -28,7 +29,7 @@ export interface BaseLeftNavLinkProps {
 export class BaseLeftNav extends React.Component<BaseLeftNavProps> {
     public static pivotItemsClassName = 'details-view-test-nav-area';
     public render(): JSX.Element {
-        const { selectedKey, links } = this.props;
+        const { selectedKey, links, setNavComponentRef } = this.props;
 
         return (
             <Nav
@@ -44,6 +45,7 @@ export class BaseLeftNav extends React.Component<BaseLeftNavProps> {
                 styles={{
                     chevronButton: 'hidden',
                 }}
+                componentRef={setNavComponentRef}
             />
         );
     }

--- a/src/DetailsView/components/left-nav/assessment-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/assessment-left-nav.tsx
@@ -4,7 +4,9 @@ import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { FeatureFlags } from 'common/feature-flags';
 import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { VisualizationType } from 'common/types/visualization-type';
+import { INav } from 'office-ui-fabric-react';
 import * as React from 'react';
+
 import { NamedFC } from '../../../common/react/named-fc';
 import { ManualTestStatus, ManualTestStatusData } from '../../../common/types/manual-test-status';
 import { DictionaryStringTo } from '../../../types/common-types';
@@ -30,6 +32,7 @@ export type AssessmentLeftNavProps = {
     featureFlagStoreData: FeatureFlagStoreData;
     expandedTest: VisualizationType | undefined;
     onRightPanelContentSwitch: () => void;
+    setNavComponentRef: (nav: INav) => void;
 };
 
 export type AssessmentLeftNavLink = {
@@ -70,6 +73,7 @@ export const AssessmentLeftNav = NamedFC<AssessmentLeftNavProps>('AssessmentLeft
         featureFlagStoreData,
         expandedTest,
         onRightPanelContentSwitch,
+        setNavComponentRef,
     } = props;
 
     const { navLinkHandler, leftNavLinkBuilder } = deps;
@@ -109,5 +113,11 @@ export const AssessmentLeftNav = NamedFC<AssessmentLeftNavProps>('AssessmentLeft
         );
     }
 
-    return <BaseLeftNav selectedKey={selectedKey} links={links} />;
+    return (
+        <BaseLeftNav
+            selectedKey={selectedKey}
+            links={links}
+            setNavComponentRef={setNavComponentRef}
+        />
+    );
 });

--- a/src/DetailsView/components/left-nav/details-view-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/details-view-left-nav.tsx
@@ -1,8 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { mapValues } from 'lodash';
-import * as React from 'react';
-
 import { AssessmentsProvider } from 'assessments/types/assessments-provider';
 import { FlaggedComponent } from 'common/components/flagged-component';
 import { FeatureFlags } from 'common/feature-flags';
@@ -10,6 +7,10 @@ import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { generateReflowAssessmentTestKey } from 'DetailsView/components/left-nav/left-nav-link-builder';
 import { Switcher, SwitcherDeps } from 'DetailsView/components/switcher';
 import { leftNavSwitcherStyleNames } from 'DetailsView/components/switcher-style-names';
+import { mapValues } from 'lodash';
+import { INav } from 'office-ui-fabric-react';
+import * as React from 'react';
+
 import { NamedFC } from '../../../common/react/named-fc';
 import { AssessmentStoreData } from '../../../common/types/store-data/assessment-result-data';
 import { FeatureFlagStoreData } from '../../../common/types/store-data/feature-flag-store-data';
@@ -36,6 +37,7 @@ export type DetailsViewLeftNavProps = {
     assessmentStoreData: AssessmentStoreData;
     selectedPivot: DetailsViewPivotType;
     onRightPanelContentSwitch: () => void;
+    setNavComponentRef: (nav: INav) => void;
 };
 
 export const DetailsViewLeftNav = NamedFC<DetailsViewLeftNavProps>('DetailsViewLeftNav', props => {
@@ -90,6 +92,7 @@ export const DetailsViewLeftNav = NamedFC<DetailsViewLeftNavProps>('DetailsViewL
                 onRightPanelContentSwitch={props.onRightPanelContentSwitch}
                 featureFlagStoreData={featureFlagStoreData}
                 expandedTest={assessmentStoreData.assessmentNavState.expandedTestType}
+                setNavComponentRef={props.setNavComponentRef}
             />
         </div>
     );

--- a/src/DetailsView/components/left-nav/fast-pass-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/fast-pass-left-nav.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { INav } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 import { NamedFC } from '../../../common/react/named-fc';
@@ -17,10 +18,11 @@ export type FastPassLeftNavProps = {
     deps: FastPassLeftNavDeps;
     selectedKey: string;
     onRightPanelContentSwitch: () => void;
+    setNavComponentRef: (nav: INav) => void;
 };
 
 export const FastPassLeftNav = NamedFC<FastPassLeftNavProps>('FastPassLeftNav', props => {
-    const { deps } = props;
+    const { deps, setNavComponentRef } = props;
 
     const { navLinkHandler } = deps;
 
@@ -32,6 +34,7 @@ export const FastPassLeftNav = NamedFC<FastPassLeftNavProps>('FastPassLeftNav', 
             onLinkClick={navLinkHandler.onFastPassTestClick}
             visualizations={tests}
             onRightPanelContentSwitch={props.onRightPanelContentSwitch}
+            setNavComponentRef={setNavComponentRef}
         />
     );
 });

--- a/src/DetailsView/components/left-nav/fluent-side-nav.tsx
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.tsx
@@ -9,11 +9,11 @@ import {
 } from 'DetailsView/components/left-nav/details-view-left-nav';
 import * as styles from 'DetailsView/components/left-nav/fluent-side-nav.scss';
 import { isNil } from 'lodash';
-import { PanelType } from 'office-ui-fabric-react';
+import { INav, PanelType } from 'office-ui-fabric-react';
 import * as React from 'react';
 
 export type FluentSideNavDeps = DetailsViewLeftNavDeps;
-export type FluentSideNavProps = DetailsViewLeftNavProps & {
+export type FluentSideNavProps = Omit<DetailsViewLeftNavProps, 'setNavComponentRef'> & {
     tabStoreData: TabStoreData;
     isSideNavOpen: boolean;
     setSideNavOpen: React.Dispatch<React.SetStateAction<boolean>>;
@@ -21,13 +21,20 @@ export type FluentSideNavProps = DetailsViewLeftNavProps & {
 };
 
 export class FluentSideNav extends React.Component<FluentSideNavProps> {
+    protected navComponentRef: INav;
+
     public render(): JSX.Element {
         const tabClosed = this.props.tabStoreData.isClosed;
 
         if (tabClosed) {
             return null;
         }
-        const navBar = <DetailsViewLeftNav {...this.props} />;
+        const navBar = (
+            <DetailsViewLeftNav
+                {...this.props}
+                setNavComponentRef={nav => this.setNavComponentRef(nav)}
+            />
+        );
 
         const dismissPanel = (ev: React.SyntheticEvent<HTMLElement, Event>) => {
             if (isNil(ev)) {
@@ -55,5 +62,23 @@ export class FluentSideNav extends React.Component<FluentSideNavProps> {
         const navBarInSideNavContainer = <div id={styles.sideNavContainer}>{navBar}</div>;
 
         return this.props.isNarrowMode ? navPanel : navBarInSideNavContainer;
+    }
+
+    protected setNavComponentRef(nav: INav): void {
+        this.navComponentRef = nav;
+    }
+
+    private isNavPanelConvertedToNavBar(prevProps: FluentSideNavProps): boolean {
+        return (
+            prevProps.isNarrowMode === true &&
+            prevProps.isSideNavOpen === true &&
+            this.props.isNarrowMode === false
+        );
+    }
+
+    public componentDidUpdate(prevProps: FluentSideNavProps): void {
+        if (this.isNavPanelConvertedToNavBar(prevProps)) {
+            this.navComponentRef.focus(true);
+        }
     }
 }

--- a/src/DetailsView/components/left-nav/visualization-based-left-nav.tsx
+++ b/src/DetailsView/components/left-nav/visualization-based-left-nav.tsx
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { INav } from 'office-ui-fabric-react';
 import * as React from 'react';
+
 import { VisualizationConfigurationFactory } from '../../../common/configs/visualization-configuration-factory';
 import { NamedFC } from '../../../common/react/named-fc';
 import { VisualizationType } from '../../../common/types/visualization-type';
@@ -23,12 +25,20 @@ export type VisualizationBasedLeftNavProps = {
     onLinkClick: onBaseLeftNavItemClick;
     visualizations: VisualizationType[];
     onRightPanelContentSwitch: () => void;
+    setNavComponentRef: (nav: INav) => void;
 };
 
 export const VisualizationBasedLeftNav = NamedFC<VisualizationBasedLeftNavProps>(
     'VisualizationBasedLeftNav',
     props => {
-        const { deps, selectedKey, onLinkClick, visualizations, onRightPanelContentSwitch } = props;
+        const {
+            deps,
+            selectedKey,
+            onLinkClick,
+            visualizations,
+            onRightPanelContentSwitch,
+            setNavComponentRef,
+        } = props;
 
         const { leftNavLinkBuilder, visualizationConfigurationFactory } = deps;
 
@@ -47,6 +57,12 @@ export const VisualizationBasedLeftNav = NamedFC<VisualizationBasedLeftNavProps>
             );
         });
 
-        return <BaseLeftNav selectedKey={selectedKey} links={links} />;
+        return (
+            <BaseLeftNav
+                selectedKey={selectedKey}
+                links={links}
+                setNavComponentRef={setNavComponentRef}
+            />
+        );
     },
 );

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/base-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/base-left-nav.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`BaseLeftNav should render 1`] = `
 <StyledNavBase
   className="details-view-test-nav-area"
+  componentRef={[Function]}
   groups={
     Array [
       Object {

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/fluent-side-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/fluent-side-nav.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`FluentSideNav render nav bar 1`] = `
     isNarrowMode={false}
     isSideNavOpen={false}
     selectedPivot={0}
+    setNavComponentRef={[Function]}
     setSideNavOpen={null}
     tabStoreData={
       Object {
@@ -36,6 +37,7 @@ exports[`FluentSideNav render sidePanel 1`] = `
     isNarrowMode={true}
     isSideNavOpen={false}
     selectedPivot={0}
+    setNavComponentRef={[Function]}
     setSideNavOpen={null}
     tabStoreData={
       Object {

--- a/src/tests/unit/tests/DetailsView/components/base-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/base-left-nav.test.tsx
@@ -29,6 +29,7 @@ describe('BaseLeftNav', () => {
         const props: BaseLeftNavProps = {
             selectedKey: 'some key',
             links: [{} as BaseLeftNavLink],
+            setNavComponentRef: _ => {},
         } as BaseLeftNavProps;
 
         const actual = shallow(<BaseLeftNav {...props} />);

--- a/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
@@ -3,12 +3,12 @@
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
 import { TabStoreData } from 'common/types/store-data/tab-store-data';
 import { GenericPanel } from 'DetailsView/components/generic-panel';
+import { DetailsViewLeftNav } from 'DetailsView/components/left-nav/details-view-left-nav';
 import { FluentSideNav, FluentSideNavProps } from 'DetailsView/components/left-nav/fluent-side-nav';
 import { shallow } from 'enzyme';
+import { INav } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
-import { INav } from 'office-ui-fabric-react';
-import { DetailsViewLeftNav } from 'DetailsView/components/left-nav/details-view-left-nav';
 
 describe(FluentSideNav, () => {
     let tabStoreData: TabStoreData;
@@ -130,7 +130,8 @@ describe(FluentSideNav, () => {
 
         wrapper.find(DetailsViewLeftNav).props().setNavComponentRef(navStub);
 
-        wrapper.setProps(props);
+        wrapper.setProps(prevProps); // won't call focus() since  navPanel not converted to  navBar
+        wrapper.setProps(props); // will call focus()
 
         focusMock.verifyAll();
     });

--- a/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/fluent-side-nav.test.tsx
@@ -7,6 +7,8 @@ import { FluentSideNav, FluentSideNavProps } from 'DetailsView/components/left-n
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { Mock, Times } from 'typemoq';
+import { INav } from 'office-ui-fabric-react';
+import { DetailsViewLeftNav } from 'DetailsView/components/left-nav/details-view-left-nav';
 
 describe(FluentSideNav, () => {
     let tabStoreData: TabStoreData;
@@ -92,5 +94,44 @@ describe(FluentSideNav, () => {
             .onDismiss({} as React.SyntheticEvent<HTMLElement, Event>);
 
         setSideNavOpenMock.verifyAll();
+    });
+
+    test('componentDidUpdate', () => {
+        const focusMock = Mock.ofInstance((forceIntoFirstElement?: boolean) => {
+            return false;
+        });
+        const navStub: INav = {
+            selectedKey: 'dummy-key',
+            focus: focusMock.object,
+        };
+        focusMock.setup(fm => fm(true)).verifiable(Times.once());
+
+        tabStoreData = {
+            isClosed: false,
+        } as TabStoreData;
+
+        const prevProps: FluentSideNavProps = {
+            tabStoreData,
+            isSideNavOpen: true,
+            setSideNavOpen: null,
+            isNarrowMode: true,
+        } as FluentSideNavProps;
+
+        props = {
+            tabStoreData,
+            isSideNavOpen: false,
+            setSideNavOpen: null,
+            isNarrowMode: false,
+        } as FluentSideNavProps;
+
+        const wrapper = shallow(
+            <FluentSideNav selectedPivot={DetailsViewPivotType.fastPass} {...prevProps} />,
+        );
+
+        wrapper.find(DetailsViewLeftNav).props().setNavComponentRef(navStub);
+
+        wrapper.setProps(props);
+
+        focusMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/assessment-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/assessment-left-nav.test.tsx.snap
@@ -13,6 +13,7 @@ exports[` renders with reflow feature flag disabled 1`] = `
     ]
   }
   selectedKey="some key"
+  setNavComponentRef={[Function]}
 />
 `;
 
@@ -29,5 +30,6 @@ exports[` renders with reflow feature flag enabled 1`] = `
     ]
   }
   selectedKey="some key"
+  setNavComponentRef={[Function]}
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/details-view-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/details-view-left-nav.test.tsx.snap
@@ -40,6 +40,7 @@ exports[` should render from switcher nav 1`] = `
     }
     featureFlagStoreData={Object {}}
     selectedKey="some key"
+    setNavComponentRef={[Function]}
   />
 </div>
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/fast-pass-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/fast-pass-left-nav.test.tsx.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` renders visualization based left nav with appropriate params 1`] = `"<VisualizationBasedLeftNav deps={{...}} selectedKey=\\"some string\\" onRightPanelContentSwitch={[Function: onRightPanelContentSwitch]} onLinkClick={[Function: onFastPassTestClick]} visualizations={{...}} />"`;
+exports[` renders visualization based left nav with appropriate params 1`] = `"<VisualizationBasedLeftNav deps={{...}} selectedKey=\\"some string\\" onRightPanelContentSwitch={[Function: onRightPanelContentSwitch]} setNavComponentRef={[Function: setNavComponentRef]} onLinkClick={[Function: onFastPassTestClick]} visualizations={{...}} />"`;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/visualization-based-left-nav.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/__snapshots__/visualization-based-left-nav.test.tsx.snap
@@ -9,5 +9,6 @@ exports[`VisualizationBasedLeftNav renders with index icon 1`] = `
     ]
   }
   selectedKey="some key"
+  setNavComponentRef={[Function]}
 />
 `;

--- a/src/tests/unit/tests/DetailsView/components/left-nav/assessment-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/assessment-left-nav.test.tsx
@@ -30,9 +30,11 @@ describe(AssessmentLeftNav, () => {
     let assessmentsDataStub: DictionaryStringTo<ManualTestStatusData>;
     const expandedTest: VisualizationType = 1;
     let onRightPanelContentSwitch: () => void;
+    let setNavComponentRef: (nav) => void;
 
     beforeEach(() => {
         onRightPanelContentSwitch = () => {};
+        setNavComponentRef = _ => {};
         assessmentsDataStub = {};
         assessmentsProviderStub = {} as AssessmentsProvider;
         leftNavLinkBuilderMock = Mock.ofType(LeftNavLinkBuilder, MockBehavior.Strict);
@@ -56,6 +58,7 @@ describe(AssessmentLeftNav, () => {
             featureFlagStoreData: {},
             expandedTest,
             onRightPanelContentSwitch,
+            setNavComponentRef,
         };
 
         leftNavLinkBuilderMock

--- a/src/tests/unit/tests/DetailsView/components/left-nav/details-view-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/details-view-left-nav.test.tsx
@@ -78,6 +78,7 @@ describe(DetailsViewLeftNav, () => {
             switcherNavConfiguration: switcherNavConfig,
             rightPanelConfiguration: rightPanelConfig,
             assessmentStoreData: assessmentStoreDataStub,
+            setNavComponentRef: nav => {},
         } as DetailsViewLeftNavProps;
 
         GetLeftNavSelectedKeyMock.setup(getter =>

--- a/src/tests/unit/tests/DetailsView/components/left-nav/fast-pass-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/fast-pass-left-nav.test.tsx
@@ -13,6 +13,7 @@ import { NavLinkHandler } from '../../../../../../DetailsView/components/left-na
 describe(FastPassLeftNav, () => {
     it('renders visualization based left nav with appropriate params', () => {
         const onRightPanelContentSwitch: () => void = () => {};
+        const setNavComponentRef = _ => {};
         const navLinkHandlerStub: NavLinkHandler = {
             onFastPassTestClick: (e, link) => null,
         } as NavLinkHandler;
@@ -23,6 +24,7 @@ describe(FastPassLeftNav, () => {
             deps,
             selectedKey: 'some string',
             onRightPanelContentSwitch,
+            setNavComponentRef,
         };
 
         const actual = shallow(<FastPassLeftNav {...props} />);

--- a/src/tests/unit/tests/DetailsView/components/left-nav/visualization-based-left-nav.test.tsx
+++ b/src/tests/unit/tests/DetailsView/components/left-nav/visualization-based-left-nav.test.tsx
@@ -27,6 +27,7 @@ describe('VisualizationBasedLeftNav', () => {
     let configFactoryMock: IMock<VisualizationConfigurationFactory>;
     let configStub: VisualizationConfiguration;
     let onRightPanelContentSwitch: () => void;
+    let setNavComponentRef: (nav) => void;
 
     beforeEach(() => {
         visualizationsStub = [-1, -2];
@@ -36,6 +37,7 @@ describe('VisualizationBasedLeftNav', () => {
         linkStub = {} as BaseLeftNavLink;
         configStub = {} as VisualizationConfiguration;
         onRightPanelContentSwitch = () => {};
+        setNavComponentRef = _ => {};
 
         deps = {
             leftNavLinkBuilder: leftNavLinkBuilderMock.object,
@@ -49,6 +51,7 @@ describe('VisualizationBasedLeftNav', () => {
             onLinkClick: onLinkClickStub,
             visualizations: visualizationsStub,
             onRightPanelContentSwitch,
+            setNavComponentRef,
         };
 
         visualizationsStub.forEach((visualizationType, index) => {


### PR DESCRIPTION
#### Description of changes
When user have side nav open and make the window wider, the panel will convert to the nav bar, and we will set the focus to the first focusable element in the nav.

![1](https://user-images.githubusercontent.com/15974344/84213409-6b851200-aa75-11ea-95c7-5cd993a61d2f.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
