### PR TITLE
feat(android-setup): add selection & device descriptions to prompt-choose-device dialog 

### DIFF
--- a/src/electron/flux/store/android-setup-store.ts
+++ b/src/electron/flux/store/android-setup-store.ts
@@ -30,7 +30,7 @@ export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
         // the value of currentStepId below is not especially meaningful
         // because the state will be overridden on the call to initialize
         // when the state machine factory is created.
-        return { currentStepId: 'detect-adb' };
+        return { currentStepId: 'prompt-choose-device' };
     }
 
     protected addActionListeners(): void {

--- a/src/electron/flux/store/android-setup-store.ts
+++ b/src/electron/flux/store/android-setup-store.ts
@@ -30,7 +30,7 @@ export class AndroidSetupStore extends BaseStoreImpl<AndroidSetupStoreData> {
         // the value of currentStepId below is not especially meaningful
         // because the state will be overridden on the call to initialize
         // when the state machine factory is created.
-        return { currentStepId: 'prompt-choose-device' };
+        return { currentStepId: 'detect-adb' };
     }
 
     protected addActionListeners(): void {

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.scss
@@ -14,3 +14,7 @@
 .checkmark {
     font-size: large;
 }
+
+.row {
+    height: 48px;
+}

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.scss
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.scss
@@ -16,5 +16,5 @@
 }
 
 .row {
-    height: 48px;
+    height: 36px;
 }

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -8,7 +8,6 @@ import {
     DetailsList,
     FontIcon,
     SelectionMode,
-    DetailsRow,
 } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
@@ -19,6 +18,9 @@ import * as styles from './prompt-choose-device-step.scss';
 export const PromptChooseDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
     'PromptChooseDeviceStep',
     (props: CommonAndroidSetupStepProps) => {
+        const [selectedDevice, setSelectedDevice] = React.useState(
+            props.androidSetupStoreData.selectedDevice ?? null,
+        );
         const onNextButton = () => {
             // To be implemented in future feature work
             console.log(`androidSetupActionCreator.next()`);
@@ -53,6 +55,7 @@ export const PromptChooseDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
                     <p>2 Android devices or emulators connected</p>
                     <DefaultButton text="Rescan" onClick={onRescanButton} />
                     <DetailsList
+                        compact={true}
                         ariaLabel="android devices"
                         className={styles.phoneList}
                         items={items}
@@ -60,7 +63,7 @@ export const PromptChooseDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
                         checkboxVisibility={CheckboxVisibility.always}
                         isHeaderVisible={false}
                         checkboxCellClassName={styles.checkmarkCell}
-                        checkButtonAriaLabel="select device"
+                        checkButtonAriaLabel="select"
                         onRenderCheckbox={checkboxProps => {
                             return checkboxProps.checked ? (
                                 <>
@@ -71,21 +74,13 @@ export const PromptChooseDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
                         onRenderItemColumn={item => {
                             return (
                                 <DeviceDescription
-                                    className="test-row-column"
+                                    className={styles.row}
                                     {...item.metadata}
                                 ></DeviceDescription>
                             );
                         }}
-                        onRenderRow={row => {
-                            return (
-                                <DetailsRow
-                                    rowFieldsAs={fieldProps => {
-                                        return <p>row field</p>;
-                                    }}
-                                    className="test-row-class"
-                                    {...row}
-                                ></DetailsRow>
-                            );
+                        onActiveItemChanged={item => {
+                            setSelectedDevice(item.metadata);
                         }}
                     />
                 </>
@@ -96,7 +91,7 @@ export const PromptChooseDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
             },
             rightFooterButtonProps: {
                 text: 'Next',
-                disabled: false,
+                disabled: selectedDevice == null,
                 onClick: onNextButton,
             },
         };

--- a/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
+++ b/src/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.tsx
@@ -1,16 +1,19 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 import { NamedFC } from 'common/react/named-fc';
+import { DeviceMetadata } from 'electron/flux/types/device-metadata';
 import {
     CheckboxVisibility,
     DefaultButton,
     DetailsList,
     FontIcon,
     SelectionMode,
+    DetailsRow,
 } from 'office-ui-fabric-react';
 import * as React from 'react';
 import { AndroidSetupStepLayout, AndroidSetupStepLayoutProps } from './android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from './android-setup-types';
+import { DeviceDescription } from './device-description';
 import * as styles from './prompt-choose-device-step.scss';
 
 export const PromptChooseDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
@@ -26,17 +29,22 @@ export const PromptChooseDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
             console.log(`androidSetupActionCreator.rescan()`);
         };
 
-        const items = [
+        const devices: DeviceMetadata[] = [
             {
-                value: 'Phone 1',
+                description: 'Phone 1',
+                isEmulator: true,
             },
             {
-                value: 'Phone 2',
+                description: 'Phone 2',
+                isEmulator: false,
             },
             {
-                value: 'Phone 3',
+                description: 'Phone 3',
+                isEmulator: true,
             },
         ];
+
+        const items = devices.map(m => ({ metadata: m }));
 
         const layoutProps: AndroidSetupStepLayoutProps = {
             headerText: 'Choose which device to use',
@@ -61,7 +69,23 @@ export const PromptChooseDeviceStep = NamedFC<CommonAndroidSetupStepProps>(
                             ) : null;
                         }}
                         onRenderItemColumn={item => {
-                            return <p>{item.value}</p>;
+                            return (
+                                <DeviceDescription
+                                    className="test-row-column"
+                                    {...item.metadata}
+                                ></DeviceDescription>
+                            );
+                        }}
+                        onRenderRow={row => {
+                            return (
+                                <DetailsRow
+                                    rowFieldsAs={fieldProps => {
+                                        return <p>row field</p>;
+                                    }}
+                                    className="test-row-class"
+                                    {...row}
+                                ></DetailsRow>
+                            );
                         }}
                     />
                 </>

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/__snapshots__/prompt-choose-device-step.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`PromptChooseDeviceStep renders per snapshot 1`] = `
   }
   rightFooterButtonProps={
     Object {
-      "disabled": false,
+      "disabled": true,
       "onClick": [Function],
       "text": "Next",
     }
@@ -19,7 +19,8 @@ exports[`PromptChooseDeviceStep renders per snapshot 1`] = `
 >
   <React.Fragment>
     <p>
-      2 Android devices or emulators connected
+      3
+       Android devices or emulators connected
     </p>
     <CustomizedDefaultButton
       onClick={[Function]}
@@ -27,27 +28,57 @@ exports[`PromptChooseDeviceStep renders per snapshot 1`] = `
     />
     <StyledWithViewportComponent
       ariaLabel="android devices"
-      checkButtonAriaLabel="select device"
+      checkButtonAriaLabel="select"
       checkboxCellClassName="checkmarkCell"
       checkboxVisibility={1}
       className="phoneList"
+      compact={true}
       isHeaderVisible={false}
       items={
         Array [
           Object {
-            "value": "Phone 1",
+            "metadata": Object {
+              "description": "Phone 1",
+              "isEmulator": true,
+            },
           },
           Object {
-            "value": "Phone 2",
+            "metadata": Object {
+              "description": "Phone 2",
+              "isEmulator": false,
+            },
           },
           Object {
-            "value": "Phone 3",
+            "metadata": Object {
+              "description": "Phone 3",
+              "isEmulator": true,
+            },
           },
         ]
       }
       onRenderCheckbox={[Function]}
       onRenderItemColumn={[Function]}
+      selection={
+        Selection {
+          "_anchoredIndex": 0,
+          "_canSelectItem": [Function],
+          "_changeEventSuppressionCount": 0,
+          "_exemptedCount": 0,
+          "_exemptedIndices": Object {},
+          "_getKey": [Function],
+          "_isModal": false,
+          "_items": Array [],
+          "_keyToIndexMap": Object {},
+          "_onSelectionChanged": [Function],
+          "_selectedItems": null,
+          "_unselectableCount": 0,
+          "_unselectableIndices": Object {},
+          "count": 0,
+          "mode": 2,
+        }
+      }
       selectionMode={1}
+      setKey="devices"
     />
   </React.Fragment>
 </AndroidSetupStepLayout>

--- a/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
+++ b/src/tests/unit/tests/electron/views/device-connect-view/components/android-setup/prompt-choose-device-step.test.tsx
@@ -3,7 +3,7 @@
 import { AndroidSetupStepLayout } from 'electron/views/device-connect-view/components/android-setup/android-setup-step-layout';
 import { CommonAndroidSetupStepProps } from 'electron/views/device-connect-view/components/android-setup/android-setup-types';
 import { PromptChooseDeviceStep } from 'electron/views/device-connect-view/components/android-setup/prompt-choose-device-step';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import * as React from 'react';
 import { AndroidSetupStepPropsBuilder } from 'tests/unit/common/android-setup-step-props-builder';
 import { IMock, Mock, Times } from 'typemoq';
@@ -29,5 +29,12 @@ describe('PromptChooseDeviceStep', () => {
         const rendered = shallow(<PromptChooseDeviceStep {...props} />);
         rendered.find(AndroidSetupStepLayout).prop('leftFooterButtonProps').onClick(stubEvent);
         closeAppMock.verify(m => m(), Times.once());
+    });
+
+    it('next button becomes enabled after device is selected', () => {
+        const rendered = mount(<PromptChooseDeviceStep {...props} />);
+        expect(rendered.find('button').at(2).props().disabled).toBeTruthy();
+        rendered.find('DeviceDescription').at(0).simulate('click');
+        expect(rendered.find('button').at(2).props().disabled).toBeUndefined();
     });
 });


### PR DESCRIPTION
#### Description of changes

This PR adds the device-description component and selection behavior to the prompt-choose-device screen. Linking the next button's enabled/disabled behavior to the selected state required overwriting the selection model of DetailsList. 

![gif of dialog](https://user-images.githubusercontent.com/7775527/84448985-fd6d5600-ac00-11ea-913c-d24199d15044.gif)

suggestions appreciated on / potential upcoming PR improvements:
- whether the Selection should be handled differently (would a separately tested and injected selection-provider make more sense?)
- when the dialog is full screen, the max-height still affects the details list. It would be nice to avoid this
- if the device description text is too long, text ellipses might be nice

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [ ] Addresses an existing issue: #0000
- [ ] Ran `yarn fastpass`
- [ ] Added/updated relevant unit test(s) (and ran `yarn test`)
- [ ] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [ ] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [ ] (UI changes only) Added screenshots/GIFs to description above
- [ ] (UI changes only) Verified usability with NVDA/JAWS
