### PR TITLE
feat(android-setup): wire up prompt-locate-adb UI to setup actions

### DIFF
--- a/src/electron/flux/action-creator/android-setup-action-creator.ts
+++ b/src/electron/flux/action-creator/android-setup-action-creator.ts
@@ -5,7 +5,11 @@ import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions'
 export class AndroidSetupActionCreator {
     constructor(private readonly setupActions: AndroidSetupActions) {}
 
-    public cancel = () => {
-        this.setupActions.cancel.invoke();
-    };
+    public cancel = () => this.setupActions.cancel.invoke();
+    public close = () => this.setupActions.close.invoke();
+    public next = () => this.setupActions.next.invoke();
+    public rescan = () => this.setupActions.rescan.invoke();
+    public saveAdbPath = (newAdbPath: string) => this.setupActions.saveAdbPath.invoke(newAdbPath);
+    public setSelectedDevice = (selectedDeviceId: string) =>
+        this.setupActions.setSelectedDevice.invoke(selectedDeviceId);
 }

--- a/src/electron/flux/action-creator/android-setup-action-creator.ts
+++ b/src/electron/flux/action-creator/android-setup-action-creator.ts
@@ -6,7 +6,6 @@ export class AndroidSetupActionCreator {
     constructor(private readonly setupActions: AndroidSetupActions) {}
 
     public cancel = () => this.setupActions.cancel.invoke();
-    public close = () => this.setupActions.close.invoke();
     public next = () => this.setupActions.next.invoke();
     public rescan = () => this.setupActions.rescan.invoke();
     public saveAdbPath = (newAdbPath: string) => this.setupActions.saveAdbPath.invoke(newAdbPath);

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.tsx
@@ -15,11 +15,6 @@ export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
 
         const { LinkComponent } = props.deps;
 
-        const onNextButton = () => {
-            // To be implemented in future feature work
-            console.log(`androidSetupActionCreator.confirmAdbLocation(${adbLocation})`);
-        };
-
         const onFolderPickerChange = (newValue?: string) => {
             setAdbLocation(newValue ?? '');
         };
@@ -38,7 +33,7 @@ export const PromptLocateAdbStep = NamedFC<CommonAndroidSetupStepProps>(
             rightFooterButtonProps: {
                 text: 'Next',
                 disabled: adbLocation === '',
-                onClick: onNextButton,
+                onClick: _ => props.deps.androidSetupActionCreator.saveAdbPath(adbLocation),
             },
         };
 

--- a/src/tests/unit/tests/electron/flux/action-creator/android-setup-action-creator.test.ts
+++ b/src/tests/unit/tests/electron/flux/action-creator/android-setup-action-creator.test.ts
@@ -14,12 +14,52 @@ describe(AndroidSetupActionCreator, () => {
         testSubject = new AndroidSetupActionCreator(androidSetupActionsMock.object);
     });
 
-    it('action creator invokes cancel action', () => {
+    it('invokes cancel action on cancel', () => {
         const actionMock = Mock.ofType<Action<void>>();
         androidSetupActionsMock.setup(actions => actions.cancel).returns(() => actionMock.object);
         actionMock.setup(s => s.invoke()).verifiable(Times.once());
 
         testSubject.cancel();
+        actionMock.verifyAll();
+    });
+
+    it('invokes next action on rescan', () => {
+        const actionMock = Mock.ofType<Action<void>>();
+        androidSetupActionsMock.setup(actions => actions.next).returns(() => actionMock.object);
+        actionMock.setup(s => s.invoke()).verifiable(Times.once());
+
+        testSubject.next();
+        actionMock.verifyAll();
+    });
+
+    it('invokes rescan action on rescan', () => {
+        const actionMock = Mock.ofType<Action<void>>();
+        androidSetupActionsMock.setup(actions => actions.rescan).returns(() => actionMock.object);
+        actionMock.setup(s => s.invoke()).verifiable(Times.once());
+
+        testSubject.rescan();
+        actionMock.verifyAll();
+    });
+
+    it('invokes setSelectedDevice action on setSelectedDevice', () => {
+        const actionMock = Mock.ofType<Action<string>>();
+        androidSetupActionsMock
+            .setup(actions => actions.setSelectedDevice)
+            .returns(() => actionMock.object);
+        actionMock.setup(s => s.invoke('new-device-id')).verifiable(Times.once());
+
+        testSubject.setSelectedDevice('new-device-id');
+        actionMock.verifyAll();
+    });
+
+    it('invokes saveAdbPath action on saveAdbPath', () => {
+        const actionMock = Mock.ofType<Action<string>>();
+        androidSetupActionsMock
+            .setup(actions => actions.saveAdbPath)
+            .returns(() => actionMock.object);
+        actionMock.setup(s => s.invoke('/new/adb/path')).verifiable(Times.once());
+
+        testSubject.saveAdbPath('/new/adb/path');
         actionMock.verifyAll();
     });
 });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step.test.tsx
@@ -1,21 +1,27 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { AndroidSetupActionCreator } from 'electron/flux/action-creator/android-setup-action-creator';
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
+import { FolderPicker } from 'electron/views/device-connect-view/components/android-setup/folder-picker';
 import { PromptLocateAdbStep } from 'electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
-import { IMock, Mock, Times } from 'typemoq';
+import { IMock, It, Mock, Times } from 'typemoq';
 
 describe('PromptLocateAdbStep', () => {
     let props: CommonAndroidSetupStepProps;
     let closeAppMock: IMock<typeof props.deps.closeApp>;
+    let setupActionCreatorMock: IMock<AndroidSetupActionCreator>;
+    const stubClickEvent = {} as React.MouseEvent<HTMLButtonElement>;
 
     beforeEach(() => {
         closeAppMock = Mock.ofInstance(() => {});
+        setupActionCreatorMock = Mock.ofType<AndroidSetupActionCreator>();
         props = new AndroidSetupStepPropsBuilder('prompt-locate-adb')
             .withDep('closeApp', closeAppMock.object)
+            .withDep('androidSetupActionCreator', setupActionCreatorMock.object)
             .build();
     });
 
@@ -31,10 +37,44 @@ describe('PromptLocateAdbStep', () => {
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
-    it('passes closeApp dep through', () => {
-        const stubEvent = {} as React.MouseEvent<HTMLButtonElement>;
+    it('invokes closeApp when left footer button is clicked', () => {
         const rendered = shallow(<PromptLocateAdbStep {...props} />);
-        rendered.find(AndroidSetupStepLayout).prop('leftFooterButtonProps').onClick(stubEvent);
+        rendered.find(AndroidSetupStepLayout).prop('leftFooterButtonProps').onClick(stubClickEvent);
         closeAppMock.verify(m => m(), Times.once());
+    });
+
+    it('does not invoke saveAdbPath for FolderPicker onChange with no next button click', () => {
+        const newValue = '/new/path';
+        const rendered = shallow(<PromptLocateAdbStep {...props} />);
+
+        rendered.find(FolderPicker).prop('onChange')(newValue);
+
+        setupActionCreatorMock.verify(m => m.saveAdbPath(It.isAny()), Times.never());
+    });
+
+    it('invokes saveAdbPath on next click, defaulting to value from saved adbLocation', () => {
+        props.userConfigurationStoreData.adbLocation = '/old/path';
+        const rendered = shallow(<PromptLocateAdbStep {...props} />);
+
+        rendered
+            .find(AndroidSetupStepLayout)
+            .prop('rightFooterButtonProps')
+            .onClick(stubClickEvent);
+
+        setupActionCreatorMock.verify(m => m.saveAdbPath('/old/path'), Times.once());
+    });
+
+    it('invokes saveAdbPath on next click using the most recent onChange value from the FolderPicker', () => {
+        const rendered = shallow(<PromptLocateAdbStep {...props} />);
+
+        rendered.find(FolderPicker).prop('onChange')('/first/new/path');
+        rendered.find(FolderPicker).prop('onChange')('/second/new/path');
+
+        rendered
+            .find(AndroidSetupStepLayout)
+            .prop('rightFooterButtonProps')
+            .onClick(stubClickEvent);
+
+        setupActionCreatorMock.verify(m => m.saveAdbPath('/second/new/path'), Times.once());
     });
 });


### PR DESCRIPTION
#### Description of changes

Wires up the "Next" button in the `prompt-locate-adb` step's UI to invoke the `saveAdbPath` setup action using the current value of the folder picker.

Needed to wire up action creator to do this, so did so with simple pass-throughs for now; may need to update later if we need to coordinate actions with other stores/etc

No visual changes (since the state machine isn't yet doing anything with the action)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: finishes 1724336
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
