### PR TITLE
feat(android-setup): Add prompt install failed step

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
@@ -7,6 +7,7 @@ import { DetectServiceStep } from 'electron/views/device-connect-view/components
 import { InstallingServiceStep } from 'electron/views/device-connect-view/components/android-setup/installing-service-step';
 import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
 import { PromptConnectToDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step';
+import { PromptInstallFailedStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-failed-step';
 import { PromptInstallServiceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
 import { PromptLocateAdbStep } from 'electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step';
 

--- a/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
@@ -16,6 +16,7 @@ export const defaultAndroidSetupComponents: AndroidSetupStepComponentProvider = 
     'prompt-choose-device': PromptChooseDeviceStep,
     'prompt-connect-to-device': PromptConnectToDeviceStep,
     'prompt-install-service': PromptInstallServiceStep,
+    'prompt-install-failed': PromptInstallFailedStep,
     'installing-service': InstallingServiceStep,
     'detect-devices': DetectDevicesStep,
     'detect-service': DetectServiceStep,

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.scss
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../../../common/styles/fonts.scss';
+
+.device-description {
+    margin-top: 16px;
+    margin-bottom: 16px;
+}

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import {
+    DeviceDescription,
+    DeviceDescriptionProps,
+} from 'electron/views/device-connect-view/components/android-setup/device-description';
+import { PrimaryButton } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
+import { CommonAndroidSetupStepProps } from './android-setup-types';
+import * as styles from './prompt-install-failed-step.scss';
+
+export const PromptInstallFailedStep = NamedFC<CommonAndroidSetupStepProps>(
+    'PromptInstallFailedStep',
+    (props: CommonAndroidSetupStepProps) => {
+        const { LinkComponent } = props.deps;
+
+        const onCancelButton = () => {
+            // To be implemented in future feature work
+            console.log(`androidSetupActionCreator.cancel()`);
+        };
+
+        const onTryAgain = () => {
+            // To be implemented in future feature work
+            console.log(`androidSetupActionCreator.installService()`);
+        };
+
+        const layoutProps: AndroidSetupStepLayoutProps = {
+            headerText: 'Installation attempt failed',
+            moreInfoLink: (
+                <LinkComponent href="https://aka.ms/accessibility-insights-for-android/troubleshootInstallation">
+                    Troubleshooting installation problems
+                </LinkComponent>
+            ),
+            leftFooterButtonProps: {
+                text: 'Cancel',
+                onClick: onCancelButton,
+            },
+            rightFooterButtonProps: {
+                text: 'Next',
+                disabled: true,
+                onClick: null,
+            },
+        };
+
+        const descriptionProps: DeviceDescriptionProps = {
+            ...props.androidSetupStoreData.selectedDevice,
+            className: styles.deviceDescription,
+        };
+
+        return (
+            <AndroidSetupStepLayout {...layoutProps}>
+                <>
+                    We were unable to install the latest version of Accessibility Insights for
+                    Android Service on your device. You can try installing the service yourself,
+                    from your device, or choose one of the options below.
+                </>
+                <DeviceDescription {...descriptionProps}></DeviceDescription>
+                <PrimaryButton text="Try again" onClick={onTryAgain} />
+            </AndroidSetupStepLayout>
+        );
+    },
+);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-failed-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-install-failed-step.test.tsx.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PromptInstallFailedStep renders with device 1`] = `
+<AndroidSetupStepLayout
+  headerText="Installation attempt failed"
+  leftFooterButtonProps={
+    Object {
+      "onClick": [Function],
+      "text": "Cancel",
+    }
+  }
+  moreInfoLink={
+    <LinkComponent
+      href="https://aka.ms/accessibility-insights-for-android/troubleshootInstallation"
+    >
+      Troubleshooting installation problems
+    </LinkComponent>
+  }
+  rightFooterButtonProps={
+    Object {
+      "disabled": true,
+      "onClick": null,
+      "text": "Next",
+    }
+  }
+>
+  <React.Fragment>
+    We were unable to install the latest version of Accessibility Insights for Android Service on your device. You can try installing the service yourself, from your device, or choose one of the options below.
+  </React.Fragment>
+  <DeviceDescription
+    className="deviceDescription"
+    description="Super-Duper Gadget"
+    isEmulator={false}
+  />
+  <CustomizedPrimaryButton
+    onClick={[Function]}
+    text="Try again"
+  />
+</AndroidSetupStepLayout>
+`;
+
+exports[`PromptInstallFailedStep renders with emulator 1`] = `
+<AndroidSetupStepLayout
+  headerText="Installation attempt failed"
+  leftFooterButtonProps={
+    Object {
+      "onClick": [Function],
+      "text": "Cancel",
+    }
+  }
+  moreInfoLink={
+    <LinkComponent
+      href="https://aka.ms/accessibility-insights-for-android/troubleshootInstallation"
+    >
+      Troubleshooting installation problems
+    </LinkComponent>
+  }
+  rightFooterButtonProps={
+    Object {
+      "disabled": true,
+      "onClick": null,
+      "text": "Next",
+    }
+  }
+>
+  <React.Fragment>
+    We were unable to install the latest version of Accessibility Insights for Android Service on your device. You can try installing the service yourself, from your device, or choose one of the options below.
+  </React.Fragment>
+  <DeviceDescription
+    className="deviceDescription"
+    description="Emulator Extraordinaire"
+    isEmulator={true}
+  />
+  <CustomizedPrimaryButton
+    onClick={[Function]}
+    text="Try again"
+  />
+</AndroidSetupStepLayout>
+`;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-install-failed-step.test.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DeviceMetadata } from 'electron/flux/types/device-metadata';
+import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
+import { PromptInstallFailedStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-failed-step';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
+
+describe('PromptInstallFailedStep', () => {
+    let props: CommonAndroidSetupStepProps;
+
+    beforeEach(() => {
+        props = new AndroidSetupStepPropsBuilder('prompt-install-failed').build();
+    });
+
+    it('renders with device', () => {
+        const selectedDevice: DeviceMetadata = {
+            isEmulator: false,
+            description: 'Super-Duper Gadget',
+        };
+
+        props.androidSetupStoreData.selectedDevice = selectedDevice;
+
+        const rendered = shallow(<PromptInstallFailedStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('renders with emulator', () => {
+        const selectedDevice: DeviceMetadata = {
+            isEmulator: true,
+            description: 'Emulator Extraordinaire',
+        };
+
+        props.androidSetupStoreData.selectedDevice = selectedDevice;
+
+        const rendered = shallow(<PromptInstallFailedStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

Add the dialog to display if the attempt to install the service to the device failed. 

Screenshot displaying an emulator:
![image](https://user-images.githubusercontent.com/45672944/84328564-21fcfb80-ab37-11ea-88b0-ba899d869164.png)

Screenshot displaying a device:
![image](https://user-images.githubusercontent.com/45672944/84328691-84ee9280-ab37-11ea-8094-f16573e096b7.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1724347](https://mseng.visualstudio.com/1ES/_workitems/edit/1724347)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
