### PR TITLE
feat(android-setup): Add support to display the current application

### DIFF
--- a/src/electron/views/device-connect-view/components/android-setup/device-description.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/device-description.scss
@@ -12,3 +12,14 @@
     font-size: 24px;
     margin-right: 10px;
 }
+
+.device-and-current-application {
+    display: flex;
+    flex-direction: column;
+}
+
+.current-application {
+    opacity: 0.7;
+    font-size: 12px;
+    margin-top: 2px;
+}

--- a/src/electron/views/device-connect-view/components/android-setup/device-description.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/device-description.tsx
@@ -15,10 +15,23 @@ export const DeviceDescription = NamedFC<DeviceDescriptionProps>('DeviceDescript
     const iconName: string = props.isEmulator ? 'Devices3' : 'CellPhone';
     const iconAriaLabel: string = props.isEmulator ? 'Emulator' : 'Device';
 
+    let descriptionAndApp;
+
+    if (props.currentApplication) {
+        descriptionAndApp = (
+            <div className={styles.deviceAndCurrentApplication}>
+                {props.description}
+                <div className={styles.currentApplication}>{props.currentApplication}</div>
+            </div>
+        );
+    } else {
+        descriptionAndApp = props.description;
+    }
+
     return (
         <div className={css(styles.content, props.className)}>
             <Icon iconName={iconName} className={styles.iconContent} ariaLabel={iconAriaLabel} />
-            {props.description}
+            {descriptionAndApp}
         </div>
     );
 });

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/device-description.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/device-description.test.tsx.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`DeviceDescription renders with currentApplication 1`] = `
+<div
+  className="content"
+>
+  <StyledIconBase
+    ariaLabel="Device"
+    className="iconContent"
+    iconName="CellPhone"
+  />
+  <div
+    className="deviceAndCurrentApplication"
+  >
+    Whizbang tablet
+    <div
+      className="currentApplication"
+    >
+      Wildlife Manager
+    </div>
+  </div>
+</div>
+`;
+
 exports[`DeviceDescription renders with device 1`] = `
 <div
   className="content"

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/device-description.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/device-description.test.tsx
@@ -38,4 +38,15 @@ describe('DeviceDescription', () => {
         const rendered = shallow(<DeviceDescription {...props} />);
         expect(rendered.getElement()).toMatchSnapshot();
     });
+
+    it('renders with currentApplication', () => {
+        const props: DeviceDescriptionProps = {
+            isEmulator: false,
+            description: 'Whizbang tablet',
+            currentApplication: 'Wildlife Manager',
+        };
+
+        const rendered = shallow(<DeviceDescription {...props} />);
+        expect(rendered.getElement()).toMatchSnapshot();
+    });
 });


### PR DESCRIPTION
#### Description of changes
The DeviceDescription control doesn't yet know how to display the current application. This change adds this ability. The change intentionally leaves the existing behavior completely unchanged.

Screenshot: First row is device, without and with application. Second row is emulator, without and with application.

![image](https://user-images.githubusercontent.com/45672944/84420604-22e16c00-abcf-11ea-8eeb-5d8dbb20b0fe.png)

Comment: The lighter color in specified in the figma as an opacity, so that's how I've implemented it here. The numbers are slightly different from the figma, based on tuning with eyeball 1.0.

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
