### PR TITLE
feat(nav-bar-functionality): Hide header text in narrow mode

### DIFF
--- a/src/DetailsView/components/interactive-header.tsx
+++ b/src/DetailsView/components/interactive-header.tsx
@@ -75,6 +75,7 @@ export const InteractiveHeader = NamedFC<InteractiveHeaderProps>('InteractiveHea
             navMenu={getNavMenu()}
             showHeaderTitle={props.showHeaderTitle}
             showFarItems={props.showFarItems}
+            isNarrowMode={props.isNarrowMode}
         ></Header>
     );
 });

--- a/src/DetailsView/details-view-container.tsx
+++ b/src/DetailsView/details-view-container.tsx
@@ -1,13 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Header } from 'common/components/header';
+import { Header, HeaderProps } from 'common/components/header';
 import { GetCardSelectionViewData } from 'common/get-card-selection-view-data';
 import { IsResultHighlightUnavailable } from 'common/is-result-highlight-unavailable';
 import { CardSelectionStoreData } from 'common/types/store-data/card-selection-store-data';
 import { ISelection, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import * as React from 'react';
 
+import { FeatureFlags } from 'common/feature-flags';
 import { DetailsViewContentWithLocalState } from 'DetailsView/components/details-view-content-with-local-state';
+import { NarrowModeDetector } from 'DetailsView/components/narrow-mode-detector';
 import { ThemeDeps } from '../common/components/theme';
 import {
     withStoreSubscription,
@@ -94,9 +96,17 @@ export class DetailsViewContainer extends React.Component<DetailsViewContainerPr
 
     public render(): JSX.Element {
         if (this.shouldShowNoContentAvailable()) {
+            const headerProps: Omit<HeaderProps, 'isNarrowMode'> = { deps: this.props.deps };
             return (
                 <>
-                    <Header deps={this.props.deps} />
+                    <NarrowModeDetector
+                        isNarrowModeEnabled={
+                            this.hasStores() &&
+                            this.props.storeState.featureFlagStoreData[FeatureFlags.reflowUI]
+                        }
+                        Component={Header}
+                        childrenProps={headerProps}
+                    />
                     <NoContentAvailable />
                 </>
             );

--- a/src/common/components/header.tsx
+++ b/src/common/components/header.tsx
@@ -15,21 +15,25 @@ export type HeaderProps = {
     navMenu?: JSX.Element;
     showHeaderTitle?: boolean;
     showFarItems?: boolean;
+    isNarrowMode?: boolean;
 };
 
 export const Header = NamedFC<HeaderProps>('Header', props => {
     const { applicationTitle } = props.deps.textContent;
 
-    const getHeaderTitle = () => {
+    const getHeaderIcon = () => {
         if (props.showHeaderTitle === false) {
             return null;
         } else {
-            return (
-                <>
-                    <HeaderIcon deps={props.deps} />
-                    <span className={styles.headerTitle}>{applicationTitle}</span>
-                </>
-            );
+            return <HeaderIcon deps={props.deps} />;
+        }
+    };
+
+    const getHeaderTitle = () => {
+        if (props.showHeaderTitle === false || props.isNarrowMode === true) {
+            return null;
+        } else {
+            return <span className={styles.headerTitle}>{applicationTitle}</span>;
         }
     };
 
@@ -44,6 +48,7 @@ export const Header = NamedFC<HeaderProps>('Header', props => {
     return (
         <header className={styles.headerBar}>
             {props.navMenu}
+            {getHeaderIcon()}
             {getHeaderTitle()}
             <div>{props.items}</div>
             <div className={styles.spacer}></div>

--- a/src/debug-tools/components/debug-tools-view.tsx
+++ b/src/debug-tools/components/debug-tools-view.tsx
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-import { Header, HeaderDeps } from 'common/components/header';
+import { Header, HeaderDeps, HeaderProps } from 'common/components/header';
 import {
     withStoreSubscription,
     WithStoreSubscriptionDeps,
 } from 'common/components/with-store-subscription';
+import { FeatureFlags } from 'common/feature-flags';
 import { NamedFC } from 'common/react/named-fc';
 import {
     CurrentView,
@@ -16,6 +17,7 @@ import {
     DebugToolsNavDeps,
     DebugToolsNavState,
 } from 'debug-tools/components/debug-tools-nav';
+import { NarrowModeDetector } from 'DetailsView/components/narrow-mode-detector';
 import * as React from 'react';
 import * as styles from './debug-tools-view.scss';
 
@@ -32,8 +34,14 @@ export interface DebugToolsViewProps {
 }
 
 export const DebugTools = NamedFC<DebugToolsViewProps>('DebugToolsView', ({ deps, storeState }) => {
+    const headerProps: Omit<HeaderProps, 'isNarrowMode'> = { deps };
     return (
         <div className={styles.debugToolsContainer}>
+            <NarrowModeDetector
+                isNarrowModeEnabled={storeState.featureFlagStoreData[FeatureFlags.reflowUI]}
+                Component={Header}
+                childrenProps={headerProps}
+            />
             <Header deps={deps} />
             <DebugToolsNav deps={deps} state={storeState} className={styles.nav} />
             <CurrentView deps={deps} storeState={storeState} />

--- a/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/__snapshots__/details-view-container.test.tsx.snap
@@ -52,15 +52,19 @@ exports[`DetailsViewContainer render content render once; should call details vi
 
 exports[`DetailsViewContainer render content show NoContentAvailable when stores are not loaded 1`] = `
 <React.Fragment>
-  <Header
-    deps={
+  <NarrowModeDetector
+    Component={[Function]}
+    childrenProps={
       Object {
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
+        "deps": Object {
+          "storesHub": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "stores": undefined,
+          },
         },
       }
     }
+    isNarrowModeEnabled={false}
   />
   <NoContentAvailable />
 </React.Fragment>
@@ -68,15 +72,19 @@ exports[`DetailsViewContainer render content show NoContentAvailable when stores
 
 exports[`DetailsViewContainer render content show NoContentAvailable when target tab is closed 1`] = `
 <React.Fragment>
-  <Header
-    deps={
+  <NarrowModeDetector
+    Component={[Function]}
+    childrenProps={
       Object {
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
+        "deps": Object {
+          "storesHub": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "stores": undefined,
+          },
         },
       }
     }
+    isNarrowModeEnabled={true}
   />
   <NoContentAvailable />
 </React.Fragment>
@@ -84,15 +92,19 @@ exports[`DetailsViewContainer render content show NoContentAvailable when target
 
 exports[`DetailsViewContainer render content shows NoContentAvailable when target page is changed and no permissions granted 1`] = `
 <React.Fragment>
-  <Header
-    deps={
+  <NarrowModeDetector
+    Component={[Function]}
+    childrenProps={
       Object {
-        "storesHub": proxy {
-          "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
-          "stores": undefined,
+        "deps": Object {
+          "storesHub": proxy {
+            "___id": "BCDF5CE5-F0DF-40B7-8BA0-69DF395033C8",
+            "stores": undefined,
+          },
         },
       }
     }
+    isNarrowModeEnabled={true}
   />
   <NoContentAvailable />
 </React.Fragment>

--- a/src/tests/unit/tests/DetailsView/components/__snapshots__/interactive-header.test.tsx.snap
+++ b/src/tests/unit/tests/DetailsView/components/__snapshots__/interactive-header.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`InteractiveHeader does render nav menu button if not in narrow mode 1`]
       featureFlagData={null}
     />
   }
+  isNarrowMode={true}
   items={
     <FlaggedComponent
       disableJSXElement={
@@ -59,6 +60,7 @@ exports[`InteractiveHeader render: tabClosed equals false 1`] = `
       }
     />
   }
+  isNarrowMode={false}
   items={
     <FlaggedComponent
       disableJSXElement={

--- a/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
+++ b/src/tests/unit/tests/DetailsView/details-view-container.test.tsx
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 import { BaseClientStoresHub } from 'common/stores/base-client-stores-hub';
 import { DetailsViewPivotType } from 'common/types/details-view-pivot-type';
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { DetailsViewActionMessageCreator } from 'DetailsView/actions/details-view-action-message-creator';
 import {
     DetailsViewContainer,
@@ -62,6 +63,9 @@ describe('DetailsViewContainer', () => {
                     tabStoreData: {
                         isClosed: true,
                     },
+                    featureFlagStoreData: {
+                        reflowUI: true,
+                    } as FeatureFlagStoreData,
                 },
                 deps: {
                     storesHub: storesHubMock.object,
@@ -87,6 +91,9 @@ describe('DetailsViewContainer', () => {
                     permissionsStateStoreData: {
                         hasAllUrlAndFilePermissions: false,
                     },
+                    featureFlagStoreData: {
+                        reflowUI: true,
+                    } as FeatureFlagStoreData,
                 },
                 deps: {
                     storesHub: storesHubMock.object,

--- a/src/tests/unit/tests/common/components/__snapshots__/header.test.tsx.snap
+++ b/src/tests/unit/tests/common/components/__snapshots__/header.test.tsx.snap
@@ -1,25 +1,46 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Header renders in narrow mode 1`] = `
+<header
+  className="headerBar"
+>
+  <WithStoreSubscriptionForHeaderIconComponent
+    deps={
+      Object {
+        "textContent": Object {
+          "applicationTitle": "THE_APPLICATION_TITLE",
+        },
+      }
+    }
+  />
+  <div />
+  <div
+    className="spacer"
+  />
+  <div
+    className="farItems"
+  />
+</header>
+`;
+
 exports[`Header renders per snapshot 1`] = `
 <header
   className="headerBar"
 >
-  <React.Fragment>
-    <WithStoreSubscriptionForHeaderIconComponent
-      deps={
-        Object {
-          "textContent": Object {
-            "applicationTitle": "THE_APPLICATION_TITLE",
-          },
-        }
+  <WithStoreSubscriptionForHeaderIconComponent
+    deps={
+      Object {
+        "textContent": Object {
+          "applicationTitle": "THE_APPLICATION_TITLE",
+        },
       }
-    />
-    <span
-      className="headerTitle"
-    >
-      THE_APPLICATION_TITLE
-    </span>
-  </React.Fragment>
+    }
+  />
+  <span
+    className="headerTitle"
+  >
+    THE_APPLICATION_TITLE
+  </span>
   <div />
   <div
     className="spacer"
@@ -34,22 +55,20 @@ exports[`Header renders with showFarItems equals false 1`] = `
 <header
   className="headerBar"
 >
-  <React.Fragment>
-    <WithStoreSubscriptionForHeaderIconComponent
-      deps={
-        Object {
-          "textContent": Object {
-            "applicationTitle": "THE_APPLICATION_TITLE",
-          },
-        }
+  <WithStoreSubscriptionForHeaderIconComponent
+    deps={
+      Object {
+        "textContent": Object {
+          "applicationTitle": "THE_APPLICATION_TITLE",
+        },
       }
-    />
-    <span
-      className="headerTitle"
-    >
-      THE_APPLICATION_TITLE
-    </span>
-  </React.Fragment>
+    }
+  />
+  <span
+    className="headerTitle"
+  >
+    THE_APPLICATION_TITLE
+  </span>
   <div />
   <div
     className="spacer"
@@ -61,22 +80,20 @@ exports[`Header renders with showFarItems equals true 1`] = `
 <header
   className="headerBar"
 >
-  <React.Fragment>
-    <WithStoreSubscriptionForHeaderIconComponent
-      deps={
-        Object {
-          "textContent": Object {
-            "applicationTitle": "THE_APPLICATION_TITLE",
-          },
-        }
+  <WithStoreSubscriptionForHeaderIconComponent
+    deps={
+      Object {
+        "textContent": Object {
+          "applicationTitle": "THE_APPLICATION_TITLE",
+        },
       }
-    />
-    <span
-      className="headerTitle"
-    >
-      THE_APPLICATION_TITLE
-    </span>
-  </React.Fragment>
+    }
+  />
+  <span
+    className="headerTitle"
+  >
+    THE_APPLICATION_TITLE
+  </span>
   <div />
   <div
     className="spacer"

--- a/src/tests/unit/tests/common/components/header.test.tsx
+++ b/src/tests/unit/tests/common/components/header.test.tsx
@@ -44,4 +44,15 @@ describe('Header', () => {
         );
         expect(wrapper.getElement()).toMatchSnapshot();
     });
+
+    it('renders in narrow mode', () => {
+        const applicationTitle = 'THE_APPLICATION_TITLE';
+        const deps = {
+            textContent: {
+                applicationTitle,
+            },
+        } as HeaderDeps;
+        const wrapper = shallow(<Header deps={deps} isNarrowMode={true} />);
+        expect(wrapper.getElement()).toMatchSnapshot();
+    });
 });

--- a/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
+++ b/src/tests/unit/tests/debug-tools/components/__snapshots__/debug-tools-view.test.tsx.snap
@@ -4,6 +4,17 @@ exports[`DebugToolsView renders 1`] = `
 <div
   className="debugToolsContainer"
 >
+  <NarrowModeDetector
+    Component={[Function]}
+    childrenProps={
+      Object {
+        "deps": Object {
+          "storesHub": null,
+        },
+      }
+    }
+    isNarrowModeEnabled={true}
+  />
   <Header
     deps={
       Object {
@@ -20,6 +31,9 @@ exports[`DebugToolsView renders 1`] = `
     }
     state={
       Object {
+        "featureFlagStoreData": Object {
+          "reflowUI": true,
+        },
         "userConfigurationStoreData": Object {
           "isFirstTime": true,
         },
@@ -34,6 +48,9 @@ exports[`DebugToolsView renders 1`] = `
     }
     storeState={
       Object {
+        "featureFlagStoreData": Object {
+          "reflowUI": true,
+        },
         "userConfigurationStoreData": Object {
           "isFirstTime": true,
         },

--- a/src/tests/unit/tests/debug-tools/components/debug-tools-view.test.tsx
+++ b/src/tests/unit/tests/debug-tools/components/debug-tools-view.test.tsx
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+import { FeatureFlagStoreData } from 'common/types/store-data/feature-flag-store-data';
 import { UserConfigurationStoreData } from 'common/types/store-data/user-configuration-store';
 import {
     DebugTools,
@@ -19,6 +20,9 @@ describe('DebugToolsView', () => {
             userConfigurationStoreData: {
                 isFirstTime: true,
             } as UserConfigurationStoreData,
+            featureFlagStoreData: {
+                reflowUI: true,
+            } as FeatureFlagStoreData,
         } as DebugToolsViewState;
 
         const wrapped = shallow(<DebugTools deps={deps} storeState={storeState} />);


### PR DESCRIPTION
#### Description of changes

Hide the "Accessibility Insights for Web" header text when the window is less than 600 px wide

![headertitle](https://user-images.githubusercontent.com/55459788/84419573-a732ef80-abcd-11ea-9139-e263f19a6d00.gif)


#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [x] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [x] (UI changes only) Added screenshots/GIFs to description above
- [x] (UI changes only) Verified usability with NVDA/JAWS
