### PR TITLE
(chore): Refactor injection of AppiumServiceConfiguratorFactory

### DIFF
--- a/src/electron/platform/android/appium-adb-creator.ts
+++ b/src/electron/platform/android/appium-adb-creator.ts
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import ADB from 'appium-adb';
+
+export type AppiumAdbCreateParameters = {
+    sdkRoot: string;
+};
+
+export interface AppiumAdbCreator {
+    createADB(opts: AppiumAdbCreateParameters): Promise<ADB>;
+}

--- a/src/electron/platform/android/appium-service-configurator-factory.ts
+++ b/src/electron/platform/android/appium-service-configurator-factory.ts
@@ -6,34 +6,19 @@ import {
     AndroidServiceConfigurator,
     AndroidServiceConfiguratorFactory,
 } from 'electron/platform/android/android-service-configurator';
+import {
+    AppiumAdbCreateParameters,
+    AppiumAdbCreator,
+} from 'electron/platform/android/appium-adb-creator';
 import { AppiumServiceConfigurator } from 'electron/platform/android/appium-service-configurator';
 
-export type AdbCreateParameters = {
-    sdkRoot: string;
-};
-
-export interface AdbCreator {
-    createADB(opts: AdbCreateParameters): Promise<ADB>;
-}
-
-class ProductionAdbCreator implements AdbCreator {
-    public createADB = async (parameters: AdbCreateParameters): Promise<ADB> => {
-        return ADB.createADB(parameters);
-    };
-}
-
 export class AppiumServiceConfiguratorFactory implements AndroidServiceConfiguratorFactory {
-    private readonly adbCreator: AdbCreator;
-
-    public constructor(adbCreator: AdbCreator) {
-        // In Production, pass null for adbCreator
-        this.adbCreator = adbCreator ?? new ProductionAdbCreator();
-    }
+    public constructor(private readonly adbCreator: AppiumAdbCreator) {}
 
     public getServiceConfigurator = async (
         sdkRoot: string,
     ): Promise<AndroidServiceConfigurator> => {
-        let parameters: AdbCreateParameters = undefined;
+        let parameters: AppiumAdbCreateParameters = undefined;
         if (sdkRoot) {
             parameters = { sdkRoot };
         }

--- a/src/electron/platform/android/appium-service-configurator-factory.ts
+++ b/src/electron/platform/android/appium-service-configurator-factory.ts
@@ -18,10 +18,11 @@ export class AppiumServiceConfiguratorFactory implements AndroidServiceConfigura
     public getServiceConfigurator = async (
         sdkRoot: string,
     ): Promise<AndroidServiceConfigurator> => {
-        let parameters: AppiumAdbCreateParameters = undefined;
-        if (sdkRoot) {
-            parameters = { sdkRoot };
-        }
+        const parameters: AppiumAdbCreateParameters = sdkRoot
+            ? {
+                  sdkRoot,
+              }
+            : undefined;
 
         const adb: ADB = await this.adbCreator.createADB(parameters);
 

--- a/src/electron/platform/android/live-appium-adb-creator.ts
+++ b/src/electron/platform/android/live-appium-adb-creator.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import ADB from 'appium-adb';
+import {
+    AppiumAdbCreateParameters,
+    AppiumAdbCreator,
+} from 'electron/platform/android/appium-adb-creator';
+
+export class LiveAppiumAdbCreator implements AppiumAdbCreator {
+    public createADB = async (parameters: AppiumAdbCreateParameters): Promise<ADB> => {
+        return ADB.createADB(parameters);
+    };
+}

--- a/src/tests/unit/tests/electron/platform/android/appium-service-configurator-factory.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/appium-service-configurator-factory.test.ts
@@ -1,18 +1,16 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+import { AppiumAdbCreator } from 'electron/platform/android/appium-adb-creator';
 import { AppiumServiceConfigurator } from 'electron/platform/android/appium-service-configurator';
-import {
-    AdbCreator,
-    AppiumServiceConfiguratorFactory,
-} from 'electron/platform/android/appium-service-configurator-factory';
+import { AppiumServiceConfiguratorFactory } from 'electron/platform/android/appium-service-configurator-factory';
 import { IMock, Mock, MockBehavior, Times } from 'typemoq';
 
 describe('AppiumServiceConfiguratorFactory tests', () => {
-    let adbCreatorMock: IMock<AdbCreator>;
+    let adbCreatorMock: IMock<AppiumAdbCreator>;
 
     beforeEach(() => {
-        adbCreatorMock = Mock.ofType<AdbCreator>(undefined, MockBehavior.Strict);
+        adbCreatorMock = Mock.ofType<AppiumAdbCreator>(undefined, MockBehavior.Strict);
     });
 
     it('getServiceConfigurator creates without parameters if no sdkRoot is provided', async () => {

--- a/src/tests/unit/tests/electron/platform/android/appium-service-configurator-factory.test.ts
+++ b/src/tests/unit/tests/electron/platform/android/appium-service-configurator-factory.test.ts
@@ -43,7 +43,7 @@ describe('AppiumServiceConfiguratorFactory tests', () => {
     });
 
     it('getServiceConfigurator propagates error to caller', async () => {
-        const expectedMessage = 'Soething bad happened';
+        const expectedMessage = 'Something bad happened';
         adbCreatorMock
             .setup(m => m.createADB(undefined))
             .throws(new Error(expectedMessage))


### PR DESCRIPTION
#### Description of changes
As discussed in today's engineering discussion, the current approach of constructing the AppiumServiceConfiguratorFactory has some downsides, especially if we want to decorate the call to `ADB.createADB` in some way. This change enables decoration and will bring the initializer more into line with what we do elsewhere. The initializer code will have no direct references to ADB, and the changes will look something like:
```
import AndroidServiceConfiguratorFactory from './android-service-configurator-factory';
import AppiumServiceConfiguratorFactory from './appium-service-configurator-factory';
import LiveAppiumAdbCreator from './live-appium-adb-creator';

// existing code

this.androidServiceConfiguratorFactory = new AppiumServiceConfiguratorFactory (
    new LiveAppiumAdbCreator()
);
```
Unit tests are changed only for imports and class names, and test coverage for `AppiumServiceConfiguratorFactory` is now 100%. Test coverage for `LiveAppiumAdbCreator` is 0%, but since it's just delegating to ADB, and since ADB's behavior depends upon the device config, we agreed that this would be OK.

<!--
  A great PR description includes:
    * A high level overview (usually a sentence or two) describing what the PR changes
    * What is the motivation for the change? This can be as simple as "addresses issue #123"
    * Were there any alternative approaches you considered? What tradeoffs did you consider?
    * What **doesn't** the change try to do? Are there any parts that you've intentionally left out-of-scope for a later PR to handle? What are the issues/work items tracking that later work?
    * Is there any other context that reviewers should consider? For example, other related issues/PRs, or any particularly tricky/subtle bits of implementation that need closer-than-normal review?
-->

#### Pull request checklist
<!-- If a checklist item is not applicable to this change, write "n/a" in the checkbox -->
- [n/a] Addresses an existing issue: #0000
- [x] Ran `yarn fastpass`
- [x] Added/updated relevant unit test(s) (and ran `yarn test`)
- [x] Verified code coverage for the changes made. Check coverage report at: `<rootDir>/test-results/unit/coverage`
- [x] PR title *AND* final merge commit title both start with a semantic tag (`fix:`, `chore:`, `feat(feature-name):`, `refactor:`). See `CONTRIBUTING.md`.
- [n/a] (UI changes only) Added screenshots/GIFs to description above
- [n/a] (UI changes only) Verified usability with NVDA/JAWS
