### PR TITLE
fix: change side nav container min width to 250px

### DIFF
--- a/src/DetailsView/components/left-nav/fluent-side-nav.scss
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.scss
@@ -4,7 +4,7 @@
 
 #side-nav-container {
     max-width: 25%;
-    min-width: 200px;
+    min-width: 250px;
 
     display: flex;
     flex-wrap: nowrap;

--- a/src/DetailsView/components/left-nav/fluent-side-nav.scss
+++ b/src/DetailsView/components/left-nav/fluent-side-nav.scss
@@ -4,7 +4,7 @@
 
 #side-nav-container {
     max-width: 25%;
-    min-width: 250px;
+    min-width: $detailsViewReflowLeftNavWidth;
 
     display: flex;
     flex-wrap: nowrap;


### PR DESCRIPTION
#### Description of changes

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

Change side-nav-container min-width from 200px to 250px to fit the text of all the requirements in the nav bar at 100% zoom.

Before
![image](https://user-images.githubusercontent.com/48259897/84213971-e995e880-aa76-11ea-8834-12209ff258fa.png)

After
![image](https://user-images.githubusercontent.com/48259897/84213984-eef33300-aa76-11ea-98d9-8a21231964db.png)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
