### PR TITLE
feat(android-setup): Add PromptGrantPermissionsStep

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
+++ b/src/electron/views/device-connect-view/components/android-setup/default-android-setup-components.ts
@@ -7,6 +7,7 @@ import { DetectServiceStep } from 'electron/views/device-connect-view/components
 import { InstallingServiceStep } from 'electron/views/device-connect-view/components/android-setup/installing-service-step';
 import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
 import { PromptConnectToDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-connect-to-device-step';
+import { PromptGrantPermissionsStep } from 'electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step';
 import { PromptInstallFailedStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-failed-step';
 import { PromptInstallServiceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
 import { PromptLocateAdbStep } from 'electron/views/device-connect-view/components/android-setup/prompt-locate-adb-step';
@@ -18,6 +19,7 @@ export const defaultAndroidSetupComponents: AndroidSetupStepComponentProvider = 
     'prompt-connect-to-device': PromptConnectToDeviceStep,
     'prompt-install-service': PromptInstallServiceStep,
     'prompt-install-failed': PromptInstallFailedStep,
+    'prompt-grant-permissions': PromptGrantPermissionsStep,
     'installing-service': InstallingServiceStep,
     'detect-devices': DetectDevicesStep,
     'detect-service': DetectServiceStep,

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.scss
@@ -1,0 +1,8 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+@import '../../../../../common/styles/fonts.scss';
+
+.device-description {
+    margin-top: 16px;
+    margin-bottom: 16px;
+}

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.tsx
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { NamedFC } from 'common/react/named-fc';
+import {
+    DeviceDescription,
+    DeviceDescriptionProps,
+} from 'electron/views/device-connect-view/components/android-setup/device-description';
+import { PrimaryButton } from 'office-ui-fabric-react';
+import * as React from 'react';
+import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
+import { CommonAndroidSetupStepProps } from './android-setup-types';
+import * as styles from './prompt-grant-permissions-step.scss';
+
+export const PromptGrantPermissionsStep = NamedFC<CommonAndroidSetupStepProps>(
+    'PromptGrantPermissionsStep',
+    (props: CommonAndroidSetupStepProps) => {
+        const { LinkComponent } = props.deps;
+
+        const onCancelButton = () => {
+            // To be implemented in future feature work
+            console.log(`androidSetupActionCreator.cancel()`);
+        };
+
+        const onTryAgain = () => {
+            // To be implemented in future feature work
+            console.log(`androidSetupActionCreator.checkPermissions()`);
+        };
+
+        const layoutProps: AndroidSetupStepLayoutProps = {
+            headerText: 'Grant permissions on your device',
+            moreInfoLink: (
+                <LinkComponent href="https://aka.ms/accessibility-insights-for-android/grantPermissions">
+                    How do I grant permissions?
+                </LinkComponent>
+            ),
+            leftFooterButtonProps: {
+                text: 'Cancel',
+                onClick: onCancelButton,
+            },
+            rightFooterButtonProps: {
+                text: 'Next',
+                disabled: true,
+                onClick: null,
+            },
+        };
+
+        const descriptionProps: DeviceDescriptionProps = {
+            ...props.androidSetupStoreData.selectedDevice,
+            className: styles.deviceDescription,
+        };
+
+        return (
+            <AndroidSetupStepLayout {...layoutProps}>
+                <>
+                    Be sure the Accessibility Insights for Android Service on your device is turned
+                    on and has permission to access your device and capture screenshots.
+                </>
+                <DeviceDescription {...descriptionProps}></DeviceDescription>
+                <PrimaryButton text="Try again" onClick={onTryAgain} />
+            </AndroidSetupStepLayout>
+        );
+    },
+);

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
@@ -2,12 +2,19 @@
 
 exports[`PromptGrantPermissionsStep renders with device 1`] = `
 <AndroidSetupStepLayout
-  headerText="Let us install the latest version on your device"
+  headerText="Grant permissions on your device"
   leftFooterButtonProps={
     Object {
       "onClick": [Function],
       "text": "Cancel",
     }
+  }
+  moreInfoLink={
+    <LinkComponent
+      href="https://aka.ms/accessibility-insights-for-android/grantPermissions"
+    >
+      How do I grant permissions?
+    </LinkComponent>
   }
   rightFooterButtonProps={
     Object {
@@ -18,7 +25,7 @@ exports[`PromptGrantPermissionsStep renders with device 1`] = `
   }
 >
   <React.Fragment>
-    It looks like the Accessibility Insights for Android Service on your device is either missing or out of date. We'll need to install the latest version.
+    Be sure the Accessibility Insights for Android Service on your device is turned on and has permission to access your device and capture screenshots.
   </React.Fragment>
   <DeviceDescription
     className="deviceDescription"
@@ -27,19 +34,26 @@ exports[`PromptGrantPermissionsStep renders with device 1`] = `
   />
   <CustomizedPrimaryButton
     onClick={[Function]}
-    text="Install"
+    text="Try again"
   />
 </AndroidSetupStepLayout>
 `;
 
 exports[`PromptGrantPermissionsStep renders with emulator 1`] = `
 <AndroidSetupStepLayout
-  headerText="Let us install the latest version on your device"
+  headerText="Grant permissions on your device"
   leftFooterButtonProps={
     Object {
       "onClick": [Function],
       "text": "Cancel",
     }
+  }
+  moreInfoLink={
+    <LinkComponent
+      href="https://aka.ms/accessibility-insights-for-android/grantPermissions"
+    >
+      How do I grant permissions?
+    </LinkComponent>
   }
   rightFooterButtonProps={
     Object {
@@ -50,7 +64,7 @@ exports[`PromptGrantPermissionsStep renders with emulator 1`] = `
   }
 >
   <React.Fragment>
-    It looks like the Accessibility Insights for Android Service on your device is either missing or out of date. We'll need to install the latest version.
+    Be sure the Accessibility Insights for Android Service on your device is turned on and has permission to access your device and capture screenshots.
   </React.Fragment>
   <DeviceDescription
     className="deviceDescription"
@@ -59,7 +73,7 @@ exports[`PromptGrantPermissionsStep renders with emulator 1`] = `
   />
   <CustomizedPrimaryButton
     onClick={[Function]}
-    text="Install"
+    text="Try again"
   />
 </AndroidSetupStepLayout>
 `;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-grant-permissions-step.test.tsx.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PromptGrantPermissionsStep renders with device 1`] = `
+<AndroidSetupStepLayout
+  headerText="Let us install the latest version on your device"
+  leftFooterButtonProps={
+    Object {
+      "onClick": [Function],
+      "text": "Cancel",
+    }
+  }
+  rightFooterButtonProps={
+    Object {
+      "disabled": true,
+      "onClick": null,
+      "text": "Next",
+    }
+  }
+>
+  <React.Fragment>
+    It looks like the Accessibility Insights for Android Service on your device is either missing or out of date. We'll need to install the latest version.
+  </React.Fragment>
+  <DeviceDescription
+    className="deviceDescription"
+    description="Super-Duper Gadget"
+    isEmulator={false}
+  />
+  <CustomizedPrimaryButton
+    onClick={[Function]}
+    text="Install"
+  />
+</AndroidSetupStepLayout>
+`;
+
+exports[`PromptGrantPermissionsStep renders with emulator 1`] = `
+<AndroidSetupStepLayout
+  headerText="Let us install the latest version on your device"
+  leftFooterButtonProps={
+    Object {
+      "onClick": [Function],
+      "text": "Cancel",
+    }
+  }
+  rightFooterButtonProps={
+    Object {
+      "disabled": true,
+      "onClick": null,
+      "text": "Next",
+    }
+  }
+>
+  <React.Fragment>
+    It looks like the Accessibility Insights for Android Service on your device is either missing or out of date. We'll need to install the latest version.
+  </React.Fragment>
+  <DeviceDescription
+    className="deviceDescription"
+    description="Emulator Extraordinaire"
+    isEmulator={true}
+  />
+  <CustomizedPrimaryButton
+    onClick={[Function]}
+    text="Install"
+  />
+</AndroidSetupStepLayout>
+`;

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 import { DeviceMetadata } from 'electron/flux/types/device-metadata';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
-import { PromptInstallServiceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
+import { PromptGrantPermissionsStep } from 'electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step';
 import { shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
@@ -22,7 +22,7 @@ describe('PromptGrantPermissionsStep', () => {
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;
 
-        const rendered = shallow(<PromptInstallServiceStep {...props} />);
+        const rendered = shallow(<PromptGrantPermissionsStep {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
 
@@ -34,7 +34,7 @@ describe('PromptGrantPermissionsStep', () => {
 
         props.androidSetupStoreData.selectedDevice = selectedDevice;
 
-        const rendered = shallow(<PromptInstallServiceStep {...props} />);
+        const rendered = shallow(<PromptGrantPermissionsStep {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
 });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-grant-permissions-step.test.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+import { DeviceMetadata } from 'electron/flux/types/device-metadata';
+import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
+import { PromptInstallServiceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-install-service-step';
+import { shallow } from 'enzyme';
+import * as React from 'react';
+import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
+
+describe('PromptGrantPermissionsStep', () => {
+    let props: CommonAndroidSetupStepProps;
+
+    beforeEach(() => {
+        props = new AndroidSetupStepPropsBuilder('prompt-grant-permissions').build();
+    });
+
+    it('renders with device', () => {
+        const selectedDevice: DeviceMetadata = {
+            isEmulator: false,
+            description: 'Super-Duper Gadget',
+        };
+
+        props.androidSetupStoreData.selectedDevice = selectedDevice;
+
+        const rendered = shallow(<PromptInstallServiceStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+
+    it('renders with emulator', () => {
+        const selectedDevice: DeviceMetadata = {
+            isEmulator: true,
+            description: 'Emulator Extraordinaire',
+        };
+
+        props.androidSetupStoreData.selectedDevice = selectedDevice;
+
+        const rendered = shallow(<PromptInstallServiceStep {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
+});


### PR DESCRIPTION
#### Description of changes

This adds the dialog to display in the prompt-grant-permissions step

Screenshot displaying an emulator:
![image](https://user-images.githubusercontent.com/45672944/84331251-912a1e00-ab3e-11ea-88e4-4650cf5eb5d9.png)

Screenshot displaying a device:
![image](https://user-images.githubusercontent.com/45672944/84331753-ec104500-ab3f-11ea-9d11-cab66b4dad7a.png)

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: [1724348](https://mseng.visualstudio.com/1ES/_workitems/edit/1724348)
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
