### PR TITLE
feat(text-reflow): Reflow info and examples grid

### DIFF
--- a/src/views/content/content.scss
+++ b/src/views/content/content.scss
@@ -135,6 +135,7 @@
             'fail-section pass-section'
             'fail-example pass-example';
         border: 1px solid $neutral-60;
+        word-break: break-word;
     }
 
     .fail-section,


### PR DESCRIPTION
#### Description of changes
Currently, the info and examples grids do not properly reflow when zoom is at 400%. This PR causes them to properly reflow at that zoom.

In action:
![infoexamples](https://user-images.githubusercontent.com/4615491/84315566-b60e9900-ab1e-11ea-9228-cc68c51c3c0d.gif)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [n/a] Added/updated relevant unit test(s) (and ran `yarn test`)
- [n/a] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
