### PR TITLE
feat(android-setup): Add all functions to AndroidSetupDeps

### DIFF
--- a/src/electron/flux/store/android-setup-store.ts
+++ b/src/electron/flux/store/android-setup-store.ts
@@ -23,7 +23,9 @@ export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
 
     public initialize(initialState?: AndroidSetupStoreData): void {
         super.initialize(initialState);
-        this.stateMachine = this.createAndroidSetupStateMachine(this.stepTransition);
+        this.stateMachine = this.createAndroidSetupStateMachine({
+            stepTransition: this.stepTransition,
+        });
     }
 
     public getDefaultState(): AndroidSetupStoreData {

--- a/src/electron/flux/types/android-setup-state-machine-types.ts
+++ b/src/electron/flux/types/android-setup-state-machine-types.ts
@@ -9,6 +9,10 @@ export type AndroidSetupStateMachine = StateMachine<AndroidSetupStepId, AndroidS
 
 export type AndroidSetupStepTransitionCallback = (nextStep: AndroidSetupStepId) => void;
 
+export type AndroidSetupStoreCallbacks = {
+    stepTransition: AndroidSetupStepTransitionCallback;
+};
+
 export type AndroidSetupStateMachineFactory = (
-    stepTransitionCallback: AndroidSetupStepTransitionCallback,
+    storeCallbacks: AndroidSetupStoreCallbacks,
 ) => AndroidSetupStateMachine;

--- a/src/electron/platform/android/setup/android-setup-deps.ts
+++ b/src/electron/platform/android/setup/android-setup-deps.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-
-export type AndroidSetupStepDeps = {
+export type AndroidSetupDeps = {
     hasAdbPath: () => Promise<boolean>;
 };

--- a/src/electron/platform/android/setup/android-setup-deps.ts
+++ b/src/electron/platform/android/setup/android-setup-deps.ts
@@ -1,6 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { DeviceInfo } from 'electron/platform/android/android-service-configurator';
+
 export type AndroidSetupDeps = {
     hasAdbPath: () => Promise<boolean>;
+    setAdbPath: (path: string) => void;
+    getDevices: () => Promise<DeviceInfo[]>;
+    setSelectedDeviceId: (id: string) => void;
+    hasExpectedServiceVersion: () => Promise<boolean>;
+    installService: () => Promise<boolean>;
+    hasExpectedPermissions: () => Promise<boolean>;
 };

--- a/src/electron/platform/android/setup/android-setup-state-machine-factory.ts
+++ b/src/electron/platform/android/setup/android-setup-state-machine-factory.ts
@@ -5,6 +5,7 @@ import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions'
 import {
     AndroidSetupStateMachineFactory,
     AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
 } from 'electron/flux/types/android-setup-state-machine-types';
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { StateMachine } from 'electron/platform/android/setup/state-machine/state-machine';
@@ -18,7 +19,7 @@ type AndroidSetupStepsFactory = (
 ) => StateMachineSteps<AndroidSetupStepId, AndroidSetupActions>;
 
 const stepsFactory = (
-    deps: Omit<AndroidSetupStepDeps, 'stepTransition'>,
+    deps: Omit<AndroidSetupStepDeps & AndroidSetupStoreCallbacks, 'stepTransition'>,
 ): AndroidSetupStepsFactory => {
     return (stateMachineStepTransition: AndroidSetupStepTransitionCallback) => {
         const allDeps = {
@@ -31,12 +32,12 @@ const stepsFactory = (
 };
 
 export const createAndroidSetupStateMachineFactory = (
-    deps: Omit<AndroidSetupStepDeps, 'stepTransition'>,
+    deps: AndroidSetupStepDeps,
 ): AndroidSetupStateMachineFactory => {
-    return storeStepTransition => {
+    return (storeCallbacks: AndroidSetupStoreCallbacks) => {
         return new StateMachine<AndroidSetupStepId, AndroidSetupActions>(
-            stepsFactory(deps),
-            storeStepTransition,
+            stepsFactory({ ...deps, ...storeCallbacks }),
+            storeCallbacks.stepTransition,
             'detect-adb',
         );
     };

--- a/src/electron/platform/android/setup/android-setup-state-machine-factory.ts
+++ b/src/electron/platform/android/setup/android-setup-state-machine-factory.ts
@@ -10,8 +10,11 @@ import {
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import { StateMachine } from 'electron/platform/android/setup/state-machine/state-machine';
 import { createStateMachineSteps } from 'electron/platform/android/setup/state-machine/state-machine-step-configs';
-import { AndroidSetupStepDeps } from './android-setup-step-deps';
-import { allAndroidSetupStepConfigs } from './android-setup-steps-configs';
+import { AndroidSetupDeps } from './android-setup-deps';
+import {
+    allAndroidSetupStepConfigs,
+    AndroidSetupStepConfigDeps,
+} from './android-setup-steps-configs';
 import { StateMachineSteps } from './state-machine/state-machine-steps';
 
 type AndroidSetupStepsFactory = (
@@ -19,7 +22,7 @@ type AndroidSetupStepsFactory = (
 ) => StateMachineSteps<AndroidSetupStepId, AndroidSetupActions>;
 
 const stepsFactory = (
-    deps: Omit<AndroidSetupStepDeps & AndroidSetupStoreCallbacks, 'stepTransition'>,
+    deps: Omit<AndroidSetupStepConfigDeps, 'stepTransition'>,
 ): AndroidSetupStepsFactory => {
     return (stateMachineStepTransition: AndroidSetupStepTransitionCallback) => {
         const allDeps = {
@@ -32,7 +35,7 @@ const stepsFactory = (
 };
 
 export const createAndroidSetupStateMachineFactory = (
-    deps: AndroidSetupStepDeps,
+    deps: AndroidSetupDeps,
 ): AndroidSetupStateMachineFactory => {
     return (storeCallbacks: AndroidSetupStoreCallbacks) => {
         return new StateMachine<AndroidSetupStepId, AndroidSetupActions>(

--- a/src/electron/platform/android/setup/android-setup-step-deps.ts
+++ b/src/electron/platform/android/setup/android-setup-step-deps.ts
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStepId } from './android-setup-step-id';
 
 export type AndroidSetupStepDeps = {
     hasAdbPath: () => Promise<boolean>;
-    stepTransition: (nextStep: AndroidSetupStepId) => void;
 };

--- a/src/electron/platform/android/setup/android-setup-step-deps.ts
+++ b/src/electron/platform/android/setup/android-setup-step-deps.ts
@@ -4,6 +4,6 @@
 import { AndroidSetupStepId } from './android-setup-step-id';
 
 export type AndroidSetupStepDeps = {
-    detectAdb: () => Promise<boolean>;
+    hasAdbPath: () => Promise<boolean>;
     stepTransition: (nextStep: AndroidSetupStepId) => void;
 };

--- a/src/electron/platform/android/setup/android-setup-steps-configs.ts
+++ b/src/electron/platform/android/setup/android-setup-steps-configs.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions';
+import { AndroidSetupStoreCallbacks } from 'electron/flux/types/android-setup-state-machine-types';
 import { AndroidSetupStepDeps } from 'electron/platform/android/setup/android-setup-step-deps';
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import {
@@ -12,7 +13,7 @@ import { detectAdb } from './steps/detect.adb';
 
 export type AndroidSetupStepConfig = StateMachineStepConfig<
     AndroidSetupActions,
-    AndroidSetupStepDeps
+    AndroidSetupStepDeps & AndroidSetupStoreCallbacks
 >;
 
 type AndroidSetupStepConfigs = StateMachineStepConfigs<

--- a/src/electron/platform/android/setup/android-setup-steps-configs.ts
+++ b/src/electron/platform/android/setup/android-setup-steps-configs.ts
@@ -3,7 +3,7 @@
 
 import { AndroidSetupActions } from 'electron/flux/action/android-setup-actions';
 import { AndroidSetupStoreCallbacks } from 'electron/flux/types/android-setup-state-machine-types';
-import { AndroidSetupStepDeps } from 'electron/platform/android/setup/android-setup-step-deps';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
 import { AndroidSetupStepId } from 'electron/platform/android/setup/android-setup-step-id';
 import {
     StateMachineStepConfig,
@@ -11,15 +11,17 @@ import {
 } from './state-machine/state-machine-step-configs';
 import { detectAdb } from './steps/detect.adb';
 
+export type AndroidSetupStepConfigDeps = AndroidSetupDeps & AndroidSetupStoreCallbacks;
+
 export type AndroidSetupStepConfig = StateMachineStepConfig<
     AndroidSetupActions,
-    AndroidSetupStepDeps & AndroidSetupStoreCallbacks
+    AndroidSetupStepConfigDeps
 >;
 
 type AndroidSetupStepConfigs = StateMachineStepConfigs<
     AndroidSetupStepId,
     AndroidSetupActions,
-    AndroidSetupStepDeps
+    AndroidSetupStepConfigDeps
 >;
 
 export const allAndroidSetupStepConfigs: AndroidSetupStepConfigs = {

--- a/src/electron/platform/android/setup/steps/detect.adb.ts
+++ b/src/electron/platform/android/setup/steps/detect.adb.ts
@@ -6,7 +6,7 @@ import { AndroidSetupStepConfig } from 'electron/platform/android/setup/android-
 export const detectAdb: AndroidSetupStepConfig = deps => ({
     actions: {},
     onEnter: async () => {
-        const detected = await deps.detectAdb();
+        const detected = await deps.hasAdbPath();
         deps.stepTransition(detected ? 'detect-devices' : 'prompt-locate-adb');
     },
 });

--- a/src/electron/views/renderer-initializer.ts
+++ b/src/electron/views/renderer-initializer.ts
@@ -73,8 +73,8 @@ import { IpcRendererShim } from 'electron/ipc/ipc-renderer-shim';
 import { createDeviceConfigFetcher } from 'electron/platform/android/device-config-fetcher';
 import { createScanResultsFetcher } from 'electron/platform/android/fetch-scan-results';
 import { ScanController } from 'electron/platform/android/scan-controller';
+import { AndroidSetupDeps } from 'electron/platform/android/setup/android-setup-deps';
 import { createAndroidSetupStateMachineFactory } from 'electron/platform/android/setup/android-setup-state-machine-factory';
-import { AndroidSetupStepDeps } from 'electron/platform/android/setup/android-setup-step-deps';
 import { createDefaultBuilder } from 'electron/platform/android/unified-result-builder';
 import { UnifiedSettingsProvider } from 'electron/settings/unified-settings-provider';
 import { defaultAndroidSetupComponents } from 'electron/views/device-connect-view/components/android-setup/default-android-setup-components';
@@ -189,7 +189,7 @@ getPersistedData(indexedDBInstance, indexedDBDataKeysToFetch).then(
 
         const androidSetupStore = new AndroidSetupStore(
             androidSetupActions,
-            createAndroidSetupStateMachineFactory({} as AndroidSetupStepDeps),
+            createAndroidSetupStateMachineFactory({} as AndroidSetupDeps),
         );
         androidSetupStore.initialize();
 

--- a/src/tests/unit/tests/electron/flux/store/android-setup-store.test.ts
+++ b/src/tests/unit/tests/electron/flux/store/android-setup-store.test.ts
@@ -5,14 +5,14 @@ import { AndroidSetupStore } from 'electron/flux/store/android-setup-store';
 import {
     AndroidSetupStateMachine,
     AndroidSetupStateMachineFactory,
-    AndroidSetupStepTransitionCallback,
+    AndroidSetupStoreCallbacks,
 } from 'electron/flux/types/android-setup-state-machine-types';
 import { AndroidSetupStoreData } from 'electron/flux/types/android-setup-store-data';
 import { createStoreWithNullParams, StoreTester } from 'tests/unit/common/store-tester';
 import { It, Mock, Times } from 'typemoq';
 
 const mockableStateMachineFactory = (
-    stepTransition: AndroidSetupStepTransitionCallback,
+    storeCallbacks: AndroidSetupStoreCallbacks,
 ): AndroidSetupStateMachine => {
     return null;
 };
@@ -86,18 +86,18 @@ describe('AndroidSetupStore', () => {
         const initialData: AndroidSetupStoreData = { currentStepId: 'detect-adb' };
         const expectedData: AndroidSetupStoreData = { currentStepId: 'prompt-choose-device' };
 
-        let stepTransition: AndroidSetupStepTransitionCallback;
+        let storeCallbacks: AndroidSetupStoreCallbacks;
 
         const stateMachineMock = Mock.ofType<AndroidSetupStateMachine>();
         stateMachineMock
             .setup(m => m.invokeAction('cancel', It.isAny()))
-            .callback((action, payload) => stepTransition('prompt-choose-device'))
+            .callback((action, payload) => storeCallbacks.stepTransition('prompt-choose-device'))
             .verifiable(Times.once());
 
         const stateMachineFactoryMock = Mock.ofInstance(mockableStateMachineFactory);
         stateMachineFactoryMock
             .setup(m => m(It.isAny()))
-            .callback(st => (stepTransition = st))
+            .callback(sc => (storeCallbacks = sc))
             .returns(_ => stateMachineMock.object)
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-adb.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-adb.test.ts
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import { AndroidSetupStoreCallbacks } from 'electron/flux/types/android-setup-state-machine-types';
-import { AndroidSetupStepDeps } from 'electron/platform/android/setup/android-setup-step-deps';
+import { AndroidSetupStepConfigDeps } from 'electron/platform/android/setup/android-setup-steps-configs';
 import { detectAdb } from 'electron/platform/android/setup/steps/detect.adb';
 import { Mock, MockBehavior, Times } from 'typemoq';
 import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: detectAdb', () => {
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepDeps & AndroidSetupStoreCallbacks;
+        const deps = {} as AndroidSetupStepConfigDeps;
         const step = detectAdb(deps);
         checkExpectedActionsAreDefined(step, []);
         expect(step.onEnter).toBeDefined();
@@ -18,10 +17,7 @@ describe('Android setup step: detectAdb', () => {
     it('onEnter transitions to detect-devices as expected', async () => {
         const p = new Promise<boolean>(resolve => resolve(true));
 
-        const depsMock = Mock.ofType<AndroidSetupStepDeps & AndroidSetupStoreCallbacks>(
-            undefined,
-            MockBehavior.Strict,
-        );
+        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.hasAdbPath())
             .returns(_ => p)
@@ -38,10 +34,7 @@ describe('Android setup step: detectAdb', () => {
     it('onEnter transitions to prompt-locate-adb as expected', async () => {
         const p = new Promise<boolean>(resolve => resolve(false));
 
-        const depsMock = Mock.ofType<AndroidSetupStepDeps & AndroidSetupStoreCallbacks>(
-            undefined,
-            MockBehavior.Strict,
-        );
+        const depsMock = Mock.ofType<AndroidSetupStepConfigDeps>(undefined, MockBehavior.Strict);
         depsMock
             .setup(m => m.hasAdbPath())
             .returns(_ => p)

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-adb.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-adb.test.ts
@@ -3,8 +3,8 @@
 
 import { AndroidSetupStepDeps } from 'electron/platform/android/setup/android-setup-step-deps';
 import { detectAdb } from 'electron/platform/android/setup/steps/detect.adb';
-import { checkExpectedActionsAreDefined } from 'tests/unit/tests/electron/platform/android/setup/steps/actions-tester';
 import { Mock, MockBehavior, Times } from 'typemoq';
+import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: detectAdb', () => {
     it('has expected properties', () => {
@@ -19,7 +19,7 @@ describe('Android setup step: detectAdb', () => {
 
         const depsMock = Mock.ofType<AndroidSetupStepDeps>(undefined, MockBehavior.Strict);
         depsMock
-            .setup(m => m.detectAdb())
+            .setup(m => m.hasAdbPath())
             .returns(_ => p)
             .verifiable(Times.once());
 
@@ -36,7 +36,7 @@ describe('Android setup step: detectAdb', () => {
 
         const depsMock = Mock.ofType<AndroidSetupStepDeps>(undefined, MockBehavior.Strict);
         depsMock
-            .setup(m => m.detectAdb())
+            .setup(m => m.hasAdbPath())
             .returns(_ => p)
             .verifiable(Times.once());
 

--- a/src/tests/unit/tests/electron/platform/android/setup/steps/detect-adb.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/setup/steps/detect-adb.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { AndroidSetupStoreCallbacks } from 'electron/flux/types/android-setup-state-machine-types';
 import { AndroidSetupStepDeps } from 'electron/platform/android/setup/android-setup-step-deps';
 import { detectAdb } from 'electron/platform/android/setup/steps/detect.adb';
 import { Mock, MockBehavior, Times } from 'typemoq';
@@ -8,7 +9,7 @@ import { checkExpectedActionsAreDefined } from './actions-tester';
 
 describe('Android setup step: detectAdb', () => {
     it('has expected properties', () => {
-        const deps = {} as AndroidSetupStepDeps;
+        const deps = {} as AndroidSetupStepDeps & AndroidSetupStoreCallbacks;
         const step = detectAdb(deps);
         checkExpectedActionsAreDefined(step, []);
         expect(step.onEnter).toBeDefined();
@@ -17,7 +18,10 @@ describe('Android setup step: detectAdb', () => {
     it('onEnter transitions to detect-devices as expected', async () => {
         const p = new Promise<boolean>(resolve => resolve(true));
 
-        const depsMock = Mock.ofType<AndroidSetupStepDeps>(undefined, MockBehavior.Strict);
+        const depsMock = Mock.ofType<AndroidSetupStepDeps & AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
         depsMock
             .setup(m => m.hasAdbPath())
             .returns(_ => p)
@@ -34,7 +38,10 @@ describe('Android setup step: detectAdb', () => {
     it('onEnter transitions to prompt-locate-adb as expected', async () => {
         const p = new Promise<boolean>(resolve => resolve(false));
 
-        const depsMock = Mock.ofType<AndroidSetupStepDeps>(undefined, MockBehavior.Strict);
+        const depsMock = Mock.ofType<AndroidSetupStepDeps & AndroidSetupStoreCallbacks>(
+            undefined,
+            MockBehavior.Strict,
+        );
         depsMock
             .setup(m => m.hasAdbPath())
             .returns(_ => p)


### PR DESCRIPTION
#### Description of changes

This change defines all the android setup dependencies. This will allow us to parallelize the work of createing the remaining setup steps in the state machine with the code for calling ADB, installation, device detection, etc.

- Renamed the function detectAdb to hasAdbPath -- better represents the client's perspective
- Removed the stepTransition function from AndroidSetupDeps because it does not need to be exposed to the calling code which creates the deps
- Created an AndroidSetupStoreCallbacks type because we will soon need to update store data from the steps themselves

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
